### PR TITLE
always open help urls in new window

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -15,11 +15,6 @@ export class DocsMenuItem extends data.Component<ISettingsProps, {}> {
         super(props);
     }
 
-    openDoc(path: string) {
-        pxt.tickEvent(`docs`, { path });
-        this.props.parent.setSideDoc(path);
-    }
-
     openTutorial(path: string) {
         pxt.tickEvent(`docstutorial`, { path });
         this.props.parent.startTutorial(path);
@@ -27,13 +22,11 @@ export class DocsMenuItem extends data.Component<ISettingsProps, {}> {
 
     render() {
         const targetTheme = pxt.appTarget.appTheme;
-        const sideDocs = !(pxt.shell.isSandboxMode() || pxt.options.light || targetTheme.hideSideDocs);
         return <sui.DropdownMenuItem icon="help circle large" class="help-dropdown-menuitem" textClass={"landscape only"} title={lf("Reference, lessons, ...") }>
             {targetTheme.docMenu.map(m =>
-               !m.tutorial ? <a href={m.path} target="docs" key={"docsmenu" + m.path} role="menuitem" title={m.name} className={`ui item ${sideDocs && !/^https?:/i.test(m.path) ? "widedesktop hide" : ""}`}>{m.name}</a>
+               !m.tutorial ? <a href={m.path} target="docs" key={"docsmenu" + m.path} role="menuitem" title={m.name} className="ui item">{m.name}</a>
                 : <sui.Item key={"docsmenututorial" + m.path} role="menuitem" text={m.name} class="" onClick={() => this.openTutorial(m.path) } />
                 ) }
-            {sideDocs ? targetTheme.docMenu.filter(m => !/^https?:/i.test(m.path) && !m.tutorial).map(m => <sui.Item key={"docsmenuwide" + m.path} role="menuitem" text={m.name} class="widedesktop only" onClick={() => this.openDoc(m.path) } />) : undefined  }
         </sui.DropdownMenuItem>
     }
 }


### PR DESCRIPTION
With this change, all links from the help menu open in new window (- tutorial)

* Provide a consistent experience accross all browser sizes
* Documentation is browsable/searchable from the full page view
* side doc is really meant to see the help of a particular block (right click help still opens sidedocs) or follow a project (starting package from "projects" dialog still opens sidedocs)
