### PR TITLE
Fix the sidebar bottom whitespace that appears on certain resolutions

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -89,7 +89,9 @@
   overflow-y: auto;
   right: 0;
   border:none;
-  height: calc(100% - (@mobileMenuHeight + 4.6rem));
+  top: 0;
+  padding-top: @mainMenuHeight;
+  height: 100%;
 }
 .rtl #sidedocs {
     right:auto;


### PR DESCRIPTION

![screen shot 2016-12-06 at 11 20 57 am](https://cloud.githubusercontent.com/assets/16690124/20940047/255e4088-bba6-11e6-8436-4b1ef71db4ab.png)


Fix ensures we no longer rely on a hard coded margin value. 
