### PR TITLE
Support valid identifiers in the blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -900,11 +900,10 @@ namespace pxt.blocks {
             return e.renames.oldToNew[name];
         }
 
-        let n = name.split(/[^a-zA-Z0-9_$]+/)
-            //.map((c, i) => (i ? c[0].toUpperCase() : c[0].toLowerCase()) + c.substr(1)) breaks roundtrip...
-            .join('');
+        let n = name.replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_$]/g, a =>
+            ts.isIdentifierPart(a.charCodeAt(0), ts.ScriptTarget.ES5) ? a : "");
 
-        if (/\d/.test(n.charAt(0)) || isReservedWord(name)) {
+        if (!n || !ts.isIdentifierStart(n.charCodeAt(0), ts.ScriptTarget.ES5)) {
             n = "_" + n;
         }
 


### PR DESCRIPTION
Fixes #652

Redo of #1216 that now lets typescript choose what characters are supported. The variable escaping now works like this:

1. Whitespace is replaced with an underscore (e.g. `my var` becomes `my_var`)
2. Invalid identifier parts (e.g. `:`, `{`, etc) are deleted
3. If the identifier doesn't start with a valid start character (e.g. starts with a number), an underscore is added to the beginning
4. If any identifiers clash as a result of renames, a number will be added to the end of the identifier and incremented until there isn't a conflict

These variable name changes will not roundtrip. That is, the decompiler will not undo them at this time. That's something we could look into doing later if we consider it important.