### PR TITLE
Exclude test files in pxt_modules from default project

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1844,7 +1844,8 @@ const defaultFiles: Map<string> = {
         "noImplicitAny": true,
         "outDir": "built",
         "rootDir": "."
-    }
+    },
+    "exclude": ["pxt_modules/**/*test.ts"]
 }
 `,
 


### PR DESCRIPTION
Fixes #1263 

Any file ending in `test.ts` will be excluded from the project (and thus not show up in vscode). This should handle neopixel without any changes there.