### PR TITLE
Prevent type inheritance info from being overwritten

### DIFF
--- a/pxtlib/emitter/service.ts
+++ b/pxtlib/emitter/service.ts
@@ -501,6 +501,14 @@ ${sipkg}
                         si.attributes = parseCommentString(
                             existing.attributes._source + "\n" +
                             si.attributes._source)
+                        if (existing.extendsTypes) {
+                            si.extendsTypes = si.extendsTypes || []
+                            existing.extendsTypes.forEach(t => {
+                                if (si.extendsTypes.indexOf(t) === -1) {
+                                    si.extendsTypes.push(t);
+                                }
+                            })
+                        }
                     }
                     res.byQName[qName] = si
                 }


### PR DESCRIPTION
This was causing a bug where fixed instance interfaces were not respecting each other's inheritance information.