### PR TITLE
Global toolbox filters from controller

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1,6 +1,5 @@
 /// <reference path="../localtypings/blockly.d.ts" />
 /// <reference path="../built/pxtlib.d.ts" />
-/// <reference path="../built/pxteditor.d.ts" />
 import Util = pxt.Util;
 
 let lf = Util.lf;
@@ -627,7 +626,19 @@ namespace pxt.blocks {
             e.parentNode.removeChild(e);
     }
 
-    export function createToolbox(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories: boolean = true, filters?: pxt.editor.ProjectFilters): Element {
+    export interface BlockFilters {
+        namespaces?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
+        blocks?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
+        defaultState?: FilterState; // hide, show or disable all by default
+    }
+
+    export enum FilterState {
+        Hidden = 0,
+        Visible = 1,
+        Disabled = 2
+    }
+
+    export function createToolbox(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories: boolean = true, filters?: BlockFilters): Element {
         init();
 
         // create new toolbox and update block definitions
@@ -769,11 +780,11 @@ namespace pxt.blocks {
                     let type = blk.getAttribute("type");
                     let blockState = filters.blocks && filters.blocks[type] != undefined ? filters.blocks[type] : (defaultState != undefined ? defaultState : filters.defaultState);
                     switch (blockState) {
-                        case pxt.editor.FilterState.Hidden:
+                        case FilterState.Hidden:
                             blk.parentNode.removeChild(blk); break;
-                        case pxt.editor.FilterState.Disabled:
+                        case FilterState.Disabled:
                             blk.setAttribute("disabled", "true");
-                        case pxt.editor.FilterState.Visible:
+                        case FilterState.Visible:
                             hasChild = true; break;
                     }
                 }
@@ -825,7 +836,7 @@ namespace pxt.blocks {
         return tb;
     }
 
-    export function initBlocks(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories: boolean = true, filters?: pxt.editor.ProjectFilters): Element {
+    export function initBlocks(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories: boolean = true, filters?: BlockFilters): Element {
         init();
         initTooltip(blockInfo);
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -29,6 +29,7 @@ namespace pxt.editor {
     export interface IAppState {
         active?: boolean; // is this tab visible at all
         header?: pxt.workspace.Header;
+        filters?: pxt.editor.ProjectFilters;
         currFile?: IFile;
         fileState?: string;
         showFiles?: boolean;
@@ -61,7 +62,21 @@ namespace pxt.editor {
         name?: string;
         documentation?: string;
         filesOverride?: pxt.Map<string>;
+        filters?: ProjectFilters;
         temporary?: boolean;
+    }
+
+    export interface ProjectFilters {
+        namespaces?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
+        blocks?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
+        fns?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
+        defaultState?: FilterState; // hide, show or disable all by default
+    }
+
+    export enum FilterState {
+        Hidden = 0,
+        Visible = 1,
+        Disabled = 2
     }
 
     export interface IProjectView {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -26,9 +26,9 @@ export class Editor extends srceditor.Editor {
     currentCommentOrWarning: B.Comment | B.Warning;
     selectedEventGroup: string;
     currentHelpCardType: string;
-    blockSubset: { [index: string]: number };
     showToolboxCategories: boolean = true;
     cachedToolbox: string;
+    filters: pxt.editor.ProjectFilters;
 
     setVisible(v: boolean) {
         super.setVisible(v);
@@ -77,7 +77,7 @@ export class Editor extends srceditor.Editor {
                     let showCategories = this.showToolboxCategories;
                     let showSearch = true;
                     let toolbox = this.getDefaultToolbox(showCategories);
-                    let tb = pxt.blocks.initBlocks(this.blockInfo, toolbox, showCategories, this.blockSubset);
+                    let tb = pxt.blocks.initBlocks(this.blockInfo, toolbox, showCategories, this.filters);
                     this.updateToolbox(tb, showCategories);
                     if (showCategories && showSearch) {
                         pxt.blocks.initSearch(this.editor, tb,
@@ -480,6 +480,11 @@ export class Editor extends srceditor.Editor {
         if (this.currFile && this.currFile != file) {
             this.filterToolbox(null);
         }
+        if (this.parent.state.filters) {
+            this.filterToolbox(this.parent.state.filters);
+        } else {
+            this.filters = null;
+        }
         this.currFile = file;
         return Promise.resolve();
     }
@@ -567,8 +572,8 @@ export class Editor extends srceditor.Editor {
             : new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinition" style="display: none"></xml>`, "text/xml").documentElement;
     }
 
-    filterToolbox(blockSubset?: { [index: string]: number }, showCategories: boolean = true): Element {
-        this.blockSubset = blockSubset;
+    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories: boolean = true): Element {
+        this.filters = filters;
         this.showToolboxCategories = showCategories;
         return this.refreshToolbox();
     }
@@ -577,7 +582,7 @@ export class Editor extends srceditor.Editor {
         if (!this.blockInfo) return undefined;
 
         let toolbox = this.getDefaultToolbox(this.showToolboxCategories);
-        let tb = pxt.blocks.createToolbox(this.blockInfo, toolbox, this.showToolboxCategories, this.blockSubset);
+        let tb = pxt.blocks.createToolbox(this.blockInfo, toolbox, this.showToolboxCategories, this.filters);
         this.updateToolbox(tb, this.showToolboxCategories);
 
         pxt.blocks.cachedSearchTb = tb;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -641,6 +641,20 @@ export class Editor extends srceditor.Editor {
         fns?: pxt.Map<pxt.vs.MethodDef>,
         onClick?: () => void,
         category?: string) {
+        // Filter the toolbox
+        let filters = this.parent.state.filters;
+        const categoryState = filters ? (filters.namespaces && filters.namespaces[ns] != undefined ? filters.namespaces[ns] : filters.defaultState) : undefined;
+        let hasChild = false;
+        if (filters) {
+            Object.keys(fns).forEach((fn) => {
+                const fnState = filters.fns && filters.fns[fn] != undefined ? filters.fns[fn] : (categoryState != undefined ? categoryState : filters.defaultState);
+                if (fnState == pxt.editor.FilterState.Disabled || fnState == pxt.editor.FilterState.Visible) hasChild = true;
+            })
+        } else {
+            hasChild = true;
+        }
+        if (!hasChild) return;
+
         let appTheme = pxt.appTarget.appTheme;
         let monacoEditor = this;
         // Create a tree item
@@ -702,14 +716,20 @@ export class Editor extends srceditor.Editor {
                     + (fn1.metaData && fn1.metaData.blockId ? 10000 : 0)
                     return w2 - w1;
                 }).forEach((fn) => {
+                    let monacoBlockDisabled = false;
+                    const fnState = filters ? (filters.fns && filters.fns[fn] != undefined ? filters.fns[fn] : (categoryState != undefined ? categoryState : filters.defaultState)) : undefined;
+                    monacoBlockDisabled = fnState == pxt.editor.FilterState.Disabled;
+                    if (fnState == pxt.editor.FilterState.Hidden) return;
+
                     let monacoBlockArea = document.createElement('div');
                     let monacoBlock = document.createElement('div');
                     monacoBlock.className = 'monacoDraggableBlock';
 
                     monacoBlock.style.fontSize = `${monacoEditor.parent.settings.editorFontSize}px`;
-                    monacoBlock.style.backgroundColor = `${color}`;
+                    monacoBlock.style.backgroundColor = monacoBlockDisabled ?
+                            `${Blockly.PXTUtils.fadeColour(color || '#ddd', 0.8, false)}` :
+                            `${color}`;
                     monacoBlock.style.borderColor = `${color}`;
-                    monacoBlock.draggable = true;
 
                     const elem = fns[fn];
                     const snippet = elem.snippet;
@@ -728,61 +748,65 @@ export class Editor extends srceditor.Editor {
 
                     monacoBlock.title = comment;
 
-                    monacoBlock.onclick = (ev2: MouseEvent) => {
-                        pxt.tickEvent("monaco.toolbox.itemclick");
+                    if (!monacoBlockDisabled) {
+                        monacoBlock.draggable = true;
+                        monacoBlock.onclick = (ev2: MouseEvent) => {
+                            pxt.tickEvent("monaco.toolbox.itemclick");
 
-                        monacoEditor.resetFlyout(true);
+                            monacoEditor.resetFlyout(true);
 
-                        let model = monacoEditor.editor.getModel();
-                        let currPos = monacoEditor.editor.getPosition();
-                        let cursor = model.getOffsetAt(currPos)
-                        let insertText = ns ? `${ns}.${snippet}` : snippet;
-                        insertText = (currPos.column > 1) ? '\n' + insertText :
-                            model.getWordUntilPosition(currPos) != undefined && model.getWordUntilPosition(currPos).word != '' ?
-                                insertText + '\n' : insertText;
+                            let model = monacoEditor.editor.getModel();
+                            let currPos = monacoEditor.editor.getPosition();
+                            let cursor = model.getOffsetAt(currPos)
+                            let insertText = ns ? `${ns}.${snippet}` : snippet;
+                            insertText = (currPos.column > 1) ? '\n' + insertText :
+                                model.getWordUntilPosition(currPos) != undefined && model.getWordUntilPosition(currPos).word != '' ?
+                                    insertText + '\n' : insertText;
 
-                        if (insertText.indexOf('{{}}') > -1) {
-                            cursor += (insertText.indexOf('{{}}'));
-                            insertText = insertText.replace('{{}}', '');
-                        } else
-                            cursor += (insertText.length);
+                            if (insertText.indexOf('{{}}') > -1) {
+                                cursor += (insertText.indexOf('{{}}'));
+                                insertText = insertText.replace('{{}}', '');
+                            } else
+                                cursor += (insertText.length);
 
-                        insertText = insertText.replace(/(?:\{\{)|(?:\}\})/g, '');
-                        monacoEditor.editor.pushUndoStop();
-                        monacoEditor.editor.executeEdits("", [
-                            {
-                                identifier: { major: 0, minor: 0 },
-                                range: new monaco.Range(currPos.lineNumber, currPos.column, currPos.lineNumber, currPos.column),
-                                text: insertText,
-                                forceMoveMarkers: false
-                            }
-                        ]);
-                        monacoEditor.beforeCompile();
-                        monacoEditor.editor.pushUndoStop();
-                        let endPos = model.getPositionAt(cursor);
-                        monacoEditor.editor.setPosition(endPos);
-                        monacoEditor.editor.focus();
-                        //monacoEditor.editor.setSelection(new monaco.Range(currPos.lineNumber, currPos.column, endPos.lineNumber, endPos.column));
-                    };
-                    monacoBlock.ondragstart = (ev2: DragEvent) => {
-                        pxt.tickEvent("monaco.toolbox.itemdrag");
-                        let clone = monacoBlock.cloneNode(true) as HTMLDivElement;
+                            insertText = insertText.replace(/(?:\{\{)|(?:\}\})/g, '');
+                            monacoEditor.editor.pushUndoStop();
+                            monacoEditor.editor.executeEdits("", [
+                                {
+                                    identifier: { major: 0, minor: 0 },
+                                    range: new monaco.Range(currPos.lineNumber, currPos.column, currPos.lineNumber, currPos.column),
+                                    text: insertText,
+                                    forceMoveMarkers: false
+                                }
+                            ]);
+                            monacoEditor.beforeCompile();
+                            monacoEditor.editor.pushUndoStop();
+                            let endPos = model.getPositionAt(cursor);
+                            monacoEditor.editor.setPosition(endPos);
+                            monacoEditor.editor.focus();
+                            //monacoEditor.editor.setSelection(new monaco.Range(currPos.lineNumber, currPos.column, endPos.lineNumber, endPos.column));
+                        };
+                        monacoBlock.ondragstart = (ev2: DragEvent) => {
+                            pxt.tickEvent("monaco.toolbox.itemdrag");
+                            let clone = monacoBlock.cloneNode(true) as HTMLDivElement;
 
-                        setTimeout(function () {
-                            monacoFlyout.style.transform = "translateX(-9999px)";
-                        });
+                            setTimeout(function () {
+                                monacoFlyout.style.transform = "translateX(-9999px)";
+                            });
 
-                        let insertText = ns ? `${ns}.${snippet}` : snippet;
-                        ev2.dataTransfer.setData('text', insertText); // IE11 only supports text
-                    }
-                    monacoBlock.ondragend = (ev2: DragEvent) => {
-                        monacoFlyout.style.transform = "none";
-                        monacoEditor.resetFlyout(true);
+                            let insertText = ns ? `${ns}.${snippet}` : snippet;
+                            ev2.dataTransfer.setData('text', insertText); // IE11 only supports text
+                        }
+                        monacoBlock.ondragend = (ev2: DragEvent) => {
+                            monacoFlyout.style.transform = "none";
+                            monacoEditor.resetFlyout(true);
+                        }
                     }
 
                     monacoBlock.appendChild(methodToken);
                     monacoBlock.appendChild(sigToken);
                     monacoBlockArea.appendChild(monacoBlock);
+
                     monacoFlyout.appendChild(monacoBlockArea);
                 })
             }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -27,6 +27,7 @@ export class File implements pxt.editor.IFile {
     diagnostics: pxtc.KsDiagnostic[];
     numDiagnosticsOverride: number;
     virtualSource: File;
+    filters: pxt.editor.ProjectFilters;
     forceChangeCallback: ((from: string, to: string) => void);
 
     constructor(public epkg: EditorPackage, public name: string, public content: string) { }

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -107,7 +107,7 @@ export class Editor implements pxt.editor.IEditor {
 
     highlightStatement(brk: pxtc.LocationInfo) { }
 
-    filterToolbox(blockSubset?: { [index: string]: number }, showCategories: boolean = true, showToolboxButtons: boolean = true): Element {
+    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories: boolean = true): Element {
         return null
     }
 }


### PR DESCRIPTION
Adding support for global toolbox filters for both blocks and javascript.

Interface:
```
   export interface ProjectFilters {
        namespaces?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
        blocks?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
        fns?: { [index: string]: FilterState; }; // Disabled = 2, Hidden = 0, Visible = 1
        defaultState?: FilterState; // hide, show or disable all by default
    }

    export enum FilterState {
        Hidden = 0,
        Visible = 1,
        Disabled = 2
    }
```