### PR TITLE
IOS Home screen UA issue

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -76,7 +76,8 @@ namespace pxt.BrowserUtils {
     //Chrome and Edge lie about being Safari
     export function isSafari(): boolean {
         //Could also check isMac but I don't want to risk excluding iOS
-        return !isChrome() && !isEdge() && !!navigator && (/Safari/i.test(navigator.userAgent) || /(iPod|iPhone|iPad)/i.test(navigator.userAgent));
+        //Checking for iPhone, iPod or iPad as well as Safari in order to detect home screen browsers on iOS
+        return !isChrome() && !isEdge() && !!navigator && /(Safari|iPod|iPhone|iPad)/i.test(navigator.userAgent);
     }
 
     //Safari and WebKit lie about being Firefox

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -76,7 +76,7 @@ namespace pxt.BrowserUtils {
     //Chrome and Edge lie about being Safari
     export function isSafari(): boolean {
         //Could also check isMac but I don't want to risk excluding iOS
-        return !isChrome() && !isEdge() && !!navigator && /Safari/i.test(navigator.userAgent);
+        return !isChrome() && !isEdge() && !!navigator && (/Safari/i.test(navigator.userAgent) || /(iPod|iPhone|iPad)/i.test(navigator.userAgent));
     }
 
     //Safari and WebKit lie about being Firefox


### PR DESCRIPTION
When saving a website to the home screen, the User Agent string of the launched website doesn't have "Safari" in it.

Example of iPhone (viewing page in Browser) :

Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1

And the same phone (viewing the same page in WebApp) :

Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69

Fix: Adding check for iPhone, iPod or iPad in the UA string for Safari detection.
Fixes #1252