### PR TITLE
Decompiler should handle property access expressions that aren't enums

### DIFF
--- a/tests/decompile-test/always_decompile_classes.ts
+++ b/tests/decompile-test/always_decompile_classes.ts
@@ -1,0 +1,10 @@
+/// <reference path="./testBlocks/mb.ts" />
+
+class Foo {
+    x: number;
+    constructor() {
+        this.x = 0
+    }
+}
+let y = new Foo()
+basic.showNumber(y.x)

--- a/tests/decompile-test/baselines/always_decompile_classes.blocks
+++ b/tests/decompile-test/baselines/always_decompile_classes.blocks
@@ -1,0 +1,24 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="typescript_statement">
+<mutation numlines="6" line0="class Foo &#123;" line1="    x&#58; number&#59;" line2="    constructor&#40;&#41; &#123;" line3="        this.x &#61; 0" line4="    &#125;" line5="&#125;" />
+<next>
+<block type="typescript_statement">
+<mutation declaredvars="y" numlines="1" line0="let y &#61; new Foo&#40;&#41;" />
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="typescript_expression">
+<field name="EXPRESSION">y.x</field>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;mb.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/testBlocks/mb.ts
+++ b/tests/decompile-test/testBlocks/mb.ts
@@ -141,4 +141,15 @@ declare namespace basic {
     //% block="show leds" icon="\uf00a"
     //% parts="ledmatrix" interval.defl=400 shim=basic::showLeds
     export function showLeds(leds: string, interval?: number): void;
+
+    /**
+     * Scroll a number on the screen. If the number fits on the screen (i.e. is a single digit), do not scroll.
+     * @param interval speed of scroll; eg: 150, 100, 200, -100
+     */
+    //% help=basic/show-number
+    //% weight=96
+    //% blockId=device_show_number block="show|number %number" blockGap=8
+    //% async
+    //% parts="ledmatrix" interval.defl=150 shim=basic::showNumber
+    export function showNumber(value: number, interval?: number): void;
 }


### PR DESCRIPTION
No issue open for this one, but the problem was that Enums are treated as a special case for the decompiler and that meant that property access expressions on class members were not decompiled properly.