### PR TITLE
Fix nasty bug with new blockly drag optimisation and semantic ui.

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -458,6 +458,9 @@ div.simframe > iframe {
 .blocklySvg {
     background-color: @blocklySvgColor !important;
 }
+#blocksEditor .injectionDiv svg {
+    overflow: visible;
+}
 
 .blocklyTreeLabel, .blocklyText, .blocklyHtmlInput {
     font-family:'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace !important;


### PR DESCRIPTION
Semantic ui does this: 

/**
 * Correct overflow not hidden in IE 9/10/11.
 */
svg:not(:root) {
  overflow: hidden;
}

Which messes with new blockly drag optimization: 
https://github.com/google/blockly/commit/e1cd21842a191bf9a2b3f90ad9f4c2d4436f58d1

This fix works around that. 
Needs to be tested on IE, since that semantic css was meant for IE.