### PR TITLE
Monaco toolbox blocks

### DIFF
--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -686,7 +686,7 @@ span.blocklyTreeIcon {
     border-bottom-right-radius: 8px;
 }
 
-.monacoFlyout div {
+.monacoFlyout > div {
     margin: 1.1rem;
 }
 
@@ -696,6 +696,7 @@ span.blocklyTreeIcon {
     border-radius: 8px;
     border: solid 3px @white;
     cursor: pointer;
+    display: inline-block;
     -moz-user-select: none;
     -ms-user-select: none;
     -webkit-user-select: none;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -702,6 +702,7 @@ export class Editor extends srceditor.Editor {
                     + (fn1.metaData && fn1.metaData.blockId ? 10000 : 0)
                     return w2 - w1;
                 }).forEach((fn) => {
+                    let monacoBlockArea = document.createElement('div');
                     let monacoBlock = document.createElement('div');
                     monacoBlock.className = 'monacoDraggableBlock';
 
@@ -781,7 +782,8 @@ export class Editor extends srceditor.Editor {
 
                     monacoBlock.appendChild(methodToken);
                     monacoBlock.appendChild(sigToken);
-                    monacoFlyout.appendChild(monacoBlock);
+                    monacoBlockArea.appendChild(monacoBlock);
+                    monacoFlyout.appendChild(monacoBlockArea);
                 })
             }
         };


### PR DESCRIPTION
Updating the monaco toolbox blocks so that they look more like blocks

Before: 
<img width="682" alt="screen shot 2017-03-17 at 9 39 37 am" src="https://cloud.githubusercontent.com/assets/16690124/24017657/b98aad3e-0af5-11e7-9875-045fd5804925.png">

After: 
<img width="738" alt="screen shot 2017-03-17 at 9 39 45 am" src="https://cloud.githubusercontent.com/assets/16690124/24017660/bd7b777a-0af5-11e7-8869-abf1314e3ab3.png">
