### PR TITLE
Remove curly braces from unsupported types in monaco toolbox

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -580,7 +580,7 @@ export class Editor extends srceditor.Editor {
             "if": {
                 sig: ``,
                 snippet: `if (true) {
-    
+
 }`,
                 comment: lf("Runs code if the condition is true"),
                 metaData: {
@@ -590,7 +590,7 @@ export class Editor extends srceditor.Editor {
             }, "if ": {
                 sig: ``,
                 snippet: `if (true) {
-    
+
 } else {
 
 }`,
@@ -602,9 +602,9 @@ export class Editor extends srceditor.Editor {
             },"switch": {
                 sig: ``,
                 snippet: `switch(item) {
-    case 0: 
+    case 0:
         break;
-    case 1: 
+    case 1:
         break;
 }`,
                 comment: lf("Runs differnt code based on a value"),
@@ -618,7 +618,7 @@ export class Editor extends srceditor.Editor {
             "while": {
                 sig: `while(...)`,
                 snippet: `while(true) {
-    
+
 }`,
                 comment: lf("Repeat code while condition is true"),
                 metaData: {
@@ -629,7 +629,7 @@ export class Editor extends srceditor.Editor {
             "for": {
                 sig: ``,
                 snippet: `for(let i = 0; i < 5; i++) {
-    
+
 }`,
                 comment: lf("Repeat code a number of times in a loop"),
                 metaData: {
@@ -730,7 +730,8 @@ export class Editor extends srceditor.Editor {
                     sigToken.innerText = snippet
                         .replace(/^[^(]*\(/, '(')
                         .replace(/^\s*\{\{\}\}\n/gm, '')
-                        .replace(/\{\n\}/g, '{}');
+                        .replace(/\{\n\}/g, '{}')
+                        .replace(/(?:\{\{)|(?:\}\})/g, '');
 
                     monacoBlock.title = comment;
 


### PR DESCRIPTION
Fixes names that show up like this: `{{buffer}}` in the Monaco toolbox