### PR TITLE
Adding a flag to enable source maps in the web app

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -6,14 +6,18 @@ var path = require("path")
 var expand = ju.expand;
 var cmdIn = ju.cmdIn;
 
-function tscIn(task, dir) {
-    cmdIn(task, dir, 'node ../node_modules/typescript/bin/tsc')
+function tscIn(task, dir, builtDir) {
+    let command = 'node ../node_modules/typescript/bin/tsc'
+    if (process.env.sourceMaps === 'true') {
+        command += ' --sourceMap --mapRoot file:///' + path.resolve(builtDir)
+    }
+    cmdIn(task, dir, command)
 }
 
 function compileDir(name, deps) {
     if (!deps) deps = []
     let dd = expand([name].concat(deps))
-    file('built/' + name + '.js', dd, { async: true }, function () { tscIn(this, name) })
+    file('built/' + name + '.js', dd, { async: true }, function () { tscIn(this, name, "built") })
 }
 
 function loadText(filename) {
@@ -299,7 +303,7 @@ file('built/webapp/src/app.js', expand([
     "built/web/pxtblocks.js",
     "built/web/pxteditor.js"
 ]), { async: true }, function () {
-    tscIn(this, "webapp")
+    tscIn(this, "webapp", "built/webapp")
 })
 
 file('built/web/main.js', ["built/webapp/src/app.js"], { async: true }, function () {

--- a/backendutils/tsconfig.json
+++ b/backendutils/tsconfig.json
@@ -5,7 +5,6 @@
         "noImplicitReturns": true,
         "declaration": true,
         "out": "../built/backendutils.js",
-        "rootDir": ".",
         "newLine": "LF",
         "sourceMap": false
     }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1033,7 +1033,7 @@ function addCmd(name: string) {
     return name + (/^win/.test(process.platform) ? ".cmd" : "")
 }
 
-function buildPxtAsync(includeSourceMaps: boolean): Promise<string[]> {
+function buildPxtAsync(includeSourceMaps = false): Promise<string[]> {
     let ksd = "node_modules/pxt-core"
     if (!fs.existsSync(ksd + "/pxtlib/main.ts")) return Promise.resolve([]);
 
@@ -1256,7 +1256,7 @@ function buildFailed(msg: string, e: any) {
     console.log("")
 }
 
-function buildAndWatchTargetAsync(includeSourceMaps: boolean) {
+function buildAndWatchTargetAsync(includeSourceMaps = false) {
     if (forkPref() && fs.existsSync("pxtarget.json")) {
         console.log("Assuming target fork; building once.")
         return buildTargetAsync()

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1033,14 +1033,14 @@ function addCmd(name: string) {
     return name + (/^win/.test(process.platform) ? ".cmd" : "")
 }
 
-function buildPxtAsync(): Promise<string[]> {
+function buildPxtAsync(includeSourceMaps: boolean): Promise<string[]> {
     let ksd = "node_modules/pxt-core"
     if (!fs.existsSync(ksd + "/pxtlib/main.ts")) return Promise.resolve([]);
 
     console.log(`building ${ksd}...`);
     return spawnAsync({
         cmd: addCmd("jake"),
-        args: [],
+        args: includeSourceMaps ? ["sourceMaps=true"] : [],
         cwd: ksd
     }).then(() => {
         console.log("local pxt-core built.")
@@ -1256,7 +1256,7 @@ function buildFailed(msg: string, e: any) {
     console.log("")
 }
 
-function buildAndWatchTargetAsync() {
+function buildAndWatchTargetAsync(includeSourceMaps: boolean) {
     if (forkPref() && fs.existsSync("pxtarget.json")) {
         console.log("Assuming target fork; building once.")
         return buildTargetAsync()
@@ -1267,7 +1267,7 @@ function buildAndWatchTargetAsync() {
         return Promise.resolve()
     }
 
-    return buildAndWatchAsync(() => buildPxtAsync()
+    return buildAndWatchAsync(() => buildPxtAsync(includeSourceMaps)
         .then(() => buildTargetAsync().then(r => { }, e => {
             buildFailed("target build failed: " + e.message, e)
         }))
@@ -1345,6 +1345,7 @@ export function serveAsync(arg?: string) {
     forceCloudBuild = !globalConfig.localBuild
     let justServe = false
     let packaged = false
+    let includeSourceMaps = false;
     if (arg == "-yt") {
         forceCloudBuild = false
     } else if (arg == "-cloud") {
@@ -1357,6 +1358,8 @@ export function serveAsync(arg?: string) {
     } else if (arg == "-no-browser") {
         justServe = true
         globalConfig.noAutoStart = true
+    } else if (arg == "-include-source-maps") {
+        includeSourceMaps = true;
     }
     if (!globalConfig.localToken) {
         globalConfig.localToken = U.guidGen();
@@ -1380,7 +1383,7 @@ export function serveAsync(arg?: string) {
             }
         }
     }
-    return (justServe ? Promise.resolve() : buildAndWatchTargetAsync())
+    return (justServe ? Promise.resolve() : buildAndWatchTargetAsync(includeSourceMaps))
         .then(() => server.serveAsync({
             localToken: localToken,
             autoStart: !globalConfig.noAutoStart,

--- a/pxtblocks/tsconfig.json
+++ b/pxtblocks/tsconfig.json
@@ -5,7 +5,6 @@
         "noImplicitReturns": true,
         "declaration": true,
         "out": "../built/pxtblocks.js",
-        "rootDir": ".",
         "newLine": "LF",
         "sourceMap": false
     }

--- a/pxteditor/tsconfig.json
+++ b/pxteditor/tsconfig.json
@@ -5,7 +5,6 @@
         "noImplicitReturns": true,
         "declaration": true,
         "out": "../built/pxteditor.js",
-        "rootDir": ".",
         "newLine": "LF",
         "sourceMap": false
     }

--- a/pxtlib/tsconfig.json
+++ b/pxtlib/tsconfig.json
@@ -5,7 +5,6 @@
         "noImplicitReturns": true,
         "declaration": true,
         "out": "../built/pxtlib.js",
-        "rootDir": ".",
         "newLine": "LF",
         "sourceMap": false
     }

--- a/pxtrunner/tsconfig.json
+++ b/pxtrunner/tsconfig.json
@@ -5,7 +5,6 @@
         "noImplicitReturns": true,
         "declaration": true,
         "out": "../built/pxtrunner.js",
-        "rootDir": ".",
         "newLine": "LF",
         "sourceMap": false
     }

--- a/pxtsim/tsconfig.json
+++ b/pxtsim/tsconfig.json
@@ -5,7 +5,6 @@
         "noImplicitReturns": true,
         "declaration": true,
         "out": "../built/pxtsim.js",
-        "rootDir": ".",
         "newLine": "LF",
         "sourceMap": false
     }


### PR DESCRIPTION
This adds an optional flag to enable source maps for debugging purposes when building and serving the web app. The source maps only seem to work with Chrome right now.

With Jake:
```
jake sourceMaps=true
```

With the CLI:
```
pxt serve -include-source-maps
```

I also removed the `rootDir` option we were specifying in a few of our `tsconfig.json` files because it wasn't doing anything (it only has an effect when used with `outDir` http://www.typescriptlang.org/docs/handbook/compiler-options.html)