### PR TITLE
Download instructions

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -111,6 +111,7 @@ declare namespace pxt {
         htmlTemplates?: Map<string>;
         githubUrl?: string;
         usbHelp?: UsbHelpImage[];
+        usbDocs?: string
     }
 
     interface DocMenuEntry {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -103,6 +103,8 @@ declare namespace pxt {
         htmlDocIncludes?: Map<string>;
         htmlTemplates?: Map<string>;
         githubUrl?: string;
+        usbPC?: string;
+        usbMac?: string
     }
 
     interface DocMenuEntry {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -77,6 +77,13 @@ declare namespace pxt {
         serviceId: string;
     }
 
+    interface UsbHelpImage {
+        name: string,
+        browser: string,
+        os: string,
+        path: string
+    }
+
     interface AppTheme {
         id?: string;
         name?: string;
@@ -103,8 +110,7 @@ declare namespace pxt {
         htmlDocIncludes?: Map<string>;
         htmlTemplates?: Map<string>;
         githubUrl?: string;
-        usbPC?: string;
-        usbMac?: string
+        usbHelp?: UsbHelpImage[];
     }
 
     interface DocMenuEntry {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -15,6 +15,18 @@ namespace pxt.BrowserUtils {
         return !!navigator && /Linux/i.test(navigator.platform);
     }
 
+    /*
+    Notes on browser detection
+
+    Actually:   Claims to be:
+                IE  Edge    Chrome  Safari  Firefox
+    IE          X                   X?
+    Edge            X       X       X
+    Chrome                  X       X
+    Safari                          X       X
+    Firefox                                 X
+    */
+
     //Edge lies about its user agent and claims to be Chrome, but Edge/Version
     //is always at the end
     export function isEdge(): boolean {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -4,9 +4,15 @@ namespace pxt.BrowserUtils {
         return !!navigator && /Win32/i.test(navigator.platform);
     }
 
-    //MacIntel on most modern Macs
+    //MacIntel on modern Macs
     export function isMac(): boolean {
         return !!navigator && /Mac/i.test(navigator.platform);
+    }
+
+    //This is generally appears for Linux
+    //Android *sometimes* returns this
+    export function isLinux(): boolean {
+        return !!navigator && /Linux/i.test(navigator.platform);
     }
 
     //Edge lies about its user agent and claims to be Chrome, but Edge/Version
@@ -27,10 +33,10 @@ namespace pxt.BrowserUtils {
         return !isEdge() && !isIE() && !!navigator && (/Chrome/i.test(navigator.userAgent) || /Chromium/i.test(navigator.userAgent));
     }
 
-    //Chrome lies about being Safari
+    //Chrome and Edge lie about being Safari
     export function isSafari(): boolean {
         //Could also check isMac but I don't want to risk excluding iOS
-        return !isChrome() && !!navigator && /Safari/i.test(navigator.userAgent);
+        return !isChrome() && !isEdge() && !!navigator && /Safari/i.test(navigator.userAgent);
     }
 
     //Safari and WebKit lie about being Firefox
@@ -43,6 +49,7 @@ namespace pxt.BrowserUtils {
         let browser = '';
         if (isWindows()) platform += "Windows ";
         if (isMac()) platform += "Mac ";
+        if (isLinux()) platform += "Linux ";
         if (isEdge()) browser += "Edge ";
         if (isIE()) browser += "IE ";
         if (isChrome()) browser += "Chrome ";

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -24,7 +24,7 @@ namespace pxt.BrowserUtils {
 
     //Edge and IE11 lie about being Chrome
     export function isChrome(): boolean {
-        return !isEdge() && !isIE() && !!navigator && /Chrome/i.test(navigator.userAgent);
+        return !isEdge() && !isIE() && !!navigator && (/Chrome/i.test(navigator.userAgent) || /Chromium/i.test(navigator.userAgent));
     }
 
     //Chrome lies about being Safari
@@ -35,7 +35,7 @@ namespace pxt.BrowserUtils {
 
     //Safari and WebKit lie about being Firefox
     export function isFirefox(): boolean {
-        return !isSafari && !navigator && /Firefox/i.test(navigator.userAgent);
+        return !isSafari && !navigator && (/Firefox/i.test(navigator.userAgent) || /Seamonkey/i.test(navigator.userAgent));
     }
 
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -35,7 +35,20 @@ namespace pxt.BrowserUtils {
 
     //Safari and WebKit lie about being Firefox
     export function isFirefox(): boolean {
-        return !isSafari && !navigator && (/Firefox/i.test(navigator.userAgent) || /Seamonkey/i.test(navigator.userAgent));
+        return !isSafari() && !!navigator && (/Firefox/i.test(navigator.userAgent) || /Seamonkey/i.test(navigator.userAgent));
+    }
+
+    export function browserTest(): string {
+        let platform = '';
+        let browser = '';
+        if (isWindows()) platform += "Windows ";
+        if (isMac()) platform += "Mac ";
+        if (isEdge()) browser += "Edge ";
+        if (isIE()) browser += "IE ";
+        if (isChrome()) browser += "Chrome ";
+        if (isSafari()) browser += "Safari ";
+        if (isFirefox()) browser += "Firefox ";
+        return `Platform = ${platform.trim()}, browser = ${browser.trim()}`;
     }
 
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -4,6 +4,40 @@ namespace pxt.BrowserUtils {
         return !!navigator && /Win32/i.test(navigator.platform);
     }
 
+    //MacIntel on most modern Macs
+    export function isMac(): boolean {
+        return !!navigator && /Mac/i.test(navigator.platform);
+    }
+
+    //Edge lies about its user agent and claims to be Chrome, but Edge/Version
+    //is always at the end
+    export function isEdge(): boolean {
+        return !!navigator && /Edge/i.test(navigator.userAgent);
+    }
+
+    //IE11 also lies about its user agent, but has Trident appear somewhere in
+    //the user agent. Detecting the different between IE11 and Edge isn't
+    //super-important because the UI is similar enough
+    export function isIE(): boolean {
+        return !!navigator && /Trident/i.test(navigator.userAgent);
+    }
+
+    //Edge and IE11 lie about being Chrome
+    export function isChrome(): boolean {
+        return !isEdge() && !isIE() && !!navigator && /Chrome/i.test(navigator.userAgent);
+    }
+
+    //Chrome lies about being Safari
+    export function isSafari(): boolean {
+        //Could also check isMac but I don't want to risk excluding iOS
+        return !isChrome() && !!navigator && /Safari/i.test(navigator.userAgent);
+    }
+
+    //Safari and WebKit lie about being Firefox
+    export function isFirefox(): boolean {
+        return !isSafari && !navigator && /Firefox/i.test(navigator.userAgent);
+    }
+
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {
         pxt.debug('trigger download')
         let buf = Util.stringToUint8Array(Util.toUTF8(text))

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -56,18 +56,20 @@ namespace pxt.BrowserUtils {
         return !isSafari() && !!navigator && (/Firefox/i.test(navigator.userAgent) || /Seamonkey/i.test(navigator.userAgent));
     }
 
-    export function browserTest(): string {
-        let platform = '';
-        let browser = '';
-        if (isWindows()) platform += "Windows ";
-        if (isMac()) platform += "Mac ";
-        if (isLinux()) platform += "Linux ";
-        if (isEdge()) browser += "Edge ";
-        if (isIE()) browser += "IE ";
-        if (isChrome()) browser += "Chrome ";
-        if (isSafari()) browser += "Safari ";
-        if (isFirefox()) browser += "Firefox ";
-        return `Platform = ${platform.trim()}, browser = ${browser.trim()}`;
+    export function os(): string {
+        if (isWindows()) return "windows";
+        else if (isMac()) return "mac";
+        else if (isLinux()) return "linux";
+        else return "unknown";
+    }
+
+    export function browser(): string {
+        if (isEdge()) return "edge";
+        else if (isIE()) return "ie";
+        else if (isChrome()) return "chrome";
+        else if (isSafari()) return "safari";
+        else if (isFirefox()) return "firefox";
+        else return "unknown";
     }
 
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -749,3 +749,10 @@ html {
 .highlight-statement {
     background-color: #FFB900;
 }
+
+.accordion .content img {
+    max-width: 450px;
+    max-height: 250px;
+    margin: auto;
+    display: block;
+}

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -36,8 +36,7 @@ function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promise<void>
         return showUploadInstructionsAsync(fn, url);
 }
 
-enum MatchLevel
-{
+enum MatchLevel {
     None,
     Any,
     Exact
@@ -60,8 +59,8 @@ function namedUsbImage(name: string): string {
     if (!pxt.appTarget.appTheme.usbHelp) return null;
     let osMatch = (img: pxt.UsbHelpImage) => matchLevelForStrings(img.os, pxt.BrowserUtils.os());
     let browserMatch = (img: pxt.UsbHelpImage) => matchLevelForStrings(img.browser, pxt.BrowserUtils.browser());
-    let matches = pxt.appTarget.appTheme.usbHelp.filter((img) => img.name == name && 
-                                                                     osMatch(img) != MatchLevel.None && 
+    let matches = pxt.appTarget.appTheme.usbHelp.filter((img) => img.name == name &&
+                                                                     osMatch(img) != MatchLevel.None &&
                                                                      browserMatch(img) != MatchLevel.None);
     if (matches.length == 0) return null;
     let bestMatch = 0;
@@ -90,23 +89,22 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     let boardDriveName = pxt.appTarget.compile.driveName || "???";
 
     let instructions: UploadInstructionStep[] = [
-        { 
+        {
             title: lf("Connect your {0} to your computer using the USB cable.", boardName),
             image: "connection"
         },
-        { 
+        {
             title: lf("Save the <code>.hex</code> file to your computer."),
             body: `<a href="${encodeURI(url)}" target="_blank">${lf("Click here if the download hasn't started")}</a>`,
             image: "save"
         },
         {
             title: lf("Copy the <code>.hex</code> file to your {0} drive", boardDriveName),
-            body: pxt.BrowserUtils.isMac() ? lf("Drag and drop the <code>.hex</code> file to your {0} drive in Finder", boardDriveName) : 
+            body: pxt.BrowserUtils.isMac() ? lf("Drag and drop the <code>.hex</code> file to your {0} drive in Finder", boardDriveName) :
                   pxt.BrowserUtils.isWindows() ? lf("Right click on the file in Windows Explorer, click 'Send To', and select {0}", boardDriveName) : "",
             image: "copy"
         }
     ];
-         
 
     let usbImagePath = namedUsbImage("connection");
     return core.confirmAsync({

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -134,7 +134,7 @@ ${pxt.BrowserUtils.isWindows() ? `
 <script type="text/javascript">$(".ui.accordion").accordion();</script>`, //This extra call needs to get fired otherwise the accordion isn't interactive
         hideCancel: true,
         agreeLbl: lf("Done!"),
-        timeout: 5000
+        timeout: 0 //We don't want this to timeout now that it is interactive
     }).then(() => { });
 }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -39,6 +39,7 @@ function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promise<void>
 function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     let boardName = pxt.appTarget.appTheme.boardName || "???";
     let boardDriveName = pxt.appTarget.compile.driveName || "???";
+    let usbImagePath = pxt.BrowserUtils.isMac() && !!pxt.appTarget.appTheme.usbMac ? pxt.appTarget.appTheme.usbMac : !!pxt.appTarget.appTheme.usbPC ? pxt.appTarget.appTheme.usbPC : null;
     return core.confirmAsync({
         header: lf("Download your code to the {0}...", boardName),
         htmlBody: `        
@@ -48,7 +49,9 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     ${lf("Connect your {0} to your computer using the USB cable.", boardName)}
   </div>
   <div class="content active">
-    <p class="transition visible" style="display: block !important">TODO: Image + explanation</p>
+    <div class="transition visible style="display:block !important;">
+    ${usbImagePath ? `<img src="${usbImagePath}" alt="${lf("Connect your {0} to your computer using the USB cable.", boardName)}" style="max-height:250px;max-width:450px;margin:auto;display:block"/>`: ''}
+    </div>
   </div>
   <div class="title">
     <i class="dropdown icon"></i>

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -100,7 +100,9 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
             image: "save"
         },
         {
-            title: lf("Copy the <code>.hex</code> file to your {0} drive", boardName),
+            title: lf("Copy the <code>.hex</code> file to your {0} drive", boardDriveName),
+            body: pxt.BrowserUtils.isMac() ? lf("Drag and drop the <code>.hex</code> file to your {0} drive in Finder", boardDriveName) : 
+                  pxt.BrowserUtils.isWindows() ? lf("Right click on the file in Windows Explorer, click 'Send To', and select {0}", boardDriveName) : "",
             image: "copy"
         }
     ];

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -83,7 +83,6 @@ interface UploadInstructionStep {
     title: string,
     body?: string,
     image?: string,
-    altText?: string
 }
 
 function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
@@ -93,15 +92,16 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     let instructions: UploadInstructionStep[] = [
         { 
             title: lf("Connect your {0} to your computer using the USB cable.", boardName),
-            image: "connection",
-            altText: lf("Connect your {0} to your computer using the USB cable.", boardName)
+            image: "connection"
         },
         { 
             title: lf("Save the <code>.hex</code> file to your computer."),
             body: `<a href="${encodeURI(url)}" target="_blank">${lf("Click here if the download hasn't started")}</a>`,
+            image: "save"
         },
         {
-            title: lf("Copy the <code>.hex</code> file to your {0} drive", boardName)
+            title: lf("Copy the <code>.hex</code> file to your {0} drive", boardName),
+            image: "copy"
         }
     ];
          
@@ -111,21 +111,19 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
         header: lf("Download your code to the {0}...", boardName),
         htmlBody: `        
 <div class="ui styled fluid accordion">
-${instructions.map((step: UploadInstructionStep, i: number) => 
-`<div class="title ${i == 0 ? "active" : ""}">
+${instructions.map((step: UploadInstructionStep) => 
+`<div class="title">
   <i class="dropdown icon"></i>
   ${step.title}
 </div>
-<div class="content ${i == 0 ? "active" : ""}">
-  <div class="content ${i == 0? "active" : "hidden"}" ${i == 0 ? "style='display: block !important'" : ""}>
+<div class="content">
     ${step.body ? step.body : ""}
-    ${step.image && namedUsbImage(step.image) ? `<img src="${namedUsbImage(step.image)}"  ${step.altText ? `alt="${step.altText}"` : ""}  />` : ""}
-  </div>
+    ${step.image && namedUsbImage(step.image) ? `<img src="${namedUsbImage(step.image)}"  alt="${step.title}"  />` : ""}
 </div>`).join('')}
 </div>
 ${pxt.appTarget.appTheme.usbDocs ? `
     <div class="ui info message">
-        <p><a href="${pxt.appTarget.appTheme.usbDocs}" target="_blank">${lf("For more details click here")}</a></p>
+        <p><a href="${pxt.appTarget.appTheme.usbDocs}" target="_blank">${lf("For more information on how to transfer the program to your {0} click here", boardName)}</a></p>
     </div>` : ""}
 ${pxt.BrowserUtils.isWindows() ? `
     <div class="ui info message landscape only">

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -42,26 +42,33 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     return core.confirmAsync({
         header: lf("Download your code to the {0}...", boardName),
         htmlBody: `        
-<div class="ui fluid vertical steps">
-  <div class="step">
-    <div class="content">
-      <div class="description">${lf("Connect your {0} to your computer using the USB cable.", boardName)}</div>
-    </div>
+<div class="ui styled fluid accordion">
+  <div class="title active">
+    <i class="dropdown icon"></i>
+    ${lf("Connect your {0} to your computer using the USB cable.", boardName)}
   </div>
-  <div class="step">
-    <div class="content">
-      <div class="description">${lf("Save the <code>.hex</code> file to your computer.")}</div>
-    </div>
+  <div class="content active">
+    <p class="transition visible" style="display: block !important">TODO: Image + explanation</p>
   </div>
-  <a href='${encodeURI(url)}' download='${Util.htmlEscape(fn)}' target='_blank' class="step">
-    <div class="content">
-      <div class="description">${lf("Move the saved <code>.hex</code> file to the <code>{0}</code> drive.", boardDriveName)}</div>
-    </div>
-  </a>
-  <div class="step">
-    <div class="content">
-      <div class="description">${lf("Wait till the yellow LED is done blinking.")}</div>
-    </div>
+  <div class="title">
+    <i class="dropdown icon"></i>
+    ${lf("Save the <code>.hex</code> file to your computer.")}
+  </div>
+  <div class="content">
+    <p><a href="${encodeURI(url)}" target="_blank">${lf("Click here if the download hasn't started")}</a></p>
+  </div>
+  <div class="title">
+    <i class="dropdown icon"></i>
+    ${lf("Move the saved <code>.hex</code> file to the <code>{0}</code> drive.", boardDriveName)}
+  </div>
+  <div class="content">
+  </div>
+  <div class="title">
+    <i class="dropdown icon"></i>
+    ${lf("Wait till the yellow LED is done blinking.")}
+  </div>
+  <div class="content">
+    <p>Does this need an explanation?</p>
   </div>
 </div>
 ${pxt.BrowserUtils.isWindows() ? `
@@ -70,7 +77,7 @@ ${pxt.BrowserUtils.isWindows() ? `
         <a href="/uploader" target="_blank">${lf("Install the Uploader!")}</a>
     </div>
     ` : ""}
-`,
+<script type="text/javascript">$(".ui.accordion").accordion();</script>`, //This extra call needs to get fired otherwise the accordion isn't interactive
         hideCancel: true,
         agreeLbl: lf("Done!"),
         timeout: 5000

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -94,14 +94,14 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
         { 
             title: lf("Connect your {0} to your computer using the USB cable.", boardName),
             image: "connection",
-            altText: lf("Connect your ${0} to your computer using the USB cable.", boardName)
+            altText: lf("Connect your {0} to your computer using the USB cable.", boardName)
         },
         { 
             title: lf("Save the <code>.hex</code> file to your computer."),
             body: `<a href="${encodeURI(url)}" target="_blank">${lf("Click here if the download hasn't started")}</a>`,
         },
         {
-            title: lf("Copy the <code>.hex</code> file to your ${0} drive", boardName)
+            title: lf("Copy the <code>.hex</code> file to your {0} drive", boardName)
         }
     ];
          
@@ -118,11 +118,15 @@ ${instructions.map((step: UploadInstructionStep, i: number) =>
 </div>
 <div class="content ${i == 0 ? "active" : ""}">
   <div class="content ${i == 0? "active" : "hidden"}" ${i == 0 ? "style='display: block !important'" : ""}>
-    ${!!step.body ? step.body : ""}
-    ${!!step.image && !!namedUsbImage(step.image) ? `<img src="${namedUsbImage(step.image)}"  ${!!step.altText ? `alt="${step.altText}"` : ""}  />` : ""}
+    ${step.body ? step.body : ""}
+    ${step.image && namedUsbImage(step.image) ? `<img src="${namedUsbImage(step.image)}"  ${step.altText ? `alt="${step.altText}"` : ""}  />` : ""}
   </div>
 </div>`).join('')}
 </div>
+${pxt.appTarget.appTheme.usbDocs ? `
+    <div class="ui info message">
+        <p><a href="${pxt.appTarget.appTheme.usbDocs}" target="_blank">${lf("For more details click here")}</a></p>
+    </div>` : ""}
 ${pxt.BrowserUtils.isWindows() ? `
     <div class="ui info message landscape only">
         ${lf("Tired of copying the .hex file?")}


### PR DESCRIPTION
This pull request resolves https://github.com/Microsoft/pxt/issues/238.

The instructions for downloading are now a little shorter, with an optional link to a help guide (the URL of which is specified in `pxtarget.json`). If you click on a step then you get more detailed instructions. For example, these instructions are show in Chrome on OS X:

![screen shot 2016-09-12 at 16 31 03](https://cloud.githubusercontent.com/assets/20356546/18441835/6b9ca234-7906-11e6-9927-6eb85612007e.png)
![screen shot 2016-09-12 at 16 31 06](https://cloud.githubusercontent.com/assets/20356546/18441837/6bb75cb4-7906-11e6-987b-061d23c7f93f.png)
![screen shot 2016-09-12 at 16 31 09](https://cloud.githubusercontent.com/assets/20356546/18441836/6bb40078-7906-11e6-80ac-83e93d20b59b.png)

The download dialog now shows until it is dismissed, to give people enough time to click on the instructions.

The URLs to the screenshots are also specified in `pxtarget.json`, and can be specialised per browser and OS. I have verified that the browser and OS detection works correctly in Edge, IE11, Chrome, and Firefox on Windows and Safari, Chrome, and Firefox on OS X. Each image should be specified as:

```js
{
    "name": "connection" //Currently one of connection, copy, or save
    "os": "windows" //A comma separated list of windows, mac, or linux, or * for any
    "browser": "*" //A comma separated list of chrome, firefox, safari, ie11, or edge, or * for any
    "path": "" //The URL for the image to use for this particular platform
}
```

The most specific image will be used for a platform, and then browser. So if there is an image defined for `mac/*` and an image for `*/chrome`, and the user is running `mac/chrome`, then the first image is picked. 

There is a separate pull request in the pxt-microbit repository that adds the appropriate URLs.