### PR TITLE
Repositioning events from existing blocks positions

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -106,6 +106,9 @@ declare namespace Blockly {
         previousConnection: Connection;
         workspace: Workspace;
 
+        // private
+        xy_: goog.math.Coordinate;
+
 
         // Returns null if the field does not exist on the specified block.
         getFieldValue(field: string): string;

--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -22,6 +22,7 @@ declare namespace goog {
             x: number;
             y: number;
             constructor(x: number, y: number);
+            clone() : Coordinate;
 
             static difference(a: Coordinate, b: Coordinate): Coordinate;
             static sum(a: Coordinate, b: Coordinate): Coordinate;

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1151,7 +1151,7 @@ namespace pxt.blocks {
     // - All variables have been assigned an initial [Point] in the union-find.
     // - Variables have been marked to indicate if they are compatible with the
     //   TouchDevelop for-loop model.
-    function mkEnv(w: B.Workspace, blockInfo: pxtc.BlocksInfo): Environment {
+    export function mkEnv(w: B.Workspace, blockInfo?: pxtc.BlocksInfo, skipVariables?: boolean): Environment {
         // The to-be-returned environment.
         let e = emptyEnv(w);
 
@@ -1186,6 +1186,8 @@ namespace pxt.blocks {
                         isIdentity: fn.attributes.shim == "TD_ID"
                     }
                 })
+
+        if (skipVariables) return e;
 
         const variableIsScoped = (b: B.Block, name: string): boolean => {
             if (!b)
@@ -1304,6 +1306,22 @@ namespace pxt.blocks {
         return [] // unreachable
     }
 
+    export function callKey(e: Environment, b: B.Block): string {
+        if (b.type == ts.pxtc.ON_START_TYPE)
+            return JSON.stringify({ name: ts.pxtc.ON_START_TYPE });
+
+        const call = e.stdCallTable[b.type];
+        if (call) {
+            // detect if same event is registered already
+            const compiledArgs = eventArgs(call).map(arg => compileArg(e, b, arg, []));
+            const key = JSON.stringify({ name: call.f, ns: call.namespace, compiledArgs })
+                .replace(/"id"\s*:\s*"[^"]+"/g, ''); // remove blockly ids
+            return key;
+        }
+
+        return undefined;
+    }
+
     function updateDisabledBlocks(e: Environment, allBlocks: B.Block[], topBlocks: B.Block[]) {
         // unset disabled
         allBlocks.forEach(b => b.setDisabled(false));
@@ -1332,9 +1350,7 @@ namespace pxt.blocks {
             else if (call && call.hasHandler) {
                 // compute key that identifies event call
                 // detect if same event is registered already
-                const compiledArgs = eventArgs(call).map(arg => compileArg(e, b, arg, []));
-                const key = JSON.stringify({ name: call.f, ns: call.namespace, compiledArgs })
-                    .replace(/"id"\s*:\s*"[^"]+"/g, ''); // remove blockly ids
+                const key = callKey(e, b);
                 flagDuplicate(key, b);
             } else {
                 // all non-events are disabled

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -4,7 +4,8 @@ namespace pxt.blocks.layout {
         let changed = false;
         let env: pxt.blocks.Environment;
         let newBlocks: pxt.Map<B.Block>;
-        oldWs.getTopBlocks(false).forEach(ob => {
+        oldWs.getTopBlocks(false).filter(ob => !ob.disabled)
+            .forEach(ob => {
             const otp = ob.xy_;
             if (otp && otp.x != 0 && otp.y != 0) {
                 if (!env) {

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -1,5 +1,20 @@
 
 namespace pxt.blocks.layout {
+    export function alignBlocks(oldWs: B.Workspace, newWs: B.Workspace) {
+        let changed = false;
+        const newBlocks = newWs.getTopBlocks(false);
+        oldWs.getTopBlocks(false).forEach(ob => {
+            const otp = ob.xy_;
+            if (otp && otp.x != 0 && otp.y != 0) {
+                const newBlock = newBlocks.filter(nb => ob.type == nb.type)[0];
+                if (newBlock) {
+                    newBlock.xy_ = otp;
+                    changed = true;
+                }
+            }
+        })
+        return changed;
+    }
 
     declare function unescape(escapeUri: string): string;
 

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -1,12 +1,19 @@
 
 namespace pxt.blocks.layout {
-    export function alignBlocks(oldWs: B.Workspace, newWs: B.Workspace) {
+    export function alignBlocks(blockInfo: ts.pxtc.BlocksInfo, oldWs: B.Workspace, newWs: B.Workspace) {
         let changed = false;
-        const newBlocks = newWs.getTopBlocks(false);
+        let env: pxt.blocks.Environment;
+        let newBlocks: pxt.Map<B.Block>;
         oldWs.getTopBlocks(false).forEach(ob => {
             const otp = ob.xy_;
             if (otp && otp.x != 0 && otp.y != 0) {
-                const newBlock = newBlocks.filter(nb => ob.type == nb.type)[0];
+                if (!env) {
+                    env = pxt.blocks.mkEnv(oldWs, blockInfo, true);
+                    newBlocks = {};
+                    newWs.getTopBlocks(false).forEach(b => newBlocks[pxt.blocks.callKey(env, b) ] = b);
+                }
+                const oldKey = pxt.blocks.callKey(env, ob);
+                const newBlock = newBlocks[oldKey];
                 if (newBlock) {
                     newBlock.xy_ = otp;
                     changed = true;

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -3,7 +3,7 @@ namespace pxt.blocks.layout {
     export function alignBlocks(blockInfo: ts.pxtc.BlocksInfo, oldWs: B.Workspace, newWs: B.Workspace) {
         let changed = false;
         let env: pxt.blocks.Environment;
-        let newBlocks: pxt.Map<B.Block>;
+        let newBlocks: pxt.Map<B.Block[]>; // support for multiple events with similar name
         oldWs.getTopBlocks(false).filter(ob => !ob.disabled)
             .forEach(ob => {
             const otp = ob.xy_;
@@ -11,10 +11,15 @@ namespace pxt.blocks.layout {
                 if (!env) {
                     env = pxt.blocks.mkEnv(oldWs, blockInfo, true);
                     newBlocks = {};
-                    newWs.getTopBlocks(false).forEach(b => newBlocks[pxt.blocks.callKey(env, b) ] = b);
+                    newWs.getTopBlocks(false).forEach(b => {
+                        const nkey = pxt.blocks.callKey(env, b);
+                        const nbs = newBlocks[nkey] || [];
+                        nbs.push(b);
+                        newBlocks[nkey] = nbs;
+                    });
                 }
                 const oldKey = pxt.blocks.callKey(env, ob);
-                const newBlock = newBlocks[oldKey];
+                const newBlock = (newBlocks[oldKey] || []).shift();
                 if (newBlock) {
                     newBlock.xy_ = otp.clone();
                     changed = true;

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -16,7 +16,7 @@ namespace pxt.blocks.layout {
                 const oldKey = pxt.blocks.callKey(env, ob);
                 const newBlock = newBlocks[oldKey];
                 if (newBlock) {
-                    newBlock.xy_ = otp;
+                    newBlock.xy_ = otp.clone();
                     changed = true;
                 }
             }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -153,7 +153,7 @@ export class Editor extends srceditor.Editor {
         // layout on first load if no data info
         const needsLayout = this.editor.getTopBlocks(false).some(b => {
             const tp = b.getBoundingRectangle().topLeft;
-            return tp.x == 0 && tp.y == 0
+            return b.type != ts.pxtc.ON_START_TYPE && tp.x == 0 && tp.y == 0
         });
         if (needsLayout)
             pxt.blocks.layout.flow(this.editor);

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -122,7 +122,7 @@ function compileCoreAsync(opts: pxtc.CompileOptions): Promise<pxtc.CompileResult
     return workerOpAsync("compile", { options: opts })
 }
 
-export function decompileAsync(fileName: string, oldWorkspace?: B.Workspace, blockFile?: string) {
+export function decompileAsync(fileName: string, blockInfo?: ts.pxtc.BlocksInfo, oldWorkspace?: B.Workspace, blockFile?: string) {
     let trg = pkg.mainPkg.getTargetOptions()
     return pkg.mainPkg.getCompileOptionsAsync(trg)
         .then(opts => {
@@ -131,9 +131,9 @@ export function decompileAsync(fileName: string, oldWorkspace?: B.Workspace, blo
         })
         .then(resp => {
             // try to patch event locations
-            if (resp.success && oldWorkspace && blockFile) {
+            if (resp.success && blockInfo && oldWorkspace && blockFile) {
                 const newWs = pxt.blocks.loadWorkspaceXml(resp.outfiles[blockFile], true);
-                if (pxt.blocks.layout.alignBlocks(oldWorkspace, newWs)) {
+                if (pxt.blocks.layout.alignBlocks(blockInfo, oldWorkspace, newWs)) {
                     resp.outfiles[blockFile] = pxt.blocks.saveWorkspaceXml(newWs);
                 }
             }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -122,7 +122,7 @@ function compileCoreAsync(opts: pxtc.CompileOptions): Promise<pxtc.CompileResult
     return workerOpAsync("compile", { options: opts })
 }
 
-export function decompileAsync(fileName: string) {
+export function decompileAsync(fileName: string, oldWorkspace?: B.Workspace, blockFile?: string) {
     let trg = pkg.mainPkg.getTargetOptions()
     return pkg.mainPkg.getCompileOptionsAsync(trg)
         .then(opts => {
@@ -130,7 +130,13 @@ export function decompileAsync(fileName: string) {
             return decompileCoreAsync(opts, fileName)
         })
         .then(resp => {
-            // TODO remove this
+            // try to patch event locations
+            if (resp.success && oldWorkspace && blockFile) {
+                const newWs = pxt.blocks.loadWorkspaceXml(resp.outfiles[blockFile], true);
+                if (pxt.blocks.layout.alignBlocks(oldWorkspace, newWs)) {
+                    resp.outfiles[blockFile] = pxt.blocks.saveWorkspaceXml(newWs);
+                }
+            }
             pkg.mainEditorPkg().outputPkg.setFiles(resp.outfiles)
             setDiagnostics(resp.diagnostics)
             return resp

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -85,16 +85,16 @@ export class Editor extends srceditor.Editor {
                 .then((bi) => {
                     blocksInfo = bi;
                     pxt.blocks.initBlocks(blocksInfo);
-                    let oldWorkspace = pxt.blocks.loadWorkspaceXml(mainPkg.files[blockFile].content);
+                    const oldWorkspace = pxt.blocks.loadWorkspaceXml(mainPkg.files[blockFile].content);
                     if (oldWorkspace) {
-                        let oldJs = pxt.blocks.compile(oldWorkspace, blocksInfo).source;
+                        const oldJs = pxt.blocks.compile(oldWorkspace, blocksInfo).source;
                         if (pxtc.format(oldJs, 0).formatted == pxtc.format(js, 0).formatted) {
-                            console.log('js not changed, skipping decompile');
+                            pxt.debug('js not changed, skipping decompile');
                             pxt.tickEvent("typescript.noChanges")
                             return this.parent.setFile(mainPkg.files[blockFile]);
                         }
                     }
-                    return compiler.decompileAsync(this.currFile.name, oldWorkspace, blockFile)
+                    return compiler.decompileAsync(this.currFile.name, blocksInfo, oldWorkspace, blockFile)
                         .then(resp => {
                             if (!resp.success) return failedAsync(blockFile);
                             xml = resp.outfiles[blockFile];

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -94,7 +94,7 @@ export class Editor extends srceditor.Editor {
                             return this.parent.setFile(mainPkg.files[blockFile]);
                         }
                     }
-                    return compiler.decompileAsync(this.currFile.name)
+                    return compiler.decompileAsync(this.currFile.name, oldWorkspace, blockFile)
                         .then(resp => {
                             if (!resp.success) return failedAsync(blockFile);
                             xml = resp.outfiles[blockFile];
@@ -520,10 +520,10 @@ export class Editor extends srceditor.Editor {
             const fn2 = fnDef[f2];
             const w2 = (fn2.metaData ? fn2.metaData.weight || 50 : 50)
                 + (fn2.metaData && fn2.metaData.advanced ? 0 : 1000);
-                + (fn2.metaData && fn2.metaData.blockId ? 10000 : 0)
+            + (fn2.metaData && fn2.metaData.blockId ? 10000 : 0)
             const w1 = (fn1.metaData ? fn1.metaData.weight || 50 : 50)
                 + (fn1.metaData && fn1.metaData.advanced ? 0 : 1000);
-                + (fn1.metaData && fn1.metaData.blockId ? 10000 : 0)
+            + (fn1.metaData && fn1.metaData.blockId ? 10000 : 0)
             return w2 - w1;
         }).filter(ns => fnDef[ns].metaData != null && fnDef[ns].metaData.color != null).forEach(function (ns) {
             let metaElement = fnDef[ns];
@@ -573,10 +573,10 @@ export class Editor extends srceditor.Editor {
                     const fn2 = fnElement.fns[f2];
                     const w2 = (fn2.metaData ? fn2.metaData.weight || 50 : 50)
                         + (fn2.metaData && fn2.metaData.advanced ? 0 : 1000);
-                        + (fn2.metaData && fn2.metaData.blockId ? 10000 : 0)
+                    + (fn2.metaData && fn2.metaData.blockId ? 10000 : 0)
                     const w1 = (fn1.metaData ? fn1.metaData.weight || 50 : 50)
                         + (fn1.metaData && fn1.metaData.advanced ? 0 : 1000);
-                        + (fn1.metaData && fn1.metaData.blockId ? 10000 : 0)
+                    + (fn1.metaData && fn1.metaData.blockId ? 10000 : 0)
                     return w2 - w1;
                 }).forEach((fn) => {
                     let monacoBlock = document.createElement('div');
@@ -672,7 +672,7 @@ export class Editor extends srceditor.Editor {
             }
             if (icon) {
                 // Inject css
-                pxt.blocks.injectToolboxIconCss(`blocklyTreeIcon${ns}`,icon);
+                pxt.blocks.injectToolboxIconCss(`blocklyTreeIcon${ns}`, icon);
             }
             treerow.style.paddingLeft = '0px';
             label.innerText = `${Util.capitalize(ns)}`;
@@ -739,12 +739,12 @@ export class Editor extends srceditor.Editor {
 
         if (mode == "typescript" && !file.isReadonly()) {
             pxt.vs.syncModels(pkg.mainPkg, this.extraLibs, file.getName(), file.isReadonly())
-            .then((definitions) => {
-                this.definitions = definitions;
-                this.initEditorCss();
-                this.updateToolbox();
-                this.resize();
-            });
+                .then((definitions) => {
+                    this.definitions = definitions;
+                    this.initEditorCss();
+                    this.updateToolbox();
+                    this.resize();
+                });
         }
 
         this.setValue(file.content)


### PR DESCRIPTION
When converting JS to blocks, lookup position of existing events to reposition blocks.