### PR TITLE
Create an editor toolbox

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -291,8 +291,9 @@ declare namespace Blockly {
         getCanvas(): any;
         getParentSvg(): Element;
         zoom(x: number, y: number, type: number): void;
+        zoomCenter(type: number): void;
         highlightBlock(id: string): void;
-        undo(): void;
+        undo(redo?: boolean): void;
         redo(): void;
         clearUndo(): void;
         isDragging(): boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Programming Experience Toolkit provides Blocks / JavaScript tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -656,7 +656,8 @@ namespace pxt.blocks {
 
     export let cachedSearchTb: Element;
     export function initSearch(workspace: Blockly.Workspace, tb: Element,
-        searchAsync: (searchFor: string) => Promise<pxtc.SymbolInfo[]>) {
+        searchAsync: (searchFor: string) => Promise<pxtc.SymbolInfo[]>,
+        updateToolbox: (tb: Element) => void) {
         if ($(`#blocklySearchArea`).length) return;
 
         let blocklySearchArea = document.createElement('div');
@@ -746,13 +747,13 @@ namespace pxt.blocks {
                             if (b) shadow.innerHTML = b.innerHTML;
                         })
 
-                        workspace.updateToolbox(searchTb);
+                        updateToolbox(searchTb);
                         blocklySearchInput.className = origClassName;
                     }
                 })
             } else {
                 // Clearing search
-                workspace.updateToolbox(pxt.blocks.cachedSearchTb);
+                updateToolbox(pxt.blocks.cachedSearchTb);
                 blocklySearchInput.className = origClassName;
             }
             // Search
@@ -792,7 +793,7 @@ namespace pxt.blocks {
                 pxt.BrowserUtils.isTouchEnabled() ?
                     addPackageButton.ontouchstart = addCallback
                     : addPackageButton.onclick = addCallback;
-                addPackageButton.className = 'ui icon button mini blocklyToolboxButton blocklyAddPackageButton';
+                addPackageButton.className = 'ui icon button small blocklyToolboxButton blocklyAddPackageButton';
                 let addpackageIcon = document.createElement('i');
                 addpackageIcon.className = 'plus icon';
                 addPackageButton.appendChild(addpackageIcon);

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1394,7 +1394,7 @@ namespace pxt.blocks {
             if (a == that.selectedItem_ || a == toolbox.tree_) {
                 return;
             }
-            
+
             if (a === null) {
                 collapseMoreCategory(that.selectedItem_);
                 editor.lastInvertedCategory = that.selectedItem_;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1189,18 +1189,6 @@ namespace pxt.blocks {
             let topBlocks = this.getTopBlocks(true);
             let eventGroup = Blockly.genUid();
 
-            // Options to undo/redo previous action.
-            let undoOption: any = {};
-            undoOption.text = lf("Undo");
-            undoOption.enabled = this.undoStack_.length > 0;
-            undoOption.callback = this.undo.bind(this, false);
-            menuOptions.push(undoOption);
-            let redoOption: any = {};
-            redoOption.text = lf("Redo");
-            redoOption.enabled = this.redoStack_.length > 0;
-            redoOption.callback = this.undo.bind(this, true);
-            menuOptions.push(redoOption);
-
             // Add a little animation to collapsing and expanding.
             const DELAY = 10;
             if (this.options.collapse) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -773,7 +773,7 @@ namespace pxt.blocks {
         $('.blocklyToolboxDiv').prepend(blocklySearchArea);
     }
 
-    export function initToolboxButtons(toolbox: HTMLElement, id: string, addCallback: (ev?: Event) => void, undoCallback: (ev?: Event) => void): void {
+    export function initToolboxButtons(toolbox: HTMLElement, id: string, addCallback: (ev?: Event) => void): void {
         if (!$(`#${id}`).length) {
             let blocklyToolboxButtons = document.createElement('div');
             blocklyToolboxButtons.id = id;
@@ -796,25 +796,6 @@ namespace pxt.blocks {
                 addPackageButton.appendChild(addpackageIcon);
                 addButtonDiv.appendChild(addPackageButton);
                 blocklyToolboxButtons.appendChild(addButtonDiv);
-            }
-
-            if (undoCallback) {
-                // add "undo" button to toolbox
-                let undoButtonDiv = document.createElement('div');
-                undoButtonDiv.className = 'column';
-                let undoButton = document.createElement('button');
-                undoButton.setAttribute('role', 'button');
-                undoButton.setAttribute('aria-label', lf("Undo"));
-                undoButton.setAttribute('title', lf("Undo"));
-                pxt.BrowserUtils.isTouchEnabled() ?
-                    undoButton.ontouchstart = undoCallback
-                    : undoButton.onclick = undoCallback;
-                undoButton.className = 'ui icon button small blocklyToolboxButton blocklyUndoButton';
-                let undoIcon = document.createElement('i');
-                undoIcon.className = 'undo icon';
-                undoButton.appendChild(undoIcon);
-                undoButtonDiv.appendChild(undoButton);
-                blocklyToolboxButtons.appendChild(undoButtonDiv);
             }
 
             toolbox.appendChild(blocklyToolboxButtons);

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -474,7 +474,7 @@ div.simframe > iframe {
 /* Blockly toolbox icons */
 .blocklyTreeIcon {
     opacity: 1;
-    margin: -0.25em 0.25em 0.0em 0.25em;
+    margin: -0.2em 0.25em 0.0em 0.25em;
     width: 1.18em;
     font-family: 'Icons';
     font-style: normal;
@@ -643,7 +643,7 @@ div.simframe > iframe {
     }
     /* Blockly */
     .blocklyTreeRow {
-        width: 230px;
+        min-width: 200px;
     }
     /* Toolbox buttons */
     #blocklyToolboxButtons, #monacoToolboxButtons {
@@ -656,7 +656,7 @@ div.simframe > iframe {
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
     /* Blockly row */
     .blocklyTreeRow {
-        width: 230px;
+        min-width: 200px;
     }
     /* Blockly Toolbox buttons */
     #blocklyToolboxButtons, #monacoToolboxButtons {
@@ -669,8 +669,8 @@ div.simframe > iframe {
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
     /* Blockly */
     .blocklyTreeRow {
-        padding-top: 0.75rem !important;
-        padding-bottom: 2rem !important;
+        padding-top: 0.25rem !important;
+        padding-bottom: 1.5rem !important;
         border-left-width: 12px !important;
     }
     .blocklyTreeRoot div div div div .blocklyTreeRow {
@@ -731,8 +731,8 @@ div.simframe > iframe {
 @media only screen and (min-width: @computerBreakpoint) {
     /* Blockly */
     .blocklyTreeRow {
-        padding-top: 0.9rem !important;
-        padding-bottom: 2.3rem !important;
+        padding-top: 0.5rem !important;
+        padding-bottom: 2.0rem !important;
         border-left-width: 12px !important;
     }
     .blocklyTreeRoot div div div div .blocklyTreeRow {
@@ -881,6 +881,14 @@ div.simframe > iframe {
         right: auto;
         left:1rem;
     }
+    /* Blockly toolbox */
+    .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
+        z-index:10;
+        position:fixed;
+        top: 0;
+        height: 100% !important;
+        bottom:0;
+    }
 }
 
 /* Mobile */
@@ -899,6 +907,9 @@ div.simframe > iframe {
     }
     .blocklyTreeRoot div div div div .blocklyTreeRow .blocklyTreeLabel {
         font-size: 0.75rem !important;
+    }
+    #blocklyTrashIcon {
+        font-size: 3rem;
     }
     /* Organization */
     .organization {

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -79,6 +79,10 @@
     background: rgba(0,0,0,0.05);
 }
 
+#simulators {
+    text-align: center;
+}
+
 /* Getting started button */
 #getting-started-btn {
     display:none;
@@ -265,6 +269,20 @@ div.simframe > iframe {
     transition-timing-function: ease-in;
 }
 
+/* Editor tools */
+#editortools {
+    position: absolute;
+    top:auto;
+    bottom:0;
+    left: 0;
+    right:0;
+    z-index:4;
+    background-color: @editorToolsBackground;
+}
+#blocksArea, #monacoEditor, #pxtJsonEditor {
+    bottom: 4rem !important;
+}
+
 /* Help card */
 #helpcard {
     position: absolute;
@@ -324,6 +342,7 @@ div.simframe > iframe {
 ::-webkit-scrollbar {
     -webkit-appearance: none;
     width: 10px;
+    height: 10px;
 }
 ::-webkit-scrollbar-thumb {
     border-radius: 4px;
@@ -395,6 +414,11 @@ div.simframe > iframe {
     fill: white !important;
 }
 
+/* Opacity of blockly flyout background */
+.blocklyFlyoutBackground {
+    fill-opacity: 0.9 !important;
+}
+
 /* This horrendous selector and the next are for subcategories in the Blockly toolbox */
 .blocklyTreeRoot div div div div .blocklyTreeRow {
     border-left-width: 12px !important;
@@ -438,7 +462,7 @@ div.simframe > iframe {
 /* Blockly toolbox icons */
 .blocklyTreeIcon {
     opacity: 1;
-    margin: 0em 0.25rem 0em 0em;
+    margin: -0.25em 0.25em 0.0em 0.25em;
     width: 1.18em;
     font-family: 'Icons';
     font-style: normal;
@@ -451,6 +475,7 @@ div.simframe > iframe {
     -webkit-font-smoothing: antialiased;
     backface-visibility: hidden;
     font-size: 1.2rem;
+    display: none;
 }
 .blocklyTreeSelected .blocklyTreeIcon{
     color: white;
@@ -654,17 +679,6 @@ div.simframe > iframe {
     #blocklyToolboxButtons.ui.stackable.grid .column, #monacoToolboxButtons.ui.stackable.grid .column {
         padding: 0.3rem 0 0.3rem 0 !important;
     }
-    #getting-started-btn {
-        top: @mobileMenuHeight;
-    }
-    /* Menu spacing */
-    .ui.menu .item {
-        padding: 0.4em !important;
-    }
-    .ui.menu .item.editor-menuitem {
-        margin-top: ((@mobileMenuHeight - 2.5rem)/2) !important;
-        margin-bottom: ((@mobileMenuHeight - 2.5rem)/2) !important;
-    }
     /* Logo */
     .ui.item.logo img {
         max-height: 2.5rem;
@@ -675,14 +689,29 @@ div.simframe > iframe {
     .blocklyTreeLabel {
         display: none !important;
     }
+    .blocklyTreeRow:hover .blocklyTreeLabel{
+        display: none !important;
+        z-index:1000;
+    }
+    .blocklyTreeRow.blocklyTreeSelected:hover .blocklyTreeLabel{
+        display: none !important;
+    }
     .blocklyTreeIcon {
         font-size: 1.5rem;
     }
     .blocklyTreeRow {
         height: 2rem;
+        text-align: center;
+    }
+    .blocklyTreeRoot div div div div .blocklyTreeRow {
+        border-left-width: 8px !important;
     }
     .blocklyToolboxDiv, .monacoToolboxDiv{
-        width: 50px;
+        width: 3.5rem;
+    }
+    /* Hide the blockly toolbox search */
+    #blocklySearchArea {
+        display: none !important;
     }
 }
 
@@ -728,8 +757,8 @@ div.simframe > iframe {
         bottom:0.5rem;
     }
     .rtl .organization {
-        left:1.5rem;
-        right:auto;
+        right:1.5rem;
+        left:auto;
     }
     /* Cookie Message */
     #cookiemsg {
@@ -752,13 +781,13 @@ div.simframe > iframe {
     /* Organization logo */
     .organization {
         top:auto !important;
-        left:0.5rem;
-        right: auto;
-        bottom: 0.5rem;
+        right:1rem;
+        left: auto;
+        bottom: 1rem;
         height: 1.3rem;
     }
     .rtl .organization {
-        left:0.5rem;
+        left:1rem;
         right: auto;
     }
     /* Blockly */
@@ -771,51 +800,34 @@ div.simframe > iframe {
         bottom: 2rem;
         margin: 0;
     }
-}
-
-/* Mobile */
-@media only screen and (max-width: @largestMobileScreen) {
-    /* Top Menu */
-    #maineditor {
-        top:@mobileMenuHeight !important;
-    }
     /* Layout */
     #filelist {
         position:absolute;
         z-index:5;
-        bottom:1rem;
-        left:3rem;
+        bottom:0rem;
+        left:0rem;
         top:auto;
         width:auto;
         min-width: inherit;
         max-width: inherit;
-        background-color: transparent;
+        background: transparent !important;
     }
     .rtl #filelist {
         left:auto;
-        right:3rem;
+        right:0;
     }
     #maineditor, .rtl #maineditor {
         left: 0;
         right:0;
     }
     #maineditor:not(.sandbox), .rtl #maineditor:not(.sandbox) {
-        bottom:2.3rem;
+        bottom: 0rem;
     }
-    /* Logo */
-    #logo {
-        font-size: 0rem;
-        padding-right: 0;
+    #editortools {
+        height: 15rem;
     }
-    /* Blockly */
-    .blocklyTreeLabel {
-        font-size: 0.75rem !important;
-    }
-    .blocklyCheckbox {
-        font-size: 17pt !important;
-    }
-    .blocklyTreeRoot div div div div .blocklyTreeRow .blocklyTreeLabel {
-        font-size: 0.75rem !important;
+    #blocksArea, #monacoEditor, #pxtJsonEditor {
+        bottom: 14rem !important;
     }
     /* Simulator */
     div.simframe {
@@ -833,9 +845,46 @@ div.simframe > iframe {
     .hideEditorFloats .editorFloat {
         display:none;
     }
+    /* Menu spacing */
+    .ui.menu .item {
+        padding: 0.4em !important;
+    }
+    .ui.menu .item.editor-menuitem {
+        margin-top: ((@mobileMenuHeight - 2.5rem)/2) !important;
+        margin-bottom: ((@mobileMenuHeight - 2.5rem)/2) !important;
+    }
+    /* Top Menu */
+    #maineditor {
+        top:@mobileMenuHeight !important;
+    }
+    #getting-started-btn {
+        top: @mobileMenuHeight;
+    }
+}
+
+/* Mobile */
+@media only screen and (max-width: @largestMobileScreen) {
+    /* Logo */
+    #logo {
+        font-size: 0rem;
+        padding-right: 0;
+    }
+    /* Blockly */
+    .blocklyTreeLabel {
+        font-size: 0.75rem !important;
+    }
+    .blocklyCheckbox {
+        font-size: 17pt !important;
+    }
+    .blocklyTreeRoot div div div div .blocklyTreeRow .blocklyTreeLabel {
+        font-size: 0.75rem !important;
+    }
     /* Organization */
     .organization {
         top: auto !important;
+    }
+    .blocklyTreeIcon {
+        margin: 0.25em 0.25em 0.0em 0.0em;
     }
 }
 
@@ -857,27 +906,33 @@ div.simframe > iframe {
 }
 
 /* smaller desktop screen */
-@media only screen and (max-width: @computerBreakpoint), only screen and (max-aspect-ratio: 12/10) {
+@media only screen and (max-width: @largestTabletScreen), only screen and (max-aspect-ratio: 12/10) {
     .ui.desktop.only {
         display:none !important;
     }
 }
 
 /* thin desktop portrait mode */
-@media only screen and (max-width: @tabletBreakpoint), only screen and (max-aspect-ratio: 7/10) {
+@media only screen and (max-width: @largestTabletScreen), only screen and (max-aspect-ratio: 7/10) {
     .ui.landscape.only {
         display:none !important;
     }
 }
 
-@media only screen and (min-width: @tabletBreakpoint) {
+@media only screen and (min-width: @computerBreakpoint) {
     .ui.portrait.only {
         display:none !important;
     }
 }
 
-/* Mobile */
-@media only screen and (max-width: @tabletBreakpoint) {
+@media only screen and (min-width: @tabletBreakpoint) {
+    .ui.tablet.only {
+        display:none !important;
+    }
+}
+
+/* Mobile + Tablet */
+@media only screen and (max-width: @largestTabletScreen) {
     .ui.portrait.only {
         display:inherit !important;
     }

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -325,6 +325,18 @@ div.simframe > iframe {
     vertical-align: middle;
 }
 
+/* Sandbox */
+.sandboxfooter {
+    position:absolute;
+    bottom:1rem;
+    left:1rem;
+    z-index:5;
+}
+.rtl .sandboxfooter{
+    left: auto;
+    right:1rem;
+}
+
 /* code card */
 
 .ui.card .image pre {
@@ -859,6 +871,15 @@ div.simframe > iframe {
     }
     #getting-started-btn {
         top: @mobileMenuHeight;
+    }
+    /* Sandbox */
+    .sandboxfooter {
+        left: auto;
+        right:1rem;
+    }
+    .rtl .sandboxfooter{
+        right: auto;
+        left:1rem;
     }
 }
 

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -642,6 +642,9 @@ div.simframe > iframe {
 .ui.widedesktop.only {
     display:none !important;
 }
+.ui.tablet.only {
+    display:none !important;
+}
 
 @media only screen and (min-width: @largeMonitorBreakpoint) and (min-height:30em) {
     .ui.widedesktop.only {
@@ -672,9 +675,10 @@ div.simframe > iframe {
     }
 }
 
-@media only screen and (min-width: @tabletBreakpoint) {
+/* Tablet only */
+@media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
     .ui.tablet.only {
-        display:none !important;
+        display:inherit !important;
     }
 }
 
@@ -731,6 +735,9 @@ div.simframe > iframe {
     /* Blockly */
     .blocklyTreeRow {
         min-width: 200px;
+    }
+    .collapsedEditorTools .organization {
+        display: block;
     }
 }
 
@@ -807,6 +814,15 @@ div.simframe > iframe {
         border-left-width: 18px !important;
         padding-top: 0px !important;
         padding-bottom: 1.6rem !important;
+    }
+    .collapsedEditorTools #filelist {
+        display: none;
+    }
+    .collapsedEditorTools #maineditor {
+        left:0 !important;
+    }
+    .collapsedEditorTools .organization {
+        display: none;
     }
 }   
 
@@ -1005,5 +1021,9 @@ div.simframe > iframe {
     }
     .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
         bottom: 4rem !important;
+    }
+    /* Hide getting stared on mobile */
+    #getting-started-btn {
+        display: none;
     }
 }

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -277,11 +277,11 @@ div.simframe > iframe {
     left: 0;
     right:0;
     z-index:3;
-    height:4.5rem;
+    height:4rem;
     background-color: @editorToolsBackground;
 }
 #blocksArea, #monacoEditor, #pxtJsonEditor {
-    bottom: 4.5rem !important;
+    bottom: 4rem !important;
 }
 
 /* Help card */
@@ -636,6 +636,78 @@ div.simframe > iframe {
 }
 
 /*******************************
+        Layout Variables
+*******************************/
+
+.ui.widedesktop.only {
+    display:none !important;
+}
+
+@media only screen and (min-width: @largeMonitorBreakpoint) and (min-height:30em) {
+    .ui.widedesktop.only {
+        display:inherit !important;
+    }
+    .ui.widedesktop.hide {
+        display:none !important;
+    }
+}
+
+/* smaller desktop screen */
+@media only screen and (max-width: @largestTabletScreen), only screen and (max-aspect-ratio: 12/10) {
+    .ui.desktop.only {
+        display:none !important;
+    }
+}
+
+/* thin desktop portrait mode */
+@media only screen and (max-width: @largestTabletScreen), only screen and (max-aspect-ratio: 7/10) {
+    .ui.landscape.only {
+        display:none !important;
+    }
+}
+
+@media only screen and (min-width: @computerBreakpoint) {
+    .ui.portrait.only {
+        display:none !important;
+    }
+}
+
+@media only screen and (min-width: @tabletBreakpoint) {
+    .ui.tablet.only {
+        display:none !important;
+    }
+}
+
+/* Mobile + Tablet */
+@media only screen and (max-width: @largestTabletScreen) {
+    .ui.portrait.only {
+        display:inherit !important;
+    }
+    .ui.portrait.hide {
+        display:none !important;
+    }
+}
+
+/* Screens with decent vertical space */
+@media only screen and (max-height: @tallEditorBreakpoint) {
+    .ui.tall.only {
+        display:none !important;
+    }
+}
+
+@media only screen and (min-width: @mobileBreakpoint) {
+    .ui.thin.only {
+        display:none !important;
+    }
+}
+
+@media only screen and (max-width: @mobileBreakpoint) {
+    .ui.wide.only {
+        display:none !important;
+    }
+}
+
+/*******************************
         Media Adjustments
 *******************************/
 
@@ -812,7 +884,6 @@ div.simframe > iframe {
         position:absolute;
         padding: 0;
         margin: 1em;
-        padding-bottom: 1em;
         z-index:5;
         bottom:0rem;
         left:0rem;
@@ -834,10 +905,19 @@ div.simframe > iframe {
         bottom: 0rem;
     }
     #editortools {
-        height: 12rem;
+        height: 10rem;
     }
     #blocksArea, #monacoEditor, #pxtJsonEditor {
-        bottom: 12rem !important;
+        bottom: 10rem !important;
+    }
+    .hideEditorFloats #editortools {
+        height: 4.5rem;
+    }
+    .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
+        bottom: 4.5rem !important;
+    }
+    .hideEditorFloats .organization {
+        display: none;
     }
     /* Simulator */
     div.simframe {
@@ -879,14 +959,6 @@ div.simframe > iframe {
         right: auto;
         left:1rem;
     }
-    /* Blockly toolbox */
-    .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
-        z-index:10;
-        position:fixed;
-        top: 0;
-        height: 100% !important;
-        bottom:0;
-    }
 }
 
 /* Mobile */
@@ -909,9 +981,17 @@ div.simframe > iframe {
     #blocklyTrashIcon {
         font-size: 3rem;
     }
-    /* Organization */
+    /* Organization logo */
     .organization {
-        top: auto !important;
+        top:auto !important;
+        right:0.5rem;
+        left: auto;
+        bottom: 0.5rem;
+        height: 1.3rem;
+    }
+    .rtl .organization {
+        left:0.5rem;
+        right: auto;
     }
     .blocklyTreeIcon {
         margin: 0.25em 0.25em 0.0em 0.0em;
@@ -920,76 +1000,10 @@ div.simframe > iframe {
     .blocklyAddPackageButton {
         margin-left: 0 !important;
     }
-}
-
-/*******************************
-        Layout Variables
-*******************************/
-
-.ui.widedesktop.only {
-    display:none !important;
-}
-
-@media only screen and (min-width: @largeMonitorBreakpoint) and (min-height:30em) {
-    .ui.widedesktop.only {
-        display:inherit !important;
+    .hideEditorFloats #editortools {
+        height: 4rem;
     }
-    .ui.widedesktop.hide {
-        display:none !important;
-    }
-}
-
-/* smaller desktop screen */
-@media only screen and (max-width: @largestTabletScreen), only screen and (max-aspect-ratio: 12/10) {
-    .ui.desktop.only {
-        display:none !important;
-    }
-}
-
-/* thin desktop portrait mode */
-@media only screen and (max-width: @largestTabletScreen), only screen and (max-aspect-ratio: 7/10) {
-    .ui.landscape.only {
-        display:none !important;
-    }
-}
-
-@media only screen and (min-width: @computerBreakpoint) {
-    .ui.portrait.only {
-        display:none !important;
-    }
-}
-
-@media only screen and (min-width: @tabletBreakpoint) {
-    .ui.tablet.only {
-        display:none !important;
-    }
-}
-
-/* Mobile + Tablet */
-@media only screen and (max-width: @largestTabletScreen) {
-    .ui.portrait.only {
-        display:inherit !important;
-    }
-    .ui.portrait.hide {
-        display:none !important;
-    }
-}
-
-/* Screens with decent vertical space */
-@media only screen and (max-height: @tallEditorBreakpoint) {
-    .ui.tall.only {
-        display:none !important;
-    }
-}
-
-@media only screen and (min-width: @mobileBreakpoint) {
-    .ui.thin.only {
-        display:none !important;
-    }
-}
-
-@media only screen and (max-width: @mobileBreakpoint) {
-    .ui.wide.only {
-        display:none !important;
+    .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
+        bottom: 4rem !important;
     }
 }

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -277,11 +277,11 @@ div.simframe > iframe {
     left: 0;
     right:0;
     z-index:3;
-    height:4rem;
+    height:4.5rem;
     background-color: @editorToolsBackground;
 }
 #blocksArea, #monacoEditor, #pxtJsonEditor {
-    bottom: 4rem !important;
+    bottom: 4.5rem !important;
 }
 
 /* Help card */
@@ -834,10 +834,10 @@ div.simframe > iframe {
         bottom: 0rem;
     }
     #editortools {
-        height: 14rem;
+        height: 12rem;
     }
     #blocksArea, #monacoEditor, #pxtJsonEditor {
-        bottom: 14rem !important;
+        bottom: 12rem !important;
     }
     /* Simulator */
     div.simframe {

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -233,7 +233,7 @@ div.simframe > iframe {
 /* Organization logo */
 .organization {
     position:absolute;
-    top:1rem;
+    top:1.3rem;
     right:2rem;
     height:2rem;
     z-index:102;
@@ -276,7 +276,8 @@ div.simframe > iframe {
     bottom:0;
     left: 0;
     right:0;
-    z-index:4;
+    z-index:3;
+    height:4rem;
     background-color: @editorToolsBackground;
 }
 #blocksArea, #monacoEditor, #pxtJsonEditor {
@@ -362,6 +363,23 @@ div.simframe > iframe {
     box-shadow: 0 0 1px #ccc;    
     -webkit-box-shadow: 0 0 1px #ccc;
 }
+
+/* Button Colors */
+.ui.button.editortools-btn {
+    &:extend(.grey all);
+}
+.ui.button.getting-started-btn {
+    &:extend(.green all);
+}
+.ui.button.download-button {
+    &:extend(.green all);
+}
+/* Blockly Toolbox Buttons */
+.ui.button.blocklyAddPackageButton {
+    &:extend(.grey all);
+    &:extend(.circular all);
+}
+
 
 /*******************************
              Docs
@@ -458,11 +476,8 @@ div.simframe > iframe {
 
 /* Blockly / Monaco Toolbox Buttons */
 #blocklyToolboxButtons, #monacoToolboxButtons {
-    margin-top: 0.5rem;
-    margin-left: auto;
-    margin-right: auto;
+    margin-top: 0.1rem;
     font-size:3rem;
-    text-align: center;
 }
 
 /* Blockly Search bar */
@@ -645,11 +660,6 @@ div.simframe > iframe {
     .blocklyTreeRow {
         min-width: 200px;
     }
-    /* Toolbox buttons */
-    #blocklyToolboxButtons, #monacoToolboxButtons {
-        margin-right: 2rem;
-        margin-left: 2rem;
-    }
 }
 
 /* Small Monitor */
@@ -657,11 +667,6 @@ div.simframe > iframe {
     /* Blockly row */
     .blocklyTreeRow {
         min-width: 200px;
-    }
-    /* Blockly Toolbox buttons */
-    #blocklyToolboxButtons, #monacoToolboxButtons {
-        margin-right: 1rem;
-        margin-left: 1rem;
     }
 }
 
@@ -678,19 +683,10 @@ div.simframe > iframe {
         padding-top: 0px !important;
         padding-bottom: 1.6rem !important;
     }
-    /* Blockly Toolbox buttons */
-    #blocklyToolboxButtons, #monacoToolboxButtons {
-        margin-right: 0.5rem;
-        margin-left: 0.5rem;
-    }
 }
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-    /* Blockly / Monaco Toolbox buttons, adjust how the stackable grid looks for these buttons in mobile view */
-    #blocklyToolboxButtons.ui.stackable.grid .column, #monacoToolboxButtons.ui.stackable.grid .column {
-        padding: 0.3rem 0 0.3rem 0 !important;
-    }
     /* Logo */
     .ui.item.logo img {
         max-height: 2.5rem;
@@ -718,8 +714,8 @@ div.simframe > iframe {
     .blocklyTreeRoot div div div div .blocklyTreeRow {
         border-left-width: 8px !important;
     }
-    .blocklyToolboxDiv, .monacoToolboxDiv{
-        width: 3.5rem;
+    .blocklyTreeRow{
+        padding-right: 0;
     }
     /* Hide the blockly toolbox search */
     #blocklySearchArea {
@@ -746,7 +742,6 @@ div.simframe > iframe {
 @media only screen and (max-width: @largestSmallMonitor) {
     /* Layout */
     #filelist {
-        bottom:3rem;
         min-width:@simulatorWidthSmall;
         max-width:@simulatorWidthSmall;
     }
@@ -815,6 +810,9 @@ div.simframe > iframe {
     /* Layout */
     #filelist {
         position:absolute;
+        padding: 0;
+        margin: 1em;
+        padding-bottom: 1em;
         z-index:5;
         bottom:0rem;
         left:0rem;
@@ -836,7 +834,7 @@ div.simframe > iframe {
         bottom: 0rem;
     }
     #editortools {
-        height: 15rem;
+        height: 14rem;
     }
     #blocksArea, #monacoEditor, #pxtJsonEditor {
         bottom: 14rem !important;
@@ -917,6 +915,10 @@ div.simframe > iframe {
     }
     .blocklyTreeIcon {
         margin: 0.25em 0.25em 0.0em 0.0em;
+    }
+    /* Remove margin around the blockly add package buttons */
+    .blocklyAddPackageButton {
+        margin-left: 0 !important;
     }
 }
 

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -911,7 +911,7 @@ div.simframe > iframe {
         bottom: 10rem !important;
     }
     .hideEditorFloats #editortools {
-        height: 4.5rem;
+        height: 4.5rem !important;
     }
     .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
         bottom: 4.5rem !important;
@@ -1001,7 +1001,7 @@ div.simframe > iframe {
         margin-left: 0 !important;
     }
     .hideEditorFloats #editortools {
-        height: 4rem;
+        height: 4rem !important;
     }
     .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
         bottom: 4rem !important;

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -18,9 +18,10 @@
     margin-right: 0.25rem;
 }
 
-@media only screen and (max-width: @largestMobileScreen) {
+@media only screen and (max-width: @largestTabletScreen) {
     #menubar .ui.menu {
         height: @mobileMenuHeight !important;
+        min-height: @mobileMenuHeight !important;
     }
 }
 

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -33,11 +33,13 @@
    Breakpoints
 --------------------*/
 
+/*
 @mobileBreakpoint            : unit( (63 * @emSize), px);
 @tabletBreakpoint            : unit( (79 * @emSize), px);
 @computerBreakpoint          : unit( (91 * @emSize), px);
 @largeMonitorBreakpoint      : unit( (99 * @emSize), px);
 @widescreenMonitorBreakpoint : unit( (119 * @emSize), px);
+*/
 
 @tallEditorBreakpoint: 44rem;
 
@@ -52,8 +54,8 @@
 @mainMenuInvertedBackground: @black;
 @mainMenuTutorialBackground: @orange;
 
-@mainMenuHeight: 4.4rem;
-@mobileMenuHeight: 4.4rem;
+@mainMenuHeight: 5.0rem;
+@mobileMenuHeight: 3.5rem;
 
 @mainMenuBlocksJsToggleColor: @primaryColor;
 
@@ -72,6 +74,7 @@
 --------------------*/
 
 @simulatorBackground: #fff;
+@editorToolsBackground: @simulatorBackground;
 @blocklySvgColor: #fff;
 
 /*-------------------

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -190,8 +190,12 @@ svg.ui.trend.black polyline {
 .sandboxfooter {
     position:absolute;
     bottom:1rem;
-    left:1rem;
+    right:1rem;
     z-index:5;
+}
+.rtl .sandboxfooter{
+    right: auto;
+    left:1rem;
 }
 
 .grayscale {

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -187,17 +187,6 @@ svg.ui.trend.black polyline {
     stroke:#000;
 }
 
-.sandboxfooter {
-    position:absolute;
-    bottom:1rem;
-    right:1rem;
-    z-index:5;
-}
-.rtl .sandboxfooter{
-    right: auto;
-    left:1rem;
-}
-
 .grayscale {
     -moz-filter: grayscale(1);
     -webkit-filter: grayscale(1);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -911,34 +911,36 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                             </div>
                         </div>
                         : <div className="ui grid">
-                            <div className="six wide column">
-                                <div className="ui grid">
-                                    <div className="row">
+                            <div className="four wide column">
+                            </div>
+                            <div className="five wide column">
+                                <div className="ui grid right aligned">
+                                    <div className="equal width row">
+                                        <div className="left aligned column">
+                                            {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                        </div>
                                         <div className="column">
-                                            {run ? <sui.Button role="menuitem" class="right floated large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                            <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
                                         </div>
                                     </div>
                                     <div className="row" style={{paddingTop: 0}}>
                                         <div className="column">
-                                            {compileBtn ? <sui.Button role="menuitem" class={`right floated large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
+                                            {compileBtn ? <sui.Button role="menuitem" class={`large fluid download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                            <div className="ten wide column">
+                            <div className="seven wide column">
                                 <div className="ui grid">
-                                    <div className="four column row">
+                                    <div className="three column row">
                                         <div className="column">
-                                            <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
-                                        </div>
-                                        <div className="column">
-                                            <div className="ui icon large buttons">
+                                            <div className="ui icon large vertical buttons">
                                                 <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
                                                 <sui.Button icon='repeat' class="editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
                                             </div>
                                         </div>
                                         <div className="column">
-                                            <div className="ui icon large buttons">
+                                            <div className="ui icon large vertical buttons">
                                                 <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
                                                 <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
                                             </div>
@@ -947,39 +949,36 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                             <sui.Button icon={collapsed ? 'angle up' : 'angle down'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                                         </div>
                                     </div>
-                                    <div className="centered row" style={{paddingTop: 0}}>
-                                        <div className="eight wide column">
-                                            <div className={`ui large left fluid input projectname-input`} title={lf("Pick a name for your project") }>
-                                                <input id="fileNameInput"
-                                                    type="text"
-                                                    placeholder={lf("Pick a name...") }
-                                                    value={state.projectName || ''}
-                                                    onChange={(e) => this.saveProjectName((e.target as any).value) }>
-                                                </input>
-                                            </div>
-                                        </div>
-                                    </div>
                                 </div>
                             </div>
                         </div> }
                     </div>
                     <div className="column computer only">
-                        <div className="ui grid container">
-                            <div className="column five wide">
-                                <div className={`ui small left fluid input projectname-input`} title={lf("Pick a name for your project") }>
-                                    <input id="fileNameInput"
-                                        type="text"
-                                        placeholder={lf("Pick a name...") }
-                                        value={state.projectName || ''}
-                                        onChange={(e) => this.saveProjectName((e.target as any).value) }>
-                                    </input>
-                                </div>
+                        <div className="ui grid">
+                            <div className="left aligned column one wide">
+                                <sui.Button icon={state.collapseEditorTools ? 'angle right' : 'angle left'} class={`small editortools-btn collapse-editortools-btn`} title={state.collapseEditorTools ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                             </div>
-                            <div className="left aligned column">
-                                <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
-                            </div>
-                            <div className="column six wide">
-                            </div>
+                            {state.collapseEditorTools ?
+                                <div className="column four wide">
+                                    <div className={`ui large left fluid input projectname-input`} title={lf("Pick a name for your project") }>
+                                        <input id="fileNameInput"
+                                            type="text"
+                                            placeholder={lf("Pick a name...") }
+                                            value={state.projectName || ''}
+                                            onChange={(e) => this.saveProjectName((e.target as any).value) }>
+                                        </input>
+                                    </div>
+                                </div> : undefined }
+                            {state.collapseEditorTools ?
+                                <div className="left aligned column">
+                                    <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
+                                </div> : undefined }
+                            {state.collapseEditorTools ?
+                                <div className="column six wide">
+                                </div> : undefined }
+                            {!state.collapseEditorTools ?
+                                <div className="column eleven wide">
+                                </div> : undefined }
                             <div className="column two wide">
                                 <div className="ui icon small buttons">
                                     <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
@@ -2280,7 +2279,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         document.title = this.state.header ? `${this.state.header.name} - ${pxt.appTarget.name}` : pxt.appTarget.name;
 
         return (
-            <div id='root' className={`full-abs ${this.state.hideEditorFloats || this.state.collapseEditorTools ? " hideEditorFloats" : ""} ${!sideDocs || !this.state.sideDocsLoadUrl || this.state.sideDocsCollapsed ? "" : "sideDocs"} ${sandbox ? "sandbox" : ""} ${tutorial ? "tutorial" : ""} ${pxt.options.light ? "light" : ""}` }>
+            <div id='root' className={`full-abs ${this.state.hideEditorFloats || this.state.collapseEditorTools ? " hideEditorFloats" : ""} ${this.state.collapseEditorTools ? " collapsedEditorTools" : ""} ${!sideDocs || !this.state.sideDocsLoadUrl || this.state.sideDocsCollapsed ? "" : "sideDocs"} ${sandbox ? "sandbox" : ""} ${tutorial ? "tutorial" : ""} ${pxt.options.light ? "light" : ""}` }>
                 <div id="menubar" role="banner">
                     <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">
                         {sandbox ? undefined :
@@ -2320,6 +2319,14 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
                             { electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => electron.checkForUpdate() } /> : undefined }
                         </sui.DropdownMenuItem>}
+                        <div className="ui item mini input projectname-input tablet only" title={lf("Pick a name for your project") }>
+                            <input id="fileNameInput"
+                                type="text"
+                                placeholder={lf("Pick a name...") }
+                                value={this.state.projectName || ''}
+                                onChange={(e) => this.updateHeaderName((e.target as any).value) }>
+                            </input>
+                        </div>
                         <div className="right menu">
                             {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/> : undefined }
                             {sandbox ? <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span> : undefined }
@@ -2344,6 +2351,23 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                     : undefined }
                 <div id="simulator">
                     <div id="filelist" className="ui items" role="complementary">
+                        <div className="ui item landscape only">
+                            <div className="ui grid container">
+                                <div className="twelve wide column">
+                                    <div className={`ui large fluid input projectname-input`} title={lf("Pick a name for your project") }>
+                                        <input id="fileNameInput"
+                                            type="text"
+                                            placeholder={lf("Pick a name...") }
+                                            value={this.state.projectName || ''}
+                                            onChange={(e) => this.updateHeaderName((e.target as any).value) }>
+                                        </input>
+                                    </div>
+                                </div>
+                                <div className="four wide column">
+                                    <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
+                                </div>
+                            </div>
+                        </div>
                         <div id="boardview" className={`ui vertical editorFloat`}>
                         </div>
                         <div className="ui item portrait hide">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -59,6 +59,7 @@ interface IAppState {
     showFiles?: boolean;
     sideDocsLoadUrl?: string; // set once to load the side docs frame
     sideDocsCollapsed?: boolean;
+    projectName?: string;
 
     tutorial?: string; // tutorial
     tutorialName?: string; // tutorial title
@@ -778,6 +779,153 @@ class TutorialCard extends data.Component<ISettingsProps, {}> {
     }
 }
 
+class EditorTools extends data.Component<ISettingsProps, {}> {
+    constructor(props: ISettingsProps) {
+        super(props);
+    }
+
+    saveProjectName (name: string) {
+        pxt.tickEvent("editortools.projectrename");
+        this.props.parent.updateHeaderName(name);
+    }
+
+    saveFile() {
+        pxt.tickEvent("editortools.save");
+        this.props.parent.saveFile();
+    }
+
+    openSettings() {
+        pxt.tickEvent("editortools.settings");
+        this.props.parent.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json"))
+    }
+
+    undo() {
+        pxt.tickEvent("editortools.undo");
+        this.props.parent.editor.undo();
+    }
+
+    redo() {
+        pxt.tickEvent("editortools.redo");
+        this.props.parent.editor.redo();
+    }
+
+    zoomIn() {
+        pxt.tickEvent("editortools.zoomIn");
+        this.props.parent.editor.zoomIn();
+    }
+
+    zoomOut() {
+        pxt.tickEvent("editortools.zoomOut");
+        this.props.parent.editor.zoomOut();
+    }
+
+    sendFeedback() {
+        pxt.tickEvent("editortools.sendFeedback");
+    }
+
+    render() {
+        const state = this.props.parent.state;
+        const isEditor = this.props.parent.editor == this.props.parent.blocksEditor || this.props.parent.editor == this.props.parent.textEditor;
+        if (!isEditor) return <div />;
+        
+        const targetTheme = pxt.appTarget.appTheme;
+        const compile = pxt.appTarget.compile;
+        const compileBtn = compile.hasHex;
+        const simOpts = pxt.appTarget.simulator;
+        const make = !sandbox && state.showParts && simOpts && (simOpts.instructions || (simOpts.parts && pxt.options.debug));
+        const compileTooltip = lf("Download your code to the {0}", targetTheme.boardName);
+        const compileLoading = !!state.compiling;
+        const runTooltip = state.running ? lf("Stop the simulator") : lf("Start the simulator");
+        const makeTooltip = lf("Open assembly instructions");
+        const run = true;
+
+        return  <div className="ui equal width grid padded">
+                    <div className="column mobile only tablet only">
+                        <div className="ui grid">
+                            <div className="eight wide mobile six wide tablet column">
+                                <div className="ui grid">
+                                    <div className="twelve wide column">
+                                    </div>
+                                    <div className="four wide column">
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="eight wide mobile ten wide tablet column">
+                                <div className="ui grid">
+                                    <div className="four column row">
+                                        <div className="column">
+                                            <sui.Button icon='undo' class="large grey" title={lf("Undo")} onClick={() => this.undo()} />
+                                        </div>
+                                        <div className="column">
+                                            <sui.Button icon='repeat' class="large grey" title={lf("Redo")} onClick={() => this.redo()} />
+                                        </div>
+                                        <div className="column">
+                                            <sui.Button icon='zoom' class="large grey" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                        </div>
+                                        <div className="column">
+                                            <sui.Button icon='zoom out' class="large grey" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                        </div>
+                                    </div>
+                                    <div className="four column row">
+                                        <div className="eight wide column">
+                                            <div className={`ui large left icon fluid input`} title={lf("Pick a name for your project") }>
+                                                <input id="fileNameInput"
+                                                    type="text"
+                                                    placeholder={lf("Pick a name...") }
+                                                    value={state.projectName || ''}
+                                                    onChange={(e) => this.saveProjectName((e.target as any).value) }>
+                                                </input>
+                                                <i className="icon font"></i>
+                                            </div>
+                                        </div>
+                                        <div className="column">
+                                            <sui.Button icon='save' class="red large grey" title={lf("Save")} onClick={() => this.saveFile()} />
+                                        </div>
+                                        <div className="column">
+                                            <sui.Button icon='announcement' class="blue large grey" title={lf("Feedback")} onClick={() => this.sendFeedback()} />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="column computer only">
+                        <div className="ui relaxed divided grid">
+                            <div className="column four wide">
+                                <div className={`ui large left icon fluid input`} title={lf("Pick a name for your project") }>
+                                    <input id="fileNameInput"
+                                        type="text"
+                                        placeholder={lf("Pick a name...") }
+                                        value={state.projectName || ''}
+                                        onChange={(e) => this.saveProjectName((e.target as any).value) }>
+                                    </input>
+                                    <i className="icon font"></i>
+                                </div>
+                            </div>
+                            <div className="column two wide">
+                                <sui.Button icon='save' class="red large grey" title={lf("Save")} onClick={() => this.saveFile()} />
+                            </div>
+                            <div className="column two wide">
+                                <sui.Button icon='undo' class="large grey" title={lf("Undo")} onClick={() => this.undo()} />
+                            </div>
+                            <div className="column two wide">
+                                <sui.Button icon='repeat' class="large grey" title={lf("Redo")} onClick={() => this.redo()} />
+                            </div>
+                            <div className="column two wide">
+                                <sui.Button icon='zoom' class="large grey" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                            </div>
+                            <div className="column two wide">
+                                <sui.Button icon='zoom out' class="large grey" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                            </div>
+                            <div className="column two wide">
+                                <sui.Button icon='announcement' class="blue large grey" title={lf("Feedback")} onClick={() => this.sendFeedback()} />
+                            </div>
+                        </div>
+                    </div>
+                </div>;
+    }
+}
+
 class SideDocs extends data.Component<ISettingsProps, {}> {
     public static notify(message: pxsim.SimulatorMessage) {
         let sd = document.getElementById("sidedocs") as HTMLIFrameElement;
@@ -1344,6 +1492,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 }
                 this.setState({
                     header: h,
+                    projectName: h.name,
                     currFile: file
                 })
                 if (!sandbox)
@@ -1880,6 +2029,40 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             })
     }
 
+    private debouncedSaveProjectName = Util.debounce(() => {
+        this.saveProjectName();
+    }, 2000, false);
+
+    updateHeaderName(name: string) {
+        this.setState({
+            projectName: name
+        })
+        this.debouncedSaveProjectName();
+    }
+
+    saveProjectName() {
+        if (!this.state.projectName || !this.state.header) return;
+
+        pxt.debug('saving project name to ' + this.state.projectName);
+        try {
+            //Save the name in the target MainPackage as well
+            pkg.mainPkg.config.name = this.state.projectName;
+
+            let f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
+            let config = JSON.parse(f.content) as pxt.PackageConfig;
+            config.name = this.state.projectName;
+            f.setContentAsync(JSON.stringify(config, null, 4) + "\n").done(() => {
+                if (this.state.header)
+                    this.setState({
+                        projectName: this.state.header.name
+                    })
+            });
+        }
+        catch (e) {
+            console.error('failed to read pxt.json')
+        }
+    }
+
     about() {
         pxt.tickEvent("menu.about");
         core.confirmAsync({
@@ -2034,13 +2217,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                                     : <span className="name">{targetTheme.name}</span>}
                                 {targetTheme.portraitLogo ? (<a className="ui image" target="_blank" href={targetTheme.logoUrl}><img className='ui logo portrait only' src={Util.toDataUri(targetTheme.portraitLogo) } /></a>) : null }
                             </span> }
-                        <div className="ui item portrait only">
-                            <div className="ui">
-                                {compileBtn ? <sui.Button role="menuitem" class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" onClick={() => this.compile() } /> : "" }
-                                {make ? <sui.Button role="menuitem" icon='configure' class="secondary" onClick={() => this.openInstructions() } /> : undefined }
-                                {run ? <sui.Button role="menuitem" class="play-button play-button-full" key='runmenubtn' icon={this.state.running ? "stop" : "play"} onClick={() => this.startStopSimulator() } /> : undefined }
-                            </div>
-                        </div>
                         {sandbox ? undefined : <div className="ui item landscape only"></div>}
                         {sandbox ? undefined : <div className="ui item landscape only"></div>}
                         {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
@@ -2071,10 +2247,11 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
                             { electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => electron.checkForUpdate() } /> : undefined }
                         </sui.DropdownMenuItem>}
-                        {sandbox ? <div className="right menu">
-                            <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/>
-                            <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span>
-                        </div> : undefined }
+                        <div className="right menu">
+                            {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/> : undefined }
+                            {sandbox ? <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span> : undefined }
+                            {!sandbox ? <span className="ui item"><sui.Button class="portrait only getting-started-btn green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span>: undefined }
+                        </div>
                         {tutorial ? <TutorialMenuItem parent={this} /> : undefined }
                         {tutorial ? <div className="right menu">
                             <sui.Item role="menuitem" icon="external" text={lf("Exit tutorial") } textClass="landscape only" onClick={() => this.exitTutorial() }/>
@@ -2089,7 +2266,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 </div>
                 {gettingStarted ?
                     <div id="getting-started-btn">
-                        <sui.Button class="bottom attached getting-started-btn green " title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } />
+                        <sui.Button class="portrait hide bottom attached getting-started-btn green " title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } />
                     </div>
                     : undefined }
                 <div id="simulator">
@@ -2100,6 +2277,11 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             {compileBtn ? <sui.Button icon='icon download' class={`huge fluid download-button ${compileLoading ? 'loading' : ''}`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile() } /> : ""}
                             {make ? <sui.Button icon='configure' class="fluid sixty secondary" text={lf("Make") } title={makeTooltip} onClick={() => this.openInstructions() } /> : undefined }
                             {run ? <sui.Button key='runbtn' class={`${compileBtn ? '' : 'huge fluid'} play-button`} text={compileBtn ? undefined : this.state.running ? lf("Stop") : lf("Run") } icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.state.running ? this.stopSimulator() : this.runSimulator() } /> : undefined }
+                        </div>
+                        <div className="ui portrait only">
+                            {compileBtn ? <sui.Button role="menuitem" class={`large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.compile() } /> : undefined }
+                            {make ? <sui.Button role="menuitem" icon='configure' class="large secondary" title={makeTooltip} onClick={() => this.openInstructions() } /> : undefined }
+                            {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator() } /> : undefined }
                         </div>
                         <div className="ui item portrait hide">
                             {pxt.options.debug && !this.state.running ? <sui.Button key='debugbtn' class='teal' icon="xicon bug" text={"Sim Debug"} onClick={() => this.runSimulator({ debug: true }) } /> : ''}
@@ -2114,6 +2296,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
                     {tutorial ? <TutorialCard ref="tutorialcard" parent={this} /> : undefined }
                     {this.allEditors.map(e => e.displayOuter()) }
+                    <div id="editortools" role="complementary">
+                        <EditorTools ref="editortools" parent={this} />
+                    </div>
                 </div>
                 {sideDocs ? <SideDocs ref="sidedoc" parent={this} /> : undefined}
                 {!sandbox && targetTheme.organizationWideLogo && targetTheme.organizationLogo ? <div><img className="organization ui widedesktop hide" src={Util.toDataUri(targetTheme.organizationLogo) } /> <img className="organization ui widedesktop only" src={Util.toDataUri(targetTheme.organizationWideLogo) } /></div> : undefined}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -882,7 +882,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                             <sui.Button icon='save' class="red large grey" title={lf("Save")} onClick={() => this.saveFile()} />
                                         </div>
                                         <div className="column">
-                                            <sui.Button icon='announcement' class="blue large grey" title={lf("Feedback")} onClick={() => this.sendFeedback()} />
+                                            <sui.Button icon='comment' class="blue large grey" title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
                                         </div>
                                     </div>
                                 </div>
@@ -918,7 +918,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 <sui.Button icon='zoom out' class="large grey" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
                             </div>
                             <div className="column two wide">
-                                <sui.Button icon='announcement' class="blue large grey" title={lf("Feedback")} onClick={() => this.sendFeedback()} />
+                                <sui.Button icon='comment' class="blue large grey" title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
                             </div>
                         </div>
                     </div>
@@ -2250,7 +2250,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         <div className="right menu">
                             {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/> : undefined }
                             {sandbox ? <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span> : undefined }
-                            {!sandbox ? <span className="ui item"><sui.Button class="portrait only getting-started-btn green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span>: undefined }
+                            {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="portrait only getting-started-btn green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span>: undefined }
                         </div>
                         {tutorial ? <TutorialMenuItem parent={this} /> : undefined }
                         {tutorial ? <div className="right menu">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -304,32 +304,22 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
             <sui.Modal visible={this.state.visible} header={headerText} addClass="large searchdialog"
                 onHide={() => this.setState({ visible: false }) }>
                 {!this.state.searchFor && this.state.mode == ScriptSearchMode.Projects ?
-                    <div className="ui vertial segment">
+                    <div className="ui vertical segment">
                         <sui.Button
                             icon="file outline"
-                            text={lf("New") }
+                            text={lf("New Project...") }
                             title={lf("Creates a new empty project") }
                             onClick={() => newProject() } />
-                        <sui.Button
-                            icon="save"
-                            text={lf("Save") }
-                            title={lf("Saves current project to a.hex file") }
-                            onClick={() => saveProject() } />
-                        <sui.Button
-                            icon="options"
-                            text={lf("Rename...") }
-                            title={lf("Rename the current project") }
-                            onClick={() => renameProject() } />
-                    </div> : undefined}
-                <div className="ui vertial segment">
-                {this.state.search ? <div className="ui search">
-                    <div className="ui fluid action input" role="search">
                         {pxt.appTarget.compile ?
                             <sui.Button
                                 icon="upload"
-                                text={lf("Import") }
-                                title={lf("Open .hex files on your computer") }
+                                text={lf("Import File...") }
+                                title={lf("Open files from your computer") }
                                 onClick={() => importHex() } /> : undefined}
+                    </div> : undefined}
+                <div className="ui vertical segment">
+                {this.state.search ? <div className="ui search">
+                    <div className="ui fluid action input" role="search">
                         <input ref="searchInput" type="text" placeholder={lf("Search...") } onKeyUp={kupd} />
                         <button title={lf("Search") } className="ui right icon button" onClick={upd}>
                             <i className="search icon"></i>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -899,29 +899,27 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                     </div>
                     <div className="column tablet only">
                         {collapsed ?
-                        <div className="ui equal width grid">
-                            <div className="left aligned column">
-                                <div className="ui icon large buttons">
-                                    {compileBtn ? <sui.Button role="menuitem" class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
-                                    {run ? <sui.Button role="menuitem" class="" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
-                                </div>
+                        <div className="ui grid seven column">
+                            <div className="left aligned six wide column">
+                                {compileBtn ? <sui.Button role="menuitem" class={`large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
+                                {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
                             </div>
-                            <div className="column">
+                            <div className="column two wide">
                                 <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
                             </div>
-                            <div className="column">
+                            <div className="column three wide">
                                 <div className="ui icon large buttons">
                                     <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
                                     <sui.Button icon='repeat' class="editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
                                 </div>
                             </div>
-                            <div className="column">
+                            <div className="column three wide">
                                 <div className="ui icon large buttons">
                                     <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
                                     <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
                                 </div>
                             </div>
-                            <div className="column">
+                            <div className="column two wide">
                                 <sui.Button icon={collapsed ? 'expand' : 'compress'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                             </div>
                         </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -854,35 +854,34 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 <div className="ui grid">
                                     <div className="four column row">
                                         <div className="column">
-                                            <sui.Button icon='undo' class="large grey" title={lf("Undo")} onClick={() => this.undo()} />
+                                            <sui.Button icon='undo' class="large editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
                                         </div>
                                         <div className="column">
-                                            <sui.Button icon='repeat' class="large grey" title={lf("Redo")} onClick={() => this.redo()} />
+                                            <sui.Button icon='repeat' class="large editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
                                         </div>
                                         <div className="column">
-                                            <sui.Button icon='zoom' class="large grey" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                            <sui.Button icon='zoom' class="large editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
                                         </div>
                                         <div className="column">
-                                            <sui.Button icon='zoom out' class="large grey" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                            <sui.Button icon='zoom out' class="large editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
                                         </div>
                                     </div>
                                     <div className="four column row">
                                         <div className="eight wide column">
-                                            <div className={`ui large left icon fluid input`} title={lf("Pick a name for your project") }>
+                                            <div className={`ui large left icon fluid input projectname-input`} title={lf("Pick a name for your project") }>
                                                 <input id="fileNameInput"
                                                     type="text"
                                                     placeholder={lf("Pick a name...") }
                                                     value={state.projectName || ''}
                                                     onChange={(e) => this.saveProjectName((e.target as any).value) }>
                                                 </input>
-                                                <i className="icon font"></i>
                                             </div>
                                         </div>
                                         <div className="column">
-                                            <sui.Button icon='save' class="red large grey" title={lf("Save")} onClick={() => this.saveFile()} />
+                                            <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
                                         </div>
                                         <div className="column">
-                                            <sui.Button icon='comment' class="blue large grey" title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
+                                            <sui.Button icon='smile' class="large editortools-btn feedback-editortools-btn" title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
                                         </div>
                                     </div>
                                 </div>
@@ -890,35 +889,37 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                         </div>
                     </div>
                     <div className="column computer only">
-                        <div className="ui relaxed divided grid">
+                        <div className="ui grid">
                             <div className="column four wide">
-                                <div className={`ui large left icon fluid input`} title={lf("Pick a name for your project") }>
+                                <div className={`ui small left icon fluid input projectname-input`} title={lf("Pick a name for your project") }>
                                     <input id="fileNameInput"
                                         type="text"
                                         placeholder={lf("Pick a name...") }
                                         value={state.projectName || ''}
                                         onChange={(e) => this.saveProjectName((e.target as any).value) }>
                                     </input>
-                                    <i className="icon font"></i>
                                 </div>
                             </div>
-                            <div className="column two wide">
-                                <sui.Button icon='save' class="red large grey" title={lf("Save")} onClick={() => this.saveFile()} />
+                            <div className="column">
+                                <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
+                            </div>
+                            <div className="column five wide">
+
+                            </div>
+                            <div className="column">
+                                <sui.Button icon='undo' class="small editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                            </div>
+                            <div className="column">
+                                <sui.Button icon='repeat' class="small editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
+                            </div>
+                            <div className="column">
+                                <sui.Button icon='zoom' class="small editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                            </div>
+                            <div className="column">
+                                <sui.Button icon='zoom out' class="small editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
                             </div>
                             <div className="column two wide">
-                                <sui.Button icon='undo' class="large grey" title={lf("Undo")} onClick={() => this.undo()} />
-                            </div>
-                            <div className="column two wide">
-                                <sui.Button icon='repeat' class="large grey" title={lf("Redo")} onClick={() => this.redo()} />
-                            </div>
-                            <div className="column two wide">
-                                <sui.Button icon='zoom' class="large grey" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
-                            </div>
-                            <div className="column two wide">
-                                <sui.Button icon='zoom out' class="large grey" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
-                            </div>
-                            <div className="column two wide">
-                                <sui.Button icon='comment' class="blue large grey" title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
+                                <sui.Button icon='smile' class="small right floated editortools-btn feedback-editortools-btn " title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
                             </div>
                         </div>
                     </div>
@@ -2250,7 +2251,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         <div className="right menu">
                             {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/> : undefined }
                             {sandbox ? <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span> : undefined }
-                            {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="portrait only getting-started-btn green" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span>: undefined }
+                            {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="portrait only small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span>: undefined }
                         </div>
                         {tutorial ? <TutorialMenuItem parent={this} /> : undefined }
                         {tutorial ? <div className="right menu">
@@ -2266,7 +2267,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 </div>
                 {gettingStarted ?
                     <div id="getting-started-btn">
-                        <sui.Button class="portrait hide bottom attached getting-started-btn green " title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } />
+                        <sui.Button class="portrait hide bottom attached small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } />
                     </div>
                     : undefined }
                 <div id="simulator">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -820,8 +820,11 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
         this.props.parent.editor.zoomOut();
     }
 
-    sendFeedback() {
-        pxt.tickEvent("editortools.sendFeedback");
+    startStopSimulator() {
+        const state = this.props.parent.state;
+        if (!state.running && state.collapseEditorTools)
+            this.props.parent.setState({collapseEditorTools: false});
+        this.props.parent.startStopSimulator();
     }
 
     toggleCollapse() {
@@ -831,6 +834,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
 
     render() {
         const state = this.props.parent.state;
+        const hideEditorFloats = state.hideEditorFloats;
         const collapsed = state.hideEditorFloats || state.collapseEditorTools;
         const isEditor = this.props.parent.editor == this.props.parent.blocksEditor || this.props.parent.editor == this.props.parent.textEditor;
         if (!isEditor) return <div />;
@@ -853,7 +857,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                             <div className="left aligned column">
                                 <div className="ui icon small buttons">
                                     {compileBtn ? <sui.Button role="menuitem" class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
-                                    {run ? <sui.Button role="menuitem" class="" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                    {run ? <sui.Button role="menuitem" class="" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator() } /> : undefined }
                                 </div>
                             </div>
                             <div className="column">
@@ -869,7 +873,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 </div>
                             </div>
                             <div className="column">
-                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class="small editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class={`small editortools-btn collapse-editortools-btn ${hideEditorFloats ? 'disabled' : ''}`} title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                             </div>
                         </div> :
                         <div className="ui equal width grid">
@@ -902,7 +906,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                         <div className="ui grid seven column">
                             <div className="left aligned six wide column">
                                 {compileBtn ? <sui.Button role="menuitem" class={`large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
-                                {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator() } /> : undefined }
                             </div>
                             <div className="column two wide">
                                 <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
@@ -920,7 +924,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 </div>
                             </div>
                             <div className="column two wide">
-                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class={`large editortools-btn collapse-editortools-btn ${hideEditorFloats ? 'disabled' : ''}`} title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                             </div>
                         </div>
                         : <div className="ui grid">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -873,7 +873,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 </div>
                             </div>
                             <div className="column">
-                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class={`small editortools-btn collapse-editortools-btn ${hideEditorFloats ? 'disabled' : ''}`} title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                <sui.Button icon={collapsed ? 'angle up' : 'angle down'} class={`small editortools-btn collapse-editortools-btn ${hideEditorFloats ? 'disabled' : ''}`} title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                             </div>
                         </div> :
                         <div className="ui equal width grid">
@@ -886,7 +886,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                             <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
                                             <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
                                             <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
-                                            <sui.Button icon={collapsed ? 'expand' : 'compress'} class="editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                            <sui.Button icon={collapsed ? 'angle up' : 'angle down'} class="editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                                         </div>
                                     </div>
                                 </div>
@@ -924,7 +924,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 </div>
                             </div>
                             <div className="column two wide">
-                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class={`large editortools-btn collapse-editortools-btn ${hideEditorFloats ? 'disabled' : ''}`} title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                <sui.Button icon={collapsed ? 'angle up' : 'angle down'} class={`large editortools-btn collapse-editortools-btn ${hideEditorFloats ? 'disabled' : ''}`} title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                             </div>
                         </div>
                         : <div className="ui grid">
@@ -961,7 +961,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                             </div>
                                         </div>
                                         <div className="column">
-                                            <sui.Button icon={collapsed ? 'expand' : 'compress'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                            <sui.Button icon={collapsed ? 'angle up' : 'angle down'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                                         </div>
                                     </div>
                                     <div className="centered row" style={{paddingTop: 0}}>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -960,7 +960,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                             </div>
                             {state.collapseEditorTools ?
                                 <div className="column four wide">
-                                    <div className={`ui large left fluid input projectname-input`} title={lf("Pick a name for your project") }>
+                                    <div className={`ui large left fluid input projectname-input projectname-computer-collapsed`} title={lf("Pick a name for your project") }>
                                         <input id="fileNameInput"
                                             type="text"
                                             placeholder={lf("Pick a name...") }
@@ -977,7 +977,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 <div className="column six wide">
                                 </div> : undefined }
                             {!state.collapseEditorTools ?
-                                <div className="column eleven wide">
+                                <div className="column ten wide">
                                 </div> : undefined }
                             <div className="column two wide">
                                 <div className="ui icon small buttons">
@@ -2319,7 +2319,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
                             { electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => electron.checkForUpdate() } /> : undefined }
                         </sui.DropdownMenuItem>}
-                        <div className="ui item mini input projectname-input tablet only" title={lf("Pick a name for your project") }>
+                        <div className="ui item mini input projectname-input projectname-tablet tablet only" title={lf("Pick a name for your project") }>
                             <input id="fileNameInput"
                                 type="text"
                                 placeholder={lf("Pick a name...") }
@@ -2354,7 +2354,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         <div className="ui item landscape only">
                             <div className="ui grid container">
                                 <div className="twelve wide column">
-                                    <div className={`ui large fluid input projectname-input`} title={lf("Pick a name for your project") }>
+                                    <div className={`ui fluid input projectname-input projectname-computer-sim`} title={lf("Pick a name for your project") }>
                                         <input id="fileNameInput"
                                             type="text"
                                             placeholder={lf("Pick a name...") }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -775,7 +775,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
 
     saveFile() {
         pxt.tickEvent("editortools.save");
-        this.props.parent.saveFile();
+        this.props.parent.compile(true);
     }
 
     openSettings() {
@@ -804,6 +804,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
     }
 
     startStopSimulator() {
+        pxt.tickEvent("editortools.startStopSimulator");
         const state = this.props.parent.state;
         if (!state.running && state.collapseEditorTools)
             this.props.parent.setState({collapseEditorTools: false});
@@ -812,6 +813,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
 
     toggleCollapse() {
         const state = this.props.parent.state;
+        pxt.tickEvent("editortools.toggleCollapse", {'collapsed': '' + !state.collapseEditorTools});
         this.props.parent.setState({collapseEditorTools: !state.collapseEditorTools});
     }
 
@@ -913,40 +915,44 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                         : <div className="ui grid">
                             <div className="four wide column">
                             </div>
-                            <div className="five wide column">
+                            <div className="twelve wide column">
                                 <div className="ui grid right aligned">
-                                    <div className="equal width row">
-                                        <div className="left aligned column">
-                                            {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
-                                        </div>
-                                        <div className="column">
-                                            <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
-                                        </div>
-                                    </div>
-                                    <div className="row" style={{paddingTop: 0}}>
-                                        <div className="column">
+                                    <div className="five column row">
+                                        <div className="six wide column">
                                             {compileBtn ? <sui.Button role="menuitem" class={`large fluid download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
                                         </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="seven wide column">
-                                <div className="ui grid">
-                                    <div className="three column row">
-                                        <div className="column">
-                                            <div className="ui icon large vertical buttons">
+                                        <div className="two wide left aligned column">
+                                            {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                        </div>
+                                        <div className="three wide column">
+                                            <div className="ui icon large buttons">
                                                 <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
                                                 <sui.Button icon='repeat' class="editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
                                             </div>
                                         </div>
-                                        <div className="column">
-                                            <div className="ui icon large vertical buttons">
+                                        <div className="three wide column">
+                                            <div className="ui icon large buttons">
                                                 <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
                                                 <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
                                             </div>
                                         </div>
-                                        <div className="column">
+                                        <div className="two wide column">
                                             <sui.Button icon={collapsed ? 'angle up' : 'angle down'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                        </div>
+                                    </div>
+                                    <div className="two column row" style={{paddingTop: 0}}>
+                                        <div className="six wide column">
+                                            <div className="ui item large fluid input projectname-input projectname-tablet" title={lf("Pick a name for your project") }>
+                                                <input id="fileNameInput"
+                                                    type="text"
+                                                    placeholder={lf("Pick a name...") }
+                                                    value={state.projectName || ''}
+                                                    onChange={(e) => this.saveProjectName((e.target as any).value) }>
+                                                </input>
+                                            </div>
+                                        </div>
+                                        <div className="left aligned column">
+                                            <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
                                         </div>
                                     </div>
                                 </div>
@@ -958,27 +964,21 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                             <div className="left aligned column one wide">
                                 <sui.Button icon={state.collapseEditorTools ? 'angle right' : 'angle left'} class={`small editortools-btn collapse-editortools-btn`} title={state.collapseEditorTools ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
                             </div>
-                            {state.collapseEditorTools ?
-                                <div className="column four wide">
-                                    <div className={`ui large left fluid input projectname-input projectname-computer-collapsed`} title={lf("Pick a name for your project") }>
-                                        <input id="fileNameInput"
-                                            type="text"
-                                            placeholder={lf("Pick a name...") }
-                                            value={state.projectName || ''}
-                                            onChange={(e) => this.saveProjectName((e.target as any).value) }>
-                                        </input>
-                                    </div>
-                                </div> : undefined }
-                            {state.collapseEditorTools ?
-                                <div className="left aligned column">
-                                    <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
-                                </div> : undefined }
-                            {state.collapseEditorTools ?
-                                <div className="column six wide">
-                                </div> : undefined }
-                            {!state.collapseEditorTools ?
-                                <div className="column ten wide">
-                                </div> : undefined }
+                            <div className={`column ${state.collapseEditorTools ? 'three' : 'five'} wide`}>
+                                <div className={`ui large left fluid input projectname-input projectname-computer`} title={lf("Pick a name for your project") }>
+                                    <input id="fileNameInput"
+                                        type="text"
+                                        placeholder={lf("Pick a name...") }
+                                        value={state.projectName || ''}
+                                        onChange={(e) => this.saveProjectName((e.target as any).value) }>
+                                    </input>
+                                </div>
+                            </div>
+                            <div className="left aligned column">
+                                <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
+                            </div>
+                            <div className={`column ${state.collapseEditorTools ? 'six' : 'four'} wide`}>
+                            </div>
                             <div className="column two wide">
                                 <div className="ui icon small buttons">
                                     <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
@@ -2319,14 +2319,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
                             { electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => electron.checkForUpdate() } /> : undefined }
                         </sui.DropdownMenuItem>}
-                        <div className="ui item mini input projectname-input projectname-tablet tablet only" title={lf("Pick a name for your project") }>
-                            <input id="fileNameInput"
-                                type="text"
-                                placeholder={lf("Pick a name...") }
-                                value={this.state.projectName || ''}
-                                onChange={(e) => this.updateHeaderName((e.target as any).value) }>
-                            </input>
-                        </div>
                         <div className="right menu">
                             {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/> : undefined }
                             {sandbox ? <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span> : undefined }
@@ -2351,23 +2343,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                     : undefined }
                 <div id="simulator">
                     <div id="filelist" className="ui items" role="complementary">
-                        <div className="ui item landscape only">
-                            <div className="ui grid container">
-                                <div className="twelve wide column">
-                                    <div className={`ui fluid input projectname-input projectname-computer-sim`} title={lf("Pick a name for your project") }>
-                                        <input id="fileNameInput"
-                                            type="text"
-                                            placeholder={lf("Pick a name...") }
-                                            value={this.state.projectName || ''}
-                                            onChange={(e) => this.updateHeaderName((e.target as any).value) }>
-                                        </input>
-                                    </div>
-                                </div>
-                                <div className="four wide column">
-                                    <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
-                                </div>
-                            </div>
-                        </div>
                         <div id="boardview" className={`ui vertical editorFloat`}>
                         </div>
                         <div className="ui item portrait hide">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -73,6 +73,7 @@ interface IAppState {
     compiling?: boolean;
     publishing?: boolean;
     hideEditorFloats?: boolean;
+    collapseEditorTools?: boolean;
     showBlocks?: boolean;
     showParts?: boolean;
 }
@@ -823,8 +824,14 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
         pxt.tickEvent("editortools.sendFeedback");
     }
 
+    toggleCollapse() {
+        const state = this.props.parent.state;
+        this.props.parent.setState({collapseEditorTools: !state.collapseEditorTools});
+    }
+
     render() {
         const state = this.props.parent.state;
+        const collapsed = state.hideEditorFloats || state.collapseEditorTools;
         const isEditor = this.props.parent.editor == this.props.parent.blocksEditor || this.props.parent.editor == this.props.parent.textEditor;
         if (!isEditor) return <div />;
         
@@ -839,36 +846,125 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
         const makeTooltip = lf("Open assembly instructions");
         const run = true;
 
-        return  <div className="ui equal width grid padded">
-                    <div className="column mobile only tablet only">
-                        <div className="ui grid">
-                            <div className="eight wide mobile six wide tablet column">
-                                <div className="ui grid">
-                                    <div className="twelve wide column">
+        return <div className="ui equal width grid right aligned padded">
+                    <div className="column mobile only">
+                        {collapsed ? 
+                        <div className="ui equal width grid">
+                            <div className="left aligned column">
+                                <div className="ui icon small buttons">
+                                    {compileBtn ? <sui.Button role="menuitem" class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
+                                    {run ? <sui.Button role="menuitem" class="" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                </div>
+                            </div>
+                            <div className="column">
+                                <div className="ui icon small buttons">
+                                    <sui.Button icon='save' class="editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
+                                    <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                                </div>
+                            </div>
+                            <div className="column">
+                                <div className="ui icon small buttons">
+                                    <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                    <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                </div>
+                            </div>
+                            <div className="column">
+                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class="small editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                            </div>
+                        </div> :
+                        <div className="ui equal width grid">
+                            <div className="column">
+                            </div>
+                            <div className="ui grid column">
+                                <div className="row">
+                                    <div className="column">
+                                        <div className="ui icon small buttons">
+                                            <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                                            <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                            <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                            <sui.Button icon={collapsed ? 'expand' : 'compress'} class="editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                        </div>
                                     </div>
-                                    <div className="four wide column">
+                                </div>
+                                <div className="row" style={{paddingTop: 0}}>
+                                    <div className="column">
+                                        <div className="ui icon large buttons">
+                                            {compileBtn ? <sui.Button role="menuitem" class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
+                                            {run ? <sui.Button role="menuitem" class="" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                            <div className="eight wide mobile ten wide tablet column">
-                                <div className="ui grid container">
-                                    <div className="four column row">
+                        </div> }
+                    </div>
+                    <div className="column tablet only">
+                        {collapsed ? 
+                        <div className="ui equal width grid">
+                            <div className="left aligned column">
+                                <div className="ui icon large buttons">
+                                    {compileBtn ? <sui.Button role="menuitem" class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
+                                    {run ? <sui.Button role="menuitem" class="" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
+                                </div>
+                            </div>
+                            <div className="column">
+                                <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
+                            </div>
+                            <div className="column">
+                                <div className="ui icon large buttons">
+                                    <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                                    <sui.Button icon='repeat' class="editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
+                                </div>
+                            </div>
+                            <div className="column">
+                                <div className="ui icon large buttons">
+                                    <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                    <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                </div>
+                            </div>
+                            <div className="column">
+                                <sui.Button icon={collapsed ? 'expand' : 'compress'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                            </div>
+                        </div>
+                        : <div className="ui grid">
+                            <div className="six wide column">
+                                <div className="ui grid">
+                                    <div className="row">
                                         <div className="column">
-                                            <sui.Button icon='undo' class="large editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
-                                        </div>
-                                        <div className="column">
-                                            <sui.Button icon='repeat' class="large editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
-                                        </div>
-                                        <div className="column">
-                                            <sui.Button icon='zoom' class="large editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
-                                        </div>
-                                        <div className="column">
-                                            <sui.Button icon='zoom out' class="large editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                            {run ? <sui.Button role="menuitem" class="right floated large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.props.parent.startStopSimulator() } /> : undefined }
                                         </div>
                                     </div>
+                                    <div className="row" style={{paddingTop: 0}}>
+                                        <div className="column">
+                                            {compileBtn ? <sui.Button role="menuitem" class={`right floated large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.props.parent.compile() } /> : undefined }
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="ten wide column">
+                                <div className="ui grid">
                                     <div className="four column row">
+                                        <div className="column">
+                                            <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
+                                        </div>
+                                        <div className="column">
+                                            <div className="ui icon large buttons">
+                                                <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                                                <sui.Button icon='repeat' class="editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
+                                            </div>
+                                        </div>
+                                        <div className="column">
+                                            <div className="ui icon large buttons">
+                                                <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                                <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                            </div>
+                                        </div>
+                                        <div className="column">
+                                            <sui.Button icon={collapsed ? 'expand' : 'compress'} class="large editortools-btn collapse-editortools-btn" title={collapsed ? lf("Expand") : lf("Collapse")} onClick={() => this.toggleCollapse()}/>
+                                        </div>
+                                    </div>
+                                    <div className="centered row" style={{paddingTop: 0}}>
                                         <div className="eight wide column">
-                                            <div className={`ui large left icon fluid input projectname-input`} title={lf("Pick a name for your project") }>
+                                            <div className={`ui large left fluid input projectname-input`} title={lf("Pick a name for your project") }>
                                                 <input id="fileNameInput"
                                                     type="text"
                                                     placeholder={lf("Pick a name...") }
@@ -877,21 +973,15 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                                 </input>
                                             </div>
                                         </div>
-                                        <div className="column">
-                                            <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
-                                        </div>
-                                        <div className="column">
-                                            <sui.Button icon='smile' class="large editortools-btn feedback-editortools-btn" title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
-                                        </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
+                        </div> }
                     </div>
                     <div className="column computer only">
-                        <div className="ui grid">
-                            <div className="column four wide">
-                                <div className={`ui small left icon fluid input projectname-input`} title={lf("Pick a name for your project") }>
+                        <div className="ui grid container">
+                            <div className="column five wide">
+                                <div className={`ui small left fluid input projectname-input`} title={lf("Pick a name for your project") }>
                                     <input id="fileNameInput"
                                         type="text"
                                         placeholder={lf("Pick a name...") }
@@ -900,26 +990,22 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                     </input>
                                 </div>
                             </div>
-                            <div className="column">
+                            <div className="left aligned column">
                                 <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save")} onClick={() => this.saveFile()} />
                             </div>
-                            <div className="column five wide">
-
+                            <div className="column six wide">
                             </div>
                             <div className="column two wide">
-                                <div className="ui icon buttons">
-                                    <sui.Button icon='undo' class="small editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
-                                    <sui.Button icon='repeat' class="small editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
+                                <div className="ui icon small buttons">
+                                    <sui.Button icon='undo' class="editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                                    <sui.Button icon='repeat' class="editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
                                 </div>
                             </div>
                             <div className="column two wide">
-                                <div className="ui icon buttons">
-                                    <sui.Button icon='zoom' class="small editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
-                                    <sui.Button icon='zoom out' class="small editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                <div className="ui icon small buttons">
+                                    <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                    <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
                                 </div>
-                            </div>
-                            <div className="column two wide">
-                                <sui.Button icon='smile' class="small right floated editortools-btn feedback-editortools-btn " title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />
                             </div>
                         </div>
                     </div>
@@ -2208,7 +2294,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         document.title = this.state.header ? `${this.state.header.name} - ${pxt.appTarget.name}` : pxt.appTarget.name;
 
         return (
-            <div id='root' className={`full-abs ${this.state.hideEditorFloats ? " hideEditorFloats" : ""} ${!sideDocs || !this.state.sideDocsLoadUrl || this.state.sideDocsCollapsed ? "" : "sideDocs"} ${sandbox ? "sandbox" : ""} ${tutorial ? "tutorial" : ""} ${pxt.options.light ? "light" : ""}` }>
+            <div id='root' className={`full-abs ${this.state.hideEditorFloats || this.state.collapseEditorTools ? " hideEditorFloats" : ""} ${!sideDocs || !this.state.sideDocsLoadUrl || this.state.sideDocsCollapsed ? "" : "sideDocs"} ${sandbox ? "sandbox" : ""} ${tutorial ? "tutorial" : ""} ${pxt.options.light ? "light" : ""}` }>
                 <div id="menubar" role="banner">
                     <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">
                         {sandbox ? undefined :
@@ -2278,11 +2364,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                             {compileBtn ? <sui.Button icon='icon download' class={`huge fluid download-button ${compileLoading ? 'loading' : ''}`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile() } /> : ""}
                             {make ? <sui.Button icon='configure' class="fluid sixty secondary" text={lf("Make") } title={makeTooltip} onClick={() => this.openInstructions() } /> : undefined }
                             {run ? <sui.Button key='runbtn' class={`${compileBtn ? '' : 'huge fluid'} play-button`} text={compileBtn ? undefined : this.state.running ? lf("Stop") : lf("Run") } icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.state.running ? this.stopSimulator() : this.runSimulator() } /> : undefined }
-                        </div>
-                        <div className="ui portrait only">
-                            {compileBtn ? <sui.Button role="menuitem" class={`large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.compile() } /> : undefined }
-                            {make ? <sui.Button role="menuitem" icon='configure' class="large secondary" title={makeTooltip} onClick={() => this.openInstructions() } /> : undefined }
-                            {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator() } /> : undefined }
                         </div>
                         <div className="ui item portrait hide">
                             {pxt.options.debug && !this.state.running ? <sui.Button key='debugbtn' class='teal' icon="xicon bug" text={"Sim Debug"} onClick={() => this.runSimulator({ debug: true }) } /> : ''}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -851,7 +851,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                                 </div>
                             </div>
                             <div className="eight wide mobile ten wide tablet column">
-                                <div className="ui grid">
+                                <div className="ui grid container">
                                     <div className="four column row">
                                         <div className="column">
                                             <sui.Button icon='undo' class="large editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
@@ -906,17 +906,17 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                             <div className="column five wide">
 
                             </div>
-                            <div className="column">
-                                <sui.Button icon='undo' class="small editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                            <div className="column two wide">
+                                <div className="ui icon buttons">
+                                    <sui.Button icon='undo' class="small editortools-btn undo-editortools-btn" title={lf("Undo")} onClick={() => this.undo()} />
+                                    <sui.Button icon='repeat' class="small editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
+                                </div>
                             </div>
-                            <div className="column">
-                                <sui.Button icon='repeat' class="small editortools-btn redo-editortools-btn" title={lf("Redo")} onClick={() => this.redo()} />
-                            </div>
-                            <div className="column">
-                                <sui.Button icon='zoom' class="small editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
-                            </div>
-                            <div className="column">
-                                <sui.Button icon='zoom out' class="small editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                            <div className="column two wide">
+                                <div className="ui icon buttons">
+                                    <sui.Button icon='zoom' class="small editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onClick={() => this.zoomIn()} />
+                                    <sui.Button icon='zoom out' class="small editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onClick={() => this.zoomOut()} />
+                                </div>
                             </div>
                             <div className="column two wide">
                                 <sui.Button icon='smile' class="small right floated editortools-btn feedback-editortools-btn " title={lf("Give Feedback")} onClick={() => this.sendFeedback()} />

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -827,7 +827,6 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
     toggleCollapse() {
         const state = this.props.parent.state;
         this.props.parent.setState({collapseEditorTools: !state.collapseEditorTools});
-        this.props.parent.fireResize();
     }
 
     render() {
@@ -1266,6 +1265,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         this.saveSettings()
         this.editor.domUpdate();
         simulator.setState(this.state.header ? this.state.header.editor : '')
+        this.editor.resize();
     }
 
     fireResize() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -827,6 +827,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
     toggleCollapse() {
         const state = this.props.parent.state;
         this.props.parent.setState({collapseEditorTools: !state.collapseEditorTools});
+        this.props.parent.fireResize();
     }
 
     render() {
@@ -834,7 +835,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
         const collapsed = state.hideEditorFloats || state.collapseEditorTools;
         const isEditor = this.props.parent.editor == this.props.parent.blocksEditor || this.props.parent.editor == this.props.parent.textEditor;
         if (!isEditor) return <div />;
-        
+
         const targetTheme = pxt.appTarget.appTheme;
         const compile = pxt.appTarget.compile;
         const compileBtn = compile.hasHex;
@@ -848,7 +849,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
 
         return <div className="ui equal width grid right aligned padded">
                     <div className="column mobile only">
-                        {collapsed ? 
+                        {collapsed ?
                         <div className="ui equal width grid">
                             <div className="left aligned column">
                                 <div className="ui icon small buttons">
@@ -898,7 +899,7 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                         </div> }
                     </div>
                     <div className="column tablet only">
-                        {collapsed ? 
+                        {collapsed ?
                         <div className="ui equal width grid">
                             <div className="left aligned column">
                                 <div className="ui icon large buttons">
@@ -2337,7 +2338,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         <div className="right menu">
                             {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Open with {0}", targetTheme.name) } textClass="landscape only" onClick={() => this.launchFullEditor() }/> : undefined }
                             {sandbox ? <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span> : undefined }
-                            {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="portrait only small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span>: undefined }
+                            {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="portrait only small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span> : undefined }
                         </div>
                         {tutorial ? <TutorialMenuItem parent={this} /> : undefined }
                         {tutorial ? <div className="right menu">

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -79,10 +79,6 @@ export class Editor extends srceditor.Editor {
                             (pxt.appTarget.cloud.packages && !this.parent.getSandboxMode() ?
                                 (() => {
                                     this.parent.addPackage();
-                                }) : null),
-                            (!this.parent.getSandboxMode() ?
-                                (() => {
-                                    this.undo();
                                 }) : null)
                         );
                     }
@@ -417,6 +413,18 @@ export class Editor extends srceditor.Editor {
         this.editor.undo();
     }
 
+    redo() {
+        this.editor.undo(true);
+    }
+
+    zoomIn() {
+        this.editor.zoomCenter(1);
+    }
+
+    zoomOut() {
+        this.editor.zoomCenter(-1);
+    }
+
     getId() {
         return "blocksArea"
     }
@@ -503,8 +511,6 @@ export class Editor extends srceditor.Editor {
         let toolbox = showCategories ?
                 document.getElementById('blocklyToolboxDefinitionCategory')
                 : document.getElementById('blocklyToolboxDefinitionFlyout');
-        let zoomEnabled = showCategories;
-        let controlsEnabled = showCategories;
         let blocklyOptions: Blockly.Options = {
             toolbox: toolbox,
             scrollbars: true,
@@ -515,8 +521,8 @@ export class Editor extends srceditor.Editor {
             comments: true,
             disable: false,
             zoom: {
-                enabled: zoomEnabled,
-                controls: controlsEnabled,
+                enabled: false,
+                controls: false,
                 /* wheel: true, wheel as a zoom is confusing and incosistent with monaco */
                 maxScale: 2.5,
                 minScale: .2,

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -361,7 +361,6 @@ export class Editor extends srceditor.Editor {
                 if (ev.element == 'category') {
                     let toolboxVisible = !!ev.newValue;
                     this.parent.setState({ hideEditorFloats: toolboxVisible });
-                    this.resize();
                 }
                 else if (ev.element == 'commentOpen'
                     || ev.element == 'warningOpen') {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -361,6 +361,7 @@ export class Editor extends srceditor.Editor {
                 if (ev.element == 'category') {
                     let toolboxVisible = !!ev.newValue;
                     this.parent.setState({ hideEditorFloats: toolboxVisible });
+                    this.resize();
                 }
                 else if (ev.element == 'commentOpen'
                     || ev.element == 'warningOpen') {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -85,7 +85,8 @@ export class Editor extends srceditor.Editor {
                     if (showCategories && showSearch) {
                         pxt.blocks.initSearch(this.editor, tb,
                             searchFor => compiler.apiSearchAsync(searchFor)
-                                .then((fns: pxtc.SymbolInfo[]) => fns));
+                                .then((fns: pxtc.SymbolInfo[]) => fns),
+                            searchTb => this.updateToolbox(searchTb, showCategories));
                     }
 
                     let xml = this.delayLoadXml;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -549,7 +549,6 @@ export class Editor extends srceditor.Editor {
                     return;
                 } else {
                     // Selected category
-                    treeitem.style.background = `${color}`;
                     treerow.style.color = '#fff';
                     treerow.className += ' blocklyTreeSelected';
                     monacoEditor.selectedCategoryItem = treeitem;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -470,7 +470,6 @@ export class Editor extends srceditor.Editor {
         this.editor.addOverlayWidget(flyoutWidget);
     }
 
-    private selectedCategoryItem: HTMLElement;
     private selectedCategoryRow: HTMLElement;
     private selectedCategoryColor: string;
 
@@ -481,14 +480,13 @@ export class Editor extends srceditor.Editor {
         flyout.style.display = 'none';
 
         // Hide the currnet toolbox category
-        if (this.selectedCategoryItem) {
-            this.selectedCategoryItem.style.background = 'none';
+        if (this.selectedCategoryRow) {
+            this.selectedCategoryRow.style.background = 'none';
             this.selectedCategoryRow.style.color = `${this.selectedCategoryColor}`;
             this.selectedCategoryRow.className = 'blocklyTreeRow';
         }
 
         if (clear) {
-            this.selectedCategoryItem = null;
             this.selectedCategoryRow = null;
         }
     }
@@ -542,16 +540,16 @@ export class Editor extends srceditor.Editor {
                 monacoEditor.resetFlyout(false);
 
                 // Hide the toolbox if the current category is clicked twice
-                if (monacoEditor.selectedCategoryItem == treeitem) {
-                    monacoEditor.selectedCategoryItem = null;
+                if (monacoEditor.selectedCategoryRow == treeitem) {
+                    monacoEditor.selectedCategoryRow = null;
                     monacoFlyout.style.display = 'none';
                     treerow.className = 'blocklyTreeRow';
                     return;
                 } else {
                     // Selected category
+                    treerow.style.background = `${color}`;
                     treerow.style.color = '#fff';
                     treerow.className += ' blocklyTreeSelected';
-                    monacoEditor.selectedCategoryItem = treeitem;
                     monacoEditor.selectedCategoryRow = treerow;
                     if (appTheme.invertedToolbox) {
                         // Inverted toolbox

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -144,6 +144,10 @@ export class Editor extends srceditor.Editor {
         this.editor.trigger('keyboard', monaco.editor.Handler.Undo, null);
     }
 
+    redo() {
+        this.editor.trigger('keyboard', monaco.editor.Handler.Redo, null)
+    }
+
     display() {
         return (
             <div className='full-abs' id="monacoEditorArea">
@@ -679,10 +683,6 @@ export class Editor extends srceditor.Editor {
             (pxt.appTarget.cloud.packages && !this.parent.getSandboxMode() ?
                 (() => {
                     this.parent.addPackage();
-                }) : null),
-            (!this.parent.getSandboxMode() ?
-                (() => {
-                    this.undo();
                 }) : null)
         );
     }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -773,7 +773,7 @@ export class Editor extends srceditor.Editor {
     }
 
     snapshotState() {
-        return this.editor.getModel().getLinesContent()
+        return this.editor ? this.editor.getModel().getLinesContent() : null;
     }
 
     setViewState(pos: monaco.IPosition) {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -540,7 +540,7 @@ export class Editor extends srceditor.Editor {
                 monacoEditor.resetFlyout(false);
 
                 // Hide the toolbox if the current category is clicked twice
-                if (monacoEditor.selectedCategoryRow == treeitem) {
+                if (monacoEditor.selectedCategoryRow == treerow) {
                     monacoEditor.selectedCategoryRow = null;
                     monacoFlyout.style.display = 'none';
                     treerow.className = 'blocklyTreeRow';

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -472,6 +472,7 @@ export class Editor extends srceditor.Editor {
 
     private selectedCategoryRow: HTMLElement;
     private selectedCategoryColor: string;
+    private selectedCategoryBackgroundColor: string;
 
     resetFlyout(clear?: boolean) {
         // Hide the flyout
@@ -481,7 +482,7 @@ export class Editor extends srceditor.Editor {
 
         // Hide the currnet toolbox category
         if (this.selectedCategoryRow) {
-            this.selectedCategoryRow.style.background = 'none';
+            this.selectedCategoryRow.style.background = `${this.selectedCategoryBackgroundColor}`;
             this.selectedCategoryRow.style.color = `${this.selectedCategoryColor}`;
             this.selectedCategoryRow.className = 'blocklyTreeRow';
         }
@@ -554,8 +555,10 @@ export class Editor extends srceditor.Editor {
                     if (appTheme.invertedToolbox) {
                         // Inverted toolbox
                         monacoEditor.selectedCategoryColor = '#fff';
+                        monacoEditor.selectedCategoryBackgroundColor = color;
                     } else {
                         monacoEditor.selectedCategoryColor = color;
+                        monacoEditor.selectedCategoryBackgroundColor = 'none';
                     }
                 }
 

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -21,26 +21,6 @@ export class Editor extends srceditor.Editor {
         return "pxtJsonEditor"
     }
 
-    /*
-                    <div className="three fields">
-                        <sui.Input inputLabel={lf("Any") } type="number" value={(card.any || 0).toString() } onChange={v => {
-                            initCard();
-                            let vi = Math.max(0, parseInt(v) || 0)
-                            update(c.card.any = vi)
-                        } } />
-                        <sui.Input inputLabel={lf("Hardware") } type="number" value={(card.hardware || 0).toString() } onChange={v => {
-                            initCard();
-                            let vi = Math.max(0, parseInt(v) || 0)
-                            update(c.card.hardware = vi)
-                        } } />
-                        <sui.Input inputLabel={lf("Software") } type="number" value={(card.software || 0).toString() } onChange={v => {
-                            initCard();
-                            let vi = Math.max(0, parseInt(v) || 0)
-                            update(c.card.software = vi)
-                        } } />
-                    </div>
-*/
-
     display() {
         const c = this.config
         const update = (v: any) => {
@@ -93,7 +73,6 @@ export class Editor extends srceditor.Editor {
             <div className="ui content">
                 <div className="ui segment form text" style={{ backgroundColor: "white" }}>
                     <sui.Input label={lf("Name")} value={c.name} onChange={v => update(c.name = v)} />
-                    <sui.Input label={lf("Description") } lines={3} value={c.description} onChange={v => update(c.description = v) } />
                     {userConfigs.map(uc =>
                         <sui.Checkbox
                             key={`userconfig-${uc.description}`}

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -65,6 +65,9 @@ export class Editor {
         return null
     }
     undo() { }
+    redo() { }
+    zoomIn() { }
+    zoomOut() { }
 
     beforeCompile() { }
 


### PR DESCRIPTION
The editor toolbox should encapsulate all the editor specific actions. 
- [x] Show a small toolbox with editor specific actions down the bottom of the screen
- [x] In the mobile view, the editor shares it's space with the simulator. 
- [x] Removed zoom buttons from blockly 
- [x] Removed undo bottom from the blockly toolbox 
- [x] Search hidden in mobile mode 
- [x] Reset grid breakpoints to default, supporting 3 main views: mobile, tablet, and computer
- [x] Collapsable toolbox for tablet and mobile views
- [x] updated projects dialog

Mobile: 
<img width="420" alt="screen shot 2017-01-09 at 12 11 04 am" src="https://cloud.githubusercontent.com/assets/16690124/21760713/272d757e-d603-11e6-8fab-07c2e9a784db.png">

Mobile collapsed: 
<img width="427" alt="screen shot 2017-01-09 at 12 11 12 am" src="https://cloud.githubusercontent.com/assets/16690124/21760716/2bc3f40a-d603-11e6-9132-7f4b9c2de486.png">

Tablet: 
<img width="849" alt="screen shot 2017-01-09 at 12 11 23 am" src="https://cloud.githubusercontent.com/assets/16690124/21760719/30afb47c-d603-11e6-9c13-637392d28658.png">

Tablet collapsed: 
<img width="871" alt="screen shot 2017-01-09 at 12 11 29 am" src="https://cloud.githubusercontent.com/assets/16690124/21760722/35821fbc-d603-11e6-9b28-147b1813e2b5.png">

Computer:
<img width="1042" alt="screen shot 2017-01-09 at 12 11 39 am" src="https://cloud.githubusercontent.com/assets/16690124/21760725/3a7aee90-d603-11e6-8c6f-e3a5ed71e8b1.png">

Widescreen: 
<img width="1233" alt="screen shot 2017-01-09 at 12 34 19 am" src="https://cloud.githubusercontent.com/assets/16690124/21760744/674e3c7e-d603-11e6-8a6c-eaf69083a78b.png">


Fixes #1042
Fixes #930
Fixes #909
Fixes #906