### PR TITLE
emit 'yotta.json' or 'platformio.json' along with build output

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -235,8 +235,8 @@ declare namespace ts.pxtc {
         functions: FuncInfo[];
         generatedFiles: pxt.Map<string>;
         extensionFiles: pxt.Map<string>;
-        yotta: pxt.YottaConfig;
-        platformio: pxt.PlatformIOConfig;
+        yotta?: pxt.YottaConfig;
+        platformio?: pxt.PlatformIOConfig;
         sha: string;
         compileData: string;
         shimsDTS: string;

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -139,21 +139,10 @@ namespace pxt.cpp {
         }
 
         pxt.debug("Generating new extinfo")
-
         const res = pxtc.emptyExtInfo();
         const isPlatformio = pxt.appTarget.compileService && !!pxt.appTarget.compileService.platformioIni;
-
-        if (isPlatformio) {
+        if (isPlatformio)
             sourcePath = "/src/"
-            res.platformio = {
-                dependencies: {}
-            };
-        } else {
-            res.yotta = {
-                config: {},
-                dependencies: {}
-            }
-        }
 
         let pointersInc = "\nPXT_SHIMS_BEGIN\n"
         let includesInc = `#include "pxt.h"\n`

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -140,16 +140,21 @@ namespace pxt.cpp {
 
         pxt.debug("Generating new extinfo")
 
-        let isPlatformio = false;
-        if (pxt.appTarget.compileService && pxt.appTarget.compileService.platformioIni) {
-            isPlatformio = true
-        }
+        const res = pxtc.emptyExtInfo();
+        const isPlatformio = pxt.appTarget.compileService && !!pxt.appTarget.compileService.platformioIni;
 
         if (isPlatformio) {
             sourcePath = "/src/"
+            res.platformio = {
+                dependencies: {}
+            };
+        } else {
+            res.yotta = {
+                config: {},
+                dependencies: {}
+            }
         }
 
-        let res = pxtc.emptyExtInfo();
         let pointersInc = "\nPXT_SHIMS_BEGIN\n"
         let includesInc = `#include "pxt.h"\n`
         let thisErrors = ""

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -624,7 +624,11 @@ namespace ts.pxtc {
         return rootFunction as MethodDeclaration
     }
 
-    export function compileBinary(program: Program, host: CompilerHost, opts: CompileOptions, res: CompileResult): EmitResult {
+    export function compileBinary(
+        program: Program,
+        host: CompilerHost,
+        opts: CompileOptions,
+        res: CompileResult): EmitResult {
         const diagnostics = createDiagnosticCollection();
         checker = program.getTypeChecker();
         let classInfos: pxt.Map<ClassInfo> = {}
@@ -888,6 +892,10 @@ namespace ts.pxtc {
                 host.writeFile(fn, data, false, null);
 
             if (opts.target.isNative) {
+                if (opts.extinfo.yotta)
+                    bin.writeFile("yotta.json", JSON.stringify(opts.extinfo.yotta, null, 2));
+                if (opts.extinfo.platformio)
+                    bin.writeFile("platformio.json", JSON.stringify(opts.extinfo.platformio, null, 2));
                 processorEmit(bin, opts, res)
             } else {
                 jsEmit(bin)
@@ -3185,14 +3193,7 @@ ${lbl}: .short 0xffff
             compileData: "",
             shimsDTS: "",
             enumsDTS: "",
-            onlyPublic: true,
-            platformio: {
-                dependencies: {}
-            },
-            yotta: {
-                dependencies: {},
-                config: {}
-            }
+            onlyPublic: true
         }
     }
 

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -3185,7 +3185,8 @@ ${lbl}: .short 0xffff
     }
 
     export function emptyExtInfo(): ExtensionInfo {
-        return {
+        const pio = pxt.appTarget.compileService && !!pxt.appTarget.compileService.platformioIni;
+        const r: ExtensionInfo = {
             functions: [],
             generatedFiles: {},
             extensionFiles: {},
@@ -3195,6 +3196,9 @@ ${lbl}: .short 0xffff
             enumsDTS: "",
             onlyPublic: true
         }
+        if (pio) r.platformio = { dependencies: {} };
+        else r.yotta = { config: {}, dependencies: {} };
+        return r;
     }
 
 


### PR DESCRIPTION
Useful to figure the exact yotta module content from the web ide.