### PR TITLE
Fixing worker crash when trying to normalize a null file path

### DIFF
--- a/pxtlib/emitter/service.ts
+++ b/pxtlib/emitter/service.ts
@@ -679,7 +679,7 @@ namespace ts.pxtc.service {
 
         getNewLine() { return "\n" }
         getCurrentDirectory(): string { return "." }
-        getDefaultLibFileName(options: CompilerOptions): string { return null }
+        getDefaultLibFileName(options: CompilerOptions): string { return "no-default-lib.d.ts" }
         log(s: string): void { console.log("LOG", s) }
         trace(s: string): void { console.log("TRACE", s) }
         error(s: string): void { console.error("ERROR", s) }


### PR DESCRIPTION
Typescript expects the host to return a string, not null. This aligns this host with the other implementations we have, but honestly I don't know what `no-default-lib.d.ts` refers to. I think it's just a non-existent file. 