### PR TITLE
Display an error for floating point numbers if not supported

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -498,23 +498,8 @@ namespace pxt.blocks {
     ///////////////////////////////////////////////////////////////////////////////
 
     function extractNumber(b: B.Block): number {
-        const isFloatingPoint = pxt.appTarget.compile.floatingPoint;
         let v = b.getFieldValue("NUM");
-        if (isFloatingPoint) {
-            let f = parseFloat(v);
-            if (f >> 0 != f) {
-                Errors.report(v + " is either too big or too small", b);
-                return 0;
-            }
-            return f;
-        } else {
-            let i = parseInt(v);
-            if (i >> 0 != i) {
-                Errors.report(v + " is either too big or too small", b);
-                return 0;
-            }
-            return i;
-        }
+        return parseFloat(v);
     }
 
     function compileNumber(e: Environment, b: B.Block, comments: string[]): Node {

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -50,7 +50,7 @@ namespace ts.pxtc {
         console.log(stringKind(n))
     }
 
-    // next free error 9257
+    // next free error 9259
     function userError(code: number, msg: string, secondary = false): Error {
         let e = new Error(msg);
         (<any>e).ksEmitterUserError = true;
@@ -1252,10 +1252,10 @@ ${lbl}: .short 0xffff
                     const parsed = parseFloat(node.text)
                     if (!opts.target.floatingPoint) {
                         if (Math.floor(parsed) !== parsed) {
-                            userError(9242, lf("Decimal numbers are not supported"))
+                            userError(9257, lf("Decimal numbers are not supported"))
                         }
                         else if (parsed << 0 !== parsed) {
-                            userError(9243, lf("Number is either too big or too small"))
+                            userError(9258, lf("Number is either too big or too small"))
                         }
                     }
                     return ir.numlit(parsed)

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -1249,7 +1249,16 @@ ${lbl}: .short 0xffff
                 if ((<any>node).imageLiteral) {
                     return ir.ptrlit((<any>node).imageLiteral, (<any>node).jsLit)
                 } else {
-                    return ir.numlit(parseInt(node.text))
+                    const parsed = parseFloat(node.text)
+                    if (!opts.target.floatingPoint) {
+                        if (Math.floor(parsed) !== parsed) {
+                            userError(9242, lf("Decimal numbers are not supported"))
+                        }
+                        else if (parsed << 0 !== parsed) {
+                            userError(9243, lf("Number is either too big or too small"))
+                        }
+                    }
+                    return ir.numlit(parsed)
                 }
             } else if (isStringLiteral(node)) {
                 return emitStringLiteral(node.text)
@@ -1757,7 +1766,7 @@ ${lbl}: .short 0xffff
 
         function layOutGlobals() {
             let globals = bin.globals.slice(0)
-            // stable-sort globals, with smallest first, because "strh/b" have 
+            // stable-sort globals, with smallest first, because "strh/b" have
             // smaller immediate range than plain "str" (and same for "ldr")
             globals.forEach((g, i) => g.index = i)
             globals.sort((a, b) =>
@@ -2635,7 +2644,7 @@ ${lbl}: .short 0xffff
                 return
             }
 
-            //As the iterator isn't declared in the usual fashion we must mark it as used, otherwise no cell will be allocated for it 
+            //As the iterator isn't declared in the usual fashion we must mark it as used, otherwise no cell will be allocated for it
             markUsed(declList.declarations[0])
             let iterVar = emitVariableDeclaration(declList.declarations[0]) // c
             //Start with null, TODO: Is this necessary
@@ -2772,7 +2781,7 @@ ${lbl}: .short 0xffff
                         }
                     }
                 } else if (cl.kind == SK.DefaultClause) {
-                    // Save default label for emit at the end of the 
+                    // Save default label for emit at the end of the
                     // tests section. Default label doesn't have to come at the
                     // end in JS.
                     assert(!defaultLabel)
@@ -2982,7 +2991,7 @@ ${lbl}: .short 0xffff
                 case SK.NumericLiteral:
                 case SK.StringLiteral:
                 case SK.NoSubstitutionTemplateLiteral:
-                    //case SyntaxKind.RegularExpressionLiteral:                    
+                    //case SyntaxKind.RegularExpressionLiteral:
                     return emitLiteral(<LiteralExpression>node);
                 case SK.PropertyAccessExpression:
                     return emitPropertyAccess(<PropertyAccessExpression>node);
@@ -3024,7 +3033,7 @@ ${lbl}: .short 0xffff
                     unhandled(node);
                     return null
 
-                /*    
+                /*
                 case SyntaxKind.TemplateSpan:
                     return emitTemplateSpan(<TemplateSpan>node);
                 case SyntaxKind.Parameter:


### PR DESCRIPTION
Fixes #2 (mostly)

Makes using floating point numbers when targeting a board that does not support them an error. It looks like this:

![decimal_errors](https://cloud.githubusercontent.com/assets/13754588/19058756/ccd05fa8-898e-11e6-9360-8a06b29a6b0e.png)

As part of this, I had to move the max-int check from the block compiler to the emitter, so typing in a huge number will give a similar error now. I also removed the max-float check because it didn't work (not sure if we want to add in a different working one?)