### PR TITLE
cached resolve github package in docs

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -73,7 +73,7 @@ namespace pxt.github {
                 if (!current) current = { sha: "", files: {} }
                 if (current.sha === sha) return Promise.resolve(current)
                 else {
-                    console.log(`Downloading ${repoWithTag} -> ${sha}`)
+                    pxt.log(`Downloading ${repoWithTag} -> ${sha}`)
                     return U.httpGetTextAsync(pref + pxt.CONFIG_NAME)
                         .then(pkg => {
                             current.files = {}

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -63,13 +63,20 @@ namespace pxt.runner {
             return Promise.resolve(null as string)
         }
 
+        private githubPackageCache: pxt.Map<Map<string>> = {};
         downloadPackageAsync(pkg: pxt.Package) {
             let proto = pkg.verProtocol()
+            let cached: pxt.Map<string> = undefined;
+            // cache resolve github packages
+            if (proto == "github")
+                cached = this.githubPackageCache[pkg._verspec];
             let epkg = getEditorPkg(pkg)
 
-            return pkg.commonDownloadAsync()
+            return (cached ? Promise.resolve(cached) : pkg.commonDownloadAsync())
                 .then(resp => {
                     if (resp) {
+                        if (proto == "github" && !cached)
+                            this.githubPackageCache[pkg._verspec] = Util.clone(resp);
                         epkg.setFiles(resp)
                         return Promise.resolve()
                     }


### PR DESCRIPTION
When rendering a document page, cached resolve github repos to avoid querying them for each snippet.