### PR TITLE
Mute button turning red when muted

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1552,7 +1552,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                 {trace ? <sui.Button key='debug'  icon="bug" title={debugTooltip} onClick={() => this.toggleTrace() } /> : undefined}
                             </div>
                             <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>
-                                {audio ? <sui.Button key='mutebtn' class={`mute-button`} icon={`${this.state.mute ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={() => this.toggleMute() } /> : undefined}
+                                {audio ? <sui.Button key='mutebtn' class={`mute-button ${this.state.mute ? 'red' : ''}`} icon={`${this.state.mute ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={() => this.toggleMute() } /> : undefined}
                                 {fullscreen ? <sui.Button key='fullscreenbtn' class={`fullscreen-button`} icon={`${this.state.fullscreen ? 'compress' : 'maximize'}`} title={fullscreenTooltip} onClick={() => this.toggleSimulatorFullscreen() } /> : undefined}
                             </div>
                         </div>


### PR DESCRIPTION
Make mute sim button turn red when muted as a better visual representation

![screen shot 2017-04-12 at 4 12 09 pm](https://cloud.githubusercontent.com/assets/16690124/24983241/b2be000a-1f9a-11e7-8c83-a1de3885c64c.png)
![screen shot 2017-04-12 at 4 12 12 pm](https://cloud.githubusercontent.com/assets/16690124/24983244/b5f6222a-1f9a-11e7-9dc1-c2189e827ea5.png)
