### PR TITLE
always go through importxml if on_start missing

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -115,7 +115,7 @@ export class Editor extends srceditor.Editor {
     }
 
     loadBlockly(s: string): boolean {
-        if (this.serializeBlocks() == s) {
+        if (this.serializeBlocks() == s && s.indexOf(`type="${ts.pxtc.ON_START_TYPE}"`) > -1) {
             pxt.debug('blocks already loaded...');
             return false;
         }


### PR DESCRIPTION
Handle empty xml file loading and missing on start.