### PR TITLE
Mute simulator using the simulator toolbar

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -155,6 +155,7 @@ declare namespace pxt {
         blocklyOptions?: Blockly.Options; // Blockly options, see Configuration: https://developers.google.com/blockly/guides/get-started/web
         simAnimationEnter?: string; // Simulator enter animation
         simAnimationExit?: string; // Simulator exit animation
+        hasAudio?: boolean; // target uses the Audio manager. if true: a mute button is added to the simulator toolbar.
         projectGallery?: string;
         crowdinProject?: string;
         monacoToolbox?: boolean; // if true: show the monaco toolbox when in the monaco editor

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -120,7 +120,7 @@ namespace pxsim {
             switch (type || '') {
                 case 'run': run(<SimulatorRunMessage>data); break;
                 case 'stop': stop(); break;
-                case 'mute': this.mute((<SimulatorMuteMessage>data).mute); break;
+                case 'mute': mute((<SimulatorMuteMessage>data).mute); break;
                 case 'debugger':
                     if (runtime) {
                         runtime.handleDebuggerMsg(data as DebuggerMessage);
@@ -145,7 +145,7 @@ namespace pxsim {
         export function run(msg: SimulatorRunMessage) {
             stop();
 
-            if (msg.mute) this.mute(msg.mute);
+            if (msg.mute) mute(msg.mute);
 
             runtime = new Runtime(msg.code);
             runtime.id = msg.id;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -15,6 +15,7 @@ namespace pxsim {
         partDefinitions?: Map<PartDefinition>
         fnArgs?: any;
         code: string;
+        mute?: boolean;
     }
 
     export interface SimulatorMuteMessage extends SimulatorMessage {
@@ -119,7 +120,7 @@ namespace pxsim {
             switch (type || '') {
                 case 'run': run(<SimulatorRunMessage>data); break;
                 case 'stop': stop(); break;
-                case 'mute': AudioContextManager.mute((<SimulatorMuteMessage>data).mute); break;
+                case 'mute': this.mute((<SimulatorMuteMessage>data).mute); break;
                 case 'debugger':
                     if (runtime) {
                         runtime.handleDebuggerMsg(data as DebuggerMessage);
@@ -144,6 +145,8 @@ namespace pxsim {
         export function run(msg: SimulatorRunMessage) {
             stop();
 
+            if (msg.mute) this.mute(msg.mute);
+
             runtime = new Runtime(msg.code);
             runtime.id = msg.id;
             runtime.board.initAsync(msg)
@@ -152,6 +155,10 @@ namespace pxsim {
                         pxsim.dumpLivePointers();
                     })
                 })
+        }
+
+        function mute(mute: boolean) {
+            AudioContextManager.mute(mute);
         }
 
         function queue(msg: SimulatorMessage) {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -17,6 +17,11 @@ namespace pxsim {
         code: string;
     }
 
+    export interface SimulatorMuteMessage extends SimulatorMessage {
+        type: "mute";
+        mute: boolean;
+    }
+
     export interface SimulatorDocMessage extends SimulatorMessage {
         docType?: string;
         src?: string;
@@ -114,6 +119,7 @@ namespace pxsim {
             switch (type || '') {
                 case 'run': run(<SimulatorRunMessage>data); break;
                 case 'stop': stop(); break;
+                case 'mute': AudioContextManager.mute((<SimulatorMuteMessage>data).mute); break;
                 case 'debugger':
                     if (runtime) {
                         runtime.handleDebuggerMsg(data as DebuggerMessage);

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -32,6 +32,7 @@ namespace pxsim {
         fnArgs?: any;
         aspectRatio?: number;
         partDefinitions?: pxsim.Map<PartDefinition>;
+        mute?: boolean;
     }
 
     export interface HwDebugger {
@@ -213,6 +214,7 @@ namespace pxsim {
                 fnArgs: opts.fnArgs,
                 code: js,
                 partDefinitions: opts.partDefinitions,
+                mute: opts.mute,
             }
 
             this.applyAspectRatio();

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -151,6 +151,10 @@ namespace pxsim {
             this.setState(SimulatorState.Unloaded);
         }
 
+        public mute(mute: boolean) {
+            this.postMessage({ type: 'mute', mute: mute } as pxsim.SimulatorMuteMessage);
+        }
+
         private frameCleanupTimeout = 0;
         private cancelFrameCleanup() {
             if (this.frameCleanupTimeout) {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -128,6 +128,8 @@ namespace pxsim {
         let _vco: any; // OscillatorNode;
         let _vca: any; // GainNode;
 
+        let _mute = false; //mute audio
+
         function context(): any {
             if (!_context) _context = freshContext();
             return _context;
@@ -145,6 +147,10 @@ namespace pxsim {
             return undefined;
         }
 
+        export function mute(mute: boolean) {
+            _mute = mute;
+        }
+
         export function stop() {
             if (_vca) _vca.gain.value = 0;
             _frequency = 0;
@@ -155,6 +161,7 @@ namespace pxsim {
         }
 
         export function tone(frequency: number, gain: number) {
+            if (_mute) return;
             if (frequency <= 0) return;
             _frequency = frequency;
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2417,7 +2417,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                                 {run ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator() } /> : undefined }
                             </div>
                             <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`}>
-                                {run ? <sui.Button key='mutebtn' class={`mute-button`} icon={`${this.state.mute ? 'volume up' : 'volume off'}`} title={muteTooltip} onClick={() => this.toggleMute() } /> : undefined }
+                                {run && targetTheme.hasAudio ? <sui.Button key='mutebtn' class={`mute-button`} icon={`${this.state.mute ? 'volume up' : 'volume off'}`} title={muteTooltip} onClick={() => this.toggleMute() } /> : undefined }
                                 {run ? <sui.Button key='fullscreenbtn' class={`fullscreen-button`} icon={`${this.state.fullscreen ? 'compress' : 'maximize'}`} title={fullscreenTooltip} onClick={() => this.toggleSimulatorFullscreen() } /> : undefined }
                             </div>
                         </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2097,8 +2097,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
             .then(resp => {
                 this.editor.setDiagnostics(this.editorFile, state)
                 if (resp.outfiles[pxtc.BINARY_JS]) {
-                    simulator.run(pkg.mainPkg, opts.debug, resp)
-                    simulator.mute(this.state.mute);
+                    simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute)
                     this.setState({ running: true, showParts: simulator.driver.runOptions.parts.length > 0 })
                 } else if (!opts.background) {
                     core.warningNotification(lf("Oops, we could not run this project. Please check your code for errors."))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -78,6 +78,7 @@ interface IAppState {
     showBlocks?: boolean;
     showParts?: boolean;
     fullscreen?: boolean;
+    mute?: boolean;
 }
 
 let theEditor: ProjectView;
@@ -2022,6 +2023,12 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         this.setState({fullscreen: !this.state.fullscreen});
     }
 
+    toggleMute() {
+        pxt.tickEvent("simulator.mute", {view: 'computer', muteTo: '' + !this.state.mute});
+        simulator.mute(!this.state.mute);
+        this.setState({mute: !this.state.mute});
+    }
+
     openInstructions() {
         pxt.tickEvent("simulator.make");
         compiler.compileAsync({ native: true })
@@ -2308,6 +2315,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
         const makeTooltip = lf("Open assembly instructions");
         const restartTooltip = lf("Restart the simulator");
         const fullscreenTooltip = this.state.fullscreen ? lf("Exit fullscreen mode") : lf("Launch in fullscreen");
+        const muteTooltip = this.state.mute ? lf("Unmute audio") : lf("Mute audio");
         const isBlocks = !this.editor.isVisible || this.getPreferredEditor() == pxt.BLOCKS_PROJECT_NAME;
         const sideDocs = !(sandbox || pxt.options.light || targetTheme.hideSideDocs);
         const tutorial = this.state.tutorial;
@@ -2407,6 +2415,9 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                                 {make ? <sui.Button icon='configure' class="fluid sixty secondary" text={lf("Make") } title={makeTooltip} onClick={() => this.openInstructions() } /> : undefined }
                                 {run ? <sui.Button key='runbtn' class={`play-button`} icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator() } /> : undefined }
                                 {run ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator() } /> : undefined }
+                            </div>
+                            <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`}>
+                                {run ? <sui.Button key='mutebtn' class={`mute-button`} icon={`${this.state.mute ? 'volume up' : 'volume off'}`} title={muteTooltip} onClick={() => this.toggleMute() } /> : undefined }
                                 {run ? <sui.Button key='fullscreenbtn' class={`fullscreen-button`} icon={`${this.state.fullscreen ? 'compress' : 'maximize'}`} title={fullscreenTooltip} onClick={() => this.toggleSimulatorFullscreen() } /> : undefined }
                             </div>
                         </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2411,12 +2411,12 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                         <div id="boardview" className={`ui vertical editorFloat`}>
                         </div>
                         <div className="ui item grid centered portrait hide simtoolbar">
-                            <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`}>
+                            <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`} style={{padding: "0"}}>
                                 {make ? <sui.Button icon='configure' class="fluid sixty secondary" text={lf("Make") } title={makeTooltip} onClick={() => this.openInstructions() } /> : undefined }
                                 {run ? <sui.Button key='runbtn' class={`play-button`} icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator() } /> : undefined }
                                 {run ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator() } /> : undefined }
                             </div>
-                            <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`}>
+                            <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`} style={{padding: "0"}}>
                                 {run && targetTheme.hasAudio ? <sui.Button key='mutebtn' class={`mute-button`} icon={`${this.state.mute ? 'volume up' : 'volume off'}`} title={muteTooltip} onClick={() => this.toggleMute() } /> : undefined }
                                 {run ? <sui.Button key='fullscreenbtn' class={`fullscreen-button`} icon={`${this.state.fullscreen ? 'compress' : 'maximize'}`} title={fullscreenTooltip} onClick={() => this.toggleSimulatorFullscreen() } /> : undefined }
                             </div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2098,6 +2098,7 @@ export class ProjectView extends data.Component<IAppProps, IAppState> {
                 this.editor.setDiagnostics(this.editorFile, state)
                 if (resp.outfiles[pxtc.BINARY_JS]) {
                     simulator.run(pkg.mainPkg, opts.debug, resp)
+                    simulator.mute(this.state.mute);
                     this.setState({ running: true, showParts: simulator.driver.runOptions.parts.length > 0 })
                 } else if (!opts.background) {
                     core.warningNotification(lf("Oops, we could not run this project. Please check your code for errors."))

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -135,6 +135,11 @@ export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResul
     driver.run(js, opts);
 }
 
+export function mute(mute: boolean) {
+    driver.mute(mute);
+    $debugger.empty();
+}
+
 export function stop(unload?: boolean) {
     pxsim.U.removeClass(driver.container, "sepia");
     driver.stop(unload);

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -115,7 +115,7 @@ export function isDirty(): boolean { // in need of a restart?
     return /sepia/.test(driver.container.className);
 }
 
-export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResult) {
+export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResult, mute?: boolean) {
     pxsim.U.removeClass(driver.container, "sepia");
     const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
@@ -125,6 +125,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResul
 
     const opts: pxsim.SimulatorRunOptions = {
         boardDefinition: boardDefinition,
+        mute: mute,
         parts: parts,
         debug: debug,
         fnArgs: fnArgs,


### PR DESCRIPTION

<img width="420" alt="screen shot 2017-01-21 at 4 57 30 pm" src="https://cloud.githubusercontent.com/assets/16690124/22178980/c92580dc-dffa-11e6-9615-446fbe435e4c.png">

<img width="358" alt="screen shot 2017-01-21 at 4 57 42 pm" src="https://cloud.githubusercontent.com/assets/16690124/22178981/cd63de00-dffa-11e6-960b-507ce90f272f.png">


<img width="338" alt="screen shot 2017-01-21 at 4 57 48 pm" src="https://cloud.githubusercontent.com/assets/16690124/22178982/d083a732-dffa-11e6-8966-4cbf4156a137.png">


Split the sim toolbar into two parts (as you can see in the screenshot)