### PR TITLE
Modifying simulator interface and fixing mutation property name

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -33,7 +33,7 @@ namespace pxt.blocks {
 
     const mutatedVariableInputName = "properties";
     const mutatorStatmentInput = "PROPERTIES";
-    export const savedMutationAttribute = "callbackProperties";
+    export const savedMutationAttribute = "callbackproperties";
 
     const blockColors: Map<number> = {
         loops: 120,

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -636,7 +636,7 @@ ${output}</xml>`;
                             return "";
                         }
                     });
-                    write(`<mutation callbackProperties="${names.join(",")}"></mutation>`)
+                    write(`<mutation callbackproperties="${names.join(",")}"></mutation>`)
                 }
 
                 function checkName(name: Node) {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -56,9 +56,19 @@ namespace pxsim {
         sim?: boolean;
     }
     export interface SimulatorRadioPacketMessage extends SimulatorMessage {
-        data: number[];
-        rssi?: number;
+        rssi: number;
+        serial: number;
+        time: number;
+
+        payload: SimulatorRadioPacketPayload;
     }
+
+    export interface SimulatorRadioPacketPayload {
+        type: number;
+        stringData?: string;
+        numberData?: number;
+    }
+
 
     export namespace Embed {
         export function start() {


### PR DESCRIPTION
This is a breaking change for the simulator. In support of https://github.com/Microsoft/pxt-microbit/pull/287