### PR TITLE
pushing target files to subfolder with targetid

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3133,15 +3133,15 @@ function buildCoreAsync(mode: BuildOption) {
 export function uploadTargetTranslationsAsync() {
     const prj = process.env[pxt.crowdin.PROJECT_VARIABLE] as string;
     if (!prj) {
-        console.log(`crowdin upload skipped, '${pxt.crowdin.PROJECT_VARIABLE}' variable missing`);
+        pxt.log(`crowdin upload skipped, '${pxt.crowdin.PROJECT_VARIABLE}' variable missing`);
         return Promise.resolve();
     }
     const key = process.env[pxt.crowdin.KEY_VARIABLE] as string;
     if (!key) {
-        console.log(`crowdin upload skipped, '${pxt.crowdin.KEY_VARIABLE}' variable missing`);
+        pxt.log(`crowdin upload skipped, '${pxt.crowdin.KEY_VARIABLE}' variable missing`);
         return Promise.resolve();
     }
-
+    const crowdinDir = pxt.appTarget.id;
     const todo: string[] = [];
     pxt.appTarget.bundleddirs.forEach(dir => {
         const locdir = path.join(dir, "_locales");
@@ -3154,7 +3154,9 @@ export function uploadTargetTranslationsAsync() {
         const f = todo.pop();
         if (!f) return Promise.resolve();
         const data = JSON.parse(fs.readFileSync(f, 'utf8'));
-        return pxt.crowdin.uploadTranslationAsync(prj, key, path.basename(f), data)
+        const crowdf = path.join(crowdinDir, path.basename(f));
+        pxt.log(`uploading ${f} to ${crowdf}`);
+        return pxt.crowdin.uploadTranslationAsync(prj, key, crowdf, data)
             .then(nextFileAsync);
     }
     return nextFileAsync();

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -22,20 +22,20 @@ namespace pxt.crowdin {
             if (!info) throw new Error("info failed")
 
             let todo = info.languages;
-            let nextFile = () : Promise<void> => {
+            let nextFile = (): Promise<void> => {
                 const item = todo.pop();
                 const exportFileUri = apiUri(prj, key, "export-file", {
                     file: filename,
                     language: item.code
                 });
-                console.log(`downloading ${item.name}`)
+                pxt.debug(`downloading ${item.name}`)
                 return Util.httpGetTextAsync(exportFileUri).then((transationsText) => {
                     try {
                         const translations = JSON.parse(transationsText) as Map<string>;
                         if (translations)
                             r[item.code] = translations;
                     } catch (e) {
-                        console.log(exportFileUri + ' ' + e)
+                        pxt.log(exportFileUri + ' ' + e)
                     }
                     if (todo.length > 0) return nextFile();
                     else return Promise.resolve();
@@ -46,38 +46,45 @@ namespace pxt.crowdin {
         }).then(() => r);
     }
 
-    export function uploadTranslationAsync(prj: string, key: string, filename: string, jsondata: pxt.Map<string>) {
-        Util.assert(!!prj);
-        Util.assert(!!key);
+    function mkIncr(filename: string): () => void {
         let cnt = 0
-
-        function incr() {
+        return function incr() {
             if (cnt++ > 10) {
                 throw new Error("Too many API calls for " + filename);
             }
         }
+    }
 
-        function createDirAsync(name: string): Promise<void> {
-            pxt.debug(`create directory ${name}`)
-            incr();
-            return Util.multipartPostAsync(apiUri(prj, key, "add-directory"), { json: "", name: name })
-                .then(resp => {
-                    if (resp.statusCode == 200)
-                        return Promise.resolve();
+    export function createDirectoryAsync(prj: string, key: string, name: string, incr?: () => void): Promise<void> {
+        pxt.debug(`create directory ${name}`)
+        if (!incr) incr = mkIncr(name);
+        return Util.multipartPostAsync(apiUri(prj, key, "add-directory"), { json: "", name: name })
+            .then(resp => {
+                if (resp.statusCode == 200)
+                    return Promise.resolve();
 
-                    const data: any = resp.json || { error: {} }
-                    if (resp.statusCode == 404 && data.error.code == 17) {
-                        pxt.log(`parent directory missing for ${name}`)
-                        const par = name.replace(/\/[^\/]+$/, "")
-                        if (par != name) {
-                            return createDirAsync(par)
-                                .then(() => createDirAsync(name)); // retry
-                        }
+                const data: any = resp.json || { error: {} }
+                if (resp.statusCode == 404 && data.error.code == 17) {
+                    pxt.log(`parent directory missing for ${name}`)
+                    const par = name.replace(/\/[^\/]+$/, "")
+                    if (par != name) {
+                        return createDirectoryAsync(prj, key, par, incr)
+                            .then(() => createDirectoryAsync(prj, key, name, incr)); // retry
                     }
+                }
 
-                    throw new Error(`cannot create dir ${name}: ${resp.toString()} ${JSON.stringify(data)}`)
-                })
-        }
+                throw new Error(`cannot create dir ${name}: ${resp.toString()} ${JSON.stringify(data)}`)
+            })
+    }
+
+    export function uploadTranslationAsync(prj: string, key: string, filename: string, jsondata: pxt.Map<string>) {
+        Util.assert(!!prj);
+        Util.assert(!!key);
+
+        // normalize file name for crowdin
+        filename = filename.replace(/\\/g, '/');
+
+        const incr = mkIncr(filename);
 
         function startAsync(): Promise<void> {
             return uploadAsync("update-file", { update_option: "update_as_unapproved" })
@@ -95,13 +102,13 @@ namespace pxt.crowdin {
             const code = resp.statusCode;
             const data: any = JSON.parse(resp.text);
 
-            console.log(`upload result: ${code}`);
+            pxt.debug(`upload result: ${code}`);
             if (code == 404 && data.error.code == 8) {
                 pxt.log(`create new translation file: ${filename}`)
                 return uploadAsync("add-file", {})
             }
             else if (code == 404 && data.error.code == 17) {
-                return createDirAsync(filename.replace(/\/[^\/]+$/, ""))
+                return createDirectoryAsync(prj, key, filename.replace(/\/[^\/]+$/, ""), incr)
                     .then(() => startAsync())
             } else if (code == 200) {
                 return Promise.resolve()


### PR DESCRIPTION
This change allows to store translations for multiple targets in the same crowdin project and share translations.