### PR TITLE
Always show scrollbars when a div can be scrolled

### DIFF
--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -13,7 +13,6 @@ body {
   overflow-scrolling: touch;
 }
 
-
 .ui.item.logo {
     font-size: 2.8rem;
     margin: 0;
@@ -361,6 +360,16 @@ html {
 }
 
 
+/* OSX Lion+ hides scrollbars while not in use, this overrides that so it's obvious when a div can be scrolled */
+::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+}
+::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0,0,0,.5);
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
 
 /*******************************
     Blockly

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -13,6 +13,7 @@ body {
   overflow-scrolling: touch;
 }
 
+
 .ui.item.logo {
     font-size: 2.8rem;
     margin: 0;


### PR DESCRIPTION
This overrides macOS Lion+ functionality to hide scrollbars when not in use. 
Fixes #814