### PR TITLE
Publish a gist under a user account using a github TOKEN.

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3438,7 +3438,7 @@ function publishGistCoreAsync(forceNewGist: boolean = false, publishPublicly: bo
     const token = globalConfig.githubAccessToken;
     return mainPkg.loadAsync()
         .then(() => {
-            let pxtConfig = U.clone(mainPkg.config);
+            const pxtConfig = U.clone(mainPkg.config);
             if (publishPublicly && pxtConfig.gistId && !pxtConfig.publicGist) {
                 console.warn("You are trying to update an existing project but the current project is secret, publishing a new public project instead.")
                 forceNewGist = true;
@@ -3447,14 +3447,14 @@ function publishGistCoreAsync(forceNewGist: boolean = false, publishPublicly: bo
                 console.warn("You are trying to update an existing project but no github token was provided, publishing a new anonymous project instead.")
                 forceNewGist = true;
             }
-            let gistId = pxtConfig.gistId;
-            let publicGist = publishPublicly || pxtConfig.publicGist;
+            const gistId = pxtConfig.gistId;
+            const publicGist = publishPublicly || pxtConfig.publicGist;
             console.log(`${forceNewGist || !pxtConfig.gistId ?
                 `Publishing a ${publicGist ? `public` : `secret`} project to gist` :
                 `Updating existing ${publicGist ? `public` : `secret`} gist project`} ${token ? `` : `anonymously`}.`);
 
-            let files: string[] = mainPkg.getFiles()
-            let filesMap: Map<{ content: string; }> = {};
+            const files: string[] = mainPkg.getFiles()
+            const filesMap: Map<{ content: string; }> = {};
 
             files.forEach((fn) => {
                 let fileContent = fs.readFileSync(fn, "utf8");
@@ -3479,7 +3479,7 @@ function publishGistCoreAsync(forceNewGist: boolean = false, publishPublicly: bo
                 "content": JSON.stringify(pxtConfig, null, 4)
             }
             console.log("Uploading....")
-            return pxt.github.publishGist(token, forceNewGist, filesMap, pxtConfig.description, gistId, publicGist)
+            return pxt.github.publishGistAsync(token, forceNewGist, filesMap, pxtConfig.name, gistId, publicGist)
         })
         .then((published_id) => {
             console.log(`Success, view your gist at https://gist.github.com/${published_id}`);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3474,7 +3474,7 @@ function publishGistCoreAsync(forceNewGist: boolean = false): Promise<void> {
             console.log(``)
             console.log(`    https://gist.github.com/${published_id}`);
             console.log(``)
-            console.log(`To share your project, make your gist public and go to ${pxt.appTarget.appTheme.homeUrl}#pub:gh/gists/${published_id}`)
+            console.log(`To share your project, go to ${pxt.appTarget.appTheme.homeUrl}#pub:gh/gists/${published_id}`)
             if (!token) console.log(`Hint: Use "pxt login" with a GitHub token to publish gists under your GitHub account`);
 
             // Save gist id to pxt.json

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3459,9 +3459,11 @@ function publishGistCoreAsync(token: string = "", forceNewGist: boolean = false,
                 console.log("Warning: You're trying to update an existing project but no github token was provided, publishing a new anonymous project instead.")
                 forceNewGist = true;
             }
+            let gistId = pxtConfig.gistId;
+            let publicGist = publishPublicly || pxtConfig.publicGist;
             console.log(`${forceNewGist || !pxtConfig.gistId ? 
-                `Publishing a ${publishPublicly ? `public` : `secret`} project to gist` :
-                `Updating existing ${publishPublicly ? `public` : `secret`} gist project`} ${token ? `using token: ${token}` : `anonymously`}.`);
+                `Publishing a ${publicGist ? `public` : `secret`} project to gist` :
+                `Updating existing ${publicGist ? `public` : `secret`} gist project`} ${token ? `using token: ${token}` : `anonymously`}.`);
 
             let files: string[] = mainPkg.getFiles()
             let filesMap: Map<{content: string;}> = {};
@@ -3481,12 +3483,15 @@ function publishGistCoreAsync(token: string = "", forceNewGist: boolean = false,
                     }
                 }
             })
+            // Strip gist fields from config
+            delete pxtConfig.gistId;
+            delete pxtConfig.publicGist;
             // Add pxt.json
             filesMap['pxt.json'] = {
                 "content": JSON.stringify(pxtConfig, null, 4)
             }
             console.log("Uploading....")
-            return pxt.github.publishGist(token, forceNewGist, filesMap, pxtConfig.description, pxtConfig.gistId, publishPublicly)
+            return pxt.github.publishGist(token, forceNewGist, filesMap, pxtConfig.description, gistId, publicGist)
         })
         .then((published_id) => {
             console.log(`Success, view your gist at https://gist.github.com/${published_id}`);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3503,7 +3503,11 @@ function publishGistCoreAsync(token: string = "", forceNewGist: boolean = false,
             mainPkg.saveConfig();
         })
         .catch((e) => {
-            console.error(e);
+            if (e == '404') {
+                console.error("Unable to access the existing project. --new to publish a new gist.")
+            } else {
+                console.error(e);
+            }
         });
 }
 

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -27,7 +27,6 @@ declare namespace pxt {
         card?: CodeCard;
         additionalFilePath?: string;
         gistId?: string;
-        publicGist?: boolean;
     }
 
     interface PlatformIOConfig {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -26,6 +26,8 @@ declare namespace pxt {
         yotta?: YottaConfig;
         card?: CodeCard;
         additionalFilePath?: string;
+        gistId?: string;
+        publicGist?: boolean;
     }
 
     interface PlatformIOConfig {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -309,6 +309,7 @@ namespace pxt.github {
     }
 
     export function publishGistAsync(token: string, forceNew: boolean, files: any, name: string, currentGistId: string): Promise<any> {
+        // Github gist API: https://developer.github.com/v3/gists/
         const data = {
             "description": name,
             "public": false, /* there is no API to make a gist public or private, so it's easier/safer to always make it private and let the user make it public from the UI */

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -308,13 +308,13 @@ namespace pxt.github {
             });
     }
 
-    export function publishGist(token: string, forceNew: boolean, files: any, description: string, currentGistId: string, publishPublicly: boolean = false): Promise<any> {
-        let data = {
-            "description": description,
+    export function publishGistAsync(token: string, forceNew: boolean, files: any, name: string, currentGistId: string, publishPublicly: boolean = false): Promise<any> {
+        const data = {
+            "description": name,
             "public": publishPublicly,
             "files": files
         };
-        let headers: Map<string> = {};
+        const headers: Map<string> = {};
         let method: string, url: string = "https://api.github.com/gists";
         if (token) headers['Authorization'] = `token ${token}`;
         if (currentGistId && token && !forceNew) {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -308,10 +308,10 @@ namespace pxt.github {
             });
     }
 
-    export function publishGistAsync(token: string, forceNew: boolean, files: any, name: string, currentGistId: string, publishPublicly: boolean = false): Promise<any> {
+    export function publishGistAsync(token: string, forceNew: boolean, files: any, name: string, currentGistId: string): Promise<any> {
         const data = {
             "description": name,
-            "public": publishPublicly,
+            "public": false, /* there is no API to make a gist public or private, so it's easier/safer to always make it private and let the user make it public from the UI */
             "files": files
         };
         const headers: Map<string> = {};
@@ -340,5 +340,4 @@ namespace pxt.github {
                 return Promise.reject(resp.text);
             });
     }
-
 }

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -308,7 +308,7 @@ namespace pxt.github {
             });
     }
 
-    export function publishGist(token: string, forceNew: boolean, files: any, description: string, currentGistId: string, publishPublicly: boolean = false): Promise<string> {
+    export function publishGist(token: string, forceNew: boolean, files: any, description: string, currentGistId: string, publishPublicly: boolean = false): Promise<any> {
         let data = {
             "description": description,
             "public": publishPublicly,
@@ -334,6 +334,8 @@ namespace pxt.github {
             .then((resp) => {
                 if ((resp.statusCode == 200 || resp.statusCode == 201) && resp.json.id) {
                     return Promise.resolve<string>(resp.json.id);
+                } else if (resp.statusCode == 404 && method == 'PATCH') {
+                    return Promise.reject(resp.statusCode);
                 }
                 return Promise.reject(resp.text);
             });


### PR DESCRIPTION
Publish a gist under a user using a github TOKEN.
Saving current gist in pxt.json
cli options to force create a new gist, and publishing a public gist (default to secret).

**Create an anonymous gist**
```
pxt gist
```

**Create an gist under a user account**
```
pxt gist --token TOKEN
```

**Create a new gist (if preexisting)**
```
pxt gist --new
```

**Create a public gist (instead of secret)*
```
pxt gist --public
```

valid example: pxt gist --token TOKEN --new --public
