### PR TITLE
Aligning categories with Scratch

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -214,7 +214,7 @@ declare namespace String {
     //% help=math/string-from-char-code
     //% shim=String_::fromCharCode
     //% advanced=true
-    //% blockNamespace="Math" blockId="stringFromCharCode" block="text from char code %code" weight=1 color=230
+    //% blockNamespace="Operators" blockId="stringFromCharCode" block="text from char code %code" weight=1 color=230
     function fromCharCode(code: number): string;
 }
 

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -214,7 +214,7 @@ declare namespace String {
     //% help=math/string-from-char-code
     //% shim=String_::fromCharCode
     //% advanced=true
-    //% blockNamespace="Operators" blockId="stringFromCharCode" block="text from char code %code" weight=1 color=230
+    //% blockNamespace="Operators" blockId="stringFromCharCode" block="text from char code %code" weight=1 color=#5CB712
     function fromCharCode(code: number): string;
 }
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -50,15 +50,9 @@ declare namespace pxt {
     }
 
     interface RuntimeOptions {
-        mathBlocks?: boolean;
         textBlocks?: boolean;
         listsBlocks?: boolean;
-        variablesBlocks?: boolean;
-        logicBlocks?: boolean;
-        loopsBlocks?: boolean;
         extraBlocks?: BlockToolboxDefinition[];
-        onStartColor?: string;
-        onStartNamespace?: string;
     }
 
     interface AppAnalytics {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1382,10 +1382,10 @@ namespace pxt.blocks {
     function initVariables() {
         (<any>Blockly.Blocks).variables.HUE = blockColors["variables"];
 
-        let varname = lf("{id:var}item");
+        const varname = lf("{id:var}item");
         Blockly.Variables.flyoutCategory = function (workspace: Blockly.Workspace) {
-            let xmlList: HTMLElement[] = [];
-            let button = goog.dom.createDom('button');
+            const xmlList: HTMLElement[] = [];
+            const button = goog.dom.createDom('button');
             button.setAttribute('text', lf("Make a Variable"));
             button.setAttribute('callbackKey', 'CREATE_VARIABLE');
 
@@ -1394,7 +1394,7 @@ namespace pxt.blocks {
             });
             xmlList.push(button);
 
-            let variableList = Blockly.Variables.allVariables(workspace);
+            const variableList = Blockly.Variables.allVariables(workspace);
             variableList.sort(goog.string.caseInsensitiveCompare);
             // In addition to the user's variables, we also want to display the default
             // variable name at the top.  We also don't want this duplicated if the
@@ -1470,7 +1470,7 @@ namespace pxt.blocks {
         };
 
         // builtin variables_get
-        let msg: any = Blockly.Msg;
+        const msg: any = Blockly.Msg;
         msg.VARIABLES_GET_CREATE_SET = lf("Create 'set %1'");
         installHelpResources(
             'variables_get',

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -5,13 +5,12 @@ import Util = pxt.Util;
 let lf = Util.lf;
 
 namespace pxt.blocks {
-    const blockColors: Map<number> = {
-        control: 43,
-        variables: 28,
-        operators: 93,
-        images: 120,
-        text: 160,
-        lists: 260,
+    export const blockColors: Map<string> = {
+        control: "#E1A91A",
+        variables: "#EE7D16",
+        operators: "#5CB712",
+        text: "160",
+        lists: "260",
     }
 
     const typeDefaults: Map<{ field: string, block: string, defaultValue: string }> = {
@@ -670,15 +669,15 @@ namespace pxt.blocks {
         };
     }
 
-    function installHelpResources(id: string, name: string, tooltip: any, url: string) {
-        let block = Blockly.Blocks[id];
-        let old = block.init;
+    function installHelpResources(id: string, name: string, tooltip: any, url: string, color?: string) {
+        const block = Blockly.Blocks[id];
+        const old = block.init;
         if (!old) return;
-
         block.init = function () {
             old.call(this);
             let block = this;
             setHelpResources(this, id, name, goog.isFunction(tooltip) ? function () { return tooltip(block); } : tooltip, url);
+            if (color) this.setColour(color)
         }
     }
 
@@ -1381,6 +1380,8 @@ namespace pxt.blocks {
     }
 
     function initVariables() {
+        (<any>Blockly.Blocks).variables.HUE = blockColors["variables"];
+
         let varname = lf("{id:var}item");
         Blockly.Variables.flyoutCategory = function (workspace: Blockly.Workspace) {
             let xmlList: HTMLElement[] = [];
@@ -1525,6 +1526,8 @@ namespace pxt.blocks {
     }
 
     function initLogic() {
+        (<any>Blockly.Blocks).logic.HUE = blockColors["operators"];
+
         let msg: any = Blockly.Msg;
 
         // builtin controls_if
@@ -1540,7 +1543,8 @@ namespace pxt.blocks {
             'controls_if',
             lf("a conditional statement"),
             undefined,
-            "blocks/logic/if"
+            "blocks/logic/if",
+            blockColors["control"]
         );
 
         // builtin logic_compare

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -6,12 +6,12 @@ let lf = Util.lf;
 
 namespace pxt.blocks {
     const blockColors: Map<number> = {
-        control: 120,
-        images: 45,
-        variables: 330,
+        control: 43,
+        variables: 28,
+        operators: 93,
+        images: 120,
         text: 160,
         lists: 260,
-        operators: 230
     }
 
     const typeDefaults: Map<{ field: string, block: string, defaultValue: string }> = {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -6,13 +6,12 @@ let lf = Util.lf;
 
 namespace pxt.blocks {
     const blockColors: Map<number> = {
-        loops: 120,
+        control: 120,
         images: 45,
         variables: 330,
         text: 160,
         lists: 260,
-        math: 230,
-        logic: 210
+        operators: 230
     }
 
     const typeDefaults: Map<{ field: string, block: string, defaultValue: string }> = {
@@ -489,11 +488,6 @@ namespace pxt.blocks {
         // add extra blocks
         if (tb && pxt.appTarget.runtime) {
             const extraBlocks = pxt.appTarget.runtime.extraBlocks || [];
-            extraBlocks.push({
-                namespace: pxt.appTarget.runtime.onStartNamespace || "loops",
-                weight: 10,
-                type: ts.pxtc.ON_START_TYPE
-            })
             extraBlocks.forEach(eb => {
                 let cat = categoryElement(tb, eb.namespace);
                 if (cat) {
@@ -519,12 +513,8 @@ namespace pxt.blocks {
         if (tb) {
             // remove unused categories
             let config = pxt.appTarget.runtime || {};
-            if (!config.mathBlocks) removeCategory(tb, "Math");
             if (!config.textBlocks) removeCategory(tb, "Text");
             if (!config.listsBlocks) removeCategory(tb, "Lists");
-            if (!config.variablesBlocks) removeCategory(tb, "Variables");
-            if (!config.logicBlocks) removeCategory(tb, "Logic");
-            if (!config.loopsBlocks) removeCategory(tb, "Loops");
 
             // Load localized names for default categories   
             let cats = tb.querySelectorAll('category');
@@ -719,7 +709,7 @@ namespace pxt.blocks {
                     ],
                     "previousStatement": null,
                     "nextStatement": null,
-                    "colour": blockColors['loops']
+                    "colour": blockColors["control"]
                 });
                 this.appendStatementInput("DO")
                     .appendField(lf("{id:while}do"));
@@ -760,7 +750,7 @@ namespace pxt.blocks {
                     ],
                     "previousStatement": null,
                     "nextStatement": null,
-                    "colour": blockColors['loops'],
+                    "colour": blockColors["control"],
                     "inputsInline": true
                 });
                 this.appendStatementInput('DO')
@@ -1236,7 +1226,7 @@ namespace pxt.blocks {
                             "name": "HANDLER"
                         }
                     ],
-                    "colour": (pxt.appTarget.runtime ? pxt.appTarget.runtime.onStartColor : '') || blockColors['loops']
+                    "colour": blockColors["control"]
                 });
 
                 setHelpResources(this,
@@ -1277,7 +1267,7 @@ namespace pxt.blocks {
                     ],
                     "inputsInline": true,
                     "output": "Number",
-                    "colour": blockColors['math']
+                    "colour": blockColors["operators"]
                 });
 
                 let thisBlock = this;
@@ -1306,7 +1296,7 @@ namespace pxt.blocks {
                     ],
                     "inputsInline": true,
                     "output": "Number",
-                    "colour": blockColors['math']
+                    "colour": blockColors["operators"]
                 });
 
                 setHelpResources(this,
@@ -1332,7 +1322,7 @@ namespace pxt.blocks {
                     ],
                     "inputsInline": true,
                     "output": "Number",
-                    "colour": blockColors['math']
+                    "colour": blockColors["operators"]
                 });
 
                 setHelpResources(this,
@@ -1378,7 +1368,7 @@ namespace pxt.blocks {
         );
 
         // builtin math_modulo
-        msg.MATH_MODULO_TITLE = lf("remainder of %1 ÷ %2");
+        msg.MATH_MODULO_TITLE = lf("%1 mod %2");
         installHelpResources(
             'math_modulo',
             lf("division remainder"),
@@ -1518,7 +1508,7 @@ namespace pxt.blocks {
                     "inputsInline": true,
                     "previousStatement": null,
                     "nextStatement": null,
-                    "colour": blockColors['variables']
+                    "colour": blockColors["variables"]
                 });
 
                 setHelpResources(this,

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -683,6 +683,8 @@ namespace pxt.blocks {
     }
 
     function initLoops() {
+        (<any>Blockly.Blocks).loops.HUE = blockColors["control"];
+
         let msg: any = Blockly.Msg;
 
         // builtin controls_repeat_ext
@@ -1240,6 +1242,7 @@ namespace pxt.blocks {
     }
 
     function initMath() {
+        (<any>Blockly.Blocks).math.HUE = blockColors["operators"];
         // pxt math_op2
         Blockly.Blocks['math_op2'] = {
             init: function () {
@@ -1385,7 +1388,7 @@ namespace pxt.blocks {
             button.setAttribute('text', lf("Make a Variable"));
             button.setAttribute('callbackKey', 'CREATE_VARIABLE');
 
-            Blockly.registerButtonCallback('CREATE_VARIABLE', function(button: Blockly.FlyoutButton) {
+            Blockly.registerButtonCallback('CREATE_VARIABLE', function (button: Blockly.FlyoutButton) {
                 Blockly.Variables.createVariable(button.getTargetWorkspace());
             });
             xmlList.push(button);

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -243,7 +243,7 @@ div.simframe > iframe {
 }
 
 .blocklyFlyoutButton {
-    fill: rgb(165, 91, 128) !important;
+    fill: #EE7D16 !important;
 }
 .blocklyFlyoutButtonShadow {
     fill: none !important;

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -1,5 +1,5 @@
 export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinition" style="display: none">
-        <category name="Control" nameid="control" colour="120" category="50">
+        <category name="Control" nameid="control" colour="43" category="50">
             <block type="${ts.pxtc.ON_START_TYPE}"></block>
             <block type="controls_repeat_ext" gap="8">
                 <value name="TIMES">
@@ -36,9 +36,9 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                 </value>
             </block>
         </category>
-        <category name="Data" nameid="variables" colour="330" custom="VARIABLE" category="48">
+        <category name="Data" nameid="variables" colour="28" custom="VARIABLE" category="48">
         </category>
-        <category name="Operators" nameid="operators" colour="230" category="47">
+        <category name="Operators" nameid="operators" colour="93" category="47">
             <block type="math_arithmetic" gap="8">
                 <value name="A">
                     <shadow type="math_number">

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -1,5 +1,5 @@
 export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinition" style="display: none">
-        <category name="Control" nameid="control" colour="43" category="50">
+        <category name="Control" nameid="control" colour="${pxt.blocks.blockColors["control"]}" category="50">
             <block type="${ts.pxtc.ON_START_TYPE}"></block>
             <block type="controls_repeat_ext" gap="8">
                 <value name="TIMES">
@@ -36,9 +36,9 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                 </value>
             </block>
         </category>
-        <category name="Data" nameid="variables" colour="28" custom="VARIABLE" category="48">
+        <category name="Data" nameid="variables" colour="${pxt.blocks.blockColors["variables"]}" custom="VARIABLE" category="48">
         </category>
-        <category name="Operators" nameid="operators" colour="93" category="47">
+        <category name="Operators" nameid="operators" colour="${pxt.blocks.blockColors["operators"]}" category="47">
             <block type="math_arithmetic" gap="8">
                 <value name="A">
                     <shadow type="math_number">
@@ -134,7 +134,7 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
             <block type="logic_boolean">
                 <field name="BOOL">FALSE</field>
             </block>
-            <category colour="230" name="More\u2026" nameid="more\u2026">
+            <category colour="${pxt.blocks.blockColors["operators"]}" name="More\u2026" nameid="more\u2026">
                 <block type="math_modulo">
                     <value name="DIVIDEND">
                         <shadow type="math_number">
@@ -181,7 +181,7 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                 </block>
             </category>
         </category>
-        <category colour="160" name="Text" nameid="text" category="46">
+        <category colour="${pxt.blocks.blockColors["text"]}" name="Text" nameid="text" category="46">
             <block type="text"></block>
             <block type="text_length">
                 <value name="VALUE">
@@ -191,7 +191,7 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                 </value>
             </block>
         </category>
-        <category colour="260" name="Lists" nameid="lists" category="45">
+        <category colour="${pxt.blocks.blockColors["text"]}" name="Lists" nameid="lists" category="45">
             <block type="lists_create_with">
                 <mutation items="1"></mutation>
                 <value name="ADD0">

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -1,13 +1,14 @@
 export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinition" style="display: none">
-        <category name="Loops" nameid="loops" colour="120" category="50">
-            <block type="controls_repeat_ext">
+        <category name="Control" nameid="control" colour="120" category="50">
+            <block type="${ts.pxtc.ON_START_TYPE}"></block>
+            <block type="controls_repeat_ext" gap="8">
                 <value name="TIMES">
                     <shadow type="math_number">
                         <field name="NUM">4</field>
                     </shadow>
                 </value>
             </block>
-            <block type="device_while">
+            <block type="device_while" gap="8">
                 <value name="COND">
                     <shadow type="logic_boolean"></shadow>
                 </value>
@@ -19,8 +20,6 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                     </shadow>
                 </value>
             </block>
-        </category>
-        <category name="Logic" nameid="logic" colour="210" category="49">
             <block type="controls_if" gap="8">
                 <value name="IF0">
                     <shadow type="logic_boolean">
@@ -36,44 +35,10 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                     </shadow>
                 </value>
             </block>
-            <block type="logic_compare" gap="8">
-                <value name="A">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-                <value name="B">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-            </block>
-            <block type="logic_compare">
-                <field name="OP">LT</field>
-                <value name="A">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-                <value name="B">
-                    <shadow type="math_number">
-                        <field name="NUM">0</field>
-                    </shadow>
-                </value>
-            </block>
-            <block type="logic_operation" gap="8"></block>
-            <block type="logic_operation" gap="8">
-                <field name="OP">OR</field>
-            </block>
-            <block type="logic_negate"></block>
-            <block type="logic_boolean" gap="8"></block>
-            <block type="logic_boolean">
-                <field name="BOOL">FALSE</field>
-            </block>
         </category>
-        <category name="Variables" nameid="variables" colour="330" custom="VARIABLE" category="48">
+        <category name="Data" nameid="variables" colour="330" custom="VARIABLE" category="48">
         </category>
-        <category name="Math" nameid="math" colour="230" category="47">
+        <category name="Operators" nameid="operators" colour="230" category="47">
             <block type="math_arithmetic" gap="8">
                 <value name="A">
                     <shadow type="math_number">
@@ -134,6 +99,40 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                         <field name="NUM">4</field>
                     </shadow>
                 </value>
+            </block>
+            <block type="logic_compare" gap="8">
+                <value name="A">
+                    <shadow type="math_number">
+                        <field name="NUM">0</field>
+                    </shadow>
+                </value>
+                <value name="B">
+                    <shadow type="math_number">
+                        <field name="NUM">0</field>
+                    </shadow>
+                </value>
+            </block>
+            <block type="logic_compare">
+                <field name="OP">LT</field>
+                <value name="A">
+                    <shadow type="math_number">
+                        <field name="NUM">0</field>
+                    </shadow>
+                </value>
+                <value name="B">
+                    <shadow type="math_number">
+                        <field name="NUM">0</field>
+                    </shadow>
+                </value>
+            </block>
+            <block type="logic_operation" gap="8"></block>
+            <block type="logic_operation" gap="8">
+                <field name="OP">OR</field>
+            </block>
+            <block type="logic_negate"></block>
+            <block type="logic_boolean" gap="8"></block>
+            <block type="logic_boolean">
+                <field name="BOOL">FALSE</field>
             </block>
             <category colour="230" name="More\u2026" nameid="more\u2026">
                 <block type="math_modulo">


### PR DESCRIPTION
This PR is realigning various aspects of the editor with Scratch.
- [ ] refactoring built-in categories (loops, Math, logic, Variables) into Scratch-like categories (Control, Data, Operators). 
- [ ] full for loop support
- [ ] random range support

Not ready for merge.

![scratchcat](https://cloud.githubusercontent.com/assets/4175913/21486035/b3c6e3a0-cb61-11e6-9735-82ae38d76c33.gif)
