### PR TITLE
Fixing the Blockly Monaco resize issue.

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -33,6 +33,7 @@ declare namespace Blockly {
     function genUid(): string;
     function terminateDrag_(): void;
     function mouseToSvg(e: Event, svg: Element): any;
+    function svgResize(workspace: Blockly.Workspace): void;
 
     let ALIGN_RIGHT: number;
 

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -67,11 +67,8 @@ namespace pxt.vs {
             tabCompletion: true,
             wordBasedSuggestions: true,
             lineNumbersMinChars: 3,
+            automaticLayout: true,
             theme: pxt.appTarget.appTheme.invertedMonaco ? 'vs-dark' : 'vs'
-        });
-
-        window.addEventListener('resize', function () {
-            editor.layout();
         });
 
         editor.layout();

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -134,9 +134,6 @@
 /*******************************
         Monaco Editor
 *******************************/
-#monacoEditor {
-    direction:ltr;
-}
 
 .monaco-editor .monaco-scrollable-element.editor-scrollable {
     margin-left: .5rem;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -32,9 +32,6 @@ body {
 .ui.item.logo img {
     height: 2.5rem;
 }
-#monacoEditor {
-    direction:ltr;
-}
 
 #cookiemsg {
    position: absolute;
@@ -540,8 +537,7 @@ html {
 *******************************/
 
 #blocksEditor {
-    right:0rem;
-    bottom:0rem;
+    position: absolute;
 }
 
 #blocksEditor > div.loading {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -799,7 +799,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         this.saveSettings()
         this.editor.domUpdate();
         simulator.setState(this.state.header ? this.state.header.editor : '')
-        this.fireResize();
     }
 
     fireResize() {
@@ -2202,6 +2201,10 @@ $(document).ready(() => {
         if (theEditor)
             theEditor.saveSettings()
     });
+    window.addEventListener("resize", ev => {
+        if (theEditor && theEditor.editor)
+            theEditor.editor.resize(ev)
+    }, false);
     window.addEventListener("message", ev => {
         let m = ev.data as pxsim.SimulatorMessage;
         if (!m) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -53,6 +53,7 @@ export class Editor extends srceditor.Editor {
 
             let loading = document.createElement("div");
             loading.className = "ui inverted loading";
+            let editorArea = document.getElementById('blocksArea');
             let editorDiv = document.getElementById("blocksEditor");
             editorDiv.appendChild(loading);
 
@@ -65,6 +66,9 @@ export class Editor extends srceditor.Editor {
                     let xml = this.delayLoadXml;
                     this.delayLoadXml = undefined;
                     this.loadBlockly(xml);
+
+                    this.resize();
+                    Blockly.svgResize(this.editor);
                     this.isFirstBlocklyLoad = false;
                 }).finally(() => {
                     editorDiv.removeChild(loading);
@@ -303,8 +307,28 @@ export class Editor extends srceditor.Editor {
                 }
             }
         })
+        this.resize();
+        Blockly.svgResize(this.editor);
 
         this.isReady = true
+    }
+
+    resize(e?: Event) {
+        let blocklyArea = document.getElementById('blocksArea');
+        let blocklyDiv = document.getElementById('blocksEditor');
+
+        // Compute the absolute coordinates and dimensions of blocklyArea.
+        let element = blocklyArea;
+        let x = 0;
+        let y = 0;
+        do {
+            x += element.offsetLeft;
+            y += element.offsetTop;
+            element = element.offsetParent as HTMLElement;
+        } while (element);
+        // Position blocklyDiv over blocklyArea.
+        blocklyDiv.style.width = blocklyArea.offsetWidth + 'px';
+        blocklyDiv.style.height = blocklyArea.offsetHeight + 'px';
     }
 
     undo() {
@@ -312,7 +336,15 @@ export class Editor extends srceditor.Editor {
     }
 
     getId() {
-        return "blocksEditor"
+        return "blocksArea"
+    }
+
+    display() {
+        return (
+            <div>
+                <div id="blocksEditor"></div>
+            </div>
+        )
     }
 
     getViewState() {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -393,6 +393,10 @@ export class Editor extends srceditor.Editor {
         this.isReady = true
     }
 
+    resize(e?: Event) {
+        this.editor.layout();
+    }
+
     zoomIn() {
         if (this.parent.settings.editorFontSize >= MAX_EDITOR_FONT_SIZE) return;
         let currentFont = this.editor.getConfiguration().fontInfo.fontSize;
@@ -477,6 +481,8 @@ export class Editor extends srceditor.Editor {
                 this.loadFile(this.currFile);
             }
         });
+
+        this.resize();
     }
 
     snapshotState() {

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -56,6 +56,7 @@ export class Editor {
     prepare() {
         this.isReady = true;
     }
+    resize(e?: Event) { }
     domUpdate() { }
     saveToTypeScript(): string {
         return null


### PR DESCRIPTION
No more global resize event firing when the Project component is updated. 

- Blockly resizing itself (as recommended: https://developers.google.com/blockly/guides/configure/web/resizable)
- Monaco using Auto layout

Tested Main and Sandbox view on Chrome and Safari. 
This needs to be tested on IE and Edge.

Fixes #691 