### PR TITLE
using "title" instead of semantic "tooltip"

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1770,7 +1770,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         <div className="ui item wide only projectname">
-                            <div className={`ui large ${targetTheme.invertedMenu ? `inverted` : ''} input`} data-tooltip={lf("Pick a name for your project") } data-position="bottom left">
+                            <div className={`ui large ${targetTheme.invertedMenu ? `inverted` : ''} input`} title={lf("Pick a name for your project") }>
                                 <input id="fileNameInput"
                                     type="text"
                                     placeholder={lf("Pick a name...") }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -428,8 +428,7 @@ export class Editor extends srceditor.Editor {
     menu() {
         return (
             <sui.Item text={lf("JavaScript") } class="javascript-menuitem" textClass="landscape only" icon="align left" onClick={() => this.openTypeScript() }
-                tooltip={lf("Convert code to JavaScript") } tooltipPosition="bottom left"
-                />
+                title={lf("Convert code to JavaScript") } />
         )
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -62,7 +62,7 @@ export class Editor extends srceditor.Editor {
                 .then(bi => {
                     this.blockInfo = bi;
                     pxt.blocks.initBlocks(this.blockInfo, this.editor, defaultToolbox.documentElement)
-                    if (!this.parent.getSandboxMode()) {
+                    if (pxt.appTarget.cloud.packages && !this.parent.getSandboxMode()) {
                         pxt.blocks.initAddPackage((ev: MouseEvent) => {
                             this.parent.addPackage();
                         });

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -143,13 +143,13 @@ export class Editor extends srceditor.Editor {
     }
 
     menu(): JSX.Element {
-        let editor = pkg.mainEditorPkg(); 
+        let editor = pkg.mainEditorPkg();
         if (this.currFile != editor.files["main.ts"]) {
             return (<sui.Item text={lf("Back to Code") } icon={"align left"} onClick={() => this.parent.setFile(editor.files["main.ts"]) } />);
         }
         else if (editor.files["main.blocks"]) { //if main.blocks file present
-            return ( <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" onClick={() => this.openBlocks() }
-                    tooltip={lf("Convert code to Blocks")} tooltipPosition="bottom left" /> );
+            return (<sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" onClick={() => this.openBlocks() }
+                title={lf("Convert code to Blocks") } />);
         }
         return null;
     }
@@ -330,11 +330,11 @@ export class Editor extends srceditor.Editor {
 
         this.editor.onDidBlurEditorText(() => {
             if (this.isIncomplete()) {
-                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({noSyntaxValidation: true});
-                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({noSemanticValidation: true});
+                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSyntaxValidation: true });
+                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSemanticValidation: true });
             } else {
-                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({noSyntaxValidation: false});
-                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({noSemanticValidation: false});
+                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSyntaxValidation: false });
+                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSemanticValidation: false });
             }
         })
 
@@ -496,7 +496,7 @@ export class Editor extends srceditor.Editor {
         if (this.fileType == FileType.Markdown)
             this.parent.setSideMarkdown(file.content);
 
-        this.currFile.setForceChangeCallback((from: string, to:string) => {
+        this.currFile.setForceChangeCallback((from: string, to: string) => {
             if (from != to) {
                 pxt.debug(`File changed (from ${from}, to ${to}). Reloading editor`)
                 this.loadFile(this.currFile);

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -10,8 +10,7 @@ export interface UiProps {
     children?: any;
     class?: string;
     role?: string;
-    tooltip?: string;
-    tooltipPosition?: string;
+    title?: string;
 }
 
 export interface WithPopupProps extends UiProps {
@@ -82,8 +81,9 @@ export class DropdownMenuItem extends UiElement<DropdownProps> {
 
     renderCore() {
         return (
-            <div className={genericClassName("ui dropdown item", this.props) } role={this.props.role} title={this.props.title ? this.props.title : this.props.text}
-                data-tooltip={this.props.tooltip} data-position={this.props.tooltipPosition}>
+            <div className={genericClassName("ui dropdown item", this.props) }
+                role={this.props.role}
+                title={this.props.title}>
                 {genericContent(this.props) }
                 <div className="menu">
                     {this.props.children}
@@ -102,7 +102,7 @@ export class Item extends data.Component<ItemProps, {}> {
         return (
             <div className={genericClassName("ui item link", this.props, true) }
                 role={this.props.role}
-                title={this.props.text}
+                title={this.props.title}
                 key={this.props.value}
                 data-value={this.props.value}
                 onClick={this.props.onClick}>
@@ -123,9 +123,8 @@ export class Button extends UiElement<ButtonProps> {
         return (
             <button className={genericClassName("ui button", this.props) + " " + (this.props.disabled ? "disabled" : "") }
                 role={this.props.role}
-                title={this.props.title ? this.props.title : this.props.text}
-                onClick={this.props.onClick}
-                data-tooltip={this.props.tooltip} data-position={this.props.tooltipPosition}>
+                title={this.props.title}
+                onClick={this.props.onClick}>
                 {genericContent(this.props) }
                 {this.props.children}
             </button>


### PR DESCRIPTION
Although built-in tooltips don' look quite as good, there are rendering issues with the Semantic CSS tooltips. Switching all tooltips to use "title" to stay on the safe side.
