### PR TITLE
Blockly / Simulator Optimizations

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -275,6 +275,7 @@ declare namespace Blockly {
         undo(): void;
         redo(): void;
         clearUndo(): void;
+        isDragging(): boolean;
         getMetrics(): {
             absoluteLeft: number;
             absoluteTop: number;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -638,17 +638,17 @@ namespace pxt.blocks {
             .keys(cachedBlocks).filter(k => !currentBlocks[k])
             .forEach(k => removeBlock(cachedBlocks[k].fn));
 
-        // remove unused categories
-        let config = pxt.appTarget.runtime || {};
-        if (!config.mathBlocks) removeCategory(tb, "Math");
-        if (!config.textBlocks) removeCategory(tb, "Text");
-        if (!config.listsBlocks) removeCategory(tb, "Lists");
-        if (!config.variablesBlocks) removeCategory(tb, "Variables");
-        if (!config.logicBlocks) removeCategory(tb, "Logic");
-        if (!config.loopsBlocks) removeCategory(tb, "Loops");
-
-        // Load localized names for default categories
         if (tb) {
+            // remove unused categories
+            let config = pxt.appTarget.runtime || {};
+            if (!config.mathBlocks) removeCategory(tb, "Math");
+            if (!config.textBlocks) removeCategory(tb, "Text");
+            if (!config.listsBlocks) removeCategory(tb, "Lists");
+            if (!config.variablesBlocks) removeCategory(tb, "Variables");
+            if (!config.logicBlocks) removeCategory(tb, "Logic");
+            if (!config.loopsBlocks) removeCategory(tb, "Loops");
+
+            // Load localized names for default categories   
             let cats = tb.querySelectorAll('category');
             for (let i = 0; i < cats.length; i++) {
                 cats[i].setAttribute('name',

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -746,6 +746,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     scriptSearch: ScriptSearch;
     shareEditor: ShareEditor;
 
+    private lastChangeTime: number;
+
     constructor(props: IAppProps) {
         super(props);
         document.title = pxt.appTarget.title || pxt.appTarget.name;
@@ -845,21 +847,26 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
 
     private autoRunBlocksSimulator = pxtc.Util.debounce(
         () => {
+            if (new Date().getTime() - this.lastChangeTime < 1000) return;
             if (!this.state.active)
                 return;
             this.runSimulator({ background: true });
         },
-        2000, false);
+        1000, true);
+
     private autoRunSimulator = pxtc.Util.debounce(
         () => {
+            if (new Date().getTime() - this.lastChangeTime < 1000) return;
             if (!this.state.active)
                 return;
             this.runSimulator({ background: true });
         },
-        4000, false);
-    private typecheck() {
-        let state = this.editor.snapshotState()
-        compiler.typecheckAsync()
+        2000, true);
+
+    private typecheck = pxtc.Util.debounce(
+        () => {
+            let state = this.editor.snapshotState()
+            compiler.typecheckAsync()
             .done(resp => {
                 this.editor.setDiagnostics(this.editorFile, state)
                 if (pxt.appTarget.simulator && pxt.appTarget.simulator.autoRun) {
@@ -872,16 +879,17 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                     }
                 }
             });
-    }
+        }, 1000, false);
 
     private markdownChangeHandler = Util.debounce(() => {
         if (this.state.currFile && /\.md$/i.test(this.state.currFile.name))
             this.setSideMarkdown(this.editor.getCurrentSource());
     }, 4000, false);
     private editorChangeHandler = Util.debounce(() => {
-        this.saveFile();
-        if (!this.editor.isIncomplete())
+        if (!this.editor.isIncomplete()) {
+            this.saveFile();
             this.typecheck();
+        }
         this.markdownChangeHandler();
     }, 1000, false);
     private initEditors() {
@@ -895,6 +903,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                     pxt.tickActivity("edit", "edit." + this.editor.getId().replace(/Editor$/, ''))
                 this.editorFile.markDirty();
             }
+            this.lastChangeTime = new Date().getTime();
             this.editorChangeHandler();
         }
         this.allEditors = [this.pxtJsonEditor, this.blocksEditor, this.textEditor]

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -225,6 +225,10 @@ export class Editor extends srceditor.Editor {
         }
     }
 
+    isIncomplete() {
+        return this.editor.isDragging();
+    }
+
     prepare() {
         let blocklyDiv = document.getElementById('blocksEditor');
         let toolboxDiv = document.getElementById('blocklyToolboxDefinition');
@@ -251,7 +255,7 @@ export class Editor extends srceditor.Editor {
         this.editor = Blockly.inject(blocklyDiv, blocklyOptions);
         pxt.blocks.initMouse(this.editor);
         this.editor.addChangeListener((ev) => {
-            if (ev.recordUndo) {
+            if (ev.type != 'ui') {
                 this.changeCallback();
             }
             if (ev.type == 'create') {


### PR DESCRIPTION
Fixes #668
- Dragging: A change is incomplete if we are still dragging. So similar to how we don't record a change in monaco when the Intellisense menu is up. Dragging now also limits the calls to typecheck / run simulator, if we are dragging.
- Saving: If a change is incomplete, dragging / intellisense, then we don't save.
- Record Undo: Fixes undo bug where we weren't recording that a change had happened when we undo in blockly. fixes #672 
- Debounce: Any change made will trigger a change of debounce events like so: 
  - A change has happened, 1 second
  - Typecheck, 1 second
  - Run Simulator, 1 second in Blocks, 2 in Javascript
 - Although, when the editor is updated (first load / switch between blocks and JS), the first step is skipped and we go straight to Typechecking. I've added a check in the Simulator to make sure first that a change hasn't happened in the last second, to limit getting in a situation where even though we just made a change, we "technically" have not made a call to run the simulator within 2 seconds and so the simulator reloads in the middle of our change.
