### PR TITLE
Make the monaco toolbox categories match the Blockly ones

### DIFF
--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -14,12 +14,14 @@ namespace pxt.vs {
         snippet: string;
         comment?: string;
         metaData?: pxtc.CommentAttrs;
+        snippetOnly?: boolean;
     }
 
     export interface NameDefiniton {
         fns: { [fn: string]: MethodDef };
         vars?: { [index: string]: string }
         metaData?: pxtc.CommentAttrs;
+        builtin?: boolean;
     }
 
     export type DefinitionMap = { [ns: string]: NameDefiniton };

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -11,7 +11,7 @@ import * as sui from "./sui";
 import * as data from "./data";
 import * as codecard from "./codecard";
 import * as blocks from "./blocks"
-
+import * as snippets from "./monacoSnippets"
 
 import Util = pxt.Util;
 const lf = Util.lf
@@ -32,6 +32,7 @@ export class Editor extends srceditor.Editor {
     extraLibs: pxt.Map<monaco.IDisposable>;
     definitions: pxt.Map<pxt.vs.NameDefiniton>;
     loadingMonaco: boolean;
+    showAdvanced: boolean;
 
     hasBlocks() {
         if (!this.currFile) return true
@@ -535,105 +536,89 @@ export class Editor extends srceditor.Editor {
         root.appendChild(group);
 
         let fnDef = this.definitions;
-        Object.keys(fnDef).sort((f1, f2) => {
-            // sort by fn weight
-            const fn1 = fnDef[f1];
-            const fn2 = fnDef[f2];
-            const w2 = (fn2.metaData ? fn2.metaData.weight || 50 : 50)
-                + (fn2.metaData && fn2.metaData.advanced ? 0 : 1000);
-            + (fn2.metaData && fn2.metaData.blockId ? 10000 : 0)
-            const w1 = (fn1.metaData ? fn1.metaData.weight || 50 : 50)
-                + (fn1.metaData && fn1.metaData.advanced ? 0 : 1000);
-            + (fn1.metaData && fn1.metaData.blockId ? 10000 : 0)
-            return w2 - w1;
-        }).filter(ns => fnDef[ns].metaData != null && fnDef[ns].metaData.color != null).forEach(function (ns) {
-            let metaElement = fnDef[ns];
-            let fnElement = fnDef[ns];
 
-            monacoEditor.addToolboxCategory(group, ns, metaElement.metaData.color, metaElement.metaData.icon, true, fnElement.fns);
-        })
+        // Add the builtin categories
+        Editor.injectBuiltinCategories(fnDef);
 
-        Editor.addBuiltinCategories(group, monacoEditor);
+        // Non-advanced categories
+        appendCategories(group, Object.keys(fnDef).filter(ns => !(fnDef[ns].metaData && fnDef[ns].metaData.advanced)));
 
-        // Add the toolbox buttons
-        if (pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
-            this.addToolboxCategory(group, "", "#717171", "addpackage", false, null, () => {
-                this.resetFlyout();
-                this.parent.addPackage();
-            }, lf("{id:category}Add Package"))
+        // Advanced seperator
+        group.appendChild(Editor.createTreeSeperator());
+
+        // Advanced toggle
+        group.appendChild(this.createCategoryElement("", "#3c3c3c", this.showAdvanced ? 'advancedexpanded' : 'advancedcollapsed',
+         false, null, () => {
+             this.showAdvanced = !this.showAdvanced;
+             this.updateToolbox();
+         }, lf("{id:category}Advanced")))
+
+        if (this.showAdvanced) {
+            appendCategories(group, Object.keys(fnDef).filter(ns => fnDef[ns].metaData && fnDef[ns].metaData.advanced));
+
+            // Add package button
+            if (pxt.appTarget.cloud && pxt.appTarget.cloud.packages) {
+                group.appendChild(this.createCategoryElement("", "#717171", "addpackage", false, null, () => {
+                    this.resetFlyout();
+                    this.parent.addPackage();
+                }, lf("{id:category}Add Package")));
+            }
         }
 
         // Inject toolbox icon css
         pxt.blocks.injectToolboxIconCss();
+
+        function appendCategories(group: Element, names: string[]) {
+            return names.filter(ns => !!(fnDef[ns].metaData && fnDef[ns].metaData.color))
+            .sort((f1, f2) => {
+                // sort by fn weight
+                const fn1 = fnDef[f1];
+                const fn2 = fnDef[f2];
+                const w2 = (fn2.metaData ? fn2.metaData.weight || 50 : 50);
+                const w1 = (fn1.metaData ? fn1.metaData.weight || 50 : 50);
+                return w2 - w1;
+            }).forEach(ns => {
+                const fnElement = fnDef[ns];
+                const md = fnElement.metaData;
+
+                let el: Element;
+
+                if (fnElement.builtin) {
+                    el = monacoEditor.createCategoryElement("", md.color, md.icon, false, fnElement.fns, null, ns);
+                }
+                else {
+                    el = monacoEditor.createCategoryElement(ns, md.color, md.icon, true, fnElement.fns);
+                }
+
+                group.appendChild(el);
+            });
+        }
     }
 
-    static addBuiltinCategories(group: HTMLDivElement, monacoEditor: Editor) {
-        monacoEditor.addToolboxCategory(group, "", pxt.blocks.blockColors["logic"].toString(), "logic", false, {
-            "if": {
-                sig: ``,
-                snippet: `if (true) {
-
-}`,
-                comment: lf("Runs code if the condition is true"),
-                metaData: {
-                    callingConvention: ts.pxtc.ir.CallingConvention.Plain,
-                    paramDefl: {}
-                }
-            }, "if ": {
-                sig: ``,
-                snippet: `if (true) {
-
-} else {
-
-}`,
-                comment: lf("Runs code if the condition is true; else run other code"),
-                metaData: {
-                    callingConvention: ts.pxtc.ir.CallingConvention.Plain,
-                    paramDefl: {}
-                }
-            },"switch": {
-                sig: ``,
-                snippet: `switch(item) {
-    case 0:
-        break;
-    case 1:
-        break;
-}`,
-                comment: lf("Runs different code based on a value"),
-                metaData: {
-                    callingConvention: ts.pxtc.ir.CallingConvention.Plain,
-                    paramDefl: {}
-                }
-            }
-        }, null, lf("{id:category}Logic"));
-        monacoEditor.addToolboxCategory(group, "", pxt.blocks.blockColors["loops"].toString(), "loops", false, {
-            "while": {
-                sig: `while(...)`,
-                snippet: `while(true) {
-
-}`,
-                comment: lf("Repeat code while condition is true"),
-                metaData: {
-                    callingConvention: ts.pxtc.ir.CallingConvention.Plain,
-                    paramDefl: {}
-                }
-            },
-            "for": {
-                sig: ``,
-                snippet: `for(let i = 0; i < 5; i++) {
-
-}`,
-                comment: lf("Repeat code a number of times in a loop"),
-                metaData: {
-                    callingConvention: ts.pxtc.ir.CallingConvention.Plain,
-                    paramDefl: {}
-                }
-            }
-        }, null, lf("{id:category}Loops"));
+    static injectBuiltinCategories(defs: pxt.Map<pxt.vs.NameDefiniton>) {
+        let config = pxt.appTarget.runtime || {};
+        if (config.loopsBlocks) defs[lf("{id:category}Loops")] = snippets.loops;
+        if (config.logicBlocks) defs[lf("{id:category}Logic")] = snippets.logic;
+        if (config.variablesBlocks) defs[lf("{id:category}Variables")] = snippets.variables;
+        if (config.mathBlocks) defs[lf("{id:category}Math")] = snippets.maths;
+        if (config.textBlocks) defs[lf("{id:category}Text")] = snippets.text;
     }
 
-    private addToolboxCategory(
-        group: HTMLDivElement,
+    static createTreeSeperator() {
+        const treeitem = Editor.createTreeItem();
+        const treeSeperator = document.createElement("div");
+        treeSeperator.setAttribute("class", "blocklyTreeSeparator");
+        treeitem.appendChild(treeSeperator);
+        return treeitem;
+    }
+
+    static createTreeItem() {
+        const treeitem = document.createElement('div');
+        treeitem.setAttribute('role', 'treeitem');
+        return treeitem;
+    }
+
+    private createCategoryElement(
         ns: string,
         metaColor: string,
         icon: string,
@@ -658,9 +643,8 @@ export class Editor extends srceditor.Editor {
         let appTheme = pxt.appTarget.appTheme;
         let monacoEditor = this;
         // Create a tree item
-        let treeitem = document.createElement('div');
+        let treeitem = Editor.createTreeItem();
         let treerow = document.createElement('div');
-        treeitem.setAttribute('role', 'treeitem');
         let color = pxt.blocks.convertColour(metaColor);
         treeitem.onclick = (ev: MouseEvent) => {
             pxt.tickEvent("monaco.toolbox.click");
@@ -736,9 +720,10 @@ export class Editor extends srceditor.Editor {
                     const comment = elem.comment;
                     const metaData = elem.metaData;
 
-                    let methodToken = document.createElement('span');
-                    methodToken.innerText = fn;
-                    let sigToken = document.createElement('span'); sigToken.className = 'sig';
+                    let sigToken = document.createElement('span');
+                    if (!elem.snippetOnly) {
+                        sigToken.className = 'sig';
+                    }
                     // completion is a bit busted but looks better
                     sigToken.innerText = snippet
                         .replace(/^[^(]*\(/, '(')
@@ -803,7 +788,11 @@ export class Editor extends srceditor.Editor {
                         }
                     }
 
-                    monacoBlock.appendChild(methodToken);
+                    if (!elem.snippetOnly) {
+                        let methodToken = document.createElement('span');
+                        methodToken.innerText = fn;
+                        monacoBlock.appendChild(methodToken);
+                    }
                     monacoBlock.appendChild(sigToken);
                     monacoBlockArea.appendChild(monacoBlock);
 
@@ -811,7 +800,6 @@ export class Editor extends srceditor.Editor {
                 })
             }
         };
-        group.appendChild(treeitem);
         treerow.className = 'blocklyTreeRow';
         treeitem.appendChild(treerow);
         let iconBlank = document.createElement('span');
@@ -857,6 +845,8 @@ export class Editor extends srceditor.Editor {
         }
         treerow.style.paddingLeft = '0px';
         label.innerText = `${Util.capitalize(category || ns)}`;
+
+        return treeitem;
     }
 
     getId() {

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -1,0 +1,290 @@
+export const loops: pxt.vs.NameDefiniton = {
+    builtin: true,
+    fns: {
+        "while": {
+            sig: `while(...)`,
+            snippet: `while(true) {\n\n}`,
+            comment: lf("Repeat code while condition is true"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "for": {
+            sig: ``,
+            snippet: `for(let i = 0; i < 5; i++) {\n\n}`,
+            comment: lf("Repeat code a number of times in a loop"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        }
+    },
+    metaData: {
+        color: pxt.blocks.blockColors["loops"].toString(),
+        callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        icon: "loops",
+        paramDefl: {}
+    }
+};
+
+export const logic: pxt.vs.NameDefiniton = {
+    builtin: true,
+    fns: {
+        "if": {
+            sig: ``,
+            snippet: `if (true) {\n\n}`,
+            comment: lf("Runs code if the condition is true"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        }, "if ": {
+            sig: ``,
+            snippet: `if (true) {\n\n} else {\n\n}`,
+            comment: lf("Runs code if the condition is true; else run other code"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },"switch": {
+            sig: ``,
+            snippet:
+`switch(item) {
+    case 0:
+        break;
+    case 1:
+        break;
+}`,
+            comment: lf("Runs different code based on a value"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        }
+    },
+    metaData: {
+        color: pxt.blocks.blockColors["logic"].toString(),
+        callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        icon: "logic",
+        paramDefl: {}
+    }
+};
+
+export const variables: pxt.vs.NameDefiniton = {
+    builtin: true,
+    fns: {
+        "let": {
+            sig: ``,
+            snippet: `let item: number`,
+            snippetOnly: true,
+            comment: lf("Declares a variable named 'item'"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "equals": {
+            sig: ``,
+            snippet: `item = 0`,
+            snippetOnly: true,
+            comment: lf("Assigns a value to a variable"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "change": {
+            sig: ``,
+            snippet: `item += 1`,
+            snippetOnly: true,
+            comment: lf("Changes the value of item by 1"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        }
+    },
+    metaData: {
+        color: pxt.blocks.blockColors["variables"].toString(),
+        callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        icon: "variables",
+        paramDefl: {}
+    }
+};
+
+export const maths: pxt.vs.NameDefiniton = {
+    builtin: true,
+    fns: {
+        "plus": {
+            sig: ``,
+            snippet: `1 + 1`,
+            snippetOnly: true,
+            comment: lf("Adds two numbers together"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "minus": {
+            sig: ``,
+            snippet: `1 - 1`,
+            snippetOnly: true,
+            comment: lf("Subtracts the value of one number from another"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "multiply": {
+            sig: ``,
+            snippet: `1 * 1`,
+            snippetOnly: true,
+            comment: lf("Multiplies two numbers together"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "divide": {
+            sig: ``,
+            snippet: `1 / 1`,
+            snippetOnly: true,
+            comment: lf("Divides one number by another"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "remainder": {
+            sig: ``,
+            snippet: `1 % 1`,
+            snippetOnly: true,
+            comment: lf("Returns the remainder of one number divided by another"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "max": {
+            sig: ``,
+            snippet: `Math.max(1, 2)`,
+            comment: lf("Returns the largest of two numbers"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "min": {
+            sig: ``,
+            snippet: `Math.min(1, 2)`,
+            comment: lf("Returns the smallest of two numbers"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "abs": {
+            sig: ``,
+            snippet: `Math.abs(-1)`,
+            comment: lf("Returns the absolute value of a number"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "random": {
+            sig: ``,
+            snippet: `Math.random(4)`,
+            comment: lf("Returns a random number between 0 and an upper bound"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "randomBoolean": {
+            sig: ``,
+            snippet: `Math.randomBoolean()`,
+            comment: lf("Randomly returns either true or false"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        }
+    },
+    metaData: {
+        color: pxt.blocks.blockColors["math"].toString(),
+        callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        icon: "math",
+        paramDefl: {}
+    }
+};
+
+export const text: pxt.vs.NameDefiniton = {
+    builtin: true,
+    fns: {
+        "length": {
+            sig: ``,
+            snippet: `"".length`,
+            snippetOnly: true,
+            comment: lf("Returns the number of characters in a string"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "concat": {
+            sig: ``,
+            snippet: `"" + 5`,
+            snippetOnly: true,
+            comment: lf("Combines a string with a number, boolean, string, or other object into one string"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "compare": {
+            sig: ``,
+            snippet: `"".compare("")`,
+            comment: lf("Compares one string against another alphabetically and returns a number"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "parseInt": {
+            sig: ``,
+            snippet: `parseInt("5")`,
+            comment: lf("Converts a number written as text into a number"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "substr": {
+            sig: ``,
+            snippet: `"".substr(0, 0)`,
+            comment: lf("Returns the part of a string starting at a given index with the given length"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        },
+        "charAt": {
+            sig: ``,
+            snippet: `"".charAt(0)`,
+            comment: lf("Returns the character at the given index"),
+            metaData: {
+                callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+                paramDefl: {}
+            }
+        }
+    },
+    metaData: {
+        advanced: true,
+        color: pxt.blocks.blockColors["text"].toString(),
+        icon: "text",
+        callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        paramDefl: {}
+    }
+}

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -24,6 +24,7 @@ export const loops: pxt.vs.NameDefiniton = {
         color: pxt.blocks.blockColors["loops"].toString(),
         callingConvention: ts.pxtc.ir.CallingConvention.Plain,
         icon: "loops",
+        weight: 50.09,
         paramDefl: {}
     }
 };
@@ -66,6 +67,7 @@ export const logic: pxt.vs.NameDefiniton = {
     metaData: {
         color: pxt.blocks.blockColors["logic"].toString(),
         callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        weight: 50.08,
         icon: "logic",
         paramDefl: {}
     }
@@ -108,6 +110,7 @@ export const variables: pxt.vs.NameDefiniton = {
     metaData: {
         color: pxt.blocks.blockColors["variables"].toString(),
         callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        weight: 50.07,
         icon: "variables",
         paramDefl: {}
     }
@@ -215,6 +218,7 @@ export const maths: pxt.vs.NameDefiniton = {
     metaData: {
         color: pxt.blocks.blockColors["math"].toString(),
         callingConvention: ts.pxtc.ir.CallingConvention.Plain,
+        weight: 50.06,
         icon: "math",
         paramDefl: {}
     }


### PR DESCRIPTION
Adds an advanced toggle to the Monaco toolbox, more built-in categories with TS snippets, and fixes the sorting of the categories.

Still to do: subcategories