### PR TITLE
computes and passes component parts list to simulators

### DIFF
--- a/pxtlib/emitter/driver.ts
+++ b/pxtlib/emitter/driver.ts
@@ -90,13 +90,15 @@ namespace ts.pxt {
         let parts: string[] = [];
         for (let symbol in resp.usedSymbols) {
             let info = resp.usedSymbols[symbol]
-            if (info && info.attributes && (<any>info.attributes)["parts"]) {
-                let partsStr = <string>(<any>info.attributes)["parts"];
-                if (partsStr) {
-                    partsStr
-                        .split(" ")
-                        .filter(p => 0 < p.length && parts.indexOf(p) < 0)
-                        .forEach(p => parts.push(p));
+            if (info && info.attributes.parts) {
+                let partsRaw = info.attributes.parts;
+                if (partsRaw) {
+                    let partsSplit = partsRaw.split(/[ ,]+/);
+                    partsSplit.forEach(p => {
+                        if (0 < p.length && parts.indexOf(p) < 0) {
+                            parts.push(p);
+                        }
+                    });
                 }
             }
         }

--- a/pxtlib/emitter/driver.ts
+++ b/pxtlib/emitter/driver.ts
@@ -83,6 +83,26 @@ namespace ts.pxt {
         usedSymbols?: U.Map<SymbolInfo>; // q-names of symbols used
     }
 
+    export function computeUsedParts(resp: CompileResult): string[] {
+        if (!resp.usedSymbols)
+            return null;
+
+        let parts: string[] = [];
+        for (let symbol in resp.usedSymbols) {
+            let info = resp.usedSymbols[symbol]
+            if (info && info.attributes && (<any>info.attributes)["parts"]) {
+                let partsStr = <string>(<any>info.attributes)["parts"];
+                if (partsStr) {
+                    partsStr
+                        .split(" ")
+                        .filter(p => 0 < p.length && parts.indexOf(p) < 0)
+                        .forEach(p => parts.push(p));
+                }
+            }
+        }
+        return parts;
+    }
+
     export function getTsCompilerOptions(opts: CompileOptions) {
         let options = ts.getDefaultCompilerOptions()
 

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -174,6 +174,7 @@ namespace ts.pxt {
         icon?: string;
         imageLiteral?: number;
         weight?: number;
+        parts?: string;
 
         // on interfaces
         indexerGet?: string;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -210,7 +210,7 @@ namespace pxt.runner {
                         options.aspectRatio = pxt.appTarget.simulator.aspectRatio;
                     let parts = ts.pxt.computeUsedParts(resp);
                     let driver = new pxsim.SimulatorDriver(container, options);
-                    driver.run(js);
+                    driver.run(js, {parts: parts});
                 }
             })
     }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -208,6 +208,7 @@ namespace pxt.runner {
                     let options: pxsim.SimulatorDriverOptions = {};
                     if (pxt.appTarget.simulator)
                         options.aspectRatio = pxt.appTarget.simulator.aspectRatio;
+                    let parts = ts.pxt.computeUsedParts(resp);
                     let driver = new pxsim.SimulatorDriver(container, options);
                     driver.run(js);
                 }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -194,6 +194,23 @@ namespace pxt.runner {
             });
     }
 
+    export function computeUsedParts(usedSymbols: U.Map<ts.pxt.SymbolInfo>): string[] { 
+        let parts: string[] = [];
+        for (let symbol in usedSymbols) {
+            let info = usedSymbols[symbol]
+            if (info && info.attributes && (<any>info.attributes)["parts"]) {
+                let partsStr = <string>(<any>info.attributes)["parts"];
+                if (partsStr) {
+                    partsStr
+                        .split(" ")
+                        .filter(p => 0 < p.length && parts.indexOf(p) < 0)
+                        .forEach(p => parts.push(p));
+                }
+            }
+        }
+        return parts;
+    }
+
     export function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
         return loadPackageAsync(simOptions.id)
             .then(() => compileAsync(false, opts => {
@@ -209,7 +226,10 @@ namespace pxt.runner {
                     if (pxt.appTarget.simulator)
                         options.aspectRatio = pxt.appTarget.simulator.aspectRatio;
                     let driver = new pxsim.SimulatorDriver(container, options);
-                    driver.run(js);
+                    let parts: string[] = null;
+                    if (resp.usedSymbols)
+                        parts = computeUsedParts(resp.usedSymbols);
+                    driver.run(js, parts);
                 }
             })
     }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -194,23 +194,6 @@ namespace pxt.runner {
             });
     }
 
-    export function computeUsedParts(usedSymbols: U.Map<ts.pxt.SymbolInfo>): string[] {
-        let parts: string[] = [];
-        for (let symbol in usedSymbols) {
-            let info = usedSymbols[symbol]
-            if (info && info.attributes && (<any>info.attributes)["parts"]) {
-                let partsStr = <string>(<any>info.attributes)["parts"];
-                if (partsStr) {
-                    partsStr
-                        .split(" ")
-                        .filter(p => 0 < p.length && parts.indexOf(p) < 0)
-                        .forEach(p => parts.push(p));
-                }
-            }
-        }
-        return parts;
-    }
-
     export function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
         return loadPackageAsync(simOptions.id)
             .then(() => compileAsync(false, opts => {
@@ -226,10 +209,7 @@ namespace pxt.runner {
                     if (pxt.appTarget.simulator)
                         options.aspectRatio = pxt.appTarget.simulator.aspectRatio;
                     let driver = new pxsim.SimulatorDriver(container, options);
-                    let parts: string[] = null;
-                    if (resp.usedSymbols)
-                        parts = computeUsedParts(resp.usedSymbols);
-                    driver.run(js, parts);
+                    driver.run(js);
                 }
             })
     }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -194,7 +194,7 @@ namespace pxt.runner {
             });
     }
 
-    export function computeUsedParts(usedSymbols: U.Map<ts.pxt.SymbolInfo>): string[] { 
+    export function computeUsedParts(usedSymbols: U.Map<ts.pxt.SymbolInfo>): string[] {
         let parts: string[] = [];
         for (let symbol in usedSymbols) {
             let info = usedSymbols[symbol]

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -8,7 +8,6 @@ namespace pxsim {
         frameCounter?: number;
         options?: any;
         parts?: string[];
-        
         code: string;
     }
 

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -7,7 +7,8 @@ namespace pxsim {
         id?: string;
         frameCounter?: number;
         options?: any;
-
+        parts?: string[];
+        
         code: string;
     }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -24,6 +24,11 @@ namespace pxsim {
         Pause
     }
 
+    export interface SimulatorRunOptions {
+        debug?: boolean;
+        parts?: string[];
+    }
+
     export interface HwDebugger {
         postMessage: (msg: pxsim.SimulatorMessage) => void;
     }
@@ -167,15 +172,15 @@ namespace pxsim {
             }
         }
 
-        public run(js: string, parts?: string[], debug?: boolean) {
-            this.debug = debug;
+        public run(js: string, opts: SimulatorRunOptions) {
+            this.debug = opts.debug;
             this.runId = this.nextId();
             this.addEventListeners();
 
             // store information
             this.currentRuntime = {
                 type: 'run',
-                parts: parts,
+                parts: opts.parts,
                 code: js
             }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -172,7 +172,7 @@ namespace pxsim {
             }
         }
 
-        public run(js: string, opts: SimulatorRunOptions) {
+        public run(js: string, opts: SimulatorRunOptions = {}) {
             this.debug = opts.debug;
             this.runId = this.nextId();
             this.addEventListeners();

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -167,7 +167,7 @@ namespace pxsim {
             }
         }
 
-        public run(js: string, debug?: boolean) {
+        public run(js: string, parts?: string[], debug?: boolean) {
             this.debug = debug;
             this.runId = this.nextId();
             this.addEventListeners();
@@ -175,6 +175,7 @@ namespace pxsim {
             // store information
             this.currentRuntime = {
                 type: 'run',
+                parts: parts,
                 code: js
             }
 

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../built/pxtsim.d.ts" />
+/// <reference path="../../built/pxtrunner.d.ts" />
 
 import U = pxt.U
 
@@ -83,8 +84,11 @@ export function isDirty(): boolean { // in need of a restart?
 export function run(debug: boolean, res: ts.pxt.CompileResult) {
     pxsim.U.removeClass(driver.container, "sepia");
     let js = res.outfiles[ts.pxt.BINARY_JS]
-    lastCompileResult = res
-    driver.run(js, debug)
+    let parts: string[] = null;
+    if (res.usedSymbols)
+        parts = pxt.runner.computeUsedParts(res.usedSymbols);
+    lastCompileResult = res;
+    driver.run(js, parts, debug);
 }
 
 export function stop(unload?: boolean) {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -83,7 +83,7 @@ export function isDirty(): boolean { // in need of a restart?
 export function run(debug: boolean, res: ts.pxt.CompileResult) {
     pxsim.U.removeClass(driver.container, "sepia");
     let js = res.outfiles[ts.pxt.BINARY_JS]
-    let parts = resp.computeUsedParts();
+    let parts = ts.pxt.computeUsedParts(res);
     lastCompileResult = res;
     driver.run(js, parts, debug);
 }

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -85,7 +85,7 @@ export function run(debug: boolean, res: ts.pxt.CompileResult) {
     let js = res.outfiles[ts.pxt.BINARY_JS]
     let parts = ts.pxt.computeUsedParts(res);
     lastCompileResult = res;
-    driver.run(js, parts, debug);
+    driver.run(js, {parts: parts, debug: debug});
 }
 
 export function stop(unload?: boolean) {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -80,29 +80,10 @@ export function isDirty(): boolean { // in need of a restart?
     return /sepia/.test(driver.container.className);
 }
 
-export function computeUsedParts(usedSymbols: U.Map<ts.pxt.SymbolInfo>): string[] {
-    let parts: string[] = [];
-    for (let symbol in usedSymbols) {
-        let info = usedSymbols[symbol]
-        if (info && info.attributes && (<any>info.attributes)["parts"]) {
-            let partsStr = <string>(<any>info.attributes)["parts"];
-            if (partsStr) {
-                partsStr
-                    .split(" ")
-                    .filter(p => 0 < p.length && parts.indexOf(p) < 0)
-                    .forEach(p => parts.push(p));
-            }
-        }
-    }
-    return parts;
-}
-
 export function run(debug: boolean, res: ts.pxt.CompileResult) {
     pxsim.U.removeClass(driver.container, "sepia");
     let js = res.outfiles[ts.pxt.BINARY_JS]
-    let parts: string[] = null;
-    if (res.usedSymbols)
-        parts = computeUsedParts(res.usedSymbols);
+    let parts = resp.computeUsedParts();
     lastCompileResult = res;
     driver.run(js, parts, debug);
 }

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -1,5 +1,4 @@
 /// <reference path="../../built/pxtsim.d.ts" />
-/// <reference path="../../built/pxtrunner.d.ts" />
 
 import U = pxt.U
 
@@ -81,12 +80,29 @@ export function isDirty(): boolean { // in need of a restart?
     return /sepia/.test(driver.container.className);
 }
 
+export function computeUsedParts(usedSymbols: U.Map<ts.pxt.SymbolInfo>): string[] {
+    let parts: string[] = [];
+    for (let symbol in usedSymbols) {
+        let info = usedSymbols[symbol]
+        if (info && info.attributes && (<any>info.attributes)["parts"]) {
+            let partsStr = <string>(<any>info.attributes)["parts"];
+            if (partsStr) {
+                partsStr
+                    .split(" ")
+                    .filter(p => 0 < p.length && parts.indexOf(p) < 0)
+                    .forEach(p => parts.push(p));
+            }
+        }
+    }
+    return parts;
+}
+
 export function run(debug: boolean, res: ts.pxt.CompileResult) {
     pxsim.U.removeClass(driver.container, "sepia");
     let js = res.outfiles[ts.pxt.BINARY_JS]
     let parts: string[] = null;
     if (res.usedSymbols)
-        parts = pxt.runner.computeUsedParts(res.usedSymbols);
+        parts = computeUsedParts(res.usedSymbols);
     lastCompileResult = res;
     driver.run(js, parts, debug);
 }


### PR DESCRIPTION
This leverages @mmoskal's work on collecting "usedSymbols" to pass a list of "parts" mentioned in the code as annotated by the `//% parts="..."` annotations. This is essential for the pxt-arduino target, but it could also be used by any target that wants to know this information statically.