### PR TITLE
removing docs from toolbox

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -656,8 +656,6 @@ export class Editor extends srceditor.Editor {
                         .replace(/^[^(]*\(/, '(')
                         .replace(/^\s*\{\{\}\}\n/gm, '')
                         .replace(/\{\n\}/g, '{}');
-                    const docToken = document.createElement('span'); docToken.className = 'docs';
-                    docToken.innerText = comment.split('.')[0];
 
                     monacoBlock.title = comment;
 
@@ -712,7 +710,6 @@ export class Editor extends srceditor.Editor {
 
                     monacoBlock.appendChild(methodToken);
                     monacoBlock.appendChild(sigToken);
-                    monacoBlock.appendChild(docToken);
                     monacoFlyout.appendChild(monacoBlock);
                 })
             }


### PR DESCRIPTION
Hiding jsdocs from monaco toolbar -- it 's too heavy on text.
* with
![image](https://cloud.githubusercontent.com/assets/4175913/22672022/36b3d1f2-ec86-11e6-9a9f-467279765f99.png)
* without
![image](https://cloud.githubusercontent.com/assets/4175913/22671982/f1390034-ec85-11e6-9648-4ec17a334946.png)
