### PR TITLE
Surface decompilation errors in monaco editor

### DIFF
--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -87,14 +87,16 @@ ${output}</xml>`;
         }
 
         function error(n: ts.Node, msg?: string) {
-            let diags = pxtc.patchUpDiagnostics([{
+            const messageText = msg || `Language feature "${n.getFullText().trim()}"" not supported in blocks`;
+            const diags = pxtc.patchUpDiagnostics([{
                 file: file,
                 start: n.getFullStart(),
                 length: n.getFullWidth(),
-                messageText: msg || `Language feature "${n.getFullText().trim()}"" not supported in blocks`,
+                messageText,
                 category: ts.DiagnosticCategory.Error,
                 code: 1001
             }])
+            pxt.debug(`decompilation error: ${messageText}`)
             U.pushRange(result.diagnostics, diags)
             result.success = false;
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1283,7 +1283,6 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     }
 
     saveFile() {
-        simulator.makeDirty();
         this.saveFileAsync().done()
     }
 
@@ -1293,6 +1292,8 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         return this.saveTypeScriptAsync()
             .then(() => {
                 let txt = this.editor.getCurrentSource()
+                if (txt != this.editorFile.content)
+                    simulator.makeDirty();
                 return this.editorFile.setContentAsync(txt);
             });
     }
@@ -1356,7 +1357,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
     }, 4000, false);
     private editorChangeHandler = Util.debounce(() => {
         if (!this.editor.isIncomplete()) {
-            this.saveFile();
+            this.saveFile(); // don't wait till save is done
             this.typecheck();
         }
         this.markdownChangeHandler();

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -68,9 +68,6 @@ export class Editor extends srceditor.Editor {
             if (!this.hasBlocks())
                 return
 
-            // needed to test roundtrip
-            let js = this.formatCode();
-
             // might be undefined
             let mainPkg = pkg.mainEditorPkg();
             let xml: string;
@@ -88,7 +85,7 @@ export class Editor extends srceditor.Editor {
                     const oldWorkspace = pxt.blocks.loadWorkspaceXml(mainPkg.files[blockFile].content);
                     if (oldWorkspace) {
                         const oldJs = pxt.blocks.compile(oldWorkspace, blocksInfo).source;
-                        if (pxtc.format(oldJs, 0).formatted == pxtc.format(js, 0).formatted) {
+                        if (pxtc.format(oldJs, 0).formatted == pxtc.format(this.editor.getValue(), 0).formatted) {
                             pxt.debug('js not changed, skipping decompile');
                             pxt.tickEvent("typescript.noChanges")
                             return this.parent.setFile(mainPkg.files[blockFile]);
@@ -543,10 +540,10 @@ export class Editor extends srceditor.Editor {
     }
 
     addToolboxCategory(group: HTMLDivElement,
-                        ns: string, metaColor: string,
-                        icon: string, injectIconClass: boolean = true,
-                        fns?: {[fn: string]: pxt.vs.MethodDef},
-                        onClick?: () => void) {
+        ns: string, metaColor: string,
+        icon: string, injectIconClass: boolean = true,
+        fns?: { [fn: string]: pxt.vs.MethodDef },
+        onClick?: () => void) {
         let appTheme = pxt.appTarget.appTheme;
         let monacoEditor = this;
         // Create a tree item

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -96,7 +96,10 @@ export class Editor extends srceditor.Editor {
                     }
                     return compiler.decompileAsync(this.currFile.name, blocksInfo, oldWorkspace, blockFile)
                         .then(resp => {
-                            if (!resp.success) return failedAsync(blockFile);
+                            if (!resp.success) {
+                                this.currFile.diagnostics = resp.diagnostics;
+                                return failedAsync(blockFile);
+                            }
                             xml = resp.outfiles[blockFile];
                             Util.assert(!!xml);
                             return mainPkg.setContentAsync(blockFile, xml)


### PR DESCRIPTION
Proper diagnostics is generated by the decompiler but not shown to the user. This change surfaces them so that the user has a chance to understand why it does not decompile.

![seeconversionerrors](https://cloud.githubusercontent.com/assets/4175913/21948945/37dafc36-d9a3-11e6-86a4-37bc3e0f5366.gif)
