### PR TITLE
PXT serve should launch browsers as a detached process

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -668,7 +668,7 @@ function openUrl(startUrl: string, browser: string) {
     console.log(`opening ${startUrl}`)
 
     if (browser) {
-        child_process.spawn(getBrowserLocation(browser), [startUrl]);
+        child_process.spawn(getBrowserLocation(browser), [startUrl], { detached: true });
     }
     else {
         child_process.exec(`${cmds[process.platform]} ${startUrl}`);


### PR DESCRIPTION
This has been annoying me for a while. When you use the `--browser` flag of `pxt serve`, launch the browser as a detached process so that `ctrl-c` doesn't kill it along with the server. Otherwise the browser complains about not being shut down properly.