### PR TITLE
nav menu refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: node_js
 node_js:
-  - "5.7.0"
+  - "6.9.2"
 before_script:
   - "npm install"
   - "tsd reinstall"
 sudo: false
 notifications:
   email:
-    - touchdevelop-build@microsoft.com
+    - yelm-eng@microsoft.com
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.9.2"
+  - "5.7.0"
 before_script:
   - "npm install"
   - "tsd reinstall"

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1766,9 +1766,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => javascriptActive ? this.textEditor.openBlocks() : !blockActive ? this.setFile(pkg.mainEditorPkg().files["main.blocks"]) : undefined } title={lf("Convert code to Blocks") } />
                         <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => blockActive ? this.blocksEditor.openTypeScript() : !javascriptActive ? this.setFile(pkg.mainEditorPkg().files["main.ts"]) : undefined } title={lf("Convert code to JavaScript") } />
                         {sandbox ? undefined : <sui.DropdownMenuItem icon='sidebar' class="more-dropdown-menuitem">
+                            {this.state.header ? <sui.Item role="menuitem" icon="setting" text={lf("Rename...") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
                             {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined }
-                            {this.state.header ? <sui.Item role="menuitem" icon="setting" text={lf("Project Settings...") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
                             {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project") } onClick={() => this.removeProject() } /> : undefined }
                             <div className="ui divider"></div>
                             <a className="ui item thin only" href="/docs" role="menuitem" target="_blank">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -288,7 +288,7 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
         }
 
         const headerText = this.state.mode == ScriptSearchMode.Packages ? lf("Add Package...")
-            : lf("Open Project...");
+            : lf("Projects");
         return (
             <sui.Modal visible={this.state.visible} header={headerText} addClass="large searchdialog"
                 onHide={() => this.setState({ visible: false }) }>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1761,7 +1761,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open" text={lf("Projects") } onClick={() => this.openProject() } />}
-                        <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => javascriptActive ? this.textEditor.openBlocks() : undefined } title={lf("Convert code to Blocks") } />);
+                        <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => javascriptActive ? this.textEditor.openBlocks() : undefined } title={lf("Convert code to Blocks") } />
                         <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => blockActive ? this.blocksEditor.openTypeScript() : undefined } title={lf("Convert code to JavaScript") } />
                         {this.editor.menu() }
                         {sandbox ? undefined : <sui.DropdownMenuItem icon='sidebar' class="more-dropdown-menuitem">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -597,7 +597,7 @@ class DocsMenuItem extends data.Component<ISettingsProps, {}> {
     render() {
         const targetTheme = pxt.appTarget.appTheme;
         const sideDocs = !(sandbox || pxt.options.light || targetTheme.hideSideDocs);
-        return <sui.DropdownMenuItem icon="help" class="help-dropdown-menuitem" title={lf("Help") }>
+        return <sui.DropdownMenuItem icon="help" class="help-dropdown-menuitem" text={lf("Help")} textClass={"landscape only"} title={lf("Reference, lessons, ...") }>
             {targetTheme.docMenu.map(m => <a href={m.path} target="docs" key={"docsmenu" + m.path} role="menuitem" title={m.name} className={`ui item ${sideDocs && !/^https?:/i.test(m.path) ? "widedesktop hide" : ""}`}>{m.name}</a>) }
             {sideDocs ? targetTheme.docMenu.filter(m => !/^https?:/i.test(m.path)).map(m => <sui.Item key={"docsmenuwide" + m.path} role="menuitem" text={m.name} class="widedesktop only" onClick={() => this.openDoc(m.path) } />) : undefined  }
         </sui.DropdownMenuItem>
@@ -1765,8 +1765,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         {sandbox ? undefined : <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open" text={lf("Projects") } onClick={() => this.openProject() } />}
                         <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => javascriptActive ? this.textEditor.openBlocks() : !blockActive ? this.setFile(pkg.mainEditorPkg().files["main.blocks"]) : undefined } title={lf("Convert code to Blocks") } />
                         <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => blockActive ? this.blocksEditor.openTypeScript() : !javascriptActive ? this.setFile(pkg.mainEditorPkg().files["main.ts"]) : undefined } title={lf("Convert code to JavaScript") } />
-                        {sandbox ? undefined : <sui.DropdownMenuItem icon='sidebar' class="more-dropdown-menuitem">
-                            {this.state.header ? <sui.Item role="menuitem" icon="setting" text={lf("Rename...") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
+                        {docMenu ? <DocsMenuItem parent={this} /> : undefined}
+                        {sandbox ? undefined : <sui.DropdownMenuItem icon='setting' class="more-dropdown-menuitem">
+                            {this.state.header ? <sui.Item role="menuitem" icon="options" text={lf("Rename...") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
                             {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined }
                             {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project") } onClick={() => this.removeProject() } /> : undefined }
@@ -1785,7 +1786,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
                             { isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => this.checkForElectronUpdate() } /> : undefined }
                         </sui.DropdownMenuItem>}
-                        {docMenu ? <DocsMenuItem parent={this} /> : undefined}
                         {sandbox ? <div className="right menu">
                             <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/>
                             <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1758,8 +1758,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         {sandbox ? undefined : <div className="ui item landscape only"></div>}
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
-                        {this.editor.menu() }
                         {sandbox ? undefined : <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open" text={lf("Projects") } onClick={() => this.openProject() } />}
+                        {this.editor.menu() }
                         {sandbox ? undefined : <sui.DropdownMenuItem icon='sidebar' class="more-dropdown-menuitem">
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
                             {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1732,6 +1732,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         const gettingStarted = !sandbox && !this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc && isBlocks;
         const gettingStartedTooltip = lf("Open beginner tutorial");
         const run = true; // !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
+        const blockActive = this.editor == this.blocksEditor;
+        const javascriptActive = this.editor == this.textEditor;
 
         // update window title
         document.title = this.state.header ? `${this.state.header.name} - ${pxt.appTarget.name}` : pxt.appTarget.name;
@@ -1759,6 +1761,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open" text={lf("Projects") } onClick={() => this.openProject() } />}
+                        <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => javascriptActive ? this.textEditor.openBlocks() : undefined } title={lf("Convert code to Blocks") } />);
+                        <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => blockActive ? this.blocksEditor.openTypeScript() : undefined } title={lf("Convert code to JavaScript") } />
                         {this.editor.menu() }
                         {sandbox ? undefined : <sui.DropdownMenuItem icon='sidebar' class="more-dropdown-menuitem">
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1016,6 +1016,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     }
 
     setFile(fn: pkg.File) {
+        if (!fn) return;
+
         this.setState({
             currFile: fn,
             helpCard: undefined,
@@ -1761,9 +1763,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
                         {sandbox ? undefined : <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open" text={lf("Projects") } onClick={() => this.openProject() } />}
-                        <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => javascriptActive ? this.textEditor.openBlocks() : undefined } title={lf("Convert code to Blocks") } />
-                        <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => blockActive ? this.blocksEditor.openTypeScript() : undefined } title={lf("Convert code to JavaScript") } />
-                        {this.editor.menu() }
+                        <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => javascriptActive ? this.textEditor.openBlocks() : !blockActive ? this.setFile(pkg.mainEditorPkg().files["main.blocks"]) : undefined } title={lf("Convert code to Blocks") } />
+                        <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => blockActive ? this.blocksEditor.openTypeScript() : !javascriptActive ? this.setFile(pkg.mainEditorPkg().files["main.ts"]) : undefined } title={lf("Convert code to JavaScript") } />
                         {sandbox ? undefined : <sui.DropdownMenuItem icon='sidebar' class="more-dropdown-menuitem">
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
                             {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -427,10 +427,6 @@ export class Editor extends srceditor.Editor {
         this.parent.openTypeScriptAsync().done();
     }
 
-    menu() {
-        return undefined as JSX.Element;
-    }
-
     cleanUpShadowBlocks() {
         const blocks = this.editor.getTopBlocks(false);
         blocks.filter(b => b.isShadow_).forEach(b => b.dispose(false));

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -428,10 +428,7 @@ export class Editor extends srceditor.Editor {
     }
 
     menu() {
-        return (
-            <sui.Item text={lf("JavaScript") } class="javascript-menuitem" textClass="landscape only" icon="align left" onClick={() => this.openTypeScript() }
-                title={lf("Convert code to JavaScript") } />
-        )
+        return undefined as JSX.Element;
     }
 
     cleanUpShadowBlocks() {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -142,14 +142,6 @@ export class Editor extends srceditor.Editor {
             })
     }
 
-    menu(): JSX.Element {
-        const editor = pkg.mainEditorPkg();
-        if (this.currFile != editor.files["main.ts"]) {
-            return (<sui.Item text={lf("Back to Code") } icon={"align left"} onClick={() => this.parent.setFile(editor.files["main.ts"]) } />);
-        }
-        return null as JSX.Element;
-    }
-
     undo() {
         this.editor.trigger('keyboard', monaco.editor.Handler.Undo, null);
     }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -143,15 +143,11 @@ export class Editor extends srceditor.Editor {
     }
 
     menu(): JSX.Element {
-        let editor = pkg.mainEditorPkg();
+        const editor = pkg.mainEditorPkg();
         if (this.currFile != editor.files["main.ts"]) {
             return (<sui.Item text={lf("Back to Code") } icon={"align left"} onClick={() => this.parent.setFile(editor.files["main.ts"]) } />);
         }
-        else if (editor.files["main.blocks"]) { //if main.blocks file present
-            return (<sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" onClick={() => this.openBlocks() }
-                title={lf("Convert code to Blocks") } />);
-        }
-        return null;
+        return null as JSX.Element;
     }
 
     undo() {

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -134,8 +134,4 @@ export class Editor extends srceditor.Editor {
         this.config = JSON.parse(file.content)
         this.setDiagnostics(file, this.snapshotState())
     }
-
-    menu() {
-        return (<sui.Item text={lf("Back to Code") } icon={this.parent.state.header.editor == pxt.BLOCKS_PROJECT_NAME ? "puzzle" : "align left"} onClick={() => this.parent.setFile(pkg.mainEditorPkg().getMainFile()) } />)
-    }
 }

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -46,6 +46,7 @@ export class Editor extends srceditor.Editor {
         const update = (v: any) => {
             const f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
             f.setContentAsync(JSON.stringify(this.config, null, 4) + "\n").then(() => {
+                pkg.mainPkg.config.name = c.name;
                 this.parent.forceUpdate()
                 Util.nextTick(this.changeCallback)
             })
@@ -91,14 +92,7 @@ export class Editor extends srceditor.Editor {
         return (
             <div className="ui content">
                 <div className="ui segment form text" style={{ backgroundColor: "white" }}>
-                    {Cloud.isLoggedIn() ?
-                        <sui.Field>
-                            <div className="ui toggle checkbox ">
-                                <input type="checkbox" name="public" checked={c.public}
-                                    onChange={() => update(c.public = !c.public) } />
-                                <label>{lf("Public package (library)") }</label>
-                            </div>
-                        </sui.Field> : ""}
+                    <sui.Input label={lf("Name")} value={c.name} onChange={v => update(c.name = v)} />
                     <sui.Input label={lf("Description") } lines={3} value={c.description} onChange={v => update(c.description = v) } />
                     {userConfigs.map(uc =>
                         <sui.Checkbox

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -36,9 +36,6 @@ export class Editor {
     acceptsFile(file: pkg.File) {
         return false
     }
-    menu(): JSX.Element {
-        return null;
-    }
     getId() {
         return "editor"
     }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -93,6 +93,7 @@ export class DropdownMenuItem extends UiElement<DropdownProps> {
 }
 
 export interface ItemProps extends UiProps {
+    active?: boolean;
     value?: string;
     onClick?: () => void;
 }
@@ -100,7 +101,7 @@ export interface ItemProps extends UiProps {
 export class Item extends data.Component<ItemProps, {}> {
     renderCore() {
         return (
-            <div className={genericClassName("ui item link", this.props, true) }
+            <div className={genericClassName("ui item link", this.props, true) + ` ${this.props.active ? 'active' : ''}` }
                 role={this.props.role}
                 title={this.props.title}
                 key={this.props.value}


### PR DESCRIPTION
- project input box moved to settings page
- project name displayed in window title
- window title gets updated with name
- projects and /blocksjavascript buttons swapped
- blocks/javascript have an active state
- remove editor specific menu item
- renamed "Project Settings..." to "Rename..."
- hamburger menu to the right, using "setting" icon

![bugreport5](https://cloud.githubusercontent.com/assets/4175913/21054587/27f42102-bde3-11e6-9d72-b6c7e25a9293.gif)

Updated icons.

![image](https://cloud.githubusercontent.com/assets/4175913/21056848/2c778c92-bdec-11e6-9dfe-8f942e1fbdc0.png)


