### PR TITLE
Fix help text cut off bug, fixes #1445

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -37,7 +37,7 @@
 #maineditor {
     left: @simulatorWidth;
     right: 0;
-    overflow: hidden;
+    overflow: visible;
 }
 .rtl #maineditor {
     left:0;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -345,6 +345,9 @@ div.blocklyWidgetDiv {
 .monacoToolboxDiv.hide {
     display: none;
 }
+.monaco-editor-hover {
+    z-index:1000;
+}
 
 #monacoEditorInner {
     position: relative !important;


### PR DESCRIPTION
Fixes monaco editor help hover text getting cut off the top screen. 