### PR TITLE
Edit button for documentation pages

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1279,7 +1279,7 @@ function renderDocs(localDir: string) {
                     name: e
                 }
             })
-            let html = pxt.docs.renderMarkdown(docsTemplate, str, pxt.appTarget.appTheme, null, bc)
+            let html = pxt.docs.renderMarkdown(docsTemplate, str, pxt.appTarget.appTheme, null, bc, `https://github.com/Microsoft/pxt-microbit/blob/master/docs/${f}`)
             html = html.replace(/(<a[^<>]*)\shref="(\/[^<>"]*)"/g, (f, beg, url) => {
                 return beg + ` href="${webpath}docs${url}.html"`
             })

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1279,7 +1279,7 @@ function renderDocs(localDir: string) {
                     name: e
                 }
             })
-            let html = pxt.docs.renderMarkdown(docsTemplate, str, pxt.appTarget.appTheme, null, bc, `https://github.com/Microsoft/pxt-microbit/blob/master/docs/${f}`)
+            let html = pxt.docs.renderMarkdown(docsTemplate, str, pxt.appTarget.appTheme, null, bc, f)
             html = html.replace(/(<a[^<>]*)\shref="(\/[^<>"]*)"/g, (f, beg, url) => {
                 return beg + ` href="${webpath}docs${url}.html"`
             })

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -582,7 +582,7 @@ export function serveAsync(options: ServeOptions) {
                         name: e
                     }
                 })
-                let html = pxt.docs.renderMarkdown(docsTemplate, fs.readFileSync(webFile, "utf8"), pxt.appTarget.appTheme, null, bc)
+                let html = pxt.docs.renderMarkdown(docsTemplate, fs.readFileSync(webFile, "utf8"), pxt.appTarget.appTheme, null, bc, `https://github.com/Microsoft/pxt-microbit/blob/master/docs/${pathname}`)
                 sendHtml(html)
             } else {
                 sendFile(webFile)

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -582,7 +582,7 @@ export function serveAsync(options: ServeOptions) {
                         name: e
                     }
                 })
-                let html = pxt.docs.renderMarkdown(docsTemplate, fs.readFileSync(webFile, "utf8"), pxt.appTarget.appTheme, null, bc, `https://github.com/Microsoft/pxt-microbit/blob/master/docs/${pathname}`)
+                let html = pxt.docs.renderMarkdown(docsTemplate, fs.readFileSync(webFile, "utf8"), pxt.appTarget.appTheme, null, bc, pathname)
                 sendHtml(html)
             } else {
                 sendFile(webFile)

--- a/docfiles/template.html
+++ b/docfiles/template.html
@@ -182,7 +182,7 @@
 
 @breadcrumb@
 @body@
-
+@github@
 
 </div>
 

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -40,6 +40,7 @@ namespace pxt.docs {
     declare var require: any;
     let marked: MarkedStatic;
     import U = pxtc.Util;
+    const lf = U.lf;
 
     let stdboxes: U.Map<string> = {
     }
@@ -113,8 +114,10 @@ namespace pxt.docs {
         return require("marked");
     }
 
-    export function renderMarkdown(template: string, src: string, theme: AppTheme = {}, pubinfo: U.Map<string> = null, breadcrumb: BreadcrumbEntry[] = []): string {
+    export function renderMarkdown(template: string, src: string, theme: AppTheme = {}, pubinfo: U.Map<string> = null, breadcrumb: BreadcrumbEntry[] = [], githubUrl: string = null): string {
         let params: U.Map<string> = pubinfo || {}
+
+        console.log(params);
 
         let boxes = U.clone(stdboxes)
         let macros = U.clone(stdmacros)
@@ -333,6 +336,12 @@ namespace pxt.docs {
         params["targetname"] = theme.name || "PXT"
         params["targetlogo"] = theme.docsLogo ? `<img class="ui mini image" src="${U.toDataUri(theme.docsLogo)}" />` : ""
         params["name"] = params["title"] + " - " + params["targetname"]
+        if (githubUrl) {
+            params["github"] = `<p style="margin-top:1em"><a href="${githubUrl}"><i class="write icon"></i>${lf("Edit this page on GitHub")}</a></p>`;
+        }
+        else {
+            params["github"] = "";
+        }
 
         let style = '';
         if (theme.accentColor) style += `
@@ -341,7 +350,7 @@ namespace pxt.docs {
 `
         params["targetstyle"] = style;
 
-        return injectHtml(template, params, ["body", "menu", "breadcrumb", "targetlogo"])
+        return injectHtml(template, params, ["body", "menu", "breadcrumb", "targetlogo", "github"])
     }
 
     function injectHtml(template: string, vars: U.Map<string>, quoted: string[] = []) {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -26,6 +26,7 @@ namespace pxt {
         cardLogo?: string;
         appLogo?: string;
         htmlDocIncludes?: pxtc.Util.Map<string>;
+        githubUrl?: string;
     }
 
     export interface DocMenuEntry {
@@ -114,10 +115,8 @@ namespace pxt.docs {
         return require("marked");
     }
 
-    export function renderMarkdown(template: string, src: string, theme: AppTheme = {}, pubinfo: U.Map<string> = null, breadcrumb: BreadcrumbEntry[] = [], githubUrl: string = null): string {
+    export function renderMarkdown(template: string, src: string, theme: AppTheme = {}, pubinfo: U.Map<string> = null, breadcrumb: BreadcrumbEntry[] = [], filepath: string = null): string {
         let params: U.Map<string> = pubinfo || {}
-
-        console.log(params);
 
         let boxes = U.clone(stdboxes)
         let macros = U.clone(stdmacros)
@@ -336,7 +335,10 @@ namespace pxt.docs {
         params["targetname"] = theme.name || "PXT"
         params["targetlogo"] = theme.docsLogo ? `<img class="ui mini image" src="${U.toDataUri(theme.docsLogo)}" />` : ""
         params["name"] = params["title"] + " - " + params["targetname"]
-        if (githubUrl) {
+        if (filepath && theme.githubUrl) {
+            //I would have used NodeJS path library, but this code may have to work in browser
+            let leadingTrailingSlash = /^\/|\/$/;
+            let githubUrl = `${theme.githubUrl.replace(leadingTrailingSlash, '')}/blob/master/docs/${filepath.replace(leadingTrailingSlash, '')}`;
             params["github"] = `<p style="margin-top:1em"><a href="${githubUrl}"><i class="write icon"></i>${lf("Edit this page on GitHub")}</a></p>`;
         }
         else {


### PR DESCRIPTION
Resolves https://github.com/Microsoft/pxt/issues/143

For any documentation page this adds a link to the corresponding Markdown on GitHub - it is necessary to set the URL to the GitHub repository in `pxtarget.json` ([I have already done this for pxt-microbit](https://github.com/Microsoft/pxt-microbit/commit/6deb0683b6bd4122ff6cf9057c1f056501cfe517)).