### PR TITLE
Fix popup in sandbox mode

### DIFF
--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -99,7 +99,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
                     break;
                 case "modal":
                     stop();
-                    if (!tutorialMode) {
+                    if (!tutorialMode && !pxt.shell.isSandboxMode()) {
                         const modalOpts: core.ConfirmOptions = {
                             header: msg.header,
                             body: msg.body,


### PR DESCRIPTION
simulator iFrame was using document.referrer to check for sandbox, but in shared projects, the sandbox flag is in the url #hash, which is not passed to the iFrame document.referrer

This blocks sim modals at the webapp level when in sandbox mode