### PR TITLE
Actually discard changes when unable to decompile

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -130,6 +130,7 @@ export class Editor extends srceditor.Editor {
                 pxt.tickEvent("typescript.keepText");
             } else {
                 pxt.tickEvent("typescript.discardText");
+                this.overrideFile(this.parent.blocksEditor.saveToTypeScript());
                 this.parent.setFile(bf);
             }
         })


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt/issues/1141

The errors still show up on the block for a second before disappearing, but they no longer stick around. I couldn't get them to not show up altogether.