### PR TITLE
New Embedded Thin View

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -53,6 +53,7 @@ namespace pxt.editor {
         showParts?: boolean;
         fullscreen?: boolean;
         mute?: boolean;
+        embedSimView?: boolean;
     }
 
     export interface ProjectCreationOptions {

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -10,6 +10,10 @@
              Layout
 *******************************/
 
+html, body {
+    min-width: 320px;
+}
+
 /* Main Layout */
 #filelist,
 #maineditor,
@@ -268,27 +272,28 @@ div.simframe > iframe {
 /* Menu */
 #menubar .ui.menu .item.editor-menuitem {
     background: fade(@black, 30%) !important;
-    margin: 0.5rem;
-    padding: 0.7rem;
+    margin: calc(@mainMenuHeight/10);
+    padding: calc(@mainMenuHeight/10);
     border-radius: 0.5rem !important;
 }
-.sandbox .ui.menu.fixed .item:first-child {
-    border-radius: 0.5rem !important;
+.ui.menu.fixed .item.editor-menuitem .item {
+    border-radius: 0px !important;
 }
-.ui.menu.fixed .item.blocks-menuitem, .ui.menu.fixed .item.javascript-menuitem {
-    border-radius: 0.2rem !important;
+.ui.inverted.menu.fixed .item.editor-menuitem :first-child {
+    border-top-left-radius: 0.2rem !important;
+    border-bottom-left-radius: 0.2rem !important;
 }
-.ui.inverted.menu .item.blocks-menuitem {
-    border-top-right-radius: 0px !important;
-    border-bottom-right-radius: 0px !important;
+.ui.inverted.menu.fixed .item.editor-menuitem :first-child[style*="display:none"] + .ui.inverted.menu.fixed .item.editor-menuitem :not([style*="display:none"]) {
+    border-top-left-radius: 0.2rem !important;
+    border-bottom-left-radius: 0.2rem !important;
 }
-.ui.inverted.menu .item.javascript-menuitem {
-    border-top-left-radius: 0px !important;
-    border-bottom-left-radius: 0px !important;
+.ui.inverted.menu.fixed .item.editor-menuitem :last-child {
+    border-top-right-radius: 0.2rem !important;
+    border-bottom-right-radius: 0.2rem !important;
 }
 
 // Add a transition between the blocks / js menu item toggle options
-.ui.inverted.menu .item.blocks-menuitem, .ui.inverted.menu .item.javascript-menuitem {
+.ui.inverted.menu .item.editor-menuitem .item {
     -webkit-transition: background 1s; /* Safari */
     -moz-transition: background 1s; /* Mozilla */
     -webkit-transition-timing-function: ease-in; /* Mozilla */
@@ -358,10 +363,12 @@ div.simframe > iframe {
 .sandboxfooter {
     position:absolute;
     bottom:0rem;
-    right:1rem;
-    z-index:5;
-    font-size: 0.7rem;
+    right:0rem;
+    z-index:100;
     margin-bottom: 0.2rem !important;
+}
+.sandboxfooter .item{
+    font-size: 0.8rem !important;
 }
 .rtl .sandboxfooter{
     right: auto;
@@ -420,6 +427,17 @@ div.simframe > iframe {
 }
 .ui.button.getting-started-btn {
     &:extend(.green all);
+}
+
+/* Icon and text */
+#content .ui.button > .icon-and-text {
+    margin-right: 4px;
+    margin-left: -2px;
+}
+
+.rtl #content .ui.button > .icon-and-text {
+    margin-left: 4px;
+    margin-right: -2px;
 }
 
 /*******************************
@@ -767,6 +785,9 @@ Avatar
 .ui.tablet.only {
     display:none !important;
 }
+.ui.mobile.only {
+    display: none !important;
+}
 
 @media only screen and (min-width: @largeMonitorBreakpoint) and (min-height:30em) {
     .ui.widedesktop.only {
@@ -814,21 +835,24 @@ Avatar
     }
 }
 
-/* Screens with decent vertical space */
+/* Mobile only */
+@media only screen and (max-width: @largestMobileScreen) {
+    .ui.mobile.only {
+        display:inherit !important;
+    }
+    .ui.mobile.hide {
+        display:none !important;
+    }
+}
+
+/* Scren heights */
 @media only screen and (max-height: @tallEditorBreakpoint) {
     .ui.tall.only {
         display:none !important;
     }
 }
-
-@media only screen and (min-width: @mobileBreakpoint) {
+@media only screen and (min-height: @thinEditorBreakpoint) {
     .ui.thin.only {
-        display:none !important;
-    }
-}
-
-@media only screen and (max-width: @mobileBreakpoint) {
-    .ui.wide.only {
         display:none !important;
     }
 }
@@ -1098,18 +1122,25 @@ Avatar
     }
     /* Menu spacing */
     #menubar .ui.menu .item {
-        padding: 0.4em !important;
+        padding: 0.3em !important;
     }
     #menubar .ui.menu .item.editor-menuitem {
-        margin-top: ((@mobileMenuHeight - 2.5rem)/2) !important;
-        margin-bottom: ((@mobileMenuHeight - 2.5rem)/2) !important;
+        margin: calc(@mobileMenuHeight/10);
+        padding: calc(@mobileMenuHeight/10);
+    }
+    .sandbox #menubar .ui.menu .item.editor-menuitem {
+        margin: calc(@sandboxMobileMenuHeight/10);
+        padding: calc(@sandboxMobileMenuHeight/10);
     }
     /* Top Menu */
     #maineditor {
-        top:@mainMenuHeight;
+        top: @mobileMenuHeight;
     }
     .hideMenuBar #maineditor {
         top: 0;
+    }
+    .sandbox #maineditor {
+        top: @sandboxMobileMenuHeight;
     }
 
     /* Logo */
@@ -1126,7 +1157,7 @@ Avatar
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
     /* Logo */
-    #logo {
+    #logo, #organization {
         font-size: 0rem;
         padding-right: 0;
     }
@@ -1169,5 +1200,117 @@ Avatar
     }
     .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
         bottom: 5rem !important;
+    }
+}
+
+/* Mobile, Tablet AND thin screen */
+@media only screen and (max-width: @largestTabletScreen) and (max-height: @thinEditorBreakpoint) {
+    /* Mobile embedded view */
+    .sandbox #simulators{
+        display: none;
+    }
+    .sandbox #maineditor {
+        overflow: hidden;
+    }
+    .sandbox #blocksArea,
+        .sandbox #monacoEditor,
+        .sandbox #pxtJsonEditor,
+        .sandbox #editortools,
+        .sandbox #msg {
+        bottom: 1.5rem !important;
+    }
+    .sandbox #cookiemsg {
+        bottom: 3rem;
+    }
+    .sandbox #editortools {
+        display: none;
+    }
+    .simView #simulators {
+        display: inherit;
+    }
+    .simView #filelist {
+        position: fixed;
+        z-index:100;
+        top:0 !important;
+        left:0 !important;
+        bottom:0 !important;
+        right:0 !important;
+        padding: 0;
+        margin: 0;
+        max-width: 100%;
+        min-width: 100%;
+        height:100%;
+    }
+    .simView #boardview {
+        position: relative;
+        height:100%;
+        background-color: white;
+        padding-top: @sandboxMobileMenuHeight;
+        padding-left: 2em;
+        padding-right: 2em;
+        padding-bottom: 2em;
+
+        background-color: @fullscreenBackgroundGradientStart;
+        background: @fullscreenBackgroundGradientStart; /* For browsers that do not support gradients */
+        background: -webkit-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Safari 5.1 to 6.0 */
+        background: -o-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Opera 11.1 to 12.0 */
+        background: -moz-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Firefox 3.6 to 15 */
+        background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
+    }
+    .simView #simulator .ui.item,
+        .simView #maineditor {
+        display: none !important;
+        z-index: -10;
+    }
+    .sandboxfooter {
+        left: 0.5em !important;
+        right: 0.5em !important;
+        margin: 0rem !important;
+        right: auto;
+        text-align: center;
+    }
+    .sandboxfooter .item{
+        font-size: 0.7rem !important;
+    }
+    .rtl .sandbox .sandboxfooter {
+        right: 0.5em;
+        left: auto;
+    }
+    .simView .sandboxfooter {
+        z-index:100;
+    }
+    .simView .ui.menu {
+        background: transparent !important;
+    }
+    .simView #simulators {
+        position: relative;
+        width: 100%;
+        height: 100%;
+    }
+    .simView div.simframe {
+        position:relative;
+        width: 50%;
+        height: 100%;
+        float: left;
+        padding-bottom: 0 !important;
+    }
+    .simView div.simframe > iframe {
+        position:relative;
+        max-width: 90%;
+    }
+    .simView div.simframe:only-child {
+        width: 100%;
+    }
+    .simView div.simframe:only-child > iframe {
+        max-width: 100%;
+    }
+    .sandbox #cookiemsg {
+        left: 0;
+        right: 0;
+        margin-left: 0.2rem;
+        margin-right: 0.2rem;
+        width: inherit;
+        bottom: 1.5rem;
+        padding: 0.3rem;
     }
 }

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -1121,12 +1121,15 @@ Avatar
         display: none;
     }
     /* Menu spacing */
-    #menubar .ui.menu .item {
+    #root:not(.sandbox) #menubar .ui.menu .item {
         padding: 0.3em !important;
     }
     #menubar .ui.menu .item.editor-menuitem {
         margin: calc(@mobileMenuHeight/10);
         padding: calc(@mobileMenuHeight/10);
+    }
+    #menubar .ui.menu .item.editor-menuitem .item {
+        padding: 0.4em !important;
     }
     .sandbox #menubar .ui.menu .item.editor-menuitem {
         margin: calc(@sandboxMobileMenuHeight/10);

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -23,6 +23,13 @@
         height: @mobileMenuHeight !important;
         min-height: @mobileMenuHeight !important;
     }
+    .sandbox #menubar .ui.menu {
+        height: @sandboxMobileMenuHeight !important;
+        min-height: @sandboxMobileMenuHeight !important;
+    }
+    .ui.menu .item > i.icon {
+        margin: 0;
+    }
 }
 
 .ui.inverted.menu .active.item {

--- a/theme/themes/pxt/collections/menu.variables
+++ b/theme/themes/pxt/collections/menu.variables
@@ -6,4 +6,4 @@
 
 @background: @mainMenuBackground;
 @invertedBackground: @mainMenuInvertedBackground;
-@mainMenuMinHeight: @minHeight;
+@mainMenuMinHeight: @mainMenuHeight;

--- a/theme/themes/pxt/elements/header.overrides
+++ b/theme/themes/pxt/elements/header.overrides
@@ -1,3 +1,9 @@
 /*******************************
          Site Overrides
 *******************************/
+
+@media only screen and (max-width: @largestMobileScreen) {
+    .ui.modal > .header {
+        padding-right: 0.75rem !important;
+    }
+}

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -42,6 +42,7 @@
 */
 
 @tallEditorBreakpoint: 44rem;
+@thinEditorBreakpoint: 24rem;
 
 /*******************************
      PXT Variables
@@ -57,8 +58,9 @@
 @mainMenuInvertedBackground: @black;
 @mainMenuTutorialBackground: @orange;
 
-@mainMenuHeight: 5.0rem;
+@mainMenuHeight: 4.5rem;
 @mobileMenuHeight: 3.5rem;
+@sandboxMobileMenuHeight: 2.5rem;
 
 @mainMenuBlocksJsToggleColor: @primaryColor;
 

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -52,16 +52,6 @@ body {
     right: 8px;
 }
 
-#content .ui.button > .icon-and-text {
-    margin-right: 4px;
-    margin-left: -2px;
-}
-
-.rtl #content .ui.button > .icon-and-text {
-    margin-left: 4px;
-    margin-right: -2px;
-}
-
 .ui.button.icon.clear {
     background: transparent;
     padding: 0;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -184,12 +184,12 @@ export class ProjectView
     }
 
     private isBlocksActive(): boolean {
-        return this.editor == this.blocksEditor
+        return !this.state.embedSimView && this.editor == this.blocksEditor
             && this.editorFile && this.editorFile.name == "main.blocks";
     }
 
     private isJavaScriptActive(): boolean {
-        return this.editor == this.textEditor
+        return !this.state.embedSimView && this.editor == this.textEditor
             && this.editorFile && this.editorFile.name == "main.ts";
     }
 
@@ -200,14 +200,20 @@ export class ProjectView
 
     openJavaScript() {
         pxt.tickEvent("menu.javascript");
-        if (this.isJavaScriptActive()) return;
+        if (this.isJavaScriptActive()) {
+            if (this.state.embedSimView) this.setState({embedSimView: false});
+            return;
+        }
         if (this.isBlocksActive()) this.blocksEditor.openTypeScript();
         else this.setFile(pkg.mainEditorPkg().files["main.ts"])
     }
 
     openBlocks() {
         pxt.tickEvent("menu.blocks");
-        if (this.isBlocksActive()) return;
+        if (this.isBlocksActive()) {
+            if (this.state.embedSimView) this.setState({embedSimView: false});
+            return;
+        }
         if (this.isJavaScriptActive()) this.textEditor.openBlocks();
         // any other editeable .ts or pxt.json
         else if (this.isAnyEditeableJavaScriptOrPackageActive()) {
@@ -233,6 +239,16 @@ export class ProjectView
                     header.pubCurrent = false
                 }
             });
+    }
+
+    openSimView() {
+        pxt.tickActivity("menu.simView");
+        if (this.state.embedSimView) {
+            this.startStopSimulator();
+        } else {
+            this.setState({embedSimView: true});
+            this.startSimulator();
+        }
     }
 
     public typecheckNow() {
@@ -378,7 +394,8 @@ export class ProjectView
 
         this.setState({
             currFile: fn,
-            showBlocks: false
+            showBlocks: false,
+            embedSimView: false
         })
         //this.fireResize();
     }
@@ -1347,6 +1364,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         const showMenuBar = !targetTheme.hideMenuBar;
         const cookieKey = "cookieconsent"
         const cookieConsented = targetTheme.hideCookieNotice || electron.isElectron || !!pxt.storage.getLocal(cookieKey);
+        const simActive = this.state.embedSimView;
         const blockActive = this.isBlocksActive();
         const javascriptActive = this.isJavaScriptActive();
 
@@ -1368,6 +1386,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
             pxt.options.light ? 'light' : '',
             pxt.BrowserUtils.isTouchEnabled() ? 'has-touch' : '',
             showMenuBar ? '' : 'hideMenuBar',
+            sandbox && simActive ? 'simView' : '',
             'full-abs'
         ]);
 
@@ -1386,8 +1405,13 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                 {!inTutorial ? <sui.Item class="openproject" role="menuitem" textClass="landscape only" icon="folder open large" text={lf("Projects") } onClick={() => this.openProject() } /> : null}
                                 {!inTutorial && this.state.header && sharingEnabled ? <sui.Item class="shareproject" role="menuitem" textClass="widedesktop only" text={lf("Share") } icon="share alternate large" onClick={() => this.embed() } /> : null}
                                 {inTutorial ? <sui.Item class="tutorialname" role="menuitem" textClass="landscape only" text={tutorialName} /> : null}
-                            </div> : undefined }
+                            </div> : <div className="left menu">
+                                <span id="logo" className="ui item logo">
+                                    <img className="ui mini image" src={Util.toDataUri(rightLogo) } onClick={() => this.launchFullEditor() }/>
+                                </span>
+                            </div> }
                             {!inTutorial && !targetTheme.blocksOnly ? <sui.Item class="editor-menuitem">
+                                {sandbox ? <sui.Item class="sim-menuitem thin portrait only" textClass="landscape only" text={lf("Simulator")} icon={simActive && this.state.running ? "stop" : "play"} active={simActive} onClick={() => this.openSimView() } title={!simActive ? lf("Show Simulator") : runTooltip} /> : undefined }
                                 <sui.Item class="blocks-menuitem" textClass="landscape only" text={lf("Blocks") } icon="puzzle" active={blockActive} onClick={() => this.openBlocks() } title={lf("Convert code to Blocks") } />
                                 <sui.Item class="javascript-menuitem" textClass="landscape only" text={lf("JavaScript") } icon="align left" active={javascriptActive} onClick={() => this.openJavaScript() } title={lf("Convert code to JavaScript") } />
                             </sui.Item> : undefined}
@@ -1400,10 +1424,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                         {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...") } onClick={() => this.addPackage() } /> : undefined}
                                         {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project") } onClick={() => this.removeProject() } /> : undefined}
                                         <div className="ui divider"></div>
-                                        <a className="ui item thin only" href="/docs" role="menuitem" target="_blank">
-                                            <i className="help icon"></i>
-                                            {lf("Help") }
-                                        </a>
                                         {
                                             // we always need a way to clear local storage, regardless if signed in or not
                                         }
@@ -1417,8 +1437,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                         {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback") } target="_blank">{lf("Give Feedback") }</a> : undefined}
                                     </sui.DropdownMenuItem> }
 
-                                {sandbox ? <sui.Item role="menuitem" icon="external" text={lf("Edit") } onClick={() => this.launchFullEditor() } /> : undefined}
-                                {sandbox ? <span className="ui item logo"><img className="ui mini image" src={Util.toDataUri(rightLogo) } /></span> : undefined}
+                                {sandbox ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit") } onClick={() => this.launchFullEditor() } /> : undefined}
                                 {!sandbox && gettingStarted ? <span className="ui item tablet only"><sui.Button class="small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started") } onClick={() => this.gettingStarted() } /></span> : undefined}
 
                                 {inTutorial ? <sui.Item role="menuitem" icon="external" text={lf("Exit tutorial") } textClass="landscape only" onClick={() => this.exitTutorial() } /> : undefined}
@@ -1474,12 +1493,13 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                 {sandbox ? undefined : <projects.Projects parent={this} ref={v => this.projects = v} />}
                 {sandbox || !sharingEnabled ? undefined : <share.ShareEditor parent={this} ref={v => this.shareEditor = v} />}
                 {sandbox ? <div className="ui horizontal small divided link list sandboxfooter">
-                    {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" href={targetTheme.organizationUrl}>{lf("Powered by {0}", targetTheme.organization) }</a> : undefined}
-                    <a target="_blank" className="item" href={targetTheme.termsOfUseUrl}>{lf("Terms of Use") }</a>
-                    <a target="_blank" className="item" href={targetTheme.privacyUrl}>{lf("Privacy") }</a>
+                        {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" href={targetTheme.organizationUrl}>{lf("Powered by {0}", targetTheme.organization) }</a> : undefined}
+                        <a target="_blank" className="item" href={targetTheme.termsOfUseUrl}>{lf("Terms of Use") }</a>
+                        <a target="_blank" className="item" href={targetTheme.privacyUrl}>{lf("Privacy") }</a>
+                        <span className="item"><a className="ui thin portrait only" title={compileTooltip} onClick={() => this.compile() }><i className="icon download"/>{lf("Download")}</a></span>
                 </div> : undefined}
                 {cookieConsented ? undefined : <div id='cookiemsg' className="ui teal inverted black segment">
-                    <button arial-label={lf("Ok") } className="ui right floated icon button" onClick={consentCookie}>
+                    <button arial-label={lf("Ok") } className="ui right floated icon button clear inverted" onClick={consentCookie}>
                         <i className="remove icon"></i>
                     </button>
                     {lf("By using this site you agree to the use of cookies for analytics.") }


### PR DESCRIPTION
Adding new embedded thin view. 
This view is for Sandbox (Embedded) AND Portrait (Tablet + Mobile) AND Thin (<24rem height) views:
<img width="656" alt="screen shot 2017-03-17 at 10 54 14 pm" src="https://cloud.githubusercontent.com/assets/16690124/24039580/a164a104-0b6a-11e7-9014-717c0dc0f721.png">
<img width="467" alt="screen shot 2017-03-17 at 10 54 01 pm" src="https://cloud.githubusercontent.com/assets/16690124/24039579/a1646a0e-0b6a-11e7-9666-d85ae671e41f.png">
<img width="456" alt="screen shot 2017-03-17 at 10 53 17 pm" src="https://cloud.githubusercontent.com/assets/16690124/24039581/a185db94-0b6a-11e7-8632-f01fdad4cf86.png">
<img width="458" alt="screen shot 2017-03-17 at 10 53 11 pm" src="https://cloud.githubusercontent.com/assets/16690124/24039578/a1648d54-0b6a-11e7-9371-a55bcd49915d.png">
<img width="474" alt="screen shot 2017-03-17 at 10 53 04 pm" src="https://cloud.githubusercontent.com/assets/16690124/24039576/a163ed2c-0b6a-11e7-9ec8-e7de7554b9a4.png">
<img width="465" alt="screen shot 2017-03-17 at 10 52 58 pm" src="https://cloud.githubusercontent.com/assets/16690124/24039582/a18b2a7c-0b6a-11e7-86ba-d76d404ace87.png">

> 24 rem height in mobile still resorts to this view: 
<img width="472" alt="screen shot 2017-03-17 at 11 33 53 pm" src="https://cloud.githubusercontent.com/assets/16690124/24039577/a16428e6-0b6a-11e7-9dde-9e2208c62316.png">