### PR TITLE
Inline blocks in docs

### DIFF
--- a/docs/writing-docs.md
+++ b/docs/writing-docs.md
@@ -31,6 +31,10 @@ The following macros are custom extensions to markdown.
 See [blink lesson](https://m.pxt.io/lessons/blink/activity) 
 and the [markdown source](https://github.com/Microsoft/pxt-microbit/blob/master/docs/lessons/blink/activity.md).
     
+## Inline code snippets
+
+If an inline code snippet start with `[` and ends with `]`, the doc engine will try to render it as a block. It must contains a value API call 
+to the desired block.
 
 ## Code snippets
 

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -274,7 +274,13 @@ namespace pxt.runner {
             return pxt.runner.decompileToBlocksAsync(code, options)
                 .then(r => {
                     if (r.blocksSvg) {
-                        $el.replaceWith($('<span class="block"/>').append(r.blocksSvg));
+                        let $newel = $('<span class="block"/>').append(r.blocksSvg);
+                        const file = r.compileJS.ast.getSourceFile("main.ts");
+                        const stmt = file.statements[0];
+                        const info = decompileCallInfo(stmt);
+                        if (info && info.attrs.help)
+                            $newel = $(`<a class="ui link"/>`).attr("href", `/reference/${info.attrs.help}`).append($newel);
+                        $el.replaceWith($newel);
                     }
                     return Promise.delay(1, renderNextAsync());
                 });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -258,7 +258,7 @@ namespace pxt.runner {
 
     function renderInlineBlocksAsync(options: pxt.blocks.BlocksRenderOptions): Promise<void> {
         options = Util.clone(options);
-        options.emPixels = 10;
+        options.emPixels = 18;
         options.snippetMode = true;
 
         const $els = $(`:not(pre) > code`);

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -257,7 +257,9 @@ namespace pxt.runner {
     }
 
     function renderInlineBlocksAsync(options: pxt.blocks.BlocksRenderOptions): Promise<void> {
-        if (!options.emPixels) options.emPixels = 14;
+        options = Util.clone(options);
+        options.emPixels = 10;
+        options.snippetMode = true;
 
         const $els = $(`:not(pre) > code`);
         let i = 0;
@@ -266,7 +268,7 @@ namespace pxt.runner {
             const $el = $($els[i++]);
             const text = $el.text();
             const m = /^\[([^\]]+)\]$/.exec(text);
-            if (!m) renderNextAsync();
+            if (!m) return renderNextAsync();
 
             const code = m[1];
             return pxt.runner.decompileToBlocksAsync(code, options)

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -214,9 +214,9 @@ div.simframe > iframe {
     font-family: @docsHeaderFont !important;
 }
 
-span.block {
+#docs span.block {
     display:inline-block;
-    vertical-align: top;
+    vertical-align: middle;
 }
 /*******************************
              Blockly

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -214,6 +214,10 @@ div.simframe > iframe {
     font-family: @docsHeaderFont !important;
 }
 
+span.block {
+    display:inline-block;
+    vertical-align: top;
+}
 /*******************************
              Blockly
 *******************************/


### PR DESCRIPTION
Inline code blocks in markdown with start/ending `[` and `]` will be rendered as  blocks.
![image](https://cloud.githubusercontent.com/assets/4175913/21366841/70df9704-c6b0-11e6-969f-e0bbaf90bf62.png)
