### PR TITLE
Add option to show the definition of a method in the sidebar

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -125,6 +125,7 @@ declare namespace pxt {
         docMenu?: DocMenuEntry[];
         hideSideDocs?: boolean;
         sideDoc?: string; // if set: show the getting started button, clicking on getting started button links to that page
+        hasReferenceDocs?: boolean; // if true: the monaco editor will add an option in the context menu to load the reference docs
         boardName?: string;
         privacyUrl?: string;
         termsOfUseUrl?: string;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -548,3 +548,9 @@ body.blocklyMinimalBody {
     padding-left: 10px !important;
     padding-right: 20px !important;
 }
+
+
+/* Fix for monaco editor Signature bug in Safari */
+.monaco-editor .parameter-hints-widget {
+    flex-direction: row !important;
+}

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -342,7 +342,7 @@ export class Editor extends srceditor.Editor {
             let referenceContextKey = this.editor.createContextKey("editorHasReference", false)
             this.editor.addAction({
                 id: "reference",
-                label: lf("Show Definition"),
+                label: lf("Help"),
                 keybindingContext: "!editorReadonly && editorHasReference",
                 contextMenuGroupId: "navigation",
                 contextMenuOrder: 0.1,

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -288,7 +288,7 @@ export class Editor extends srceditor.Editor {
             keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S],
             keybindingContext: "!editorReadonly",
             contextMenuGroupId: "0_pxtnavigation",
-            contextMenuOrder: 0.1,
+            contextMenuOrder: 0.2,
             run: () => Promise.resolve(this.parent.typecheckNow())
         });
 
@@ -298,7 +298,7 @@ export class Editor extends srceditor.Editor {
             keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
             keybindingContext: "!editorReadonly",
             contextMenuGroupId: "0_pxtnavigation",
-            contextMenuOrder: 0.11,
+            contextMenuOrder: 0.21,
             run: () => Promise.resolve(this.parent.runSimulator())
         });
 
@@ -309,7 +309,7 @@ export class Editor extends srceditor.Editor {
                 keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.Enter],
                 keybindingContext: "!editorReadonly",
                 contextMenuGroupId: "0_pxtnavigation",
-                contextMenuOrder: 0.12,
+                contextMenuOrder: 0.22,
                 run: () => Promise.resolve(this.parent.compile())
             });
         }
@@ -337,6 +337,27 @@ export class Editor extends srceditor.Editor {
                 monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({noSemanticValidation: false});
             }
         })
+
+        if (pxt.appTarget.appTheme.hasReferenceDocs) {
+            let referenceContextKey = this.editor.createContextKey("editorHasReference", false)
+            this.editor.addAction({
+                id: "reference",
+                label: lf("Show Definition"),
+                keybindingContext: "!editorReadonly && editorHasReference",
+                contextMenuGroupId: "navigation",
+                contextMenuOrder: 0.1,
+                run: () => Promise.resolve(this.loadReference())
+            });
+
+            this.editor.onDidChangeCursorPosition((e: monaco.editor.ICursorPositionChangedEvent) => {
+                let word = this.editor.getModel().getWordAtPosition(e.position);
+                if (word) {
+                    referenceContextKey.set(true);
+                } else {
+                    referenceContextKey.reset()
+                }
+            })
+        }
 
         this.editor.onDidLayoutChange((e: monaco.editor.EditorLayoutInfo) => {
             // Update editor font size in settings after a ctrl+scroll zoom
@@ -397,6 +418,20 @@ export class Editor extends srceditor.Editor {
         this.parent.settings.editorFontSize = currentFont - 1;
         this.editor.updateOptions({ fontSize: this.parent.settings.editorFontSize });
         this.forceDiagnosticsUpdate();
+    }
+
+    loadReference() {
+        let currentPosition = this.editor.getPosition();
+        let wordInfo = this.editor.getModel().getWordAtPosition(currentPosition);
+        let prevWordInfo = this.editor.getModel().getWordUntilPosition(new monaco.Position(currentPosition.lineNumber, wordInfo.startColumn - 1));
+        if (prevWordInfo && wordInfo) {
+            let namespaceName = prevWordInfo.word.replace(/([A-Z]+)/g, "-$1");
+            let methodName = wordInfo.word.replace(/([A-Z]+)/g, "-$1");
+            this.parent.setSideDoc(`/reference/${namespaceName}/${methodName}`);
+        } else if (wordInfo) {
+            let methodName = wordInfo.word.replace(/([A-Z]+)/g, "-$1");
+            this.parent.setSideDoc(`/reference/${methodName}`);
+        }
     }
 
     getId() {


### PR DESCRIPTION
Add an option in the monaco editor context menu to load up the reference docs of a specific function or namespace in the side docs. 

![screen shot 2016-11-22 at 9 55 11 am](https://cloud.githubusercontent.com/assets/16690124/20535486/cc02be36-b099-11e6-953b-4bb900b0a125.png)

Fixes #799

Also, (custom.css) fix for monaco editor signaturehelp CSS bug in Safari: https://github.com/Microsoft/monaco-editor/issues/253