### PR TITLE
resurect  "save .pxt file" support

### DIFF
--- a/pxtlib/emitter/driver.ts
+++ b/pxtlib/emitter/driver.ts
@@ -57,7 +57,9 @@ namespace ts.pxtc {
         quickFlash?: {
             words: number[];
             startAddr: number;
-        }
+        };
+        // client options
+        saveOnly?: boolean;
     }
 
     export function computeUsedParts(resp: CompileResult, ignoreBuiltin = false): string[] {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -269,7 +269,7 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
         const saveProject = () => {
             pxt.tickEvent("projects.save");
             this.hide();
-            this.props.parent.saveProjectToFile();
+            this.props.parent.compile(true);
         }
         const isEmpty = () => {
             if (this.state.searchFor) {
@@ -1460,7 +1460,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         });
     }
 
-    compile() {
+    compile(saveOnly = false) {
         pxt.tickEvent("compile");
         pxt.debug('compiling...');
         if (this.state.compiling) {
@@ -1482,6 +1482,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                     core.warningNotification(lf("Compilation failed, please check your code for errors."));
                     return Promise.resolve()
                 }
+                resp.saveOnly = saveOnly
                 return pxt.commands.deployCoreAsync(resp)
                     .catch(e => {
                         core.warningNotification(lf(".hex file upload, please try again."));

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -272,9 +272,14 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
             this.props.parent.importFileDialog();
         }
         const newProject = () => {
-            pxt.tickEvent("projects.import");
+            pxt.tickEvent("projects.new");
             this.hide();
             this.props.parent.newEmptyProject();
+        }
+        const saveProject = () => {
+            pxt.tickEvent("projects.save");
+            this.hide();
+            this.props.parent.saveProjectToFile();
         }
         const isEmpty = () => {
             if (this.state.searchFor) {
@@ -311,13 +316,21 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
                             description={lf("Open .hex files on your computer") }
                             onClick={() => importHex() }
                             /> : undefined}
-                    {pxt.appTarget.compile && !this.state.searchFor && this.state.mode == ScriptSearchMode.Projects ?
+                    {!this.state.searchFor && this.state.mode == ScriptSearchMode.Projects ?
                         <codecard.CodeCardView
                             color="pink"
                             key="newproject"
                             name={lf("New Project...") }
                             description={lf("Creates a new empty project") }
                             onClick={() => newProject() }
+                            /> : undefined}
+                    {!this.state.searchFor && this.state.mode == ScriptSearchMode.Projects ?
+                        <codecard.CodeCardView
+                            color="pink"
+                            key="saveproject"
+                            name={lf("Save Project...") }
+                            description={lf("Saves current project to a file") }
+                            onClick={() => saveProject() }
                             /> : undefined}
                     {bundles.map(scr =>
                         <codecard.CodeCardView

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -319,7 +319,7 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
                             color="pink"
                             key="saveproject"
                             name={lf("Save Project...") }
-                            description={lf("Saves current project to a file") }
+                            description={lf("Saves current project to a.hex file") }
                             onClick={() => saveProject() }
                             /> : undefined}
                     {bundles.map(scr =>

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -15,7 +15,7 @@ function browserDownloadAsync(text: string, name: string, contentType: string): 
     return Promise.resolve();
 }
 
-function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
+export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     let url = ""
     let fn = ""
     if (pxt.appTarget.compile.useUF2) {
@@ -49,7 +49,8 @@ function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promise<void>
         }).then(() => { });
     }
 
-    return showUploadInstructionsAsync(fn, url);
+    if (resp.saveOnly) return Promise.resolve();
+    else return showUploadInstructionsAsync(fn, url);
 }
 
 //Searches the known USB image, matching on platform and browser


### PR DESCRIPTION
Add a "Save Project" button under "Project" that generates a .pxt file (LZMA project contents).