### PR TITLE
Fix for pxtCoreDir path on npm 3+

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3599,7 +3599,9 @@ export function mainCli(targetDir: string, args: string[] = process.argv.slice(2
         compileId = trg.compileService.buildEngine || "yotta"
     }
 
-    process.stderr.write(`Using PXT/${trg.id} from ${targetDir} with build engine ${compileId}.\n`)
+    pxt.log(`Using target PXT/${trg.id} with build engine ${compileId}`)
+    pxt.log(`  Target dir:   ${nodeutil.targetDir}`)
+    pxt.log(`  PXT Core dir: ${nodeutil.pxtCoreDir}`)
 
     if (compileId != "none") {
         build.thisBuild = build.buildEngines[compileId]

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -19,7 +19,16 @@ export var pxtCoreDir: string = path.join(targetDir, "node_modules/pxt-core")
 
 export function setTargetDir(dir: string) {
     targetDir = dir;
-    pxtCoreDir = path.join(targetDir, "node_modules/pxt-core");
+    pxtCoreDir = path.join(targetDir, "node_modules", "pxt-core");
+
+    if (!fs.existsSync(pxtCoreDir)) {
+        // Fix for NPM 3: dependencies are flattened, which means pxt-core is not under [target]/node_modules/pxt-core.
+        // In that case, use the pxt-core that nodeutil.js script is running in. It's in pxt-core/built/nodeutil.js, so
+        // go up once to reach root of pxt-core.
+        pxtCoreDir = path.join(__dirname, "..");
+    }
+
+    console.log("Set pxtCoreDir to:" + pxtCoreDir);
 }
 
 export function readResAsync(g: events.EventEmitter) {

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -19,16 +19,24 @@ export var pxtCoreDir: string = path.join(targetDir, "node_modules/pxt-core")
 
 export function setTargetDir(dir: string) {
     targetDir = dir;
-    pxtCoreDir = path.join(targetDir, "node_modules", "pxt-core");
+    let newPxtCoreDir = path.join(targetDir, "node_modules", "pxt-core");
 
-    if (!fs.existsSync(pxtCoreDir)) {
+    if (!fs.existsSync(newPxtCoreDir)) {
         // Fix for NPM 3: dependencies are flattened, which means pxt-core is not under [target]/node_modules/pxt-core.
         // In that case, use the pxt-core that nodeutil.js script is running in. It's in pxt-core/built/nodeutil.js, so
         // go up once to reach root of pxt-core.
-        pxtCoreDir = path.join(__dirname, "..");
+        newPxtCoreDir = path.join(__dirname, "..");
+
+        let packageJsonFile = path.join(newPxtCoreDir, "package.json");
+        if (!fs.existsSync(packageJsonFile) || JSON.parse(fs.readFileSync(packageJsonFile, "utf8")).name !== "pxt-core") {
+            newPxtCoreDir = null;
+        }
     }
 
-    console.log("Set pxtCoreDir to:" + pxtCoreDir);
+    if (!!newPxtCoreDir && newPxtCoreDir !== pxtCoreDir) {
+        pxtCoreDir = newPxtCoreDir;
+        console.log("Set pxtCoreDir to: " + pxtCoreDir);
+    }
 }
 
 export function readResAsync(g: events.EventEmitter) {

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -35,7 +35,6 @@ export function setTargetDir(dir: string) {
 
     if (!!newPxtCoreDir && newPxtCoreDir !== pxtCoreDir) {
         pxtCoreDir = newPxtCoreDir;
-        console.log("Set pxtCoreDir to: " + pxtCoreDir);
     }
 }
 


### PR DESCRIPTION
Our CLI does not account for NPM 3 vs NPM 2, and assumes that pxt-core is under pxt-microbit/node_modules/pxt-core (which is not always true in NPM 3).

This is a band-aid fix until we can come up with a way for the target to expose its pxt-core dependency, so the CLI won't need to guess where pxt-core is anymore.