### PR TITLE
Add support for website updates

### DIFF
--- a/electron/dev_tools/test_data/release.json
+++ b/electron/dev_tools/test_data/release.json
@@ -6,7 +6,7 @@
                 "v0.7.4"
             ],
             "prompt": "v0.8.0",
-            "url": {
+            "urls": {
                 "v0.7.4": "http://www.example.com"
             }
         }

--- a/electron/dev_tools/test_data/release.json
+++ b/electron/dev_tools/test_data/release.json
@@ -1,11 +1,14 @@
 {
     "versions": {
         "0": {
-            "latest": "v0.6.46",
+            "latest": "v0.7.8",
             "banned": [
-                "v0.6.45"
+                "v0.7.4"
             ],
-            "prompt": "v0.5.0"
+            "prompt": "v0.8.0",
+            "url": {
+                "v0.7.4": "http://www.example.com"
+            }
         }
     }
 }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -20,7 +20,7 @@ let appOptions: I.AppOptions = {};
 let win: Electron.BrowserWindow = null;
 let windowsMutex: Mutex = null;
 let updateService: UpdateService = null;
-let messagingDelay = Promise.delay(10000);
+let messagingDelay = Promise.delay(15000);
 
 function parseArgs() {
     const opts: minimist.Opts = {

--- a/electron/src/typings/interfaces.d.ts
+++ b/electron/src/typings/interfaces.d.ts
@@ -54,7 +54,7 @@ export interface VersionInfo {
     banned: string[];
     latest: string;
     prompt: string;
-    url: { [versionRange: string]: string };
+    urls: { [versionRange: string]: string };
 }
 
 export interface ReleaseManifest {

--- a/electron/src/typings/interfaces.d.ts
+++ b/electron/src/typings/interfaces.d.ts
@@ -54,6 +54,7 @@ export interface VersionInfo {
     banned: string[];
     latest: string;
     prompt: string;
+    url: { [versionRange: string]: string };
 }
 
 export interface ReleaseManifest {

--- a/electron/src/updater/updateservice.ts
+++ b/electron/src/updater/updateservice.ts
@@ -120,7 +120,7 @@ export class UpdateService extends EventEmitter {
      * version is a tag, the associated installer is downloaded and run.
      */
     public update(targetVersion: string, isCritical: boolean = false): void {
-        if (/^https?:\/\//.test(targetVersion)) {
+        if (/^https:\/\//.test(targetVersion)) {
             shell.openExternal(targetVersion);
 
             if (isCritical) {
@@ -181,9 +181,9 @@ export class UpdateService extends EventEmitter {
         const versionInfo = this.getCurrentVersionInfo(releaseManifest);
         let urlUpdate: string;
 
-        versionInfo.url && Object.keys(versionInfo.url).find((semverRange) => {
+        versionInfo.urls && Object.keys(versionInfo.urls).find((semverRange) => {
             if (semver.satisfies(product.version, semverRange)) {
-                urlUpdate = versionInfo.url[semverRange];
+                urlUpdate = versionInfo.urls[semverRange];
                 return true;
             }
 

--- a/electron/src/updater/updateservice.ts
+++ b/electron/src/updater/updateservice.ts
@@ -1,6 +1,7 @@
 "use strict";
 
 import * as Promise from "bluebird";
+import { app, shell } from "electron";
 import { EventEmitter } from "events";
 import * as fs from "fs";
 import * as I from "../typings/interfaces";
@@ -115,11 +116,20 @@ export class UpdateService extends EventEmitter {
     }
 
     /**
-     * Performs the update to the specified target version by using the AutoUpdater implementation for the current
-     * platform. By using the AutoUpdater.checkForUpdates(), any available update is downloaded automatically. When the
-     * download is complete, we install the update in the update-downloaded handler.
+     * Performs an update. If the target version is a URL, the URL is opened in the default browser. If the target
+     * version is a tag, the associated installer is downloaded and run.
      */
     public update(targetVersion: string, isCritical: boolean = false): void {
+        if (/^https?:\/\//.test(targetVersion)) {
+            shell.openExternal(targetVersion);
+
+            if (isCritical) {
+                app.exit();
+            }
+
+            return;
+        }
+
         const deferred = Utils.defer<void>();
 
         this.updaterImpl.addListener("update-downloaded", () => {
@@ -149,7 +159,9 @@ export class UpdateService extends EventEmitter {
         this.updaterImpl.checkForUpdates();
 
         deferred.promise.catch((e) => {
-            this.emit("update-download-error", isCritical);
+            this.emit("update-download-error", {
+                isCritical
+            });
             console.log("Error during update: " + e);
         });
     }
@@ -160,8 +172,27 @@ export class UpdateService extends EventEmitter {
         return releaseManifest.versions[major];
     }
 
+    /**
+     * Decides which version to update to. First looks in the list of URLs to see if the current version is listed, and
+     * returns the URL to visit if found. If current version is not listed in the URL updates, then returns the latest
+     * version, if it is higher than the current version. Returns null if no update is available.
+     */
     private getTargetRelease(releaseManifest: I.ReleaseManifest): string {
         const versionInfo = this.getCurrentVersionInfo(releaseManifest);
+        let urlUpdate: string;
+
+        versionInfo.url && Object.keys(versionInfo.url).find((semverRange) => {
+            if (semver.satisfies(product.version, semverRange)) {
+                urlUpdate = versionInfo.url[semverRange];
+                return true;
+            }
+
+            return false;
+        });
+
+        if (urlUpdate) {
+            return urlUpdate;
+        }
 
         if (versionInfo && semver.lt(product.version, versionInfo.latest)) {
             return versionInfo.latest;

--- a/webapp/src/electron.ts
+++ b/webapp/src/electron.ts
@@ -25,7 +25,7 @@ export function init() {
     }
 
     function onCriticalUpdate(args: UpdateEventInfo) {
-        const isUrl = /^https?:\/\//.test(args.targetVersion);
+        const isUrl = /^https:\/\//.test(args.targetVersion);
         let body = lf("To continue using {0}, you must install an update.", args.appName || lf("this application"));
         let agreeLbl = lf("Update");
 
@@ -57,7 +57,7 @@ export function init() {
     }
 
     function onUpdateAvailable(args: UpdateEventInfo) {
-        const isUrl = /^https?:\/\//.test(args.targetVersion);
+        const isUrl = /^https:\/\//.test(args.targetVersion);
         let header = lf("Version {0} available", args.targetVersion);
         let body = lf("A new version of {0} is ready to download and install. The app will restart during the update. Update now?", args.appName || lf("this application"));
         let agreeLbl = lf("Update");

--- a/webapp/src/electron.ts
+++ b/webapp/src/electron.ts
@@ -25,10 +25,19 @@ export function init() {
     }
 
     function onCriticalUpdate(args: UpdateEventInfo) {
+        const isUrl = /^https?:\/\//.test(args.targetVersion);
+        let body = lf("To continue using {0}, you must install an update.", args.appName || lf("this application"));
+        let agreeLbl = lf("Update");
+
+        if (isUrl) {
+            body = lf("To continue using {0}, you must install an update from the website.", args.appName || lf("this application"));
+            agreeLbl = lf("Go to website");
+        }
+
         core.confirmAsync({
             header: lf("Critical update required"),
-            body: lf("To continue using {0}, you must install an update.", args.appName || lf("this application")),
-            agreeLbl: lf("Update"),
+            body,
+            agreeLbl,
             disagreeLbl: lf("Quit"),
             disagreeClass: "red",
             size: "medium"
@@ -48,12 +57,21 @@ export function init() {
     }
 
     function onUpdateAvailable(args: UpdateEventInfo) {
-        const header = lf("Version {0} available", args.targetVersion);
+        const isUrl = /^https?:\/\//.test(args.targetVersion);
+        let header = lf("Version {0} available", args.targetVersion);
+        let body = lf("A new version of {0} is ready to download and install. The app will restart during the update. Update now?", args.appName || lf("this application"));
+        let agreeLbl = lf("Update");
+
+        if (isUrl) {
+            header = lf("Update available from website");
+            body = lf("A new version of {0} is available from the website.", args.appName || lf("this application"));
+            agreeLbl = lf("Go to website");
+        }
 
         core.confirmAsync({
             header,
-            body: lf("A new version of {0} is ready to download and install. The app will restart during the update. Update now?", args.appName || lf("this application")),
-            agreeLbl: lf("Update"),
+            body,
+            agreeLbl,
             disagreeLbl: lf("Not now"),
             size: "medium"
         }).then(b => {
@@ -64,8 +82,16 @@ export function init() {
                     pxt.tickEvent("update.refused");
                 }
             } else {
-                pxt.tickEvent("update.accepted");
-                core.showLoading(lf("Downloading update..."));
+                if (args.isInitialCheck) {
+                    pxt.tickEvent("update.acceptedInitial");
+                } else {
+                    pxt.tickEvent("update.accepted");
+                }
+
+                if (!isUrl) {
+                    core.showLoading(lf("Downloading update..."));
+                }
+
                 sendMessage("update", {
                     targetVersion: args.targetVersion
                 });


### PR DESCRIPTION
Enables us to mark certain versions for "url updates", which causes the update prompts to open a URL in the default browser instead of downloading the update directly.