### PR TITLE
"Open in full editor" button in sandbox mode, fixes #426

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1169,39 +1169,17 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     }
 
     launchFullEditor() {
-        let sandbox = /sandbox=1/i.test(window.location.href)
-        let sandboxPub = /#sandbox:/i.test(window.location.href)
-        let sandboxProject = /#sandboxproject:/i.test(window.location.href)
-        Util.assert(sandbox || sandboxPub || sandboxProject);
+        Util.assert(sandbox);
 
         let rootUrl = pxt.appTarget.appTheme.embedUrl;
         if (!/\/$/.test(rootUrl)) rootUrl += '/';
 
-        const launchEditor = (url: string) => {
-            pxt.tickEvent("sandbox.launchexternaleditor");
-            let editUrl = `${rootUrl}${url}`;
-            window.open(editUrl, '_blank')
-        }
-
-        if (sandboxPub) {
-            let mpkg = pkg.mainPkg
-            let epkg = pkg.getEditorPkg(mpkg)
-            if (epkg.header.pubCurrent) {
-                launchEditor(`#pub:${epkg.header.pubId}`);
-            } else {
-                this.publishAsync()
-                    .done(() => {
-                        launchEditor(`#pub:${epkg.header.pubId}`);
-                    })
-            }
-        } else if (sandboxProject) {
-            this.exportAsync()
-                .then(fileContent => {
-                    launchEditor(`#project:${fileContent}`);
-                })
-        } else {
-            launchEditor(``);
-        }
+        this.exportAsync()
+            .then(fileContent => {
+                pxt.tickEvent("sandbox.launchexternaleditor");
+                let editUrl = `${rootUrl}#project:${fileContent}`;
+                window.open(editUrl, '_parent')
+            })
     }
 
     addPackage() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1563,7 +1563,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <div className={`ui item right ${sandbox ? "" : "wide only"}`}>
                                 {sandbox ?
                                     <div>
-                                        <sui.Button role="menuitem" class="ui landscape only" icon="external" text={lf("Open in full editor")} onClick={() => this.launchFullEditor()}/>
+                                        <sui.Button role="menuitem" class="ui landscape only" icon="external" text={lf("Open in ") + targetTheme.name} onClick={() => this.launchFullEditor()}/>
                                         <sui.Button role="menuitem" class="ui portrait only" icon="external" onClick={() => this.launchFullEditor()}/>
                                     </div>
                                     : undefined }


### PR DESCRIPTION
If in sandboxOn mode (sandbox=1)
- launch full editor without sandbox
If in sandboxPub mode (sandbox:PUBID) 
- ensure published project is the latest, if not, publish the project, then go to full editor with new published project id (pub:PUBID in the path)
If in sandboxProject mode (sandbox:FILECONTENTS)
- export project to get the latest file contents, then go to full editor with project:FILECONTENTS in the path
