### PR TITLE
Inject toolbox icon css optimization

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -174,7 +174,7 @@ namespace pxt.blocks {
                     }
                     if (nsn && nsn.attributes.icon) {
                         const nsnIconClassName = `blocklyTreeIcon${nsn.name.toLowerCase()}`.replace(/\s/g, '');
-                        injectToolboxIconCss(nsnIconClassName, nsn.attributes.icon);
+                        appendToolboxIconCss(nsnIconClassName, nsn.attributes.icon);
                         category.setAttribute("iconclass", nsnIconClassName);
                         category.setAttribute("expandedclass", nsnIconClassName);
                     } else {
@@ -218,6 +218,7 @@ namespace pxt.blocks {
             else {
                 if (showCategories) {
                     category.appendChild(block);
+                    injectToolboxIconCss();
                 } else {
                     tb.appendChild(block);
                 }
@@ -225,30 +226,32 @@ namespace pxt.blocks {
         }
     }
 
-    export function injectToolboxIconCss(className: string, i: string): void {
-        let head = document.head || document.getElementsByTagName('head')[0];
-        let style = document.getElementById('blocklyToolboxIcons') as HTMLStyleElement;
-
-        if (!style) {
-            style = document.createElement('style');
-            style.id = "blocklyToolboxIcons";
-            style.type = 'text/css';
-            head.appendChild(style);
-        }
-
-        if (style.innerText.indexOf(className) > -1) return;
+    let toolboxStyle: HTMLStyleElement;
+    let toolboxStyleBuffer: string = '';
+    export function appendToolboxIconCss(className: string, i: string): void {
+        if (toolboxStyleBuffer.indexOf(className) > -1) return;
 
         const icon = Util.unicodeToChar(i);
-        const cssContent = style.innerText + `
+        toolboxStyleBuffer += `
             .blocklyTreeIcon.${className}::before {
                 content: "${icon}";
             }
         `;
+    }
 
-        if (style.sheet) {
-            style.textContent = cssContent;
+    export function injectToolboxIconCss(): void {
+        if (!toolboxStyle) {
+            toolboxStyle = document.createElement('style');
+            toolboxStyle.id = "blocklyToolboxIcons";
+            toolboxStyle.type = 'text/css';
+            let head = document.head || document.getElementsByTagName('head')[0];
+            head.appendChild(toolboxStyle);
+        }
+
+        if (toolboxStyle.sheet) {
+            toolboxStyle.textContent = toolboxStyleBuffer;
         } else {
-            style.appendChild(document.createTextNode(cssContent));
+            toolboxStyle.appendChild(document.createTextNode(toolboxStyleBuffer));
         }
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -517,6 +517,9 @@ export class Editor extends srceditor.Editor {
             this.resetFlyout();
             this.parent.addPackage();
         })
+
+        // Inject toolbox icon css
+        pxt.blocks.injectToolboxIconCss();
     }
 
     addToolboxCategory(group: HTMLDivElement,
@@ -687,8 +690,7 @@ export class Editor extends srceditor.Editor {
             treerow.style.borderLeft = `8px solid ${color}`;
         }
         if (icon && injectIconClass) {
-            // Inject css
-            pxt.blocks.injectToolboxIconCss(iconClass, icon);
+            pxt.blocks.appendToolboxIconCss(iconClass, icon);
         }
         treerow.style.paddingLeft = '0px';
         label.innerText = `${Util.capitalize(ns)}`;


### PR DESCRIPTION
Before: 
<img width="437" alt="screen shot 2017-01-18 at 10 03 03 am" src="https://cloud.githubusercontent.com/assets/16690124/22076761/4ef77bda-dd66-11e6-8ce4-2077dffd48f0.png">

After: 
<img width="444" alt="screen shot 2017-01-18 at 10 03 23 am" src="https://cloud.githubusercontent.com/assets/16690124/22076768/5484bb4e-dd66-11e6-8182-e7c8acd33824.png">
<img width="458" alt="screen shot 2017-01-18 at 10 03 35 am" src="https://cloud.githubusercontent.com/assets/16690124/22076772/57852702-dd66-11e6-8c0f-75498fbb7e01.png">

Initially it was making two document calls and writing the style at every category. n = number of categories. Once for each toolbox (blockly / monaco).

Changed to append to a buffer, and only write to the page at the end of the toolbox processing.