### PR TITLE
fixing hex files not retaining the old code

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -151,7 +151,7 @@ namespace pxt.runner {
         console.error(msg)
     }
 
-    function loadPackageAsync(id: string, code? : string) {
+    function loadPackageAsync(id: string, code?: string) {
         let host = mainPkg.host();
         mainPkg = new pxt.MainPackage(host)
         mainPkg._verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj"
@@ -163,7 +163,7 @@ namespace pxt.runner {
                 return mainPkg.installAllAsync().then( () => {
                     if (code) {
                         //Set the custom code if provided for docs
-                        getEditorPkg(mainPkg).files["main.ts"] = code;                        
+                        getEditorPkg(mainPkg).files["main.ts"] = code;
                     }
                 }).catch(e => {
                         showError(lf("Cannot load package: {0}", e.message))


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/133
Asm code in the hex was file. The source code was incorrect as it always included the default happy face. 