### PR TITLE
Lower Blockly scrollbar Z index to be shown beneath the widget

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -453,13 +453,18 @@ span.docs.inlineblock {
              Blockly
 *******************************/
 
-/* Lower Z index for BLocklyWidgetDiv and grid picker tooltips */
+/* Lower Z index for BlocklyWidgetDiv and grid picker tooltips */
 .blocklyWidgetDiv {
     z-index: 9;
 }
 
 .blocklyGridPickerTooltip {
     z-index: 10;
+}
+
+/* Set Z index of the Blockly scrollbars to be beneath the BlocklyWidgetDiv */
+.blocklyScrollbarHorizontal, .blocklyScrollbarVertical {
+    z-index: 8;
 }
 
 .blocklyTooltipDiv {


### PR DESCRIPTION
When the Z index of the BlocklyWidgetDiv was lowered, we also should have lowered the Blockly scrollbars so that they're still shown beneath it.