### PR TITLE
Fixing async usage in jakefile

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -98,7 +98,7 @@ task('upload', ["wapp", "built/pxt.js"], { async: true }, function () {
         "node built/pxt.js travis",
         "node built/pxt.js buildtarget",
         "node built/pxt.js uploaddoc",
-    ], { printStdout: true });
+    ], { printStdout: true }, complete.bind(this));
 })
 
 task("lint", [], { async: true }, function () {
@@ -151,7 +151,7 @@ file('built/localization.json', ju.expand1(
         if (!/\.(ts|tsx|html)$/.test(filename)) return
         if (/\.d\.ts$/.test(filename)) return
 
-        //console.log('extracting strings from %s', filename);    
+        //console.log('extracting strings from %s', filename);
         loadText(filename).split('\n').forEach((line, idx) => {
             function err(msg) {
                 console.log("%s(%d): %s", filename, idx, msg);
@@ -248,7 +248,7 @@ task('monaco-editor', [
     "built/web/vs/language/typescript/src/mode.js"
 ])
 
-file('built/web/vs/editor/editor.main.js', ['node_modules/pxt-monaco-typescript/release/src/monaco.contribution.js'], { async: true }, function () {
+file('built/web/vs/editor/editor.main.js', ['node_modules/pxt-monaco-typescript/release/src/monaco.contribution.js'], function () {
     console.log(`Updating the monaco editor bits`)
     jake.mkdirP("built/web/vs/editor")
     let monacotypescriptcontribution = fs.readFileSync("node_modules/pxt-monaco-typescript/release/src/monaco.contribution.js", "utf8")
@@ -279,7 +279,7 @@ file('built/web/vs/editor/editor.main.js', ['node_modules/pxt-monaco-typescript/
     jake.cpR("node_modules/monaco-editor/dev/vs/language/json/", "webapp/public/vs/language/")
 })
 
-file('built/web/vs/language/typescript/src/mode.js', ['node_modules/pxt-monaco-typescript/release/src/mode.js'], { async: true }, function () {    
+file('built/web/vs/language/typescript/src/mode.js', ['node_modules/pxt-monaco-typescript/release/src/mode.js'], function () {
     console.log(`Updating the monaco typescript language service`)
     jake.mkdirP("built/web/vs/language/typescript/src")
     jake.mkdirP("built/web/vs/language/typescript/lib")


### PR DESCRIPTION
We had a few tasks that were marked as async when they actually weren't and one task that was async but never called complete. This was preventing our tests from running in Travis even though the build claims it passed.