### PR TITLE
Remove top-level shadow blocks when created by editor

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -111,6 +111,7 @@ declare namespace Blockly {
         inputList: Input[];
         disabled: boolean;
         comment: string | Comment;
+        dispose(healGap: boolean): void;
     }
 
     class Comment {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -217,6 +217,8 @@ export class Editor extends srceditor.Editor {
         this.editor.addChangeListener((ev) => {
             if (ev.recordUndo)
                 this.changeCallback();
+            if (ev.type == 'create' && ev.xml.tagName == 'SHADOW')
+                this.cleanUpShadowBlocks();
             if (ev.type == 'ui') {
                 if (ev.element == 'category') {
                     let toolboxVisible = !!ev.newValue;
@@ -335,5 +337,14 @@ export class Editor extends srceditor.Editor {
         return (
             <sui.Button text={lf("JavaScript") } textClass="ui landscape only" icon="keyboard" onClick={() => this.openTypeScript() } />
         )
+    }
+
+    cleanUpShadowBlocks() {
+        const blocks = this.editor.getTopBlocks(false);
+        for (const block of blocks) {
+            if (block.isShadow_) {
+                block.dispose(false);
+            }
+        }
     }
 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -341,10 +341,6 @@ export class Editor extends srceditor.Editor {
 
     cleanUpShadowBlocks() {
         const blocks = this.editor.getTopBlocks(false);
-        for (const block of blocks) {
-            if (block.isShadow_) {
-                block.dispose(false);
-            }
-        }
+        blocks.filter(b => b.isShadow_).forEach(b => b.dispose(false));
     }
 }


### PR DESCRIPTION
Fixes #112 

Walks the top blocks and removes any shadow blocks whenever a shadow block is created. Unfortunately, you can still see a flicker of the shadow block appearing and disappearing. Not sure if there is a better solution that doesn't involve altering Blockly.