### PR TITLE
resolve rtcss/autoprefixer when compiling semantic only

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -25,8 +25,6 @@ import * as serial from './serial';
 import * as gdb from './gdb';
 
 const rimraf: (f: string, opts: any, cb: () => void) => void = require('rimraf');
-const rtlcss = require('rtlcss');
-const autoprefixer = require('autoprefixer');
 
 let forceCloudBuild = process.env["KS_FORCE_CLOUD"] === "yes"
 let forceLocalBuild = process.env["PXT_FORCE_LOCAL"] === "yes"
@@ -884,7 +882,7 @@ function uploadCoreAsync(opts: UploadOptions) {
         "var pxtConfig = null": "var pxtConfig = @cfg@",
         "@defaultLocaleStrings@": defaultLocale ? "@commitCdnUrl@" + "locales/" + defaultLocale + "/strings.json" : "",
         "@cachedHexFiles@": hexFiles.length ? hexFiles.join("\n") : "",
-        "@targetEditorJs@" : targetEditorJs
+        "@targetEditorJs@": targetEditorJs
     }
 
     if (opts.localDir) {
@@ -1375,6 +1373,9 @@ function saveThemeJson(cfg: pxt.TargetBundle) {
 }
 
 function buildSemanticUIAsync() {
+    const rtlcss = require('rtlcss');
+    const autoprefixer = require('autoprefixer');
+
     if (!fs.existsSync(path.join("theme", "style.less")) ||
         !fs.existsSync(path.join("theme", "theme.config")))
         return Promise.resolve();


### PR DESCRIPTION
Build specific libraries should be called on demand to avoid creating hard bound dependencies.
rtlcss/autoprefixer are only needed for LESS compilation and not require in other cases.