### PR TITLE
On start block support

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3385,6 +3385,8 @@ function checkDocsAsync(): Promise<void> {
         // look for broken urls
         text.replace(/]\((\/[^)]+?)(\s+"[^"]+")?\)/g, (m) => {
             let url = /]\((\/[^)]+?)(\s+"[^"]+")?\)/.exec(m)[1];
+            // remove hash
+            url = url.replace(/#.*$/, '');
             if (!urls[url]) {
                 console.error(`${f}: broken link ${url}`);
                 broken++;

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2838,19 +2838,13 @@ function testSnippetsAsync(parsed?: commandParser.ParsedCommand): Promise<void> 
                 if (resp.success) {
                     if (/^block/.test(snippet.type)) {
                         //Similar to pxtc.decompile but allows us to get blocksInfo for round trip
-                        let file = resp.ast.getSourceFile('main.ts');
-                        let apis = pxtc.getApiInfo(resp.ast);
-                        let blocksInfo = pxtc.getBlocksInfo(apis);
-                        let bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file)
-
-                        let success = !!bresp.outfiles['main.blocks']
-
-                        if (success) {
-                            return addSuccess(name)
-                        }
-                        else {
-                            return addFailure(name, bresp.diagnostics)
-                        }
+                        const file = resp.ast.getSourceFile('main.ts');
+                        const apis = pxtc.getApiInfo(resp.ast);
+                        const blocksInfo = pxtc.getBlocksInfo(apis);
+                        const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, { snippetMode: false })
+                        const success = !!bresp.outfiles['main.blocks']
+                        if (success) return addSuccess(name)
+                        else return addFailure(name, bresp.diagnostics)
                     }
                     else {
                         return addSuccess(name)

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -41,6 +41,13 @@ declare namespace pxt {
         files: Map<string>;
     }
 
+    interface BlockToolboxDefinition {
+        namespace: string;
+        type: string;
+        gap?: number;
+        weight?: number;
+        fields?: Map<string>;
+    }
 
     interface RuntimeOptions {
         mathBlocks?: boolean;
@@ -49,14 +56,9 @@ declare namespace pxt {
         variablesBlocks?: boolean;
         logicBlocks?: boolean;
         loopsBlocks?: boolean;
-
-        extraBlocks?: {
-            namespace: string;
-            type: string;
-            gap?: number;
-            weight?: number;
-            fields?: Map<string>;
-        }[]
+        extraBlocks?: BlockToolboxDefinition[];
+        onStartColor?: string;
+        onStartNamespace?: string;
     }
 
     interface AppAnalytics {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -165,14 +165,6 @@ declare namespace pxt {
         subitems?: DocMenuEntry[];
     }
 
-    interface TargetVersions {
-        target: string;
-        pxt: string;
-        tag?: string;
-        branch?: string;
-        commits?: string; // URL
-    }
-
     interface TargetBundle extends AppTarget {
         bundledpkgs: Map<Map<string>>;
         bundleddirs: string[];

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -3,6 +3,14 @@ declare namespace pxt {
         [index: string]: T;
     }
 
+    interface TargetVersions {
+        target: string;
+        pxt: string;
+        tag?: string;
+        branch?: string;
+        commits?: string; // URL
+    }
+
     /**
      * The schema for the pxt.json package files
      */
@@ -12,7 +20,7 @@ declare namespace pxt {
         installedVersion?: string;
         // semver description for support target version
         documentation?: string; // doc page to open when loading project
-        targetVersion?: string;
+        targetVersions?: TargetVersions; // versions of the target/pxt the package was compiled against
         description?: string;
         dependencies: Map<string>;
         license?: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "Programming Experience Toolkit provides Blocks / JavaScript tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -9,7 +9,6 @@
 import B = Blockly;
 
 namespace pxt.blocks {
-    const ON_START_TYPE = "pxtStart";
 
     export enum NT {
         Prefix, // op + map(children)
@@ -1174,13 +1173,13 @@ namespace pxt.blocks {
 
             // all compiled top level blocks are event, move on start to bottom
             const topblocks = w.getTopBlocks(true).sort((a, b) => {
-                return (a.type == ON_START_TYPE ? 1 : 0) - (b.type == ON_START_TYPE ? 1 : 0);
+                return (a.type == ts.pxtc.decompiler.ON_START_TYPE ? 1 : 0) - (b.type == ts.pxtc.decompiler.ON_START_TYPE ? 1 : 0);
             });
 
             updateDisabledBlocks(e, w.getAllBlocks(), topblocks);
 
             topblocks.forEach(b => {
-                if (b.type == ON_START_TYPE)
+                if (b.type == ts.pxtc.decompiler.ON_START_TYPE)
                     append(stmtsMain, compileStartEvent(e, b).children);
                 else {
                     const compiled = compileStatements(e, b)

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -941,8 +941,6 @@ namespace pxt.blocks {
     function compileStartEvent(e: Environment, b: B.Block): JsNode {
         const bBody = b.getInputTargetBlock("HANDLER");
         const body = compileStatements(e, bBody);
-        if (body.type == NT.Block && body.children && body.children.length == 1)
-            return body.children[0];
         return body;
     }
 

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1216,7 +1216,10 @@ namespace pxt.blocks {
         topBlocks.forEach(b => {
             const call = e.stdCallTable[b.type];
             // is this an event?
-            if (call && call.hasHandler && !call.attrs.blockAllowMultiple) {
+            if (call && call.hasHandler) {
+                // multiple calls allowed
+                if (call.attrs.blockAllowMultiple)
+                    return;
                 // compute key that identifies event call
                 // detect if same event is registered already   
                 const compiledArgs = eventArgs(call).map(arg => compileArg(e, b, arg, []));

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1171,13 +1171,13 @@ namespace pxt.blocks {
 
             // all compiled top level blocks are event, move on start to bottom
             const topblocks = w.getTopBlocks(true).sort((a, b) => {
-                return (a.type == ts.pxtc.decompiler.ON_START_TYPE ? 1 : 0) - (b.type == ts.pxtc.decompiler.ON_START_TYPE ? 1 : 0);
+                return (a.type == ts.pxtc.ON_START_TYPE ? 1 : 0) - (b.type == ts.pxtc.ON_START_TYPE ? 1 : 0);
             });
 
             updateDisabledBlocks(e, w.getAllBlocks(), topblocks);
 
             topblocks.forEach(b => {
-                if (b.type == ts.pxtc.decompiler.ON_START_TYPE)
+                if (b.type == ts.pxtc.ON_START_TYPE)
                     append(stmtsMain, compileStartEvent(e, b).children);
                 else {
                     const compiled = compileStatements(e, b)

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -41,7 +41,8 @@ namespace pxt.blocks {
             // does this block is disable or have s nested statement block?
             const nodeType = node.getAttribute("type");
             if (!node.getAttribute("disabled") && !node.querySelector("statement")
-                && (blocks[nodeType] && blocks[nodeType].retType == "void")) {
+                && (pxt.blocks.buildinBlockStatements[nodeType] || (blocks[nodeType] && blocks[nodeType].retType == "void"))
+            ) {
                 // old block, needs to be wrapped in onstart
                 if (!onstart) {
                     onstart = dom.ownerDocument.createElement("block");
@@ -52,12 +53,16 @@ namespace pxt.blocks {
                     insertNode.appendChild(node);
                     newnodes.push(onstart);
 
+                    node.removeAttribute("x");
+                    node.removeAttribute("y");
                     insertNode = node;
                 } else {
                     // add nested statement
                     const next = dom.ownerDocument.createElement("next");
                     next.appendChild(node);
                     insertNode.appendChild(next);
+                    node.removeAttribute("x");
+                    node.removeAttribute("y");
                     insertNode = node;
                 }
             }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -480,10 +480,41 @@ namespace pxt.blocks {
                 }
             })
 
-        // remove ununsed blocks
+        // remove unused blocks
         Object
             .keys(cachedBlocks).filter(k => !currentBlocks[k])
             .forEach(k => removeBlock(cachedBlocks[k].fn));
+
+
+        // add extra blocks
+        if (tb && pxt.appTarget.runtime) {
+            const extraBlocks = pxt.appTarget.runtime.extraBlocks || [];
+            extraBlocks.push({
+                namespace: pxt.appTarget.runtime.onStartNamespace || "loops",
+                weight: 10,
+                type: ts.pxtc.ON_START_TYPE
+            })
+            extraBlocks.forEach(eb => {
+                let cat = categoryElement(tb, eb.namespace);
+                if (cat) {
+                    let el = document.createElement("block");
+                    el.setAttribute("type", eb.type);
+                    el.setAttribute("weight", (eb.weight || 50).toString());
+                    if (eb.gap) el.setAttribute("gap", eb.gap.toString());
+                    if (eb.fields) {
+                        for (let f in eb.fields) {
+                            let fe = document.createElement("field");
+                            fe.setAttribute("name", f);
+                            fe.appendChild(document.createTextNode(eb.fields[f]));
+                            el.appendChild(fe);
+                        }
+                    }
+                    cat.appendChild(el);
+                } else {
+                    console.error(`trying to add block ${eb.type} to unknown category ${eb.namespace}`)
+                }
+            })
+        }
 
         if (tb) {
             // remove unused categories
@@ -513,30 +544,6 @@ namespace pxt.blocks {
         // lf("{id:category}Math")
         // lf("{id:category}Advanced")
         // lf("{id:category}More\u2026")
-
-        // add extra blocks
-        if (tb && pxt.appTarget.runtime && pxt.appTarget.runtime.extraBlocks) {
-            pxt.appTarget.runtime.extraBlocks.forEach(eb => {
-                let cat = categoryElement(tb, eb.namespace);
-                if (cat) {
-                    let el = document.createElement("block");
-                    el.setAttribute("type", eb.type);
-                    el.setAttribute("weight", (eb.weight || 50).toString());
-                    if (eb.gap) el.setAttribute("gap", eb.gap.toString());
-                    if (eb.fields) {
-                        for (let f in eb.fields) {
-                            let fe = document.createElement("field");
-                            fe.setAttribute("name", f);
-                            fe.appendChild(document.createTextNode(eb.fields[f]));
-                            el.appendChild(fe);
-                        }
-                    }
-                    cat.appendChild(el);
-                } else {
-                    console.error(`trying to add block ${eb.type} to unknown category ${eb.namespace}`)
-                }
-            })
-        }
 
         // update shadow types
         if (tb) {
@@ -1219,7 +1226,7 @@ namespace pxt.blocks {
                             "name": "HANDLER"
                         }
                     ],
-                    "colour": blockColors['loops']
+                    "colour": (pxt.appTarget.runtime ? pxt.appTarget.runtime.onStartColor : '') || blockColors['loops']
                 });
 
                 setHelpResources(this,

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -645,6 +645,7 @@ namespace pxt.blocks {
         Blockly.FieldCheckbox.CHECK_CHAR = '■';
 
         initContextMenu();
+        initOnStart();
         initMath();
         initVariables();
         initLoops();
@@ -1201,6 +1202,34 @@ namespace pxt.blocks {
             return myParent === parent || isChild(myParent, parent);
         }
         return false;
+    }
+
+    function initOnStart() {
+        // pxt math_op2
+        Blockly.Blocks[ts.pxtc.ON_START_TYPE] = {
+            init: function () {
+                this.jsonInit({
+                    "message0": lf("on start %1 %2"),
+                    "args0": [
+                        {
+                            "type": "input_dummy"
+                        },
+                        {
+                            "type": "input_statement",
+                            "name": "HANDLER"
+                        }
+                    ],
+                    "colour": blockColors['loops']
+                });
+
+                setHelpResources(this,
+                    ts.pxtc.ON_START_TYPE,
+                    lf("on start event"),
+                    lf("Run code when the program starts"),
+                    '/blocks/on-start'
+                );
+            }
+        };
     }
 
     function initMath() {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -40,6 +40,15 @@ namespace pxt.blocks {
     }> = {};
     Object.keys(Blockly.Blocks)
         .forEach(k => builtinBlocks[k] = { block: Blockly.Blocks[k] });
+    export const buildinBlockStatements: Map<boolean> = {
+        "controls_if": true,
+        "controls_for": true,
+        "controls_simple_for": true,
+        "controls_repeat_ext": true,
+        "variables_set": true,
+        "variables_change": true,
+        "device_while": true
+    }
 
     // blocks cached
     interface CachedBlock {

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -29,6 +29,7 @@ namespace pxt.blocks {
         clean?: boolean;
         aspectRatio?: number;
         package?: string;
+        snippetMode?: boolean;
     }
 
     export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 14, layout: BlockLayout.Flow }): HTMLElement {

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -610,7 +610,7 @@ namespace pxt.cpp {
         } else {
             res.yotta.config = configJson;
             let name = "pxt-app"
-            if (pxt.appTarget.compileService)
+            if (pxt.appTarget.compileService && pxt.appTarget.compileService.yottaBinary)
                 name = pxt.appTarget.compileService.yottaBinary
                     .replace(/-combined/, "").replace(/\.hex$/, "")
             let moduleJson = {

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -748,7 +748,7 @@ int main() {
     export interface HexFile {
         meta?: {
             cloudId: string;
-            targetVersion?: string;
+            targetVersions?: pxt.TargetVersions;
             editor: string;
             name: string;
         };

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -1,6 +1,5 @@
 
 namespace ts.pxtc.decompiler {
-    export const ON_START_TYPE = "pxtStart";
     const SK = ts.SyntaxKind;
 
     type NextNode = ts.Node | "ScopeEnd";

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -1,5 +1,6 @@
 
 namespace ts.pxtc.decompiler {
+    export const ON_START_TYPE = "pxtStart";
     const SK = ts.SyntaxKind;
 
     type NextNode = ts.Node | "ScopeEnd";

--- a/pxtlib/emitter/driver.ts
+++ b/pxtlib/emitter/driver.ts
@@ -278,13 +278,13 @@ namespace ts.pxtc {
     }
 
     export function decompile(opts: CompileOptions, fileName: string) {
-        let resp = compile(opts);
+        const resp = compile(opts);
         if (!resp.success) return resp;
 
-        let file = resp.ast.getSourceFile(fileName);
-        let apis = getApiInfo(resp.ast);
-        let blocksInfo = pxtc.getBlocksInfo(apis);
-        let bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file)
+        const file = resp.ast.getSourceFile(fileName);
+        const apis = getApiInfo(resp.ast);
+        const blocksInfo = pxtc.getBlocksInfo(apis);
+        const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, { snippetMode: false })
         return bresp;
     }
 

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -6,6 +6,7 @@ namespace ts.pxtc {
     export const oops = Util.oops;
     export import U = pxtc.Util;
 
+    export const ON_START_TYPE = "pxtStart";
     export const BINARY_JS = "binary.js";
     export const BINARY_HEX = "binary.hex";
     export const BINARY_ASM = "binary.asm";

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -6,7 +6,7 @@ namespace ts.pxtc {
     export const oops = Util.oops;
     export import U = pxtc.Util;
 
-    export const ON_START_TYPE = "pxtStart";
+    export const ON_START_TYPE = "pxt-on-start";
     export const BINARY_JS = "binary.js";
     export const BINARY_HEX = "binary.hex";
     export const BINARY_ASM = "binary.asm";

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -291,10 +291,11 @@ namespace pxt {
             if (typeof this.config.name != "string" || !this.config.name ||
                 (this.config.public && !/^[a-z][a-z0-9\-_]+$/i.test(this.config.name)))
                 U.userError("Invalid package name: " + this.config.name)
-            const targetVersion = this.config.targetVersion
-            if (targetVersion && semver.strcmp(targetVersion, appTarget.versions.target) > 0)
+            if (this.config.targetVersions
+                && this.config.targetVersions.target
+                && semver.strcmp(this.config.targetVersions.target, appTarget.versions.target) > 0)
                 U.userError(lf("Package {0} requires target version {1} (you are running {2})",
-                    this.config.name, targetVersion, appTarget.versions.target))
+                    this.config.name, this.config.targetVersions.target, appTarget.versions.target))
         }
 
         addMissingPackages(config: pxt.PackageConfig, ts: string) {
@@ -563,7 +564,7 @@ namespace pxt {
                             scriptId: this.config.installedVersion,
                             cloudId: pxt.CLOUD_ID + appTarget.id,
                             editor: target.preferredEditor ? target.preferredEditor : (U.lookup(files, "main.blocks") ? pxt.BLOCKS_PROJECT_NAME : pxt.JAVASCRIPT_PROJECT_NAME),
-                            targetVersion: pxt.appTarget.versions ? pxt.appTarget.versions.target : undefined
+                            targetVersions: pxt.appTarget.versions
                         })
                         const programText = JSON.stringify(files)
                         return lzmaCompressAsync(headerString + programText)

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -162,7 +162,9 @@ namespace pxt.runner {
         }
     }
 
-    function renderNextSnippetAsync(cls: string, render: (container: JQuery, r: pxt.runner.DecompileResult) => void, options?: pxt.blocks.BlocksRenderOptions): Promise<void> {
+    function renderNextSnippetAsync(cls: string,
+        render: (container: JQuery, r: pxt.runner.DecompileResult) => void,
+        options?: pxt.blocks.BlocksRenderOptions): Promise<void> {
         if (!cls) return Promise.resolve();
 
         let $el = $("." + cls).first();
@@ -230,7 +232,7 @@ namespace pxt.runner {
             let js = $('<code class="lang-typescript highlight"/>').text(sig);
             if (options.snippetReplaceParent) c = c.parent();
             fillWithWidget(options, c, js, s, { showJs: true, hideGutter: true });
-        }, { package: options.package });
+        }, { package: options.package, snippetMode: true });
     }
 
     function renderShuffleAsync(options: ClientRenderOptions): Promise<void> {
@@ -250,7 +252,7 @@ namespace pxt.runner {
             let s = r.blocksSvg;
             if (options.snippetReplaceParent) c = c.parent();
             c.replaceWith(s);
-        }, { package: options.package });
+        }, { package: options.package, snippetMode: true });
     }
 
     function renderProjectAsync(options: ClientRenderOptions): Promise<void> {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -517,7 +517,10 @@ ${files["main.ts"]}
                     .then(() => {
                         let blocksInfo = pxtc.getBlocksInfo(apis);
                         pxt.blocks.initBlocks(blocksInfo);
-                        let bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, resp.ast.getSourceFile("main.ts"))
+                        let bresp = pxtc.decompiler.decompileToBlocks(
+                            blocksInfo,
+                            resp.ast.getSourceFile("main.ts"),
+                            { snippetMode: options && options.snippetMode })
                         if (bresp.diagnostics && bresp.diagnostics.length > 0)
                             bresp.diagnostics.forEach(diag => console.error(diag.messageText));
                         if (!bresp.success)

--- a/tests/decompile-test/baselines/allblocks.blocks
+++ b/tests/decompile-test/baselines/allblocks.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">item</field>
 <value name="VALUE">
@@ -322,5 +324,7 @@
 </statement>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/block_change.blocks
+++ b/tests/decompile-test/baselines/block_change.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">i</field>
 <value name="VALUE">
@@ -145,5 +147,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/block_for.blocks
+++ b/tests/decompile-test/baselines/block_for.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="controls_simple_for">
 <field name="VAR">i</field>
 <value name="TO">
@@ -251,5 +253,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/block_for2.blocks
+++ b/tests/decompile-test/baselines/block_for2.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="controls_simple_for">
 <field name="VAR">i</field>
 <value name="TO">
@@ -9,5 +11,7 @@
 <statement name="DO">
 </statement>
 <comment pinned="false">prefix unary incrementor</comment>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/block_logic_control.blocks
+++ b/tests/decompile-test/baselines/block_logic_control.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="controls_if">
 <mutation elseif="0" else="0"></mutation>
 <value name="IF0">
@@ -423,5 +425,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/block_logic_operators.blocks
+++ b/tests/decompile-test/baselines/block_logic_operators.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -49,6 +51,8 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 <block type="logic_operation">
 <field name="OP">AND</field>

--- a/tests/decompile-test/baselines/block_math.blocks
+++ b/tests/decompile-test/baselines/block_math.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -143,6 +145,8 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 <block type="math_arithmetic">
 <field name="OP">ADD</field>

--- a/tests/decompile-test/baselines/block_repeat.blocks
+++ b/tests/decompile-test/baselines/block_repeat.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="controls_simple_for">
 <field name="VAR">q</field>
 <value name="TO">
@@ -70,5 +72,7 @@
 </statement>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/block_while.blocks
+++ b/tests/decompile-test/baselines/block_while.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="device_while">
 <value name="COND">
 <block type="logic_operation">
@@ -129,5 +131,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/codeBlock.blocks
+++ b/tests/decompile-test/baselines/codeBlock.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -32,5 +34,7 @@
 </value>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/comments.blocks
+++ b/tests/decompile-test/baselines/comments.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -117,5 +119,7 @@
 </block>
 </next>
 <comment pinned="false">Single-line comment</comment>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/functions_classes.blocks
+++ b/tests/decompile-test/baselines/functions_classes.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">var1</field>
 <value name="VALUE">
@@ -63,5 +65,7 @@
 </block>
 </next>
 <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/functions_optional_parameters.blocks
+++ b/tests/decompile-test/baselines/functions_optional_parameters.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="test_single_default_argument">
 <value name="arg1">
 <shadow type="math_number">
@@ -23,6 +25,8 @@
 </block>
 </next>
 <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
 </block>
 <block type="test_optional_argument_2">
 <statement name="HANDLER">

--- a/tests/decompile-test/baselines/functions_output.blocks
+++ b/tests/decompile-test/baselines/functions_output.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x1</field>
 <value name="VALUE">
@@ -201,5 +203,7 @@
 </block>
 </next>
 <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/functions_statements.blocks
+++ b/tests/decompile-test/baselines/functions_statements.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="test_no_argument">
 <next>
 <block type="test_boolean_argument">
@@ -52,5 +54,7 @@
 </block>
 </next>
 <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_1.blocks
+++ b/tests/decompile-test/baselines/name_collision_1.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -201,5 +203,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_2.blocks
+++ b/tests/decompile-test/baselines/name_collision_2.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">i</field>
 <value name="VALUE">
@@ -59,5 +61,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_3.blocks
+++ b/tests/decompile-test/baselines/name_collision_3.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">a</field>
 <value name="VALUE">
@@ -122,5 +124,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_4.blocks
+++ b/tests/decompile-test/baselines/name_collision_4.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -17,6 +19,8 @@
 </block>
 </next>
 <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
 </block>
 <block type="test_callback_with_argument">
 <field name="arg1">TestEnum.testValue1</field>

--- a/tests/decompile-test/baselines/name_collision_5.blocks
+++ b/tests/decompile-test/baselines/name_collision_5.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -35,5 +37,7 @@
 </value>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_6.blocks
+++ b/tests/decompile-test/baselines/name_collision_6.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -98,5 +100,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_7.blocks
+++ b/tests/decompile-test/baselines/name_collision_7.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -103,5 +105,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_8.blocks
+++ b/tests/decompile-test/baselines/name_collision_8.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
@@ -36,5 +38,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/tests/decompile-test/baselines/name_collision_9.blocks
+++ b/tests/decompile-test/baselines/name_collision_9.blocks
@@ -1,4 +1,6 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
 <block type="variables_set">
 <field name="VAR">a</field>
 <value name="VALUE">
@@ -437,5 +439,7 @@
 </next>
 </block>
 </next>
+</block>
+</statement>
 </block>
 </xml>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1423,7 +1423,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
 
     newEmptyProject(name?: string, documentation?: string) {
         this.newProject({
-            filesOverride: { "main.blocks": "<xml xmlns=\"http://www.w3.org/1999/xhtml\"></xml>" },
+            filesOverride: { "main.blocks": '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="pxtStart"></block></xml>' },
             name, documentation
         })
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1361,7 +1361,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 const project: pxt.cpp.HexFile = {
                     meta: {
                         cloudId: pxt.CLOUD_ID + pxt.appTarget.id,
-                        targetVersion: pxt.appTarget.versions.target,
+                        targetVersions: pxt.appTarget.versions,
                         editor: this.getPreferredEditor(),
                         name: mpkg.config.name
                     },

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1295,8 +1295,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 pubCurrent: false
             };
             const files = JSON.parse(data.source) as pxt.Map<string>;
-            if (files["main.blocks"]) // TODO check version
-                files["main.blocks"] = pxt.blocks.importXml(files["main.blocks"]);
             // basic xml validation of main.blocks.
             if (files["main.blocks"] && !pxt.blocks.loadWorkspaceXml(files["main.blocks"], true)) {
                 // block code seems invalid., reset blocks to force decompilation

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1423,7 +1423,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
 
     newEmptyProject(name?: string, documentation?: string) {
         this.newProject({
-            filesOverride: { "main.blocks": '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="pxtStart"></block></xml>' },
+            filesOverride: { "main.blocks": `<xml xmlns="http://www.w3.org/1999/xhtml"><block type="${ts.pxtc.ON_START_TYPE}"></block></xml>` },
             name, documentation
         })
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1260,7 +1260,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             compiler.getBlocksAsync()
                 .then(info => this.createProjectAsync({
                     filesOverride: {
-                        "main.blocks": pxt.blocks.importXml(info, data.source)
+                        "main.blocks": pxt.blocks.importXml(data.source, info)
                     }, name: data.meta.name
                 })).done(() => core.hideLoading());
             return;
@@ -1295,6 +1295,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 pubCurrent: false
             };
             const files = JSON.parse(data.source) as pxt.Map<string>;
+            if (files["main.blocks"]) // TODO check version
+                files["main.blocks"] = pxt.blocks.importXml(files["main.blocks"]);
             // basic xml validation of main.blocks.
             if (files["main.blocks"] && !pxt.blocks.loadWorkspaceXml(files["main.blocks"], true)) {
                 // block code seems invalid., reset blocks to force decompilation

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -64,13 +64,13 @@ export class Editor extends srceditor.Editor {
                     pxt.blocks.initBlocks(this.blockInfo, this.editor, defaultToolbox.documentElement)
                     pxt.blocks.initToolboxButtons($(".blocklyToolboxDiv").get(0), 'blocklyToolboxButtons',
                         (pxt.appTarget.cloud.packages && !this.parent.getSandboxMode() ?
-                        (() => {
-                            this.parent.addPackage();
-                        }) : null),
+                            (() => {
+                                this.parent.addPackage();
+                            }) : null),
                         (!this.parent.getSandboxMode() ?
-                        (() => {
-                        this.undo();
-                        }) : null)
+                            (() => {
+                                this.undo();
+                            }) : null)
                     );
 
                     let xml = this.delayLoadXml;
@@ -133,16 +133,16 @@ export class Editor extends srceditor.Editor {
 
     private initLayout() {
         // layout on first load if no data info
-        const layoutInfo = this.editor.getTopBlocks(false).some(b => {
+        const needsLayout = this.editor.getTopBlocks(false).some(b => {
             const tp = b.getBoundingRectangle().topLeft;
-            return tp.x != 0 || tp.y != 0
+            return tp.x == 0 && tp.y == 0
         });
-        if (!layoutInfo)
+        if (needsLayout)
             pxt.blocks.layout.flow(this.editor);
     }
 
     private reportDeprecatedBlocks() {
-        const deprecatedMap: { [index: string]: number } = {};
+        const deprecatedMap: pxt.Map<number> = {};
         let deprecatedBlocksFound = false;
 
         this.blockInfo.blocks.forEach(symbolInfo => {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -115,8 +115,8 @@ export class Editor extends srceditor.Editor {
 
         this.editor.clear();
         try {
-            let text = s || `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`;
-            let xml = Blockly.Xml.textToDom(text);
+            const text = pxt.blocks.importXml(s || `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`, this.blockInfo, true);
+            const xml = Blockly.Xml.textToDom(text);
             Blockly.Xml.domToWorkspace(xml, this.editor);
 
             this.initLayout();

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -19,6 +19,7 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                     </shadow>
                 </value>
             </block>
+            <block type="${ts.pxtc.ON_START_TYPE}"></block>
         </category>
         <category name="Logic" nameid="logic" colour="210" category="49">
             <block type="controls_if" gap="8">

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -19,7 +19,6 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                     </shadow>
                 </value>
             </block>
-            <block type="${ts.pxtc.ON_START_TYPE}"></block>
         </category>
         <category name="Logic" nameid="logic" colour="210" category="49">
             <block type="controls_if" gap="8">


### PR DESCRIPTION
This PR adds support for a "on start" block. Merge when all steps are completed.
- [x] on start compile to unscope JS
- [x] unscoped JS compiles into on start block
- [x] blocks outside of top-level events are disabled
- [x] built-in 'on start' event
- [x] fix decompiler test suite
- [x] update docs

![onstart](https://cloud.githubusercontent.com/assets/4175913/21327631/f674fc14-c5e4-11e6-8077-832b25bfc089.gif)
