### PR TITLE
Detect and disable duplicate events

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -210,29 +210,6 @@ namespace pxt.blocks {
         throw e;
     }
 
-    namespace Errors {
-
-        export interface CompilationError {
-            msg: string;
-            block: B.Block;
-        }
-
-        let errors: CompilationError[] = [];
-
-        export function report(m: string, b: B.Block) {
-            errors.push({ msg: m, block: b });
-        }
-
-        export function clear() {
-            errors = [];
-        }
-
-        export function get() {
-            return errors;
-        }
-
-    }
-
     ///////////////////////////////////////////////////////////////////////////////
     // Types
     //
@@ -480,10 +457,9 @@ namespace pxt.blocks {
                         }
                 }
             } catch (e) {
-                if ((<any>e).block)
-                    Errors.report(e + "", (<any>e).block);
-                else
-                    Errors.report(e + "", b);
+                const be = ((<any>e).block as B.Block) || b;
+                be.setWarningText(e + "");
+                e.push(be);
             }
         });
 
@@ -700,6 +676,7 @@ namespace pxt.blocks {
         workspace: Blockly.Workspace;
         bindings: Binding[];
         stdCallTable: pxt.Map<StdFunc>;
+        errors: B.Block[];
     }
 
     export enum VarUsage {
@@ -725,7 +702,8 @@ namespace pxt.blocks {
         return {
             workspace: e.workspace,
             bindings: [{ name: x, type: ground(t), declaredInLocalScope: 0 }].concat(e.bindings),
-            stdCallTable: e.stdCallTable
+            stdCallTable: e.stdCallTable,
+            errors: e.errors
         };
     }
 
@@ -748,7 +726,8 @@ namespace pxt.blocks {
         return {
             workspace: w,
             bindings: [],
-            stdCallTable: {}
+            stdCallTable: {},
+            errors: []
         }
     };
 
@@ -1240,7 +1219,6 @@ namespace pxt.blocks {
     }
 
     export function compile(b: B.Workspace, blockInfo: pxtc.BlocksInfo): BlockCompilationResult {
-        Errors.clear();
         return tdASTtoTS(compileWorkspace(b, blockInfo));
     }
 

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -939,9 +939,11 @@ namespace pxt.blocks {
         // compute key that identifies event call
         // detect if same event is registered already
         const key = JSON.stringify({ event, compiledArgs });
-        if (e.events[key]) {
+        const otherEvent = e.events[key];
+        if (otherEvent) {
             // another block is already registered
-            e.events[key].setDisabled(true);
+            otherEvent.setDisabled(true);
+            otherEvent.setWarningText(lf("This event is already used."))
         }
         // remember last event
         e.events[key] = b;
@@ -1182,7 +1184,10 @@ namespace pxt.blocks {
             });
 
             topblocks.forEach(b => {
-                b.setDisabled(false);
+                if (b.disabled) {
+                    b.setDisabled(false);
+                    b.setWarningText(undefined);
+                }
                 let compiled = compileStatements(e, b)
                 if (compiled.type == NT.Block)
                     append(stmtsMain, compiled.children);

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1213,7 +1213,8 @@ namespace pxt.blocks {
                 // compute key that identifies event call
                 // detect if same event is registered already   
                 const compiledArgs = eventArgs(call).map(arg => compileArg(e, b, arg, []));
-                const key = JSON.stringify({ name: call.f, ns: call.namespace, compiledArgs });
+                const key = JSON.stringify({ name: call.f, ns: call.namespace, compiledArgs })
+                    .replace(/"id"\s*:\s*"[^"]+"/g, ''); // remove blockly ids
                 const otherEvent = events[key];
                 if (otherEvent) {
                     // another block is already registered

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -407,8 +407,8 @@ export class Editor extends srceditor.Editor {
         if (!this.compilationResult || this.delayLoadXml || this.loadingXml)
             return;
 
-        // clear previous warnings
-        this.editor.getAllBlocks().forEach(b => b.setWarningText(null));
+        // clear previous warnings on non-disabled blocks
+        this.editor.getAllBlocks().filter(b => !b.disabled).forEach(b => b.setWarningText(null));
         let tsfile = file.epkg.files[file.getVirtualFileName()];
         if (!tsfile || !tsfile.diagnostics) return;
 


### PR DESCRIPTION
- [x] detect when duplicate events are registered in blocks taking into account event arguments
- [x] disable insert duplicate event
- [x] add warning on disabled event
- [x] remove warning when compilation update

![dupdetect](https://cloud.githubusercontent.com/assets/4175913/21272604/cf7dc298-c374-11e6-9f25-493220043708.gif)

Issue not addressed in this PR: in general, we don't store disabled blocks in Javascript. This creates a rountrip issue where we potentially loose code when the user modifies the javascript. We need to support this scenario for the "on start" event functionality any so it will be addressed in a future PR.
