### PR TITLE
Fix TOC docs search on IOS Safari.

### DIFF
--- a/docfiles/toc.html
+++ b/docfiles/toc.html
@@ -6,10 +6,10 @@
             Documentation
         </a>
         <div class="item">
-            <form method="get" target="_blank" action="https://www.bing.com/search">
+            <form id="tocsearch2" method="get" target="_blank" action="https://www.bing.com/search">
                 <div class="ui fluid icon input">
                     <input type="hidden" name="q1" value="site:@homeurl@" />
-                    <input type="text" name="q" placeholder="Search...">
+                    <input type="search" name="q" placeholder="Search...">
                     <i class="search link icon"></i>
                 </div>
             </form>

--- a/docfiles/tocheader.html
+++ b/docfiles/tocheader.html
@@ -5,10 +5,10 @@
         Documentation
     </a>
     <div class="item">
-        <form method="get" target="_blank" action="https://www.bing.com/search">
+        <form id="tocsearch1" method="get" action="https://www.bing.com/search">
             <div class="ui fluid icon input">
                 <input type="hidden" name="q1" value="site:@homeurl@" />
-                <input type="text" name="q" placeholder="Search...">
+                <input type="search" name="q" placeholder="Search...">
                 <i class="search link icon"></i>
             </div>
         </form>


### PR DESCRIPTION
#1652

form has id
input type=search
no target _blank for sidebar TOC (so it works in Safari)