### PR TITLE
Fixing ie11 tutorial fix.

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -665,7 +665,7 @@ namespace pxt.blocks {
             for (let bi = 0; bi < blocks.length; ++bi) {
                 let blk = blocks.item(bi);
                 let type = blk.getAttribute("type");
-                let catName = blk.parentElement.getAttribute("name");
+                let catName = (blk.parentNode as Element).getAttribute("name");
                 let sticky = blk.getAttribute("sticky");
                 if (!blockSubset[type] && !sticky) {
                     blk.parentNode.removeChild(blk);


### PR DESCRIPTION
Fix issue where IE11 returns null for parentElement. (for XML). 
Having to use parentNode instead. 

Fixes #1431