### PR TITLE
Control event value and event timestamp

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -34,16 +34,14 @@ namespace pxsim {
         }
 
         export function now(): number {
-            return Date.now();
-        }
-
-        export function nowUs(): number {
-            return (performance as any).now() ||
-                   (performance as any).mozNow    ||
-                   (performance as any).msNow     ||
-                   (performance as any).oNow      ||
-                   (performance as any).webkitNow ||
-                    Date.now();
+            if(typeof performance != "undefined")
+              return (performance as any).now() ||
+                     (performance as any).mozNow()    ||
+                     (performance as any).msNow()     ||
+                     (performance as any).oNow()      ||
+                     (performance as any).webkitNow() ||
+                     Date.now();
+            return process.hrtime();
         }
 
         export function nextTick(f: () => void) {
@@ -234,7 +232,6 @@ namespace pxsim {
         dead = false;
         running = false;
         startTime = 0;
-        startTimeUs = 0;
         id: string;
         globals: any = {};
         currFrame: StackFrame;
@@ -297,7 +294,6 @@ namespace pxsim {
                 this.running = r;
                 if (this.running) {
                     this.startTime = U.now();
-                    this.startTimeUs = U.nowUs();
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'running' });
                 } else {
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'killed' });

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1,6 +1,8 @@
 /// <reference path="../typings/globals/bluebird/index.d.ts"/>
 /// <reference path="../localtypings/pxtparts.d.ts"/>
 
+declare const process: any;
+
 namespace pxsim {
     export namespace U {
         export function addClass(el: HTMLElement, cls: string) {
@@ -34,14 +36,20 @@ namespace pxsim {
         }
 
         export function now(): number {
+            return Date.now();
+        }
+
+        export function perfNow(): number {
             if (typeof performance != "undefined")
-                return (performance as any).now()       ||
-                       (performance as any).mozNow()    ||
-                       (performance as any).msNow()     ||
-                       (performance as any).oNow()      ||
-                       (performance as any).webkitNow() ||
-                    Date.now();
-            return process.hrtime();
+                return performance.now()                 ||
+                        (performance as any).mozNow()    ||
+                        (performance as any).msNow()     ||
+                        (performance as any).oNow()      ||
+                        (performance as any).webkitNow() ||
+                         Date.now();
+            else if (typeof window != "undefined")
+                return process.hrtime();
+            return Date.now();
         }
 
         export function nextTick(f: () => void) {
@@ -232,6 +240,7 @@ namespace pxsim {
         dead = false;
         running = false;
         startTime = 0;
+        startTimeUs = 0;
         id: string;
         globals: any = {};
         currFrame: StackFrame;
@@ -294,6 +303,7 @@ namespace pxsim {
                 this.running = r;
                 if (this.running) {
                     this.startTime = U.now();
+                    this.startTimeUs = U.perfNow();
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'running' });
                 } else {
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'killed' });

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -39,10 +39,10 @@ namespace pxsim {
 
         export function perfNow(): number {
             const perf = typeof performance != "undefined" ?
-                        performance.now ||
-                        (performance as any).mozNow ||
-                        (performance as any).msNow ||
-                        (performance as any).oNow ||
+                        performance.now                ||
+                        (performance as any).mozNow    ||
+                        (performance as any).msNow     ||
+                        (performance as any).oNow      ||
                         (performance as any).webkitNow ||
                         Date.now : Date.now;
             return perf();

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -40,11 +40,11 @@ namespace pxsim {
         export function perfNow(): number {
             const perf = typeof performance != "undefined" ?
                         performance.now ||
-                        (performance as any).mozNow    ||
-                        (performance as any).msNow     ||
-                        (performance as any).oNow      ||
-                        (performance as any).webkitNow :
-                        Date.now;
+                        (performance as any).mozNow ||
+                        (performance as any).msNow ||
+                        (performance as any).oNow ||
+                        (performance as any).webkitNow ||
+                        Date.now : Date.now;
             return perf();
         }
 

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -38,12 +38,13 @@ namespace pxsim {
         }
 
         export function perfNow(): number {
-            const perf = performance.now               ||
-                       (performance as any).mozNow     ||
-                       (performance as any).msNow      ||
-                       (performance as any).oNow       ||
-                       (performance as any).webkitNow  ||
-                       Date.now;
+            const perf = typeof performance != "undefined" ?
+                        performance.now ||
+                        (performance as any).mozNow    ||
+                        (performance as any).msNow     ||
+                        (performance as any).oNow      ||
+                        (performance as any).webkitNow :
+                        Date.now;
             return perf();
         }
 

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -34,13 +34,13 @@ namespace pxsim {
         }
 
         export function now(): number {
-            if(typeof performance != "undefined")
-              return (performance as any).now() ||
-                     (performance as any).mozNow()    ||
-                     (performance as any).msNow()     ||
-                     (performance as any).oNow()      ||
-                     (performance as any).webkitNow() ||
-                     Date.now();
+            if (typeof performance != "undefined")
+                return (performance as any).now()       ||
+                       (performance as any).mozNow()    ||
+                       (performance as any).msNow()     ||
+                       (performance as any).oNow()      ||
+                       (performance as any).webkitNow() ||
+                    Date.now();
             return process.hrtime();
         }
 

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -38,7 +38,12 @@ namespace pxsim {
         }
 
         export function nowUs(): number {
-            return performance.now() || Date.now();
+            return (performance as any).now() ||
+                   (performance as any).mozNow    ||
+                   (performance as any).msNow     ||
+                   (performance as any).oNow      ||
+                   (performance as any).webkitNow ||
+                    Date.now();
         }
 
         export function nextTick(f: () => void) {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -38,14 +38,13 @@ namespace pxsim {
         }
 
         export function perfNow(): number {
-            if (typeof performance != "undefined")
-                return performance.now()                 ||
-                        (performance as any).mozNow()    ||
-                        (performance as any).msNow()     ||
-                        (performance as any).oNow()      ||
-                        (performance as any).webkitNow() ||
-                         Date.now();
-            return Date.now();
+            const perf = performance.now               ||
+                       (performance as any).mozNow     ||
+                       (performance as any).msNow      ||
+                       (performance as any).oNow       ||
+                       (performance as any).webkitNow  ||
+                       Date.now;
+            return perf();
         }
 
         export function nextTick(f: () => void) {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1,8 +1,6 @@
 /// <reference path="../typings/globals/bluebird/index.d.ts"/>
 /// <reference path="../localtypings/pxtparts.d.ts"/>
 
-declare const process: any;
-
 namespace pxsim {
     export namespace U {
         export function addClass(el: HTMLElement, cls: string) {
@@ -47,8 +45,6 @@ namespace pxsim {
                         (performance as any).oNow()      ||
                         (performance as any).webkitNow() ||
                          Date.now();
-            else if (typeof window != "undefined")
-                return process.hrtime();
             return Date.now();
         }
 

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -37,6 +37,10 @@ namespace pxsim {
             return Date.now();
         }
 
+        export function nowUs(): number {
+            return performance.now() || Date.now();
+        }
+
         export function nextTick(f: () => void) {
             (<any>Promise)._async._schedule(f)
         }
@@ -225,6 +229,7 @@ namespace pxsim {
         dead = false;
         running = false;
         startTime = 0;
+        startTimeUs = 0;
         id: string;
         globals: any = {};
         currFrame: StackFrame;
@@ -287,6 +292,7 @@ namespace pxsim {
                 this.running = r;
                 if (this.running) {
                     this.startTime = U.now();
+                    this.startTimeUs = U.nowUs();
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'running' });
                 } else {
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'killed' });

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -48,7 +48,7 @@ namespace pxsim {
             let queue = this.queues[k];
             if (queue) {
                 this.lastEvent = evid;
-                this.lastEventTimestamp = U.nowUs();
+                this.lastEventTimestamp = U.now();
                 queue.push(value);
             }
         }
@@ -58,7 +58,7 @@ namespace pxsim {
         }
 
         getLastEventTime() {
-            let starTime = runtime.startTimeUs;
+            let starTime = runtime.startTime;
             let lastEventTime = this.lastEventTimestamp;
             return Math.floor((lastEventTime - starTime) * 1000);
         }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -31,6 +31,8 @@ namespace pxsim {
 
     export class EventBus {
         private queues: Map<EventQueue<number>> = {};
+        private lastEvent: number | string;
+        private lastEventTimestamp: number;
 
         constructor(private runtime: Runtime) { }
 
@@ -44,7 +46,19 @@ namespace pxsim {
         queue(id: number | string, evid: number | string, value: number = 0) {
             let k = id + ":" + evid;
             let queue = this.queues[k];
-            if (queue) queue.push(value);
+            if (queue) {
+                this.lastEvent = evid;
+                this.lastEventTimestamp = Date.now();
+                queue.push(value);
+            }
+        }
+
+        getLastEvent() {
+            return this.lastEvent;
+        }
+
+        getLastEventTimestamp() {
+            return this.lastEventTimestamp;
         }
     }
 

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -48,7 +48,7 @@ namespace pxsim {
             let queue = this.queues[k];
             if (queue) {
                 this.lastEvent = evid;
-                this.lastEventTimestamp = U.now();
+                this.lastEventTimestamp = U.perfNow();
                 queue.push(value);
             }
         }
@@ -58,7 +58,7 @@ namespace pxsim {
         }
 
         getLastEventTime() {
-            let starTime = runtime.startTime;
+            let starTime = runtime.startTimeUs;
             let lastEventTime = this.lastEventTimestamp;
             return Math.floor((lastEventTime - starTime) * 1000);
         }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -48,7 +48,7 @@ namespace pxsim {
             let queue = this.queues[k];
             if (queue) {
                 this.lastEvent = evid;
-                this.lastEventTimestamp = Date.now();
+                this.lastEventTimestamp = U.nowUs();
                 queue.push(value);
             }
         }
@@ -57,8 +57,10 @@ namespace pxsim {
             return this.lastEvent;
         }
 
-        getLastEventTimestamp() {
-            return this.lastEventTimestamp;
+        getLastEventTime() {
+            let starTime = runtime.startTimeUs;
+            let lastEventTime = this.lastEventTimestamp;
+            return Math.floor((lastEventTime - starTime) * 1000);
         }
     }
 


### PR DESCRIPTION
Helper methods to enable: 
pxsim.control.eventValue and pxsim.control.eventTimestamp

Note: using performance.now() in order to get microsecond precision since start time

Fixes #395

@mmoskal please review