### PR TITLE
allow on start to be deleteable

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -150,7 +150,6 @@ declare namespace Blockly {
         setColour(colour: number | string): void;
         setCommentText(text: string): void;
         setConnectionsHidden(hidden: boolean): void;
-        setDeletable(deletable: boolean): void;
         setDisabled(disabled: boolean): void;
         setEditable(editable: boolean): void;
         setFieldValue(newValue: string, name: string): void;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -57,7 +57,9 @@ declare namespace pxt {
         logicBlocks?: boolean;
         loopsBlocks?: boolean;
         extraBlocks?: BlockToolboxDefinition[];
+        onStartNamespace?: string; // default = loops
         onStartColor?: string;
+        onStartWeight?: number;
     }
 
     interface AppAnalytics {

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -26,17 +26,12 @@ namespace pxt.blocks {
 
     function patchFloatingBlocks(dom: Element, info: pxtc.BlocksInfo) {
         let onstart = dom.querySelector(`block[type=${ts.pxtc.ON_START_TYPE}]`)
-        if (onstart) { // nothing to doc        
-            onstart.setAttribute("deletable", "false");
+        if (onstart) { // nothing to do
+            onstart.removeAttribute("deletable");
             return;
         }
 
         let newnodes: Element[] = [];
-
-        onstart = dom.ownerDocument.createElement("block");
-        onstart.setAttribute("type", ts.pxtc.ON_START_TYPE);
-        onstart.setAttribute("deletable", "false");
-        newnodes.push(onstart);
 
         const blocks: Map<pxtc.SymbolInfo> = {};
         info.blocks.forEach(b => blocks[b.attributes.blockId] = b);
@@ -55,6 +50,11 @@ namespace pxt.blocks {
                 if (!insertNode) {
                     insertNode = dom.ownerDocument.createElement("statement");
                     insertNode.setAttribute("name", "HANDLER");
+                    if (!onstart) {
+                        onstart = dom.ownerDocument.createElement("block");
+                        onstart.setAttribute("type", ts.pxtc.ON_START_TYPE);
+                        newnodes.push(onstart);
+                    }
                     onstart.appendChild(insertNode);
                     insertNode.appendChild(node);
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -541,6 +541,11 @@ namespace pxt.blocks {
         // add extra blocks
         if (tb && pxt.appTarget.runtime) {
             const extraBlocks = pxt.appTarget.runtime.extraBlocks || [];
+            extraBlocks.push({
+                namespace: pxt.appTarget.runtime.onStartNamespace || "loops",
+                weight: pxt.appTarget.runtime.onStartWeight || 10,
+                type: ts.pxtc.ON_START_TYPE
+            })
             extraBlocks.forEach(eb => {
                 let el = document.createElement("block");
                 el.setAttribute("type", eb.type);
@@ -1932,87 +1937,87 @@ namespace pxt.blocks {
          * @return {Node} Tree node to open at startup (or null).
          * @private
          */
-        (Blockly as any).Toolbox.prototype.syncTrees_ = function(treeIn: any, treeOut: any, pathToMedia: any) {
+        (Blockly as any).Toolbox.prototype.syncTrees_ = function (treeIn: any, treeOut: any, pathToMedia: any) {
             let openNode: any = null;
             let lastElement: any = null;
             for (let i = 0, childIn: any; childIn = treeIn.childNodes[i]; i++) {
                 if (!childIn.tagName) {
-                // Skip over text.
-                continue;
+                    // Skip over text.
+                    continue;
                 }
                 switch (childIn.tagName.toUpperCase()) {
-                case 'CATEGORY':
-                    let childOut = this.tree_.createNode(childIn.getAttribute('name'));
-                    childOut.blocks = [];
-                    treeOut.add(childOut);
-                    let custom = childIn.getAttribute('custom');
-                    if (custom) {
-                        // Variables and procedures are special dynamic categories.
-                        childOut.blocks = custom;
-                    } else {
-                        let newOpenNode = this.syncTrees_(childIn, childOut, pathToMedia);
-                        if (newOpenNode) {
-                            openNode = newOpenNode;
-                        }
-                    }
-                    let colour = childIn.getAttribute('colour');
-                    if ((goog as any).isString(colour)) {
-                        if (colour.match(/^#[0-9a-fA-F]{6}$/)) {
-                            childOut.hexColour = colour;
+                    case 'CATEGORY':
+                        let childOut = this.tree_.createNode(childIn.getAttribute('name'));
+                        childOut.blocks = [];
+                        treeOut.add(childOut);
+                        let custom = childIn.getAttribute('custom');
+                        if (custom) {
+                            // Variables and procedures are special dynamic categories.
+                            childOut.blocks = custom;
                         } else {
-                            childOut.hexColour = Blockly.hueToRgb(colour);
+                            let newOpenNode = this.syncTrees_(childIn, childOut, pathToMedia);
+                            if (newOpenNode) {
+                                openNode = newOpenNode;
+                            }
                         }
-                        this.hasColours_ = true;
-                    } else {
-                        childOut.hexColour = '';
-                    }
-                    let iconClass = childIn.getAttribute('iconclass');
-                    if ((goog as any).isString(iconClass)) {
-                        childOut.setIconClass(this.config_['cssTreeIcon'] + ' ' + iconClass);
-                    }
-                    let expandedClass = childIn.getAttribute('expandedclass');
-                    if ((goog as any).isString(expandedClass)) {
-                        childOut.setExpandedIconClass(this.config_['cssTreeIcon'] + ' ' + expandedClass);
-                    }
-                    if (childIn.getAttribute('expanded') == 'true') {
-                        if (childOut.blocks.length) {
-                            // This is a category that directly contians blocks.
-                            // After the tree is rendered, open this category and show flyout.
-                            openNode = childOut;
+                        let colour = childIn.getAttribute('colour');
+                        if ((goog as any).isString(colour)) {
+                            if (colour.match(/^#[0-9a-fA-F]{6}$/)) {
+                                childOut.hexColour = colour;
+                            } else {
+                                childOut.hexColour = Blockly.hueToRgb(colour);
+                            }
+                            this.hasColours_ = true;
+                        } else {
+                            childOut.hexColour = '';
                         }
-                        childOut.setExpanded(true);
-                    } else {
-                        childOut.setExpanded(false);
-                    }
-                    lastElement = childIn;
-                    break;
-                case 'SEP':
+                        let iconClass = childIn.getAttribute('iconclass');
+                        if ((goog as any).isString(iconClass)) {
+                            childOut.setIconClass(this.config_['cssTreeIcon'] + ' ' + iconClass);
+                        }
+                        let expandedClass = childIn.getAttribute('expandedclass');
+                        if ((goog as any).isString(expandedClass)) {
+                            childOut.setExpandedIconClass(this.config_['cssTreeIcon'] + ' ' + expandedClass);
+                        }
+                        if (childIn.getAttribute('expanded') == 'true') {
+                            if (childOut.blocks.length) {
+                                // This is a category that directly contians blocks.
+                                // After the tree is rendered, open this category and show flyout.
+                                openNode = childOut;
+                            }
+                            childOut.setExpanded(true);
+                        } else {
+                            childOut.setExpanded(false);
+                        }
+                        lastElement = childIn;
+                        break;
+                    case 'SEP':
                         if (lastElement) {
                             if (lastElement.tagName.toUpperCase() == 'CATEGORY') {
                                 // Separator between two categories.
                                 // <sep></sep>
                                 treeOut.add(new (Blockly as any).Toolbox.TreeSeparator(
                                     this.treeSeparatorConfig_));
-                        } else {
-                            // Change the gap between two blocks.
-                            // <sep gap="36"></sep>
-                            // The default gap is 24, can be set larger or smaller.
-                            // Note that a deprecated method is to add a gap to a block.
-                            // <block type="math_arithmetic" gap="8"></block>
-                            let newGap = parseFloat(childIn.getAttribute('gap'));
-                            if (!isNaN(newGap) && lastElement) {
-                                lastElement.setAttribute('gap', newGap);
+                            } else {
+                                // Change the gap between two blocks.
+                                // <sep gap="36"></sep>
+                                // The default gap is 24, can be set larger or smaller.
+                                // Note that a deprecated method is to add a gap to a block.
+                                // <block type="math_arithmetic" gap="8"></block>
+                                let newGap = parseFloat(childIn.getAttribute('gap'));
+                                if (!isNaN(newGap) && lastElement) {
+                                    lastElement.setAttribute('gap', newGap);
+                                }
                             }
                         }
-                    }
-                    break;
-                case 'BLOCK':
-                case 'SHADOW':
-                case 'LABEL':
-                case 'BUTTON':
-                    treeOut.blocks.push(childIn);
-                    lastElement = childIn;
-                    break;
+                        break;
+                    case 'BLOCK':
+                    case 'SHADOW':
+                    case 'LABEL':
+                    case 'BUTTON':
+                        treeOut.blocks.push(childIn);
+                        lastElement = childIn;
+                        break;
                 }
             }
             return openNode;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -276,7 +276,7 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
         const newProject = () => {
             pxt.tickEvent("projects.new");
             this.hide();
-            this.props.parent.newEmptyProject();
+            this.props.parent.newProject();
         }
         const saveProject = () => {
             pxt.tickEvent("projects.save");
@@ -308,6 +308,7 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
                 {!this.state.searchFor && this.state.mode == ScriptSearchMode.Projects ?
                     <div className="ui vertical segment">
                         <sui.Button
+                            class="primary"
                             icon="file outline"
                             text={lf("New Project...") }
                             title={lf("Creates a new empty project") }
@@ -1817,7 +1818,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 let hexFile = JSON.parse(project) as pxt.cpp.HexFile;
                 return this.importHex(hexFile);
             }).catch(() => {
-                return this.newEmptyProject();
+                return this.newProject();
             })
     }
 
@@ -1851,7 +1852,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
 
     newEmptyProject(name?: string, documentation?: string) {
         this.newProject({
-            filesOverride: { "main.blocks": `<xml xmlns="http://www.w3.org/1999/xhtml"><block type="${ts.pxtc.ON_START_TYPE}"></block></xml>` },
+            filesOverride: { "main.blocks": `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>` },
             name, documentation
         })
     }
@@ -2690,7 +2691,7 @@ function handleHash(hash: { cmd: string; arg: string }) {
             break;
         case "newproject":
             pxt.tickEvent("hash.newproject")
-            editor.newEmptyProject();
+            editor.newProject();
             break;
         case "gettingstarted":
             pxt.tickEvent("hash.gettingstarted")

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -117,7 +117,7 @@ export class Editor extends srceditor.Editor {
     }
 
     loadBlockly(s: string): boolean {
-        if (this.serializeBlocks() == s && s.indexOf(`type="${ts.pxtc.ON_START_TYPE}"`) > -1) {
+        if (this.serializeBlocks() == s) {
             this.typeScriptSaveable = true;
             pxt.debug('blocks already loaded...');
             return false;
@@ -126,14 +126,13 @@ export class Editor extends srceditor.Editor {
         this.typeScriptSaveable = false;
         this.editor.clear();
         try {
-            const text = pxt.blocks.importXml(s || `<block type="${ts.pxtc.ON_START_TYPE}" deletable="false"></block>`, this.blockInfo, true);
+            const text = pxt.blocks.importXml(s || `<block type="${ts.pxtc.ON_START_TYPE}"></block>`, this.blockInfo, true);
             const xml = Blockly.Xml.textToDom(text);
             Blockly.Xml.domToWorkspace(xml, this.editor);
 
             this.initLayout();
             this.editor.clearUndo();
             this.reportDeprecatedBlocks();
-            this.ensureOnStart();
 
             this.typeScriptSaveable = true;
         } catch (e) {
@@ -320,12 +319,6 @@ export class Editor extends srceditor.Editor {
 
     isIncomplete() {
         return this.editor ? this.editor.isDragging() : false;
-    }
-
-    ensureOnStart() {
-        this.editor.getTopBlocks(false)
-            .filter(b => b.type == ts.pxtc.ON_START_TYPE)
-            .forEach(b => b.setDeletable(!!b.disabled));
     }
 
     prepare() {


### PR DESCRIPTION
Preventing the deletion of "on start" creates frustration when it is not needed. This change allows onstart to be deletable and adds it to the toolbox.