### PR TITLE
Adding support for deprecated flag

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -81,6 +81,46 @@ The following types are supported in function signatures that are meant to be ex
 * custom classes that are also exported
 * arrays of the above
 
+## Callbacks with Parameters
+
+APIs that take in a callback function will have that callback converted into a statement input.
+If the callback in the API is designed to take in parameters, the best way to map that pattern
+to the blocks is by passing the callback a single parameter with a class type that contains
+all the other values. For example:
+
+```typescript
+
+export class ArgumentClass {
+    argumentA: number;
+    argumentB: string;
+}
+
+//% mutate=true
+//% mutateText="My Arguments"
+//% mutateDefaults="argumentA;argumentA,argumentB"
+// ...
+export function addSomeEventHandler((a: ArgumentClass) => void) { };
+```
+
+In the above example, setting `mutate=true` will cause this API to use Blockly "mutators"
+to let users change what parameters appear in the blocks. Each parameter will be given an
+optional variable field in the block that defines a variable that can be used within the callback.
+The variable fields compile to object destructuring in the TypeScript code. For example:
+
+```typescript
+
+addSomeEventHandler(({argumentA, argumentB}) => {
+
+})
+
+```
+
+For an example of this pattern in action, see the `radio.onDataPacketReceived` block. The other attributes
+related to mutators include:
+
+* `mutateText` - defines the text that appears in the top block of the Blockly mutator dialog (the dialog that appears when you click the blue gear)
+* `mutateDefaults` - defines the versions of this block that should appear in the toolbox. Block definitions are separated by semicolons and property names should be separated by commas
+
 ## Enums
 
 Enum are supported and will automatically be represented by a dropdown in blocks.
@@ -204,6 +244,19 @@ To do so, the ideal setup is:
 - refresh the browser and try out the changes on a dummy program.
 
 Interrestingly, you can design your entire API without implementing it!
+
+## Deprecating Blocks
+
+To deprecate an existing API, you can add the **deprecated** attribute like so:
+
+```
+//% deprecated=true
+```
+
+This will cause the API to still be usable in TypeScript, but prevent the block from appearing in the
+Blockly toolbox. If a user tries to load a project that uses the old API, the project will still load
+correctly as long as the TypeScript API is present. Any deprecated blocks in the project will appear in
+the editor but not the toolbox.
 
 ## API design Tips and Tricks
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -195,62 +195,64 @@ namespace pxt.blocks {
         if (fn.attributes.shim == "TD_ID")
             return;
 
-        let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
-        let nsn = info.apis.byQName[ns];
-        if (nsn) ns = nsn.attributes.block || ns;
-        let catName = ts.pxtc.blocksCategory(fn);
-        let category = categoryElement(tb, catName);
+        if (!fn.attributes.deprecated) {
+            let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
+            let nsn = info.apis.byQName[ns];
+            if (nsn) ns = nsn.attributes.block || ns;
+            let catName = ts.pxtc.blocksCategory(fn);
+            let category = categoryElement(tb, catName);
 
-        if (!category) {
-            let categories = getChildCategories(tb)
-            let parentCategoryList = tb;
+            if (!category) {
+                let categories = getChildCategories(tb)
+                let parentCategoryList = tb;
 
-            pxt.debug('toolbox: adding category ' + ns)
+                pxt.debug('toolbox: adding category ' + ns)
 
-            const nsWeight = (nsn ? nsn.attributes.weight : 50) || 50;
-            category = createCategoryElement(catName, nsWeight)
+                const nsWeight = (nsn ? nsn.attributes.weight : 50) || 50;
+                category = createCategoryElement(catName, nsWeight)
 
-            if (nsn && nsn.attributes.color) {
-                category.setAttribute("colour", nsn.attributes.color);
-            }
-            else if (blockColors[ns]) {
-                category.setAttribute("colour", blockColors[ns].toString());
-            }
-
-            if (nsn.attributes.advanced) {
-                const advancedCategoryName = Util.lf("{id:category}Advanced")
-                parentCategoryList = getOrAddSubcategory(tb, advancedCategoryName, 1)
-                categories = getChildCategories(parentCategoryList)
-            }
-
-            // Insert the category based on weight
-            let ci = 0;
-            for (ci = 0; ci < categories.length; ++ci) {
-                let cat = categories[ci];
-                if (parseInt(cat.getAttribute("weight") || "50") < nsWeight) {
-                    parentCategoryList.insertBefore(category, cat);
-                    break;
+                if (nsn && nsn.attributes.color) {
+                    category.setAttribute("colour", nsn.attributes.color);
                 }
-            }
-            if (ci == categories.length)
-                parentCategoryList.appendChild(category);
-        }
-        if (fn.attributes.advanced) {
-            category = getOrAddSubcategory(category, Util.lf("More\u2026"), 1, category.getAttribute("colour"))
-        }
+                else if (blockColors[ns]) {
+                    category.setAttribute("colour", blockColors[ns].toString());
+                }
 
-        if (fn.attributes.mutateDefaults) {
-            const mutationValues = fn.attributes.mutateDefaults.split(";");
-            mutationValues.forEach(mutation => {
-                const mutatedBlock = block.cloneNode(true);
-                const mutationElement = document.createElement("mutation");
-                mutationElement.setAttribute(savedMutationAttribute, mutation);
-                mutatedBlock.appendChild(mutationElement);
-                category.appendChild(mutatedBlock);
-            });
-        }
-        else {
-            category.appendChild(block);
+                if (nsn.attributes.advanced) {
+                    const advancedCategoryName = Util.lf("{id:category}Advanced")
+                    parentCategoryList = getOrAddSubcategory(tb, advancedCategoryName, 1)
+                    categories = getChildCategories(parentCategoryList)
+                }
+
+                // Insert the category based on weight
+                let ci = 0;
+                for (ci = 0; ci < categories.length; ++ci) {
+                    let cat = categories[ci];
+                    if (parseInt(cat.getAttribute("weight") || "50") < nsWeight) {
+                        parentCategoryList.insertBefore(category, cat);
+                        break;
+                    }
+                }
+                if (ci == categories.length)
+                    parentCategoryList.appendChild(category);
+            }
+            if (fn.attributes.advanced) {
+                category = getOrAddSubcategory(category, Util.lf("More\u2026"), 1, category.getAttribute("colour"))
+            }
+
+            if (fn.attributes.mutateDefaults) {
+                const mutationValues = fn.attributes.mutateDefaults.split(";");
+                mutationValues.forEach(mutation => {
+                    const mutatedBlock = block.cloneNode(true);
+                    const mutationElement = document.createElement("mutation");
+                    mutationElement.setAttribute(savedMutationAttribute, mutation);
+                    mutatedBlock.appendChild(mutationElement);
+                    category.appendChild(mutatedBlock);
+                });
+            }
+            else {
+                category.appendChild(block);
+            }
         }
     }
 

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -276,6 +276,7 @@ namespace ts.pxtc {
         parts?: string;
         trackArgs?: number[];
         advanced?: boolean;
+        deprecated?: boolean;
 
         // on interfaces
         indexerGet?: string;


### PR DESCRIPTION
If you mark a typescript API with `//% deprecated=true`, the blocks will not appear in the toolbox but can still be loaded into projects.

Also added some documentation for mutators while I was in that file because I forgot to add it earlier.