### PR TITLE
Show description in About dialog

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1708,6 +1708,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             agreeLbl: lf("Ok"),
             htmlBody: `
 <p>${Util.htmlEscape(pxt.appTarget.name)} version: ${pxt.appTarget.versions.target}</p>
+<p>${Util.htmlEscape(pxt.appTarget.description)}</p>
 `
         }).done();
     }


### PR DESCRIPTION
How do you think to show "description" string from "pxtarget.json" in the About dialog? This could be useful to show the origin of this software (PXT) and who are providing when customized by the target.