### PR TITLE
Fix for issue 141: Opening an existing project or dragging a HEX file…

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -804,13 +804,20 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 let e = this.settings.fileHistory.filter(e => e.id == h.id)[0]
                 let main = pkg.getEditorPkg(pkg.mainPkg)
                 let file = main.getMainFile()
+                if (pkg.File.blocksFileNameRx.test(file.getName()) && file.getVirtualFileName())
+                    file = main.lookupFile("this/" + file.getVirtualFileName()) || file
                 if (e)
-                    file = main.lookupFile(e.name) || file
+                    file = main.lookupFile("this/" + e.name) || file
                 this.setState({
                     header: h,
                     projectName: h.name,
                     currFile: file
                 })
+                if (!e && pkg.File.tsFileNameRx.test(file.getName()) && file.getVirtualFileName()) {
+                    this.aceEditor.checkRoundTrip(file.getVirtualFileName(), () => {
+                        return Promise.resolve()
+                    })
+                }
                 core.infoNotification(lf("Project loaded: {0}", h.name))
                 pkg.getEditorPkg(pkg.mainPkg).onupdate = () => {
                     this.loadHeaderAsync(h).done()

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -104,6 +104,8 @@ export interface ConfirmOptions extends DialogOptions {
 export interface DialogOptions {
     hideCancel?: boolean;
     disagreeLbl?: string;
+    disagreeClass?: string;
+    disagreeIcon?: string;
     logos?: string[];
     header: string;
     body?: string;
@@ -133,8 +135,8 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
     if (!options.hideCancel) {
         options.buttons.push({
             label: options.disagreeLbl || lf("Cancel"),
-            class: "cancel",
-            icon: "cancel"
+            class: options.disagreeClass || "cancel",
+            icon: options.disagreeIcon || "cancel"
         })
     }
 


### PR DESCRIPTION
Fix for issue 141: Opening an existing project or dragging a HEX file to the editor should open it in Java if fails to open in Blocks

+ Change to make the default option of the Js->Blocks dialog be to stay in JS.

fixes issue #141 