### PR TITLE
Support target experiments

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -35,6 +35,13 @@ declare namespace pxt {
         appTheme: AppTheme;
         compileService?: TargetCompileService;
         analytics?: AppAnalytics;
+        experiments?: pxt.Map<AppExperiment>;
+    }
+
+    interface AppExperiment {
+        name: string;
+        description?: string;
+        appTheme: AppTheme;
     }
 
     interface ProjectTemplate {

--- a/pxteditor/shell.ts
+++ b/pxteditor/shell.ts
@@ -46,4 +46,8 @@ namespace pxt.shell {
         return isSandboxMode()
             && !/[?&]edit=1/i.test(window.location.href);
     }
+
+    export function inExperiment(key: string) {
+        return (new RegExp(`${key}=1`, "i")).test(window.location.href);
+    }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1956,6 +1956,7 @@ function initTheme() {
     if (pxt.appTarget.experiments) {
         Object.keys(pxt.appTarget.experiments).forEach((key) => {
             if (pxt.shell.inExperiment(key)) {
+                pxt.tickEvent(`app.experiment.${key}`)
                 Util.jsonMergeFrom(theme, pxt.appTarget.experiments[key].appTheme);
             }
         })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1952,6 +1952,14 @@ function initTheme() {
             if (boardDef.outlineImage) boardDef.outlineImage = patchCdn(boardDef.outlineImage)
         }
     }
+
+    if (pxt.appTarget.experiments) {
+        Object.keys(pxt.appTarget.experiments).forEach((key) => {
+            if (pxt.shell.inExperiment(key)) {
+                Util.jsonMergeFrom(theme, pxt.appTarget.experiments[key]);
+            }
+        })
+    }
 }
 
 function parseHash(): { cmd: string; arg: string } {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1956,7 +1956,7 @@ function initTheme() {
     if (pxt.appTarget.experiments) {
         Object.keys(pxt.appTarget.experiments).forEach((key) => {
             if (pxt.shell.inExperiment(key)) {
-                Util.jsonMergeFrom(theme, pxt.appTarget.experiments[key]);
+                Util.jsonMergeFrom(theme, pxt.appTarget.experiments[key].appTheme);
             }
         })
     }


### PR DESCRIPTION
This would be useful for switching certain target flags for key experiments. 

For example: If I wanted to run an experiment where the following flags in pxt-microbit are switched to false:
```
        "invertedMenu": false,
        "coloredToolbox": false,
        "monacoToolbox": false,
        "hasAudio": false,
```

In the target, under experiments, author it like this: 
```
    "experiments": {
        "coolexperiment": {
            "name": "My Cool experiment",
            "description": "Cool experiment description ",
            "appTheme": {
                "invertedMenu": false,
                "coloredToolbox": false,
                 "monacoToolbox": false,
                 "hasAudio": false,
             }
        }
    }
```

To get to this experiment, I just need to go to pxt.microbit.org?coolexperiment=1

Note: I added the name and description field, so we're able to pop this up in some way to our beta users and give them the option to look at these experiment, and check them out :)

