### PR TITLE
Fix for sizing issue of the red blocks within the showLed block

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -201,8 +201,11 @@
 
 
 @media only screen and (max-width: @largestMobileScreen) {
-    .blocklyTreeLabel, .blocklyText {
+    .blocklyTreeLabel {
         font-size: 0.75rem !important;
+    }
+    .blocklyCheckbox {
+        font-size: 17pt !important;
     }
     .blocklyTreeRoot div div div div .blocklyTreeRow .blocklyTreeLabel {
         font-size: 0.75rem !important;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -509,9 +509,6 @@ html {
         font-size: 0rem;
         padding-right: 0;
     }
-    .blocklyCheckbox {
-        font-size: 17pt !important;
-    }
     div.simframe {
         display:inline-block;
         width: 10rem;


### PR DESCRIPTION
Fixes #693

<img width="374" alt="screen shot 2016-11-04 at 2 19 26 pm" src="https://cloud.githubusercontent.com/assets/16690124/20022929/1ffa9d1e-a29a-11e6-858c-0ff552d3c8aa.png">
