### PR TITLE
Editorcontext

### DIFF
--- a/pxtlib/emitter/service.ts
+++ b/pxtlib/emitter/service.ts
@@ -68,6 +68,44 @@ namespace ts.pxtc {
 . . . . .
 `
 
+    export function localizeApisAsync(apis: pxtc.ApisInfo, mainPkg: pxt.MainPackage): Promise<pxtc.ApisInfo> {
+        const lang = pxtc.Util.userLanguage();
+        if (pxtc.Util.userLanguage() == "en") return Promise.resolve(apis);
+
+        return mainPkg.localizationStringsAsync(lang)
+            .then(loc => Util.values(apis.byQName).forEach(fn => {
+                const jsDoc = loc[fn.qName]
+                if (jsDoc) {
+                    fn.attributes.jsDoc = jsDoc;
+                    if (fn.parameters)
+                        fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || pi.description);
+                }
+                if (fn.attributes.block) {
+                    const locBlock = loc[`${fn.qName}|block`];
+                    if (locBlock) {
+                        try {
+                            if (pxt.blocks.areFieldsEquivalent(fn.attributes.block, locBlock))
+                                fn.attributes.block = locBlock;
+                            else {
+                                const fields = JSON.stringify(pxt.blocks.parseFields(fn.attributes.block), null, 2);
+                                const locFields = JSON.stringify(pxt.blocks.parseFields(locBlock), null, 2);
+                                console.error(`localized block description of ${fn.attributes.block} invalid`);
+                                console.debug(`original: `, fields);
+                                console.debug(`loc: `, locFields);
+                            }
+                        } catch (e) {
+                            console.error(`error while parsing localized block of ${fn.attributes.block}`);
+                        }
+                    }
+                }
+                const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
+                if (nsDoc) {
+                    fn.attributes.block = nsDoc;
+                }
+            }))
+            .then(() => apis);
+    }
+
     /**
      * Unlocalized category name for a symbol
      */

--- a/pxtlib/emitter/util.ts
+++ b/pxtlib/emitter/util.ts
@@ -529,6 +529,12 @@ namespace ts.pxtc.Util {
     export var localizeLive = false;
 
     /**
+     * Returns the current user language, prepended by "live-" if in live mode
+     */
+    export function localeInfo(): string {
+        return `${localizeLive ? "live-" : ""}${userLanguage()}`;
+    }
+    /**
      * Returns current user language iSO-code. Default is `en`.
      */
     export function userLanguage(): string {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -19,6 +19,7 @@ namespace pxt.runner {
         pxtUrl?: string;
         packageClass?: string;
         package?: string;
+        showJavaScript?: boolean; // default is to show blocks first
         downloadScreenshots?: boolean
     }
 
@@ -30,9 +31,13 @@ namespace pxt.runner {
         hex?: string;
     }
 
+    function appendBlocks($parent: JQuery, $svg: JQuery) {
+        $parent.append($('<div class="ui content blocks"/>').append($svg));
+    }
+
     function appendJs($parent: JQuery, $js: JQuery, woptions: WidgetOptions) {
         $parent.append($('<div class="ui content js"/>').append($js));
-        $('code.highlight').each(function(i, block) {
+        $('code.highlight').each(function (i, block) {
             let hljs = pxt.docs.requireHighlightJs();
             if (hljs) hljs.highlightBlock(block);
         });
@@ -59,22 +64,40 @@ namespace pxt.runner {
         let $c = $('<div class="ui top attached segment"></div>');
         let $menu = $h.find('.right.menu');
 
-        // blocks
-        $c.append($svg);
+        if (options.showJavaScript) {
+            // blocks
+            $c.append($js);
 
-        // js menu
-        if (woptions.showJs) {
-            appendJs($c, $js, woptions);
+            // js menu
+            if ($svg) {
+                const $svgBtn = $('<a class="item blocks"><i aria-label="Blocks" class="puzzle icon"></i></a>').click(() => {
+                    if ($c.find('.blocks')[0])
+                        $c.find('.blocks').remove();
+                    else {
+                        if ($js) appendBlocks($js.parent(), $svg);
+                        else appendBlocks($c, $svg);
+                    }
+                })
+                $menu.append($svgBtn);
+            }
         } else {
-            let $jsBtn = $('<a class="item js"><i aria-label="JavaScript" class="align left icon"></i></a>').click(() => {
-                if ($c.find('.js')[0])
-                    $c.find('.js').remove(); // remove previous simulators
-                else {
-                    if ($svg) appendJs($svg.parent(), $js, woptions);
-                    else appendJs($c, $js, woptions);
-                }
-            })
-            $menu.append($jsBtn);
+            // blocks
+            $c.append($svg);
+
+            // js menu
+            if (woptions.showJs) {
+                appendJs($c, $js, woptions);
+            } else {
+                const $jsBtn = $('<a class="item js"><i aria-label="JavaScript" class="align left icon"></i></a>').click(() => {
+                    if ($c.find('.js')[0])
+                        $c.find('.js').remove();
+                    else {
+                        if ($svg) appendJs($svg.parent(), $js, woptions);
+                        else appendJs($c, $js, woptions);
+                    }
+                })
+                $menu.append($jsBtn);
+            }
         }
 
         // runner menu

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -340,10 +340,12 @@ namespace pxt.runner {
         }
 
         function renderHash() {
-            let m = /^#(doc|md):([^&?:]+)(:([^&?:]+))?/i.exec(window.location.hash);
+            let m = /^#(doc|md):([^&?:]+)(:([^&?:]+):([^&?:]+))?/i.exec(window.location.hash);
             if (m) {
                 // navigation occured
-                if (m[4]) setEditorContext(languageMode, m[4]);
+                if (m[4]) setEditorContext(
+                    /^blocks$/.test(m[4]) ? LanguageMode.Blocks : LanguageMode.TypeScript,
+                    m[5]);
                 render(m[1], decodeURIComponent(m[2]));
             }
         }
@@ -475,6 +477,7 @@ ${files["main.ts"]}
             snippetReplaceParent: true,
             simulator: true,
             hex: true,
+            showJavaScript: languageMode == LanguageMode.TypeScript,
             hexName: pxt.appTarget.id
         }).then(() => {
             // patch a elements

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -266,12 +266,14 @@ namespace pxt.runner {
 
     export var languageMode = LanguageMode.Blocks;
     export var editorLocale = "en";
+    export var editorLocaleLive = false;
     export var onEditorContextChanged: () => void = undefined;
 
     export function setEditorContext(mode: LanguageMode, locale: string) {
         if (mode != languageMode || locale != editorLocale) {
             languageMode = mode;
-            editorLocale = locale;
+            editorLocale = locale.replace(/^live-/, '');
+            editorLocaleLive = editorLocale != locale;
             if (onEditorContextChanged) onEditorContextChanged();
         }
     }
@@ -375,7 +377,10 @@ ${files["main.ts"]}
     function renderDocAsync(content: HTMLElement, docid: string): Promise<void> {
         docid = docid.replace(/^\//, "");
         let url = `md/${pxt.appTarget.id}/${docid}`;
-        if (editorLocale != "en") url += `?lang=${encodeURIComponent(editorLocale)}`
+        if (editorLocale != "en") {
+            url += `?lang=${encodeURIComponent(editorLocale)}`
+            if (editorLocaleLive) url += "&live=1"
+        }
         return pxt.Cloud.privateGetTextAsync(url)
             .then(md => renderMarkdownAsync(content, md, docid))
     }

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -24,6 +24,7 @@ namespace pxsim {
 
     export interface SimulatorFileLoadedMessage extends SimulatorMessage {
         name: string;
+        locale: string;
         content?: string;
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -600,13 +600,13 @@ class SideDocs extends data.Component<ISettingsProps, {}> {
 
     setPath(path: string) {
         const docsUrl = pxt.webConfig.docsUrl || '/--docs';
-        const url = `${docsUrl}#doc:${path}`;
+        const url = `${docsUrl}#doc:${path}:${pxt.Util.userLanguage()}`;
         this.setUrl(url);
     }
 
     setMarkdown(md: string) {
         const docsUrl = pxt.webConfig.docsUrl || '/--docs';
-        const url = `${docsUrl}#md:${encodeURIComponent(md)}`;
+        const url = `${docsUrl}#md:${encodeURIComponent(md)}:${pxt.Util.userLanguage()}`;
         this.setUrl(url);
     }
 
@@ -970,7 +970,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
 
         SideDocs.notify({
             type: "fileloaded",
-            name: this.editorFile.getName()
+            name: this.editorFile.getName(),
+            locale: pxt.Util.userLanguage()
         } as pxsim.SimulatorFileLoadedMessage)
 
         if (this.state.showBlocks && this.editor == this.textEditor) this.textEditor.openBlocks();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -602,7 +602,7 @@ class SideDocs extends data.Component<ISettingsProps, {}> {
         const docsUrl = pxt.webConfig.docsUrl || '/--docs';
         const mode = this.props.parent.editor == this.props.parent.blocksEditor
             ? "blocks" : "js";
-        const url = `${docsUrl}#doc:${path}:${mode}:${pxt.Util.userLanguage()}`;
+        const url = `${docsUrl}#doc:${path}:${mode}:${pxt.Util.localeInfo()}`;
         this.setUrl(url);
     }
 
@@ -610,7 +610,7 @@ class SideDocs extends data.Component<ISettingsProps, {}> {
         const docsUrl = pxt.webConfig.docsUrl || '/--docs';
         const mode = this.props.parent.editor == this.props.parent.blocksEditor
             ? "blocks" : "js";
-        const url = `${docsUrl}#md:${encodeURIComponent(md)}:${mode}:${pxt.Util.userLanguage()}`;
+        const url = `${docsUrl}#md:${encodeURIComponent(md)}:${mode}:${pxt.Util.localeInfo()}`;
         this.setUrl(url);
     }
 
@@ -975,7 +975,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         SideDocs.notify({
             type: "fileloaded",
             name: this.editorFile.getName(),
-            locale: pxt.Util.userLanguage()
+            locale: pxt.Util.localeInfo()
         } as pxsim.SimulatorFileLoadedMessage)
 
         if (this.state.showBlocks && this.editor == this.textEditor) this.textEditor.openBlocks();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -600,13 +600,17 @@ class SideDocs extends data.Component<ISettingsProps, {}> {
 
     setPath(path: string) {
         const docsUrl = pxt.webConfig.docsUrl || '/--docs';
-        const url = `${docsUrl}#doc:${path}:${pxt.Util.userLanguage()}`;
+        const mode = this.props.parent.editor == this.props.parent.blocksEditor
+            ? "blocks" : "js";
+        const url = `${docsUrl}#doc:${path}:${mode}:${pxt.Util.userLanguage()}`;
         this.setUrl(url);
     }
 
     setMarkdown(md: string) {
         const docsUrl = pxt.webConfig.docsUrl || '/--docs';
-        const url = `${docsUrl}#md:${encodeURIComponent(md)}:${pxt.Util.userLanguage()}`;
+        const mode = this.props.parent.editor == this.props.parent.blocksEditor
+            ? "blocks" : "js";
+        const url = `${docsUrl}#md:${encodeURIComponent(md)}:${mode}:${pxt.Util.userLanguage()}`;
         this.setUrl(url);
     }
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -155,50 +155,12 @@ function waitForFirstTypecheckAsync() {
     else return typecheckAsync();
 }
 
-function localizeApisAsync(apis: pxtc.ApisInfo): Promise<pxtc.ApisInfo> {
-    const lang = pxtc.Util.userLanguage();
-    if (pxtc.Util.userLanguage() == "en") return Promise.resolve(apis);
-
-    return pkg.mainPkg.localizationStringsAsync(lang)
-        .then(loc => Util.values(apis.byQName).forEach(fn => {
-            const jsDoc = loc[fn.qName]
-            if (jsDoc) {
-                fn.attributes.jsDoc = jsDoc;
-                if (fn.parameters)
-                    fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || pi.description);
-            }
-            if (fn.attributes.block) {
-                const locBlock = loc[`${fn.qName}|block`];
-                if (locBlock) {
-                    try {
-                        if (pxt.blocks.areFieldsEquivalent(fn.attributes.block, locBlock))
-                            fn.attributes.block = locBlock;
-                        else {
-                            const fields = JSON.stringify(pxt.blocks.parseFields(fn.attributes.block), null, 2);
-                            const locFields = JSON.stringify(pxt.blocks.parseFields(locBlock), null, 2);
-                            console.error(`localized block description of ${fn.attributes.block} invalid`);
-                            console.debug(`original: `, fields);
-                            console.debug(`loc: `, locFields);
-                        }
-                    } catch (e) {
-                        console.error(`error while parsing localized block of ${fn.attributes.block}`);
-                    }
-                }
-            }
-            const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
-            if (nsDoc) {
-                fn.attributes.block = nsDoc;
-            }
-        }))
-        .then(() => apis);
-}
-
 function ensureApisInfoAsync(): Promise<void> {
     if (refreshApis || !cachedApis)
         return workerOpAsync("apiInfo", {})
             .then(apis => {
                 refreshApis = false;
-                return localizeApisAsync(apis);
+                return ts.pxtc.localizeApisAsync(apis, pkg.mainPkg);
             }).then(apis => {
                 cachedApis = apis;
             })


### PR DESCRIPTION
When opening side doc page, transfer locale + language context to allow doc rendering to fetch proper translations and show JS or Blocks by default.