### PR TITLE
Display code card as tooltip

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -13,6 +13,8 @@ declare namespace goog {
 
     namespace dom {
         function createDom(name: string, ns?: string, children?: any): HTMLElement;
+        function removeChildren(el: Element): void;
+        function getViewportSize(): any;
     }
 
     namespace math {
@@ -43,6 +45,10 @@ declare namespace Blockly {
     function prompt(message: string, defaultValue: string, callback: (response: string) => void): void;
 
     let ALIGN_RIGHT: number;
+
+    namespace utils {
+        function wrap(tip: string, limit: number): string;
+    }
 
     class FieldImage {
         constructor(url: string, width: number, height: number, def: string);
@@ -430,4 +436,6 @@ declare namespace Blockly {
             setSelectedItem(t: TreeNode): void;
         }
     }
+
+    var Tooltip: any;
 }

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -63,6 +63,7 @@ declare namespace pxt {
     interface CodeCard {
         name?: string;
         shortName?: string;
+        title?: string;
 
         color?: string; // one of semantic ui colors
         description?: string;

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -66,7 +66,6 @@ declare namespace pxt {
 
         color?: string; // one of semantic ui colors
         description?: string;
-        promoUrl?: string;
         blocksXml?: string;
         typeScript?: string;
         imageUrl?: string;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -298,9 +298,6 @@ namespace pxt.blocks {
     }
 
     function mkCard(fn: pxtc.SymbolInfo, blockXml: HTMLElement): pxt.CodeCard {
-        let xml = blockXml.outerHTML
-            // remove IE11
-            .replace(/^<\?[^>]*>/, '');
         return {
             name: fn.namespace + '.' + fn.name,
             shortName: fn.name,
@@ -444,6 +441,7 @@ namespace pxt.blocks {
 
     export function initBlocks(blockInfo: pxtc.BlocksInfo, workspace?: Blockly.Workspace, toolbox?: Element): Element {
         init();
+        initTooltip(blockInfo);
 
         // create new toolbox and update block definitions
         let tb = toolbox ? <Element>toolbox.cloneNode(true) : undefined;
@@ -785,7 +783,6 @@ namespace pxt.blocks {
         initDrag();
         initToolboxColor();
         initExpandToolbox();
-        initTooltip();
     }
 
     function setHelpResources(block: any, id: string, name: string, tooltip: any, url: string) {
@@ -1761,7 +1758,7 @@ namespace pxt.blocks {
         );
     }
 
-    function initTooltip() {
+    function initTooltip(blockInfo: pxtc.BlocksInfo) {
         // TODO: update this when pulling new blockly
         /**
          * Create the tooltip and show it.
@@ -1775,9 +1772,17 @@ namespace pxt.blocks {
             // Erase all existing text.
             goog.dom.removeChildren(/** @type {!Element} */(Blockly.Tooltip.DIV));
             // Get the new text.
-            const card = Blockly.Tooltip.element_.codeCard;
+            const card = Blockly.Tooltip.element_.codeCard as pxt.CodeCard;
             if (card) {
-                const cardEl = pxt.docs.codeCard.render(card, { shortName: true })
+                let r = {
+                    header: "JavaScript",
+                    javascript: 1,
+                    title: lf("Selected Blocks converted to JavaScript")
+                }
+                const cardEl = pxt.docs.codeCard.render({
+                    header: card.description,
+                    typeScript: pxt.blocks.compileBlock(Blockly.Tooltip.element_, blockInfo).source
+                })
                 Blockly.Tooltip.DIV.appendChild(cardEl);
             } else {
                 let tip = Blockly.Tooltip.element_.tooltip;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1759,6 +1759,14 @@ namespace pxt.blocks {
     }
 
     function initTooltip(blockInfo: pxtc.BlocksInfo) {
+
+        const renderTip = (el: any) => {
+            let tip = el.tooltip;
+            while (goog.isFunction(tip)) {
+                tip = tip();
+            }
+            return tip;
+        }
         // TODO: update this when pulling new blockly
         /**
          * Create the tooltip and show it.
@@ -1774,21 +1782,13 @@ namespace pxt.blocks {
             // Get the new text.
             const card = Blockly.Tooltip.element_.codeCard as pxt.CodeCard;
             if (card) {
-                let r = {
-                    header: "JavaScript",
-                    javascript: 1,
-                    title: lf("Selected Blocks converted to JavaScript")
-                }
                 const cardEl = pxt.docs.codeCard.render({
-                    header: card.description,
+                    header: card.description || renderTip(Blockly.Tooltip.element_),
                     typeScript: pxt.blocks.compileBlock(Blockly.Tooltip.element_, blockInfo).source
                 })
                 Blockly.Tooltip.DIV.appendChild(cardEl);
             } else {
-                let tip = Blockly.Tooltip.element_.tooltip;
-                while (goog.isFunction(tip)) {
-                    tip = tip();
-                }
+                let tip = renderTip(Blockly.Tooltip.element_);
                 tip = Blockly.utils.wrap(tip, Blockly.Tooltip.LIMIT);
                 // Create new text, line by line.
                 let lines = tip.split('\n');

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -773,6 +773,7 @@ namespace pxt.blocks {
         }
 
         Blockly.FieldCheckbox.CHECK_CHAR = '■';
+        Blockly.BlockSvg.START_HAT = !!pxt.appTarget.appTheme.blockHats;
 
         initContextMenu();
         initOnStart();
@@ -784,8 +785,7 @@ namespace pxt.blocks {
         initDrag();
         initToolboxColor();
         initExpandToolbox();
-
-        Blockly.BlockSvg.START_HAT = !!pxt.appTarget.appTheme.blockHats;
+        initTooltip();
     }
 
     function setHelpResources(block: any, id: string, name: string, tooltip: any, url: string) {
@@ -1326,7 +1326,7 @@ namespace pxt.blocks {
         };
 
         // Fix highlighting bug in edge
-        (<any>Blockly).Flyout.prototype.addBlockListeners_ = function(root: any, block: any, rect: any) {
+        (<any>Blockly).Flyout.prototype.addBlockListeners_ = function (root: any, block: any, rect: any) {
             this.listeners_.push((<any>Blockly).bindEventWithChecks_(root, 'mousedown', null,
                 this.blockMouseDown_(block)));
             this.listeners_.push((<any>Blockly).bindEventWithChecks_(rect, 'mousedown', null,
@@ -1759,6 +1759,75 @@ namespace pxt.blocks {
             lf("Returns the number of letters (including spaces) in the provided text."),
             "reference/types/string-functions"
         );
+    }
+
+    function initTooltip() {
+        // TODO: update this when pulling new blockly
+        /**
+         * Create the tooltip and show it.
+         * @private
+         */
+        Blockly.Tooltip.show_ = function () {
+            Blockly.Tooltip.poisonedElement_ = Blockly.Tooltip.element_;
+            if (!Blockly.Tooltip.DIV) {
+                return;
+            }
+            // Erase all existing text.
+            goog.dom.removeChildren(/** @type {!Element} */(Blockly.Tooltip.DIV));
+            // Get the new text.
+            const card = Blockly.Tooltip.element_.codeCard;
+            if (card) {
+                const cardEl = pxt.docs.codeCard.render(card, { shortName: true })
+                Blockly.Tooltip.DIV.appendChild(cardEl);
+            } else {
+                let tip = Blockly.Tooltip.element_.tooltip;
+                while (goog.isFunction(tip)) {
+                    tip = tip();
+                }
+                tip = Blockly.utils.wrap(tip, Blockly.Tooltip.LIMIT);
+                // Create new text, line by line.
+                let lines = tip.split('\n');
+                for (let i = 0; i < lines.length; i++) {
+                    let div = document.createElement('div');
+                    div.appendChild(document.createTextNode(lines[i]));
+                    Blockly.Tooltip.DIV.appendChild(div);
+                }
+            }
+            let rtl = Blockly.Tooltip.element_.RTL;
+            let windowSize = goog.dom.getViewportSize();
+            // Display the tooltip.
+            Blockly.Tooltip.DIV.style.direction = rtl ? 'rtl' : 'ltr';
+            Blockly.Tooltip.DIV.style.display = 'block';
+            Blockly.Tooltip.visible = true;
+            // Move the tooltip to just below the cursor.
+            let anchorX = Blockly.Tooltip.lastX_;
+            if (rtl) {
+                anchorX -= Blockly.Tooltip.OFFSET_X + Blockly.Tooltip.DIV.offsetWidth;
+            } else {
+                anchorX += Blockly.Tooltip.OFFSET_X;
+            }
+            let anchorY = Blockly.Tooltip.lastY_ + Blockly.Tooltip.OFFSET_Y;
+
+            if (anchorY + Blockly.Tooltip.DIV.offsetHeight >
+                windowSize.height + window.scrollY) {
+                // Falling off the bottom of the screen; shift the tooltip up.
+                anchorY -= Blockly.Tooltip.DIV.offsetHeight + 2 * Blockly.Tooltip.OFFSET_Y;
+            }
+            if (rtl) {
+                // Prevent falling off left edge in RTL mode.
+                anchorX = Math.max(Blockly.Tooltip.MARGINS - window.scrollX, anchorX);
+            } else {
+                if (anchorX + Blockly.Tooltip.DIV.offsetWidth >
+                    windowSize.width + window.scrollX - 2 * Blockly.Tooltip.MARGINS) {
+                    // Falling off the right edge of the screen;
+                    // clamp the tooltip on the edge.
+                    anchorX = windowSize.width - Blockly.Tooltip.DIV.offsetWidth -
+                        2 * Blockly.Tooltip.MARGINS;
+                }
+            }
+            Blockly.Tooltip.DIV.style.top = anchorY + 'px';
+            Blockly.Tooltip.DIV.style.left = anchorX + 'px';
+        }
     }
 
     function initExpandToolbox() {

--- a/pxtblocks/codecardrenderer.ts
+++ b/pxtblocks/codecardrenderer.ts
@@ -1,31 +1,6 @@
 namespace pxt.docs.codeCard {
 
-    let repeat = pxt.Util.repeatMap;
-
-    interface SocialNetwork {
-        parse: (text: string) => { source: string; id: string }
-    }
-
-    let socialNetworks: SocialNetwork[] = [{
-        parse: text => {
-            let links: string[] = [];
-            if (text)
-                text.replace(/https?:\/\/(youtu\.be\/([a-z0-9\-_]+))|(www\.youtube\.com\/watch\?v=([a-z0-9\-_]+))/i,
-                    (m, m2, id1, m3, id2) => {
-                        let ytid = id1 || id2;
-                        links.push(ytid); return ''
-                    });
-            if (links[0]) return { source: 'youtube', id: links[0] };
-            else return undefined;
-        }
-    }, {
-            parse: text => {
-                let m = /https?:\/\/vimeo\.com\/\S*?(\d{6,})/i.exec(text)
-                if (m) return { source: "vimeo", id: m[1] };
-                else return undefined;
-            }
-        }
-    ];
+    const repeat = pxt.Util.repeatMap;
 
     export interface CodeCardRenderOptions {
         hideHeader?: boolean;
@@ -34,7 +9,6 @@ namespace pxt.docs.codeCard {
 
     export function render(card: pxt.CodeCard, options: CodeCardRenderOptions = {}): HTMLElement {
         const repeat = pxt.Util.repeatMap;
-        const promo = socialNetworks.map(sn => sn.parse(card.promoUrl)).filter(p => !!p)[0];
         let color = card.color || "";
         if (!color) {
             if (card.hardware && !card.software) color = 'black';
@@ -76,13 +50,6 @@ namespace pxt.docs.codeCard {
         }
 
         let img = div(r, "ui image" + (card.responsive ? " tall landscape only" : ""));
-        if (promo) {
-            let promoDiv = div(img, "ui embed");
-            promoDiv.dataset["source"] = promo.source;
-            promoDiv.dataset["id"] = promo.id;
-
-            ($(promoDiv) as any).embed();
-        }
 
         if (card.blocksXml) {
             let svg = pxt.blocks.render(card.blocksXml);
@@ -108,21 +75,22 @@ namespace pxt.docs.codeCard {
             img.appendChild(image)
         }
 
-
-        let ct = div(r, "ui content");
         const name = (options.shortName ? card.shortName : '') || card.name;
-        if (name) {
-            if (url && !link) a(ct, url, name, 'header');
-            else div(ct, 'header', 'div', name);
-        }
-        if (card.time) {
-            let meta = div(ct, "ui meta");
-            let m = div(meta, "date", "span");
-            m.appendChild(document.createTextNode(pxt.Util.timeSince(card.time)));
-        }
-        if (card.description) {
-            let descr = div(ct, 'ui description');
-            descr.appendChild(document.createTextNode(card.description.split('.')[0] + '.'));
+        if (name || card.description) {
+            let ct = div(r, "ui content");
+            if (name) {
+                if (url && !link) a(ct, url, name, 'header');
+                else div(ct, 'header', 'div', name);
+            }
+            if (card.time) {
+                let meta = div(ct, "ui meta");
+                let m = div(meta, "date", "span");
+                m.appendChild(document.createTextNode(pxt.Util.timeSince(card.time)));
+            }
+            if (card.description) {
+                let descr = div(ct, 'ui description');
+                descr.appendChild(document.createTextNode(card.description.split('.')[0] + '.'));
+            }
         }
 
         return r;

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -213,6 +213,7 @@ div.simframe > iframe {
     bottom: 2.2rem;
     margin: 0;
     z-index: 5;
+    font-size:0.8rem;
 }
 .rtl #helpcard {
     left:7rem;
@@ -245,6 +246,17 @@ div.simframe > iframe {
     max-width: 10em;
     max-height: 3em;
     vertical-align: middle;
+}
+
+/* code card */
+
+.ui.card .image pre {
+    margin-left:0.5rem;
+    margin-right:0.5rem;
+    color: #000;
+    font-size:0.7rem;
+    white-space: pre-wrap;
+    max-height: 9rem;
 }
 
 /* Scrollbars */

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -256,7 +256,8 @@ div.simframe > iframe {
     color: #000;
     font-size:0.7rem;
     white-space: pre-wrap;
-    max-height: 9rem;
+    max-height: 10rem;
+    overflow-y: hidden;
 }
 
 /* Scrollbars */

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -292,6 +292,13 @@ div.simframe > iframe {
              Blockly
 *******************************/
 
+.blocklyTooltipDiv {
+    border:none !important;
+    box-shadow: none !important;
+    background-color: transparent !important;
+    opacity: 1 !important;
+}
+
 .blocklyToolboxDiv, .monacoToolboxDiv {
     background: @blocklyToolboxColor;
     z-index: 1;

--- a/webapp/public/runnertest.html
+++ b/webapp/public/runnertest.html
@@ -179,7 +179,6 @@ images.createImage(`
 
         "color": "red",
         "description": "description",
-        "promoUrl": "https://www.youtube.com/watch?v=Wuza5WXiMkc",
         "header": "header",
         "time": 1459783388895,
         "url": "/test",

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1816,7 +1816,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={javascriptClick} title={lf("Convert code to JavaScript") } />
                         </sui.Item>
                         {docMenu ? <DocsMenuItem parent={this} /> : undefined}
-                        {sandbox ? undefined : <sui.DropdownMenuItem icon='setting' title={lf("More...")} class="more-dropdown-menuitem">
+                        {sandbox ? undefined : <sui.DropdownMenuItem icon='setting' title={lf("More...") } class="more-dropdown-menuitem">
                             {this.state.header ? <sui.Item role="menuitem" icon="options" text={lf("Rename...") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
                             {this.state.header && packages && sharingEnabled ? <sui.Item role="menuitem" text={lf("Embed Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
                             {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined }
@@ -2177,7 +2177,7 @@ $(document).ready(() => {
 
     if (wsPortMatch) {
         pxt.options.wsPort = parseInt(wsPortMatch[1]) || 3233;
-        window.location.hash = window.location.hash.replace(wsPortMatch[0], ""); 
+        window.location.hash = window.location.hash.replace(wsPortMatch[0], "");
     } else {
         pxt.options.wsPort = 3233;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -57,8 +57,6 @@ interface IAppState {
     currFile?: pkg.File;
     fileState?: string;
     showFiles?: boolean;
-    helpCard?: pxt.CodeCard;
-    helpCardClick?: (e: React.MouseEvent) => boolean;
     sideDocsLoadUrl?: string; // set once to load the side docs frame
     sideDocsCollapsed?: boolean;
 
@@ -1047,7 +1045,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
 
         this.setState({
             currFile: fn,
-            helpCard: undefined,
             showBlocks: false
         })
         //this.fireResize();
@@ -1134,7 +1131,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         let logs = this.refs["logs"] as logview.LogView;
         logs.clear();
         this.setState({
-            helpCard: undefined,
             showFiles: false
         })
         return pkg.loadPkgAsync(h.id)
@@ -1693,14 +1689,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             })
     }
 
-    setHelpCard(card: pxt.CodeCard, onClick?: (e: React.MouseEvent) => boolean) {
-        if (pxt.options.light) return; // avoid rendering blocks in low-end devices
-        this.setState({
-            helpCard: card,
-            helpCardClick: onClick
-        })
-    }
-
     about() {
         pxt.tickEvent("menu.about");
         core.confirmAsync({
@@ -1855,7 +1843,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                     : undefined }
                 <div id="simulator">
                     <div id="filelist" className="ui items" role="complementary">
-                        <div id="boardview" className={`ui vertical editorFloat ${this.state.helpCard ? "landscape only " : ""}`}>
+                        <div id="boardview" className={`ui vertical editorFloat`}>
                         </div>
                         <div className="ui item portrait hide">
                             {compileBtn ? <sui.Button icon='icon download' class={`huge fluid download-button ${compileLoading ? 'loading' : ''}`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile() } /> : ""}
@@ -1874,7 +1862,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 </div>
                 <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
                     {this.allEditors.map(e => e.displayOuter()) }
-                    {this.state.helpCard ? <div id="helpcard" className="ui editorFloat wide only"><codecard.CodeCardView responsive={true} onClick={this.state.helpCardClick} {...this.state.helpCard} target={pxt.appTarget.id} /></div> : null }
                 </div>
                 {sideDocs ? <SideDocs ref="sidedoc" parent={this} /> : undefined}
                 {!sandbox && targetTheme.organizationWideLogo && targetTheme.organizationLogo ? <div><img className="organization ui widedesktop hide" src={Util.toDataUri(targetTheme.organizationLogo) } /> <img className="organization ui widedesktop only" src={Util.toDataUri(targetTheme.organizationWideLogo) } /></div> : undefined}

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -239,41 +239,6 @@ export class Editor extends srceditor.Editor {
         }
     }
 
-    updateHelpCard(clear?: boolean) {
-        let selected = Blockly.selected;
-        let selectedType = selected ? selected.type : null;
-        if (selectedType != this.currentHelpCardType || clear) {
-            if (selected && selected.inputList && selected.codeCard && !clear) {
-                this.currentHelpCardType = selectedType;
-                //Unfortunately Blockly doesn't provide an API for getting all of the fields of a blocks
-                let props: any = {};
-                for (let i = 0; i < selected.inputList.length; i++) {
-                    let input = selected.inputList[i];
-                    for (let j = 0; j < input.fieldRow.length; j++) {
-                        let field = input.fieldRow[j];
-                        if (field.name != undefined && field.value_ != undefined) {
-                            props[field.name] = field.value_;
-                        }
-                    }
-                }
-
-                let card: pxt.CodeCard = selected.codeCard;
-                card.description = goog.isFunction(selected.tooltip) ? selected.tooltip() : selected.tooltip;
-                if (!selected.mutation) {
-                    card.blocksXml = this.updateFields(card.blocksXml, props);
-                }
-                else {
-                    card.blocksXml = this.updateFields(card.blocksXml, undefined, selected.mutation.mutationToDom());
-                }
-                this.parent.setHelpCard(card);
-            }
-            else {
-                this.currentHelpCardType = null;
-                this.parent.setHelpCard(null);
-            }
-        }
-    }
-
     contentSize(): { height: number; width: number } {
         if (this.editor) {
             return pxt.blocks.blocksMetrics(this.editor);
@@ -384,7 +349,6 @@ export class Editor extends srceditor.Editor {
                 if (ev.element == 'category') {
                     let toolboxVisible = !!ev.newValue;
                     this.parent.setState({ hideEditorFloats: toolboxVisible });
-                    this.updateHelpCard(ev.newValue != null);
                 }
                 else if (ev.element == 'commentOpen'
                     || ev.element == 'warningOpen') {
@@ -407,12 +371,9 @@ export class Editor extends srceditor.Editor {
                     }
                 }
                 else if (ev.element == 'selected') {
-                    this.updateHelpCard();
-
                     if (this.currentCommentOrWarning) {
                         this.currentCommentOrWarning.setVisible(false)
                     }
-
                     const selected = Blockly.selected
                     if (selected && selected.warning && typeof (selected.warning) !== "string") {
                         (selected.warning as Blockly.Icon).setVisible(true)

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -22,7 +22,6 @@ export class Editor extends srceditor.Editor {
     isFirstBlocklyLoad = true;
     currentCommentOrWarning: B.Comment | B.Warning;
     selectedEventGroup: string;
-    currentHelpCardType: string;
 
     setVisible(v: boolean) {
         super.setVisible(v);
@@ -341,7 +340,7 @@ export class Editor extends srceditor.Editor {
             if (ev.type == 'create') {
                 let lastCategory = (this.editor as any).toolbox_.lastCategory_ ? (this.editor as any).toolbox_.lastCategory_.element_.innerText.trim() : 'unknown';
                 let blockId = ev.xml.getAttribute('type');
-                pxt.tickEvent("blocks.create", {category: lastCategory, block: blockId});
+                pxt.tickEvent("blocks.create", { category: lastCategory, block: blockId });
                 if (ev.xml.tagName == 'SHADOW')
                     this.cleanUpShadowBlocks();
             }

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -3,34 +3,8 @@ import * as ReactDOM from "react-dom";
 import * as sui from "./sui"
 import * as blockspreview from "./blockspreview"
 
-let lf = pxt.Util.lf;
-let repeat = pxt.Util.repeatMap;
-
-interface SocialNetwork {
-    parse: (text: string) => { source: string; id: string }
-}
-
-let socialNetworks: SocialNetwork[] = [{
-    parse: text => {
-        let links: string[] = [];
-        if (text)
-            text.replace(/https?:\/\/(youtu\.be\/([a-z0-9\-_]+))|(www\.youtube\.com\/watch\?v=([a-z0-9\-_]+))/i,
-                (m, m2, id1, m3, id2) => {
-                    let ytid = id1 || id2;
-                    links.push(ytid); return ''
-                });
-        if (links[0]) return { source: 'youtube', id: links[0] };
-        else return undefined;
-    }
-}, {
-        parse: text => {
-            let m = /https?:\/\/vimeo\.com\/\S*?(\d{6,})/i.exec(text)
-            if (m) return { source: "vimeo", id: m[1] };
-            else return undefined;
-        }
-    }
-];
-
+const lf = pxt.Util.lf;
+const repeat = pxt.Util.repeatMap;
 
 export interface CodeCardState { }
 
@@ -48,7 +22,6 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
 
     render() {
         let card = this.props
-        let promo = socialNetworks.map(sn => sn.parse(card.promoUrl)).filter(p => !!p)[0];
         let color = card.color || "";
         if (!color) {
             if (card.hardware && !card.software) color = 'black';
@@ -71,7 +44,6 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
                     {card.header}
                 </div> : null }
             <div className={"ui image" + (card.responsive ? " tall landscape only" : "") }>
-                {promo ? <div key="promoembed" className="ui embed" data-source={promo.source} data-id={promo.id}></div> : null}
                 {card.blocksXml ? <blockspreview.BlocksPreview key="promoblocks" xml={card.blocksXml} /> : null}
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : null}
                 {card.imageUrl ? <img src={card.imageUrl} className="ui image" /> : null}

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -21,17 +21,18 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
     }
 
     render() {
-        let card = this.props
+        const card = this.props
         let color = card.color || "";
         if (!color) {
             if (card.hardware && !card.software) color = 'black';
             else if (card.software && !card.hardware) color = 'teal';
         }
+        const renderMd = (md: string) => md.replace(/`/g, '');
         const url = card.url ? /^[^:]+:\/\//.test(card.url) ? card.url : ('/' + card.url.replace(/^\.?\/?/, ''))
             : undefined;
         const sideUrl = url && /^\//.test(url) ? "#doc:" + url : url;
         const className = card.className;
-        const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`} onClick={e => card.onClick ? card.onClick(e) : undefined } >
+        const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`} title={card.title} onClick={e => card.onClick ? card.onClick(e) : undefined } >
             {card.header || card.blocks || card.javascript || card.hardware || card.software || card.any ?
                 <div key="header" className={"ui content " + (card.responsive ? " tall desktop only" : "") }>
                     <div className="right floated meta">
@@ -43,18 +44,19 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
                     </div>
                     {card.header}
                 </div> : null }
-            <div className={"ui image" + (card.responsive ? " tall landscape only" : "") }>
+            <div className={"ui image"}>
                 {card.blocksXml ? <blockspreview.BlocksPreview key="promoblocks" xml={card.blocksXml} /> : null}
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : null}
                 {card.imageUrl ? <img src={card.imageUrl} className="ui image" /> : null}
             </div>
-            <div className="content">
-                {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}
-                <div className="meta">
-                    {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
-                </div>
-                {card.description ? <div className="description">{card.description}</div> : null}
-            </div>
+            {card.shortName || card.name || card.description ?
+                <div className="content">
+                    {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}
+                    {card.time ? <div className="meta tall">
+                        {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
+                    </div> : undefined}
+                    {card.description ? <div className="description tall">{renderMd(card.description)}</div> : null}
+                </div> : undefined }
         </div>;
 
         if (!card.onClick && url) {


### PR DESCRIPTION
Display the code card as a tooltip rather than anchored in the lower right.
- tooltip shows rendered javascript ( https://github.com/Microsoft/pxt/pull/1030 )
- codecard removed https://github.com/Microsoft/pxt/pull/987
![codecardtip](https://cloud.githubusercontent.com/assets/4175913/21671160/53776b04-d2ce-11e6-9c0a-b1a5dba60003.gif)
