### PR TITLE
Sharing and publishing feature configuration

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -58,6 +58,8 @@ declare namespace pxt {
     interface AppCloud {
         workspaces?: boolean;
         packages?: boolean;
+        sharing?: boolean;
+        publishing?: boolean;
         preferredPackages?: string[]; // list of company/project(#tag) of packages
     }
 

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -375,8 +375,8 @@ namespace pxt.docs {
         });
     }
 
-    export function embedUrl(rootUrl: string, id: string, height?: number): string {
-        const url = `${rootUrl}#sandbox:${id}`;
+    export function embedUrl(rootUrl: string, tag:string, id: string, height?: number): string {
+        const url = `${rootUrl}#${tag}:${id}`;
         let padding = '70%';
         return `<div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" frameborder="0" sandbox="allow-scripts allow-same-origin"></iframe></div>`;
     }


### PR DESCRIPTION
- limit sharing and publishing features
- handing #project and #sandboxproject hash
- only re-render the share editor when necessary
- render screenshot svg and encoded file contents on button click