### PR TITLE
Don't decompile empty on start handlers

### DIFF
--- a/pxtlib/emitter/decompiler.ts
+++ b/pxtlib/emitter/decompiler.ts
@@ -1233,14 +1233,16 @@ ${output}</xml>`;
                         current = v;
                     });
 
-                    return {
-                        kind: "statement",
-                        type: ts.pxtc.ON_START_TYPE,
-                        handlers: [{
-                            name: "HANDLER",
-                            statement: current
-                        }]
-                    } as StatementNode;
+                    if (current) {
+                        return {
+                            kind: "statement",
+                            type: ts.pxtc.ON_START_TYPE,
+                            handlers: [{
+                                name: "HANDLER",
+                                statement: current
+                            }]
+                        } as StatementNode;
+                    }
                 }
                 return stmt;
             }

--- a/tests/decompile-test/baselines/no_extra_on_start.blocks
+++ b/tests/decompile-test/baselines/no_extra_on_start.blocks
@@ -1,0 +1,14 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="device_forever">
+<statement name="HANDLER">
+<block type="variables_change">
+<field name="VAR">i</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/no_extra_on_start.ts
+++ b/tests/decompile-test/no_extra_on_start.ts
@@ -1,0 +1,5 @@
+/// <reference path="./testBlocks/mb.ts" />
+let i = 0;
+basic.forever(() => {
+    i ++;
+});

--- a/tests/decompile-test/testBlocks/mb.ts
+++ b/tests/decompile-test/testBlocks/mb.ts
@@ -152,6 +152,14 @@ declare namespace basic {
     //% async
     //% parts="ledmatrix" interval.defl=150 shim=basic::showNumber
     export function showNumber(value: number, interval?: number): void;
+
+    /**
+     * Repeats the code forever in the background. On each iteration, allows other codes to run.
+     * @param body code to execute
+     */
+    //% help=basic/forever weight=55 blockGap=8 blockAllowMultiple=1
+    //% blockId=device_forever block="forever" icon="\uf01e" shim=basic::forever
+    export function forever(a: () => void): void;
 }
 
 enum Melodies {


### PR DESCRIPTION
Fixes an error in some docs snippets where an empty on start block gets decompiled alongside the event handler code.