### PR TITLE
Fix network request error on search

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -177,7 +177,7 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
 
         let scriptid = pxt.Cloud.parseScriptId(this.state.searchFor)
         if (scriptid) {
-            let res = this.getData(`cloud:${scriptid}`)
+            let res = this.getData(`cloud-silent:${scriptid}`)
             if (res) {
                 if (!this.prevUrlData) this.prevUrlData = [res]
                 else this.prevUrlData.push(res)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -177,10 +177,12 @@ class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
 
         let scriptid = pxt.Cloud.parseScriptId(this.state.searchFor)
         if (scriptid) {
-            let res = this.getData(`cloud-silent:${scriptid}`)
+            let res = this.getData(`cloud-search:${scriptid}`)
             if (res) {
-                if (!this.prevUrlData) this.prevUrlData = [res]
-                else this.prevUrlData.push(res)
+                if (res.statusCode !== 404) {
+                    if (!this.prevUrlData) this.prevUrlData = [res]
+                    else this.prevUrlData.push(res)
+                }
             }
         }
         return this.prevUrlData;

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -114,12 +114,15 @@ export function cookieNotification() {
     }
 }
 
-export function handleNetworkError(e: any) {
+export function handleNetworkError(e: any, ignoredCodes?: number[]) {
     let statusCode = parseInt(e.statusCode);
 
     if (e.isOffline || statusCode === 0) {
         warningNotification(lf("Network request failed; you appear to be offline"));
     } else if (!isNaN(statusCode) && statusCode !== 200) {
+        if (ignoredCodes && ignoredCodes.indexOf(statusCode) !== -1) {
+            return e;
+        }
         warningNotification(lf("Network request failed"));
     }
 

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -28,8 +28,8 @@ mountVirtualApi("cloud", {
     isOffline: () => !Cloud.isOnline(),
 })
 
-mountVirtualApi("cloud-silent", {
-    getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(() => {}),
+mountVirtualApi("cloud-search", {
+    getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(e => core.handleNetworkError(e, [404])),
     expirationTime: p => 60 * 1000,
     isOffline: () => !Cloud.isOnline(),
 })

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -28,6 +28,12 @@ mountVirtualApi("cloud", {
     isOffline: () => !Cloud.isOnline(),
 })
 
+mountVirtualApi("cloud-silent", {
+    getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(() => {}),
+    expirationTime: p => 60 * 1000,
+    isOffline: () => !Cloud.isOnline(),
+})
+
 mountVirtualApi("gallery", {
     getAsync: p => gallery.loadGalleryAsync(stripProtocol(p)).catch(core.handleNetworkError),
     expirationTime: p => 3600 * 1000,


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt/issues/1184

Our current setup for network requests always reports 404's even when performing a search (where a 404 might be a legitimate response to indicate no results). This adds another API that lets the caller deal with 404 errors instead.