### PR TITLE
Fix for issue 101: Increase the length of the "Browse" edit field when importing .hex file

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -998,7 +998,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             htmlBody: `<div class="ui form">
   <div class="ui field">
     <label>${lf("Select an .hex file to import.")}</label>
-    <input type="file" style="width:100%"></input>
+    <input type="file" class="ui button blue fluid"></input>
   </div>
 </div>`,
         }).done(res => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -998,7 +998,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             htmlBody: `<div class="ui form">
   <div class="ui field">
     <label>${lf("Select an .hex file to import.")}</label>
-    <input type="file"></input>
+    <input type="file" style="width:100%"></input>
   </div>
 </div>`,
         }).done(res => {


### PR DESCRIPTION
PR fixes #101 

Before (Chrome): 
![image](https://cloud.githubusercontent.com/assets/16690124/17227112/9642d152-54c1-11e6-9baa-552834d74a14.png)

After (Chrome): 
![image](https://cloud.githubusercontent.com/assets/16690124/17227120/a2e86566-54c1-11e6-818d-2a5741dd8338.png)

After (Firefox): 
![image](https://cloud.githubusercontent.com/assets/16690124/17227134/aed1bca6-54c1-11e6-9a24-a7ff207f11fe.png)

After (Edge): 
![image](https://cloud.githubusercontent.com/assets/16690124/17227140/b99032d0-54c1-11e6-9145-9e9c776b5273.png)



