### PR TITLE
Persist the renames in object destructuring mutators

### DIFF
--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -643,16 +643,25 @@ ${output}</xml>`;
             function emitDestructuringMutation(callback: ts.ArrowFunction) {
                 if (callback.parameters.length === 1 && callback.parameters[0].name.kind === SK.ObjectBindingPattern) {
                     const elements = (callback.parameters[0].name as ObjectBindingPattern).elements;
-                    const names = elements.map(e => {
+
+                    const renames: {[index: string]: string} = {};
+
+                    const properties = elements.map(e => {
                         if (checkName(e.propertyName) && checkName(e.name)) {
                             const name = (e.name as Identifier).text;
-                            return e.propertyName ? `${(e.propertyName as Identifier).text}:${name}` : name;
+                            if (e.propertyName) {
+                                const propName = (e.propertyName as Identifier).text;
+                                renames[propName] = name;
+                                return propName;
+                            }
+                            return name;
                         }
                         else {
                             return "";
                         }
                     });
-                    write(`<mutation callbackproperties="${names.join(",")}"></mutation>`)
+
+                    write(`<mutation callbackproperties="${properties.join(",")}" renamemap="${Util.htmlEscape(JSON.stringify(renames))}"></mutation>`)
                 }
 
                 function checkName(name: Node) {

--- a/tests/decompile-test/baselines/mutator_object_destructuring.blocks
+++ b/tests/decompile-test/baselines/mutator_object_destructuring.blocks
@@ -4,17 +4,17 @@
 </statement>
 <next>
 <block type="test_object_destructuring">
-<mutation callbackproperties=""></mutation>
+<mutation callbackproperties="" renamemap="&#123;&#125;"></mutation>
 <statement name="HANDLER">
 </statement>
 <next>
 <block type="test_object_destructuring">
-<mutation callbackproperties="n"></mutation>
+<mutation callbackproperties="n" renamemap="&#123;&#125;"></mutation>
 <statement name="HANDLER">
 </statement>
 <next>
 <block type="test_object_destructuring">
-<mutation callbackproperties="n,text:data"></mutation>
+<mutation callbackproperties="n,text" renamemap="&#123;&#34;text&#34;&#58;&#34;data&#34;&#125;"></mutation>
 <statement name="HANDLER">
 </statement>
 </block>


### PR DESCRIPTION
Fixes #641 
This fixes the issue where if you rename a piece of a radio packet and then remove and re-add the variable in the callback block, the variable name in the block reverts back to the property name instead of the user name. Now renames done by the user will be persisted.