### PR TITLE
Fixing decompilation of fixed instance APIs

### DIFF
--- a/tests/decompile-test/always_fixed_instance.ts
+++ b/tests/decompile-test/always_fixed_instance.ts
@@ -1,0 +1,4 @@
+/// <reference path="./testBlocks/cp.ts" />
+
+let a = pins.A9
+pins.A10.analogPitch(0, 0)

--- a/tests/decompile-test/baselines/always_fixed_instance.blocks
+++ b/tests/decompile-test/baselines/always_fixed_instance.blocks
@@ -1,0 +1,25 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="typescript_statement">
+<mutation declaredvars="a" numlines="1" line0="let a &#61; pins.A9" />
+<next>
+<block type="pin_analog_pitch">
+<field name="pin">pins.A10</field>
+<value name="frequency">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<value name="ms">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;cp.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/testBlocks/cp.ts
+++ b/tests/decompile-test/testBlocks/cp.ts
@@ -1,0 +1,29 @@
+declare interface PwmPin {
+    /**
+     * Emits a Pulse-width modulation (PWM) signal for a given duration.
+     * @param name the pin that modulate
+     * @param frequency frequency to modulate in Hz.
+     * @param ms duration of the pitch in milli seconds.
+     */
+    //% blockId=pin_analog_pitch block="analog pitch|pin %pin|at (Hz)%frequency|for (ms) %ms"
+    //% help=pins/analog-pitch weight=4 async advanced=true blockGap=8
+    //% blockNamespace=pins shim=PwmPinMethods::analogPitch
+    analogPitch(frequency: number, ms: number): void;
+}
+
+declare namespace pins {
+    //% fixedInstance shim=pxt::getPin(8)
+    const A8: PwmPin;
+
+
+    //% fixedInstance shim=pxt::getPin(9)
+    const A9: PwmPin;
+
+
+    //% fixedInstance shim=pxt::getPin(10)
+    const A10: PwmPin;
+
+
+    //% fixedInstance shim=pxt::getPin(11)
+    const A11: PwmPin;
+}

--- a/tests/decompile-test/testBlocks/pxt.json
+++ b/tests/decompile-test/testBlocks/pxt.json
@@ -4,6 +4,7 @@
     "files": [
         "basic.ts",
         "mb.ts",
+        "cp.ts",
         "core.ts"
     ],
     "public": true,


### PR DESCRIPTION
Fixes #1773

Like enums, these should decompile to dropdowns. Also like enums, we should go to grey blocks if they are accessed anywhere other than in a direct method call of the format we support. I couldn't add full tests for this because it requires C++ and our decompiler test suite isn't currently set up to handle that.