### PR TITLE
use externalinputs information when generating TS

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -99,6 +99,7 @@ declare namespace Blockly {
         // Returns null if the input does not exist on the specified block, or
         // is disconnected.
         getInputTargetBlock(field: string): Block;
+        getInputsInline(): boolean;
         // Returns null if no next block or is disconnected.
         getNextBlock(): Block;
         // Unplug this block from its superior block.  If this block is a statement, optionally reconnect the block underneath with the block on top.


### PR DESCRIPTION
- when a block has external inputs turned on, generate argument on new lines.
- apply formatting to generated TS code.