### PR TITLE
ARM Assembly highlighting support

### DIFF
--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -32,6 +32,94 @@ namespace pxt.vs {
     export function initMonacoAsync(element: HTMLElement): monaco.editor.IStandaloneCodeEditor {
         if (!monaco.languages.typescript) return;
 
+        monaco.languages.register({id: 'asm', extensions: ['.asm']});
+        monaco.languages.setMonarchTokensProvider('asm', <monaco.languages.IMonarchLanguage>{
+            // Set defaultToken to invalid to see what you do not tokenize yet
+            // defaultToken: 'invalid',
+            tokenPostfix: '',
+
+            //Extracted from http://infocenter.arm.com/help/topic/com.arm.doc.qrc0006e/QRC0006_UAL16.pdf
+            //Should be a superset of the instructions emitted
+            keywords: [
+                'movs', 'mov', 'adds', 'add', 'adcs', 'adr', 'subs', 'sbcs', 'sub', 'rsbs',
+                'muls', 'cmp', 'cmn', 'ands', 'eors', 'orrs', 'bics', 'mvns', 'tst', 'lsls',
+                'lsrs', 'asrs', 'rors', 'ldr', 'ldrh', 'ldrb', 'ldrsh', 'ldrsb', 'ldm',
+                'str', 'strh', 'strb', 'stm', 'push', 'pop', 'cbz', 'cbnz', 'b', 'bl', 'bx', 'blx',
+                'sxth', 'sxtb', 'uxth', 'uxtb', 'rev', 'rev16', 'revsh', 'svc', 'cpsid', 'cpsie',
+                'setend', 'bkpt', 'nop', 'sev', 'wfe', 'wfi', 'yield',
+                'beq', 'bne', 'bcs', 'bhs', 'bcc', 'blo', 'bmi', 'bpl', 'bvs', 'bvc', 'bhi', 'bls',
+                'bge', 'blt', 'bgt', 'ble', 'bal',
+                //Registers
+                'r0', 'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'r10', 'r11', 'r12', 'r13', 'r14', 'r15',
+                'pc', 'sp', 'lr'
+            ],
+
+            typeKeywords: [
+                '.startaddr', '.hex', '.short', '.space', '.section', '.string', '.byte'
+            ],
+
+            operators: [],
+
+            // Not all of these are valid in ARM Assembly
+            symbols:  /[:\*]+/,
+
+            // C# style strings
+            escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+            // The main tokenizer for our languages
+            tokenizer: {
+                root: [
+                // identifiers and keywords
+                [/(\.)?[a-z_$\.][\w$]*/, { cases: { '@typeKeywords': 'keyword',
+                                            '@keywords': 'keyword',
+                                            '@default': 'identifier' } }],
+
+                // whitespace
+                { include: '@whitespace' },
+
+                // delimiters and operators
+                [/[{}()\[\]]/, '@brackets'],
+                [/[<>](?!@symbols)/, '@brackets'],
+                [/@symbols/, { cases: { '@operators': 'operator',
+                                        '@default'  : '' } } ],
+
+                // @ annotations.
+                [/@\s*[a-zA-Z_\$][\w\$]*/, { token: 'annotation', log: 'annotation token: $0' }],
+
+                // numbers
+                //[/\d*\.\d+([eE][\-+]?\d+)?/, 'number.float'],
+                [/(#|(0[xX]))?[0-9a-fA-F]+/, 'number'],
+
+                // delimiter: after number because of .\d floats
+                [/[;,.]/, 'delimiter'],
+
+                // strings
+                [/"([^"\\]|\\.)*$/, 'string.invalid' ],  // non-teminated string
+                [/"/,  { token: 'string.quote', bracket: '@open', next: '@string' } ],
+
+                // characters
+                [/'[^\\']'/, 'string'],
+                [/(')(@escapes)(')/, ['string','string.escape','string']],
+                [/'/, 'string.invalid']
+                ],
+
+                comment: [],
+
+                string: [
+                [/[^\\"]+/,  'string'],
+                [/@escapes/, 'string.escape'],
+                [/\\./,      'string.escape.invalid'],
+                [/"/,        { token: 'string.quote', bracket: '@close', next: '@pop' } ]
+                ],
+
+                whitespace: [
+                [/[ \t\r\n]+/, 'white'],
+                [/\/\*/,       'comment', '@comment' ],
+                [/;.*$/,    'comment'],
+                ],
+            }
+        });
+
         // validation settings
         let diagnosticOptions = monaco.languages.typescript.typescriptDefaults.diagnosticsOptions;
         diagnosticOptions.noSyntaxValidation = false;

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -84,7 +84,7 @@ namespace pxt.vs {
                                         '@default'  : '' } } ],
 
                 // @ annotations.
-                [/@\s*[a-zA-Z_\$][\w\$]*/, { token: 'annotation', log: 'annotation token: $0' }],
+                [/@\s*[a-zA-Z_\$][\w\$]*/, { token: 'annotation' }],
 
                 // numbers
                 //[/\d*\.\d+([eE][\-+]?\d+)?/, 'number.float'],

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -430,7 +430,7 @@ export class Editor extends srceditor.Editor {
             "ts": "typescript",
             "js": "javascript",
             "blocks": "xml",
-            "asm": "bat"
+            "asm": "asm"
         }
         let mode = "text"
         if (modeMap.hasOwnProperty(ext)) mode = modeMap[ext]


### PR DESCRIPTION
Ensures that ARM assembly is correctly highlighted in the Monaco editor.

Before:

<img width="588" alt="screen shot 2016-09-05 at 14 52 54" src="https://cloud.githubusercontent.com/assets/20356546/18249887/784dbefc-7378-11e6-9331-3ea1d0ecf0e1.png">

After:

<img width="587" alt="screen shot 2016-09-05 at 14 51 07" src="https://cloud.githubusercontent.com/assets/20356546/18249891/7d18f91a-7378-11e6-8c81-c603450999a4.png">

The highlighting rules are based on the [guide to Monarch](https://microsoft.github.io/monaco-editor/monarch.html) and the [ARM Assembly reference](http://infocenter.arm.com/help/topic/com.arm.doc.qrc0006e/QRC0006_UAL16.pdf).