### PR TITLE
Adding an undo button in the blockly toolbox

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -529,22 +529,43 @@ namespace pxt.blocks {
         }
     }
 
-    export function initAddPackage(callback: (ev: MouseEvent) => void): void {
-        // add "Add package" button to toolbox
-        if (!$('#blocklyAddPackage').length) {
-            let addpackageDiv = document.createElement('div');
-            addpackageDiv.id = "blocklyAddPackage";
+    export function initToolboxButtons(addCallback: (ev?: MouseEvent) => void, undoCallback: (ev?: MouseEvent) => void): void {
+        if (!$('#blocklyToolboxButtons').length) {
+            let blocklyToolboxButtons = document.createElement('div');
+            blocklyToolboxButtons.id = "blocklyToolboxButtons";
+            blocklyToolboxButtons.className = 'ui equal width stackable grid';
+
+            // add "Add package" button to toolbox
+            let addButtonDiv = document.createElement('div');
+            addButtonDiv.className = 'column';
             let addPackageButton = document.createElement('button');
             addPackageButton.setAttribute('role', 'button');
             addPackageButton.setAttribute('aria-label', lf("Add Package..."));
             addPackageButton.setAttribute('title', lf("Add Package..."));
-            addPackageButton.onclick = callback;
-            addPackageButton.className = 'circular ui icon button';
+            addPackageButton.onclick = addCallback;
+            addPackageButton.className = 'circular ui icon button blocklyToolboxButton blocklyAddPackageButton';
             let addpackageIcon = document.createElement('i');
             addpackageIcon.className = 'plus icon';
             addPackageButton.appendChild(addpackageIcon);
-            addpackageDiv.appendChild(addPackageButton);
-            $('.blocklyToolboxDiv').append(addpackageDiv);
+            addButtonDiv.appendChild(addPackageButton);
+            blocklyToolboxButtons.appendChild(addButtonDiv);
+
+            // add "undo" button to toolbox
+            let undoButtonDiv = document.createElement('div');
+            undoButtonDiv.className = 'column';
+            let undoButton = document.createElement('button');
+            undoButton.setAttribute('role', 'button');
+            undoButton.setAttribute('aria-label', lf("Undo"));
+            undoButton.setAttribute('title', lf("Undo"));
+            undoButton.onclick = undoCallback;
+            undoButton.className = 'circular ui icon button blocklyToolboxButton blocklyUndoButton';
+            let undoIcon = document.createElement('i');
+            undoIcon.className = 'undo icon';
+            undoButton.appendChild(undoIcon);
+            undoButtonDiv.appendChild(undoButton);
+            blocklyToolboxButtons.appendChild(undoButtonDiv);
+
+            $('.blocklyToolboxDiv').append(blocklyToolboxButtons);
         }
     }
 

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -204,18 +204,12 @@
     color: @trashIconColor;
 }
 
-/* The Add package button at the bottom of the toolbox */
-#blocklyAddPackage {
-    margin-top: 1rem;
-    margin-left: auto;
-    margin-right: auto;
+/* Blockly Toolbox Buttons */
+#blocklyToolboxButtons {
+    margin-top: 0.5rem;
     font-size:3rem;
     text-align: center;
 }
-#blocklyAddPackage button {
-    color: @addPackageColor;
-}
-
 /*******************************
         Monaco Editor
 *******************************/
@@ -301,10 +295,20 @@
     #getting-started-btn:not(.sideDocs) {
         display: block;
     }
+    /* Blockly Toolbox buttons */
+    #blocklyToolboxButtons {
+        margin-right: 2rem;
+        margin-left: 2rem;
+    }
 }
 
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
+    /* Blockly Toolbox buttons */
+    #blocklyToolboxButtons {
+        margin-right: 1rem;
+        margin-left: 1rem;
+    }
 }
 
 /* Tablet */
@@ -320,11 +324,19 @@
         padding-top: 0px !important;
         padding-bottom: 1.6rem !important;
     }
+    /* Blockly Toolbox buttons */
+    #blocklyToolboxButtons {
+        margin-right: 0.5rem;
+        margin-left: 0.5rem;
+    }
 }
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-
+    /* Blockly Toolbox buttons, adjust how the stackable grid looks for these buttons in mobile view */
+    #blocklyToolboxButtons.ui.stackable.grid .column {
+        padding: 0.3rem 0 0.3rem 0 !important;
+    }
 }
 
 /* >= Small Monitor (Small Monitor + Large Monitor + Wide Monitor) */

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -63,8 +63,10 @@ export class Editor extends srceditor.Editor {
                     this.blockInfo = bi;
                     pxt.blocks.initBlocks(this.blockInfo, this.editor, defaultToolbox.documentElement)
                     if (pxt.appTarget.cloud.packages && !this.parent.getSandboxMode()) {
-                        pxt.blocks.initAddPackage((ev: MouseEvent) => {
+                        pxt.blocks.initToolboxButtons(() => {
                             this.parent.addPackage();
+                        },() => {
+                            this.undo();
                         });
                     }
 


### PR DESCRIPTION
Adding an undo button at the bottom of the blockly toolbox.

<img width="337" alt="screen shot 2016-12-05 at 9 21 43 pm" src="https://cloud.githubusercontent.com/assets/16690124/20914050/7c68198c-bb31-11e6-993b-75099afd63e5.png">


In Mobile: 


<img width="191" alt="screen shot 2016-12-05 at 9 21 49 pm" src="https://cloud.githubusercontent.com/assets/16690124/20914056/8901f9c4-bb31-11e6-884f-c4058624d78b.png">


Fixes #851 