### PR TITLE
Fixing modal dimmer jquery selector

### DIFF
--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -165,7 +165,7 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
     let html = `
   <div class="ui ${options.size || "small"} modal">
     <div class="header">
-        ${Util.htmlEscape(options.header)}      
+        ${Util.htmlEscape(options.header)}
     </div>
     <div class="content">
       ${options.body ? "<p>" + Util.htmlEscape(options.body) + "</p>" : ""}
@@ -227,6 +227,7 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
         mo = modal.modal({
             observeChanges: true,
             closeable: !options.hideCancel,
+            context: "body.dimmable",
             onHidden: () => {
                 modal.remove()
             },
@@ -302,9 +303,9 @@ export function shareLinkAsync(options: ShareOptions) {
     let html = `
   <div class="ui small modal">
     <div class="header">
-        ${Util.htmlEscape(options.header)}      
+        ${Util.htmlEscape(options.header)}
     </div>
-    <div class="content">    
+    <div class="content">
       <p>${Util.htmlEscape(options.body || "")}</p>
       <div class="ui fluid action input">
          <input class="linkinput" type="text" value="${Util.htmlEscape(options.link)}">


### PR DESCRIPTION
Fixes #793 

By default, semantic just uses a selector that gets all `<body />` elements when it tries to dim the screen for a modal (it assumes there is only one in the page). Blockly comments use `<body />` elements for their bubbles, so when a bubble is present Semantic throws an exception. This fix just overrides that selector.