### PR TITLE
JavaScript code card

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -63,6 +63,7 @@ declare namespace pxt {
     interface CodeCard {
         name?: string;
         shortName?: string;
+        title?: string;
 
         color?: string; // one of semantic ui colors
         description?: string;

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1243,6 +1243,14 @@ namespace pxt.blocks {
         return e;
     }
 
+    export function compileBlock(b: B.Block, blockInfo: pxtc.BlocksInfo): BlockCompilationResult {
+        const w = b.workspace;
+        const e = mkEnv(w, blockInfo);
+        infer(e, w);
+        const compiled = compileStatementBlock(e, b)
+        return tdASTtoTS(compiled);
+    }
+
     function compileWorkspace(w: B.Workspace, blockInfo: pxtc.BlocksInfo): JsNode[] {
         try {
             const e = mkEnv(w, blockInfo);
@@ -1362,49 +1370,49 @@ namespace pxt.blocks {
         return tdASTtoTS(compileWorkspace(b, blockInfo));
     }
 
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
+    const infixPriTable: Map<number> = {
+        // 0 = comma/sequence
+        // 1 = spread (...)
+        // 2 = yield, yield*
+        // 3 = assignment
+        "=": 3,
+        "+=": 3,
+        "-=": 3,
+        // 4 = conditional (?:)
+        "||": 5,
+        "&&": 6,
+        "|": 7,
+        "^": 8,
+        "&": 9,
+        // 10 = equality
+        "==": 10,
+        "!=": 10,
+        "===": 10,
+        "!==": 10,
+        // 11 = comparison (excludes in, instanceof)
+        "<": 11,
+        ">": 11,
+        "<=": 11,
+        ">=": 11,
+        // 12 = bitise shift
+        ">>": 12,
+        ">>>": 12,
+        "<<": 12,
+        "+": 13,
+        "-": 13,
+        "*": 14,
+        "/": 14,
+        "%": 14,
+        "!": 15,
+        ".": 18,
+    }
+
     function tdASTtoTS(app: JsNode[]): BlockCompilationResult {
         let sourceMap: SourceInterval[] = [];
         let output = ""
         let indent = ""
         let variables: Map<string>[] = [{}];
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
-        let infixPriTable: Map<number> = {
-            // 0 = comma/sequence
-            // 1 = spread (...)
-            // 2 = yield, yield*
-            // 3 = assignment
-            "=": 3,
-            "+=": 3,
-            "-=": 3,
-            // 4 = conditional (?:)
-            "||": 5,
-            "&&": 6,
-            "|": 7,
-            "^": 8,
-            "&": 9,
-            // 10 = equality
-            "==": 10,
-            "!=": 10,
-            "===": 10,
-            "!==": 10,
-            // 11 = comparison (excludes in, instanceof)
-            "<": 11,
-            ">": 11,
-            "<=": 11,
-            ">=": 11,
-            // 12 = bitise shift
-            ">>": 12,
-            ">>>": 12,
-            "<<": 12,
-            "+": 13,
-            "-": 13,
-            "*": 14,
-            "/": 14,
-            "%": 14,
-            "!": 15,
-            ".": 18,
-        }
-
 
         function flatten(e0: JsNode) {
             function rec(e: JsNode, outPrio: number) {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1119,7 +1119,9 @@ namespace pxt.blocks {
             case 'device_while':
                 r = compileWhile(e, b, comments);
                 break;
-
+            case ts.pxtc.ON_START_TYPE:
+                r = compileStartEvent(e, b).children;
+                break;
             default:
                 let call = e.stdCallTable[b.type];
                 if (call) r = [compileCall(e, b, comments)];

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -250,9 +250,10 @@ div.simframe > iframe {
 
 /* code card */
 
-.ui.card pre {
+.ui.card .ui.image pre {
     margin-left:0.5rem;
     margin-right:0.5rem;
+    color: @black;
     font-size:0.7rem;
     white-space: pre-wrap;
     max-height: 9rem;

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -250,10 +250,10 @@ div.simframe > iframe {
 
 /* code card */
 
-.ui.card .ui.image pre {
+.ui.card .image pre {
     margin-left:0.5rem;
     margin-right:0.5rem;
-    color: @black;
+    color: #000;
     font-size:0.7rem;
     white-space: pre-wrap;
     max-height: 9rem;

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -213,6 +213,7 @@ div.simframe > iframe {
     bottom: 2.2rem;
     margin: 0;
     z-index: 5;
+    font-size:0.8rem;
 }
 .rtl #helpcard {
     left:7rem;
@@ -245,6 +246,16 @@ div.simframe > iframe {
     max-width: 10em;
     max-height: 3em;
     vertical-align: middle;
+}
+
+/* code card */
+
+.ui.card pre {
+    margin-left:0.5rem;
+    margin-right:0.5rem;
+    font-size:0.7rem;
+    white-space: pre-wrap;
+    max-height: 9rem;
 }
 
 /* Scrollbars */

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1816,7 +1816,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={javascriptClick} title={lf("Convert code to JavaScript") } />
                         </sui.Item>
                         {docMenu ? <DocsMenuItem parent={this} /> : undefined}
-                        {sandbox ? undefined : <sui.DropdownMenuItem icon='setting' title={lf("More...")} class="more-dropdown-menuitem">
+                        {sandbox ? undefined : <sui.DropdownMenuItem icon='setting' title={lf("More...") } class="more-dropdown-menuitem">
                             {this.state.header ? <sui.Item role="menuitem" icon="options" text={lf("Rename...") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
                             {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined }
@@ -2177,7 +2177,7 @@ $(document).ready(() => {
 
     if (wsPortMatch) {
         pxt.options.wsPort = parseInt(wsPortMatch[1]) || 3233;
-        window.location.hash = window.location.hash.replace(wsPortMatch[0], ""); 
+        window.location.hash = window.location.hash.replace(wsPortMatch[0], "");
     } else {
         pxt.options.wsPort = 3233;
     }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -242,6 +242,7 @@ export class Editor extends srceditor.Editor {
         const selected: B.Block = Blockly.selected;
         let card: pxt.CodeCard = (selected as any).codeCard;
         if (card) {
+            // render js only
             card = {
                 description: card.description,
                 typeScript: pxt.blocks.compileBlock(selected, this.blockInfo).source,

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -244,7 +244,8 @@ export class Editor extends srceditor.Editor {
         if (card) {
             card = {
                 description: card.description,
-                typeScript: pxt.blocks.compileBlock(selected, this.blockInfo).source
+                typeScript: pxt.blocks.compileBlock(selected, this.blockInfo).source,
+                url: card.url
             }
         }
         this.parent.setHelpCard(card);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -247,7 +247,8 @@ export class Editor extends srceditor.Editor {
                 header: "JavaScript",
                 javascript: 1,
                 typeScript: pxt.blocks.compileBlock(selected, this.blockInfo).source,
-                url: card.url
+                url: card.url,
+                title: lf("Selected Blocks converted to JavaScript")
             }
         }
         this.parent.setHelpCard(card);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -239,12 +239,13 @@ export class Editor extends srceditor.Editor {
     }
 
     updateHelpCard(clear?: boolean) {
+        let card: pxt.CodeCard = undefined;
         const selected: B.Block = Blockly.selected;
-        let card: pxt.CodeCard = (selected as any).codeCard;
-        if (card) {
+        if (!clear && selected && (card = (selected as any).codeCard)) {
             // render js only
             card = {
-                description: card.description,
+                header: "JavaScript",
+                javascript: 1,
                 typeScript: pxt.blocks.compileBlock(selected, this.blockInfo).source,
                 url: card.url
             }

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -78,9 +78,9 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
             </div>
             <div className="content">
                 {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}
-                <div className="meta">
+                {card.time ? <div className="meta">
                     {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
-                </div>
+                </div> : undefined}
                 {card.description ? <div className="description">{card.description}</div> : null}
             </div>
         </div>;

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -47,13 +47,14 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
     }
 
     render() {
-        let card = this.props
-        let promo = socialNetworks.map(sn => sn.parse(card.promoUrl)).filter(p => !!p)[0];
+        const card = this.props
+        const promo = socialNetworks.map(sn => sn.parse(card.promoUrl)).filter(p => !!p)[0];
         let color = card.color || "";
         if (!color) {
             if (card.hardware && !card.software) color = 'black';
             else if (card.software && !card.hardware) color = 'teal';
         }
+        const renderMd = (md: string) => md.replace('`', '');
         const url = card.url ? /^[^:]+:\/\//.test(card.url) ? card.url : ('/' + card.url.replace(/^\.?\/?/, ''))
             : undefined;
         const sideUrl = url && /^\//.test(url) ? "#doc:" + url : url;
@@ -81,7 +82,7 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
                 {card.time ? <div className="meta">
                     {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
                 </div> : undefined}
-                {card.description ? <div className="description">{card.description}</div> : null}
+                {card.description ? <div className="description">{renderMd(card.description)}</div> : null}
             </div>
         </div>;
 

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -71,19 +71,20 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
                     </div>
                     {card.header}
                 </div> : null }
-            <div className={"ui image" + (card.responsive ? " tall landscape only" : "") }>
+            <div className={"ui image"}>
                 {promo ? <div key="promoembed" className="ui embed" data-source={promo.source} data-id={promo.id}></div> : null}
                 {card.blocksXml ? <blockspreview.BlocksPreview key="promoblocks" xml={card.blocksXml} /> : null}
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : null}
                 {card.imageUrl ? <img src={card.imageUrl} className="ui image" /> : null}
             </div>
-            <div className="content">
-                {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}
-                {card.time ? <div className="meta">
-                    {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
-                </div> : undefined}
-                {card.description ? <div className="description">{renderMd(card.description)}</div> : null}
-            </div>
+            {card.shortName || card.name || card.description ?
+                <div className="content">
+                    {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}
+                    {card.time ? <div className="meta tall">
+                        {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
+                    </div> : undefined}
+                    {card.description ? <div className="description tall">{renderMd(card.description)}</div> : null}
+                </div> : undefined }
         </div>;
 
         if (!card.onClick && url) {

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -54,7 +54,7 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
             if (card.hardware && !card.software) color = 'black';
             else if (card.software && !card.hardware) color = 'teal';
         }
-        const renderMd = (md: string) => md.replace('`', '');
+        const renderMd = (md: string) => md.replace(/`/g, '');
         const url = card.url ? /^[^:]+:\/\//.test(card.url) ? card.url : ('/' + card.url.replace(/^\.?\/?/, ''))
             : undefined;
         const sideUrl = url && /^\//.test(url) ? "#doc:" + url : url;

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -59,7 +59,7 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
             : undefined;
         const sideUrl = url && /^\//.test(url) ? "#doc:" + url : url;
         const className = card.className;
-        const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`} onClick={e => card.onClick ? card.onClick(e) : undefined } >
+        const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`} title={card.title} onClick={e => card.onClick ? card.onClick(e) : undefined } >
             {card.header || card.blocks || card.javascript || card.hardware || card.software || card.any ?
                 <div key="header" className={"ui content " + (card.responsive ? " tall desktop only" : "") }>
                     <div className="right floated meta">


### PR DESCRIPTION
This change renders the selected block as javascript in the codecard -- instead of the jsdocs/block.
- jsdoc is already available in the tooltip
- subtle way to show the JavaScript code related to a block
Not addressed: code card getting in the way.
![image](https://cloud.githubusercontent.com/assets/4175913/21656418/f15628f8-d272-11e6-978f-a3a05d8a1574.png)

- height is limited so that long snippets don't cover the entire screen
