### PR TITLE
Better advanced category and subcategory support

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -809,11 +809,9 @@ namespace pxt.blocks {
             insertTopLevelCategory(document.createElement("sep"), tb, 1.5, false);
             insertTopLevelCategory(cat, tb, 1, false);
 
-            if (showCategories === ShowCategoryMode.All) {
+            if (showCategories === ShowCategoryMode.All && pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
                 // Add the "Add package" category
-                if (tb && showCategories !== ShowCategoryMode.None && pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
-                    getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Add Package"), "Add Package", 1, "#717171", 'blocklyTreeIconaddpackage')
-                }
+                getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Add Package"), "Add Package", 1, "#717171", 'blocklyTreeIconaddpackage')
             }
         }
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -15,7 +15,7 @@ namespace pxt.blocks {
         lists: '#D83B01'
     }
 
-    export enum ShowCategoryMode {
+    export enum CategoryMode {
         All,
         None,
         Basic
@@ -164,7 +164,7 @@ namespace pxt.blocks {
         return result;
     }
 
-    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: HTMLElement, showCategories = ShowCategoryMode.Basic) {
+    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: HTMLElement, showCategories = CategoryMode.Basic) {
         // identity function are just a trick to get an enum drop down in the block
         // while allowing the parameter to be a number
         if (fn.attributes.blockHidden)
@@ -175,7 +175,7 @@ namespace pxt.blocks {
             let nsn = info.apis.byQName[ns];
             let isAdvanced = nsn && nsn.attributes.advanced;
 
-            if (showCategories !== ShowCategoryMode.All && isAdvanced) {
+            if (showCategories !== CategoryMode.All && isAdvanced) {
                 return;
             }
 
@@ -183,7 +183,7 @@ namespace pxt.blocks {
             let catName = ts.pxtc.blocksCategory(fn);
             let category = categoryElement(tb, catName);
 
-            if (showCategories !== ShowCategoryMode.None) {
+            if (showCategories !== CategoryMode.None) {
                 if (!category) {
                     let categories = getChildCategories(tb)
                     let parentCategoryList = tb;
@@ -234,7 +234,7 @@ namespace pxt.blocks {
                 mutationValues.forEach(mutation => {
                     const mutatedBlock = block.cloneNode(true);
                     mutateToolboxBlock(mutatedBlock, fn.attributes.mutate, mutation);
-                    if (showCategories !== ShowCategoryMode.None) {
+                    if (showCategories !== CategoryMode.None) {
                         category.appendChild(mutatedBlock);
                     } else {
                         tb.appendChild(mutatedBlock);
@@ -242,7 +242,7 @@ namespace pxt.blocks {
                 });
             }
             else {
-                if (showCategories !== ShowCategoryMode.None) {
+                if (showCategories !== CategoryMode.None) {
                     category.appendChild(block);
                     injectToolboxIconCss();
                 } else {
@@ -684,7 +684,7 @@ namespace pxt.blocks {
         Disabled = 2
     }
 
-    export function createToolbox(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories = ShowCategoryMode.Basic, filters?: BlockFilters): Element {
+    export function createToolbox(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories = CategoryMode.Basic, filters?: BlockFilters): Element {
         init();
 
         // create new toolbox and update block definitions
@@ -751,7 +751,7 @@ namespace pxt.blocks {
                         el.appendChild(fe);
                     }
                 }
-                if (showCategories !== ShowCategoryMode.None) {
+                if (showCategories !== CategoryMode.None) {
                     let cat = categoryElement(tb, eb.namespace);
                     if (cat) {
                         cat.appendChild(el);
@@ -764,12 +764,12 @@ namespace pxt.blocks {
             })
         }
 
-        if (tb && showCategories !== ShowCategoryMode.None) {
+        if (tb && showCategories !== CategoryMode.None) {
             // remove unused categories
             let config = pxt.appTarget.runtime || {};
             if (!config.mathBlocks) removeCategory(tb, "Math");
-            if (!config.textBlocks || showCategories === ShowCategoryMode.Basic) removeCategory(tb, "Text");
-            if (!config.listsBlocks || showCategories === ShowCategoryMode.Basic) removeCategory(tb, "Lists");
+            if (!config.textBlocks || showCategories === CategoryMode.Basic) removeCategory(tb, "Text");
+            if (!config.listsBlocks || showCategories === CategoryMode.Basic) removeCategory(tb, "Lists");
             if (!config.variablesBlocks) removeCategory(tb, "Variables");
             if (!config.logicBlocks) removeCategory(tb, "Logic");
             if (!config.loopsBlocks) removeCategory(tb, "Loops");
@@ -804,12 +804,12 @@ namespace pxt.blocks {
         }
 
         // Add the "Advanced" category
-        if (tb && showCategories !== ShowCategoryMode.None) {
-            const cat = createCategoryElement(Util.lf("{id:category}Advanced"), "Advanced", 1, "#3c3c3c", showCategories === ShowCategoryMode.Basic ? 'blocklyTreeIconadvancedcollapsed' : 'blocklyTreeIconadvancedexpanded');
+        if (tb && showCategories !== CategoryMode.None) {
+            const cat = createCategoryElement(Util.lf("{id:category}Advanced"), "Advanced", 1, "#3c3c3c", showCategories === CategoryMode.Basic ? 'blocklyTreeIconadvancedcollapsed' : 'blocklyTreeIconadvancedexpanded');
             insertTopLevelCategory(document.createElement("sep"), tb, 1.5, false);
             insertTopLevelCategory(cat, tb, 1, false);
 
-            if (showCategories === ShowCategoryMode.All && pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
+            if (showCategories === CategoryMode.All && pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
                 // Add the "Add package" category
                 getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Add Package"), "Add Package", 1, "#717171", 'blocklyTreeIconaddpackage')
             }
@@ -836,7 +836,7 @@ namespace pxt.blocks {
                 return hasChild;
             }
 
-            if (showCategories !== ShowCategoryMode.None) {
+            if (showCategories !== CategoryMode.None) {
                 // Go through namespaces and keep the ones with an override
                 let categories = tb.querySelectorAll("xml > category");
                 for (let ci = 0; ci < categories.length; ++ci) {
@@ -854,7 +854,7 @@ namespace pxt.blocks {
                 filterBlocks(blocks);
             }
 
-            if (showCategories !== ShowCategoryMode.None) {
+            if (showCategories !== CategoryMode.None) {
                 // Go through all categories, hide the ones that have no blocks inside
                 let categories = tb.querySelectorAll("category");
                 for (let ci = 0; ci < categories.length; ++ci) {
@@ -881,7 +881,7 @@ namespace pxt.blocks {
         return tb;
     }
 
-    export function initBlocks(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories = ShowCategoryMode.Basic, filters?: BlockFilters): Element {
+    export function initBlocks(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories = CategoryMode.Basic, filters?: BlockFilters): Element {
         init();
         initTooltip(blockInfo);
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -15,6 +15,12 @@ namespace pxt.blocks {
         lists: '#D83B01'
     }
 
+    export enum ShowCategoryMode {
+        All,
+        None,
+        Basic
+    }
+
     const typeDefaults: Map<{ field: string, block: string, defaultValue: string }> = {
         "string": {
             field: "TEXT",
@@ -158,7 +164,7 @@ namespace pxt.blocks {
         return result;
     }
 
-    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: HTMLElement, showCategories: boolean) {
+    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: HTMLElement, showCategories = ShowCategoryMode.Basic) {
         // identity function are just a trick to get an enum drop down in the block
         // while allowing the parameter to be a number
         if (fn.attributes.blockHidden)
@@ -167,11 +173,17 @@ namespace pxt.blocks {
         if (!fn.attributes.deprecated) {
             let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
             let nsn = info.apis.byQName[ns];
+            let isAdvanced = nsn && nsn.attributes.advanced;
+
+            if (showCategories !== ShowCategoryMode.All && isAdvanced) {
+                return;
+            }
+
             if (nsn) ns = nsn.attributes.block || ns;
             let catName = ts.pxtc.blocksCategory(fn);
             let category = categoryElement(tb, catName);
 
-            if (showCategories) {
+            if (showCategories !== ShowCategoryMode.None) {
                 if (!category) {
                     let categories = getChildCategories(tb)
                     let parentCategoryList = tb;
@@ -198,22 +210,7 @@ namespace pxt.blocks {
                         category.setAttribute("expandedclass", `blocklyTreeIconDefault`);
                     }
 
-                    if (nsn && nsn.attributes.advanced) {
-                        parentCategoryList = getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Advanced"), "Advanced", 1, "#3c3c3c", 'blocklyTreeIconadvanced')
-                        categories = getChildCategories(parentCategoryList)
-                    }
-
-                    // Insert the category based on weight
-                    let ci = 0;
-                    for (ci = 0; ci < categories.length; ++ci) {
-                        let cat = categories[ci];
-                        if (parseInt(cat.getAttribute("weight") || "50") < nsWeight) {
-                            parentCategoryList.insertBefore(category, cat);
-                            break;
-                        }
-                    }
-                    if (ci == categories.length)
-                        parentCategoryList.appendChild(category);
+                    insertTopLevelCategory(category, tb, nsWeight, isAdvanced);
                 }
                 if (fn.attributes.advanced) {
                     category = getOrAddSubcategoryByWeight(category, lf("More"), "More", 1, category.getAttribute("colour"), 'blocklyTreeIconmore')
@@ -237,7 +234,7 @@ namespace pxt.blocks {
                 mutationValues.forEach(mutation => {
                     const mutatedBlock = block.cloneNode(true);
                     mutateToolboxBlock(mutatedBlock, fn.attributes.mutate, mutation);
-                    if (showCategories) {
+                    if (showCategories !== ShowCategoryMode.None) {
                         category.appendChild(mutatedBlock);
                     } else {
                         tb.appendChild(mutatedBlock);
@@ -245,7 +242,7 @@ namespace pxt.blocks {
                 });
             }
             else {
-                if (showCategories) {
+                if (showCategories !== ShowCategoryMode.None) {
                     category.appendChild(block);
                     injectToolboxIconCss();
                 } else {
@@ -330,6 +327,37 @@ namespace pxt.blocks {
         }
 
         return result;
+    }
+
+    function insertTopLevelCategory(category: Element, tb: Element, nsWeight: number, isAdvanced: boolean) {
+        let categories = getChildCategories(tb);
+        if (isAdvanced) {
+            category.setAttribute("advanced", "true");
+        }
+
+        // Insert the category based on weight
+        let ci = 0;
+        for (ci = 0; ci < categories.length; ++ci) {
+            let cat = categories[ci];
+
+            // Advanced categories always come last
+            if (isAdvanced) {
+                if (!cat.hasAttribute("advanced")) {
+                    continue;
+                }
+            }
+            else if (cat.hasAttribute("advanced")) {
+                tb.insertBefore(category, cat);
+                break;
+            }
+
+            if (parseInt(cat.getAttribute("weight") || "50") < nsWeight) {
+                tb.insertBefore(category, cat);
+                break;
+            }
+        }
+        if (ci == categories.length)
+            tb.appendChild(category);
     }
 
     function getOrAddSubcategoryByWeight(parent: Element, name: string, nameid: string, weight: number, colour?: string, iconClass?: string) {
@@ -656,7 +684,7 @@ namespace pxt.blocks {
         Disabled = 2
     }
 
-    export function createToolbox(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories: boolean = true, filters?: BlockFilters): Element {
+    export function createToolbox(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories = ShowCategoryMode.Basic, filters?: BlockFilters): Element {
         init();
 
         // create new toolbox and update block definitions
@@ -723,7 +751,7 @@ namespace pxt.blocks {
                         el.appendChild(fe);
                     }
                 }
-                if (showCategories) {
+                if (showCategories !== ShowCategoryMode.None) {
                     let cat = categoryElement(tb, eb.namespace);
                     if (cat) {
                         cat.appendChild(el);
@@ -736,12 +764,12 @@ namespace pxt.blocks {
             })
         }
 
-        if (tb && showCategories) {
+        if (tb && showCategories !== ShowCategoryMode.None) {
             // remove unused categories
             let config = pxt.appTarget.runtime || {};
             if (!config.mathBlocks) removeCategory(tb, "Math");
-            if (!config.textBlocks) removeCategory(tb, "Text");
-            if (!config.listsBlocks) removeCategory(tb, "Lists");
+            if (!config.textBlocks || showCategories === ShowCategoryMode.Basic) removeCategory(tb, "Text");
+            if (!config.listsBlocks || showCategories === ShowCategoryMode.Basic) removeCategory(tb, "Lists");
             if (!config.variablesBlocks) removeCategory(tb, "Variables");
             if (!config.logicBlocks) removeCategory(tb, "Logic");
             if (!config.loopsBlocks) removeCategory(tb, "Loops");
@@ -750,17 +778,8 @@ namespace pxt.blocks {
             let cats = tb.querySelectorAll('category');
             let removeAdvanced = false;
             for (let i = 0; i < cats.length; i++) {
-                if (cats[i].getAttribute('name') === "Advanced" && cats[i].childElementCount === 0) {
-                    removeAdvanced = true;
-                }
-                else {
-                    cats[i].setAttribute('name',
-                        Util.rlf(`{id:category}${cats[i].getAttribute('name')}`, []));
-                }
-            }
-
-            if (removeAdvanced) {
-                removeCategory(tb, "Advanced");
+                cats[i].setAttribute('name',
+                    Util.rlf(`{id:category}${cats[i].getAttribute('name')}`, []));
             }
         }
 
@@ -784,10 +803,20 @@ namespace pxt.blocks {
             })
         }
 
-        // Add the "Add package" category
-        if (tb && showCategories && pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
-            getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Add Package"), "Add Package", 1, "#717171", 'blocklyTreeIconaddpackage')
+        // Add the "Advanced" category
+        if (tb && showCategories !== ShowCategoryMode.None) {
+            const cat = createCategoryElement(Util.lf("{id:category}Advanced"), "Advanced", 1, "#3c3c3c", showCategories === ShowCategoryMode.Basic ? 'blocklyTreeIconadvancedcollapsed' : 'blocklyTreeIconadvancedexpanded');
+            insertTopLevelCategory(document.createElement("sep"), tb, 1.5, false);
+            insertTopLevelCategory(cat, tb, 1, false);
+
+            if (showCategories === ShowCategoryMode.All) {
+                // Add the "Add package" category
+                if (tb && showCategories !== ShowCategoryMode.None && pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
+                    getOrAddSubcategoryByWeight(tb, Util.lf("{id:category}Add Package"), "Add Package", 1, "#717171", 'blocklyTreeIconaddpackage')
+                }
+            }
         }
+
 
         // Filter the blocks
         if (filters) {
@@ -809,7 +838,7 @@ namespace pxt.blocks {
                 return hasChild;
             }
 
-            if (showCategories) {
+            if (showCategories !== ShowCategoryMode.None) {
                 // Go through namespaces and keep the ones with an override
                 let categories = tb.querySelectorAll("xml > category");
                 for (let ci = 0; ci < categories.length; ++ci) {
@@ -827,7 +856,7 @@ namespace pxt.blocks {
                 filterBlocks(blocks);
             }
 
-            if (showCategories) {
+            if (showCategories !== ShowCategoryMode.None) {
                 // Go through all categories, hide the ones that have no blocks inside
                 let categories = tb.querySelectorAll("category");
                 for (let ci = 0; ci < categories.length; ++ci) {
@@ -854,7 +883,7 @@ namespace pxt.blocks {
         return tb;
     }
 
-    export function initBlocks(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories: boolean = true, filters?: BlockFilters): Element {
+    export function initBlocks(blockInfo: pxtc.BlocksInfo, toolbox?: Element, showCategories = ShowCategoryMode.Basic, filters?: BlockFilters): Element {
         init();
         initTooltip(blockInfo);
 
@@ -916,7 +945,7 @@ namespace pxt.blocks {
 
             if (searchFor != '') {
                 pxt.tickEvent("blocks.search");
-                let searchTb = tb ? <Element>tb.cloneNode(true) : undefined;
+                let searchTb = pxt.blocks.cachedSearchTb ? <Element>pxt.blocks.cachedSearchTb.cloneNode(true) : undefined;
 
                 let catName = 'Search';
                 let category = categoryElement(searchTb, catName);
@@ -1424,29 +1453,16 @@ namespace pxt.blocks {
 
             if (!that.isSelected()) {
                 // Collapse the currently selected node and its parent nodes
-                collapseMoreCategory(that.getTree().getSelectedItem(), that);
+                collapseSubcategories(that.getTree().getSelectedItem(), that);
             }
 
             if (that.hasChildren() && that.isUserCollapsible_) {
-                // If this is a category of categories, we want to toggle when clicked
-                if (that.getChildCount() > 1) {
-                    that.toggle();
-                    if (that.isSelected()) {
-                        that.getTree().setSelectedItem(null);
-                    }
-                    else {
-                        that.select();
-                    }
-                }
-                else {
-                    // If this category has 1 or less children, don't bother toggling; we always want "More..." to show
-                    if (that.isSelected()) {
-                        collapseMoreCategory(that.getTree().getSelectedItem(), that);
-                        that.getTree().setSelectedItem(null);
-                    } else {
-                        that.setExpanded(true);
-                        that.select();
-                    }
+                if (that.isSelected()) {
+                    collapseSubcategories(that.getTree().getSelectedItem(), that);
+                    that.getTree().setSelectedItem(null);
+                } else {
+                    that.setExpanded(true);
+                    that.select();
                 }
             } else if (that.isSelected()) {
                 that.getTree().setSelectedItem(null);
@@ -1468,7 +1484,7 @@ namespace pxt.blocks {
             }
 
             if (a === null) {
-                collapseMoreCategory(that.selectedItem_);
+                collapseSubcategories(that.selectedItem_);
                 editor.lastInvertedCategory = that.selectedItem_;
             }
 
@@ -1497,10 +1513,9 @@ namespace pxt.blocks {
         };
     }
 
-    function collapseMoreCategory(cat: Blockly.Toolbox.TreeNode, child?: Blockly.Toolbox.TreeNode) {
+    function collapseSubcategories(cat: Blockly.Toolbox.TreeNode, child?: Blockly.Toolbox.TreeNode) {
         while (cat) {
-            // Only collapse categories that have a single child (e.g. "More...")
-            if (cat.getChildCount() === 1 && cat.isUserCollapsible_ && cat != child && (!child || !isChild(child, cat))) {
+            if (cat.isUserCollapsible_ && cat != child && (!child || !isChild(child, cat))) {
                 cat.setExpanded(false);
                 cat.updateRow();
             }

--- a/pxtlib/emitter/service.ts
+++ b/pxtlib/emitter/service.ts
@@ -859,7 +859,7 @@ namespace ts.pxtc.service {
                 return weight;
             }
 
-            if (!lastFuse) {
+            if (!lastFuse || search.subset) {
                 const blockInfo = blocksInfoOp(); // cache
                 const weights: pxt.Map<number> = {};
                 let builtinSearchSet: SearchInfo[];

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -532,6 +532,11 @@ text.blocklyText {
 
 span.blocklyTreeLabel {
     font-size:1.25rem;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .blocklyFlyoutButtonShadow {

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -615,8 +615,11 @@ span.blocklyTreeIcon {
 .blocklyTreeIcon.blocklyTreeIconDefault::before {
     content: "\f12e";
 }
-.blocklyTreeIcon.blocklyTreeIconadvanced::before {
-    content: "\f141";
+.blocklyTreeIcon.blocklyTreeIconadvancedcollapsed::before {
+    content: "\f078";
+}
+.blocklyTreeIcon.blocklyTreeIconadvancedexpanded::before {
+    content: "\f077";
 }
 .blocklyTreeIcon.blocklyTreeIconmore::before {
     content: "\f141";

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -47,6 +47,7 @@ type ProjectCreationOptions = pxt.editor.ProjectCreationOptions;
 
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
+import ShowCategoryMode = pxt.blocks.ShowCategoryMode;
 const lf = Util.lf
 
 pxsim.util.injectPolyphils();
@@ -501,7 +502,7 @@ export class ProjectView
                 switch (t.subtype) {
                     case 'steploaded':
                         let tt = msg as pxsim.TutorialStepLoadedMessage;
-                        let showCategories = tt.showCategories ? tt.showCategories : Object.keys(tt.data).length > 7;
+                        let showCategories = (tt.showCategories ? tt.showCategories : Object.keys(tt.data).length > 7) ? ShowCategoryMode.All : ShowCategoryMode.None;
                         this.editor.filterToolbox({ blocks: tt.data, defaultState: pxt.editor.FilterState.Hidden }, showCategories);
                         this.setState({ tutorialReady: true, tutorialCardLocation: tt.location });
                         tutorial.TutorialContent.refresh();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -47,7 +47,7 @@ type ProjectCreationOptions = pxt.editor.ProjectCreationOptions;
 
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
-import ShowCategoryMode = pxt.blocks.ShowCategoryMode;
+import CategoryMode = pxt.blocks.CategoryMode;
 const lf = Util.lf
 
 pxsim.util.injectPolyphils();
@@ -502,7 +502,7 @@ export class ProjectView
                 switch (t.subtype) {
                     case 'steploaded':
                         let tt = msg as pxsim.TutorialStepLoadedMessage;
-                        let showCategories = (tt.showCategories ? tt.showCategories : Object.keys(tt.data).length > 7) ? ShowCategoryMode.All : ShowCategoryMode.None;
+                        let showCategories = (tt.showCategories ? tt.showCategories : Object.keys(tt.data).length > 7) ? CategoryMode.Basic : CategoryMode.None;
                         this.editor.filterToolbox({ blocks: tt.data, defaultState: pxt.editor.FilterState.Hidden }, showCategories);
                         this.setState({ tutorialReady: true, tutorialCardLocation: tt.location });
                         tutorial.TutorialContent.refresh();

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -10,6 +10,7 @@ import * as sui from "./sui";
 import * as data from "./data";
 import defaultToolbox from "./toolbox"
 
+import ShowCategoryMode = pxt.blocks.ShowCategoryMode;
 import Util = pxt.Util;
 let lf = Util.lf
 
@@ -26,7 +27,7 @@ export class Editor extends srceditor.Editor {
     currentCommentOrWarning: B.Comment | B.Warning;
     selectedEventGroup: string;
     currentHelpCardType: string;
-    showToolboxCategories: boolean = true;
+    showToolboxCategories: ShowCategoryMode = ShowCategoryMode.Basic;
     cachedToolbox: string;
     filters: pxt.editor.ProjectFilters;
 
@@ -74,16 +75,15 @@ export class Editor extends srceditor.Editor {
                 .finally(() => { this.loadingXml = false })
                 .then(bi => {
                     this.blockInfo = bi;
-                    let showCategories = this.showToolboxCategories;
                     let showSearch = true;
-                    let toolbox = this.getDefaultToolbox(showCategories);
-                    let tb = pxt.blocks.initBlocks(this.blockInfo, toolbox, showCategories, this.filters);
-                    this.updateToolbox(tb, showCategories);
-                    if (showCategories && showSearch) {
+                    let toolbox = this.getDefaultToolbox(this.showToolboxCategories);
+                    let tb = pxt.blocks.initBlocks(this.blockInfo, toolbox, this.showToolboxCategories, this.filters);
+                    this.updateToolbox(tb, this.showToolboxCategories);
+                    if (this.showToolboxCategories !== ShowCategoryMode.None && showSearch) {
                         pxt.blocks.initSearch(this.editor, tb,
                             searchFor => compiler.apiSearchAsync(searchFor)
                                 .then((fns: pxtc.service.SearchInfo[]) => fns),
-                            searchTb => this.updateToolbox(searchTb, showCategories));
+                            searchTb => this.updateToolbox(searchTb, this.showToolboxCategories, true));
                     }
 
                     let xml = this.delayLoadXml;
@@ -329,7 +329,7 @@ export class Editor extends srceditor.Editor {
         this.isReady = true
     }
 
-    private prepareBlockly(showCategories: boolean = true) {
+    private prepareBlockly(showCategories = this.showToolboxCategories) {
         let blocklyDiv = document.getElementById('blocksEditor');
         blocklyDiv.innerHTML = '';
         let blocklyOptions = this.getBlocklyOptions(showCategories);
@@ -361,6 +361,15 @@ export class Editor extends srceditor.Editor {
                     if (ev.newValue == lf("{id:category}Add Package")) {
                         (this.editor as any).toolbox_.clearSelection();
                         this.parent.addPackage();
+                    }
+                    else if (ev.newValue == lf("{id:category}Advanced")) {
+                        if (this.showToolboxCategories === ShowCategoryMode.All) {
+                            this.showToolboxCategories = ShowCategoryMode.Basic;
+                        }
+                        else if (this.showToolboxCategories === ShowCategoryMode.Basic) {
+                            this.showToolboxCategories = ShowCategoryMode.All;
+                        }
+                        this.refreshToolbox();
                     }
                 }
                 else if (ev.element == 'commentOpen'
@@ -537,9 +546,9 @@ export class Editor extends srceditor.Editor {
         blocks.filter(b => b.isShadow_).forEach(b => b.dispose(false));
     }
 
-    private getBlocklyOptions(showCategories: boolean = true) {
+    private getBlocklyOptions(showCategories = this.showToolboxCategories) {
         const readOnly = pxt.shell.isReadOnly();
-        const toolbox = showCategories ?
+        const toolbox = showCategories !== ShowCategoryMode.None ?
             document.getElementById('blocklyToolboxDefinitionCategory')
             : document.getElementById('blocklyToolboxDefinitionFlyout');
         const blocklyOptions: Blockly.ExtendedOptions = {
@@ -566,13 +575,13 @@ export class Editor extends srceditor.Editor {
         return blocklyOptions;
     }
 
-    private getDefaultToolbox(showCategories: boolean = true): HTMLElement {
-        return showCategories ?
+    private getDefaultToolbox(showCategories = this.showToolboxCategories): HTMLElement {
+        return showCategories !== ShowCategoryMode.None ?
             defaultToolbox.documentElement
             : new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinition" style="display: none"></xml>`, "text/xml").documentElement;
     }
 
-    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories: boolean = true): Element {
+    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories = this.showToolboxCategories): Element {
         this.filters = filters;
         this.showToolboxCategories = showCategories;
         return this.refreshToolbox();
@@ -589,17 +598,24 @@ export class Editor extends srceditor.Editor {
         return tb;
     }
 
-    private updateToolbox(tb: Element, showCategories: boolean) {
+    private updateToolbox(tb: Element, showCategories = this.showToolboxCategories, search = false) {
         // no toolbox when readonly
         if (pxt.shell.isReadOnly()) return;
 
         pxt.debug('updating toolbox');
-        if (((this.editor as any).toolbox_ && showCategories) || ((this.editor as any).flyout_ && !showCategories)) {
+        const editor_ = (this.editor as any);
+        if ((editor_.toolbox_ && showCategories !== ShowCategoryMode.None) || (editor_.flyout_ && showCategories === ShowCategoryMode.None)) {
             // Toolbox is consistent with current mode, safe to update
             let tbString = new XMLSerializer().serializeToString(tb);
             if (tbString == this.cachedToolbox) return;
             this.cachedToolbox = tbString;
             this.editor.updateToolbox(tb);
+
+            // We need to set the toolbox's selected item to null so that it doesn't
+            // try to send key events to a category that no longer exists (exception)
+            if (!search && editor_.toolbox_ && editor_.toolbox_.tree_) {
+                editor_.toolbox_.tree_.setSelectedItem(null);
+            }
         } else {
             // Toolbox mode is different, need to refresh.
             this.delayLoadXml = this.getCurrentSource();

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -10,7 +10,7 @@ import * as sui from "./sui";
 import * as data from "./data";
 import defaultToolbox from "./toolbox"
 
-import ShowCategoryMode = pxt.blocks.ShowCategoryMode;
+import CategoryMode = pxt.blocks.CategoryMode;
 import Util = pxt.Util;
 let lf = Util.lf
 
@@ -27,7 +27,7 @@ export class Editor extends srceditor.Editor {
     currentCommentOrWarning: B.Comment | B.Warning;
     selectedEventGroup: string;
     currentHelpCardType: string;
-    showToolboxCategories: ShowCategoryMode = ShowCategoryMode.Basic;
+    showToolboxCategories: CategoryMode = CategoryMode.Basic;
     cachedToolbox: string;
     filters: pxt.editor.ProjectFilters;
 
@@ -79,7 +79,7 @@ export class Editor extends srceditor.Editor {
                     let toolbox = this.getDefaultToolbox(this.showToolboxCategories);
                     let tb = pxt.blocks.initBlocks(this.blockInfo, toolbox, this.showToolboxCategories, this.filters);
                     this.updateToolbox(tb, this.showToolboxCategories);
-                    if (this.showToolboxCategories !== ShowCategoryMode.None && showSearch) {
+                    if (this.showToolboxCategories !== CategoryMode.None && showSearch) {
                         pxt.blocks.initSearch(this.editor, tb,
                             searchFor => compiler.apiSearchAsync(searchFor)
                                 .then((fns: pxtc.service.SearchInfo[]) => fns),
@@ -363,11 +363,11 @@ export class Editor extends srceditor.Editor {
                         this.parent.addPackage();
                     }
                     else if (ev.newValue == lf("{id:category}Advanced")) {
-                        if (this.showToolboxCategories === ShowCategoryMode.All) {
-                            this.showToolboxCategories = ShowCategoryMode.Basic;
+                        if (this.showToolboxCategories === CategoryMode.All) {
+                            this.showToolboxCategories = CategoryMode.Basic;
                         }
-                        else if (this.showToolboxCategories === ShowCategoryMode.Basic) {
-                            this.showToolboxCategories = ShowCategoryMode.All;
+                        else if (this.showToolboxCategories === CategoryMode.Basic) {
+                            this.showToolboxCategories = CategoryMode.All;
                         }
                         this.refreshToolbox();
                     }
@@ -548,7 +548,7 @@ export class Editor extends srceditor.Editor {
 
     private getBlocklyOptions(showCategories = this.showToolboxCategories) {
         const readOnly = pxt.shell.isReadOnly();
-        const toolbox = showCategories !== ShowCategoryMode.None ?
+        const toolbox = showCategories !== CategoryMode.None ?
             document.getElementById('blocklyToolboxDefinitionCategory')
             : document.getElementById('blocklyToolboxDefinitionFlyout');
         const blocklyOptions: Blockly.ExtendedOptions = {
@@ -576,7 +576,7 @@ export class Editor extends srceditor.Editor {
     }
 
     private getDefaultToolbox(showCategories = this.showToolboxCategories): HTMLElement {
-        return showCategories !== ShowCategoryMode.None ?
+        return showCategories !== CategoryMode.None ?
             defaultToolbox.documentElement
             : new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinition" style="display: none"></xml>`, "text/xml").documentElement;
     }
@@ -604,7 +604,7 @@ export class Editor extends srceditor.Editor {
 
         pxt.debug('updating toolbox');
         const editor_ = (this.editor as any);
-        if ((editor_.toolbox_ && showCategories !== ShowCategoryMode.None) || (editor_.flyout_ && showCategories === ShowCategoryMode.None)) {
+        if ((editor_.toolbox_ && showCategories !== CategoryMode.None) || (editor_.flyout_ && showCategories === CategoryMode.None)) {
             // Toolbox is consistent with current mode, safe to update
             let tbString = new XMLSerializer().serializeToString(tb);
             if (tbString == this.cachedToolbox) return;

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -107,7 +107,7 @@ export class Editor implements pxt.editor.IEditor {
 
     highlightStatement(brk: pxtc.LocationInfo) { }
 
-    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories = pxt.blocks.ShowCategoryMode.All): Element {
+    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories = pxt.blocks.CategoryMode.All): Element {
         return null
     }
 }

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -107,7 +107,7 @@ export class Editor implements pxt.editor.IEditor {
 
     highlightStatement(brk: pxtc.LocationInfo) { }
 
-    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories: boolean = true): Element {
+    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories = pxt.blocks.ShowCategoryMode.All): Element {
         return null
     }
 }

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -182,40 +182,38 @@ export default new DOMParser().parseFromString(`<xml id="blocklyToolboxDefinitio
                 </block>
             </category>
         </category>
-        <category name="Advanced" nameid="advanced" colour="#3c3c3c" weight="1" iconclass="blocklyTreeIconadvanced" expandedclass="blocklyTreeIconadvanced">
-            <category colour="#D83B01" name="Lists" nameid="lists" category="45" iconclass="blocklyTreeIconlists">
-                <block type="lists_create_with">
-                    <mutation items="1"></mutation>
-                    <value name="ADD0">
-                        <shadow type="math_number">
-                            <field name="NUM">0</field>
-                        </shadow>
-                    </value>
-                </block>
-                <block type="lists_length"></block>
-            </category>
-            <category colour="#996600" name="Text" nameid="text" category="46" iconclass="blocklyTreeIcontext">
-                <block type="text"></block>
-                <block type="text_length">
-                    <value name="VALUE">
-                        <shadow type="text">
-                            <field name="TEXT">abc</field>
-                        </shadow>
-                    </value>
-                </block>
-                <block type="text_join">
-                    <mutation items="2"></mutation>
-                    <value name="ADD0">
-                        <shadow type="text">
-                            <field name="TEXT"></field>
-                        </shadow>
-                    </value>
-                    <value name="ADD1">
-                        <shadow type="text">
-                            <field name="TEXT"></field>
-                        </shadow>
-                    </value>
-                </block>
-            </category>
+        <category colour="#D83B01" name="Lists" nameid="lists" category="45" iconclass="blocklyTreeIconlists" advanced="true">
+            <block type="lists_create_with">
+                <mutation items="1"></mutation>
+                <value name="ADD0">
+                    <shadow type="math_number">
+                        <field name="NUM">0</field>
+                    </shadow>
+                </value>
+            </block>
+            <block type="lists_length"></block>
+        </category>
+        <category colour="#996600" name="Text" nameid="text" category="46" iconclass="blocklyTreeIcontext" advanced="true">
+            <block type="text"></block>
+            <block type="text_length">
+                <value name="VALUE">
+                    <shadow type="text">
+                        <field name="TEXT">abc</field>
+                    </shadow>
+                </value>
+            </block>
+            <block type="text_join">
+                <mutation items="2"></mutation>
+                <value name="ADD0">
+                    <shadow type="text">
+                        <field name="TEXT"></field>
+                    </shadow>
+                </value>
+                <value name="ADD1">
+                    <shadow type="text">
+                        <field name="TEXT"></field>
+                    </shadow>
+                </value>
+            </block>
         </category>
     </xml>`, "text/xml");


### PR DESCRIPTION
Fixes #1725 

This is a minor UI breaking change! This PR fixes the subcategory behavior and removes our hack for advanced categories. Instead, advanced categories and the "Add Package" category are now hidden underneath a toggle.

Regular toolbox:

![advanced_expand_collapse_microbit](https://cloud.githubusercontent.com/assets/13754588/24317452/609b13c0-10b4-11e7-80f3-a624feb8fa89.gif)

Inverted toolbox:

![advanced_expand_collapse_adafruit](https://cloud.githubusercontent.com/assets/13754588/24317453/61d90a44-10b4-11e7-9253-439d34eb1d95.gif)
