### PR TITLE
Support for overriding files in bundled packages from npm

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1869,6 +1869,7 @@ class SnippetHost implements pxt.Host {
 class Host
     implements pxt.Host {
     resolve(module: pxt.Package, filename: string) {
+        pxt.debug(`resolving ${module.level}:${module.id} -- ${filename}`)
         if (module.level == 0) {
             return "./" + filename
         } else if (module.verProtocol() == "file") {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1088,7 +1088,7 @@ function forEachBundledPkgAsync(f: (pkg: pxt.MainPackage, dirname: string) => Pr
             const bdir = m[1];
             const overridePath = path.join("libs", bdir);
             pxt.debug(`override with files from ${overridePath}`)
-            if (nodeutil.existDirSync(overridePath)) {
+            if (nodeutil.existsDirSync(overridePath)) {
                 host.fileoverrides = {};
                 nodeutil.allFiles(overridePath)
                     .filter(f => fs.existsSync(f))
@@ -2442,7 +2442,7 @@ function runCoreAsync(res: pxtc.CompileResult) {
 }
 
 function simulatorCoverage(pkgCompileRes: pxtc.CompileResult, pkgOpts: pxtc.CompileOptions) {
-    if (!nodeutil.existDirSync("sim")) return;
+    if (!nodeutil.existsDirSync("sim")) return;
 
     let decls: Map<ts.Symbol> = {}
 
@@ -2544,7 +2544,7 @@ function testForBuildTargetAsync(): Promise<pxtc.CompileOptions> {
 
 function simshimAsync() {
     console.log("Looking for shim annotations in the simulator.")
-    if (!nodeutil.existDirSync("sim")) {
+    if (!nodeutil.existsDirSync("sim")) {
         console.log("no sim folder, skipping.")
         return Promise.resolve();
     }
@@ -3625,7 +3625,7 @@ function fetchTextAsync(filename: string): Promise<Buffer> {
 }
 
 function extractAsyncInternal(filename: string, out: string, vscode: boolean): Promise<void> {
-    if (filename && nodeutil.existDirSync(filename)) {
+    if (filename && nodeutil.existsDirSync(filename)) {
         pxt.log(`extracting folder ${filename}`);
         return Promise.all(fs.readdirSync(filename)
             .filter(f => /\.(hex|uf2)/.test(f))
@@ -3815,7 +3815,7 @@ function checkDocsAsync(parsed?: commandParser.ParsedCommand): Promise<void> {
 }
 
 function internalCheckDocsAsync(compileSnippets?: boolean, re?: string): Promise<void> {
-    if (!nodeutil.existDirSync("docs"))
+    if (!nodeutil.existsDirSync("docs"))
         return Promise.resolve();
     const docsRoot = nodeutil.targetDir;
     const summaryMD = nodeutil.resolveMd(docsRoot, "SUMMARY");

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -477,7 +477,7 @@ function bumpPxtCoreDepAsync(): Promise<void> {
     if (pkg["name"] == "pxt-core") return Promise.resolve(pkg)
 
     let gitPull = Promise.resolve();
-    let commitMsg: string = undefined;
+    let commitMsg: string = "";
 
     ["pxt-core", "pxt-common-packages"].forEach(knownPackage => {
         const modulePath = path.join("node_modules", knownPackage)
@@ -2258,7 +2258,7 @@ export function initAsync(parsed: commandParser.ParsedCommand) {
                     newCfg[f] = configMap[f]
             }
 
-            files["pxt.json"] = JSON.stringify(newCfg, null, 4) + "\n"
+            files[pxt.CONFIG_NAME] = JSON.stringify(newCfg, null, 4) + "\n"
 
             configMap = U.clone(configMap)
             configMap["target"] = pxt.appTarget.id

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -325,8 +325,14 @@ export function allFiles(top: string, maxDepth = 8, allowMissing = false, includ
     return res
 }
 
-export function existDirSync(name: string): boolean {
-    return fs.existsSync(name) && fs.statSync(name).isDirectory();
+export function existsDirSync(name: string): boolean {
+    try {
+        const stats = fs.lstatSync(name);
+        return stats && stats.isDirectory();
+    }
+    catch (e) {
+        return false;
+    }
 }
 
 export function openUrl(startUrl: string, browser: string) {
@@ -402,16 +408,6 @@ function getBrowserLocation(browser: string) {
     }
 
     return browser;
-}
-
-export function directoryExistsSync(p: string): boolean {
-    try {
-        let stats = fs.lstatSync(p);
-        return stats && stats.isDirectory();
-    }
-    catch (e) {
-        return false;
-    }
 }
 
 export function fileExistsSync(p: string): boolean {

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -505,9 +505,8 @@ namespace pxt {
 
             let initPromise = Promise.resolve()
 
-            this.isLoaded = true
+            this.isLoaded = true;
             const str = this.readFile(pxt.CONFIG_NAME);
-            const mainTs = this.readFile("main.ts");
             if (str == null) {
                 if (!isInstall)
                     U.userError("Package not installed: " + this.id)
@@ -541,7 +540,10 @@ namespace pxt {
                 .then(() => {
                     if (this.level === 0) {
                         // Check for missing packages. We need to add them 1 by 1 in case they conflict with eachother.
-                        const missingPackages = this.getMissingPackages(<PackageConfig>JSON.parse(str), mainTs);
+                        const mainTs = this.readFile("main.ts");
+                        if (!mainTs) return Promise.resolve(null);
+
+                        const missingPackages = this.getMissingPackages(this.config, mainTs);
                         let didAddPackages = false;
                         let addPackagesPromise = Promise.resolve();
                         Object.keys(missingPackages).reduce((addPackagesPromise, missing) => {


### PR DESCRIPTION
When a package is bundled from ``node_modules/..../libs/yyyy``, all files under ``libs/yyyy`` will automatically override the imported files.