### PR TITLE
Ensure minimum node version is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm link ../pxt
 
 ## Build
 
-First, install Node (http://nodejs.org/). Then install the following:
+First, install (Node)[http://nodejs.org/]: minimum version 5.7. Then install the following:
 ```
 npm install -g jake
 npm install -g tsd


### PR DESCRIPTION
The code ensures node version is correct, but the user is not warned of requirements in connection with planning the installation of pxt.