### PR TITLE
Friendly namespace

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -176,9 +176,10 @@ namespace pxt.blocks {
             let isAdvanced = nsn && nsn.attributes.advanced;
 
             if (nsn) ns = nsn.attributes.block || ns;
-            let catName = ns
-            if (!catName)
-                catName = ts.pxtc.blocksCategory(fn);
+            let catName = ts.pxtc.blocksCategory(fn);
+            if (nsn && nsn.attributes.block)
+                catName = nsn.attributes.block
+
             let category = categoryElement(tb, catName);
 
             if (showCategories === CategoryMode.All || showCategories == CategoryMode.Basic && !isAdvanced) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -176,7 +176,9 @@ namespace pxt.blocks {
             let isAdvanced = nsn && nsn.attributes.advanced;
 
             if (nsn) ns = nsn.attributes.block || ns;
-            let catName = ts.pxtc.blocksCategory(fn);
+            let catName = nsn ? ts.pxtc.blocksCategory(nsn) : undefined;
+            if (!catName)
+                catName = ts.pxtc.blocksCategory(fn);
             let category = categoryElement(tb, catName);
 
             if (showCategories === CategoryMode.All || showCategories == CategoryMode.Basic && !isAdvanced) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -176,7 +176,7 @@ namespace pxt.blocks {
             let isAdvanced = nsn && nsn.attributes.advanced;
 
             if (nsn) ns = nsn.attributes.block || ns;
-            let catName = nsn ? ts.pxtc.blocksCategory(nsn) : undefined;
+            let catName = ns
             if (!catName)
                 catName = ts.pxtc.blocksCategory(fn);
             let category = categoryElement(tb, catName);

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -96,14 +96,13 @@ namespace ts.pxtc {
         promise?: boolean;
         hidden?: boolean;
         callingConvention: ir.CallingConvention;
-        block?: string; // format of the block
+        block?: string; // format of the block, used at namespace level for category name
         blockId?: string; // unique id of the block
         blockGap?: string; // pixels in toolbox after the block is inserted
         blockExternalInputs?: boolean; // force external inputs
         blockImportId?: string;
         blockBuiltin?: boolean;
         blockNamespace?: string;
-        blockFriendlyNamespace?: string;
         blockIdentity?: string;
         blockAllowMultiple?: boolean; // override single block behavior for events
         blockHidden?: boolean; // not available directly in toolbox
@@ -260,12 +259,8 @@ namespace ts.pxtc {
      * Unlocalized category name for a symbol
      */
     export function blocksCategory(si: SymbolInfo): string {
-        if (si && si.attributes.blockFriendlyNamespace) {
-            return si.attributes.blockFriendlyNamespace;
-        } else {
-            const n = !si ? undefined : (si.attributes.blockNamespace || si.namespace);
-            return n ? Util.capitalize(n.split('.')[0]) : undefined;
-        }
+        const n = !si ? undefined : (si.attributes.blockNamespace || si.namespace);
+        return n ? Util.capitalize(n.split('.')[0]) : undefined;
     }
 
     export function getBlocksInfo(info: ApisInfo): BlocksInfo {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -103,6 +103,7 @@ namespace ts.pxtc {
         blockImportId?: string;
         blockBuiltin?: boolean;
         blockNamespace?: string;
+        blockFriendlyNamespace?: string;
         blockIdentity?: string;
         blockAllowMultiple?: boolean; // override single block behavior for events
         blockHidden?: boolean; // not available directly in toolbox
@@ -259,8 +260,12 @@ namespace ts.pxtc {
      * Unlocalized category name for a symbol
      */
     export function blocksCategory(si: SymbolInfo): string {
-        const n = !si ? undefined : (si.attributes.blockNamespace || si.namespace);
-        return n ? Util.capitalize(n.split('.')[0]) : undefined;
+        if (si && si.attributes.blockFriendlyNamespace) {
+            return si.attributes.blockFriendlyNamespace;
+        } else {
+            const n = !si ? undefined : (si.attributes.blockNamespace || si.namespace);
+            return n ? Util.capitalize(n.split('.')[0]) : undefined;
+        }
     }
 
     export function getBlocksInfo(info: ApisInfo): BlocksInfo {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -25,6 +25,7 @@ enum FileType {
     Markdown
 }
 
+// this is a supertype of pxtc.SymbolInfo (see partitionBlocks)
 export interface MonacoBlockDefinition {
     name: string;
     snippet?: string;
@@ -590,7 +591,8 @@ export class Editor extends srceditor.Editor {
 
                 if (!snippets.isBuiltin(ns)) {
                     const blocks = monacoEditor.nsMap[ns].filter(block => !(block.attributes.blockHidden || block.attributes.deprecated));
-                    el = monacoEditor.createCategoryElement(ns, md.color, md.icon, true, blocks);
+                    let categoryName = md.block ? md.block : undefined
+                    el = monacoEditor.createCategoryElement(ns, md.color, md.icon, true, blocks, undefined, categoryName);
                 }
                 else {
                     el = monacoEditor.createCategoryElement("", md.color, md.icon, false, snippets.getBuiltinCategory(ns).blocks, null, ns);
@@ -886,7 +888,7 @@ export class Editor extends srceditor.Editor {
             pxt.blocks.appendToolboxIconCss(iconClass, icon);
         }
         treerow.style.paddingLeft = '0px';
-        label.innerText = `${Util.capitalize(category || ns)}`;
+        label.innerText = category ? category : `${Util.capitalize(ns)}`;
 
         return treeitem;
     }


### PR DESCRIPTION
use block attribute on namespace as friendly category name:
```
//% color=#B4009E weight=90
//% block="Shift Instructions"
namespace shift { }
```
Yields

![image](https://cloud.githubusercontent.com/assets/10767146/25504974/c4eeccc6-2b54-11e7-8f7e-fe05f793a44d.png)
