### PR TITLE
Remove check for translated block definition

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -65,10 +65,4 @@ namespace pxt.blocks {
             return { n, ni, pre, p };
         });
     }
-
-    export function areFieldsEquivalent(original: string, localized: string): boolean {
-        const o = parseFields(original);
-        const l = parseFields(localized);
-        return o.length == l.length && !o.some((ofield, i) => !!ofield.pre != !!l[i].pre || !!ofield.p != !!l[i].p)
-    }
 }

--- a/pxtlib/emitter/service.ts
+++ b/pxtlib/emitter/service.ts
@@ -83,19 +83,7 @@ namespace ts.pxtc {
                 if (fn.attributes.block) {
                     const locBlock = loc[`${fn.qName}|block`];
                     if (locBlock) {
-                        try {
-                            if (pxt.blocks.areFieldsEquivalent(fn.attributes.block, locBlock))
-                                fn.attributes.block = locBlock;
-                            else {
-                                const fields = JSON.stringify(pxt.blocks.parseFields(fn.attributes.block), null, 2);
-                                const locFields = JSON.stringify(pxt.blocks.parseFields(locBlock), null, 2);
-                                console.error(`localized block description of ${fn.attributes.block} invalid`);
-                                console.debug(`original: `, fields);
-                                console.debug(`loc: `, locFields);
-                            }
-                        } catch (e) {
-                            console.error(`error while parsing localized block of ${fn.attributes.block}`);
-                        }
+                        fn.attributes.block = locBlock;
                     }
                 }
                 const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];


### PR DESCRIPTION
You know that the natural languages have different structures and logic. It is unable to translate phrases one-to-one basis.

Currently, PXT is checking translated block name strings have same structures in compared to the original strings in its runtime (`localizeApisAsync()` in `pxtlib/emitter/service.ts`). This constraint makes it very hard to translate blocks.

This PR is to remove the constraint. However, the vertical bar `|` is still required after argument names `%var`.