### PR TITLE
Feedback and Getting started in the Menu

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -138,6 +138,7 @@ declare namespace pxt {
         hideSideDocs?: boolean;
         sideDoc?: string; // if set: show the getting started button, clicking on getting started button links to that page
         hasReferenceDocs?: boolean; // if true: the monaco editor will add an option in the context menu to load the reference docs
+        feedbackUrl?: string; // is set: a feedback link will show in the settings menu
         boardName?: string;
         privacyUrl?: string;
         termsOfUseUrl?: string;
@@ -178,6 +179,7 @@ declare namespace pxt {
         name: string;
         // needs to have one of `path` or `subitems`
         path?: string;
+        tutorial?: boolean;
         subitems?: DocMenuEntry[];
     }
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -114,6 +114,8 @@ namespace pxt.editor {
         toggleSimulatorCollapse(): void;
         proxySimulatorMessage(content: string): void;
 
+        startTutorial(tutorialId: string): void;
+
         addPackage(): void;
         typecheckNow(): void;
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1394,6 +1394,8 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                         {targetTheme.termsOfUseUrl ? <a className="ui item" href={targetTheme.termsOfUseUrl} role="menuitem" title={lf("Terms Of Use") } target="_blank">{lf("Terms Of Use") }</a> : undefined}
                                         <sui.Item role="menuitem" text={lf("About...") } onClick={() => this.about() } />
                                         {electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...") } onClick={() => electron.checkForUpdate() } /> : undefined}
+                                        {targetTheme.feedbackUrl ? <div className="ui divider"></div> : undefined }
+                                        {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback") } target="_blank">{lf("Give Feedback") }</a> : undefined}
                                     </sui.DropdownMenuItem> }
 
                                 {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Edit") } onClick={() => this.launchFullEditor() } /> : undefined}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -20,12 +20,20 @@ export class DocsMenuItem extends data.Component<ISettingsProps, {}> {
         this.props.parent.setSideDoc(path);
     }
 
+    openTutorial(path: string) {
+        pxt.tickEvent(`docstutorial`, { path });
+        this.props.parent.startTutorial(path);
+    }
+
     render() {
         const targetTheme = pxt.appTarget.appTheme;
         const sideDocs = !(pxt.shell.isSandboxMode() || pxt.options.light || targetTheme.hideSideDocs);
         return <sui.DropdownMenuItem icon="help circle large" class="help-dropdown-menuitem" textClass={"landscape only"} title={lf("Reference, lessons, ...") }>
-            {targetTheme.docMenu.map(m => <a href={m.path} target="docs" key={"docsmenu" + m.path} role="menuitem" title={m.name} className={`ui item ${sideDocs && !/^https?:/i.test(m.path) ? "widedesktop hide" : ""}`}>{m.name}</a>) }
-            {sideDocs ? targetTheme.docMenu.filter(m => !/^https?:/i.test(m.path)).map(m => <sui.Item key={"docsmenuwide" + m.path} role="menuitem" text={m.name} class="widedesktop only" onClick={() => this.openDoc(m.path) } />) : undefined  }
+            {targetTheme.docMenu.map(m =>
+               !m.tutorial ? <a href={m.path} target="docs" key={"docsmenu" + m.path} role="menuitem" title={m.name} className={`ui item ${sideDocs && !/^https?:/i.test(m.path) ? "widedesktop hide" : ""}`}>{m.name}</a>
+                : <sui.Item key={"docsmenututorial" + m.path} role="menuitem" text={m.name} class="" onClick={() => this.openTutorial(m.path) } />
+                ) }
+            {sideDocs ? targetTheme.docMenu.filter(m => !/^https?:/i.test(m.path) && !m.tutorial).map(m => <sui.Item key={"docsmenuwide" + m.path} role="menuitem" text={m.name} class="widedesktop only" onClick={() => this.openDoc(m.path) } />) : undefined  }
         </sui.DropdownMenuItem>
     }
 }


### PR DESCRIPTION
Feedback button:
![screen shot 2017-03-06 at 3 09 58 pm](https://cloud.githubusercontent.com/assets/16690124/23634469/2d8e5f5c-027f-11e7-831b-d7d956daa951.png)

based on feedbackUrl path in target.

Getting started: 
![screen shot 2017-03-06 at 3 09 52 pm](https://cloud.githubusercontent.com/assets/16690124/23634472/2f720422-027f-11e7-93ef-6cd2825c97e2.png)

based on tutorial:true field for docsMenu in target.
Note: this will support adding other tutorials in the Menu.

Fixes #1541