### PR TITLE
Fix not being able to create new variables in blockly.

### DIFF
--- a/docs/develop/blocklyupgrade.md
+++ b/docs/develop/blocklyupgrade.md
@@ -57,3 +57,6 @@ Test the following on various browsers:
 ### Sandbox Mode
 
 * Check sandbox mode for both the blocks editor and the Javascript editor. 
+
+### Custom Variables Flyout 
+* Check that the custom variables flyout looks right, and that you're able to create, delete, and change variables from within Blockly.

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1426,6 +1426,11 @@ namespace pxt.blocks {
     function initVariables() {
         let varname = lf("{id:var}item");
         Blockly.Variables.flyoutCategory = function (workspace) {
+            let xmlList: HTMLElement[] = [];
+            let button = goog.dom.createDom('button');
+            button.setAttribute('text', (<any>Blockly).Msg.NEW_VARIABLE);
+            xmlList.push(button);
+
             let variableList = Blockly.Variables.allVariables(workspace);
             variableList.sort(goog.string.caseInsensitiveCompare);
             // In addition to the user's variables, we also want to display the default
@@ -1434,7 +1439,6 @@ namespace pxt.blocks {
             goog.array.remove(variableList, varname);
             variableList.unshift(varname);
 
-            let xmlList: HTMLElement[] = [];
             // variables getters first
             for (let i = 0; i < variableList.length; i++) {
                 // <block type="variables_get" gap="24">

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1428,7 +1428,7 @@ namespace pxt.blocks {
         Blockly.Variables.flyoutCategory = function (workspace) {
             let xmlList: HTMLElement[] = [];
             let button = goog.dom.createDom('button');
-            button.setAttribute('text', (<any>Blockly).Msg.NEW_VARIABLE);
+            button.setAttribute('text', lf("Make a Variable"));
             xmlList.push(button);
 
             let variableList = Blockly.Variables.allVariables(workspace);

--- a/theme/themes/pxt/globals/site.overrides
+++ b/theme/themes/pxt/globals/site.overrides
@@ -26,6 +26,10 @@
     font-size:1.25rem !important;
 }
 
+.blocklyFlyoutButton {
+    fill: rgb(165, 91, 128) !important;
+}
+
 /* This horrendous selector and the next are for subcategories in the Blockly toolbox */
 .blocklyTreeRoot div div div div .blocklyTreeRow {
     border-left-width: 12px !important;


### PR DESCRIPTION
Blockly removed the option to create a new variable from the variables dropdown. 
Adding option in the Variables menu to create a new variable, like so: 
 
![screen shot 2016-10-31 at 5 56 26 pm](https://cloud.githubusercontent.com/assets/16690124/19876442/621f3150-9f93-11e6-83a1-6f6330c8ac88.png)

fixes #630 