### PR TITLE
Add runtime check to generated JS code

### DIFF
--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -332,11 +332,16 @@ switch (step) {
                     args.splice(1, 0, procid.mapIdx.toString())
                     write(`  s.retval = ${shimToJs(procid.mapMethod)}(${args.join(", ")});`)
                     write(`  ${frameRef}.fn = doNothing;`)
-                    write(`} else`)
+                    write(`} else {`)
                 }
+                write (`pxsim.check(typeof ${frameRef}.arg0  != "number", "Can't access property of null/undefined.")`)
                 write(`${frameRef}.fn = ${frameRef}.arg0.vtable.iface[${procid.ifaceIndex}];`)
+                if (procid.mapMethod) {
+                    write(`}`)
+                }
             } else if (procid.virtualIndex != null) {
                 assert(procid.virtualIndex >= 0)
+                write (`pxsim.check(typeof ${frameRef}.arg0  != "number", "Can't access property of null/undefined.")`)
                 write(`${frameRef}.fn = ${frameRef}.arg0.vtable.methods[${procid.virtualIndex}];`)
             }
             write(`return actionCall(${frameRef})`)

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -3,10 +3,10 @@
 namespace pxsim {
     export var quiet = false;
 
-    export function check(cond: boolean) {
+    export function check(cond: boolean, msg: string = "sim: check failed") {
         if (!cond) {
             debugger
-            throw new Error("sim: check failed")
+            throw new Error(msg)
         }
     }
 


### PR DESCRIPTION
Added check in generated JS code to make sure we don't try to dereference a property of null/undefined. 