### PR TITLE
API autoupdate support

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -158,7 +158,7 @@ declare namespace ts.pxtc {
         jsRefCounting?: boolean;
         floatingPoint?: boolean;
         deployDrives?: string; // partial name of drives where the .hex file should be copied
-        upgrades?: PackageUpgradePolicy[];
+        upgrades?: UpgradePolicy[];
     }
 
     interface CompileOptions {
@@ -179,8 +179,17 @@ declare namespace ts.pxtc {
         embedBlob?: string; // base64
     }
 
-    interface PackageUpgradePolicy {
+    interface UpgradePolicy {
+        type: string;
+    }
+
+    interface PackageUpgradePolicy extends UpgradePolicy {
         type: "package";
+        map: pxt.Map<string>;
+    }
+
+    interface APIUpgradePolicy extends UpgradePolicy {
+        type: "api";
         map: pxt.Map<string>;
     }
 

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -707,7 +707,7 @@ int main() {
                     return { meta: metajs, source: text }
                 })
         } else if (hd.compression) {
-            pxt.debug(lf("Compression type {0} not supported.", hd.compression))
+            pxt.debug(`Compression type ${hd.compression} not supported.`)
             return undefined
         } else {
             return Promise.resolve({ source: fromUTF8Bytes(tmp.text) });

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -113,7 +113,7 @@ namespace pxt {
 
     export interface Host {
         readFile(pkg: Package, filename: string): string;
-        writeFile(pkg: Package, filename: string, contents: string): void;
+        writeFile(pkg: Package, filename: string, contents: string, force?: boolean): void;
         downloadPackageAsync(pkg: Package): Promise<void>;
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<any>;
         cacheStoreAsync(id: string, val: string): Promise<void>;
@@ -262,15 +262,33 @@ namespace pxt {
             if (upgrades) {
                 upgrades.forEach((rule) => {
                     if (rule.type == "package") {
-                        for (let match in rule.map) {
+                        let pkgRule = rule as ts.pxtc.PackageUpgradePolicy;
+                        for (let match in pkgRule.map) {
                             if (newPackage == match) {
-                                newPackage = rule.map[match];
+                                newPackage = pkgRule.map[match];
                             }
                         }
                     }
                 });
             }
             return newPackage;
+        }
+
+        upgradeAPI(fileContents: string): string {
+            const upgrades = appTarget.compile ? appTarget.compile.upgrades : undefined;
+            let updatedContents = fileContents;
+            if (upgrades) {
+                upgrades.forEach((rule) => {
+                    if (rule.type == "api") {
+                        let apiRule = rule as ts.pxtc.APIUpgradePolicy;
+                        for (let match in apiRule.map) {
+                            let regex = new RegExp(match, 'g');
+                            updatedContents = updatedContents.replace(regex, apiRule.map[match]);
+                        }
+                    }
+                });
+            }
+            return updatedContents;
         }
 
         private parseConfig(str: string) {
@@ -432,9 +450,19 @@ namespace pxt {
                     U.userError(lf("please add '{0}' to \"files\" in {1}", fn, pxt.CONFIG_NAME))
                 cont = "// Auto-generated. Do not edit.\n" + cont + "\n// Auto-generated. Do not edit. Really.\n"
                 if (this.host().readFile(this, fn) !== cont) {
-                    pxt.debug(lf("updating {0} (size={1})...", fn, cont.length))
+                    pxt.debug(`updating ${fn} (size=${cont.length})...`)
                     this.host().writeFile(this, fn, cont)
                 }
+            }
+
+            let upgradeFile = (fn: string, cont: string) => {
+                let updatedCont = this.upgradeAPI(cont);
+                if (updatedCont != cont) {
+                    // save file (force write)
+                    pxt.debug(`updating APIs in ${fn} (size=${cont.length})...`)
+                    this.host().writeFile(this, fn, updatedCont, true)
+                }
+                return updatedCont;
             }
 
             return this.loadAsync()
@@ -456,6 +484,7 @@ namespace pxt {
                 .then(() => this.config.binaryonly ? null : this.filesToBePublishedAsync(true))
                 .then(files => {
                     if (files) {
+                        files = U.mapMap(files, upgradeFile);
                         let headerString = JSON.stringify({
                             name: this.config.name,
                             comment: this.config.description,

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -487,6 +487,13 @@ export class Editor extends srceditor.Editor {
 
         if (this.fileType == FileType.Markdown)
             this.parent.setSideMarkdown(file.content);
+
+        this.currFile.setForceChangeCallback((from: string, to:string) => {
+            if (from != to) {
+                pxt.debug(`File changed (from ${from}, to ${to}). Reloading editor`)
+                this.loadFile(this.currFile);
+            }
+        });
     }
 
     snapshotState() {


### PR DESCRIPTION
Support for API updates configured in the pxttarget.json under upgrades. 
- Defining a new upgrade policy type: API upgrade
- Upgrade a file if it matches any of the upgrade regexes
- Forcing a write file when there is a match 
- Updating the editor when a force update happens