### PR TITLE
Subcategories

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -15,7 +15,7 @@ interface Array<T> {
     //% shim=Array_::push weight=75
     //% blockId="array_push" block="push into %this|with last item %item" blockNamespace="lists"
     push(item: T): void;
-    
+
     /**
       * Removes the last element from an array and returns it.
       */
@@ -24,12 +24,12 @@ interface Array<T> {
     pop(): T;
 
     /**
-      * Reverses the elements in an Array. 
+      * Reverses the elements in an Array.
       */
     //% helper=arrayReverse weight=10
     //% blockId="array_reverse" block="reverse %this" blockNamespace="lists"
     reverse(): void;
-    
+
     /**
       * Removes the first element from an array and returns it.
       */
@@ -44,8 +44,8 @@ interface Array<T> {
     //% helper=arrayUnshift weight=69
     //% blockId="array_unshift" block="unshift into %this|with first item %item" blockNamespace="lists"
     unshift(item:T): void;
-    
-    /** 
+
+    /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array. eg: 0
       * @param end The end of the specified portion of the array. eg: 0
@@ -64,14 +64,14 @@ interface Array<T> {
 
     /**
       * Calls a defined callback function on each element of an array, and returns an array that contains the results.
-      * @param callbackfn A function that accepts up to two arguments. The map method calls the callbackfn function one time for each element in the array. 
+      * @param callbackfn A function that accepts up to two arguments. The map method calls the callbackfn function one time for each element in the array.
       */
     //% helper=arrayMap weight=40
     map<U>(callbackfn: (value: T, index: number) => U): U[];
 
     /**
-      * Returns the elements of an array that meet the condition specified in a callback function. 
-      * @param callbackfn A function that accepts up to two arguments. The filter method calls the callbackfn function one time for each element in the array. 
+      * Returns the elements of an array that meet the condition specified in a callback function.
+      * @param callbackfn A function that accepts up to two arguments. The filter method calls the callbackfn function one time for each element in the array.
       */
     //% helper=arrayFilter weight=40
     filter(callbackfn: (value: T, index: number) => boolean): T[];
@@ -88,19 +88,19 @@ interface Array<T> {
     /** Removes the first occurence of an object. Returns true if removed. */
     //% shim=Array_::removeElement weight=48
     removeElement(element:T) : boolean;
-    
+
     /** Removes the object at position index. */
     //% shim=Array_::removeAt weight=49
     //% blockId="array_removeat" block="remove from %this|at %index" blockNamespace="lists"
     removeAt(index:number) : void;
-    
+
     /**
       * Returns the index of the first occurrence of a value in an array.
       * @param item The value to locate in the array.
       * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
       */
     //% shim=Array_::indexOf weight=50
-    //% blockId="array_indexof" block="index in %this|of %item" blockNamespace="lists"    
+    //% blockId="array_indexof" block="index in %this|of %item" blockNamespace="lists"
     indexOf(item: T, fromIndex?: number): number;
 
     /**
@@ -126,7 +126,7 @@ interface Array<T> {
 declare interface String {
     /**
      * Returns a string that contains the concatenation of two or more strings.
-     * @param other The string to append to the end of the string.  
+     * @param other The string to append to the end of the string.
      */
     //% shim=String_::concat weight=80
     //% blockId="string_concat" block="join %this|%other" blockNamespace="text"
@@ -139,13 +139,13 @@ declare interface String {
     //% shim=String_::charAt weight=77
     //% blockId="string_get" block="char from %this|at %pos" blockNamespace="text"
     charAt(index: number): string;
-    
+
     /** Returns the length of a String object. */
     //% property shim=String_::length weight=75
     //% blockId="text_length" block="length of %VALUE" blockBuiltin=true blockNamespace="text"
     length: number;
-    
-    /** 
+
+    /**
      * Returns the Unicode value of the character at the specified location.
      * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
      */
@@ -168,10 +168,10 @@ declare interface String {
     //% shim=String_::substr length.defl=1000000
     //% blockId="string_substr" block="substring of %this|from %start|of length %length" blockNamespace="text"
     substr(start:number, length?:number): string;
-    
+
     /** Returns a value indicating if the string is empty */
     //% shim=String_::isEmpty
-    //% blockId="string_isempty" block="%this| is empty" blockNamespace="text" 
+    //% blockId="string_isempty" block="%this| is empty" blockNamespace="text"
     isEmpty() : boolean;
 
     [index: number]: string;
@@ -209,10 +209,11 @@ declare interface Boolean {
 declare namespace String {
 
     /**
-     * Make a string from the given ASCII character code. 
+     * Make a string from the given ASCII character code.
      */
     //% help=math/string-from-char-code
     //% shim=String_::fromCharCode
+    //% advanced=true
     //% blockNamespace="Math" blockId="stringFromCharCode" block="text from char code %code" weight=1 color=230
     function fromCharCode(code: number): string;
 }
@@ -229,15 +230,15 @@ declare interface Number {
 declare namespace Math {
 
     /**
-     * Returns the value of a base expression taken to a specified power. 
+     * Returns the value of a base expression taken to a specified power.
      * @param x The base value of the expression.
      * @param y The exponent value of the expression.
      */
     //% shim=Math_::pow
     function pow(x: number, y: number): number;
 
-    /** 
-     * Returns a pseudorandom number between 0 and `max`. 
+    /**
+     * Returns a pseudorandom number between 0 and `max`.
      */
     //% shim=Math_::random
     function random(max: number): number;

--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -309,4 +309,28 @@ declare namespace Blockly {
         const UI: string;
         function setGroup(group: any): void;
     }
+
+    namespace Toolbox {
+        class TreeNode {
+            isUserCollapsible_: boolean;
+
+            getChildCount(): number;
+            getParent(): TreeNode;
+            getTree(): TreeControl;
+            hasChildren(): boolean;
+            isSelected(): boolean;
+            onMouseDown(e: Event): void;
+            select(): void;
+            setExpanded(expanded: boolean): void;
+            toggle(): void;
+            updateRow(): void;
+        }
+
+        class TreeControl {
+            selectedItem_: TreeNode;
+
+            getSelectedItem(): TreeNode;
+            setSelectedItem(t: TreeNode): void;
+        }
+    }
 }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -897,50 +897,52 @@ namespace pxt.blocks {
         // We override Blockly's category mouse event handler so that only one
         // category can be expanded at a time. Also prevent categories from toggling
         // once openend.
-        (<any>Blockly).Toolbox.TreeNode.prototype.onMouseDown = function(a: any) {
+        Blockly.Toolbox.TreeNode.prototype.onMouseDown = function(a: Event) {
+            const that = <Blockly.Toolbox.TreeNode>this;
 
             // Collapse the currently selected node and its parent nodes
-            if (!this.isSelected()) {
-                collapseMoreCategory(this.getTree().getSelectedItem(), this);
+            if (!that.isSelected()) {
+                collapseMoreCategory(that.getTree().getSelectedItem(), that);
             }
 
-            if (this.hasChildren() && this.isUserCollapsible_) {
+            if (that.hasChildren() && that.isUserCollapsible_) {
                 // If this is a category of categories, we want to toggle when clicked
-                if (this.getChildCount() > 1) {
-                    this.toggle();
-                    if (this.isSelected()) {
-                        this.getTree().setSelectedItem(null);
+                if (that.getChildCount() > 1) {
+                    that.toggle();
+                    if (that.isSelected()) {
+                        that.getTree().setSelectedItem(null);
                     }
                     else {
-                        this.select();
+                        that.select();
                     }
                 }
                 else {
                     // If this category has 1 or less children, don't bother toggling; we always want "More..." to show
-                    this.setExpanded(true);
-                    this.select();
+                    that.setExpanded(true);
+                    that.select();
                 }
             }
-            else if (!this.isSelected()) {
-                 this.select();
+            else if (!that.isSelected()) {
+                 that.select();
             }
 
-            this.updateRow()
+            that.updateRow()
         }
 
         // We also must override this handler to handle the case where no category is selected (e.g. clicking outside the toolbox)
-        const oldSetSelectedItem = (<any>Blockly).Toolbox.TreeControl.prototype.setSelectedItem;
-        (<any>Blockly).Toolbox.TreeControl.prototype.setSelectedItem = function(a: any) {
+        const oldSetSelectedItem = Blockly.Toolbox.TreeControl.prototype.setSelectedItem;
+        (<any>Blockly).Toolbox.TreeControl.prototype.setSelectedItem = function(a: Blockly.Toolbox.TreeNode) {
+            const that = <Blockly.Toolbox.TreeControl>this;
 
             if (a === null) {
-                collapseMoreCategory(this.selectedItem_);
+                collapseMoreCategory(that.selectedItem_);
             }
 
-            oldSetSelectedItem.call(this, a);
+            oldSetSelectedItem.call(that, a);
         }
     }
 
-    function collapseMoreCategory(cat: any, child?: any) {
+    function collapseMoreCategory(cat: Blockly.Toolbox.TreeNode, child?: Blockly.Toolbox.TreeNode) {
         while (cat) {
             // Only collapse categories that have a single child (e.g. "More...")
             if (cat.getChildCount() === 1 && cat.isUserCollapsible_ && (!child || !isChild(child, cat))) {
@@ -951,7 +953,7 @@ namespace pxt.blocks {
         }
     }
 
-    function isChild(child: any, parent: any): boolean {
+    function isChild(child: Blockly.Toolbox.TreeNode, parent: Blockly.Toolbox.TreeNode): boolean {
         const myParent = child.getParent();
         if (myParent) {
             return myParent === parent || isChild(myParent, parent);

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -275,6 +275,7 @@ namespace ts.pxtc {
         weight?: number;
         parts?: string;
         trackArgs?: number[];
+        advanced?: boolean;
 
         // on interfaces
         indexerGet?: string;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -296,6 +296,7 @@ div.simframe > iframe {
     font-size:1.25rem !important;
 }
 
+/* This horrendous selector and the next are for subcategories in the Blockly toolbox */
 .blocklyTreeRoot div div div div .blocklyTreeRow {
     border-left-width: 18px !important;
     padding-top: 0px !important;
@@ -307,6 +308,7 @@ div.simframe > iframe {
     font-size: 1rem !important;
 }
 
+/* This prevents the arrow icon from showing for categories that have subcategories in the toolbox */
 .blocklyTreeIcon {
     opacity: 0 !important;
 }
@@ -711,7 +713,10 @@ html {
         padding-right: 0;
     }
     .blocklyTreeLabel, .blocklyText {
-        font-size:0.75rem !important;
+        font-size: 0.75rem !important;
+    }
+    .blocklyTreeRoot div div div div .blocklyTreeRow .blocklyTreeLabel {
+        font-size: 0.75rem !important;
     }
     div.simframe {
         display:inline-block;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -10,7 +10,7 @@ body {
   overflow: auto;
   margin: 0;
   -webkit-overflow-scrolling: touch;
-  overflow-scrolling: touch;  
+  overflow-scrolling: touch;
 }
 
 
@@ -74,7 +74,7 @@ body {
 }
 
 #logo img, #rightlogo img {
-    height: 2.5rem;    
+    height: 2.5rem;
 }
 #rightlogo {
     line-height: 1;
@@ -95,14 +95,14 @@ body {
 
 #cookiemsg > a {
    color:white;
-   text-decoration: underline;    
+   text-decoration: underline;
 }
 
 .organization {
     position:absolute;
     top:1rem;
     right:1rem;
-    height:2rem;        
+    height:2rem;
     z-index:100;
 }
 .rtl .organization {
@@ -118,7 +118,7 @@ div.simframe {
     border:none;
     margin:0 0 0.5rem 0;
     position: relative;
-    background:transparent;    
+    background:transparent;
     width:100%;
     padding-bottom: 81.96%;
 }
@@ -132,12 +132,12 @@ div.simframe > iframe {
   padding: 0em 1em 0em 0.5em;
   overflow-x: hidden;
   overflow-y: auto;
-  margin-top: 0;  
+  margin-top: 0;
   margin-bottom: 0;
 }
 
 .filemenu {
-  direction:ltr;    
+  direction:ltr;
 }
 
 #menubar {
@@ -145,7 +145,7 @@ div.simframe > iframe {
   left: 0;
   top: 0;
   right: 0;
-  height: 4rem;    
+  height: 4rem;
 }
 
 #menubar .item > .button {
@@ -228,7 +228,7 @@ div.simframe > iframe {
     max-height: 23rem;
     overflow-y: auto;
     overflow-x: hidden;
-    margin-top:0.5rem; 
+    margin-top:0.5rem;
 }
 
 .ui.card > .content > a.header {
@@ -269,7 +269,7 @@ div.simframe > iframe {
     right: 0;
     bottom: 0;
     z-index: 1;
-    opacity: 0.7;    
+    opacity: 0.7;
 }
 
 .blocklyToolboxDiv {
@@ -281,10 +281,10 @@ div.simframe > iframe {
 }
 
 .blocklyTreeLabel, .blocklyText, .blocklyHtmlInput {
-    font-family:'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace !important;   
+    font-family:'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace !important;
 }
 
-.blocklyText {    
+.blocklyText {
     font-size:1rem !important;
 }
 
@@ -294,6 +294,21 @@ div.simframe > iframe {
 
 .blocklyTreeLabel {
     font-size:1.25rem !important;
+}
+
+.blocklyTreeRoot div div div div .blocklyTreeRow {
+    border-left-width: 18px !important;
+    padding-top: 0px !important;
+    padding-bottom: 1.6rem !important;
+    padding-left: 0px !important;
+}
+
+.blocklyTreeRoot div div div div .blocklyTreeRow .blocklyTreeLabel {
+    font-size: 1rem !important;
+}
+
+.blocklyTreeIcon {
+    opacity: 0 !important;
 }
 
 .blocklyTreeSelected {
@@ -308,9 +323,9 @@ div.simframe > iframe {
 
 .blocklyPreview {
  position: absolute;
- top: 50%; 
+ top: 50%;
  left: 50%;
- transform: translate(-50%,-50%);    
+ transform: translate(-50%,-50%);
  width: calc(100% - 1em);
  max-height: calc(100% - 1em);
 }
@@ -333,10 +348,10 @@ body.blocklyMinimalBody {
     }
 }
 
-.modal img.ui.logo {    
+.modal img.ui.logo {
     max-width: 10em;
     max-height: 3em;
-    vertical-align: middle;    
+    vertical-align: middle;
 }
 
 .ui.logs {
@@ -376,7 +391,7 @@ body.blocklyMinimalBody {
 .ui.log.black {
     border-left-color:#202020;
 }
-    
+
 .ui.log.gauge, .ui.log.counter {
     color:white;
     border-radius: 4px;
@@ -387,7 +402,7 @@ body.blocklyMinimalBody {
 }
 
 .ui.log.counter {
-    background:grey;    
+    background:grey;
 }
 
 .ui.log.gauge.blue {
@@ -445,7 +460,7 @@ svg.ui.trend.black polyline {
     z-index:5;
 }
 
-.grayscale {    
+.grayscale {
     -moz-filter: grayscale(1);
     -webkit-filter: grayscale(1);
     filter: grayscale(1);
@@ -456,14 +471,14 @@ svg.ui.trend.black polyline {
     filter: sepia(1);
 }
 
-.blur {    
+.blur {
     -moz-filter: blur(1);
     -webkit-filter: blur(1);
     filter: blur(1);
 }
-  
+
 .highlight {
-    border-bottom: 2px solid #FFC107;     
+    border-bottom: 2px solid #FFC107;
 }
 
 .ui.hideempty:empty {
@@ -515,7 +530,7 @@ html {
     animation: flash-animation 0.4s alternate infinite;
 }
 
-@keyframes flash-animation {  
+@keyframes flash-animation {
     from { opacity: 1; }
     to   { opacity: 0.4; }
 }
@@ -524,7 +539,7 @@ html {
     animation: cloud-flash-animation 0.8s alternate infinite;
 }
 
-@keyframes cloud-flash-animation {  
+@keyframes cloud-flash-animation {
     from { opacity: 1; }
     to   { opacity: 0.8; }
 }
@@ -563,7 +578,7 @@ html {
 
 @media only screen and (max-width: 64em), only screen and (max-aspect-ratio: 14/10) {
     .organization {
-        right:auto; 
+        right:auto;
         top:auto;
         left:1.5rem;
         bottom:0.5rem;
@@ -593,7 +608,7 @@ html {
 @media only screen and (max-width: 60em), only screen and (max-aspect-ratio: 12/10) {
     #logo .name {
         display: none !important;
-    }    
+    }
     .ui.desktop.only {
         display:none !important;
     }
@@ -604,7 +619,7 @@ html {
     }
     .blocklyTreeLabel {
         font-size:1rem;
-    }    
+    }
 }
 
 /* thin desktop portrait mode */
@@ -619,34 +634,34 @@ html {
         left:0.5rem;
         right: auto;
         bottom: 0.5rem;
-        height: 1.3rem;        
+        height: 1.3rem;
     }
     .rtl .organization {
         left:0.5rem;
         right: auto;
-    }    
-    #maineditor, .rtl #maineditor {     
+    }
+    #maineditor, .rtl #maineditor {
         left: 0;
         right:0;
-    }            
-    #maineditor:not(.sandbox), .rtl #maineditor:not(.sandbox) {     
+    }
+    #maineditor:not(.sandbox), .rtl #maineditor:not(.sandbox) {
         bottom:2rem;
-    }       
+    }
     .ui.landscape.only {
         display:none !important;
     }
     .hideEditorFloats .editorFloat {
         display:none;
-    }    
+    }
     #filelist {
         position:absolute;
         z-index:5;
         bottom:3rem;
         left:1rem;
-        top:auto;      
-        width:auto;  
-        min-width: inherit;   
-        max-width: inherit;   
+        top:auto;
+        width:auto;
+        min-width: inherit;
+        max-width: inherit;
     }
     .rtl #filelist {
         left:auto;
@@ -659,15 +674,15 @@ html {
     }
     div.simframe:not(:first-child) {
         display:none !important;
-    }    
+    }
     .blocklyTreeLabel {
         font-size:1rem;
-    }    
+    }
 }
 
 @media only screen and (min-width: 55em) {
     .ui.portrait.only {
-        display:none !important;    
+        display:none !important;
     }
 }
 
@@ -680,24 +695,24 @@ html {
 /* thin display, mobile */
 @media only screen and (min-width:36em) {
     .ui.thin.only {
-        display:none !important;        
+        display:none !important;
     }
 }
 
 @media only screen and (max-width:36em) {
     .ui.wide.only {
-        display:none !important;        
+        display:none !important;
     }
 }
 
 @media only screen and (max-width:50em) {
     #logo {
         font-size: 0rem;
-        padding-right: 0;        
+        padding-right: 0;
     }
     .blocklyTreeLabel, .blocklyText {
         font-size:0.75rem !important;
-    }    
+    }
     div.simframe {
         display:inline-block;
         width: 10rem;
@@ -705,7 +720,7 @@ html {
     }
     div.simframe:not(:first-child) {
         display:none !important;
-    }    
+    }
     div.simframe iframe.grayscale {
         display:none !important;
     }

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -138,50 +138,6 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                 </value>
                 <field name="OP">DIVIDE</field>
             </block>
-            <block type="math_modulo">
-                <value name="DIVIDEND">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-                <value name="DIVISOR">
-                    <shadow type="math_number">
-                        <field name="NUM">1</field>
-                    </shadow>
-                </value>
-            </block>
-            <block type="math_op2" gap="8">
-                <value name="x">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-                <value name="y">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-            </block>
-            <block type="math_op2" gap="8">
-                <value name="x">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-                <value name="y">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-                <field name="op">max</field>
-            </block>
-            <block type="math_op3">
-                <value name="x">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-            </block>
             <block type="math_number" gap="8">
                 <field name="NUM">0</field>
             </block>
@@ -192,6 +148,52 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                     </shadow>
                 </value>
             </block>
+            <category colour="230" name="More\u2026">
+                <block type="math_modulo">
+                    <value name="DIVIDEND">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                    <value name="DIVISOR">
+                        <shadow type="math_number">
+                            <field name="NUM">1</field>
+                        </shadow>
+                    </value>
+                </block>
+                <block type="math_op2" gap="8">
+                    <value name="x">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                    <value name="y">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                </block>
+                <block type="math_op2" gap="8">
+                    <value name="x">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                    <value name="y">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                    <field name="op">max</field>
+                </block>
+                <block type="math_op3">
+                    <value name="x">
+                        <shadow type="math_number">
+                            <field name="NUM">0</field>
+                        </shadow>
+                    </value>
+                </block>
+            </category>
         </category>
         <category colour="160" name="Text" category="46">
             <block type="text"></block>


### PR DESCRIPTION
Fixes #436 

Adds support for the "advanced" comment attribute for blocks and namespaces. If a block is marked as advanced, it will be placed in a "More..." subcategory of its parent category like so:


![toolbox_1](https://cloud.githubusercontent.com/assets/13754588/19284973/0b1d84f6-8fad-11e6-8773-a5726aab59c0.PNG)

Here is the subcategory expanded:


![toolbox_2](https://cloud.githubusercontent.com/assets/13754588/19284975/0ceee0e0-8fad-11e6-8ce2-17e5dfaad8cf.PNG)


Namespaces that are marked as advanced will be placed in a special "Advanced" subcategory at the end of the toolbox

![toolbox_3](https://cloud.githubusercontent.com/assets/13754588/19285029/4bb9748e-8fad-11e6-8543-6b0385767d33.PNG)

And here is what that category looks like when expanded


![toolbox_4](https://cloud.githubusercontent.com/assets/13754588/19285031/510ee914-8fad-11e6-8686-c62f992c69ee.PNG)
