### PR TITLE
Asmoutput

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -86,6 +86,15 @@ export function compileAsync(options: CompileOptions = {}): Promise<pxtc.Compile
         })
         .then(compileCoreAsync)
         .then(resp => {
+            let outpkg = pkg.mainEditorPkg().outputPkg
+
+            // keep the assembly file - it is only generated when user hits "Download"
+            // and is usually overwritten by the autorun very quickly, so it's impossible to see it
+            let prevasm = outpkg.files[pxtc.BINARY_ASM]
+            if (prevasm && !resp.outfiles[pxtc.BINARY_ASM]) {
+                resp.outfiles[pxtc.BINARY_ASM] = prevasm.content
+            }
+            
             pkg.mainEditorPkg().outputPkg.setFiles(resp.outfiles)
             setDiagnostics(resp.diagnostics)
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -86,7 +86,6 @@ export function compileAsync(options: CompileOptions = {}): Promise<pxtc.Compile
         })
         .then(compileCoreAsync)
         .then(resp => {
-            // TODO remove this
             pkg.mainEditorPkg().outputPkg.setFiles(resp.outfiles)
             setDiagnostics(resp.diagnostics)
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -94,7 +94,7 @@ export function compileAsync(options: CompileOptions = {}): Promise<pxtc.Compile
             if (prevasm && !resp.outfiles[pxtc.BINARY_ASM]) {
                 resp.outfiles[pxtc.BINARY_ASM] = prevasm.content
             }
-            
+
             pkg.mainEditorPkg().outputPkg.setFiles(resp.outfiles)
             setDiagnostics(resp.diagnostics)
 


### PR DESCRIPTION
  keep the assembly file in built/ in explorer - it is only generated when user hits "Download" and is usually overwritten by the autorun very quickly, so it's impossible to see it