### PR TITLE
Automatically route block help of packages to package doc page.

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2012,7 +2012,7 @@ class Host
                 }
                 let proto = pkg.verProtocol()
                 if (proto == "file") {
-                    console.log(`skip download of local pkg: ${pkg.version()}`)
+                    pxt.log(`skipping download of local pkg: ${pkg.version()}`)
                     return Promise.resolve()
                 } else {
                     return Promise.reject(`Cannot download ${pkg.version()}; unknown protocol`)

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -522,6 +522,11 @@ namespace pxt.blocks {
 
         if (fn.attributes.help)
             block.setHelpUrl("/reference/" + fn.attributes.help.replace(/^\//, ''));
+        else if (fn.pkg && !pxt.appTarget.bundledpkgs[fn.pkg]) {// added package
+            let anchor = fn.qName.toLowerCase().split('.');
+            if (anchor[0] == fn.pkg) anchor.shift();
+            block.setHelpUrl(`/pkg/${fn.pkg}#${encodeURIComponent(anchor.join('-'))}`)
+        }
 
         block.setTooltip(fn.attributes.jsDoc);
         block.setColour(color);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -331,6 +331,7 @@ export class Editor extends srceditor.Editor {
 
     prepare() {
         pxt.blocks.openHelpUrl = (url: string) => {
+            pxt.tickEvent("blocks.help", { url });
             const m = /^\/pkg\/([^#]+)#(.+)$/.exec(url);
             if (m) {
                 const dep = pkg.mainPkg.deps[m[1]];

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -338,7 +338,7 @@ export class Editor extends srceditor.Editor {
                 if (dep && dep.verProtocol() == "github") {
                     // rewrite url to point to current endpoint
                     url = `/pkg/${dep.verArgument().replace(/#.*$/, '')}#${m[2]}`;
-                    window.open(url, 'docs');
+                    window.open(url, m[1]);
                     return; // TODO support serving package docs in docs frame.
                 }
             };

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -331,7 +331,19 @@ export class Editor extends srceditor.Editor {
 
     prepare() {
         pxt.blocks.openHelpUrl = (url: string) => {
-            /^\//.test(url) ? this.parent.setSideDoc(url) : window.open(url, 'docs');
+            const m = /^\/pkg\/([^#]+)#(.+)$/.exec(url);
+            if (m) {
+                const dep = pkg.mainPkg.deps[m[1]];
+                if (dep && dep.verProtocol() == "github") {
+                    // rewrite url to point to current endpoint
+                    url = `/pkg/${dep.verArgument().replace(/#.*$/, '')}#${m[2]}`;
+                    window.open(url, 'docs');
+                    return; // TODO support serving package docs in docs frame.
+                }
+            };
+            if (/^\//.test(url))
+                this.parent.setSideDoc(url);
+            else window.open(url, 'docs');
         }
 
         this.prepareBlockly();


### PR DESCRIPTION
When a user loads blocks from 3rd party packages, automatically generate a help url that points back to ``/pkg/::org::/::repo::#::qName::``. Makes package docs much more intuitive to find.
