### PR TITLE
inject disabled blocks after conversion

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -132,10 +132,8 @@ export function decompileAsync(fileName: string, blockInfo?: ts.pxtc.BlocksInfo,
         .then(resp => {
             // try to patch event locations
             if (resp.success && blockInfo && oldWorkspace && blockFile) {
-                const newWs = pxt.blocks.loadWorkspaceXml(resp.outfiles[blockFile], true);
-                if (pxt.blocks.layout.alignBlocks(blockInfo, oldWorkspace, newWs)) {
-                    resp.outfiles[blockFile] = pxt.blocks.saveWorkspaceXml(newWs);
-                }
+                const newXml = pxt.blocks.layout.patchBlocksFromOldWorkspace(blockInfo, oldWorkspace, resp.outfiles[blockFile]);
+                resp.outfiles[blockFile] = newXml;
             }
             pkg.mainEditorPkg().outputPkg.setFiles(resp.outfiles)
             setDiagnostics(resp.diagnostics)


### PR DESCRIPTION
After decompiling javascript to blocks, reinject disabled blocks that were stripped out.