### PR TITLE
Revert @param regex

### DIFF
--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -407,6 +407,12 @@ namespace ts.pxtc {
                     let v = v0 ? JSON.parse(v0) : (d0 ? (v0 || v1 || v2) : "true");
                     if (U.endsWith(n, ".defl")) {
                         res.paramDefl[n.slice(0, n.length - 5)] = v
+                    } else if (U.endsWith(n, ".min")) {
+                        if (!res.paramMin) res.paramMin = {}
+                        res.paramMin[n.slice(0, n.length - 4)] = v
+                    } else if (U.endsWith(n, ".max")) {
+                        if (!res.paramMax) res.paramMax = {}
+                        res.paramMax[n.slice(0, n.length - 4)] = v
                     } else if (U.startsWith(n, "blockFieldEditorParams")) {
                         if (!res.blockFieldEditorParams) res.blockFieldEditorParams = {}
                         res.blockFieldEditorParams[n.slice(23, n.length)] = v
@@ -428,20 +434,11 @@ namespace ts.pxtc {
         }
 
         res.paramHelp = {}
-        res.paramMin = {}
-        res.paramMax = {}
         res.jsDoc = ""
         cmt = cmt.replace(/\/\*\*([^]*?)\*\//g, (full: string, doccmt: string) => {
             doccmt = doccmt.replace(/\n\s*(\*\s*)?/g, "\n")
-            doccmt = doccmt.replace(/^\s*@param\s+(\w+)\s+(\[.*\])?\s+(.*)$/mg, (full: string, name: string, type: string, desc: string) => {
+            doccmt = doccmt.replace(/^\s*@param\s+(\w+)\s+(.*)$/mg, (full: string, name: string, desc: string) => {
                 res.paramHelp[name] = desc
-                if (type) {
-                    type.replace(/^\[([0-9]+)-([0-9]+)\]$/i, (full: string, min: string, max: string) => {
-                        res.paramMin[name] = min
-                        res.paramMax[name] = max
-                        return ""
-                    })
-                }
                 return ""
             })
             res.jsDoc += doccmt

--- a/pxtlib/emitter/service.ts
+++ b/pxtlib/emitter/service.ts
@@ -270,8 +270,8 @@ namespace ts.pxtc {
                 parameters: !hasParams ? null : (decl.parameters || []).map(p => {
                     let n = getName(p)
                     let desc = attributes.paramHelp[n] || ""
-                    let minVal = attributes.paramMin[n] || undefined
-                    let maxVal = attributes.paramMax[n] || undefined
+                    let minVal = attributes.paramMin ? attributes.paramMin[n] : undefined
+                    let maxVal = attributes.paramMax ? attributes.paramMax[n] : undefined
                     let m = /\beg\.?:\s*(.+)/.exec(desc)
                     let props: PropertyDesc[];
                     if (attributes.mutate && p.type.kind === SK.FunctionType) {


### PR DESCRIPTION
Reverting to previous regex for the @param. Using parameter.min and parameter.max in the comments to set min and max values for a parameter.