### PR TITLE
avoiding 1rem in Edge to avoid blockly bug

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -483,9 +483,10 @@ span.blocklyTreeLabel, text.blocklyText, input.blocklyHtmlInput {
     font-family:'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace !important;
 }
 
+/* Using 1rem creates font size issues in Edge
 text.blocklyText {
     font-size:1rem !important;
-}
+} */
 
 span.blocklyTreeLabel {
     font-size:1.25rem;


### PR DESCRIPTION
Fixes font overlap issues in Edge.

Tested in Windows Chrome, FF, Edge, IE11. Looking good.