### PR TITLE
Save as msg

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -107,6 +107,10 @@ namespace pxt.BrowserUtils {
                 || navigator.maxTouchPoints > 0);       // works on IE10/11 and Surface);
     }
 
+    export function hasSaveAs(): boolean {
+        return isEdge() || isIE() || isFirefox();
+    }
+
     export function os(): string {
         if (isWindows()) return "windows";
         else if (isMac()) return "mac";

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -65,7 +65,7 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     const docUrl = pxt.appTarget.appTheme.usbDocs;
     const saveAs = pxt.BrowserUtils.hasSaveAs();
     const body = saveAs
-        ? lf("Click 'Save As' in the bottom bar and save the {0} file to the {1} drive to transfer the code into your {2}.",
+        ? lf("Click 'Save As' and save the {0} file to the {1} drive to transfer the code into your {2}.",
             pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex",
             boardDriveName, boardName)
         : lf("Move the {0} file to the {1} drive to transfer the code into your {2}.",

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -56,13 +56,21 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
 
 function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     const boardName = pxt.appTarget.appTheme.boardName || "???";
-    const boardDriveName = pxt.appTarget.compile.driveName || "???";
+    const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
 
     // https://msdn.microsoft.com/en-us/library/cc848897.aspx
     // "For security reasons, data URIs are restricted to downloaded resources. 
     // Data URIs cannot be used for navigation, for scripting, or to populate frame or iframe elements"
     const downloadAgain = !pxt.BrowserUtils.isIE() && !pxt.BrowserUtils.isEdge();
     const docUrl = pxt.appTarget.appTheme.usbDocs;
+    const saveAs = pxt.BrowserUtils.hasSaveAs();
+    const body = saveAs
+        ? lf("Click 'Save As' in the bottom bar and save the {0} file to the {1} drive to transfer the code into your {2}.",
+            pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex",
+            boardDriveName, boardName)
+        : lf("Move the {0} file to the {1} drive to transfer the code into your {2}.",
+            pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex",
+            boardDriveName, boardName)
     return core.confirmAsync({
         header: lf("Download completed..."),
         body: lf("Move the {0} file to the {1} drive to transfer the code into your {2}.",

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -64,8 +64,7 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
     const downloadAgain = !pxt.BrowserUtils.isIE() && !pxt.BrowserUtils.isEdge();
     const docUrl = pxt.appTarget.appTheme.usbDocs;
     const saveAs = pxt.BrowserUtils.hasSaveAs();
-    const body = saveAs
-        ? lf("Click 'Save As' and save the {0} file to the {1} drive to transfer the code into your {2}.",
+    const body = saveAs ? lf("Click 'Save As' and save the {0} file to the {1} drive to transfer the code into your {2}.",
             pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex",
             boardDriveName, boardName)
         : lf("Move the {0} file to the {1} drive to transfer the code into your {2}.",
@@ -73,13 +72,11 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
             boardDriveName, boardName)
     return core.confirmAsync({
         header: lf("Download completed..."),
-        body: lf("Move the {0} file to the {1} drive to transfer the code into your {2}.",
-            pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex",
-            boardDriveName, boardName),
+        body,
         hideCancel: true,
         agreeLbl: lf("Done!"),
         buttons: [downloadAgain ? {
-            label: lf("Download again"),
+            label: fn,
             icon: "download",
             class: "lightgrey",
             url,


### PR DESCRIPTION
- [x] When the browser supports it, suggest to "save as" directly into the board drive
- [x] display .hex file name instead of "download again"