### PR TITLE
Updating menubar UI

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -257,23 +257,6 @@ div.simframe > iframe {
     top:0; left: 0; width:100%; height:100%;
 }
 
-/* Organization logo */
-.organization {
-    position:absolute;
-    top:1.3rem;
-    right:2rem;
-    height:2rem;
-    z-index:102;
-}
-.rtl .organization {
-    right:auto;
-    left:2rem;
-}
-
-.hideMenuBar .organization {
-    display: none;
-}
-
 /* Menu */ 
 .ui.menu .item.editor-menuitem {
     background: fade(@black, 30%) !important;
@@ -339,7 +322,7 @@ div.simframe > iframe {
 .ui.item.logo {
     font-size: 2.8rem;
     margin: 0;
-    padding: 0 0.3rem;
+    padding: 0.3rem;
 }
 .ui.item.logo .name {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, inherit;
@@ -1000,18 +983,6 @@ Avatar
 
 /* <= Tablet (Mobile + Tablet) */
 @media only screen and (max-width: @largestTabletScreen) {
-    /* Organization logo */
-    .organization {
-        top:auto !important;
-        right:1rem;
-        left: auto;
-        bottom: 1rem;
-        height: 1.3rem;
-    }
-    .rtl .organization {
-        left:1rem;
-        right: auto;
-    }
     /* Blockly */
     span.blocklyTreeLabel {
         font-size:1rem;
@@ -1064,9 +1035,6 @@ Avatar
     }
     .hideEditorFloats #tutorialcard.bottom {
         bottom: 5rem !important;
-    }
-    .hideEditorFloats .organization {
-        display: none;
     }
     /* Simulator */
     div.simframe {
@@ -1150,18 +1118,6 @@ Avatar
     /* Hide the blockly toolbox search */
     #blocklySearchArea {
         display: none !important;
-    }
-    /* Organization logo */
-    .organization {
-        top:auto !important;
-        right:0.4rem;
-        left: auto;
-        bottom: 0.4rem;
-        height: 1.0rem;
-    }
-    .rtl .organization {
-        left:0.5rem;
-        right: auto;
     }
     .hideEditorFloats #editortools {
         height: 5rem !important;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1237,8 +1237,9 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         const isBlocks = !this.editor.isVisible || this.getPreferredEditor() == pxt.BLOCKS_PROJECT_NAME;
         const sideDocs = !(sandbox || pxt.options.light || targetTheme.hideSideDocs);
         const inTutorial = !!this.state.tutorial;
+        const tutorialName = this.state.tutorialName;
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial;
-        const gettingStarted = !sandbox && !tutorial && !this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc && isBlocks;
+        const gettingStarted = !sandbox && !inTutorial && !this.state.sideDocsLoadUrl && targetTheme && targetTheme.sideDoc && isBlocks;
         const gettingStartedTooltip = lf("Open beginner tutorial");
         const run = true; // !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
         const restart = run && !simOpts.hideRestart;
@@ -1269,51 +1270,52 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                         : <span className="name">{targetTheme.name}</span>}
                                     {targetTheme.portraitLogo ? (<a className="ui" target="_blank" href={targetTheme.logoUrl}><img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo) } /></a>) : null}
                                 </span>}
-                            {sandbox ? undefined : <div className="ui item landscape only"></div>}
-                            {sandbox ? undefined : <div className="ui item landscape only"></div>}
-                            {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
-                            {sandbox ? undefined : <div className="ui item widedesktop only"></div>}
-                            {sandbox || inTutorial ? undefined : <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open" text={lf("Projects") } onClick={() => this.openProject() } />}
-                            {inTutorial ? undefined : <sui.Item class="editor-menuitem">
+                            {!sandbox ? <div className="left menu">
+                                {!inTutorial ? <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open large" text={lf("Projects") } onClick={() => this.openProject() } /> : null}
+                                {!inTutorial && this.state.header && sharingEnabled ? <sui.Item class="shareproject" role="menuitem" textClass="landscape only" text={lf("Share") } icon="share alternate large" onClick={() => this.embed() } /> : null}
+                                {inTutorial ? <sui.Item class="tutorialname" role="menuitem" textClass="landscape only" text={tutorialName} /> : null}
+                            </div> : undefined }
+                            {!inTutorial ? <sui.Item class="editor-menuitem">
                                 <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => this.openBlocks() } title={lf("Convert code to Blocks") } />
                                 <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => this.openJavaScript() } title={lf("Convert code to JavaScript") } />
-                            </sui.Item>}
-                            {docMenu ? <container.DocsMenuItem parent={this} /> : undefined}
-                            {sandbox || inTutorial ? undefined : <sui.DropdownMenuItem icon='setting' title={lf("More...") } class="more-dropdown-menuitem">
-                                {this.state.header ? <sui.Item role="menuitem" icon="options" text={lf("Project Settings") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
-                                {this.state.header && sharingEnabled ? <sui.Item role="menuitem" text={lf("Share Project...") } icon="share alternate" onClick={() => this.embed() } /> : null}
-                                {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined}
-                                {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project") } onClick={() => this.removeProject() } /> : undefined}
-                                <div className="ui divider"></div>
-                                <a className="ui item thin only" href="/docs" role="menuitem" target="_blank">
-                                    <i className="help icon"></i>
-                                    {lf("Help") }
-                                </a>
-                                {
-                                    // we always need a way to clear local storage, regardless if signed in or not
-                                }
-                                <sui.Item role="menuitem" icon='sign out' text={lf("Reset") } onClick={() => this.reset() } />
-                                <div className="ui divider"></div>
-                                {targetTheme.privacyUrl ? <a className="ui item" href={targetTheme.privacyUrl} role="menuitem" title={lf("Privacy & Cookies") } target="_blank">{lf("Privacy & Cookies") }</a> : undefined}
-                                {targetTheme.termsOfUseUrl ? <a className="ui item" href={targetTheme.termsOfUseUrl} role="menuitem" title={lf("Terms Of Use") } target="_blank">{lf("Terms Of Use") }</a> : undefined}
-                                <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
-                                {electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => electron.checkForUpdate() } /> : undefined}
-                            </sui.DropdownMenuItem>}
-                            <div className="right menu">
-                                {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Edit") } onClick={() => this.launchFullEditor() } /> : undefined}
-                                {sandbox ? <span className="ui item logo"><img className="ui image" src={Util.toDataUri(rightLogo) } /></span> : undefined}
-                                {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="tablet only small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span> : undefined}
-                            </div>
+                            </sui.Item> : undefined}
                             {inTutorial ? <tutorial.TutorialMenuItem parent={this} /> : undefined}
-                            {inTutorial ? <div className="right menu">
-                                <sui.Item role="menuitem" icon="external" text={lf("Exit tutorial") } textClass="landscape only" onClick={() => this.exitTutorial() } />
-                                <div className="ui item widedesktop only"></div>
-                                <div className="ui item widedesktop only"></div>
-                                <div className="ui item widedesktop only"></div>
-                                <div className="ui item widedesktop only"></div>
-                                <div className="ui item widedesktop only"></div>
-                                <div className="ui item widedesktop only"></div>
-                            </div> : undefined}
+                            <div className="right menu">
+                                {docMenu ? <container.DocsMenuItem parent={this} /> : undefined}
+                                {sandbox || inTutorial ? undefined :
+                                    <sui.DropdownMenuItem icon='setting large' title={lf("More...") } class="more-dropdown-menuitem">
+                                        {this.state.header ? <sui.Item role="menuitem" icon="options" text={lf("Project Settings") } onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")) } /> : undefined}
+                                        {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined}
+                                        {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project") } onClick={() => this.removeProject() } /> : undefined}
+                                        <div className="ui divider"></div>
+                                        <a className="ui item thin only" href="/docs" role="menuitem" target="_blank">
+                                            <i className="help icon"></i>
+                                            {lf("Help") }
+                                        </a>
+                                        {
+                                            // we always need a way to clear local storage, regardless if signed in or not
+                                        }
+                                        <sui.Item role="menuitem" icon='sign out' text={lf("Reset") } onClick={() => this.reset() } />
+                                        <div className="ui divider"></div>
+                                        {targetTheme.privacyUrl ? <a className="ui item" href={targetTheme.privacyUrl} role="menuitem" title={lf("Privacy & Cookies") } target="_blank">{lf("Privacy & Cookies") }</a> : undefined}
+                                        {targetTheme.termsOfUseUrl ? <a className="ui item" href={targetTheme.termsOfUseUrl} role="menuitem" title={lf("Terms Of Use") } target="_blank">{lf("Terms Of Use") }</a> : undefined}
+                                        <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
+                                        {electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => electron.checkForUpdate() } /> : undefined}
+                                    </sui.DropdownMenuItem> }
+
+                                {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Edit") } onClick={() => this.launchFullEditor() } /> : undefined}
+                                {sandbox ? <span className="ui item logo"><img className="ui mini image" src={Util.toDataUri(rightLogo) } /></span> : undefined}
+                                {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="tablet only small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span> : undefined}
+
+                                {inTutorial ? <sui.Item role="menuitem" icon="external" text={lf("Exit tutorial") } textClass="landscape only" onClick={() => this.exitTutorial() } /> : undefined}
+
+                                {!sandbox ? <span id="organization" className="ui item logo">
+                                    {targetTheme.organizationWideLogo || targetTheme.organizationLogo
+                                        ? <img className={`ui logo ${targetTheme.portraitLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo) } />
+                                        : <span className="name">{targetTheme.organization}</span>}
+                                    {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo) } />) : null}
+                                </span> : undefined }
+                            </div>
                         </div>
                     </div> : undefined}
                 {gettingStarted ?
@@ -1354,8 +1356,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                     <editortoolbar.EditorToolbar ref="editortools" parent={this} />
                 </div>
                 {sideDocs ? <container.SideDocs ref="sidedoc" parent={this} /> : undefined}
-                {!sandbox && targetTheme.organizationWideLogo && targetTheme.organizationLogo ? <div><img className="organization ui landscape hide" src={Util.toDataUri(targetTheme.organizationLogo) } /> <img className="organization ui landscape only" src={Util.toDataUri(targetTheme.organizationWideLogo) } /></div> : undefined}
-                {!sandbox && !targetTheme.organizationWideLogo && targetTheme.organizationLogo ? <img className="organization" src={Util.toDataUri(targetTheme.organizationLogo) } /> : undefined}
                 {sandbox ? undefined : <scriptsearch.ScriptSearch parent={this} ref={v => this.scriptSearch = v} />}
                 {sandbox ? undefined : <projects.Projects parent={this} ref={v => this.projects = v} />}
                 {sandbox || !sharingEnabled ? undefined : <share.ShareEditor parent={this} ref={v => this.shareEditor = v} />}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1305,7 +1305,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
 
                                 {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Edit") } onClick={() => this.launchFullEditor() } /> : undefined}
                                 {sandbox ? <span className="ui item logo"><img className="ui mini image" src={Util.toDataUri(rightLogo) } /></span> : undefined}
-                                {!sandbox && gettingStarted ? <span className="ui item"><sui.Button class="tablet only small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span> : undefined}
+                                {!sandbox && gettingStarted ? <span className="ui item tablet only"><sui.Button class="small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span> : undefined}
 
                                 {inTutorial ? <sui.Item role="menuitem" icon="external" text={lf("Exit tutorial") } textClass="landscape only" onClick={() => this.exitTutorial() } /> : undefined}
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -23,7 +23,7 @@ export class DocsMenuItem extends data.Component<ISettingsProps, {}> {
     render() {
         const targetTheme = pxt.appTarget.appTheme;
         const sideDocs = !(pxt.shell.isSandboxMode() || pxt.options.light || targetTheme.hideSideDocs);
-        return <sui.DropdownMenuItem icon="help" class="help-dropdown-menuitem" text={lf("Help") } textClass={"landscape only"} title={lf("Reference, lessons, ...") }>
+        return <sui.DropdownMenuItem icon="help circle large" class="help-dropdown-menuitem" textClass={"landscape only"} title={lf("Reference, lessons, ...") }>
             {targetTheme.docMenu.map(m => <a href={m.path} target="docs" key={"docsmenu" + m.path} role="menuitem" title={m.name} className={`ui item ${sideDocs && !/^https?:/i.test(m.path) ? "widedesktop hide" : ""}`}>{m.name}</a>) }
             {sideDocs ? targetTheme.docMenu.filter(m => !/^https?:/i.test(m.path)).map(m => <sui.Item key={"docsmenuwide" + m.path} role="menuitem" text={m.name} class="widedesktop only" onClick={() => this.openDoc(m.path) } />) : undefined  }
         </sui.DropdownMenuItem>

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -30,9 +30,6 @@ export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
         const tutorialName = state.tutorialName;
 
         return <div className="ui item">
-            <div className="ui item">
-                {tutorialName}
-            </div>
             <div className="ui item tutorial-menuitem">
                 {tutorialSteps.map((step, index) =>
                     <sui.Button key={'tutorialStep' + index} class={`icon circular ${currentStep == index ? 'red selected' : 'inverted'} ${!tutorialReady ? 'disabled' : ''}`} text={` ${index + 1} `} onClick={() => this.openTutorialStep(index) }/>


### PR DESCRIPTION
Updating the menubar UI. 

- [x] Increasing icon sizes
- [x] Adding share button in the menu
- [x] Docking the organization logo in the top right, switching to portrait organization logo if available
- [x] Fixing bug where getting started button wasn't showing
- [x] Centering the blocks / javascript toggle 
- [x] The rest are left / right aligned
- [x] Tested for Sandbox
- [x] Fixed sandbox logo issue
- [x] Tested for tutorial mode


![screen shot 2017-02-16 at 2 07 16 pm](https://cloud.githubusercontent.com/assets/16690124/23043481/465e21b6-f451-11e6-8f4b-4ec1128ec253.png)


![screen shot 2017-02-16 at 2 07 23 pm](https://cloud.githubusercontent.com/assets/16690124/23043486/497cf566-f451-11e6-8edf-87a7b984549c.png)
