### PR TITLE
Don't decompile output call expressions as statements

### DIFF
--- a/tests/decompile-test/baselines/block_max.blocks
+++ b/tests/decompile-test/baselines/block_max.blocks
@@ -4,11 +4,7 @@
 <block type="variables_set">
 <field name="VAR">level</field>
 <value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">10</field>
-</shadow>
-</value>
-<next>
+<shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="math_op2">
 <field name="op">max</field>
 <value name="x">
@@ -17,8 +13,28 @@
 </shadow>
 </value>
 <value name="y">
-<block type="variables_get">
-<field name="VAR">level</field>
+<shadow type="math_number">
+<field name="NUM">10</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">level2</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_op2">
+<value name="x">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<value name="y">
+<shadow type="math_number">
+<field name="NUM">10</field>
+</shadow>
+</value>
 </block>
 </value>
 </block>

--- a/tests/decompile-test/baselines/functions_outputs_as_statements.blocks
+++ b/tests/decompile-test/baselines/functions_outputs_as_statements.blocks
@@ -1,46 +1,26 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
 <block type="pxt-on-start">
 <statement name="HANDLER">
-<block type="test_no_argument_output">
+<block type="typescript_statement">
+<mutation numlines="1" line0="testNamespace.noArgumentOutput&#40;&#41;" />
 <next>
-<block type="test_boolean_argument_output">
-<value name="arg">
-<shadow type="logic_boolean">
-<field name="BOOL">TRUE</field>
-</shadow>
-</value>
+<block type="typescript_statement">
+<mutation numlines="1" line0="testNamespace.booleanArgumentOutput&#40;true&#41;" />
 <next>
-<block type="test_number_argument_output">
-<value name="arg">
-<shadow type="math_number">
-<field name="NUM">5</field>
-</shadow>
-</value>
+<block type="typescript_statement">
+<mutation numlines="1" line0="testNamespace.numberArgumentOutput&#40;5&#41;" />
 <next>
-<block type="test_string_argument_output">
-<value name="arg">
-<shadow type="text">
-<field name="TEXT">okay</field>
-</shadow>
-</value>
+<block type="typescript_statement">
+<mutation numlines="1" line0="testNamespace.stringArgumentOutput&#40;&#34;okay&#34;&#41;" />
 <next>
-<block type="test_enum_argument_output">
-<field name="arg">TestEnum.testValue1</field>
+<block type="typescript_statement">
+<mutation numlines="1" line0="testNamespace.enumArgumentOutput&#40;TestEnum.testValue1&#41;" />
 <next>
-<block type="test_enum_function_argument_output">
-<field name="arg">EnumWithValueBlock.testValue2</field>
+<block type="typescript_statement">
+<mutation numlines="1" line0="testNamespace.enumFunctionArgumentOutput&#40;EnumWithValueBlock.testValue2&#41;" />
 <next>
-<block type="test_multiple_argument_output">
-<value name="arg1">
-<shadow type="math_number">
-<field name="NUM">2</field>
-</shadow>
-</value>
-<value name="arg2">
-<shadow type="logic_boolean">
-<field name="BOOL">FALSE</field>
-</shadow>
-</value>
+<block type="typescript_statement">
+<mutation numlines="1" line0="testNamespace.multipleArgumentsOutput&#40;2&#44; false&#41;" />
 </block>
 </next>
 </block>

--- a/tests/decompile-test/block_max.ts
+++ b/tests/decompile-test/block_max.ts
@@ -1,4 +1,4 @@
 /// <reference path="./testBlocks/core.ts" />
 
-let level = 10
-Math.max(0, level);
+let level = Math.max(0, 10);
+let level2 = Math.min(0, 10);

--- a/tests/decompile-test/testBlocks/core.ts
+++ b/tests/decompile-test/testBlocks/core.ts
@@ -62,9 +62,16 @@ declare interface String {
 
 namespace Math {
     /**
-      * Returns the larger of two supplied numeric expressions. 
+      * Returns the larger of two supplied numeric expressions.
       */
     export function max(a: number, b: number): number {
+        return 0;
+    }
+
+    /**
+      * Returns the smaller of two supplied numeric expressions.
+      */
+    export function min(a: number, b: number): number {
         return 0;
     }
 }


### PR DESCRIPTION
Also fixing some incorrect test cases.