### PR TITLE
Remove unused temp dir

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -21,7 +21,6 @@ let simdirs = [""]
 let docfilesdirs = [""]
 let userProjectsDir = path.join(process.cwd(), userProjectsDirName);
 let docsDir = ""
-let tempDir = ""
 let packagedDir = ""
 let localHexDir = path.join("built", "hexcache");
 
@@ -61,7 +60,6 @@ function setupRootDir() {
     ]
     simdirs = [path.join(nodeutil.targetDir, "built"), path.join(nodeutil.targetDir, "sim/public")]
     docsDir = path.join(root, "docs")
-    tempDir = path.join(root, "built/docstmp")
     packagedDir = path.join(root, "built/packaged")
     setupDocfilesdirs()
     setupProjectsDir()
@@ -655,12 +653,8 @@ export interface ServeOptions {
 let serveOptions: ServeOptions;
 export function serveAsync(options: ServeOptions) {
     serveOptions = options;
-
     setupRootDir();
-
-    nodeutil.mkdirP(tempDir)
-
-    initTargetCommands()
+    initTargetCommands();
     initSerialMonitor();
 
     let server = http.createServer((req, res) => {


### PR DESCRIPTION
This dir doesn't seem to be used at all; after running local serve and playing around with my project, it is still empty. Also, searching both repos for "docstmp" doesn't give any result.

This temp dir is making the Electron app crash when it is installed in C:\Program Files, because you need admin privileges to create a folder in that directory