### PR TITLE
Adding getting started button

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -146,6 +146,7 @@ declare namespace pxt {
         simAnimationEnter?: string;
         simAnimationExit?: string;
         projectGallery?: string;
+        gettingStarted?: string;
     }
 
     interface DocMenuEntry {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -124,12 +124,12 @@ declare namespace pxt {
         embedUrl?: string;
         docMenu?: DocMenuEntry[];
         hideSideDocs?: boolean;
+        sideDoc?: string; // if set: show the getting started button, clicking on getting started button links to that page
         boardName?: string;
         privacyUrl?: string;
         termsOfUseUrl?: string;
         contactUrl?: string;
         accentColor?: string;
-        invertedMenu?: boolean;
         locales?: Map<AppTheme>;
         cardLogo?: string;
         appLogo?: string;
@@ -140,13 +140,13 @@ declare namespace pxt {
         usbDocs?: string;
         exportVsCode?: boolean;
         browserSupport?: SpecializedResource[];
-        invertedToolbox?: boolean;
-        invertedMonaco?: boolean;
-        blocklyOptions?: Blockly.Options;
-        simAnimationEnter?: string;
-        simAnimationExit?: string;
+        invertedMenu?: boolean; // if true: apply the inverted class to the menu
+        invertedToolbox?: boolean; // if true: use the blockly inverted toolbox
+        invertedMonaco?: boolean; // if true: use the vs-dark monaco theme
+        blocklyOptions?: Blockly.Options; // Blockly options, see Configuration: https://developers.google.com/blockly/guides/get-started/web
+        simAnimationEnter?: string; // Simulator enter animation
+        simAnimationExit?: string; // Simulator exit animation
         projectGallery?: string;
-        gettingStarted?: string;
     }
 
     interface DocMenuEntry {

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -10,7 +10,7 @@
              Layout
 *******************************/
 
-
+/* Main Layout */
 #filelist,
 #maineditor,
 #sidedocs {
@@ -18,6 +18,64 @@
   top:@mainMenuHeight;
   bottom: 0rem;
 }
+
+/* Main Editor layout */
+#maineditor {
+  left: @simulatorWidth;
+  right: 0;
+  overflow: hidden;
+}
+.rtl #maineditor {
+    left:0;
+    right:@simulatorWidth;
+}
+
+/* File list / Simulator layout */
+#filelist {
+  left: 0;
+  min-width: @simulatorWidth;
+  max-width: @simulatorWidth;
+  background-color: @simulatorBackground;
+}
+.rtl #filelist {
+    left: auto;
+    right: 0;
+}
+
+#filelist {
+  padding: 1em 2em 1em 1.5em;
+  overflow-x: hidden;
+  overflow-y: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.filemenu {
+  direction:ltr;
+}
+
+#filelist .menu {
+  width: 100%;
+}
+
+#filelist .nested.item {
+    padding-left: 4rem;
+}
+
+#filelist .header {
+    background: rgba(0,0,0,0.05);
+}
+
+/* Getting started button */
+#getting-started-btn {
+    display:none;
+    z-index:9;
+    position: absolute;
+    top: @mainMenuHeight;
+    right: 2rem;
+}
+
+/* Side Docs layout */
 #sidedocs {
   display:none;
   overflow-y: auto;
@@ -51,15 +109,20 @@
     left:1.25rem;
 }
 
-/* default layout */
-#filelist {
-  left: 0;
-  min-width: @simulatorWidth;
-  max-width: @simulatorWidth;
+/* Cookie Message */
+#cookiemsg {
+   position: absolute;
+   left: 1rem;
+   bottom: 0.5rem;
+   width: 18rem;
+   text-align: left;
+   display:none;
+   z-index:1000;
 }
-.rtl #filelist {
-    left: auto;
-    right: 0;
+
+#cookiemsg > a {
+   color:white;
+   text-decoration: underline;
 }
 
 .rtl #cookiemsg {
@@ -67,15 +130,6 @@
     right:1rem;
 }
 
-#maineditor {
-  right: 0;
-  left: @simulatorWidth;
-  overflow: hidden;
-}
-.rtl #maineditor {
-    left:0;
-    right:@simulatorWidth;
-}
 
 /*******************************
              Blockly
@@ -227,7 +281,6 @@
     }
 }
 
-
 /* extra-large desktop screen */
 @media only screen and (min-width: 92em) and (min-height:30em) {
     .sideDocs #maineditor {
@@ -240,6 +293,9 @@
     .sideDocs #sidedocs {
         display:block;
         width:@sideBarWidth;
+    }
+    #sidedocspopout, #sidedocsexpand {
+        display:block;
     }
 }
 
@@ -256,5 +312,39 @@
     .rtl #maineditor {
         right:@simulatorWidthSmall;
         left:0;
+    }
+}
+
+/* thin desktop portrait mode */
+@media only screen and (max-width: 55em), only screen and (max-aspect-ratio: 7/10) {
+    #filelist {
+        position:absolute;
+        z-index:5;
+        bottom:3rem;
+        left:1rem;
+        top:auto;
+        width:auto;
+        min-width: inherit;
+        max-width: inherit;
+        background-color: transparent;
+    }
+    .rtl #filelist {
+        left:auto;
+        right:1rem;
+    }
+    #maineditor, .rtl #maineditor {
+        left: 0;
+        right:0;
+    }
+    #maineditor:not(.sandbox), .rtl #maineditor:not(.sandbox) {
+        bottom:2.3rem;
+    }
+}
+
+/* Large Monitor */
+@media only screen and (min-width: @largeMonitorBreakpoint) {
+    /* Getting started button */
+    #getting-started-btn:not(.sideDocs) {
+        display: block;
     }
 }

--- a/theme/themes/pxt/collections/menu.variables
+++ b/theme/themes/pxt/collections/menu.variables
@@ -2,5 +2,7 @@
     User Variable Overrides
 *******************************/
 
+/* PXT Variables */
+
 @mainMenuHeight: 3.6rem;
 @mainMenuMinHeight: @minHeight;

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -48,6 +48,8 @@
 @simulatorWidth: 27rem;
 @simulatorWidthSmall: 20rem;
 
+@simulatorBackground: #fff;
+
 @blocklyToolboxColor: rgba(0, 0, 0, 0.05);
 @blocklySvgColor: #fff;
 @trashIconColor: @primaryColor;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -33,21 +33,6 @@ body {
     height: 2.5rem;
 }
 
-#cookiemsg {
-   position: absolute;
-   left: 1rem;
-   bottom: 0.5rem;
-   width: 18rem;
-   text-align: left;
-   display:none;
-   z-index:1000;
-}
-
-#cookiemsg > a {
-   color:white;
-   text-decoration: underline;
-}
-
 .organization {
     position:absolute;
     top:1rem;
@@ -76,30 +61,6 @@ div.simframe {
 div.simframe > iframe {
     position:absolute;
     top:0; left: 0; width:100%; height:100%;
-}
-
-#filelist {
-  padding: 0em 1em 0em 0.5em;
-  overflow-x: hidden;
-  overflow-y: auto;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.filemenu {
-  direction:ltr;
-}
-
-#filelist .menu {
-  width: 100%;
-}
-
-#filelist .nested.item {
-    padding-left: 4rem;
-}
-
-#filelist .header {
-    background: rgba(0,0,0,0.05);
 }
 
 #helpcard {
@@ -372,9 +333,6 @@ html {
     .ui.widedesktop.hide {
         display:none !important;
     }
-    #sidedocspopout, #sidedocsexpand {
-        display:block;
-    }
 }
 
 @media only screen and (min-width: 55em) and (min-height:30em) {
@@ -439,32 +397,11 @@ html {
         left:0.5rem;
         right: auto;
     }
-    #maineditor, .rtl #maineditor {
-        left: 0;
-        right:0;
-    }
-    #maineditor:not(.sandbox), .rtl #maineditor:not(.sandbox) {
-        bottom:2.3rem;
-    }
     .ui.landscape.only {
         display:none !important;
     }
     .hideEditorFloats .editorFloat {
         display:none;
-    }
-    #filelist {
-        position:absolute;
-        z-index:5;
-        bottom:3rem;
-        left:1rem;
-        top:auto;
-        width:auto;
-        min-width: inherit;
-        max-width: inherit;
-    }
-    .rtl #filelist {
-        left:auto;
-        right:1rem;
     }
     div.simframe {
         display:inline-block;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1668,8 +1668,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     gettingStarted() {
         pxt.tickEvent("btn.gettingstarted");
         const targetTheme = pxt.appTarget.appTheme;
-        Util.assert(!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted != undefined);
-        this.setSideDoc(targetTheme.gettingStarted);
+        Util.assert(!this.state.sideDocsLoadUrl && targetTheme && !!targetTheme.sideDoc);
+        this.setSideDoc(targetTheme.sideDoc);
         this.setState({sideDocsCollapsed: false})
     }
 
@@ -1763,7 +1763,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         </div> : undefined }
                     </div>
                 </div>
-                {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted ? 
+                {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc ? 
                     <div id="getting-started-btn">
                         <sui.Button class="bottom attached green" title={gettingStartedTooltip} text={lf("Getting Started")} onClick={() => this.gettingStarted() } />
                     </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1666,10 +1666,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     }
 
     gettingStarted() {
-        Util.assert(!this.state.sideDocsLoadUrl);
         const targetTheme = pxt.appTarget.appTheme;
-        const gettingStartedUrl = targetTheme.gettingStarted || 'getting-started';
-        this.setSideDoc(gettingStartedUrl);
+        Util.assert(!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted != undefined);
+        this.setSideDoc(targetTheme.gettingStarted);
         this.setState({sideDocsCollapsed: false})
     }
 
@@ -1762,11 +1761,11 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         </div> : undefined }
                     </div>
                 </div>
-                {this.state.sideDocsLoadUrl && targetTheme.gettingStarted ? undefined : 
+                {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted != undefined ? 
                     <div id="getting-started-btn">
                         <div className="ui bottom attached button green" onClick={() => this.gettingStarted() }>Getting Started</div>
                     </div>
-                }
+                    : undefined }
                 <div id="filelist" className="ui items" role="complementary">
                     <div id="boardview" className={`ui vertical editorFloat ${this.state.helpCard ? "landscape only " : ""}`}>
                     </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1695,6 +1695,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         const compileTooltip = lf("Download your code to the {0}", targetTheme.boardName);
         const runTooltip = this.state.running ? lf("Stop the simulator") : lf("Start the simulator");
         const makeTooltip = lf("Open assembly instructions");
+        const gettingStartedTooltip = lf("Open Getting Started help");
         const isBlocks = !this.editor.isVisible || this.getPreferredEditor() == pxt.BLOCKS_PROJECT_NAME;
         const sideDocs = !(sandbox || pxt.options.light || targetTheme.hideSideDocs);
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox;
@@ -1762,9 +1763,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         </div> : undefined }
                     </div>
                 </div>
-                {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted != undefined ? 
+                {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted ? 
                     <div id="getting-started-btn">
-                        <sui.Button class="bottom attached green" title={lf("Getting Started")} text={lf("Getting Started")} onClick={() => this.gettingStarted() } />
+                        <sui.Button class="bottom attached green" title={gettingStartedTooltip} text={lf("Getting Started")} onClick={() => this.gettingStarted() } />
                     </div>
                     : undefined }
                 <div id="filelist" className="ui items" role="complementary">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1665,6 +1665,14 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         this.shareEditor.show(header);
     }
 
+    gettingStarted() {
+        Util.assert(!this.state.sideDocsLoadUrl);
+        const targetTheme = pxt.appTarget.appTheme;
+        const gettingStartedUrl = targetTheme.gettingStarted || 'getting-started';
+        this.setSideDoc(gettingStartedUrl);
+        this.setState({sideDocsCollapsed: false})
+    }
+
     renderCore() {
         theEditor = this;
 
@@ -1687,7 +1695,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         const compileTooltip = lf("Download your code to the {0}", targetTheme.boardName);
         const runTooltip = this.state.running ? lf("Stop the simulator") : lf("Start the simulator");
         const makeTooltip = lf("Open assembly instructions");
-        const isBlocks = this.getPreferredEditor() == pxt.BLOCKS_PROJECT_NAME;
+        const isBlocks = !this.editor.isVisible || this.getPreferredEditor() == pxt.BLOCKS_PROJECT_NAME;
         const sideDocs = !(sandbox || pxt.options.light || targetTheme.hideSideDocs);
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox;
         const run = !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
@@ -1754,6 +1762,11 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         </div> : undefined }
                     </div>
                 </div>
+                {this.state.sideDocsLoadUrl && targetTheme.gettingStarted ? undefined : 
+                    <div id="getting-started-btn">
+                        <div className="ui bottom attached button green" onClick={() => this.gettingStarted() }>Getting Started</div>
+                    </div>
+                }
                 <div id="filelist" className="ui items" role="complementary">
                     <div id="boardview" className={`ui vertical editorFloat ${this.state.helpCard ? "landscape only " : ""}`}>
                     </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1666,6 +1666,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     }
 
     gettingStarted() {
+        pxt.tickEvent("btn.gettingstarted");
         const targetTheme = pxt.appTarget.appTheme;
         Util.assert(!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted != undefined);
         this.setSideDoc(targetTheme.gettingStarted);
@@ -1763,7 +1764,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 </div>
                 {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.gettingStarted != undefined ? 
                     <div id="getting-started-btn">
-                        <div className="ui bottom attached button green" onClick={() => this.gettingStarted() }>Getting Started</div>
+                        <sui.Button class="bottom attached green" title={lf("Getting Started")} text={lf("Getting Started")} onClick={() => this.gettingStarted() } />
                     </div>
                     : undefined }
                 <div id="filelist" className="ui items" role="complementary">


### PR DESCRIPTION
Adding getting started button for the widescreen view (in the top right corner). See screenshot:
<img width="285" alt="screen shot 2016-11-11 at 1 33 24 pm" src="https://cloud.githubusercontent.com/assets/16690124/20230949/75b56760-a813-11e6-8842-fe2b5b5b8aec.png">

+ Ui layout cleanups
+ Fix for Explorer / Sim buttons showing up before the editor has fully loaded.

The getting started button disappears after the user has loaded any content in the side docs.