### PR TITLE
live translations from editor

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -187,7 +187,8 @@ declare namespace pxt {
             tutorialStep?: string;
             tutorialNext?: string;
             dialogClick?: string;            
-        }
+        },
+        disableLiveTranslations?: boolean; // don't load translations from crowdin
     }
 
     interface DocMenuEntry {

--- a/pxtlib/emitter/util.ts
+++ b/pxtlib/emitter/util.ts
@@ -659,24 +659,28 @@ namespace ts.pxtc.Util {
         return _localizeStrings[s] || s;
     }
 
-    export function downloadLiveTranslationsAsync(lang: string, filename: string) {
-        return Util.httpGetJsonAsync(`https://www.pxt.io/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}`);
+    export function downloadLiveTranslationsAsync(lang: string, filename: string, branch?: string): Promise<pxt.Map<string>> {
+        // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
+        let url = `https://www.pxt.io/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
+        if (branch) url += '&branch=' + encodeURIComponent(branch);
+        return Util.httpGetJsonAsync(url);
     }
 
-    export function updateLocalizationAsync(baseUrl: string, code: string, live?: boolean): Promise<any> {
+    export function updateLocalizationAsync(pxtVersion: string, baseUrl: string, code: string, live?: boolean): Promise<any> {
         // normalize code (keep synched with localized files)
         if (!/^(es|pt|si|sv|zh)/i.test(code))
             code = code.split("-")[0]
 
-        if (live) {
-            console.log(`loading live translations for ${code}`)
-            return downloadLiveTranslationsAsync(code, "strings.json")
+        const m = /^v\d+/.exec(pxtVersion);
+        const branch = m ? m[0] : undefined;
+        if (_localizeLang != code && live) {
+            return downloadLiveTranslationsAsync(code, "strings.json", branch)
                 .then(tr => {
                     _localizeStrings = tr || {};
                     _localizeLang = code;
                     localizeLive = true;
                 }, e => {
-                    console.error('failed to load localizations')
+                    console.log('failed to load localizations')
                 })
         }
 

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -601,6 +601,7 @@ namespace pxt {
             const targetId = pxt.appTarget.id;
             const filenames = [this.id + "-jsdoc", this.id];
             const r: Map<string> = {};
+            /*
             if (pxt.Util.localizeLive && this.id != "this") {
                 pxt.log(`loading live translations for ${this.id}`)
                 const code = pxt.Util.userLanguage();
@@ -610,6 +611,7 @@ namespace pxt {
                         .catch(e => pxt.log(`error while downloading ${targetId}/${fn}-strings.json`)))
                 ).then(() => r);
             }
+            */
 
             const files = this.config.files;
             filenames.map(name => {

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -601,8 +601,9 @@ namespace pxt {
             const targetId = pxt.appTarget.id;
             const filenames = [this.id + "-jsdoc", this.id];
             const r: Map<string> = {};
-            /*
-            if (pxt.Util.localizeLive && this.id != "this") {
+
+            // live loc of bundled packages
+            if (pxt.Util.localizeLive && this.id != "this" && pxt.appTarget.bundledpkgs[this.id]) {
                 pxt.log(`loading live translations for ${this.id}`)
                 const code = pxt.Util.userLanguage();
                 return Promise.all(filenames.map(
@@ -611,7 +612,6 @@ namespace pxt {
                         .catch(e => pxt.log(`error while downloading ${targetId}/${fn}-strings.json`)))
                 ).then(() => r);
             }
-            */
 
             const files = this.config.files;
             filenames.map(name => {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -132,11 +132,11 @@ namespace pxt.runner {
 
         const mlang = /(live)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
         const lang = mlang ? mlang[2] : (pxt.appTarget.appTheme.defaultLocale || navigator.userLanguage || navigator.language);
-        const live = mlang && !!mlang[1];
+        const live = !pxt.appTarget.appTheme.disableLiveTranslations || (mlang && !!mlang[1]);
 
         patchSemantic();
         const cfg = pxt.webConfig
-        return Util.updateLocalizationAsync(cfg.commitCdnUrl, lang, live)
+        return Util.updateLocalizationAsync(cfg.pxtVersion, cfg.commitCdnUrl, lang, live)
             .then(() => {
                 mainPkg = new pxt.MainPackage(new Host());
             })
@@ -272,7 +272,7 @@ namespace pxt.runner {
         if (locale != editorLocale) {
             const localeLiveRx = /^live-/;
             editorLocale = locale;
-            return pxt.Util.updateLocalizationAsync(pxt.webConfig.commitCdnUrl,
+            return pxt.Util.updateLocalizationAsync(pxt.webConfig.pxtVersion, pxt.webConfig.commitCdnUrl,
                 editorLocale.replace(localeLiveRx, ''),
                 localeLiveRx.test(editorLocale)
             );

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1948,9 +1948,9 @@ $(document).ready(() => {
         .then(() => {
             const mlang = /(live)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
             const lang = mlang ? mlang[2] : (pxt.appTarget.appTheme.defaultLocale || navigator.userLanguage || navigator.language);
-            const live = mlang && !!mlang[1];
+            const live = !pxt.appTarget.appTheme.disableLiveTranslations || (mlang && !!mlang[1]);
             if (lang) pxt.tickEvent("locale." + lang + (live ? ".live" : ""));
-            return Util.updateLocalizationAsync(config.commitCdnUrl, lang, live);
+            return Util.updateLocalizationAsync(config.pxtVersion, config.commitCdnUrl, lang, live);
         })
         .then(() => initTheme())
         .then(() => cmds.initCommandsAsync())


### PR DESCRIPTION
Add flag to load translations from crowdin by default. This change allows to pull in translations without having to push a new release.