### PR TITLE
Electron support

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3091,7 +3091,7 @@ function errorHandler(reason: any) {
     process.exit(20)
 }
 
-export function mainCli(targetDir: string) {
+export function mainCli(targetDir: string, args: string[] = process.argv.slice(2)) {
     process.on("unhandledRejection", errorHandler);
     process.on('uncaughtException', errorHandler);
 
@@ -3109,8 +3109,6 @@ export function mainCli(targetDir: string) {
     process.stderr.write(`Using PXT/${trg.id} from ${targetDir}.\n`)
 
     commonfiles = readJson(__dirname + "/pxt-common.json")
-
-    let args = process.argv.slice(2)
 
     initConfig();
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1365,7 +1365,7 @@ export function serveAsync(arg?: string) {
     let localToken = globalConfig.localToken;
     if (!fs.existsSync("pxtarget.json")) {
         //Specifically when the target is being used as a library
-        let targetDepLoc = path.join(process.cwd(), nodeutil.targetDir);
+        let targetDepLoc = nodeutil.targetDir
         if (fs.existsSync(path.join(targetDepLoc, "pxtarget.json"))) {
             console.log(`Going to ${targetDepLoc}`)
             process.chdir(targetDepLoc)

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1364,12 +1364,20 @@ export function serveAsync(arg?: string) {
     }
     let localToken = globalConfig.localToken;
     if (!fs.existsSync("pxtarget.json")) {
-        let upper = path.join(__dirname, "../../..")
-        if (fs.existsSync(path.join(upper, "pxtarget.json"))) {
-            console.log("going to " + upper)
-            process.chdir(upper)
-        } else {
-            U.userError("Cannot find pxtarget.json to serve.")
+        //Specifically when the target is being used as a library
+        let targetDepLoc = path.join(process.cwd(), nodeutil.targetDir);
+        if (fs.existsSync(path.join(targetDepLoc, "pxtarget.json"))) {
+            console.log(`Going to ${targetDepLoc}`)
+            process.chdir(targetDepLoc)
+        }
+        else {
+            let upper = path.join(__dirname, "../../..")
+            if (fs.existsSync(path.join(upper, "pxtarget.json"))) {
+                console.log("going to " + upper)
+                process.chdir(upper)
+            } else {
+                U.userError("Cannot find pxtarget.json to serve.")
+            }
         }
     }
     return (justServe ? Promise.resolve() : buildAndWatchTargetAsync())

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -22,10 +22,10 @@ import * as uploader from './uploader';
 let forceCloudBuild = process.env["KS_FORCE_CLOUD"] === "yes"
 
 function initTargetCommands() {
-    let cmdsjs = nodeutil.targetDir + '/built/cmds.js';
+    let cmdsjs = path.join(process.cwd(), nodeutil.targetDir, 'built/cmds.js');
     if (fs.existsSync(cmdsjs)) {
         pxt.debug(`loading cli extensions...`)
-        let cli = require(cmdsjs)
+        let cli = require.main.require(cmdsjs)
         if (cli.deployCoreAsync) {
             pxt.commands.deployCoreAsync = cli.deployCoreAsync
         }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1354,6 +1354,9 @@ export function serveAsync(arg?: string) {
     } else if (arg == "-pkg") {
         justServe = true
         packaged = true
+    } else if (arg == "-no-browser") {
+        justServe = true
+        globalConfig.noAutoStart = true
     }
     if (!globalConfig.localToken) {
         globalConfig.localToken = U.guidGen();

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -70,7 +70,7 @@ function fatal(msg: string): Promise<any> {
     throw new Error(msg)
 }
 
-let globalConfig: UserConfig = {}
+export let globalConfig: UserConfig = {}
 
 function homePxtDir() {
     return path.join(process.env["HOME"] || process.env["UserProfile"], ".pxt")

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -11,7 +11,11 @@ Promise = require("bluebird");
 
 import Util = pxt.Util;
 
+//This should be correct at startup when running from command line
+//When running inside Electron it gets updated to the correct path
 export var targetDir: string = process.cwd();
+//When running the Electron app, this will be based on the initial value
+export var pxtCoreDir: string = path.join(targetDir, "node_modules/pxt-core")
 
 export function readResAsync(g: events.EventEmitter) {
     return new Promise<Buffer>((resolve, reject) => {

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -502,7 +502,7 @@ export function serveAsync(options: ServeOptions) {
     nodeutil.mkdirP(tempDir)
 
     initTargetCommands()
-    //initSerialMonitor();
+    initSerialMonitor();
 
     let server = http.createServer((req, res) => {
         let error = (code: number, msg: string = null) => {

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -41,14 +41,15 @@ function forkDirs(lst: string[]) {
 }
 
 function setupDocfilesdirs() {
-    docfilesdirs = forkDirs(["docfiles", "node_modules/pxt-core/docfiles"])
+    docfilesdirs = [path.join(nodeutil.pxtCoreDir, "docfiles"), path.join(nodeutil.pxtCoreDir, "docfiles")]
 }
 
 function setupRootDir() {
-    root = process.cwd()
+    root = nodeutil.targetDir
     console.log("Starting server in", root)
-    dirs = forkDirs(["node_modules/pxt-core/built/web", "node_modules/pxt-core/webapp/public"])
-    simdirs = forkDirs(["built", "sim/public"])
+    console.log(`With pxt core at ${nodeutil.pxtCoreDir}`)
+    dirs = [path.join(nodeutil.pxtCoreDir, "built/web"), path.join(nodeutil.pxtCoreDir, "webapp/public")]
+    simdirs = [path.join(nodeutil.targetDir, "built"), path.join(nodeutil.targetDir, "sim/public")]
     docsDir = path.join(root, "docs")
     tempDir = path.join(root, "built/docstmp")
     packagedDir = path.join(root, "built/packaged")
@@ -581,20 +582,20 @@ export function serveAsync(options: ServeOptions) {
             return
         }
 
-        let publicDir = forkPref() + 'node_modules/pxt-core/webapp/public/'
+        let publicDir = path.join(nodeutil.pxtCoreDir, "webapp/public")
 
         if (pathname == "/--embed") {
-            sendFile(path.join(root, publicDir + 'embed.js'));
+            sendFile(path.join(publicDir, 'embed.js'));
             return
         }
 
         if (pathname == "/--run") {
-            sendFile(path.join(root, publicDir + 'run.html'));
+            sendFile(path.join(publicDir, 'run.html'));
             return
         }
 
         if (pathname == "/--docs") {
-            sendFile(path.join(root, publicDir + 'docs.html'));
+            sendFile(path.join(publicDir,  'docs.html'));
             return
         }
 

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -501,7 +501,7 @@ export function serveAsync(options: ServeOptions) {
     nodeutil.mkdirP(tempDir)
 
     initTargetCommands()
-    initSerialMonitor();
+    //initSerialMonitor();
 
     let server = http.createServer((req, res) => {
         let error = (code: number, msg: string = null) => {


### PR DESCRIPTION
These changes allow a PXT target to be used as a dependency in another project, such as an Electron app. Normally the directory structure is:

```
pxt-microbit
| node_modules
  | pxt-core
```

This pull request supports structures such as:

```
- electron_app
| node_modules
  | pxt-core
  | pxt-microbit
```

It also adds an (undocumented) flag `-no-browser` on `pxt serve` that ensures a browser window is not opened and PXT is not rebuilt.