### PR TITLE
Detection of unsupported browsers

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -103,6 +103,7 @@ declare namespace pxt {
         privacyUrl?: string;
         termsOfUseUrl?: string;
         contactUrl?: string;
+        unsupportedBrowserUrl?: string;
         accentColor?: string;
         locales?: Map<AppTheme>;
         cardLogo?: string;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -77,10 +77,10 @@ declare namespace pxt {
         serviceId: string;
     }
 
-    interface UsbHelpImage {
+    interface SpecializedResource {
         name: string,
-        browser: string,
-        os: string,
+        browser?: string,
+        os?: string,
         path: string
     }
 
@@ -103,7 +103,6 @@ declare namespace pxt {
         privacyUrl?: string;
         termsOfUseUrl?: string;
         contactUrl?: string;
-        unsupportedBrowserUrl?: string;
         accentColor?: string;
         locales?: Map<AppTheme>;
         cardLogo?: string;
@@ -111,8 +110,9 @@ declare namespace pxt {
         htmlDocIncludes?: Map<string>;
         htmlTemplates?: Map<string>;
         githubUrl?: string;
-        usbHelp?: UsbHelpImage[];
+        usbHelp?: SpecializedResource[];
         usbDocs?: string
+        browserSupport?: SpecializedResource[];
     }
 
     interface DocMenuEntry {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -82,6 +82,7 @@ namespace pxt.BrowserUtils {
     export function os(): string {
         if (isWindows()) return "windows";
         else if (isMac()) return "mac";
+        else if (isLinux() && isARM()) return "rpi";
         else if (isLinux()) return "linux";
         else return "unknown";
     }
@@ -146,6 +147,61 @@ namespace pxt.BrowserUtils {
         const isNotSupported = isUnsupportedRPI;
 
         return isSupported && !isNotSupported;
+    }
+
+
+    export function bestResourceForOsAndBrowser(resources: pxt.SpecializedResource[], name: string): pxt.SpecializedResource {
+        if (resources === null || resources.length == 0) {
+            return null;
+        }
+
+        enum MatchLevel {
+            None,
+            Any,
+            Exact
+        };
+
+        function matchLevelForStrings(haystack: string, needle: string): MatchLevel {
+            if (!haystack || !needle) {
+                return MatchLevel.Any; //If either browser or OS isn't defined then we behave the same as *
+            }
+            if (haystack.indexOf(needle) !== -1) {
+                return MatchLevel.Exact;
+            }
+            else if (haystack.indexOf("*") !== -1) {
+                return MatchLevel.Any;
+            }
+            else {
+                return MatchLevel.None
+            }
+        }
+
+        let osMatch = (res: pxt.SpecializedResource) => matchLevelForStrings(res.os, os());
+        let browserMatch = (res: pxt.SpecializedResource) => matchLevelForStrings(res.browser, browser());
+        let matches = resources.filter((res) => res.name == name &&
+                                                osMatch(res) != MatchLevel.None &&
+                                                browserMatch(res) != MatchLevel.None);
+        if (matches.length == 0) {
+            return null;
+        }
+        let bestMatch = 0;
+
+        for (let i = 1; i < matches.length; i++) {
+            //First we want to match on OS, then on browser
+            if (osMatch(matches[i]) > osMatch(matches[bestMatch])) {
+                bestMatch = i;
+            }
+            else if (browserMatch(matches[i]) > browserMatch(matches[bestMatch])) {
+                bestMatch = i;
+            }
+        }
+
+        return matches[bestMatch];
+    }
+
+    export function suggestedBrowserPath(): string {
+        let match = bestResourceForOsAndBrowser(pxt.appTarget.appTheme.browserSupport, "unsupported");
+        return match ? match.path : null;
     }
 
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -30,6 +30,8 @@ namespace pxt.BrowserUtils {
     Chrome                  X       X
     Safari                          X       X
     Firefox                                 X
+
+    I allow Opera to go about claiming to be Chrome because it might as well be
     */
 
     //Edge lies about its user agent and claims to be Chrome, but Edge/Version
@@ -61,6 +63,11 @@ namespace pxt.BrowserUtils {
         return !isSafari() && !!navigator && (/Firefox/i.test(navigator.userAgent) || /Seamonkey/i.test(navigator.userAgent));
     }
 
+    //These days Opera's core is based on Chromium so we shouldn't distinguish between them too much
+    export function isOpera(): boolean {
+        return !!navigator && /Opera|OPR/i.test(navigator.userAgent);
+    }
+
     export function os(): string {
         if (isWindows()) return "windows";
         else if (isMac()) return "mac";
@@ -70,6 +77,7 @@ namespace pxt.BrowserUtils {
 
     export function browser(): string {
         if (isEdge()) return "edge";
+        else if (isOpera()) return "opera";
         else if (isIE()) return "ie";
         else if (isChrome()) return "chrome";
         else if (isSafari()) return "safari";

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -68,6 +68,17 @@ namespace pxt.BrowserUtils {
         return !!navigator && /Opera|OPR/i.test(navigator.userAgent);
     }
 
+    //Midori *was* the default browser on Raspbian, however isn't any more
+    export function isMidori(): boolean {
+        return !!navigator && /Midori/i.test(navigator.userAgent);
+    }
+
+    //Epiphany (code name for GNOME Web) is the default browser on Raspberry Pi
+    //Epiphany also lies about being Chrome, Safari, and Chromium
+    export function isEpiphany(): boolean {
+        return !!navigator && /Epiphany/i.test(navigator.userAgent);
+    }
+
     export function os(): string {
         if (isWindows()) return "windows";
         else if (isMac()) return "mac";
@@ -77,6 +88,8 @@ namespace pxt.BrowserUtils {
 
     export function browser(): string {
         if (isEdge()) return "edge";
+        if (isEpiphany()) return "epiphany";
+        else if (isMidori()) return "midori";
         else if (isOpera()) return "opera";
         else if (isIE()) return "ie";
         else if (isChrome()) return "chrome";
@@ -92,6 +105,12 @@ namespace pxt.BrowserUtils {
         if (isOpera()) {
             matches = /(Opera|OPR)\/([0-9\.]+)/i.exec(navigator.userAgent);
         }
+        if (isEpiphany()) {
+            matches = /Epiphany\/([0-9\.]+)/i.exec(navigator.userAgent);
+        }
+        else if (isMidori()) {
+            matches = /Midori\/([0-9\.]+)/i.exec(navigator.userAgent);
+        }
         else if (isSafari()) {
             matches = /Safari\/([0-9\.]+)/i.exec(navigator.userAgent);
         }
@@ -105,7 +124,7 @@ namespace pxt.BrowserUtils {
             matches = /(MSIE |rv:)([0-9\.]+)/i.exec(navigator.userAgent);
         }
         else {
-            matches = /(Chrome|Chromium|Firefox|Seamonkey|Opera|OPR)\/([0-9\.]+)/i.exec(navigator.userAgent);
+            matches = /(Firefox|Seamonkey)\/([0-9\.]+)/i.exec(navigator.userAgent);
         }
         if (matches.length == 0) {
             return null;
@@ -114,11 +133,19 @@ namespace pxt.BrowserUtils {
     }
 
     export function isBrowserSupported(): boolean {
+        if (!!navigator) {
+            return true; //All browsers define this, but we can't make any predictions if it isn't defined, so assume the best
+        }
         const v = browserVersion();
         const isModernUpdatedBrowser = isChrome() || isFirefox() || isEdge() || isSafari();
         const isLastVersionOfIE = isIE() && /^11./.test(v);
         const isOperaBasedOnChromium = isOpera() && isChrome();
-        return isModernUpdatedBrowser || isLastVersionOfIE || isOperaBasedOnChromium;
+        const isUnsupportedRPI = isMidori();
+
+        const isSupported = isModernUpdatedBrowser || isLastVersionOfIE || isOperaBasedOnChromium;
+        const isNotSupported = isUnsupportedRPI;
+
+        return isSupported && !isNotSupported;
     }
 
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -141,7 +141,7 @@ namespace pxt.BrowserUtils {
         const isModernUpdatedBrowser = isChrome() || isFirefox() || isEdge() || isSafari();
         const isLastVersionOfIE = isIE() && /^11./.test(v);
         const isOperaBasedOnChromium = isOpera() && isChrome();
-        const isUnsupportedRPI = isMidori();
+        const isUnsupportedRPI = isMidori() || (isLinux() && isARM() && isEpiphany());
 
         const isSupported = isModernUpdatedBrowser || isLastVersionOfIE || isOperaBasedOnChromium;
         const isNotSupported = isUnsupportedRPI;

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -114,7 +114,11 @@ namespace pxt.BrowserUtils {
     }
 
     export function isBrowserSupported(): boolean {
-        return false;
+        const v = browserVersion();
+        const isModernUpdatedBrowser = isChrome() || isFirefox() || isEdge() || isSafari();
+        const isLastVersionOfIE = isIE() && /^11./.test(v);
+        const isOperaBasedOnChromium = isOpera() && isChrome();
+        return isModernUpdatedBrowser || isLastVersionOfIE || isOperaBasedOnChromium;
     }
 
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -85,6 +85,34 @@ namespace pxt.BrowserUtils {
         else return "unknown";
     }
 
+    export function browserVersion(): string {
+        if (!navigator) return null;
+        //Unsurprisingly browsers also lie about this and include other browser versions...
+        let matches: string[] = [];
+        if (isOpera()) {
+            matches = /(Opera|OPR)\/([0-9\.]+)/i.exec(navigator.userAgent);
+        }
+        else if (isSafari()) {
+            matches = /Safari\/([0-9\.]+)/i.exec(navigator.userAgent);
+        }
+        else if (isChrome()) {
+            matches = /(Chrome|Chromium)\/([0-9\.]+)/i.exec(navigator.userAgent);
+        }
+        else if (isEdge()) {
+            matches = /Edge\/([0-9\.]+)/i.exec(navigator.userAgent);
+        }
+        else if (isIE()) {
+            matches = /(MSIE |rv:)([0-9\.]+)/i.exec(navigator.userAgent);
+        }
+        else {
+            matches = /(Chrome|Chromium|Firefox|Seamonkey|Opera|OPR)\/([0-9\.]+)/i.exec(navigator.userAgent);
+        }
+        if (matches.length == 0) {
+            return null;
+        }
+        return matches[matches.length - 1];
+    }
+
     export function isBrowserSupported(): boolean {
         return false;
     }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1,7 +1,7 @@
 
 namespace pxt.BrowserUtils {
     export function isWindows(): boolean {
-        return !!navigator && /Win32/i.test(navigator.platform);
+        return !!navigator && /(Win32|Win64|WOW64)/i.test(navigator.platform);
     }
 
     //MacIntel on modern Macs

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -77,6 +77,10 @@ namespace pxt.BrowserUtils {
         else return "unknown";
     }
 
+    export function isBrowserSupported(): boolean {
+        return false;
+    }
+
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {
         pxt.debug('trigger download')
         let buf = Util.stringToUint8Array(Util.toUTF8(text))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1656,7 +1656,7 @@ $(document).ready(() => {
         .then(pkg.setupAppTarget)
         .then(() => {
             if (!pxt.BrowserUtils.isBrowserSupported() && !!pxt.appTarget.appTheme.unsupportedBrowserUrl) {
-                window.location.href = pxt.appTarget.appTheme.unsupportedBrowserUrl + `?browser=${pxt.BrowserUtils.browser()}&os=${pxt.BrowserUtils.os()}`;
+                window.location.href = pxt.appTarget.appTheme.unsupportedBrowserUrl + `?browser=${pxt.BrowserUtils.browser()}&os=${pxt.BrowserUtils.os()}&version=${pxt.BrowserUtils.browserVersion()}`;
             }
         })
         .then(() => Util.updateLocalizationAsync(cfg.pxtCdnUrl, lang ? lang[1] : (navigator.userLanguage || navigator.language)))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1654,6 +1654,11 @@ $(document).ready(() => {
     const cfg = pxt.webConfig;
     Util.httpGetJsonAsync(config.targetCdnUrl + "target.json")
         .then(pkg.setupAppTarget)
+        .then(() => {
+            if (!pxt.BrowserUtils.isBrowserSupported() && !!pxt.appTarget.appTheme.unsupportedBrowserUrl) {
+                window.location.href = pxt.appTarget.appTheme.unsupportedBrowserUrl + `?browser=${pxt.BrowserUtils.browser()}&os=${pxt.BrowserUtils.os()}`;
+            }
+        })
         .then(() => Util.updateLocalizationAsync(cfg.pxtCdnUrl, lang ? lang[1] : (navigator.userLanguage || navigator.language)))
         .then(() => initTheme())
         .then(() => cmds.initCommandsAsync())

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1655,8 +1655,11 @@ $(document).ready(() => {
     Util.httpGetJsonAsync(config.targetCdnUrl + "target.json")
         .then(pkg.setupAppTarget)
         .then(() => {
-            if (!pxt.BrowserUtils.isBrowserSupported() && !!pxt.appTarget.appTheme.unsupportedBrowserUrl) {
-                window.location.href = pxt.appTarget.appTheme.unsupportedBrowserUrl + `?browser=${pxt.BrowserUtils.browser()}&os=${pxt.BrowserUtils.os()}&version=${pxt.BrowserUtils.browserVersion()}`;
+            if (!pxt.BrowserUtils.isBrowserSupported()) {
+                let redirect = pxt.BrowserUtils.suggestedBrowserPath();
+                if (redirect) {
+                    window.location.href = redirect;
+                }
             }
         })
         .then(() => Util.updateLocalizationAsync(cfg.pxtCdnUrl, lang ? lang[1] : (navigator.userLanguage || navigator.language)))

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -36,46 +36,10 @@ function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promise<void>
         return showUploadInstructionsAsync(fn, url);
 }
 
-enum MatchLevel {
-    None,
-    Any,
-    Exact
-};
-
-function matchLevelForStrings(haystack: string, needle: string): MatchLevel {
-    if (haystack.indexOf(needle) !== -1) {
-        return MatchLevel.Exact;
-    }
-    else if (haystack.indexOf("*") !== -1) {
-        return MatchLevel.Any;
-    }
-    else {
-        return MatchLevel.None
-    }
-}
-
 //Searches the known USB image, matching on platform and browser
 function namedUsbImage(name: string): string {
-    if (!pxt.appTarget.appTheme.usbHelp) return null;
-    let osMatch = (img: pxt.UsbHelpImage) => matchLevelForStrings(img.os, pxt.BrowserUtils.os());
-    let browserMatch = (img: pxt.UsbHelpImage) => matchLevelForStrings(img.browser, pxt.BrowserUtils.browser());
-    let matches = pxt.appTarget.appTheme.usbHelp.filter((img) => img.name == name &&
-                                                                     osMatch(img) != MatchLevel.None &&
-                                                                     browserMatch(img) != MatchLevel.None);
-    if (matches.length == 0) return null;
-    let bestMatch = 0;
-
-    for (let i = 1; i < matches.length; i++) {
-        //First we want to match on OS, then on browser
-        if (osMatch(matches[i]) > osMatch(matches[bestMatch])) {
-            bestMatch = i;
-        }
-        else if (browserMatch(matches[i]) > browserMatch(matches[bestMatch])) {
-            bestMatch = i;
-        }
-    }
-
-    return matches[bestMatch].path;
+    let match = pxt.BrowserUtils.bestResourceForOsAndBrowser(pxt.appTarget.appTheme.usbHelp, name);
+    return match ? match.path : null;
 }
 
 interface UploadInstructionStep {


### PR DESCRIPTION
This pull request improves the browser detection code, adds a function [`isBrowserSupported`](https://github.com/Microsoft/pxt/blob/browser-redirect/pxtlib/browserutils.ts#L136) for determining which browsers we allow, and adds rules to `pxtarget.json` for a redirection policy depending on which unsupported OS or browser is being used (it uses the system introduced in https://github.com/Microsoft/pxt/pull/330).

Currently I'm enforcing the following policy:

* If a browser is *actually* one of Edge, Safari, Chrome, or Firefox I allow it. These browsers are all frequently updated, and I have not run into any major issues using any of them with PXT. I also allow Opera, if it is one of the more recent versions that is essentially a skinned Chromium
* Older versions of Opera are not allowed
* IE11 is allowed (the last version of IE, which runs on Windows 7 and 8). Other versions of IE are not allowed. Due to the common-place use of IE in schools, it may be necessary to allow earlier versions (although nothing earlier than 9)
* Midori, which used to be the default browser on Raspbian, is banned on all OSes. When I tested it on other OSes I found PXT crashed the browser whilst the loading animation was still playing
* Epiphany (GNOME Web) running on Raspberry Pi is not supported
* Mobile browsers (iOS Safari, Android Chrome) are allowed by this policy, although I've not tested them

Resolves https://github.com/Microsoft/pxt/issues/331