### PR TITLE
ensure that 'on start' is always present in workspace

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -58,7 +58,6 @@ declare namespace pxt {
         loopsBlocks?: boolean;
         extraBlocks?: BlockToolboxDefinition[];
         onStartColor?: string;
-        onStartNamespace?: string;
     }
 
     interface AppAnalytics {

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -26,8 +26,10 @@ namespace pxt.blocks {
 
     function patchFloatingBlocks(dom: Element, info: pxtc.BlocksInfo) {
         let onstart = dom.querySelector(`block[type=${ts.pxtc.ON_START_TYPE}]`)
-        if (onstart) // nothing to doc
+        if (onstart) { // nothing to doc        
+            onstart.setAttribute("deletable", "false")
             return;
+        }
 
         const blocks: Map<pxtc.SymbolInfo> = {};
         info.blocks.forEach(b => blocks[b.attributes.blockId] = b);
@@ -47,6 +49,7 @@ namespace pxt.blocks {
                 if (!onstart) {
                     onstart = dom.ownerDocument.createElement("block");
                     onstart.setAttribute("type", ts.pxtc.ON_START_TYPE);
+                    onstart.setAttribute("deletable", "false");
                     insertNode = dom.ownerDocument.createElement("statement");
                     insertNode.setAttribute("name", "HANDLER");
                     onstart.appendChild(insertNode);

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -489,11 +489,6 @@ namespace pxt.blocks {
         // add extra blocks
         if (tb && pxt.appTarget.runtime) {
             const extraBlocks = pxt.appTarget.runtime.extraBlocks || [];
-            extraBlocks.push({
-                namespace: pxt.appTarget.runtime.onStartNamespace || "loops",
-                weight: 10,
-                type: ts.pxtc.ON_START_TYPE
-            })
             extraBlocks.forEach(eb => {
                 let cat = categoryElement(tb, eb.namespace);
                 if (cat) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -119,13 +119,14 @@ export class Editor extends srceditor.Editor {
 
         this.editor.clear();
         try {
-            const text = pxt.blocks.importXml(s || `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`, this.blockInfo, true);
+            const text = pxt.blocks.importXml(s || `<block type="${ts.pxtc.ON_START_TYPE}" deletable="false"></block>`, this.blockInfo, true);
             const xml = Blockly.Xml.textToDom(text);
             Blockly.Xml.domToWorkspace(xml, this.editor);
 
             this.initLayout();
             this.editor.clearUndo();
             this.reportDeprecatedBlocks();
+            this.ensureOnStart();
         } catch (e) {
             pxt.log(e);
         }
@@ -343,6 +344,12 @@ export class Editor extends srceditor.Editor {
         return this.editor ? this.editor.isDragging() : false;
     }
 
+    ensureOnStart() {
+        this.editor.getTopBlocks(false)
+            .filter(b => b.type == ts.pxtc.ON_START_TYPE)
+            .forEach(b => b.setDeletable(!!b.disabled));
+    }
+
     prepare() {
         let blocklyDiv = document.getElementById('blocksEditor');
         let toolboxDiv = document.getElementById('blocklyToolboxDefinition');
@@ -376,7 +383,7 @@ export class Editor extends srceditor.Editor {
             if (ev.type == 'create') {
                 let lastCategory = (this.editor as any).toolbox_.lastCategory_ ? (this.editor as any).toolbox_.lastCategory_.element_.innerText.trim() : 'unknown';
                 let blockId = ev.xml.getAttribute('type');
-                pxt.tickEvent("blocks.create", {category: lastCategory, block: blockId});
+                pxt.tickEvent("blocks.create", { category: lastCategory, block: blockId });
                 if (ev.xml.tagName == 'SHADOW')
                     this.cleanUpShadowBlocks();
             }


### PR DESCRIPTION
This PR ensures that an "on start" event is always available in blocks.
- [x] 'on start' cannot be deleted, unless disabled (for existing duplicates)
- [x] 'on start' added as needed
- [x] 'on start` made not deletable when importing as well.
- [x] removed from toolbox
