### PR TITLE
Adding mixpanel event for loading projects that use deprecated blocks

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -58,7 +58,7 @@ namespace pxt {
     /**
      * Track an event.
      */
-    export var tickEvent: (id: string, data?: Map<string | number> | string[]) => void = function (id) { }
+    export var tickEvent: (id: string, data?: Map<string | number>) => void = function (id) { }
 
     let activityEvents: Map<number> = {};
     const tickActivityDebounced = Util.debounce(() => {

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -51,14 +51,14 @@ namespace pxt {
     }
 
     /**
-     * Time an event by including the time between this call 
+     * Time an event by including the time between this call
      * and a later 'tickEvent' call for the same event in the properties sent with the event.
      */
     export var timeEvent: (id: string) => void = function (id) { }
     /**
      * Track an event.
      */
-    export var tickEvent: (id: string, data?: Map<string | number>) => void = function (id) { }
+    export var tickEvent: (id: string, data?: Map<string | number> | string[]) => void = function (id) { }
 
     let activityEvents: Map<number> = {};
     const tickActivityDebounced = Util.debounce(() => {
@@ -469,7 +469,7 @@ namespace pxt {
             let upgradeFile = (fn: string, cont: string) => {
                 let updatedCont = this.upgradeAPI(cont);
                 if (updatedCont != cont) {
-                    // save file (force write) 
+                    // save file (force write)
                     pxt.debug(`updating APIs in ${fn} (size=${cont.length})...`)
                     this.host().writeFile(this, fn, updatedCont, true)
                 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -120,7 +120,6 @@ export class Editor extends srceditor.Editor {
 
     private reportDeprecatedBlocks() {
         const deprecatedMap: {[index: string]: FoundState } = {};
-        let deprecatedFound = false;
 
         this.blockInfo.blocks.forEach(symbolInfo => {
             if (symbolInfo.attributes.deprecated) {
@@ -131,18 +130,19 @@ export class Editor extends srceditor.Editor {
         this.editor.getAllBlocks().forEach(block => {
             if (deprecatedMap[block.type]) {
                 deprecatedMap[block.type] = FoundState.IsPresent;
-                deprecatedFound = true;
             }
         });
 
-        if (deprecatedFound) {
-            for (const block in deprecatedMap) {
-                if (deprecatedMap[block] === FoundState.MaybePresent) {
-                    delete deprecatedMap[block];
-                }
-            }
+        const foundBlocks: string[] = []
 
-            pxt.tickEvent("blocks.usingDeprecated", deprecatedMap);
+        for (const block in deprecatedMap) {
+            if (deprecatedMap[block] === FoundState.IsPresent) {
+                foundBlocks.push(block);
+            }
+        }
+
+        if (foundBlocks.length) {
+            pxt.tickEvent("blocks.usingDeprecated", foundBlocks);
         }
     }
 


### PR DESCRIPTION
Fixes #571 

This event will fire whenever a Blockly project is loaded, including when you switch from TypeScript to Blockly after making a change in the TypeScript. The payload for the event is a map of deprecated block IDs to the number "1" because the API of `pxt.tickEvent` will only take a number or string map. Does `mixpanel.track()` support arrays? If so, I'll change it to just be an array of block IDs.