### PR TITLE
Support for default classes in OOBlocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -451,8 +451,7 @@ namespace pxt.blocks {
 
                     default:
                         if (b.type in e.stdCallTable) {
-                            const func = e.stdCallTable[b.type];
-                            func.args.forEach((p: StdArg) => {
+                            e.stdCallTable[b.type].args.forEach((p: StdArg) => {
                                 if (p.field && !b.getFieldValue(p.field)) {
                                     let i = b.inputList.filter((i: B.Input) => i.name == p.field)[0];
                                     // This will throw if someone modified blocks-custom.js and forgot to add

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -423,7 +423,9 @@ namespace pxt.blocks {
                 } else if (/\[\]$/.test(pr.type)) { // Array type
                     i = initField(block.appendValueInput(p), field.ni, fn, nsinfo, pre, true, "Array");
                 } else if (instance && n == "this") {
-                    i = initField(block.appendValueInput(p), field.ni, fn, nsinfo, pre, true, pr.type);
+                    if (!fn.attributes.defaultInstance) {
+                        i = initField(block.appendValueInput(p), field.ni, fn, nsinfo, pre, true, pr.type);
+                    }
                 } else if (pr.type == "number") {
                     if (pr.shadowType && pr.shadowType == "value") {
                         i = block.appendDummyInput();

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -447,6 +447,9 @@ namespace pxt.blocks {
         if (fn.attributes.mutate) {
             addMutation(block as MutatingBlock, fn, fn.attributes.mutate);
         }
+        else if (fn.attributes.defaultInstance) {
+            addMutation(block as MutatingBlock, fn, MutatorTypes.DefaultInstanceMutator);
+        }
 
         const body = fn.parameters ? fn.parameters.filter(pr => pr.type == "() => void")[0] : undefined;
         if (body) {

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -8,7 +8,7 @@ namespace pxt.blocks {
 
     export function parameterNames(fn: pxtc.SymbolInfo): Map<BlockParameter> {
         // collect blockly parameter name mapping
-        const instance = fn.kind == pxtc.SymbolKind.Method || fn.kind == pxtc.SymbolKind.Property;
+        const instance = (fn.kind == pxtc.SymbolKind.Method || fn.kind == pxtc.SymbolKind.Property) && !fn.attributes.defaultInstance;
         let attrNames: Map<BlockParameter> = {};
 
         if (instance) attrNames["this"] = { name: "this", type: fn.namespace };

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -704,6 +704,16 @@ ${output}</xml>`;
                 openBlockTag(info.attrs.blockId);
                 if (extraArgs) write(extraArgs);
                 info.args.forEach((e, i) => {
+                    if (i === 0 && info.attrs.defaultInstance) {
+                        if (e.getText() === info.attrs.defaultInstance) {
+                            return;
+                        }
+                        else {
+                            argNames[0] = "__instance__";
+                            write(`<mutation showing="true"></mutation>`);
+                        }
+                    }
+
                     switch (e.kind) {
                         case SK.ArrowFunction:
                             emitDestructuringMutation(e as ArrowFunction);

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -692,7 +692,7 @@ ${output}</xml>`;
                 });
 
                 const argumentDifference = info.args.length - argNames.length;
-                if (argumentDifference > 0) {
+                if (argumentDifference > 0 && !(info.attrs.defaultInstance && argumentDifference === 1)) {
                     const hasCallback = hasArrowFunction(info);
                     if (argumentDifference > 1 || !hasCallback) {
                         pxt.tickEvent("decompiler.optionalParameters");
@@ -709,7 +709,7 @@ ${output}</xml>`;
                             return;
                         }
                         else {
-                            argNames[0] = "__instance__";
+                            argNames.unshift("__instance__");
                             write(`<mutation showing="true"></mutation>`);
                         }
                     }

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -290,6 +290,7 @@ namespace ts.pxtc {
         fixedInstance?: boolean;
         indexedInstanceNS?: string;
         indexedInstanceShim?: string;
+        defaultInstance?: string;
         autoCreate?: string;
         noRefCounting?: boolean;
         color?: string;


### PR DESCRIPTION
Adds the ability to specify a default instance for object-oriented blocks so that the ability to change the instance being referenced in the blocks is hidden behind a mutator. Right now the input is tacked onto the end of the block due to limitations in Blockly.