### PR TITLE
Save project to compressed json when no hex file is available

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -840,7 +840,13 @@ export class ProjectView
 
     saveAndCompile() {
         this.saveFile();
-        this.compile(true);
+
+        if (!pxt.appTarget.compile.hasHex) {
+            this.saveProjectToFile();
+        }
+        else {
+            this.compile(true);
+        }
     }
 
     compile(saveOnly = false) {


### PR DESCRIPTION
If the target sets `hasHex` to false, use the download button to save a `.pxt` file (download button does not appear in this scenario)