### PR TITLE
fix detecting if a function has an arrow function argument

### DIFF
--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -103,8 +103,7 @@ ${output}</xml>`;
 
         function hasArrowFunction(info: CallInfo): boolean {
             const parameters = (info.decl as FunctionLikeDeclaration).parameters;
-            return info.args.some((arg, index) =>
-                arg && arg.kind === SK.ArrowFunction && parameters && !parameters[index].questionToken && !parameters[index].initializer);
+            return info.args.some((arg, index) => arg && arg.kind === SK.ArrowFunction);
         }
 
         function isEventExpression(expr: ts.ExpressionStatement): boolean {

--- a/tests/decompile-test/errors/optional_parameters.ts
+++ b/tests/decompile-test/errors/optional_parameters.ts
@@ -10,6 +10,3 @@ testNamespace.optionalArgument(40, 50);
 
 // @case: optional param after callback
 testNamespace.optionalArgumentWithCallback(() => {}, 500);
-
-// @case: optional callback
-testNamespace.optionalCallback(() => {});

--- a/tests/decompile-test/testBlocks/basic.ts
+++ b/tests/decompile-test/testBlocks/basic.ts
@@ -88,11 +88,6 @@ namespace testNamespace {
     //% block="Callback with optional arg"
     export function optionalArgumentWithCallback(arg1: () => void, arg2?: number) { }
 
-    //% blockId=test_optional_argument_3
-    //% block="Optional callback"
-    export function optionalCallback(arg1?: () => void) { }
-
-
     /**
      * Enum value function
      */


### PR DESCRIPTION
The number of arguments does not match in the OO case.