### PR TITLE
Allow targets to run simulator even while collapsed

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -85,7 +85,7 @@ declare namespace pxt {
     }
 
     interface AppSimulator {
-        autoRun?: boolean;        
+        autoRun?: boolean;
         stopOnChange?: boolean;
         hideRestart?: boolean;
         hideFullscreen?: boolean;
@@ -95,6 +95,7 @@ declare namespace pxt {
         parts?: boolean; // parts enabled?
         instructions?: boolean;
         partsAspectRatio?: number; // aspect ratio of the simulator when parts are displayed
+        headless?: boolean; // whether simulator should still run while collapsed
     }
 
     interface TargetCompileService {
@@ -174,7 +175,7 @@ declare namespace pxt {
 
     interface DocMenuEntry {
         name: string;
-        // needs to have one of `path` or `subitems` 
+        // needs to have one of `path` or `subitems`
         path?: string;
         subitems?: DocMenuEntry[];
     }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -2,6 +2,7 @@ namespace pxsim {
     export interface SimulatorDriverOptions {
         revealElement?: (el: HTMLElement) => void;
         removeElement?: (el: HTMLElement, onComplete?: () => void) => void;
+        unhideElement?: (el: HTMLElement) => void;
         onDebuggerWarning?: (wrn: DebuggerWarningMessage) => void;
         onDebuggerBreakpoint?: (brk: DebuggerBreakpointMessage) => void;
         onDebuggerResume?: () => void;
@@ -198,6 +199,15 @@ namespace pxsim {
             for (let i = 0; i < frames.length; ++i) {
                 let frame = frames[i];
                 this.options.removeElement(frame.parentElement, completeHandler);
+            }
+        }
+
+        public unhide() {
+            if (!this.options.unhideElement) return;
+            let frames = this.container.getElementsByTagName("iframe");
+            for (let i = 0; i < frames.length; ++i) {
+                let frame = frames[i];
+                this.options.unhideElement(frame.parentElement);
             }
         }
 

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -257,7 +257,12 @@ div.simframe > iframe {
     top:0; left: 0; width:100%; height:100%;
 }
 
-/* Menu */ 
+.simHeadless {
+    height: 0 !important;
+    width: 0 !important;
+}
+
+/* Menu */
 .ui.menu .item.editor-menuitem {
     background: fade(@black, 30%) !important;
     margin: 0.5rem;
@@ -402,7 +407,7 @@ div.simframe > iframe {
 ::-webkit-scrollbar-thumb {
     border-radius: 4px;
     background-color: #ccc;
-    box-shadow: 0 0 1px #ccc;    
+    box-shadow: 0 0 1px #ccc;
     -webkit-box-shadow: 0 0 1px #ccc;
 }
 
@@ -711,7 +716,7 @@ Avatar
 
 #root .avatar .message {
     margin-left: 4em;
-    margin-bottom: 1em;                    
+    margin-bottom: 1em;
 }
 
 .avatar .avatar-image {
@@ -899,7 +904,7 @@ Avatar
     }
     #cookiemsg {
         bottom: 7.5rem;
-    }        
+    }
 
     /* Full screen */
     .fullscreen #filelist {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -102,7 +102,8 @@ export class ProjectView
         this.settings = JSON.parse(pxt.storage.getLocal("editorSettings") || "{}")
         this.state = {
             showFiles: false,
-            active: document.visibilityState == 'visible'
+            active: document.visibilityState == 'visible',
+            collapseEditorTools: pxt.appTarget.simulator.headless
         };
         if (!this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 20;
         if (!this.settings.fileHistory) this.settings.fileHistory = [];
@@ -935,7 +936,12 @@ export class ProjectView
     }
 
     expandSimulator() {
-        this.startSimulator();
+        if (pxt.appTarget.simulator.headless) {
+            simulator.unhide();
+        }
+        else {
+            this.startSimulator();
+        }
         this.setState({ collapseEditorTools: false });
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -52,12 +52,12 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     }
 
     startStopSimulator(view?: string) {
-        pxt.tickEvent("editortools.startStopSimulator", { view: view, collapsed: this.getCollapsedState() });
+        pxt.tickEvent("editortools.startStopSimulator", { view: view, collapsed: this.getCollapsedState(), headless: this.getHeadlessState() });
         this.props.parent.startStopSimulator();
     }
 
     restartSimulator(view?: string) {
-        pxt.tickEvent("editortools.restart", { view: view, collapsed: this.getCollapsedState() });
+        pxt.tickEvent("editortools.restart", { view: view, collapsed: this.getCollapsedState(), headless: this.getHeadlessState() });
         this.props.parent.restartSimulator();
     }
 
@@ -68,6 +68,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
 
     private getCollapsedState(): string {
         return '' + this.props.parent.state.collapseEditorTools;
+    }
+
+    private getHeadlessState(): string {
+        return pxt.appTarget.simulator.headless ? "true": "false";
     }
 
     render() {

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -90,6 +90,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const makeTooltip = lf("Open assembly instructions");
         const restartTooltip = lf("Restart the simulator");
         const collapseTooltip = collapsed ? lf("Show the simulator") : lf("Hide the simulator");
+        const headless = pxt.appTarget.simulator.headless;
 
         const hasUndo = this.props.parent.editor.hasUndo();
         const hasRedo = this.props.parent.editor.hasRedo();
@@ -104,6 +105,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         <div className="left aligned column">
                             <div className="ui icon small buttons">
                                 <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${hideEditorFloats ? 'disabled' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('mobile') } />
+                                {headless && run ? <sui.Button class="" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('mobile') } /> : undefined }
+                                {headless && restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('mobile') } /> : undefined }
                                 {compileBtn ? <sui.Button class={`download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
                             </div>
                         </div>
@@ -157,10 +160,19 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             <div className="column tablet only">
                 {collapsed ?
                     <div className="ui grid seven column">
-                        <div className="left aligned six wide column">
-                            <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`large collapse-button ${hideEditorFloats ? 'disabled' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
-                            {compileBtn ? <sui.Button class={`large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
-                        </div>
+                        {headless ?
+                            <div className="left aligned six wide column">
+                                <div className="ui icon large buttons">
+                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`large collapse-button ${hideEditorFloats ? 'disabled' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
+                                    {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('tablet') } /> : undefined }
+                                    {restart ? <sui.Button key='restartbtn' class={`large restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('tablet') } /> : undefined }
+                                    {compileBtn ? <sui.Button class={`large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
+                                </div>
+                            </div> :
+                            <div className="left aligned six wide column">
+                                <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`large collapse-button ${hideEditorFloats ? 'disabled' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
+                                {compileBtn ? <sui.Button class={`large download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon="download" text={ lf("Download") } title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
+                            </div> }
                         {readOnly ? undefined :
                             <div className="column four wide">
                                 <sui.Button icon='save' class="large editortools-btn save-editortools-btn" title={lf("Save") } onClick={() => this.saveFile('tablet') } />
@@ -230,10 +242,20 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             <div className="column computer only">
                 <div className="ui grid equal width">
                     <div id="downloadArea" className="ui column items">
-                        <div className="ui item">
-                            <sui.Button icon={`${state.collapseEditorTools ? 'toggle right' : 'toggle left'}`} class="large collapse-button" title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } />
-                            {compileBtn ? <sui.Button icon='icon download' class={`huge fluid download-button ${compileLoading ? 'loading' : ''}`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
-                        </div>
+                        {headless && collapsed ?
+                            <div className="ui item">
+                                <div className="ui icon large buttons">
+                                    <sui.Button icon={`${state.collapseEditorTools ? 'toggle right' : 'toggle left'}`} class="large collapse-button" title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } />
+                                    {run ? <sui.Button role="menuitem" class="large" key='runmenubtn' icon={state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('tablet') } /> : undefined }
+                                    {restart ? <sui.Button key='restartbtn' class={`large restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('tablet') } /> : undefined }
+                                    {compileBtn ? <sui.Button icon='icon download' class={`large download-button ${compileLoading ? 'loading' : ''}`} title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
+                                </div>
+                            </div> :
+                            <div className="ui item">
+                                <sui.Button icon={`${state.collapseEditorTools ? 'toggle right' : 'toggle left'}`} class="large collapse-button" title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } />
+                                {compileBtn ? <sui.Button icon='icon download' class={`huge fluid download-button ${compileLoading ? 'loading' : ''}`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
+                            </div>
+                        }
                     </div>
                     {readOnly ? undefined :
                         <div className="column left aligned">

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -36,18 +36,27 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
             })
         },
         removeElement: (el, completeHandler) => {
-            ($(el) as any).transition({
-                animation: pxt.appTarget.appTheme.simAnimationExit || 'fly right out',
-                duration: '0.5s',
-                onComplete: function () {
+            if (pxt.appTarget.simulator.headless) {
+                $(el).addClass('simHeadless');
+                completeHandler();
+            }
+            else {
+                ($(el) as any).transition({
+                    animation: pxt.appTarget.appTheme.simAnimationExit || 'fly right out',
+                    duration: '0.5s',
+                    onComplete: function () {
+                        if (completeHandler) completeHandler();
+                        $(el).remove();
+                    }
+                }).error(() => {
+                    // Problem with animation, still complete
                     if (completeHandler) completeHandler();
                     $(el).remove();
-                }
-            }).error(() => {
-                // Problem with animation, still complete
-                if (completeHandler) completeHandler();
-                $(el).remove();
-            })
+                })
+            }
+        },
+        unhideElement: (el) => {
+            $(el).removeClass("simHeadless");
         },
         onDebuggerBreakpoint: function (brk) {
             updateDebuggerButtons(brk)
@@ -150,9 +159,15 @@ export function stop(unload?: boolean) {
 }
 
 export function hide(completeHandler?: () => void) {
-    pxsim.U.addClass(driver.container, "sepia");
+    if (!pxt.appTarget.simulator.headless) {
+        pxsim.U.addClass(driver.container, "sepia");
+    }
     driver.hide(completeHandler);
     $debugger.empty();
+}
+
+export function unhide() {
+    driver.unhide();
 }
 
 export function proxy(message: pxsim.SimulatorCustomMessage) {


### PR DESCRIPTION
Also, targets that set headless to true will default to a collapsed simulator.