### PR TITLE
Setting the default editor font size to be smaller on mobile devices.

### DIFF
--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -65,7 +65,7 @@ namespace pxt.vs {
             experimentalScreenReader: true,
             mouseWheelZoom: true,
             tabCompletion: true,
-            wordBasedSuggestions: true, 
+            wordBasedSuggestions: true,
             lineNumbersMinChars: 2
         });
 

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -66,7 +66,7 @@ namespace pxt.vs {
             mouseWheelZoom: true,
             tabCompletion: true,
             wordBasedSuggestions: true,
-            lineNumbersMinChars: 2
+            lineNumbersMinChars: 3
         });
 
         window.addEventListener('resize', function () {

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -65,7 +65,8 @@ namespace pxt.vs {
             experimentalScreenReader: true,
             mouseWheelZoom: true,
             tabCompletion: true,
-            wordBasedSuggestions: true
+            wordBasedSuggestions: true, 
+            lineNumbersMinChars: 3
         });
 
         window.addEventListener('resize', function () {

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -66,7 +66,7 @@ namespace pxt.vs {
             mouseWheelZoom: true,
             tabCompletion: true,
             wordBasedSuggestions: true, 
-            lineNumbersMinChars: 3
+            lineNumbersMinChars: 2
         });
 
         window.addEventListener('resize', function () {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -136,7 +136,7 @@ namespace pxt.BrowserUtils {
         else {
             matches = /(Firefox|Seamonkey)\/([0-9\.]+)/i.exec(navigator.userAgent);
         }
-        if (matches.length == 0) {
+        if (!matches || matches.length == 0) {
             return null;
         }
         return matches[matches.length - 1];
@@ -275,7 +275,7 @@ namespace pxt.BrowserUtils {
     }
 
     export function browserDownloadUInt8Array(buf: Uint8Array, name: string, contentType: string = "application/octet-stream", onError?: (err: any) => void): string {
-        const isMobileBrowser = /mobile/.test(navigator.userAgent);
+        const isMobileBrowser = /mobile/i.test(navigator.userAgent);
         const isDesktopIE = (<any>window).navigator.msSaveOrOpenBlob && !isMobileBrowser;
 
         const dataurl = "data:" + contentType + ";base64," + btoa(Util.uint8ArrayToString(buf))

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -739,6 +739,18 @@ html {
 
 /* monaco: Editor */
 
+.monaco-editor .margin-view-overlays.monaco-editor-background {
+    background: rgba(0, 0, 0, 0.05);
+}
+
+.monaco-editor .monaco-scrollable-element.editor-scrollable {
+    margin-left: .5rem;
+}
+
+.monaco-editor.vs .line-numbers {
+    color: #2c3e50 !important;
+}
+
 .monaco-editor .current-line {
 	background: rgba(0, 0, 255, 0.1);
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -717,7 +717,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             showFiles: false,
             active: document.visibilityState == 'visible'
         };
-        if (this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 20;
+        if (!this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 20;
         if (!this.settings.fileHistory) this.settings.fileHistory = [];
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -717,7 +717,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             showFiles: false,
             active: document.visibilityState == 'visible'
         };
-        if (!this.settings.editorFontSize) this.settings.editorFontSize = 27;
+        if (this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 20;
         if (!this.settings.fileHistory) this.settings.fileHistory = [];
     }
 


### PR DESCRIPTION
Mobile default: 
<img width="486" alt="screen shot 2016-10-18 at 1 38 04 pm" src="https://cloud.githubusercontent.com/assets/16690124/19495429/30305756-9538-11e6-915f-6ab49b96f987.png">


Desktop default:
<img width="519" alt="screen shot 2016-10-18 at 1 38 21 pm" src="https://cloud.githubusercontent.com/assets/16690124/19495433/35ee1d90-9538-11e6-8c4f-db0233ab0b6c.png">

