### PR TITLE
Support prefix unary incrementors when decompiling for loops

### DIFF
--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -521,8 +521,8 @@ ${output}</xml>`;
                 popScope()
 
                 function incrementorIsValid(varName: string): boolean {
-                    if (n.incrementor.kind === SK.PostfixUnaryExpression) {
-                        const incrementor = n.incrementor as ts.PostfixUnaryExpression;
+                    if (n.incrementor.kind === SK.PostfixUnaryExpression || n.incrementor.kind === SK.PrefixUnaryExpression) {
+                        const incrementor = n.incrementor as ts.PostfixUnaryExpression | ts.PrefixUnaryExpression;
                         if (incrementor.operator === SK.PlusPlusToken && incrementor.operand.kind === SK.Identifier) {
                             return (incrementor.operand as ts.Identifier).text === varName;
                         }

--- a/tests/decompile-test/baselines/block_for2.blocks
+++ b/tests/decompile-test/baselines/block_for2.blocks
@@ -1,0 +1,13 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="controls_simple_for">
+<field name="VAR">i</field>
+<value name="TO">
+<shadow type="math_number">
+<field name="NUM">4</field>
+</shadow>
+</value>
+<statement name="DO">
+</statement>
+<comment pinned="false">prefix unary incrementor</comment>
+</block>
+</xml>

--- a/tests/decompile-test/block_for2.ts
+++ b/tests/decompile-test/block_for2.ts
@@ -1,0 +1,2 @@
+// prefix unary incrementor
+for (let i = 0; i <= 4; ++i) { }


### PR DESCRIPTION
Now we support both `++i` and `i++`. I could also special-case `i += 1`, but I don't think it's worth it because there are just too many cases to consider.

Fixes #520 