### PR TITLE
Bump with optional update

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -526,7 +526,7 @@ function justBumpPkgAsync() {
 }
 
 function bumpAsync(parsed: commandParser.ParsedCommand) {
-    const bumpPxt = !parsed.flags["noupdate"];
+    const bumpPxt = parsed.flags["update"];
     const upload = parsed.flags["upload"];
     if (fs.existsSync(pxt.CONFIG_NAME)) {
         if (upload) throw U.userError("upload only supported on packages");
@@ -3786,7 +3786,7 @@ function initCommands() {
         name: "bump",
         help: "bump target or package version",
         flags: {
-            noupdate: { description: "Don't publish the updated version" },
+            update: { description: "(package only) Updates pxt-core reference to the latest release" },
             upload: { description: "(package only) Upload after bumping" }
         }
     }, bumpAsync);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,3 +77,5 @@ where ``EMBEDURL`` is the published project URL.
 * [build](/cli/build), builds the current project
 * [deploy](/cli/deploy), builds and deploys the current project
 * [login](/cli/login), store a GitHub token
+* [bump](/cli/bump), increment the version number
+* [update](/cli/update), updates the ``pxt-core`` dependency and runs installation steps

--- a/docs/cli/bump.md
+++ b/docs/cli/bump.md
@@ -1,0 +1,24 @@
+# pxt-bump Manual Page
+
+### @description Bumps the current version number
+
+Bumps the version number of the package.
+
+```
+pxt bump [--update] [--upload] 
+```
+
+## Options
+
+### --update
+
+Updates the pxt-core dependency version to the latest tag.
+
+
+### --upload
+
+Uploads the target upon bumping
+
+## See Also
+
+[pxt](/cli) tool

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -1,0 +1,13 @@
+# pxt-update Manual Page
+
+### @description Updates the pxt-core dependency version to the latest tag.
+
+Updates the pxt-core dependency version to the latest tag.
+
+```
+pxt update
+```
+
+## See Also
+
+[pxt](/cli) tool


### PR DESCRIPTION
Make pxt-core update optional in "pxt bump" . Use ``pxt bump --update`` to update the pxt reference as well.