### PR TITLE
support for specifying download protocol in target

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -178,6 +178,7 @@ declare namespace pxt {
         hideMenuBar?: boolean; // Hides the main menu bar
         hideEditorToolbar?: boolean; // Hides the bottom editor toolbar
         appStoreID?: string; // Apple iTune Store ID if any
+        mobileSafariDownloadProtocol?: string; // custom protocol to be used on iOS
     }
 
     interface DocMenuEntry {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -286,7 +286,7 @@ namespace pxt.BrowserUtils {
     }
 
     export function isBrowserDownloadInSameWindow(): boolean {
-        const windowOpen = /downloadWindowOpen=1/i.test(window.location.href);
+        const windowOpen = isMobile() && isSafari() && !/downloadWindowOpen=0/i.test(window.location.href);
         return windowOpen;
     }
 
@@ -342,9 +342,11 @@ namespace pxt.BrowserUtils {
         const isMobileBrowser = pxt.BrowserUtils.isMobile();
         const saveBlob = (<any>window).navigator.msSaveOrOpenBlob && !isMobileBrowser;
         let protocol = "data";
+        if (isMobile() && isSafari() && pxt.appTarget.appTheme.mobileSafariDownloadProtocol)
+            protocol = pxt.appTarget.appTheme.mobileSafariDownloadProtocol;
+
         const m = /downloadProtocol=([a-z0-9:/?]+)/i.exec(window.location.href);
         if (m) protocol = m[1];
-
         const dataurl = protocol + ":" + contentType + ";base64," + b64
         try {
             if (saveBlob) {


### PR DESCRIPTION
On mobile safari, always use app protocol instead relying on query arguments.