### PR TITLE
report tick instead of crash for user error

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -45,7 +45,7 @@ namespace pxt.blocks {
             return new XMLSerializer().serializeToString(doc);
         }
         catch (e) {
-            reportException(e, xml);
+            reportException(e, { xml: xml });
             return xml;
         }
     }

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -54,7 +54,7 @@ namespace pxt.blocks.layout {
                 resolve(canvasdata);
             };
             img.onerror = ev => {
-                pxt.reportError("blocks", "blocks screenshot failed", { "xml": data });
+                pxt.reportError("blocks", "blocks screenshot failed");
                 resolve(undefined)
             }
             img.src = data;

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -20,31 +20,29 @@ namespace pxt.analytics {
         }
 
         const rexp = pxt.reportException;
-        pxt.reportException = function (err: any, data: any): void {
+        pxt.reportException = function (err: any, data: pxt.Map<string>): void {
             if (rexp) rexp(err, data);
             const props: pxt.Map<string> = {
                 target: pxt.appTarget.id,
                 version: pxt.appTarget.versions.target
             }
-            if (data)
-                for (let k in data)
-                    props[k] = typeof data[k] === "string" ? data[k] : JSON.stringify(data[k]);
+            if (data) Util.jsonMergeFrom(props, data);
             ai.trackException(err, 'exception', props)
         }
         const re = pxt.reportError;
-        pxt.reportError = function (msg: string, data: any): void {
-            if (re) re(msg, data);
+        pxt.reportError = function (cat: string, msg: string, data?: pxt.Map<string>): void {
+            if (re) re(cat, msg, data);
             try {
                 throw msg
             }
             catch (err) {
-                let props: pxt.Map<string> = {
+                const props: pxt.Map<string> = {
                     target: pxt.appTarget.id,
-                    version: pxt.appTarget.versions.target
+                    version: pxt.appTarget.versions.target,
+                    category: cat,
+                    message: msg
                 }
-                if (data)
-                    for (let k in data)
-                        props[k] = typeof data[k] === "string" ? data[k] : JSON.stringify(data[k]);
+                if (data) Util.jsonMergeFrom(props, data);
                 ai.trackException(err, 'error', props)
             }
         }

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -46,7 +46,7 @@ namespace pxt {
             console.log(msg);
         } : () => { };
 
-    export var reportException: (err: any, data: any) => void = function (e, d) {
+    export var reportException: (err: any, data?: Map<string>) => void = function (e, d) {
         if (console) {
             console.error(e);
             if (d) {
@@ -56,7 +56,7 @@ namespace pxt {
             }
         }
     }
-    export var reportError: (cat: string, msg: string, data?: Map<number | string>) => void = function (cat, msg, data) {
+    export var reportError: (cat: string, msg: string, data?: Map<string>) => void = function (cat, msg, data) {
         if (console) {
             console.error(`${cat}: ${msg}`);
             if (data) {
@@ -627,7 +627,7 @@ namespace pxt {
                             }
                         }
                     } catch (e) {
-                        pxt.reportError(lf("invalid pxtparts.json file"), undefined);
+                        pxt.reportError("parts", "invalid pxtparts.json file");
                     }
                 }
             })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1448,10 +1448,11 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 return pxt.commands.deployCoreAsync(resp)
                     .catch(e => {
                         core.warningNotification(lf(".hex file upload, please try again."));
-                        pxt.reportException(e, resp);
+                        pxt.reportException(e, resp.outfiles);
                     })
-            }).catch(e => {
-                pxt.reportError("compile", "compile failed", e);
+            }).catch((e: Error) => {
+                pxt.reportException(e);
+                core.errorNotification(lf("Compilation failed, please contact support."));
             }).finally(() => pxt.tickEvent("perf.compile"))
             .done();
     }
@@ -1671,7 +1672,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         const targetTheme = pxt.appTarget.appTheme;
         Util.assert(!this.state.sideDocsLoadUrl && targetTheme && !!targetTheme.sideDoc);
         this.setSideDoc(targetTheme.sideDoc);
-        this.setState({sideDocsCollapsed: false})
+        this.setState({ sideDocsCollapsed: false })
     }
 
     renderCore() {
@@ -1764,9 +1765,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         </div> : undefined }
                     </div>
                 </div>
-                {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc ? 
+                {!this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc ?
                     <div id="getting-started-btn">
-                        <sui.Button class="bottom attached green" title={gettingStartedTooltip} text={lf("Getting Started")} onClick={() => this.gettingStarted() } />
+                        <sui.Button class="bottom attached green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } />
                     </div>
                     : undefined }
                 <div id="filelist" className="ui items" role="complementary">

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -40,7 +40,7 @@ export class Editor extends srceditor.Editor {
             this.compilationResult = pxt.blocks.compile(this.editor, this.blockInfo);
             return this.compilationResult.source;
         } catch (e) {
-            pxt.reportException(e, { blocks: this.serializeBlocks() })
+            pxt.reportException(e, { blocks: this.serializeBlocks(true) })
             core.errorNotification(lf("Sorry, we were not able to convert this program."))
             return '';
         }
@@ -89,8 +89,10 @@ export class Editor extends srceditor.Editor {
         return this.serializeBlocks();
     }
 
-    serializeBlocks(): string {
+    serializeBlocks(normalize?: boolean): string {
         let xml = pxt.blocks.saveWorkspaceXml(this.editor);
+        // strip out id, x, y attributes
+        if (normalize) xml = xml.replace(/(x|y|id)="[^"]*"/g, '')
         pxt.debug(xml)
         return xml;
     }
@@ -291,7 +293,7 @@ export class Editor extends srceditor.Editor {
                     this.updateHelpCard(ev.newValue != null);
                 }
                 else if (ev.element == 'commentOpen'
-                || ev.element == 'warningOpen') {
+                    || ev.element == 'warningOpen') {
                     /*
                      * We override the default selection behavior so that when a block is selected, its
                      * comment is expanded. However, if a user selects a block by clicking on its comment

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -81,7 +81,7 @@ function htmlmsg(kind: string, msg: string) {
 }
 
 export function errorNotification(msg: string) {
-    pxt.reportError("notification", msg)
+    pxt.tickEvent("notification.error", { message : msg })
     htmlmsg("err", msg)
 }
 

--- a/webapp/src/workeriface.ts
+++ b/webapp/src/workeriface.ts
@@ -38,7 +38,7 @@ export function wrap(send: (v: any) => void): Iface {
                     pxt.reportError("worker", "no response")
                     reject(new Error("no response"))
                 } else if (v.errorMessage) {
-                    pxt.reportError("worker", "response: " + v.errorMessage)
+                    pxt.reportError("worker", v.errorMessage)
                     reject(new Error(v.errorMessage))
                 } else {
                     resolve(v)


### PR DESCRIPTION
Reporting "error" popup as a tick -- as the error should have been handled upstream. Also sending message as property instead of string to avoid incorrect hashing.