### PR TITLE
Moving the Uint8Array.slice polyfill back to the original location

### DIFF
--- a/pxtlib/emitter/util.ts
+++ b/pxtlib/emitter/util.ts
@@ -6,15 +6,6 @@ namespace ts.pxtc {
 
 import pxtc = ts.pxtc
 
-
-// Polyfill for Uint8Array.slice for IE and Safari
-// https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice
-if (!Uint8Array.prototype.slice) {
-    Object.defineProperty(Uint8Array.prototype, 'slice', {
-        value: Array.prototype.slice
-    });
-}
-
 namespace ts.pxtc.Util {
     export function assert(cond: boolean, msg = "Assertion failed") {
         if (!cond) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -51,6 +51,7 @@ const lf = Util.lf
 
 // Polyfill for Uint8Array.slice for IE and Safari
 // https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice
+// TODO: Move this polyfill to a more appropriate file. It is left here for now because moving it causes a crash in IE; see PXT issue #1301.
 if (!Uint8Array.prototype.slice) {
     Object.defineProperty(Uint8Array.prototype, 'slice', {
         value: Array.prototype.slice

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -49,6 +49,14 @@ import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 const lf = Util.lf
 
+// Polyfill for Uint8Array.slice for IE and Safari
+// https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice
+if (!Uint8Array.prototype.slice) {
+    Object.defineProperty(Uint8Array.prototype, 'slice', {
+        value: Array.prototype.slice
+    });
+}
+
 let theEditor: ProjectView;
 
 /*


### PR DESCRIPTION
Original polyfill was moved to a different file. This changed the load order of stuff and is now causing a crash in IE11, which prevents our webapp from loading at all. Moving the polyfill back to the original place for now.

FIxes #1296 