### PR TITLE
mobile: hide zoom / download text in expanded mode

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -1141,10 +1141,10 @@ Avatar
     /* Organization logo */
     .organization {
         top:auto !important;
-        right:0.5rem;
+        right:0.4rem;
         left: auto;
-        bottom: 0.5rem;
-        height: 1.3rem;
+        bottom: 0.4rem;
+        height: 1.0rem;
     }
     .rtl .organization {
         left:0.5rem;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -956,17 +956,15 @@ class EditorTools extends data.Component<ISettingsProps, {}> {
                         <div className="ui grid column">
                             <div className="row">
                                 <div className="column">
-                                    <div className="ui icon small buttons">
+                                    <div className="ui icon large buttons">
                                         <sui.Button icon='undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo") } onClick={() => this.undo('mobile') } />
-                                        <sui.Button icon='zoom' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={() => this.zoomIn('mobile') } />
-                                        <sui.Button icon='zoom out' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={() => this.zoomOut('mobile') } />
                                     </div>
                                 </div>
                             </div>
                             <div className="row" style={{ paddingTop: 0 }}>
                                 <div className="column">
                                     <div className="ui icon large buttons">
-                                        {compileBtn ? <sui.Button class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
+                                        {compileBtn ? <sui.Button class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Hiding zoom, download text in mobile to avoid simulator overlap
![image](https://cloud.githubusercontent.com/assets/4175913/22492053/997ae338-e7dc-11e6-9f22-dcd07680df84.png)
