### PR TITLE
Make a variable button

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -498,9 +498,6 @@ span.blocklyTreeLabel {
     font-size:1.25rem;
 }
 
-.blocklyFlyoutButton {
-    fill: rgb(165, 91, 128) !important;
-}
 .blocklyFlyoutButtonShadow {
     fill: none !important;
 }


### PR DESCRIPTION
Removing color from the make a variable block to make it appear different to the other blocks under Variables, and highlight the fact that it's not a block (but a button). 

Before: 
![screen shot 2017-02-21 at 10 31 05 am](https://cloud.githubusercontent.com/assets/16690124/23179127/acba1630-f821-11e6-93a6-bffa1e59aadc.png)


After: 
![screen shot 2017-02-21 at 10 37 50 am](https://cloud.githubusercontent.com/assets/16690124/23179169/d05ae308-f821-11e6-92f4-c4ed491ce5bc.png)


Fixes #915