### PR TITLE
Handle string concatenation in the blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -570,7 +570,14 @@ namespace pxt.blocks {
 
             const compiled = compileExpression(e, val, comments);
             if (!last) {
-                last = compiled
+                if (val.type.indexOf("text") === 0) {
+                    last = compiled;
+                }
+                else {
+                    // If we don't start with a string, then the TS won't match
+                    // the implied semantics of the blocks
+                    last = H.mkSimpleCall("+", [mkText("\"\""), compiled]);
+                }
             }
             else {
                 last = H.mkSimpleCall("+", [last, compiled]);

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -565,7 +565,12 @@ namespace pxt.blocks {
             i++;
 
             if (!val) {
-                break;
+                if (i < b.inputList.length) {
+                    continue;
+                }
+                else {
+                    break;
+                }
             }
 
             const compiled = compileExpression(e, val, comments);
@@ -576,13 +581,18 @@ namespace pxt.blocks {
                 else {
                     // If we don't start with a string, then the TS won't match
                     // the implied semantics of the blocks
-                    last = H.mkSimpleCall("+", [mkText("\"\""), compiled]);
+                    last = H.mkSimpleCall("+", [H.mkStringLiteral(""), compiled]);
                 }
             }
             else {
                 last = H.mkSimpleCall("+", [last, compiled]);
             }
         }
+
+        if (!last) {
+            return H.mkStringLiteral("");
+        }
+
         return last;
     }
 

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -345,6 +345,11 @@ namespace ts.pxtc {
         ctor?: ir.Procedure;
     }
 
+    export interface BinaryExpressionInfo {
+        leftType: string;
+        rightType: string;
+    }
+
     let lf = assembler.lf;
     let checker: TypeChecker;
     let lastSecondaryError: string
@@ -2486,6 +2491,12 @@ ${lbl}: .short 0xffff
 
             let lt = typeOf(node.left)
             let rt = typeOf(node.right)
+
+            if (node.operatorToken.kind == SK.PlusToken) {
+                if (lt.flags & TypeFlags.String || rt.flags & TypeFlags.String) {
+                    (node as any).exprInfo = { leftType: checker.typeToString(lt), rightType: checker.typeToString(rt) } as BinaryExpressionInfo;
+                }
+            }
 
             let shim = (n: string) => rtcallMask(n, [node.left, node.right]);
 

--- a/tests/decompile-test/baselines/string_concat.blocks
+++ b/tests/decompile-test/baselines/string_concat.blocks
@@ -1,0 +1,32 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+<block type="text_join">
+<mutation items="3"></mutation>
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello</field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<value name="ADD2">
+<shadow type="text">
+<field name="TEXT">okay</field>
+</shadow>
+</value>
+</block>
+</value>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/string_concat.ts
+++ b/tests/decompile-test/string_concat.ts
@@ -1,0 +1,1 @@
+let x = "hello" + 1 + "okay";


### PR DESCRIPTION
Fixes #678 

This makes it so that string concatenation works when going from typescript to blocks. I think the future plan is to have a whole string package that gets added when you use strings, but I don't think that story is 100% thought out yet. In the blocks, I am using Blockly's built in `text_join` block. For example,

With this typescript:

```typescript
let x = "hello" + (5 + 6) + "okay";
```

You get these blocks:

![text_join](https://cloud.githubusercontent.com/assets/13754588/21558218/2377cbca-cdeb-11e6-9267-310319f41fc2.PNG)

I don't do type checking in the blocks for the inputs. Rather, I ensure that the block always outputs a string by checking if the first input is a string and adding an empty string if it is not. That ensures that these blocks:

![text_concat2](https://cloud.githubusercontent.com/assets/13754588/21558457/334010fe-cdef-11e6-9441-9409dae043af.PNG)

Produce this TS:

```typescript
//  A string 
let x = "" + 5 + 6
```

And not this TS:

```typescript
// A number
let x = 5 + 6
```

Blockly solves that issue by generating code that looks like this:

```typescript
let x = new String("hello") + new String(5 + 6) + new String("okay");
```

...but that code is much uglier.
