### PR TITLE
unbreaking passing localtoken to server (but probably breaking wsport…

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -908,7 +908,8 @@ export function serveAsync(options: ServeOptions) {
 
     return Promise.all([wsServerPromise, serverPromise])
         .then(() => {
-            let start = `http://localhost:${serveOptions.port}/#ws=${serveOptions.wsPort}&local_token=${options.localToken}`;
+
+            const start = `http://localhost:${serveOptions.port}/#local_token=${options.localToken}&wsport=${serveOptions.wsPort}`;
             console.log(`---------------------------------------------`);
             console.log(``);
             console.log(`To launch the editor, open this URL:`);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1900,7 +1900,7 @@ $(document).ready(() => {
     const config = pxt.webConfig
     pxt.options.debug = /dbg=1/i.test(window.location.href);
     pxt.options.light = /light=1/i.test(window.location.href) || pxt.BrowserUtils.isARM() || pxt.BrowserUtils.isIE();
-    const wsPortMatch = /ws=(\d+)/i.exec(window.location.href);
+    const wsPortMatch = /wsport=(\d+)/i.exec(window.location.href);
     if (wsPortMatch) {
         pxt.options.wsPort = parseInt(wsPortMatch[1]) || 3233;
         window.location.hash = window.location.hash.replace(wsPortMatch[0], "");


### PR DESCRIPTION
… option)

When launching the browser from `pxt serve`, localtoken is lost. This is VERY bad for new users.