### PR TITLE
Fix project dialog freezing

### DIFF
--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -18,6 +18,14 @@ export type Component<S, T> = data.Component<S, T>;
 export function hideLoading() {
     $('.ui.page.dimmer .loadingcontent').remove();
     $('body.main').dimmer('hide');
+
+    // If hiding failed, then the dimmer was probably never initialized
+    if (!$('.ui.page.dimmer').hasClass('hidden')) {
+        $('body.main').dimmer({
+            closable: false
+        });
+        $('body.main').dimmer('hide');
+    }
 }
 
 export function showLoading(msg: string) {

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -15,23 +15,22 @@ const lf = Util.lf;
 
 export type Component<S, T> = data.Component<S, T>;
 
+let dimmerInitialized = false;
+
 export function hideLoading() {
     $('.ui.page.dimmer .loadingcontent').remove();
     $('body.main').dimmer('hide');
 
-    // If hiding failed, then the dimmer was probably never initialized
-    if (!$('.ui.page.dimmer').hasClass('hidden')) {
+    if (!dimmerInitialized) {
         $('body.main').dimmer({
             closable: false
         });
-        $('body.main').dimmer('hide');
     }
+    $('body.main').dimmer('hide');
 }
 
 export function showLoading(msg: string) {
-    $('body.main').dimmer({
-        closable: false
-    });
+    initializeDimmer();
     $('body.main').dimmer('show');
     $('.ui.page.dimmer').html(`
   <div class="content loadingcontent">
@@ -39,6 +38,13 @@ export function showLoading(msg: string) {
   </div>
 `)
     $('.ui.page.dimmer .msg').text(msg)
+}
+
+function initializeDimmer() {
+    $('body.main').dimmer({
+        closable: false
+    });
+    dimmerInitialized = true;
 }
 
 let asyncLoadingTimeout: number;

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -22,9 +22,7 @@ export function hideLoading() {
     $('body.main').dimmer('hide');
 
     if (!dimmerInitialized) {
-        $('body.main').dimmer({
-            closable: false
-        });
+        initializeDimmer();
     }
     $('body.main').dimmer('hide');
 }


### PR DESCRIPTION
This was a race condition that only happened when Blockly loaded too fast and the loading dimmer never got initialized. In that case, the dimmer would get created incorrectly and start consuming all the clicks for the projects dialog for some reason.