### PR TITLE
swallow cache storage failure

### DIFF
--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -304,7 +304,10 @@ class Host
         return hostCache.forceSetAsync({
             id: id,
             val: val
-        }).then(() => { })
+        }).then(() => { }, e => {
+            pxt.tickEvent('cache.store.failed', { error: e.name });
+            pxt.log(`cache store failed for ${id}: ${e.name}`)
+        })
     }
 
     cacheGetAsync(id: string): Promise<string> {


### PR DESCRIPTION
When a conflict happens trying to cache a stored value, clear cache and try again.