### PR TITLE
Refine search to only the toolbox and include builtin blocks

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -1,3 +1,5 @@
+/// <reference path="main.ts"/>
+
 namespace pxt.blocks {
     export interface BlockParameter {
         name: string;
@@ -65,4 +67,110 @@ namespace pxt.blocks {
             return { n, ni, pre, p };
         });
     }
+
+    export interface HelpItem {
+        name: string;
+        url: string;
+        tooltip?: string;
+        operators?: Map<string[]>;
+        block?: string;
+    }
+
+    export const helpResources: Map<HelpItem> = {
+        'device_while': {
+            name: Util.lf("a loop that repeats while the condition is true"),
+            tooltip: Util.lf("Run the same sequence of actions while the condition is met."),
+            url: '/blocks/loops/while',
+        },
+        'controls_simple_for': {
+            name: Util.lf("a loop that repeats the number of times you say"),
+            url: 'blocks/loops/for'
+        },
+        'math_op2': {
+            name: Util.lf("minimum or maximum of 2 numbers"),
+            url: '/blocks/math',
+            operators: {
+                'op': ["min", "max"]
+            }
+        },
+        'math_op3': {
+            name: Util.lf("absolute number"),
+            tooltip: Util.lf("absolute value of a number"),
+            url: '/blocks/math/abs'
+        },
+        'device_random': {
+            name: Util.lf("pick random number"),
+            tooltip: Util.lf("Returns a random integer between 0 and the specified bound (inclusive)."),
+            url: '/blocks/math/random'
+        },
+        'math_number': {
+            name: Util.lf("{id:block}number"),
+            url: '/blocks/math/random'
+        },
+        'math_arithmetic': {
+            name: Util.lf("arithmetic operation"),
+            url: '/blocks/math',
+            operators: {
+                'OP': ["ADD", "MINUS", "MULTIPLY", "DIVIDE", "POWER"]
+            }
+        },
+        'math_modulo': {
+            name: Util.lf("division remainder"),
+            tooltip: Util.lf("Return the remainder from dividing the two numbers."),
+            url: '/blocks/math',
+        },
+        'variables_change': {
+            name: Util.lf("update the value of a number variable"),
+            tooltip: Util.lf("Changes the value of the variable by this amount"),
+            url: '/blocks/variables/change-var',
+        },
+        'controls_repeat_ext': {
+            name: Util.lf("a loop that repeats and increments an index"),
+            tooltip: Util.lf("Do some statements several times."),
+            url: '/blocks/loops/repeat',
+        },
+        'variables_get': {
+            name: Util.lf("get the value of a variable"),
+            tooltip: Util.lf("Returns the value of this variable."),
+            url: '/blocks/variables',
+        },
+        'variables_set': {
+            name: Util.lf("assign the value of a variable"),
+            tooltip: Util.lf("Sets this variable to be equal to the input."),
+            url: '/blocks/variables/assign',
+        },
+        'controls_if': {
+            name: Util.lf("a conditional statement"),
+            tooltip: Util.lf("If a value is true, then do some statements."),
+            url: '/blocks/logic/if',
+        },
+        'logic_compare': {
+            name: Util.lf("comparing two numbers"),
+            url: '/blocks/logic/boolean',
+        },
+        'logic_operation': {
+            name: Util.lf("boolean operation"),
+            url: '/blocks/logic/boolean',
+        },
+        'logic_negate': {
+            name: Util.lf("logical negation"),
+            tooltip: Util.lf("Returns true if the input is false. Returns false if the input is true."),
+            url: '/blocks/logic/boolean',
+        },
+        'logic_boolean': {
+            name: Util.lf("a `true` or `false` value"),
+            tooltip: Util.lf("Returns either true or false."),
+            url: '/blocks/logic/boolean',
+        },
+        'text': {
+            name: Util.lf("a piece of text"),
+            tooltip: Util.lf("A letter, word, or line of text."),
+            url: 'reference/types/string',
+        },
+        'text_length': {
+            name: Util.lf("number of characters in the string"),
+            tooltip: Util.lf("Returns the number of letters (including spaces) in the provided text."),
+            url: 'reference/types/string-functions',
+        }
+    };
 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -77,7 +77,7 @@ export class Editor extends srceditor.Editor {
                     if (showCategories && showSearch) {
                         pxt.blocks.initSearch(this.editor, tb,
                             searchFor => compiler.apiSearchAsync(searchFor)
-                                .then((fns: pxtc.SymbolInfo[]) => fns),
+                                .then((fns: pxtc.service.SearchInfo[]) => fns),
                             searchTb => this.updateToolbox(searchTb, showCategories));
                     }
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -62,7 +62,7 @@ function catchUserErrorAndSetDiags(r: any) {
 export interface CompileOptions {
     native?: boolean;
     debug?: boolean;
-    background?: boolean; // not explicitely requested by user (hint for simulator)
+    background?: boolean; // not explicitly requested by user (hint for simulator)
     forceEmit?: boolean;
     preferredEditor?: string;
 }
@@ -180,7 +180,7 @@ function ensureApisInfoAsync(): Promise<void> {
     else return Promise.resolve()
 }
 
-export function apiSearchAsync(searchFor: string) {
+export function apiSearchAsync(searchFor: pxtc.service.SearchOptions) {
     return ensureApisInfoAsync()
         .then(() => workerOpAsync("apiSearch", { search: searchFor }));
 }


### PR DESCRIPTION
Fixes #1140

Part of this PR moves strings for the blocks into a different file and JSON format so that I could use them for searching. I don't think this change has a large impact on perf; I tried to cache data wherever possible to reduce search times. The results aren't perfect either; most blocks turn up just fine in the results but blocks with generic names ("if", "change", etc.) are hard to search for.