### PR TITLE
Reduce false negative rate when testing documentation snippets

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2785,10 +2785,12 @@ export function helpAsync(all?: string) {
     } else {
         console.log("Common commands (use 'pxt help all' to show all):")
     }
+    let commandWidth = Math.max(10, 1 + Math.max(...cmds.map(cmd => cmd.name.length)))
+    let argWidth = Math.max(20, 1 + Math.max(...cmds.map(cmd => cmd.argDesc.length)))
     cmds.forEach(cmd => {
         if (cmd.priority >= 10) return;
         if (showAll || !cmd.priority) {
-            console.log(f(cmd.name, 10) + f(cmd.argDesc, 20) + cmd.desc);
+            console.log(f(cmd.name, commandWidth) + f(cmd.argDesc, argWidth) + cmd.desc);
         }
     })
     return Promise.resolve()

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2527,11 +2527,16 @@ function testSnippetsAsync(...args: string[]): Promise<void> {
                 console.log(`  L ${diag.line}\t${diag.messageText}`)
             }
         }
-        let successData = successes.join("\n")
-        if (!fs.existsSync(path.dirname(ignorePath))) {
-            fs.mkdirSync(path.dirname(ignorePath))
+        if (filenameMatch.source == '.*' && !ignorePreviousSuccesses) {
+            let successData = successes.join("\n")
+            if (!fs.existsSync(path.dirname(ignorePath))) {
+                fs.mkdirSync(path.dirname(ignorePath))
+            }
+            fs.writeFileSync(ignorePath, successData)
         }
-        fs.writeFileSync(ignorePath, successData)
+        else {
+            console.log("Some files were ignored, therefore won't write success log")
+        }
     })
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2474,7 +2474,7 @@ function testSnippetsAsync(...args: string[]): Promise<void> {
         let snippets = uploader.getSnippets(source)
         // [].concat.apply([], ...) takes an array of arrays and flattens it
         let extraDeps: string[] = [].concat.apply([], snippets.filter(s => s.type == "package").map(s => s.code.split('\n')))
-        let ignoredTypes = ["Text", "sig", "pre", "codecard", "package", "namespaces"]
+        let ignoredTypes = ["Text", "sig", "pre", "codecard", "cards", "package", "namespaces"]
         let snippetsToCheck = snippets.filter(s => ignoredTypes.indexOf(s.type) < 0 && !s.ignore)
         ignoreCount += snippets.length - snippetsToCheck.length
 

--- a/cli/uploader.ts
+++ b/cli/uploader.ts
@@ -146,7 +146,7 @@ function uploadFileAsync(fn: string) {
     return uploadPromises[fn]
 }
 
-function getFiles() {
+export function getFiles() {
     let res: string[] = []
     function loop(path: string) {
         for (let fn of fs.readdirSync(path)) {
@@ -233,19 +233,34 @@ export function checkDocsAsync(...args: string[]): Promise<void> {
             return '';
         })
 
-        // extract all snippets
-        let snipIndex = 0;
-        text.replace(/^`{3}([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm, (m, type, code) => {
-            type = type || "pre"
-            let dir = "built/docs/snippets/" + type;
-            let fn = `${dir}/${f.replace(/^\//, '').replace(/\//g, '-').replace(/\.\w+$/, '')}-${snipIndex++}.ts`;
+        let snippets = getSnippets(text)
+        snipCount += snippets.length
+        for (let snipIndex = 0; snipIndex < snippets.length; snipIndex++) {
+            let dir = "built/docs/snippets/" + snippets[snipIndex].type;
+            let fn = `${dir}/${f.replace(/^\//, '').replace(/\//g, '-').replace(/\.\w+$/, '')}-${snipIndex}.ts`;
             nodeutil.mkdirP(dir);
-            fs.writeFileSync(fn, code);
-            snipCount++;
-            return '';
-        });
+            fs.writeFileSync(fn, snippets[snipIndex].code);
+        }
     });
 
     console.log(`checked ${checked} files: ${broken} broken links, ${snipCount} snippets`);
     return Promise.resolve();
+}
+
+export interface SnippetInfo {
+    type: string;
+    code: string;
+}
+
+export function getSnippets(source: string): SnippetInfo[] {
+    let snippets: SnippetInfo[] = []
+    let re = /^`{3}([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm;
+    source.replace(re, (match, type, code) => {
+        snippets.push({
+            type: type || "pre",
+            code: code
+        })
+        return ''
+    })
+    return snippets
 }

--- a/cli/uploader.ts
+++ b/cli/uploader.ts
@@ -248,18 +248,24 @@ export function checkDocsAsync(...args: string[]): Promise<void> {
 }
 
 export interface SnippetInfo {
-    type: string;
-    code: string;
+    type: string
+    code: string
+    ignore: boolean
+    index: number
 }
 
 export function getSnippets(source: string): SnippetInfo[] {
     let snippets: SnippetInfo[] = []
     let re = /^`{3}([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm;
+    let index = 0
     source.replace(re, (match, type, code) => {
         snippets.push({
-            type: type || "pre",
-            code: code
+            type: type ? type.replace("-ignore", "") : "pre",
+            code: code,
+            ignore: type ? /-ignore/g.test(type) : false,
+            index: index
         })
+        index++
         return ''
     })
     return snippets

--- a/cli/uploader.ts
+++ b/cli/uploader.ts
@@ -235,7 +235,7 @@ export function checkDocsAsync(...args: string[]): Promise<void> {
 
         // extract all snippets
         let snipIndex = 0;
-        text.replace(/^`{3}([\S]+)?\n([\s\S]+?)\n`{3}\s*?$/gm, (m, type, code) => {
+        text.replace(/^`{3}([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm, (m, type, code) => {
             type = type || "pre"
             let dir = "built/docs/snippets/" + type;
             let fn = `${dir}/${f.replace(/^\//, '').replace(/\//g, '-').replace(/\.\w+$/, '')}-${snipIndex++}.ts`;

--- a/cli/uploader.ts
+++ b/cli/uploader.ts
@@ -235,7 +235,7 @@ export function checkDocsAsync(...args: string[]): Promise<void> {
 
         // extract all snippets
         let snipIndex = 0;
-        text.replace(/^`{3}([\S]+)?\n([\s\S]+?)\n`{3}$/gm, (m, type, code) => {
+        text.replace(/^`{3}([\S]+)?\n([\s\S]+?)\n`{3}\s*?$/gm, (m, type, code) => {
             type = type || "pre"
             let dir = "built/docs/snippets/" + type;
             let fn = `${dir}/${f.replace(/^\//, '').replace(/\//g, '-').replace(/\.\w+$/, '')}-${snipIndex++}.ts`;

--- a/cli/uploader.ts
+++ b/cli/uploader.ts
@@ -146,7 +146,7 @@ function uploadFileAsync(fn: string) {
     return uploadPromises[fn]
 }
 
-export function getFiles() {
+export function getFiles(): string[] {
     let res: string[] = []
     function loop(path: string) {
         for (let fn of fs.readdirSync(path)) {

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -44,6 +44,13 @@ function dirAuto($el) {
 }
 
 function renderSnippets() {
+    var codeElems = $('code')
+    for (var i = 0; i < codeElems.length; i++) {
+        console.log("Previously " + codeElems[i].className)
+        codeElems[i].className = codeElems[i].className.replace('-ignore', '')
+        console.log("Now " + codeElems[i].className)
+    }
+
     var path = window.location.href.split('/').pop().split(/[?#]/)[0];
     console.log(path)
     ksRunnerReady(function() {        

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -186,7 +186,7 @@ namespace pxt.docs {
                     try {
                         let hljs = require('highlight.js');
                         if (!hljs) return code;
-                        return hljs.highlightAuto(code, [lang]).value;
+                        return hljs.highlightAuto(code, [lang.replace('-ignore', '')]).value;
                     }
                     catch (e) {
                         return code;


### PR DESCRIPTION
- Renamed`pxt testsnippets` to `pxt snippets`
- Added `-i` flag to ignore snippets previously believed to compile correctly
- Added `-re REGEX` option to only test snippets in files whose name matches the regex
- Ignore certain snippet types that are never meant to be compiled to blocks, such as those that are strictly TypeScript or are meant to demonstrate syntax errors. You can force the test to ignore a snippet by appending `-ignore` after its type
- Use the `package` snippet at the end of a file to determine whether to use extra packages when compiling (e.g. `microbit-radio`, `microbit-bluetooth`, etc)
- Search the original documentation files for snippets, rather than the snippets directory. This means that `pxt snippets` can be run without running `pxt checkdocs` or `pxt serve`

This pull request also includes a minor change to the output of `pxt help` that produces wider columns when necessary.