### PR TITLE
Opening the getting started docs in new tab when sidedocs is not supported

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -87,6 +87,9 @@
     top: @mainMenuHeight;
     right: 2rem;
 }
+#getting-started-btn:not(.sideDocs) {
+    display: block;
+}
 
 /* Side Docs layout */
 #sidedocs {
@@ -351,10 +354,6 @@ div.simframe > iframe {
     #sidedocspopout, #sidedocsexpand {
         display:block;
     }
-    /* Getting started button */
-    #getting-started-btn:not(.sideDocs) {
-        display: block;
-    }
 }
 
 /* Small Monitor */
@@ -381,6 +380,10 @@ div.simframe > iframe {
     /* Blockly Toolbox buttons, adjust how the stackable grid looks for these buttons in mobile view */
     #blocklyToolboxButtons.ui.stackable.grid .column {
         padding: 0.3rem 0 0.3rem 0 !important;
+    }
+    /* Hide the getting started button in the mobile view */
+    #getting-started-btn {
+        display: none !important;
     }
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1730,6 +1730,13 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         this.setState({ sideDocsCollapsed: false })
     }
 
+    gettingStartedLink() {
+        pxt.tickEvent("btn.gettingstartedlink");
+        const targetTheme = pxt.appTarget.appTheme;
+        Util.assert(!this.state.sideDocsLoadUrl && targetTheme && !!targetTheme.sideDoc);
+        window.open(targetTheme.sideDoc)
+    }
+
     getSandboxMode() {
         return sandbox;
     }
@@ -1757,10 +1764,11 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         const compileLoading = !!this.state.compiling;
         const runTooltip = this.state.running ? lf("Stop the simulator") : lf("Start the simulator");
         const makeTooltip = lf("Open assembly instructions");
-        const gettingStartedTooltip = lf("Open beginner tutorial");
         const isBlocks = !this.editor.isVisible || this.getPreferredEditor() == pxt.BLOCKS_PROJECT_NAME;
         const sideDocs = !(sandbox || pxt.options.light || targetTheme.hideSideDocs);
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox;
+        const gettingStarted = !sandbox && !this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc && isBlocks;
+        const gettingStartedTooltip = lf("Open beginner tutorial");
         const run = true; // !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
 
         return (
@@ -1824,9 +1832,15 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         </div> : undefined }
                     </div>
                 </div>
-                {!sandbox && !this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc && isBlocks ?
+                {gettingStarted && sideDocs ?
                     <div id="getting-started-btn">
-                        <sui.Button class="bottom attached getting-started-btn green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } />
+                        <sui.Button class="bottom attached widedesktop only getting-started-btn green " title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } />
+                        <sui.Button class="bottom attached widedesktop hide getting-started-btn green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStartedLink() } />
+                    </div>
+                    : undefined }
+                {gettingStarted && !sideDocs ?
+                    <div id="getting-started-btn">
+                        <sui.Button class="bottom attached getting-started-btn green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStartedLink() } />
                     </div>
                     : undefined }
                 <div id="simulator">


### PR DESCRIPTION
Showing the getting started button for the computer and tablet form factors, as well as on browsers that don't support sidedocs. Opening the getting started docs in a new tab in that case.

Fixes #841