### PR TITLE
Adding an "Add package" button to the blockly toolbox

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -529,6 +529,24 @@ namespace pxt.blocks {
         }
     }
 
+    export function initAddPackage(callback: (ev: MouseEvent) => void): void {
+        // add "Add package" button to toolbox
+        if (!$('#blocklyAddPackage').length) {
+            let addpackageDiv = document.createElement('div');
+            addpackageDiv.id = "blocklyAddPackage";
+            let addPackageButton = document.createElement('button');
+            addPackageButton.setAttribute('role', 'button');
+            addPackageButton.setAttribute('aria-label', lf("Add Package..."));
+            addPackageButton.onclick = callback;
+            addPackageButton.className = 'circular ui icon button';
+            let addpackageIcon = document.createElement('i');
+            addpackageIcon.className = 'plus icon';
+            addPackageButton.appendChild(addpackageIcon);
+            addpackageDiv.appendChild(addPackageButton);
+            $('.blocklyToolboxDiv').append(addpackageDiv);
+        }
+    }
+
     function categoryElement(tb: Element, nameid: string): Element {
         return tb ? tb.querySelector(`category[nameid="${nameid.toLowerCase()}"]`) : undefined;
     }

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -184,6 +184,16 @@
     color: @trashIconColor;
 }
 
+/* The Add package button at the bottom of the toolbox */
+#blocklyAddPackage {
+    margin-left: auto;
+    margin-right: auto;
+    font-size:3rem;
+    text-align: center;
+}
+#blocklyAddPackage button {
+    color: @addPackageColor;
+}
 
 /*******************************
         Monaco Editor

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -53,3 +53,4 @@
 @blocklyToolboxColor: rgba(0, 0, 0, 0.05);
 @blocklySvgColor: #fff;
 @trashIconColor: @primaryColor;
+@addPackageColor: @primaryColor;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1779,7 +1779,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         {sandbox ? undefined : <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open" text={lf("Open Project") } onClick={() => this.openProject() } />}
                         {sandbox ? undefined : <sui.DropdownMenuItem icon='sidebar' class="more-dropdown-menuitem">
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
-                            {this.state.header ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined }
                             {this.state.header ? <sui.Item role="menuitem" icon="setting" text={lf("Project Settings...") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
                             {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project") } onClick={() => this.removeProject() } /> : undefined }
                             <div className="ui divider"></div>

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -62,6 +62,9 @@ export class Editor extends srceditor.Editor {
                 .then(bi => {
                     this.blockInfo = bi;
                     pxt.blocks.initBlocks(this.blockInfo, this.editor, defaultToolbox.documentElement)
+                    pxt.blocks.initAddPackage((ev: MouseEvent) => {
+                        this.parent.addPackage();
+                    });
 
                     let xml = this.delayLoadXml;
                     this.delayLoadXml = undefined;


### PR DESCRIPTION
Adding an "Add package" button to the blockly toolbox. Clicking on the button opens up the Add package dialog.

Button is the same size in all viewports.

See examples below:

<img width="258" alt="screen shot 2016-11-28 at 11 32 45 pm" src="https://cloud.githubusercontent.com/assets/16690124/20700585/ff863e62-b5c2-11e6-95cd-9d42db943cd9.png">

<img width="388" alt="screen shot 2016-11-28 at 11 11 55 pm" src="https://cloud.githubusercontent.com/assets/16690124/20700554/d182b072-b5c2-11e6-9a3e-5475a39a2805.png">