### PR TITLE
Remove set top and bottom radius in inverted blackly toolbox.

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -814,12 +814,10 @@ namespace pxt.blocks {
                     let nextElement = element.parentNode.nextSibling;
                     let previousElement = element.parentNode.previousSibling;
                     if (!nextElement && !onlyChild) {
-                        element.style.borderBottomLeftRadius = "10px";
-                        element.style.borderBottomRightRadius = "10px";
+                        element.className += ' blocklyTreeRowBottom';
                     }
                     if (!previousElement && !onlyChild) {
-                        element.style.borderTopLeftRadius = "10px";
-                        element.style.borderTopRightRadius = "10px";
+                        element.className += ' blocklyTreeRowTop';
                     }
                     if (this.hasColours_) {
                         element.style.color = '#fff';

--- a/pxtlib/emitter/assembler.ts
+++ b/pxtlib/emitter/assembler.ts
@@ -187,7 +187,7 @@ namespace ts.pxtc.assembler {
         public lineNo: number;
         public words: string[]; // the tokens in this line 
         public scope: string;
-        public location: number; 
+        public location: number;
         public instruction: Instruction;
         public numArgs: number[];
 


### PR DESCRIPTION
This change requires the following fix in any target that relies on the inverted toolbox having rounded top and bottom corners: 

Add this in style.less:

.blocklyTreeRow.blocklyTreeRowTop {
    border-top-left-radius: 10px;
    border-top-right-radius: 10px;
}

.blocklyTreeRow.blocklyTreeRowBottom {
    border-bottom-left-radius: 10px;
    border-bottom-right-radius: 10px;
}

This fix means the rounded corner radius is no longer a hard coded radius inside pxt, and can be altered in the target using the classname blocklyTreeRowTop and blocklyTreeRowBottom.