### PR TITLE
Fixes to browser detection

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -136,7 +136,7 @@ namespace pxt.BrowserUtils {
     let hasLoggedBrowser = false
 
     export function isBrowserSupported(): boolean {
-        if (!!navigator) {
+        if (!navigator) {
             return true; //All browsers define this, but we can't make any predictions if it isn't defined, so assume the best
         }
         const versionString = browserVersion();

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -113,7 +113,7 @@ namespace pxt.BrowserUtils {
             matches = /Midori\/([0-9\.]+)/i.exec(navigator.userAgent);
         }
         else if (isSafari()) {
-            matches = /Safari\/([0-9\.]+)/i.exec(navigator.userAgent);
+            matches = /Version\/([0-9\.]+)/i.exec(navigator.userAgent);
         }
         else if (isChrome()) {
             matches = /(Chrome|Chromium)\/([0-9\.]+)/i.exec(navigator.userAgent);

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -135,6 +135,18 @@ namespace pxt.BrowserUtils {
 
     let hasLoggedBrowser = false
 
+    export function isLocalStorageSupported(): boolean {
+        let testKey = "-pxt-local-storage-test-", storage = window.sessionStorage
+        try {
+            storage.setItem(testKey, testKey)
+            storage.removeItem(testKey)
+            return "localStorage" in window && typeof localStorage === "object"
+        }
+        catch (e) {
+            return false
+        }
+    }
+
     export function isBrowserSupported(): boolean {
         if (!navigator) {
             return true; //All browsers define this, but we can't make any predictions if it isn't defined, so assume the best
@@ -152,7 +164,7 @@ namespace pxt.BrowserUtils {
 
         //In the future this should check for the availability of features, such
         //as web workers
-        let isSupported = isModernBrowser
+        let isSupported = isModernBrowser && isLocalStorageSupported()
 
         const isUnsupportedRPI = isMidori() || (isLinux() && isARM() && isEpiphany());
         const isNotSupported = isUnsupportedRPI;

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -164,7 +164,7 @@ namespace pxt.BrowserUtils {
 
         //In the future this should check for the availability of features, such
         //as web workers
-        let isSupported = isModernBrowser && isLocalStorageSupported()
+        let isSupported = isModernBrowser
 
         const isUnsupportedRPI = isMidori() || (isLinux() && isARM() && isEpiphany());
         const isNotSupported = isUnsupportedRPI;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1629,8 +1629,26 @@ function initHashchange() {
     });
 }
 
+function unsupportedBrowserRedirect() {
+    Util.httpGetJsonAsync(pxt.webConfig.targetCdnUrl + "target.json")
+        .then(pkg.setupAppTarget)
+        .then(() => {
+            let redirect = pxt.BrowserUtils.suggestedBrowserPath();
+            if (redirect) {
+                window.location.href = redirect;
+            }
+        })
+}
+
 $(document).ready(() => {
     pxt.setupWebConfig((window as any).pxtConfig);
+
+    //Browser check needs to be as early as possible
+    if (!pxt.BrowserUtils.isBrowserSupported()) {
+        unsupportedBrowserRedirect()
+        return
+    }
+
     let config = pxt.webConfig
     ksVersion = config.pxtVersion;
     targetVersion = config.targetVersion;
@@ -1659,14 +1677,6 @@ $(document).ready(() => {
     const cfg = pxt.webConfig;
     Util.httpGetJsonAsync(config.targetCdnUrl + "target.json")
         .then(pkg.setupAppTarget)
-        .then(() => {
-            if (!pxt.BrowserUtils.isBrowserSupported()) {
-                let redirect = pxt.BrowserUtils.suggestedBrowserPath();
-                if (redirect) {
-                    window.location.href = redirect;
-                }
-            }
-        })
         .then(() => Util.updateLocalizationAsync(cfg.pxtCdnUrl, lang ? lang[1] : (navigator.userLanguage || navigator.language)))
         .then(() => initTheme())
         .then(() => cmds.initCommandsAsync())


### PR DESCRIPTION
Per https://github.com/Microsoft/pxt/issues/355, Safari throws an exception when trying to access local storage in private browsing mode. This pull request therefore prevents access to the editor when local storage is not available, as well as a few other minor corrections to the browser check.