### PR TITLE
Fix missing blocks and duplicated categories when language is not EN

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -196,7 +196,7 @@ namespace pxt.blocks {
                     pxt.debug('toolbox: adding category ' + ns)
 
                     const nsWeight = (nsn ? nsn.attributes.weight : 50) || 50;
-                    const locCatName = (nsn ? nsn.attributes.block : "") || catName;
+                    const locCatName = Util.capitalize((nsn ? nsn.attributes.block : "") || catName);
                     category = createCategoryElement(locCatName, catName, nsWeight);
 
                     if (nsn && nsn.attributes.color) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -183,8 +183,8 @@ namespace pxt.blocks {
 
             if (nsn) ns = nsn.attributes.block || ns;
             let catName = ts.pxtc.blocksCategory(fn);
-            if (nsn && nsn.attributes.block)
-                catName = nsn.attributes.block
+            if (nsn && nsn.name)
+                catName = Util.capitalize(nsn.name);
 
             let category = categoryElement(tb, catName);
 
@@ -1390,7 +1390,7 @@ namespace pxt.blocks {
         msg.HELP = lf("Help");
 
         // inject hook to handle openings docs
-        (<any>Blockly).BlockSvg.prototype.showHelp_ = function() {
+        (<any>Blockly).BlockSvg.prototype.showHelp_ = function () {
             const url = goog.isFunction(this.helpUrl) ? this.helpUrl() : this.helpUrl;
             if (url) (pxt.blocks.openHelpUrl || window.open)(url);
         };

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -286,15 +286,18 @@ namespace ts.pxtc {
                     if (fn.parameters)
                         fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || pi.description);
                 }
-                if (fn.attributes.block) {
-                    const locBlock = loc[`${fn.qName}|block`];
-                    if (locBlock) {
-                        fn.attributes.block = locBlock;
+                const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
+                const locBlock = loc[`${fn.qName}|block`];
+                if (nsDoc) {
+                    // Check for "friendly namespace"
+                    if (fn.attributes.block) {
+                        fn.attributes.block = locBlock || fn.attributes.block;
+                    } else {
+                        fn.attributes.block = nsDoc;
                     }
                 }
-                const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
-                if (nsDoc) {
-                    fn.attributes.block = nsDoc;
+                else if (fn.attributes.block && locBlock) {
+                    fn.attributes.block = locBlock;
                 }
             }))
             .then(() => apis);


### PR DESCRIPTION
`nsn.attributes.block` is already translated; for the category's `nameid`, we want the non-translated name

Fixes #2001 