### PR TITLE
Add most commonly used Jake tasks to NPM run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,16 @@
     "webfonts-generator": "^0.3.3"
   },
   "scripts": {
-    "test": "jake travis --trace"
+    "test": "jake travis --trace",
+    "clean": "jake clean",
+    "lint": "jake lint",
+    "start": "jake default",
+    "test:all": "jake test",
+    "test:decompiler": "jake testdecompiler",
+    "test:decompiler-errors": "jake testdecompilererrors",
+    "test:err": "jake testerr",
+    "test:fmt": "jake testfmt",
+    "test:lang": "jake testlang",
+    "update": "jake update"
   }
 }


### PR DESCRIPTION
This adds some Jake tasks most frequently used during local development
as NPM run scripts to avoid requirement of installing Jake tool globally
as adviced in README. Instead default NPM client behavior is used to run
local version of Jake from locally installed modules:

https://docs.npmjs.com/cli/run-script

Thanks!

```bash
npm run
Lifecycle scripts included in pxt-core:
  test
    jake travis --trace
  start
    jake default

available via `npm run-script`:
  clean
    jake clean
  lint
    jake lint
  test:all
    jake test
  test:decompiler
    jake testdecompiler
  test:decompiler-errors
    jake testdecompilererrors
  test:err
    jake testerr
  test:fmt
    jake testfmt
  test:lang
    jake testlang
  update
    jake update
```