### PR TITLE
Updating Projects and Share dialog UI.

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -81,6 +81,9 @@ declare namespace pxt {
         blocks?: number;
         javascript?: number;
 
+        icon?: string;
+        iconColor?: string;
+
         onClick?: (e: any) => void; // React event
 
         target?: string;

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -433,6 +433,29 @@ div.simframe > iframe {
     display:inline-block;
     vertical-align: middle;
 }
+
+
+/*******************************
+        Projects Modal
+*******************************/
+
+
+.projectsdialog .ui.dividing.header, .projectsdialog .content > .header{
+    font-weight: normal !important;
+}
+
+.projectsdialog .ui.secondary.inverted.pointing.menu {
+    border: 0;
+}
+
+.projectsdialog .group {
+    padding:1rem;
+}
+
+.projectsdialog .tabsegment {
+    min-height: 450px;
+}
+
 /*******************************
              Blockly
 *******************************/

--- a/theme/themes/pxt/elements/segment.variables
+++ b/theme/themes/pxt/elements/segment.variables
@@ -1,3 +1,5 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+@invertedBackground: @mainMenuInvertedBackground;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -35,11 +35,6 @@ body {
     margin-right: 0.25rem;
 }
 
-
-.searchdialog {
-    margin-top: -20rem !important;
-}
-
 .searchdialog .cards {
     max-height: 20rem;
     overflow-y: auto;

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -9,8 +9,8 @@
 
 </head>
 
-<body class="dimmable">
-    <div id='loading' class="ui active inverted dimmer">
+<body class="main">
+    <div id='loading' class="ui active dimmer">
         <div class="ui large loader"></div>
     </div>
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1258,8 +1258,21 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         // update window title
         document.title = this.state.header ? `${this.state.header.name} - ${pxt.appTarget.name}` : pxt.appTarget.name;
 
+        const rootClasses = sui.cx([
+                this.state.hideEditorFloats || this.state.collapseEditorTools ? " hideEditorFloats" : '',
+                this.state.collapseEditorTools ? " collapsedEditorTools" : '',
+                this.state.fullscreen ? 'fullscreen' : '',
+                !sideDocs || !this.state.sideDocsLoadUrl || this.state.sideDocsCollapsed ? '' : 'sideDocs',
+                pxt.shell.layoutTypeClass(),
+                inTutorial ? 'tutorial' : '',
+                pxt.options.light ? 'light' : '',
+                pxt.BrowserUtils.isTouchEnabled() ? 'has-touch' : '',
+                showMenuBar ? '' : 'hideMenuBar',
+                'full-abs'
+            ]);
+
         return (
-            <div id='root' className={`full-abs ${this.state.hideEditorFloats || this.state.collapseEditorTools ? " hideEditorFloats" : ""} ${this.state.collapseEditorTools ? " collapsedEditorTools" : ""} ${this.state.fullscreen ? 'fullscreen' : ''} ${!sideDocs || !this.state.sideDocsLoadUrl || this.state.sideDocsCollapsed ? "" : "sideDocs"} ${pxt.shell.layoutTypeClass()} ${inTutorial ? "tutorial" : ""} ${pxt.options.light ? "light" : ""} ${pxt.BrowserUtils.isTouchEnabled() ? 'has-touch' : ''} ${showMenuBar ? '' : 'hideMenuBar'}`}>
+            <div id='root' className={rootClasses}>
                 {showMenuBar ?
                     <div id="menubar" role="banner">
                         <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -49,6 +49,8 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : null}
                 {card.imageUrl ? <img src={card.imageUrl} className="ui image" /> : null}
             </div>
+            {card.icon ?
+                <div className={`${'ui button massive ' + card.iconColor}`}> <i className={`${'icon ' + card.icon}`}></i> </div> : null}
             {card.shortName || card.name || card.description ?
                 <div className="content">
                     {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -17,11 +17,14 @@ export type Component<S, T> = data.Component<S, T>;
 
 export function hideLoading() {
     $('.ui.page.dimmer .loadingcontent').remove();
-    $('body.dimmable').dimmer('hide');
+    $('body.main').dimmer('hide');
 }
 
 export function showLoading(msg: string) {
-    $('body.dimmable').dimmer('show');
+    $('body.main').dimmer({
+        closable: false
+    });
+    $('body.main').dimmer('show');
     $('.ui.page.dimmer').html(`
   <div class="content loadingcontent">
     <div class="ui text large loader msg">{lf("Please wait")}</div>
@@ -227,7 +230,7 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
         mo = modal.modal({
             observeChanges: true,
             closeable: !options.hideCancel,
-            context: "body.dimmable",
+            context: "body.main",
             onHidden: () => {
                 modal.remove();
                 mo.remove();
@@ -363,7 +366,7 @@ export function shareLinkAsync(options: ShareOptions) {
     let modal = $(html)
     enableCopyable(modal);
     let done = false
-    $('body.dimmable').append(modal)
+    $('body.main').append(modal)
 
     return new Promise((resolve, reject) =>
         modal.modal({

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -180,6 +180,8 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             return false;
         }
 
+        const targetTheme = pxt.appTarget.appTheme;
+
         const tabs = [ProjectsTab.MyStuff];
         if (pxt.appTarget.appTheme.projectGallery) tabs.push(ProjectsTab.Make);
         if (pxt.appTarget.appTheme.exampleGallery) tabs.push(ProjectsTab.Code);
@@ -218,8 +220,8 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             <sui.Modal open={visible} className="projectsdialog" size="fullscreen" closeIcon={true}
                 onClose={() => this.setState({ visible: false })} header={lf("Projects")} dimmer="blurring"
                 closeOnDimmerClick closeOnDocumentClick>
-                <sui.Segment inverted attached="top">
-                    <sui.Menu inverted pointing secondary>
+                <sui.Segment inverted={targetTheme.invertedMenu} attached="top">
+                    <sui.Menu inverted={targetTheme.invertedMenu} pointing secondary>
                         {tabs.map(t =>
                         <sui.MenuItem key={`tab${t}`} active={tab == t} name={tabNames[t]} onClick={() => this.setState({ tab: t }) } />) }
                     </sui.Menu>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -96,10 +96,15 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             || this.state.searchFor != nextState.searchFor;
     }
 
-    renderCore() {
-        if (!this.state.visible) return null;
+    private numDaysOld(d1: number) {
+        let diff = Math.abs((Date.now() / 1000) - d1);
+        return Math.floor(diff / (60 * 60 * 24));
+    }
 
-        const tab = this.state.tab;
+    renderCore() {
+        const {visible, tab} = this.state;
+        if (!visible) return <div />;
+
         const tabNames = [
             lf("My Stuff"),
             lf("Make"),
@@ -179,57 +184,108 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         if (pxt.appTarget.appTheme.projectGallery) tabs.push(ProjectsTab.Make);
         if (pxt.appTarget.appTheme.exampleGallery) tabs.push(ProjectsTab.Code);
 
+        const headersToday = headers.filter(
+            (h) => { let days = this.numDaysOld(h.modificationTime); return days == 0; });
+        const headersYesterday = headers.filter(
+            (h) => { let days = this.numDaysOld(h.modificationTime); return days == 1; });
+        const headersThisWeek = headers.filter(
+            (h) => { let days = this.numDaysOld(h.modificationTime); return days > 1 && days <= 7; });
+        const headersLastWeek = headers.filter(
+            (h) => { let days = this.numDaysOld(h.modificationTime); return days > 7 && days <= 14; });
+        const headersThisMonth = headers.filter(
+            (h) => { let days = this.numDaysOld(h.modificationTime); return days > 14 && days <= 30; });
+        const headersOlder = headers.filter(
+            (h) => { let days = this.numDaysOld(h.modificationTime); return days > 30; });
+        const headersGrouped: {name: string, headers: pxt.workspace.Header[] }[] = [
+            {name: lf("Today"), headers: headersToday},
+            {name: lf("Yesterday"), headers: headersYesterday},
+            {name: lf("This Week"), headers: headersThisWeek},
+            {name: lf("Last Week"), headers: headersLastWeek},
+            {name: lf("This Month"), headers: headersThisMonth},
+            {name: lf("Older"), headers: headersOlder},
+        ];
+
+        const isLoading =
+            (tab == ProjectsTab.Make && makes.length == 0) ||
+            (tab == ProjectsTab.Code && codes.length == 0);
+
+        const tabClasses = sui.cx([
+                isLoading ? 'loading' : '',
+                'ui segment bottom attached tab active tabsegment'
+            ]);
+
         return (
-            <sui.Modal visible={this.state.visible} addClass="large searchdialog"
-                onHide={() => this.setState({ visible: false }) }>
-                <sui.Button
-                    icon="close"
-                    text={lf("Close") }
-                    class="cancel right labeled right floated"
-                    onClick={() => this.hide() } />
-                <div className="ui pointing secondary menu">
-                    {tabs.map(t =>
-                        <sui.Item key={`tab${t}`} class={`item ${tab == t ? "active" : ""}`} text={tabNames[t]} onClick={() => this.setState({ tab: t }) } />) }
-                </div>
-                {tab == ProjectsTab.MyStuff ? <div className="ui bottom attached tab active">
-                    <sui.Button
-                        class="primary"
-                        icon="file outline"
-                        text={lf("New Project...") }
-                        title={lf("Creates a new empty project") }
-                        onClick={() => newProject() } />
-                    {pxt.appTarget.compile ?
-                        <sui.Button
-                            icon="upload"
-                            text={lf("Import File...") }
-                            title={lf("Open files from your computer") }
-                            onClick={() => importHex() } /> : undefined}
-                    <div className="ui cards">
-                        {headers.map(scr =>
+            <sui.Modal open={visible} className="projectsdialog" size="fullscreen" closeIcon={true}
+                onClose={() => this.setState({ visible: false })} header={lf("Projects")} dimmer="blurring"
+                closeOnDimmerClick closeOnDocumentClick>
+                <sui.Segment inverted attached="top">
+                    <sui.Menu inverted pointing secondary>
+                        {tabs.map(t =>
+                        <sui.MenuItem key={`tab${t}`} active={tab == t} name={tabNames[t]} onClick={() => this.setState({ tab: t }) } />) }
+                    </sui.Menu>
+                </sui.Segment>
+                {tab == ProjectsTab.MyStuff ? <div className={tabClasses}>
+                    <div className="group">
+                        <h3 className="ui dividing header disabled">
+                            {lf("Create new")}
+                        </h3>
+                        <div className="ui cards">
                             <codecard.CodeCardView
-                                key={'local' + scr.id}
-                                name={scr.name}
-                                time={scr.recentUse}
-                                imageUrl={scr.icon}
-                                url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}
-                                onClick={() => chgHeader(scr) }
+                                key={'newproject'}
+                                icon="file outline"
+                                iconColor="primary"
+                                name={lf("New Project...")}
+                                description={lf("Creates a new empty project") }
+                                onClick={() => newProject() }
                                 />
-                        ) }
-                        {urldata.map(scr =>
+                            {pxt.appTarget.compile ?
                             <codecard.CodeCardView
-                                name={scr.name}
-                                time={scr.time}
-                                header={'/' + scr.id}
-                                description={scr.description}
-                                key={'cloud' + scr.id}
-                                onClick={() => installScript(scr) }
-                                url={'/' + scr.id}
-                                color="blue"
-                                />
-                        ) }
+                                key={'import'}
+                                icon="upload"
+                                iconColor="secondary"
+                                name={lf("Import File...") }
+                                description={lf("Open files from your computer") }
+                                onClick={() => importHex() }
+                                /> : undefined }
+                        </div>
+                    </div>
+                    {headersGrouped.filter(g => g.headers.length != 0).map(headerGroup =>
+                        <div key={'localgroup' + headerGroup.name} className="group">
+                            <h3 className="ui dividing header disabled">
+                                {headerGroup.name}
+                            </h3>
+                            <div className="ui cards">
+                                {headerGroup.headers.map(scr =>
+                                    <codecard.CodeCardView
+                                        key={'local' + scr.id}
+                                        name={scr.name}
+                                        time={scr.recentUse}
+                                        imageUrl={scr.icon}
+                                        url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}
+                                        onClick={() => chgHeader(scr) }
+                                        />
+                                ) }
+                            </div>
+                        </div>
+                    )}
+                    <div className="group">
+                        <div className="ui cards">
+                            {urldata.map(scr =>
+                                <codecard.CodeCardView
+                                    name={scr.name}
+                                    time={scr.time}
+                                    header={'/' + scr.id}
+                                    description={scr.description}
+                                    key={'cloud' + scr.id}
+                                    onClick={() => installScript(scr) }
+                                    url={'/' + scr.id}
+                                    color="blue"
+                                    />
+                            ) }
+                        </div>
                     </div>
                 </div> : undefined }
-                {tab == ProjectsTab.Make ? <div className="ui bottom attached tab active">
+                {tab == ProjectsTab.Make ? <div className={tabClasses}>
                     <div className="ui cards">
                         {makes.map(scr => <codecard.CodeCardView
                             key={'gal' + scr.name}
@@ -241,7 +297,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                         ) }
                     </div>
                 </div> : undefined }
-                {tab == ProjectsTab.Code ? <div className="ui bottom attached tab active">
+                {tab == ProjectsTab.Code ? <div className={tabClasses}>
                     <div className="ui cards">
                         {codes.map(scr => <codecard.CodeCardView
                             key={'gal' + scr.name}

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -175,8 +175,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
         const headerText = lf("Add Package...");
         return (
-            <sui.Modal visible={this.state.visible} header={headerText} addClass="large searchdialog"
-                onHide={() => this.setState({ visible: false }) }>
+            <sui.Modal open={this.state.visible} header={headerText} className="large searchdialog"
+                onClose={() => this.setState({ visible: false }) }>
                 <div className="ui vertical segment">
                     <div className="ui search">
                         <div className="ui fluid action input" role="search">

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -56,7 +56,8 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
     }
 
     renderCore() {
-        if (!this.state.visible) return null;
+        const { visible } = this.state;
+        if (!visible) return <div />;
 
         const cloud = pxt.appTarget.cloud || {};
         const embedding = !!cloud.embedding;
@@ -143,45 +144,48 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
         const action = !ready ? lf("Publish project") : undefined;
         const actionLoading = this.props.parent.state.publishing;
 
-        return <sui.Modal visible={this.state.visible} addClass="searchdialog" header={lf("Share Project") }
-            onHide={() => this.setState({ visible: false }) }
-            action={action}
-            actionClick={publish}
-            actionLoading={actionLoading}
-            hideClose={true}
-            >
-            <div className={`ui form`}>
-                { action ?
-                    <p>{lf("You need to publish your project to share it or embed it in other web pages.") +
-                        lf("You acknowledge having consent to publish this project.") }</p>
-                    : undefined }
-                { url && ready ? <div>
-                    <p>{lf("Your project is ready! Use the address below to share your projects.") }</p>
-                    <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} />
-                </div>
-                    : undefined }
-                { ready ? <div>
-                    <div className="ui divider"></div>
-                    <sui.Button class="labeled" icon={`chevron ${advancedMenu ? "down" : "right"}`} text={lf("Embed") } onClick={() => this.setState({ advancedMenu: !advancedMenu }) } />
-                    { advancedMenu ?
-                        <div className="ui form">
-                            <div className="inline fields">
-                                {formats.map(f =>
-                                    <div key={f.mode.toString() } className="field">
-                                        <div className="ui radio checkbox">
-                                            <input type="radio" checked={mode == f.mode} onChange={() => this.setState({ mode: f.mode }) }/>
-                                            <label>{f.label}</label>
+        return (
+            <sui.Modal open={this.state.visible} dimmer="blurring" className="sharedialog" header={lf("Share Project")} size="small"
+                onClose={() => this.setState({ visible: false }) }
+                action={action}
+                actionClick={publish}
+                actionLoading={actionLoading}
+                closeIcon={false}
+                closeOnDimmerClick closeOnDocumentClick
+                >
+                <div className={`ui form`}>
+                    { action ?
+                        <p>{lf("You need to publish your project to share it or embed it in other web pages.") +
+                            lf("You acknowledge having consent to publish this project.") }</p>
+                        : undefined }
+                    { url && ready ? <div>
+                        <p>{lf("Your project is ready! Use the address below to share your projects.") }</p>
+                        <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} />
+                    </div>
+                        : undefined }
+                    { ready ? <div>
+                        <div className="ui divider"></div>
+                        <sui.Button class="labeled" icon={`chevron ${advancedMenu ? "down" : "right"}`} text={lf("Embed") } onClick={() => this.setState({ advancedMenu: !advancedMenu }) } />
+                        { advancedMenu ?
+                            <div className="ui form">
+                                <div className="inline fields">
+                                    {formats.map(f =>
+                                        <div key={f.mode.toString() } className="field">
+                                            <div className="ui radio checkbox">
+                                                <input type="radio" checked={mode == f.mode} onChange={() => this.setState({ mode: f.mode }) }/>
+                                                <label>{f.label}</label>
+                                            </div>
                                         </div>
-                                    </div>
-                                ) }
-                            </div>
-                        </div> : undefined }
-                    { advancedMenu ?
-                        <sui.Field>
-                            <sui.Input class="mini" readOnly={true} lines={4} value={embed} copy={ready} disabled={!ready} />
-                        </sui.Field> : null }
-                </div> : undefined }
-            </div>
-        </sui.Modal>
+                                    ) }
+                                </div>
+                            </div> : undefined }
+                        { advancedMenu ?
+                            <sui.Field>
+                                <sui.Input class="mini" readOnly={true} lines={4} value={embed} copy={ready} disabled={!ready} />
+                            </sui.Field> : null }
+                    </div> : undefined }
+                </div>
+            </sui.Modal>
+            )
     }
 }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -167,18 +167,10 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
                         <div className="ui divider"></div>
                         <sui.Button class="labeled" icon={`chevron ${advancedMenu ? "down" : "right"}`} text={lf("Embed") } onClick={() => this.setState({ advancedMenu: !advancedMenu }) } />
                         { advancedMenu ?
-                            <div className="ui form">
-                                <div className="inline fields">
-                                    {formats.map(f =>
-                                        <div key={f.mode.toString() } className="field">
-                                            <div className="ui radio checkbox">
-                                                <input type="radio" checked={mode == f.mode} onChange={() => this.setState({ mode: f.mode }) }/>
-                                                <label>{f.label}</label>
-                                            </div>
-                                        </div>
-                                    ) }
-                                </div>
-                            </div> : undefined }
+                            <sui.Menu pointing secondary>
+                                {formats.map(f =>
+                                    <sui.MenuItem key={`tab${f.label}`} active={mode == f.mode} name={f.label} onClick={() => this.setState({ mode: f.mode }) } />) }
+                            </sui.Menu> : undefined }
                         { advancedMenu ?
                             <sui.Field>
                                 <sui.Input class="mini" readOnly={true} lines={4} value={embed} copy={ready} disabled={!ready} />

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -150,7 +150,7 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
                 action={action}
                 actionClick={publish}
                 actionLoading={actionLoading}
-                closeIcon={false}
+                closeIcon={true}
                 closeOnDimmerClick closeOnDocumentClick
                 >
                 <div className={`ui form`}>

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -23,6 +23,14 @@ export interface DropdownProps extends WithPopupProps {
     onChange?: (v: string) => void;
 }
 
+export interface SidebarProps extends UiProps {
+    visible?: boolean;
+}
+
+export function cx(classes: string[]): string {
+    return classes.filter((c) => c && c.length !== 0 && c.trim() != '').join(' ');
+}
+
 function genericClassName(cls: string, props: UiProps, ignoreIcon: boolean = false): string {
     return `${cls} ${ignoreIcon ? '' : props.icon && props.text ? 'icon-and-text' : props.icon ? 'icon' : ""} ${props.class || ""}`;
 }
@@ -262,72 +270,553 @@ export class Checkbox extends data.Component<{
     }
 }
 
+export interface SegmentProps {
+    attached?: boolean | 'top' | 'bottom';
+    basic?: boolean;
+    children?: React.ReactNode;
+    circular?: boolean;
+    className?: string;
+    clearing?: boolean;
+    color?: string;
+    compact?: boolean;
+    disabled?: boolean;
+    floated?: string;
+    inverted?: boolean;
+    loading?: boolean;
+    padded?: boolean | 'very';
+    piled?: boolean;
+    raised?: boolean;
+    secondary?: boolean;
+    size?: string;
+    stacked?: boolean;
+    tertiary?: boolean;
+    textAlign?: string;
+    vertical?: boolean;
+}
+
+export interface SegmentState {
+}
+
+export class Segment extends data.Component<SegmentProps, SegmentState> {
+    renderCore() {
+        const {
+            attached,
+            basic,
+            children,
+            circular,
+            className,
+            clearing,
+            color,
+            compact,
+            disabled,
+            floated,
+            inverted,
+            loading,
+            padded,
+            piled,
+            raised,
+            secondary,
+            size,
+            stacked,
+            tertiary,
+            textAlign,
+            vertical,
+        } = this.props;
+
+        const classes = cx([
+            'ui',
+            color,
+            size,
+            basic ? 'basic' : '',
+            circular ? 'circular' : '',
+            clearing ? 'clearing' : '',
+            compact ? 'compact' : '',
+            disabled ? 'disabled' : '',
+            inverted ? 'inverted' : '',
+            loading ? 'loading' : '',
+            piled ? 'piled' : '',
+            raised ? 'raised' : '',
+            secondary ? 'secondary' : '',
+            stacked ? 'stacked' : '',
+            tertiary ? 'tertiary' : '',
+            vertical ? 'vertical' : '',
+            attached ? `${attached} attached` : '',
+            padded ? `${padded} padded` : '',
+            textAlign ? (textAlign == 'justified' ? 'justified' : `${textAlign} aligned`) : '',
+            floated ? `${floated} floated` : '',
+            'segment',
+            className,
+        ]);
+
+        return (
+            <div className={classes}>
+                {children}
+            </div>
+        )
+    }
+}
+
+export interface MenuProps {
+    activeIndex?: number;
+    attached?: boolean | 'bottom' | 'top';
+    borderless?: boolean;
+    children?: React.ReactNode;
+    className?: string;
+    color?: string;
+    compact?: boolean;
+    defaultActiveIndex?: number;
+    fixed?: 'left'| 'right'| 'bottom'| 'top';
+    floated?: boolean | 'right';
+    fluid?: boolean;
+    icon?: boolean | 'labeled';
+    inverted?: boolean;
+    pagination?: boolean;
+    pointing?: boolean;
+    secondary?: boolean;
+    size?: 'mini' | 'tiny' | 'small' | 'large' | 'huge' | 'massive';
+    stackable?: boolean;
+    tabular?: boolean | 'right';
+    text?: boolean;
+    vertical?: boolean;
+}
+
+export interface MenuItemProps {
+    active?: boolean;
+    children?: React.ReactNode;
+    className?: string;
+    color?: string;
+    content?: React.ReactNode;
+    fitted?: boolean | 'horizontally' | 'vertically';
+    header?: boolean;
+    icon?: any | boolean;
+    index?: number;
+    link?: boolean;
+    name?: string;
+    onClick?: (event: React.MouseEvent, data: MenuItemProps) => void;
+    position?: 'right';
+}
+
+export class MenuItem extends data.Component<MenuItemProps, {}> {
+    constructor(props: MenuItemProps) {
+        super(props);
+    }
+
+    handleClick = (e: React.MouseEvent) => {
+        const { onClick } = this.props;
+        if (onClick) onClick(e, this.props);
+    }
+
+    renderCore() {
+        const {
+            active,
+            children,
+            className,
+            color,
+            content,
+            fitted,
+            header,
+            icon,
+            link,
+            name,
+            onClick,
+            position,
+            } = this.props;
+
+            const classes = cx([
+                color,
+                position,
+                active ? 'active' : '',
+                icon === true || icon && !(name || content) ? 'icon' : '',
+                header ? 'header' : '',
+                link ? 'link' : '',
+                fitted ? (fitted == true ? `${fitted}` : `fitted ${fitted}`) : '',
+                'item',
+                className
+            ]);
+
+            if (children ) {
+                return <div className={classes} onClick={this.handleClick}>{children}</div>
+            }
+
+            return (
+                <div className={classes} onClick={this.handleClick}>
+                    {icon ? <i className={`icon ${icon}`} ></i> : undefined}
+                    {content || name}
+                </div>
+            )
+    }
+}
+
+export interface MenuState {
+    activeIndex?: number;
+}
+
+export class Menu extends data.Component<MenuProps, MenuState> {
+    constructor(props: MenuProps) {
+        super(props);
+    }
+
+    renderCore() {
+        const {
+            attached,
+            borderless,
+            children,
+            className,
+            color,
+            compact,
+            fixed,
+            floated,
+            fluid,
+            icon,
+            inverted,
+            pagination,
+            pointing,
+            secondary,
+            size,
+            stackable,
+            tabular,
+            text,
+            vertical
+        } = this.props;
+
+        const classes = cx([
+            'ui',
+            color,
+            size,
+            borderless ? 'borderless' : '',
+            compact ? 'compact' : '',
+            fluid ? 'fluid' : '',
+            inverted ? 'inverted' : '',
+            pagination ? 'pagination' : '',
+            pointing ? 'pointing' : '',
+            secondary ? 'secondary' : '',
+            stackable ? 'stackable' : '',
+            text ? 'text' : '',
+            vertical ? 'vertical' : '',
+            attached ? (attached == true ? 'attached' : `${attached} attached `) : '',
+            floated ? (floated == true ? 'floated' : `${floated} floated`) : '',
+            icon ? (icon == true ? 'icon' : `${icon} icon`) : '',
+            tabular ? (tabular == true ? 'tabular' : `${tabular} tabular`) : '',
+            fixed ? `tabular ${tabular}` : '',
+            className,
+            'menu'
+        ]);
+
+        return (
+            <div className={classes}>
+                {children}
+            </div>
+        )
+    }
+}
+
 export interface ModalProps {
+    basic?: boolean;
     children?: any;
-    addClass?: string;
+    className?: string;
+    closeIcon?: any;
+    closeOnDimmerClick?: boolean;
+    closeOnDocumentClick?: boolean;
+    defaultOpen?: boolean;
+    dimmer?: boolean | 'blurring' | 'inverted';
+    dimmerClassName?: string;
+
+    onClose?: Function;
+    onOpen?: Function;
+
+    open?: boolean;
+    mountNode?: any;
+    size?: string;
+
     headerClass?: string;
     header?: string;
-    onHide: () => void;
-    visible?: boolean;
     helpUrl?: string;
 
     action?: string;
     actionClick?: () => void;
     actionLoading?: boolean;
-
-    hideClose?: boolean;
 }
 
 export interface ModalState {
+    marginTop?: number;
+    scrolling?: boolean;
 }
 
 export class Modal extends data.Component<ModalProps, ModalState> {
+    _modalNode: any;
     id: string;
+    animationId: number;
     constructor(props: ModalProps) {
         super(props)
         this.id = Util.guidGen();
     }
 
-    hide() {
-        this.props.onHide();
+    componentDidMount() {
+        this.setPosition()
+    }
+
+    componentWillUnmount() {
+        this.handleUnmount()
+    }
+
+    getMountNode = () => this.props.mountNode || document.body;
+
+    handleClose = (e: Event) => {
+        const { onClose } = this.props;
+        if (onClose) onClose(e, this.props);
+    }
+
+    handleOpen = (e: Event) => {
+        const { onOpen } = this.props;
+        if (onOpen) onOpen(e, this.props);
+    }
+
+    setPosition = () => {
+        if (this._modalNode) {
+            const mountNode = this.getMountNode();
+            const { height } = this._modalNode.getBoundingClientRect();
+
+            const marginTop = -Math.round(height / 2);
+            const scrolling = height >= window.innerHeight;
+
+            const newState: ModalState = {};
+
+            if (this.state.marginTop !== marginTop) {
+                newState.marginTop = marginTop;
+            }
+
+            if (this.state.scrolling !== scrolling) {
+                newState.scrolling = scrolling;
+
+                if (scrolling) {
+                    mountNode.classList.add('scrolling');
+                } else {
+                    mountNode.classList.remove('scrolling');
+                }
+            }
+
+            if (Object.keys(newState).length > 0) this.setState(newState);
+        }
+
+        this.animationId = requestAnimationFrame(this.setPosition);
+    }
+
+    handleMount = () => {
+        const { dimmer } = this.props;
+        const mountNode = this.getMountNode();
+
+        if (dimmer) {
+            mountNode.classList.add('dimmable', 'dimmed');
+
+            if (dimmer === 'blurring') {
+                mountNode.classList.add('blurring');
+            }
+        }
+
+        this.setPosition()
+    }
+
+    handleUnmount = () => {
+        const mountNode = this.getMountNode();
+        mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable');
+        cancelAnimationFrame(this.animationId);
     }
 
     renderCore() {
-        if (!this.props.visible) return null;
-        return (
-            <div id={this.id} className={`ui mydimmer dimmer modals page ${pxt.options.light ? "" : "transition"} visible active`} onClick={ev => {
-                if (/mydimmer/.test((ev.target as HTMLElement).className))
-                    this.hide()
-            } }>
-                <div role="dialog" aria-labelledby={this.id + 'title'} aria-describedby={this.id + 'desc'} className={"ui modal transition visible active " + (this.props.addClass || "") }>
-                    {this.props.header ? <div id={this.id + 'title'} className={"header " + (this.props.headerClass || "") }>
-                        {this.props.header}
-                        {this.props.hideClose ? undefined : <Button
-                            icon="close"
-                            text={lf("Close") }
-                            class="cancel right labeled right floated"
-                            onClick={() => this.hide() } /> }
-                        {this.props.helpUrl ?
-                            <a className="ui button icon-and-text right floated labeled" href={this.props.helpUrl} target="_docs">
-                                <i className="help icon"></i>
-                                {lf("Help") }</a>
-                            : undefined}
-                    </div> : undefined }
-                    <div id={this.id + 'desc'} className="content">
-                        {this.props.children}
-                    </div>
-                    {this.props.action && this.props.actionClick ?
-                        <div className="actions">
-                            <Button
-                                text={this.props.action}
-                                class={`approve primary ${this.props.actionLoading ? "loading" : ""}`}
-                                onClick={() => {
-                                    this.props.actionClick();
-                                } } />
-                        </div> : undefined }
+        const {
+            open,
+            basic,
+            children,
+            className,
+            closeIcon,
+            closeOnDimmerClick,
+            closeOnDocumentClick,
+            dimmer,
+            dimmerClassName,
+            size,
+        } = this.props
+
+        const { marginTop, scrolling } = this.state
+        const classes = cx([
+            'ui',
+            size,
+            basic ? 'basic' : '',
+            scrolling ? 'scrolling' : '',
+            'modal transition visible active',
+            className,
+        ]);
+
+        const closeIconName = closeIcon === true ? 'close' : closeIcon;
+
+        const modalJSX = (
+            <div className={classes} style={{ marginTop }} ref={c => (this._modalNode = c)} role="dialog" aria-labelledby={this.id + 'title'} aria-describedby={this.id + 'desc'} >
+                {this.props.header ? <div id={this.id + 'title'} className={"header " + (this.props.headerClass || "") }>
+                    {this.props.header}
+                    {this.props.closeIcon ? <Button
+                        icon={closeIconName}
+                        text={lf("Close") }
+                        class="cancel right labeled right floated"
+                        onClick={() => this.handleClose(null) } /> : undefined }
+                    {this.props.helpUrl ?
+                        <a className="ui button icon-and-text right floated labeled" href={this.props.helpUrl} target="_docs">
+                            <i className="help icon"></i>
+                            {lf("Help") }</a>
+                        : undefined}
+                </div> : undefined }
+                <div id={this.id + 'desc'} className="content">
+                    {children}
                 </div>
+                {this.props.action && this.props.actionClick ?
+                    <div className="actions">
+                        <Button
+                            text={this.props.action}
+                            class={`approve primary ${this.props.actionLoading ? "loading" : ""}`}
+                            onClick={() => {
+                                this.props.actionClick();
+                            } } />
+                    </div> : undefined }
             </div>
-        );
+        )
+
+        const dimmerClasses = !dimmer
+        ? null
+        : cx([
+            'ui',
+            dimmer === 'inverted' ? 'inverted' : '',
+            pxt.options.light ? '' : "transition",
+            'page modals dimmer visible active',
+            dimmerClassName
+        ]);
+
+        const blurring = dimmer === 'blurring';
+
+        return (
+            <Portal
+                closeOnRootNodeClick={closeOnDimmerClick}
+                closeOnDocumentClick={closeOnDocumentClick}
+                className={dimmerClasses}
+                mountNode={this.getMountNode()}
+                onMount={this.handleMount}
+                onUnmount={this.handleUnmount}
+                onClose={this.handleClose}
+                onOpen={this.handleOpen}
+                open={open}>
+                {modalJSX}
+            </Portal>
+        )
     }
 }
 
+interface PortalProps {
+    children?: any;
+    className?: string;
+    open?: boolean;
+    onOpen?: Function;
+    onClose?: Function;
+    onMount?: Function;
+    onUnmount?: Function;
+    mountNode?: HTMLElement;
+    closeOnRootNodeClick?: boolean;
+    closeOnDocumentClick?: boolean;
+    closeOnEscape?: boolean;
+}
+
+interface PortalState {
+}
+
+export class Portal extends data.Component<PortalProps, PortalState> {
+    rootNode: HTMLElement;
+    portalNode: Element;
+    constructor(props: PortalProps) {
+        super(props);
+    }
+
+    componentDidMount() {
+        if (this.props.open) {
+            this.renderPortal();
+        }
+    }
+
+    componentDidUpdate(prevProps: PortalProps, prevState: PortalState) {
+        this.renderPortal();
+
+        if (prevProps.open && !this.props.open) {
+            this.unmountPortal();
+        }
+    }
+
+    componentWillUnmount() {
+        this.unmountPortal();
+    }
+
+    handleDocumentClick = (e: MouseEvent) => {
+        const { closeOnDocumentClick, closeOnRootNodeClick } = this.props;
+
+        if ( !this.rootNode || !this.portalNode || this.portalNode.contains(e.target as Node)) return;
+        const didClickInRootNode = this.rootNode.contains(e.target as Node);
+
+        if (closeOnDocumentClick && !didClickInRootNode || closeOnRootNodeClick && didClickInRootNode) {
+            this.close(e);
+        }
+    }
+
+    close = (e: Event) => {
+        const { onClose } = this.props;
+        if (onClose) onClose(e);
+    }
+
+    open = (e: Event) => {
+        const { onOpen } = this.props;
+        if (onOpen) onOpen(e);
+    }
+
+    mountPortal = () => {
+        if (this.rootNode) return;
+
+        const { mountNode = document.body } = this.props;
+
+        this.rootNode = document.createElement('div');
+        mountNode.appendChild(this.rootNode);
+
+        document.addEventListener('click', this.handleDocumentClick)
+
+        const { onMount } = this.props
+        if (onMount) onMount()
+    }
+
+    unmountPortal = () => {
+        if (!this.rootNode) return;
+
+        ReactDOM.unmountComponentAtNode(this.rootNode);
+        this.rootNode.parentNode.removeChild(this.rootNode);
+
+        this.rootNode = null;
+        this.portalNode = null;
+
+        document.removeEventListener('click', this.handleDocumentClick);
+
+        const { onUnmount } = this.props;
+        if (onUnmount) onUnmount();
+    }
+
+    renderPortal() {
+        const { children, className, open} = this.props;
+
+        this.mountPortal();
+
+        this.rootNode.className = className || '';
+
+        ReactDOM.unstable_renderSubtreeIntoContainer(
+            this,
+            React.Children.only(children),
+            this.rootNode
+        )
+
+        this.portalNode = this.rootNode.firstElementChild;
+    }
+
+    renderCore() {
+        return <div />;
+    }
+
+}


### PR DESCRIPTION
- [x] Updating projects dialog to include big cards for new project and import project
- [x] Categorizing past projects in timeline view in projects dialog 
- [x] Blurring dimmer in projects and share dialog
- [x] Using tabs instead of radio buttons in share dialog
- [x] Show loader on startup of the project
- [x] Don't allow closing of the loader by click
- [x] Better modal and dimmer support in react.

<img width="961" alt="screen shot 2017-02-17 at 11 12 08 pm" src="https://cloud.githubusercontent.com/assets/16690124/23091255/91e48e02-f566-11e6-989a-1adf523d4290.png">

<img width="984" alt="screen shot 2017-02-17 at 11 12 15 pm" src="https://cloud.githubusercontent.com/assets/16690124/23091257/9565dc84-f566-11e6-9fd5-0f5f6bf9cd3e.png">

