### PR TITLE
fixes instructions visual regressions and improves instructions readability

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -69,7 +69,6 @@ declare namespace pxt {
         parts?: boolean; // parts enabled?
         instructions?: boolean;
         partsAspectRatio?: number; // aspect ratio of the simulator when parts are displayed
-        builtinParts?: Map<boolean>;
     }
 
     interface TargetCompileService {

--- a/pxtlib/emitter/driver.ts
+++ b/pxtlib/emitter/driver.ts
@@ -81,9 +81,9 @@ namespace ts.pxtc {
         }
 
         if (ignoreBuiltin) {
-            const builtinParts = pxt.appTarget.simulator.builtinParts;
+            const builtinParts = pxt.appTarget.simulator.boardDefinition.onboardComponents;
             if (builtinParts)
-                parts = parts.filter(p => !builtinParts[p]);
+                parts = parts.filter(p => builtinParts.indexOf(p) < 0);
         }
 
         //sort parts (so breadboarding layout is stable w.r.t. code ordering)

--- a/pxtlib/emitter/driver.ts
+++ b/pxtlib/emitter/driver.ts
@@ -85,6 +85,13 @@ namespace ts.pxtc {
             if (builtinParts)
                 parts = parts.filter(p => !builtinParts[p]);
         }
+
+        //sort parts (so breadboarding layout is stable w.r.t. code ordering)
+        parts.sort();
+        parts = parts.reverse(); //not strictly necessary, but it's a little
+                                 // nicer for demos to have "ledmatrix"
+                                 // before "buttonpair"
+
         return parts;
     }
 

--- a/pxtsim/instructions.ts
+++ b/pxtsim/instructions.ts
@@ -302,7 +302,7 @@ namespace pxsim.instructions {
         let allocRes = allocateDefinitions(allocOpts);
         let stepToWires: WireInst[][] = [];
         let stepToCmps: PartInst[][] = [];
-        let stepOffset = 0;
+        let stepOffset = 1;
         allocRes.partsAndWires.forEach(cAndWs => {
             let part = cAndWs.part;
             let wires = cAndWs.wires;
@@ -528,11 +528,14 @@ namespace pxsim.instructions {
                 } else {
                     topLbl = "";
                 }
+                let scale = REQ_CMP_SCALE;
+                if (c.visual.builtIn === "buttonpair")
+                    scale *= 0.5; //TODO: don't special case
                 let cmp = mkCmpDiv(c.visual, {
                     top: topLbl,
                     topSize: LOC_LBL_SIZE,
                     cmpHeight: REQ_CMP_HEIGHT,
-                    cmpScale: REQ_CMP_SCALE
+                    cmpScale: scale
                 })
                 addClass(cmp, "cmp-div");
                 reqsDiv.appendChild(cmp);
@@ -587,7 +590,6 @@ namespace pxsim.instructions {
         let dummyBreadboard = new visuals.Breadboard({});
         let onboardCmps = options.boardDef.onboardComponents || [];
         let activeComponents = (options.parts || []).filter(c => onboardCmps.indexOf(c) < 0);
-        activeComponents.sort();
         let props = mkBoardProps({
             boardDef: options.boardDef,
             partDefs: cmpDefs,

--- a/pxtsim/instructions.ts
+++ b/pxtsim/instructions.ts
@@ -341,16 +341,18 @@ namespace pxsim.instructions {
             allWireColors: allWireColors,
         };
     }
-    function mkBlankBoardAndBreadboard(boardDef: BoardDefinition, cmpDefs: Map<PartDefinition>, fnArgs: any, width: number, buildMode: boolean = false): visuals.BoardHost {
+    function mkBlankBoardAndBreadboard(props: BoardProps, width: number, buildMode: boolean = false): visuals.BoardHost {
         const state = runtime.board as pxsim.CoreBoard;
         const opts: visuals.BoardHostOpts = {
             state: state,
-            boardDef: boardDef,
-            forceBreadboard: true,
-            partDefs: cmpDefs,
+            boardDef: props.boardDef,
+            forceBreadboardLayout: true,
+            forceBreadboardRender: props.allAlloc.requiresBreadboard,
+            partDefs: props.cmpDefs,
             maxWidth: `${width}px`,
-            fnArgs: fnArgs,
+            fnArgs: props.fnArgs,
             wireframe: buildMode,
+            partsList: []
         };
         let boardHost = new visuals.BoardHost(pxsim.visuals.mkBoardView({
             visual: opts.boardDef.visual,
@@ -472,7 +474,7 @@ namespace pxsim.instructions {
         let panel = mkPanel();
 
         //board
-        let board = mkBlankBoardAndBreadboard(props.boardDef, props.cmpDefs, props.fnArgs, BOARD_WIDTH, true)
+        let board = mkBlankBoardAndBreadboard(props, BOARD_WIDTH, true)
         drawSteps(board, step, props);
         panel.appendChild(board.getView());
 
@@ -547,7 +549,7 @@ namespace pxsim.instructions {
     function updateFrontPanel(props: BoardProps): [HTMLElement, BoardProps] {
         let panel = document.getElementById("front-panel");
 
-        let board = mkBlankBoardAndBreadboard(props.boardDef, props.cmpDefs, props.fnArgs, FRONT_PAGE_BOARD_WIDTH, false);
+        let board = mkBlankBoardAndBreadboard(props, FRONT_PAGE_BOARD_WIDTH, false);
         board.addAll(props.allAlloc);
         panel.appendChild(board.getView());
 
@@ -557,7 +559,7 @@ namespace pxsim.instructions {
 
         let panel = mkPanel();
         addClass(panel, "back-panel");
-        let board = mkBlankBoardAndBreadboard(props.boardDef, props.cmpDefs, props.fnArgs, BACK_PAGE_BOARD_WIDTH, false)
+        let board = mkBlankBoardAndBreadboard(props, BACK_PAGE_BOARD_WIDTH, false)
         board.addAll(props.allAlloc);
         panel.appendChild(board.getView());
 
@@ -588,12 +590,10 @@ namespace pxsim.instructions {
 
         //props
         let dummyBreadboard = new visuals.Breadboard({});
-        let onboardCmps = options.boardDef.onboardComponents || [];
-        let activeComponents = (options.parts || []).filter(c => onboardCmps.indexOf(c) < 0);
         let props = mkBoardProps({
             boardDef: options.boardDef,
             partDefs: cmpDefs,
-            partsList: activeComponents,
+            partsList: options.parts,
             fnArgs: options.fnArgs,
             getBBCoord: dummyBreadboard.getCoord.bind(dummyBreadboard)
         });

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -339,7 +339,7 @@ namespace pxsim.visuals {
 
     export type WireColor =
         "black" | "white" | "gray" | "purple" | "blue" | "green" | "yellow" | "orange" | "red" | "brown" | "pink";
-    export const GPIO_WIRE_COLORS = ["pink", "green", "purple", "orange", "yellow"];
+    export const GPIO_WIRE_COLORS = ["pink", "orange", "yellow", "green", "purple" ];
     export const WIRE_COLOR_MAP: Map<string> = {
         black: "#514f4d",
         white: "#fcfdfc",

--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -44,7 +44,6 @@ namespace pxsim.visuals {
             this.state = opts.state;
             let onboardCmps = opts.boardDef.onboardComponents || [];
             let activeComponents = (opts.partsList || []).filter(c => onboardCmps.indexOf(c) < 0);
-            activeComponents.sort();
             this.useCrocClips = opts.boardDef.useCrocClips;
 
             let useBreadboard = 0 < activeComponents.length || opts.forceBreadboard;

--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -7,13 +7,14 @@ namespace pxsim.visuals {
     export interface BoardHostOpts {
         state: CoreBoard,
         boardDef: BoardDefinition,
-        partsList?: string[],
+        partsList: string[],
         partDefs: Map<PartDefinition>,
         fnArgs: any,
-        forceBreadboard?: boolean,
+        forceBreadboardLayout?: boolean,
+        forceBreadboardRender?: boolean,
         maxWidth?: string,
-        maxHeight?: string
-        wireframe?: boolean
+        maxHeight?: string,
+        wireframe?: boolean,
     }
 
     export var mkBoardView = (opts: BoardViewOptions): BoardView => {
@@ -42,11 +43,10 @@ namespace pxsim.visuals {
         constructor(view: BoardView, opts: BoardHostOpts) {
             this.boardView = view;
             this.state = opts.state;
-            let onboardCmps = opts.boardDef.onboardComponents || [];
-            let activeComponents = (opts.partsList || []).filter(c => onboardCmps.indexOf(c) < 0);
+            let activeComponents = opts.partsList;
             this.useCrocClips = opts.boardDef.useCrocClips;
 
-            let useBreadboard = 0 < activeComponents.length || opts.forceBreadboard;
+            let useBreadboard = 0 < activeComponents.length || opts.forceBreadboardLayout;
             if (useBreadboard) {
                 this.breadboard = new Breadboard({
                     wireframe: opts.wireframe,
@@ -87,7 +87,8 @@ namespace pxsim.visuals {
 
                 this.addAll(allocRes);
 
-                if (!allocRes.requiresBreadboard) this.breadboard.hide();
+                if (!allocRes.requiresBreadboard && !opts.forceBreadboardRender)
+                    this.breadboard.hide();
             } else {
                 let el = this.boardView.getView().el;
                 this.view = el;
@@ -136,6 +137,7 @@ namespace pxsim.visuals {
         }
         private getPinCoord(pin: string) {
             let boardCoord = this.boardView.getCoord(pin);
+            U.assert(!!boardCoord, `Unable to find coord for pin: ${pin}`);
             return this.fromMBCoord(boardCoord);
         }
         public getLocCoord(loc: Loc): Coord {

--- a/pxtsim/visuals/breadboard.ts
+++ b/pxtsim/visuals/breadboard.ts
@@ -72,25 +72,36 @@ namespace pxsim.visuals {
         .sim-bb-outline .sim-bb-mid-channel {
             fill: #FFF;
             stroke: #888;
-            stroke-width: 1px;
+            stroke-width: 2px;
         }
         /* grayed out */
+        .grayed .sim-bb-background {
+            stroke-width: ${PIN_DIST / 5}px;
+        }
         .grayed .sim-bb-red,
         .grayed .sim-bb-blue {
             fill: #BBB;
         }
+        .grayed .sim-bb-bar {
+            fill: #FFF;
+        }
         .grayed .sim-bb-pin {
-            fill:none;
-            stroke: #BBB;
+            fill: #000;
+            stroke: #FFF;
+            stroke-width: 3px;
         }
         .grayed .sim-bb-label {
-            fill: #BBB;
+            fill: none;
         }
         .grayed .sim-bb-background {
-            stroke: #BBB;
+            stroke-width: ${PIN_DIST / 2}px;
+            stroke: #555;
         }
         .grayed .sim-bb-group-wire {
             stroke: #DDD;
+        }
+        .grayed .sim-bb-channel {
+            visibility: hidden;
         }
         /* highlighted */
         .sim-bb-label.highlight {
@@ -104,6 +115,9 @@ namespace pxsim.visuals {
         }
         .sim-bb-red.highlight {
             fill:${RED};
+        }
+        .sim-bb-bar.highlight {
+            stroke-width: 0px;
         }
         `
     // Pin rows and coluns
@@ -377,8 +391,8 @@ namespace pxsim.visuals {
             }
 
             mkChannel(BAR_HEIGHT + MID_HEIGHT / 2, CHANNEL_HEIGHT, "sim-bb-mid-channel");
-            mkChannel(BAR_HEIGHT, SMALL_CHANNEL_HEIGHT);
-            mkChannel(BAR_HEIGHT + MID_HEIGHT, SMALL_CHANNEL_HEIGHT);
+            mkChannel(BAR_HEIGHT, SMALL_CHANNEL_HEIGHT, "sim-bb-sml-channel");
+            mkChannel(BAR_HEIGHT + MID_HEIGHT, SMALL_CHANNEL_HEIGHT), "sim-bb-sml-channel";
 
             //-----pins
             const getMidTopOrBot = (rowIdx: number) => rowIdx < BREADBOARD_MID_ROWS / 2.0 ? "b" : "t";

--- a/pxtsim/visuals/genericboard.ts
+++ b/pxtsim/visuals/genericboard.ts
@@ -22,7 +22,7 @@ namespace pxsim.visuals {
         }
         .gray-cover {
             fill:#FFF;
-            opacity: 0.7;
+            opacity: 0.3;
             stroke-width:0;
             visibility: hidden;
         }
@@ -167,7 +167,7 @@ namespace pxsim.visuals {
                     width: width,
                     height: width,
                 });
-                return { el: el, w: width, h: width, x: 0, y: 0 };
+                return {el: el, w: width, h: width, x: 0, y: 0};
             }
             const mkSquareHoverPin = (): SVGElAndSize => {
                 let el = svg.elt("rect");
@@ -177,7 +177,7 @@ namespace pxsim.visuals {
                     width: width,
                     height: width
                 });
-                return { el: el, w: width, h: width, x: 0, y: 0 };
+                return {el: el, w: width, h: width, x: 0, y: 0};
             }
             const mkPinBlockGrid = (pinBlock: PinBlockDefinition, blockIdx: number) => {
                 let xOffset = scaleFn(pinBlock.x) + PIN_DIST / 2.0;
@@ -213,13 +213,8 @@ namespace pxsim.visuals {
             //tooltip
             this.allPins.forEach(p => {
                 let tooltip = p.col;
-                svg.hydrate(p.el, { title: tooltip });
-                svg.hydrate(p.hoverEl, { title: tooltip });
-            });
-            //attach pins
-            this.allPins.forEach(p => {
-                this.g.appendChild(p.el);
-                this.g.appendChild(p.hoverEl);
+                svg.hydrate(p.el, {title: tooltip});
+                svg.hydrate(p.hoverEl, {title: tooltip});
             });
             //catalog pins
             this.allPins.forEach(p => {
@@ -249,22 +244,27 @@ namespace pxsim.visuals {
                 svg.addClass(el, "sim-board-pin-lbl");
                 let hoverEl = mkLabelTxtEl(pinX, pinY, PIN_LBL_HOVER_SIZE, txt, pos);
                 svg.addClass(hoverEl, "sim-board-pin-lbl-hover");
-                let label: GridLabel = { el: el, hoverEl: hoverEl, txt: txt };
+                let label: GridLabel = {el: el, hoverEl: hoverEl, txt: txt};
                 return label;
             }
             this.allLabels = this.allPins.map((p, pIdx) => {
                 let blk = pinToBlockDef[pIdx];
                 return mkLabel(p.cx, p.cy, p.col, blk.labelPosition);
             });
-            //attach labels
-            this.allLabels.forEach(l => {
-                this.g.appendChild(l.el);
-                this.g.appendChild(l.hoverEl);
-            });
             //catalog labels
             this.allPins.forEach((pin, pinIdx) => {
                 let lbl = this.allLabels[pinIdx];
                 this.pinNmToLbl[pin.col] = lbl;
+            });
+
+            //attach pins & labels
+            this.allPins.forEach((p, idx) => {
+                let lbl = this.allLabels[idx];
+                //pins and labels must be adjacent for hover CSS
+                this.g.appendChild(p.el);
+                this.g.appendChild(p.hoverEl);
+                this.g.appendChild(lbl.el);
+                this.g.appendChild(lbl.hoverEl);
             });
         }
 
@@ -277,13 +277,13 @@ namespace pxsim.visuals {
 
         private mkGrayCover(x: number, y: number, w: number, h: number) {
             let rect = <SVGRectElement>svg.elt("rect");
-            svg.hydrate(rect, { x: x, y: y, width: w, height: h, class: "gray-cover" });
+            svg.hydrate(rect, {x: x, y: y, width: w, height: h, class: "gray-cover"});
             return rect;
         }
 
 
         public getView(): SVGAndSize<SVGSVGElement> {
-            return { el: this.element, w: this.width, h: this.height, x: 0, y: 0 };
+            return {el: this.element, w: this.width, h: this.height, x: 0, y: 0};
         }
 
         public getPinDist() {


### PR DESCRIPTION
Especially notice how the breadboard wireframe looks:

**Before**
<img width="300" alt="screen shot 2016-09-27 at 5 32 12 pm" src="https://cloud.githubusercontent.com/assets/6453828/18896697/aa5f5222-84d8-11e6-99da-39cae0b629bf.png">

**After**
<img width="300" alt="screen shot 2016-09-27 at 5 28 53 pm" src="https://cloud.githubusercontent.com/assets/6453828/18896698/aa61f680-84d8-11e6-89b2-30da9d69e643.png">