### PR TITLE
Add local server support for external messaging

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3620,8 +3620,8 @@ function errorHandler(reason: any) {
     process.exit(20)
 }
 
-let externalMessageHandlers: server.ExternalMessageHandlerDictionary;
-export function mainCli(targetDir: string, args: string[] = process.argv.slice(2), externalHandlers?: server.ExternalMessageHandlerDictionary) {
+let externalMessageHandlers: pxt.Map<server.ExternalMessageHandler>;
+export function mainCli(targetDir: string, args: string[] = process.argv.slice(2), externalHandlers?: pxt.Map<server.ExternalMessageHandler>) {
     process.on("unhandledRejection", errorHandler);
     process.on('uncaughtException', errorHandler);
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1530,6 +1530,7 @@ export function serveAsync(...args: string[]) {
             autoStart: !globalConfig.noAutoStart,
             packaged: packaged,
             electron: hasArg("electron"),
+            externalHandlers: externalMessageHandlers || void 0,
             browser
         }))
 }
@@ -3619,7 +3620,8 @@ function errorHandler(reason: any) {
     process.exit(20)
 }
 
-export function mainCli(targetDir: string, args: string[] = process.argv.slice(2)) {
+let externalMessageHandlers: server.ExternalMessageHandlerDictionary;
+export function mainCli(targetDir: string, args: string[] = process.argv.slice(2), externalHandlers?: server.ExternalMessageHandlerDictionary) {
     process.on("unhandledRejection", errorHandler);
     process.on('uncaughtException', errorHandler);
 
@@ -3627,6 +3629,10 @@ export function mainCli(targetDir: string, args: string[] = process.argv.slice(2
         console.error("Please upgrade your pxt CLI module.")
         console.error("   npm update -g pxt")
         process.exit(30)
+    }
+
+    if (externalHandlers) {
+        externalMessageHandlers = externalHandlers;
     }
 
     nodeutil.setTargetDir(targetDir);

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -23,7 +23,7 @@ let userProjectsDir = path.join(process.cwd(), userProjectsDirName);
 let docsDir = ""
 let packagedDir = ""
 let localHexDir = path.join("built", "hexcache");
-let externalMessageHandlers: ExternalMessageHandlerDictionary = {};
+let externalMessageHandlers: pxt.Map<ExternalMessageHandler> = {};
 
 export function forkPref() {
     if (pxt.appTarget.forkof)
@@ -678,7 +678,6 @@ export interface ExternalMessageResult {
 }
 export interface ExternalCallback { (res: ExternalMessageResult): void }
 export interface ExternalMessageHandler { (cb: ExternalCallback, data?: ExternalMessageData): void }
-export interface ExternalMessageHandlerDictionary { [messageType: string]: ExternalMessageHandler }
 
 export interface ServeOptions {
     localToken: string;
@@ -686,7 +685,7 @@ export interface ServeOptions {
     packaged?: boolean;
     electron?: boolean;
     browser?: string;
-    externalHandlers?: ExternalMessageHandlerDictionary;
+    externalHandlers?: pxt.Map<ExternalMessageHandler>;
 }
 
 let serveOptions: ServeOptions;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -67,7 +67,16 @@ interface IAppState {
     showParts?: boolean;
 }
 
+interface ExternalMessageData {
+    messageType: string;
+    args: any
+}
+interface ExternalMessageResult {
+    error?: any;
+    result?: any;
+}
 
+let isElectron = /[?&]electron=1/.test(window.location.href);
 let theEditor: ProjectView;
 
 interface ISettingsProps {
@@ -1673,6 +1682,25 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         }).done();
     }
 
+    checkForElectronUpdate() {
+        const errorMessage = lf("Unable to check for updates");
+        pxt.tickEvent("menu.electronupdate");
+        Util.requestAsync({
+            url: "http://localhost:3232/api/externalmsg",
+            headers: { "Authorization": Cloud.localToken },
+            method: "POST",
+            data: {
+                messageType: "checkForUpdate"
+            } as ExternalMessageData
+        }).then((res: ExternalMessageResult) => {
+            if (res.error) {
+                core.errorNotification(errorMessage);
+            }
+        }).catch((e) => {
+            core.errorNotification(errorMessage);
+        });
+    }
+
     embed() {
         pxt.tickEvent("menu.embed");
         const header = this.state.header;
@@ -1767,6 +1795,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             { targetTheme.privacyUrl ? <a className="ui item" href={targetTheme.privacyUrl} role="menuitem" title={lf("Privacy & Cookies") } target="_blank">{lf("Privacy & Cookies") }</a> : undefined }
                             { targetTheme.termsOfUseUrl ? <a className="ui item" href={targetTheme.termsOfUseUrl} role="menuitem" title={lf("Terms Of Use") } target="_blank">{lf("Terms Of Use") }</a> : undefined }
                             <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
+                            { isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => this.checkForElectronUpdate() } /> : undefined }
                         </sui.DropdownMenuItem>}
                         {docMenu ? <DocsMenuItem parent={this} /> : undefined}
                         {sandbox ? <div className="right menu">


### PR DESCRIPTION
Needed by Electron to communicate with the WebApp. The built-in Electron messaging channels are a security issue for us, because they would let the web app require Node core modules such as fs.