### PR TITLE
Verspec conflict logic now ignores 'file:' versions completely

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -518,7 +518,7 @@ namespace pxt {
                     let mod = this.resolveDep(id)
                     ver = ver || "*"
                     if (mod) {
-                        if (mod._verspec != ver && (!/^file:/.test(mod._verspec) || !/^file:/.test(ver)))
+                        if (mod._verspec != ver && !/^file:/.test(mod._verspec) && !/^file:/.test(ver))
                             U.userError("Version spec mismatch on " + id)
                         mod.level = Math.min(mod.level, this.level + 1)
                         mod.addedBy.push(this)


### PR DESCRIPTION
Fixes #1258