### PR TITLE
Fix for 'Dialogs in JavaScript completely break the layout'

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -9,7 +9,7 @@
 
 </head>
 
-<body>
+<body class="dimmable">
     <div id='loading' class="ui active inverted dimmer">
         <div class="ui large loader"></div>
     </div>

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -17,11 +17,11 @@ export type Component<S, T> = data.Component<S, T>;
 
 export function hideLoading() {
     $('.ui.page.dimmer .loadingcontent').remove();
-    $('body').dimmer('hide');
+    $('body.dimmable').dimmer('hide');
 }
 
 export function showLoading(msg: string) {
-    $('body').dimmer('show');
+    $('body.dimmable').dimmer('show');
     $('.ui.page.dimmer').html(`
   <div class="content loadingcontent">
     <div class="ui text large loader msg">{lf("Please wait")}</div>
@@ -375,7 +375,7 @@ export function shareLinkAsync(options: ShareOptions) {
     let modal = $(html)
     enableCopyable(modal);
     let done = false
-    $('body').append(modal)
+    $('body.dimmable').append(modal)
 
     return new Promise((resolve, reject) =>
         modal.modal({


### PR DESCRIPTION
Fixes #857 

To Test: 
- Load PXT in Blocks view, add a comment to a block, show a dialog (eg: Reset)
- Load PXT in JS view, show a dialog (eg: Reset)
- Load PXT in JS view, switch to Blocks view, add comment to block, show a dialog (eg: Reset)

@guillaumejenkins could you test the fix in an electron app