### PR TITLE
do not nest events when importing old scripts

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -44,7 +44,8 @@ namespace pxt.blocks {
             // does this block is disable or have s nested statement block?
             const nodeType = node.getAttribute("type");
             if (!node.getAttribute("disabled") && !node.querySelector("statement")
-                && (pxt.blocks.buildinBlockStatements[nodeType] || (blocks[nodeType] && blocks[nodeType].retType == "void"))
+                && (pxt.blocks.buildinBlockStatements[nodeType] ||
+                (blocks[nodeType] && blocks[nodeType].retType == "void" && !hasArrowFunction(blocks[nodeType])))
             ) {
                 // old block, needs to be wrapped in onstart
                 if (!insertNode) {
@@ -62,7 +63,7 @@ namespace pxt.blocks {
                     node.removeAttribute("y");
                     insertNode = node;
                 } else {
-                    // add nested statement
+                    // event, add nested statement
                     const next = dom.ownerDocument.createElement("next");
                     next.appendChild(node);
                     insertNode.appendChild(next);

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -480,13 +480,18 @@ namespace pxt.blocks {
         }
 
         // hook up/down if return value is void
-        const hasHandlers = fn.parameters
-            ? fn.parameters.filter(pr => /^\([^\)]*\)\s*=>/.test(pr.type))[0]
-            : undefined;
+        const hasHandlers = hasArrowFunction(fn);
         block.setPreviousStatement(!hasHandlers && fn.retType == "void");
         block.setNextStatement(!hasHandlers && fn.retType == "void");
 
         block.setTooltip(fn.attributes.jsDoc);
+    }
+
+    export function hasArrowFunction(fn: pxtc.SymbolInfo): boolean {
+        const r = fn.parameters
+            ? fn.parameters.filter(pr => /^\([^\)]*\)\s*=>/.test(pr.type))[0]
+            : undefined;
+        return !!r;
     }
 
     function removeCategory(tb: Element, name: string) {


### PR DESCRIPTION
When importing a script without 'on start', we assume that the script is old and might need patching. This change makes sure not to nest events under 'on start'.