### PR TITLE
stop simulator while compiling

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1459,6 +1459,10 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     compile() {
         pxt.tickEvent("compile");
         pxt.debug('compiling...');
+        if (this.state.compiling) {
+            pxt.tickEvent("compile.double");
+            return;
+        }
         const simRestart = this.state.running;
         this.setState({ compiling: true });
         this.clearLog();
@@ -1829,7 +1833,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                     <div id="boardview" className={`ui vertical editorFloat ${this.state.helpCard ? "landscape only " : ""}`}>
                     </div>
                     <div className="ui item landscape only">
-                        {compileBtn ? <sui.Button icon='icon download' class={`huge fluid download-button`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile() } /> : ""}
+                        {compileBtn ? <sui.Button icon='icon download' class={`huge fluid download-button ${compileLoading ? 'loading' : ''}`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile() } /> : ""}
                         {make ? <sui.Button icon='configure' class="fluid sixty secondary" text={lf("Make") } title={makeTooltip} onClick={() => this.openInstructions() } /> : undefined }
                         {run ? <sui.Button key='runbtn' class={`${compileBtn ? '' : 'huge fluid'} play-button`} text={compileBtn ? undefined : this.state.running ? lf("Stop") : lf("Start") } icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.state.running ? this.stopSimulator() : this.runSimulator() } /> : undefined }
                     </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1457,9 +1457,11 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
 
     compile() {
         pxt.tickEvent("compile");
-        pxt.debug('compiling...')
+        pxt.debug('compiling...');
         this.clearLog();
         this.editor.beforeCompile();
+        const simRestart = this.state.running;
+        if (simRestart) this.stopSimulator();        
         let state = this.editor.snapshotState()
         compiler.compileAsync({ native: true, forceEmit: true, preferredEditor: this.getPreferredEditor() })
             .then(resp => {
@@ -1478,7 +1480,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             }).catch((e: Error) => {
                 pxt.reportException(e);
                 core.errorNotification(lf("Compilation failed, please contact support."));
-            }).finally(() => pxt.tickEvent("perf.compile"))
+            }).finally(() => {
+                if (simRestart) this.runSimulator()
+            })
             .done();
     }
 


### PR DESCRIPTION
- stop simulator and restart as needed around compilation
- display "loading" circle on download button and prevent multiple-download for overzealous button smashers