### PR TITLE
Add optional comment when compiling on start event

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -222,6 +222,7 @@ declare namespace ts.pxtc {
         upgrades?: UpgradePolicy[];
         openocdScript?: string;
         flashChecksumAddr?: number;
+        onStartText?: boolean;
     }
 
     interface CompileOptions {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1066,6 +1066,11 @@ namespace pxt.blocks {
     function compileStartEvent(e: Environment, b: B.Block): JsNode {
         const bBody = getInputTargetBlock(b, "HANDLER");
         const body = compileStatements(e, bBody);
+
+        if (pxt.appTarget.compile && pxt.appTarget.compile.onStartText && body && body.children) {
+            body.children.unshift(mkStmt(mkText(`// ${pxtc.ON_START_COMMENT}\n`)))
+        }
+
         return body;
     }
 

--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -1301,6 +1301,11 @@ ${output}</xml>`;
                 const match = regex.exec(line)
                 if (match) {
                     const matched = match[1].trim()
+
+                    if (matched === ON_START_COMMENT) {
+                        return;
+                    }
+
                     if (matched) {
                         currentLine += currentLine ? " " + matched : matched
                     } else {
@@ -1529,11 +1534,9 @@ ${output}</xml>`;
                     if (instance && i === 0) {
                         return;
                     }
-                    const aName = argNames[i];
                     const paramInfo = api.parameters[instance ? i - 1 : i];
                     if (paramInfo.isEnum) {
                         if (e.kind === SK.PropertyAccessExpression) {
-                            // fail
                             const enumName = (e as PropertyAccessExpression).expression as Identifier;
                             if (enumName.kind === SK.Identifier && enumName.text === paramInfo.type) {
                                 return;

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -7,6 +7,7 @@ namespace ts.pxtc {
     export import U = pxtc.Util;
 
     export const ON_START_TYPE = "pxt-on-start";
+    export const ON_START_COMMENT = U.lf("On Start");
     export const TS_STATEMENT_TYPE = "typescript_statement";
     export const TS_OUTPUT_TYPE = "typescript_expression";
     export const BINARY_JS = "binary.js";

--- a/pxtlib/emitter/emitter.ts
+++ b/pxtlib/emitter/emitter.ts
@@ -7,7 +7,7 @@ namespace ts.pxtc {
     export import U = pxtc.Util;
 
     export const ON_START_TYPE = "pxt-on-start";
-    export const ON_START_COMMENT = U.lf("On Start");
+    export const ON_START_COMMENT = U.lf("on start");
     export const TS_STATEMENT_TYPE = "typescript_statement";
     export const TS_OUTPUT_TYPE = "typescript_expression";
     export const BINARY_JS = "binary.js";


### PR DESCRIPTION
Configurable in the target. Prevents you from having comments in your code that say "On start" but we don't really have a better way of managing that in the decompiler and it's an unlikely scenario.