### PR TITLE
Hats

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -154,6 +154,7 @@ declare namespace pxt {
         projectGallery?: string;
         crowdinProject?: string;
         monacoToolbox?: boolean; // if true: show the monaco toolbox when in the monaco editor
+        blockHats?: boolean; // if true, event blocks have hats
     }
 
     interface DocMenuEntry {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "0.5.102",
+  "version": "0.6.0",
   "description": "Programming Experience Toolkit provides Blocks / JavaScript tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1071,11 +1071,6 @@ namespace pxt.blocks {
         return mkBlock(stmts);
     }
 
-    function isTopBlock(b: B.Block): boolean {
-        if (!b.parentBlock_) return true;
-        return isTopBlock(b.parentBlock_);
-    }
-
     // This function creates an empty environment where type inference has NOT yet
     // been performed.
     // - All variables have been assigned an initial [Point] in the union-find.

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -11,19 +11,20 @@ namespace pxt.blocks {
     /**
      * Loads the xml into a off-screen workspace (not suitable for size computations)
      */
-    export function loadWorkspaceXml(xml: string) {
-        let workspace = new Blockly.Workspace();
+    export function loadWorkspaceXml(xml: string, skipReport = false) {
+        const workspace = new Blockly.Workspace();
         try {
             Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
             return workspace;
         } catch (e) {
-            pxt.reportException(e, { xml: xml });
+            if (!skipReport)
+                pxt.reportException(e);
             return null;
         }
     }
 
 
-    export function importXml(info: pxtc.BlocksInfo, xml: string): string {
+    export function importXml(info: pxtc.BlocksInfo, xml: string, skipReport = false): string {
         try {
             let parser = new DOMParser();
             let doc = parser.parseFromString(xml, "application/xml");
@@ -33,7 +34,8 @@ namespace pxt.blocks {
             for (let k in info.apis.byQName) {
                 let api = info.apis.byQName[k];
                 if (api.kind == pxtc.SymbolKind.EnumMember)
-                    enums[api.namespace + '.' + (api.attributes.blockImportId || api.attributes.block || api.attributes.blockId || api.name)] = api.namespace + '.' + api.name;
+                    enums[api.namespace + '.' + (api.attributes.blockImportId || api.attributes.block || api.attributes.blockId || api.name)]
+                        = api.namespace + '.' + api.name;
             }
 
             // walk through blocks and patch enums
@@ -45,7 +47,8 @@ namespace pxt.blocks {
             return new XMLSerializer().serializeToString(doc);
         }
         catch (e) {
-            reportException(e, { xml: xml });
+            if (!skipReport)
+                reportException(e);
             return xml;
         }
     }

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -129,9 +129,9 @@ namespace pxt.blocks.layout {
     }
 
     function flowBlocks(blocks: Blockly.Block[], ratio: number = 1.62) {
-        const gap = 14;
-        const marginx = 14;
-        const marginy = 14;
+        const gap = 16;
+        const marginx = 20;
+        const marginy = 20;
 
         // compute total block surface and infer width
         let surface = 0;

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -21,7 +21,11 @@ namespace pxt.blocks.layout {
         // randomize order
         fisherYates(blocks);
         // apply layout
-        flow(blocks, ratio || 1.62);
+        flowBlocks(blocks, ratio);
+    }
+
+    export function flow(ws: B.Workspace, ratio?: number) {
+        flowBlocks(ws.getTopBlocks(true), ratio);
     }
 
     export function screenshotAsync(ws: B.Workspace): Promise<string> {
@@ -124,8 +128,11 @@ namespace pxt.blocks.layout {
         return { width: width, height: height, xml: data };
     }
 
-    function flow(blocks: Blockly.Block[], ratio: number) {
+    function flowBlocks(blocks: Blockly.Block[], ratio: number = 1.62) {
         const gap = 14;
+        const marginx = 14;
+        const marginy = 14;
+
         // compute total block surface and infer width
         let surface = 0;
         for (let block of blocks) {
@@ -134,8 +141,8 @@ namespace pxt.blocks.layout {
         }
         const maxx = Math.sqrt(surface) * ratio;
 
-        let insertx = 0;
-        let inserty = 0;
+        let insertx = marginx;
+        let inserty = marginy;
         let endy = 0;
         for (let block of blocks) {
             let r = block.getBoundingRectangle();
@@ -145,7 +152,7 @@ namespace pxt.blocks.layout {
             insertx += s.width + gap;
             endy = Math.max(endy, inserty + s.height + gap);
             if (insertx > maxx) { // start new line
-                insertx = 0;
+                insertx = marginx;
                 inserty = endy;
             }
         }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -620,7 +620,7 @@ namespace pxt.blocks {
         initDrag();
         initToolboxColor();
 
-        Blockly.BlockSvg.START_HAT = true;
+        Blockly.BlockSvg.START_HAT = !!pxt.appTarget.appTheme.blockHats;
     }
 
     function setHelpResources(block: any, id: string, name: string, tooltip: any, url: string) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -368,7 +368,7 @@ namespace pxt.blocks {
             addMutation(block as MutatingBlock, fn, fn.attributes.mutate);
         }
 
-        let body = fn.parameters ? fn.parameters.filter(pr => pr.type == "() => void")[0] : undefined;
+        const body = fn.parameters ? fn.parameters.filter(pr => pr.type == "() => void")[0] : undefined;
         if (body) {
             block.appendStatementInput("HANDLER")
                 .setCheck("null");
@@ -397,8 +397,8 @@ namespace pxt.blocks {
         }
 
         // hook up/down if return value is void
-        block.setPreviousStatement(fn.retType == "void");
-        block.setNextStatement(fn.retType == "void");
+        block.setPreviousStatement(!body && fn.retType == "void");
+        block.setNextStatement(!body && fn.retType == "void");
 
         block.setTooltip(fn.attributes.jsDoc);
     }
@@ -620,9 +620,7 @@ namespace pxt.blocks {
         initDrag();
         initToolboxColor();
 
-        // hats creates issues when trying to round-trip events between JS and blocks. To better support that scenario,
-        // we're taking off hats.
-        // Blockly.BlockSvg.START_HAT = true;
+        Blockly.BlockSvg.START_HAT = true;
     }
 
     function setHelpResources(block: any, id: string, name: string, tooltip: any, url: string) {

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -19,7 +19,8 @@ namespace pxt.blocks {
     export enum BlockLayout {
         Align = 1,
         Shuffle = 2,
-        Clean = 3
+        Clean = 3,
+        Flow = 4
     }
 
     export interface BlocksRenderOptions {
@@ -30,7 +31,7 @@ namespace pxt.blocks {
         package?: string;
     }
 
-    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 14, layout: BlockLayout.Align }): HTMLElement {
+    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 14, layout: BlockLayout.Flow }): HTMLElement {
         if (!workspace) {
             blocklyDiv = document.createElement("div");
             blocklyDiv.style.position = "absolute";
@@ -60,6 +61,8 @@ namespace pxt.blocks {
                     pxt.blocks.layout.verticalAlign(workspace, options.emPixels); break;
                 case BlockLayout.Shuffle:
                     pxt.blocks.layout.shuffle(workspace, options.aspectRatio); break;
+                case BlockLayout.Flow:
+                    pxt.blocks.layout.flow(workspace, options.aspectRatio); break;
                 case BlockLayout.Clean:
                     if ((<any>workspace).cleanUp_)
                         (<any>workspace).cleanUp_();

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -93,6 +93,25 @@ ${output}</xml>`;
             result.success = false;
         }
 
+        function hasArrowFunction(info: CallInfo): boolean {
+            const parameters = (info.decl as FunctionLikeDeclaration).parameters;
+            return info.args.some((arg, index) =>
+                arg && arg.kind === SK.ArrowFunction && parameters && !parameters[index].questionToken && !parameters[index].initializer);
+        }
+
+        function isEventExpression(expr: ts.ExpressionStatement): boolean {
+            if (expr.expression.kind == SK.CallExpression) {
+                const call = expr.expression as ts.CallExpression;
+                const callInfo: pxtc.CallInfo = (expr as any).callInfo
+                if (!callInfo) {
+                    error(expr)
+                    return false;
+                }
+                return !callInfo.isExpression && hasArrowFunction(callInfo);
+            }
+            return false;
+        }
+
         function isOutputExpression(expr: ts.Expression): boolean {
 
             switch (expr.kind) {
@@ -143,7 +162,10 @@ ${output}</xml>`;
 
             // Go over the statements in reverse so that we can insert the nodes into the existing list if there is one
             statements.reverse().forEach(statement => {
-                if (statement.kind == SK.ExpressionStatement && isOutputExpression((statement as ts.ExpressionStatement).expression)) {
+                if (statement.kind == SK.ExpressionStatement &&
+                    (isOutputExpression((statement as ts.ExpressionStatement).expression) ||
+                        isEventExpression((statement as ts.ExpressionStatement))
+                    )) {
                     if (!topLevel) {
                         error(statement, Util.lf("Output expressions can only exist in the top level scope"))
                     }
@@ -377,7 +399,7 @@ ${output}</xml>`;
                                 addVariableDeclaration(decl);
                                 return false;
                             }
-                        break;
+                            break;
                         default:
                     }
                     return true;
@@ -601,11 +623,7 @@ ${output}</xml>`;
 
                 const argumentDifference = info.args.length - argNames.length;
                 if (argumentDifference > 0) {
-                    const parameters = (info.decl as FunctionLikeDeclaration).parameters;
-
-                    const hasCallback = info.args.some((arg, index) =>
-                        arg && arg.kind === SK.ArrowFunction && parameters && !parameters[index].questionToken && !parameters[index].initializer);
-
+                    const hasCallback = hasArrowFunction(info);
                     if (argumentDifference > 1 || !hasCallback) {
                         pxt.tickEvent("decompiler.optionalParameters");
                         error(node, Util.lf("Function call has more arguments than are supported by its block"));
@@ -658,7 +676,7 @@ ${output}</xml>`;
                 if (callback.parameters.length === 1 && callback.parameters[0].name.kind === SK.ObjectBindingPattern) {
                     const elements = (callback.parameters[0].name as ObjectBindingPattern).elements;
 
-                    const renames: {[index: string]: string} = {};
+                    const renames: { [index: string]: string } = {};
 
                     const properties = elements.map(e => {
                         if (checkName(e.propertyName) && checkName(e.name)) {

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -102,7 +102,7 @@ ${output}</xml>`;
         function isEventExpression(expr: ts.ExpressionStatement): boolean {
             if (expr.expression.kind == SK.CallExpression) {
                 const call = expr.expression as ts.CallExpression;
-                const callInfo: pxtc.CallInfo = (expr as any).callInfo
+                const callInfo: pxtc.CallInfo = (call as any).callInfo
                 if (!callInfo) {
                     error(expr)
                     return false;

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -169,7 +169,7 @@ namespace pxt.runner {
         if (!$el[0]) return Promise.resolve();
 
         if (!options.emPixels) options.emPixels = 14;
-        if (!options.layout) options.layout = pxt.blocks.BlockLayout.Align;
+        if (!options.layout) options.layout = pxt.blocks.BlockLayout.Flow;
 
         return pxt.runner.decompileToBlocksAsync($el.text(), options)
             .then((r) => {

--- a/tests/decompile-test/baselines/functions_callbacks.blocks
+++ b/tests/decompile-test/baselines/functions_callbacks.blocks
@@ -2,13 +2,14 @@
 <block type="test_callback">
 <statement name="HANDLER">
 </statement>
-<next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
 <block type="test_callback">
 <statement name="HANDLER">
 <block type="test_no_argument">
 </block>
 </statement>
-<next>
+</block>
 <block type="test_callback">
 <statement name="HANDLER">
 <block type="test_no_argument">
@@ -18,7 +19,7 @@
 </next>
 </block>
 </statement>
-<next>
+</block>
 <block type="test_callback_with_argument">
 <field name="arg1">TestEnum.testValue2</field>
 <value name="arg2">
@@ -30,12 +31,5 @@
 <block type="test_no_argument">
 </block>
 </statement>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/functions_optional_parameters.blocks
+++ b/tests/decompile-test/baselines/functions_optional_parameters.blocks
@@ -15,10 +15,6 @@
 </shadow>
 </value>
 <next>
-<block type="test_optional_argument_2">
-<statement name="HANDLER">
-</statement>
-<next>
 <block type="test_optional_argument_3">
 </block>
 </next>
@@ -26,8 +22,10 @@
 </next>
 </block>
 </next>
-</block>
-</next>
 <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+<block type="test_optional_argument_2">
+<statement name="HANDLER">
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/mutator_object_destructuring.blocks
+++ b/tests/decompile-test/baselines/mutator_object_destructuring.blocks
@@ -2,27 +2,21 @@
 <block type="test_object_destructuring">
 <statement name="HANDLER">
 </statement>
-<next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
 <block type="test_object_destructuring">
 <mutation callbackproperties="" renamemap="&#123;&#125;"></mutation>
 <statement name="HANDLER">
 </statement>
-<next>
+</block>
 <block type="test_object_destructuring">
 <mutation callbackproperties="n" renamemap="&#123;&#125;"></mutation>
 <statement name="HANDLER">
 </statement>
-<next>
+</block>
 <block type="test_object_destructuring">
 <mutation callbackproperties="n,text" renamemap="&#123;&#34;text&#34;&#58;&#34;data&#34;&#125;"></mutation>
 <statement name="HANDLER">
 </statement>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_4.blocks
+++ b/tests/decompile-test/baselines/name_collision_4.blocks
@@ -7,6 +7,17 @@
 </shadow>
 </value>
 <next>
+<block type="variables_change">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
 <block type="test_callback_with_argument">
 <field name="arg1">TestEnum.testValue1</field>
 <value name="arg2">
@@ -50,18 +61,5 @@
 </next>
 </block>
 </statement>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
-</block>
-</next>
-</block>
-</next>
-<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
 </block>
 </xml>

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -119,6 +119,7 @@ export class Editor extends srceditor.Editor {
             let xml = Blockly.Xml.textToDom(text);
             Blockly.Xml.domToWorkspace(xml, this.editor);
 
+            this.initLayout();
             this.editor.clearUndo();
             this.reportDeprecatedBlocks();
         } catch (e) {
@@ -128,6 +129,16 @@ export class Editor extends srceditor.Editor {
         this.changeCallback();
 
         return true;
+    }
+
+    private initLayout() {
+        // layout on first load if no data info
+        const layoutInfo = this.editor.getTopBlocks(false).some(b => {
+            const tp = b.getBoundingRectangle().topLeft;
+            return tp.x != 0 || tp.y != 0
+        });
+        if (!layoutInfo)
+            pxt.blocks.layout.flow(this.editor);
     }
 
     private reportDeprecatedBlocks() {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -136,12 +136,9 @@ export class Editor extends srceditor.Editor {
         })
     }
 
-    decompile(blockFile: string): Promise<boolean> {
-        let xml: string;
+    decompileAsync(blockFile: string): Promise<boolean> {
         return compiler.decompileAsync(blockFile)
-            .then(resp => {
-                return Promise.resolve(resp.success);
-            })
+            .then(resp => resp.success);
     }
 
     undo() {


### PR DESCRIPTION
- [x] render events with hats
- [x] compile to javascript
- [x] decompile from javascript
- [x] layout blocks as needed
- [x] fix test suite
- [x] when importing legacy script, bail out to javascript and decompile from there (to recover blocks)
- [x] use flow layout (squarish) instead of just stacking blocks in docs

Note that we are not enabling hats currently; Blockly does not properly compute the bounding box of blocks with hats which messes up our docs rendering. hats can be enabled via pxtarget.json flag.

![image](https://cloud.githubusercontent.com/assets/4175913/21170860/f3c04882-c17c-11e6-9288-6d2601478aff.png)

Flow layout works better for docs

![image](https://cloud.githubusercontent.com/assets/4175913/21170882/1d15b852-c17d-11e6-9a4a-3bdee9bb60b9.png)
