### PR TITLE
Rename variables with entirely non-ascii names

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -890,7 +890,10 @@ namespace pxt.blocks {
             //.map((c, i) => (i ? c[0].toUpperCase() : c[0].toLowerCase()) + c.substr(1)) breaks roundtrip...
             .join('');
 
-        if (/\d/.test(n.charAt(0)) || isReservedWord(name)) {
+        if (!n) {
+            n = "myVariable";
+        }
+        else if (/\d/.test(n.charAt(0)) || isReservedWord(name)) {
             n = "_" + n;
         }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt/issues/652

Rename variables with completely non-ascii names to `myVariable` (or `myVariable2`, `myVariable3`, etc.). This matches our current strategy of throwing out non-ascii characters when going to TS but allowing anything in the blocks.