### PR TITLE
Fix interleaving of events in simulator event queue

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -169,6 +169,7 @@ namespace pxsim {
         max: number = 5;
         events: T[] = [];
         private mHandler: RefAction;
+        private lock: boolean;
 
         constructor(public runtime: Runtime) { }
 
@@ -178,17 +179,22 @@ namespace pxsim {
             this.events.push(e)
 
             // if this is the first event pushed - start processing
-            if (this.events.length == 1)
+            if (this.events.length == 1 && !this.lock)
                 this.poke();
         }
 
         private poke() {
+            this.lock = true;
             let top = this.events.shift()
             this.runtime.runFiberAsync(this.handler, top)
                 .done(() => {
                     // we're done processing the current event, if there is still something left to do, do it
-                    if (this.events.length > 0)
+                    if (this.events.length > 0) {
                         this.poke();
+                    }
+                    else {
+                        this.lock = false;
+                    }
                 })
         }
 


### PR DESCRIPTION
Here is a project that illustrates the issue:

https://pxt.microbit.org/58676-87874-12525-65291

In the simulator, press the A button three times quickly. It should show "AAA", "BBB", "AAA" but it instead shows "AAA", "AAA", "AAA" because each fiber is executing immediately instead of being queued.