### PR TITLE
Easier packages

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -109,9 +109,9 @@ namespace pxt.Cloud {
         const target = pxt.appTarget;
         if (!uri || !target.appTheme || !target.appTheme.embedUrl) return undefined;
 
-        let embedUrl = Util.escapeForRegex(Util.stripUrlProtocol(target.appTheme.embedUrl));
-        let m = new RegExp(`^((https:\/\/)?${embedUrl})?(api\/oembed\?url=.*%2F([^&]*)&.*?|(.+))$`, 'i').exec(uri.trim());
-        let scriptid = m && (m[3] || m[4]) ? (m[3] ? m[3].toLowerCase() : m[4].toLowerCase()) : null
+        const embedUrl = Util.escapeForRegex(Util.stripUrlProtocol(target.appTheme.embedUrl));
+        const m = new RegExp(`^((https:\/\/)?${embedUrl})?(api\/oembed\?url=.*%2F([^&]*)&.*?|([a-z0-9\-]+))$`, 'i').exec(uri.trim());
+        const scriptid = m && (!m[1] || m[1] == "https://" + Util.stripUrlProtocol(target.appTheme.embedUrl)) && (m[3] || m[4]) ? (m[3] ? m[3].toLowerCase() : m[4].toLowerCase()) : null
         return scriptid;
     }
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -61,9 +61,9 @@ namespace pxt.github {
             return Promise.resolve<CachedPackage>(undefined);
         }
 
-        if (!isRepoApproved(p, config)) {
-            pxt.tickEvent("github.download.unauthorized");
-            pxt.log('Github repo not approved');
+        if (isRepoBanned(p, config)) {
+            pxt.tickEvent("github.download.banned");
+            pxt.log('Github repo is banned');
             return Promise.resolve<CachedPackage>(undefined);
         }
 
@@ -329,11 +329,12 @@ namespace pxt.github {
             method = 'POST';
         }
         return U.requestAsync({
-                url: url,
-                allowHttpErrors: true,
-                headers: headers,
-                method: method,
-                data: data || {} })
+            url: url,
+            allowHttpErrors: true,
+            headers: headers,
+            method: method,
+            data: data || {}
+        })
             .then((resp) => {
                 if ((resp.statusCode == 200 || resp.statusCode == 201) && resp.json.id) {
                     return Promise.resolve<string>(resp.json.id);

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -248,7 +248,8 @@ namespace pxt.github {
 
         query += ` in:name,description,readme "for PXT/${appTarget.id}"`
         return U.httpGetJsonAsync("https://api.github.com/search/repositories?q=" + encodeURIComponent(query))
-            .then((rs: SearchResults) => rs.items.map(item => mkRepo(item, config)).filter(r => r.status == GitRepoStatus.Approved));
+            .then((rs: SearchResults) => rs.items.map(item => mkRepo(item, config)).filter(r => r.status == GitRepoStatus.Approved))
+            .catch(err => []); // offline
     }
 
     export function parseRepoUrl(url: string): { repo: string; tag?: string; path?: string; } {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -244,7 +244,7 @@ namespace pxt.github {
         let repos = query.split('|').map(parseRepoUrl).filter(repo => !!repo);
         if (repos.length > 0)
             return Promise.all(repos.map(id => repoAsync(id.path, config)))
-                .then(rs => rs.filter(r => r.status == GitRepoStatus.Approved));
+                .then(rs => rs.filter(r => r.status != GitRepoStatus.Banned)); // allow deep links to github repos
 
         query += ` in:name,description,readme "for PXT/${appTarget.id}"`
         return U.httpGetJsonAsync("https://api.github.com/search/repositories?q=" + encodeURIComponent(query))

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -175,7 +175,8 @@ namespace pxt.github {
     }
 
     function isOrgBanned(repo: ParsedRepo, config: pxt.PackagesConfig): boolean {
-        if (!repo || !config || !repo.owner) return true;
+        if (!config) return false; // don't know
+        if (!repo || !repo.owner) return true;
         if (config.bannedOrgs
             && config.bannedOrgs.some(org => org.toLowerCase() == repo.owner.toLowerCase()))
             return true;
@@ -185,7 +186,8 @@ namespace pxt.github {
     function isRepoBanned(repo: ParsedRepo, config: pxt.PackagesConfig): boolean {
         if (isOrgBanned(repo, config))
             return true;
-        if (!repo || !config || !repo.fullName) return true;
+        if (!config) return false; // don't know
+        if (!repo || !repo.fullName) return true;
         if (config.bannedRepos
             && config.bannedRepos.some(fn => fn.toLowerCase() == repo.fullName.toLowerCase()))
             return true;

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -843,9 +843,13 @@ namespace pxt {
 
     let _targetConfig: pxt.TargetConfig = undefined;
     export function targetConfigAsync(): Promise<pxt.TargetConfig> {
+        if (!_targetConfig && !Cloud.isOnline()) // offline
+            return Promise.resolve(undefined);
         return _targetConfig ? Promise.resolve(_targetConfig)
             : Cloud.privateGetAsync(`config/${pxt.appTarget.id}/targetconfig`)
-                .then(js => { _targetConfig = js; return _targetConfig; });
+                .then(
+                    js => { _targetConfig = js; return _targetConfig; },
+                    err => { _targetConfig = undefined; return undefined; });
     }
     export function packagesConfigAsync(): Promise<pxt.PackagesConfig> {
         return targetConfigAsync().then(config => config ? config.packages : undefined);

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -72,11 +72,11 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     }
 
     fetchBundled(): pxt.PackageConfig[] {
-        if (!!this.state.searchFor) return [];
-
+        const query = this.state.searchFor;
         const bundled = pxt.appTarget.bundledpkgs;
         return Object.keys(bundled).filter(k => !/prj$/.test(k))
-            .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig);
+            .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig)
+            .filter(pkg => !query || pkg.name.toLowerCase().indexOf(query.toLowerCase()) > -1);
     }
 
     shouldComponentUpdate(nextProps: ISettingsProps, nextState: ScriptSearchState, nextContext: any): boolean {

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -62,8 +62,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     fetchGhData(): pxt.github.GitRepo[] {
         const cloud = pxt.appTarget.cloud || {};
         if (!cloud.packages) return [];
-        let searchFor = cloud.githubPackages ? this.state.searchFor : undefined;
-        let res: pxt.github.GitRepo[] =
+        const searchFor = cloud.githubPackages ? this.state.searchFor : undefined;
+        const res: pxt.github.GitRepo[] =
             searchFor || cloud.preferredPackages
                 ? this.getData(`gh-search:${searchFor || cloud.preferredPackages.join('|')}`)
                 : null

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -76,7 +76,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const bundled = pxt.appTarget.bundledpkgs;
         return Object.keys(bundled).filter(k => !/prj$/.test(k))
             .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig)
-            .filter(pkg => !query || pkg.name.toLowerCase().indexOf(query.toLowerCase()) > -1);
+            .filter(pk => !query || pk.name.toLowerCase().indexOf(query.toLowerCase()) > -1) // search filter
+            .filter(pk => !pkg.mainPkg.deps[pk.name]); // don't show package already referenced
     }
 
     shouldComponentUpdate(nextProps: ISettingsProps, nextState: ScriptSearchState, nextContext: any): boolean {

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -188,6 +188,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             <sui.Modal open={this.state.visible} dimmer={true} header={headerText} className="searchdialog" size="large"
                 onClose={() => this.setState({ visible: false }) }
                 closeIcon={true}
+                helpUrl="/packages"
                 closeOnDimmerClick>
                 <div className="ui vertical segment">
                     <div className="ui search">


### PR DESCRIPTION
Follow up of #1657 

- [x] gracefully handle missing target config in offline mode
- [x] treat packages as "unknown" when target config cannot be loaded
- [x] NOT IMPLEMENTED prompt the user that the project references a non-approved package
- [x] support for referencing shared projects (https://github.com/Microsoft/pxt/issues/1657)
- [x] search bundled packages (#1573)
- [x] do not show referenced bundled packages (#1146)
- [x] allow reference github repo by deep url
