### PR TITLE
Bundled npm modules

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -181,7 +181,8 @@ declare namespace pxt {
 
     interface TargetBundle extends AppTarget {
         bundledpkgs: Map<Map<string>>;
-        bundleddirs: string[];
+        bundleddirs?: string[];
+        bundledmodules?: string[]; // bundled NPM modules
         versions: TargetVersions;
     }
 }


### PR DESCRIPTION
Allow to specify a NPM module folder to be bundled in the target build process (as opposed to having it under /libs)