### PR TITLE
Publish anonymous gist from command line

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3425,15 +3425,12 @@ function checkDocsAsync(...args: string[]): Promise<void> {
 
 function publishGistCoreAsync(): Promise<void> {
     console.log("Publishing project to gist anonymously.");
-    return Promise.resolve()
-        .then(() => {
-            return mainPkg.loadAsync()
-        })
+    return mainPkg.loadAsync()
         .then(() => {
             console.log("Uploading....")
             let files: string[] = mainPkg.getFiles()
             let pxtConfig = mainPkg.config;
-            let filesMap: Map<{}> = {};
+            let filesMap: Map<{content: string;}> = {};
 
             files.forEach((fn) => {
                 let fileContent = fs.readFileSync(fn, "utf8");
@@ -3442,7 +3439,7 @@ function publishGistCoreAsync(): Promise<void> {
                         "content": fileContent
                     }
                 } else {
-                    // Cannot publish empty files, go through and remove empty file references form pxt.json
+                    // Cannot publish empty files, go through and remove empty file references from pxt.json
                     if (pxtConfig.files && pxtConfig.files.indexOf(fn) > -1) {
                         pxtConfig.files.splice(pxtConfig.files.indexOf(fn), 1);
                     } else if (pxtConfig.testFiles && pxtConfig.testFiles.indexOf(fn) > -1) {
@@ -3452,7 +3449,7 @@ function publishGistCoreAsync(): Promise<void> {
             })
             // Add pxt.json
             filesMap['pxt.json'] = {
-                "content": JSON.stringify(pxtConfig)
+                "content": JSON.stringify(pxtConfig, null, 4)
             }
             return pxt.github.publishGist(filesMap, pxtConfig.description, false)
         })

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3423,6 +3423,52 @@ function checkDocsAsync(...args: string[]): Promise<void> {
     return Promise.resolve();
 }
 
+function publishGistCoreAsync(): Promise<void> {
+    console.log("Publishing project to gist anonymously.");
+    return Promise.resolve()
+        .then(() => {
+            return mainPkg.loadAsync()
+        })
+        .then(() => {
+            console.log("Uploading....")
+            let files: string[] = mainPkg.getFiles()
+            let pxtConfig = mainPkg.config;
+            let filesMap: Map<{}> = {};
+
+            files.forEach((fn) => {
+                let fileContent = fs.readFileSync(fn, "utf8");
+                if (fileContent) {
+                    filesMap[fn] = {
+                        "content": fileContent
+                    }
+                } else {
+                    // Cannot publish empty files, go through and remove empty file references form pxt.json
+                    if (pxtConfig.files && pxtConfig.files.indexOf(fn) > -1) {
+                        pxtConfig.files.splice(pxtConfig.files.indexOf(fn), 1);
+                    } else if (pxtConfig.testFiles && pxtConfig.testFiles.indexOf(fn) > -1) {
+                        pxtConfig.testFiles.splice(pxtConfig.testFiles.indexOf(fn), 1);
+                    }
+                }
+            })
+            // Add pxt.json
+            filesMap['pxt.json'] = {
+                "content": JSON.stringify(pxtConfig)
+            }
+            return pxt.github.publishGist(filesMap, pxtConfig.description, false)
+        })
+        .then((published_id) => {
+            console.log(`Success, your gist url is https://gist.github.com/${published_id}`);
+            console.log(`You can load your published project at ${pxt.appTarget.appTheme.homeUrl}#pub:gh/gists/${published_id}`)
+        })
+        .catch((e) => {
+            console.error(e);
+        });
+}
+
+export function publishGistAsync(arg?: string) {
+    return publishGistCoreAsync();
+}
+
 interface SnippetInfo {
     type: string
     code: string
@@ -3487,7 +3533,7 @@ cmd("help     [all]               - display this message", helpAsync)
 cmd("init                         - start new package (library) in current directory", initAsync)
 cmd("install  [PACKAGE...]        - install new packages, or all packages", installAsync)
 
-cmd("build    [--cloud]            - build current package, --cloud forces a build in the cloud", buildAsync)
+cmd("build    [--cloud]           - build current package, --cloud forces a build in the cloud", buildAsync)
 cmd("deploy                       - build and deploy current package", deployAsync)
 cmd("run                          - build and run current package in the simulator", runAsync)
 cmd("extract [--code] [--out DIRNAME]  [FILENAME] - extract sources from .hex file, folder of .hex files, stdin (-), or URL", extractAsync)
@@ -3500,7 +3546,7 @@ cmd("testdecompiler  DIR          - decompile files from DIR one-by-one and comp
 cmd("testdecompilererrors  DIR    - decompile unsupported files from DIR one-by-one and check for errors", testDecompilerErrorsAsync, 1)
 cmd("testdir  DIR                 - compile files from DIR one-by-one", testDirAsync, 1)
 cmd("testconv JSONURL             - test TD->TS converter", testConverterAsync, 2)
-cmd("snippets [--re NAME] [--i]     - verifies that all documentation snippets compile to blocks", testSnippetsAsync)
+cmd("snippets [--re NAME] [--i]   - verifies that all documentation snippets compile to blocks", testSnippetsAsync)
 
 cmd("serve [-yt] [-browser NAME]  - start web server for your local target; -yt = use local yotta build", serveAsync)
 cmd("update                       - update pxt-core reference and install updated version", updateAsync)
@@ -3510,6 +3556,7 @@ cmd("uploadtrg [LABEL]            - upload target release", uploadTargetAsync, 1
 cmd("uploadtrgtranslations [--docs] - upload translations for target, --docs uploads markdown as well", uploadTargetTranslationsAsync, 1)
 cmd("downloadtrgtranslations [PACKAGE] - download translations from bundled projects", downloadTargetTranslationsAsync, 1)
 cmd("checkdocs                    - check docs for broken links, typing errors, etc...", checkDocsAsync, 1)
+cmd("gist                         - publish current package to an anonymous gist", publishGistAsync)
 
 cmd("login    ACCESS_TOKEN        - set access token config variable", loginAsync, 1)
 cmd("logout                       - clears access token", logoutAsync, 1)

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -76,7 +76,6 @@ declare namespace pxt {
         publishing?: boolean;
         preferredPackages?: string[]; // list of company/project(#tag) of packages
         githubPackages?: boolean; // allow searching github for packages
-        apiRoot?: string; // url of cloud API
     }
 
     interface AppSimulator {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -76,6 +76,7 @@ declare namespace pxt {
         publishing?: boolean;
         preferredPackages?: string[]; // list of company/project(#tag) of packages
         githubPackages?: boolean; // allow searching github for packages
+        apiRoot?: string; // url of cloud API
     }
 
     interface AppSimulator {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -220,7 +220,7 @@ namespace pxt.github {
             return Promise.resolve<GitRepo>(undefined);
 
         // always use proxy
-        return Util.httpGetJsonAsync(`${pxt.appTarget.appTheme.homeUrl}api/gh/${rid.fullName}`)
+        return Util.httpGetJsonAsync(`${pxt.appTarget.cloud.apiRoot}/gh/${rid.fullName}`)
             .then(meta => {
                 if (!meta) return undefined;
                 return {
@@ -305,6 +305,24 @@ namespace pxt.github {
                         else
                             return tagToShaAsync(scr.fullName, scr.defaultBranch)
                     })
+            });
+    }
+
+    export function publishGist(files: any, description: string, publishPublicly: boolean = false): Promise<string> {
+        let data = {
+            "description": description,
+            "public": publishPublicly,
+            "files": files
+        };
+        return U.requestAsync({
+                url: "https://api.github.com/gists",
+                allowHttpErrors: true,
+                data: data || {} })
+            .then((resp) => {
+                if (resp.statusCode == 201 && resp.json.id) {
+                    return Promise.resolve<string>(resp.json.id);
+                }
+                return Promise.reject(resp.text);
             });
     }
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -220,7 +220,7 @@ namespace pxt.github {
             return Promise.resolve<GitRepo>(undefined);
 
         // always use proxy
-        return Util.httpGetJsonAsync(`${pxt.appTarget.cloud.apiRoot}/gh/${rid.fullName}`)
+        return Util.httpGetJsonAsync(`${pxt.Cloud.apiRoot}/gh/${rid.fullName}`)
             .then(meta => {
                 if (!meta) return undefined;
                 return {


### PR DESCRIPTION
Adding feature to publish a project to an anonymous gist.
To test: 
```
mkdir testproject; cd testproject
pxt init
pxt gist
```

Command line output: 
Publishing project to gist anonymously.
Uploading....
Success, your gist url is https://gist.github.com/527cb76153bb38b5c86aac5697619a6e
You can load your published project at https://pxt.microbit.org/#pub:gh/gists/527cb76153bb38b5c86aac5697619a6e

Also fixed issue with package install, see github.ts