### PR TITLE
Subcategories redo

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -199,7 +199,7 @@ namespace pxt.blocks {
                     }
 
                     if (nsn && nsn.attributes.advanced) {
-                        parentCategoryList = getOrAddSubcategory(tb, Util.lf("{id:category}Advanced"), "Advanced", 1, "#3c3c3c", 'blocklyTreeIconadvanced')
+                        parentCategoryList = getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Advanced"), "Advanced", 1, "#3c3c3c", 'blocklyTreeIconadvanced')
                         categories = getChildCategories(parentCategoryList)
                     }
 
@@ -216,7 +216,20 @@ namespace pxt.blocks {
                         parentCategoryList.appendChild(category);
                 }
                 if (fn.attributes.advanced) {
-                    category = getOrAddSubcategory(category, lf("More"), "More", 1, category.getAttribute("colour"), 'blocklyTreeIconmore')
+                    category = getOrAddSubcategoryByWeight(category, lf("More"), "More", 1, category.getAttribute("colour"), 'blocklyTreeIconmore')
+                }
+                else if (fn.attributes.subcategory) {
+                    const sub = fn.attributes.subcategory;
+                    const all = nsn.attributes.subcategories;
+                    if (all && all.indexOf(sub) !== -1) {
+                        // Respect the weights given by the package
+                        const weight = 10000 - all.indexOf(sub);
+                        category = getOrAddSubcategoryByWeight(category, sub, sub, weight, category.getAttribute("colour"), 'blocklyTreeIconmore')
+                    }
+                    else {
+                        // If no weight is specified, insert alphabetically after the weighted subcategories but above "More"
+                        category = getOrAddSubcategoryByName(category, sub, sub, category.getAttribute("colour"), 'blocklyTreeIconmore')
+                    }
                 }
             }
             if (fn.attributes.mutateDefaults) {
@@ -301,14 +314,78 @@ namespace pxt.blocks {
         return result;
     }
 
-    function getOrAddSubcategory(parent: Element, name: string, nameid: string, weight: number, colour?: string, iconClass?: string) {
+    function getOrAddSubcategoryByWeight(parent: Element, name: string, nameid: string, weight: number, colour?: string, iconClass?: string) {
         const existing = parent.querySelector(`category[nameid="${nameid.toLowerCase()}"]`);
         if (existing) {
             return existing;
         }
 
         const newCategory = createCategoryElement(name, nameid, weight, colour, iconClass);
-        parent.appendChild(newCategory)
+        const siblings = parent.querySelectorAll("category");
+
+        let ci = 0;
+        for (ci = 0; ci < siblings.length; ++ci) {
+            let cat = siblings[ci];
+            if (parseInt(cat.getAttribute("weight") || "50") < weight) {
+                parent.insertBefore(newCategory, cat);
+                break;
+            }
+        }
+        if (ci == siblings.length)
+            parent.appendChild(newCategory);
+
+        return newCategory;
+    }
+
+    function getOrAddSubcategoryByName(parent: Element, name: string, nameid: string, colour?: string, iconClass?: string) {
+        const existing = parent.querySelector(`category[nameid="${nameid.toLowerCase()}"]`);
+        if (existing) {
+            return existing;
+        }
+
+        const newCategory = createCategoryElement(name, nameid, 100, colour, iconClass);
+
+        const siblings = parent.querySelectorAll("category");
+        const filtered: Element[] = [];
+
+        let ci = 0;
+        let inserted = false;
+        let last: Element = undefined;
+        for (ci = 0; ci < siblings.length; ++ci) {
+            let cat = siblings[ci];
+            const sibWeight = parseInt(cat.getAttribute("weight") || "50")
+
+            if (sibWeight >= 1000) {
+                continue;
+            }
+            else if (sibWeight === 1) {
+                last = cat;
+                break;
+            }
+
+            filtered.push(cat);
+
+            if (!inserted && cat.getAttribute("name").localeCompare(name) >= 0) {
+                parent.insertBefore(newCategory, cat);
+                filtered.splice(filtered.length - 1, 0, newCategory);
+                inserted = true;
+            }
+        }
+
+        if (!inserted) {
+            filtered.push(newCategory);
+
+            if (last) {
+                parent.insertBefore(newCategory, last);
+            }
+            else {
+                parent.appendChild(newCategory);
+            }
+        }
+
+        filtered.forEach((e, i) => {
+            e.setAttribute("weight", (200 - i).toString());
+        });
 
         return newCategory;
     }
@@ -679,7 +756,7 @@ namespace pxt.blocks {
 
         // Add the "Add package" category
         if (tb && showCategories && pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
-            getOrAddSubcategory(tb, Util.lf("{id:category}Add Package"), "Add Package", 1, "#717171", 'blocklyTreeIconaddpackage')
+            getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Add Package"), "Add Package", 1, "#717171", 'blocklyTreeIconaddpackage')
         }
 
         // Filter the blocks

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -307,6 +307,11 @@ namespace ts.pxtc {
         deprecated?: boolean;
         useEnumVal?: boolean; // for conversion from typescript to blocks with enumVal
 
+        // On block
+        subcategory?: string;
+        // On namepspace
+        subcategories?: string[];
+
         // on interfaces
         indexerGet?: string;
         indexerSet?: string;
@@ -452,6 +457,14 @@ namespace ts.pxtc {
             res.callingConvention = ir.CallingConvention.Async
         if (res.promise)
             res.callingConvention = ir.CallingConvention.Promise
+        if (res.subcategories) {
+            try {
+                res.subcategories = JSON.parse(res.subcategories as any);
+            }
+            catch (e) {
+                res.subcategories = undefined;
+            }
+        }
 
         return res
     }


### PR DESCRIPTION
Resurrecting this old PR, updated to master. Allows namespace to have subcategories. By default subcategories are sorted by name, but namespaces may also specify an ordering as an array of strings. The ordering is always deterministic. Not really sure how to do localization, @pelikhan thoughts?