### PR TITLE
Make the blockly widget appear above the top menu bar

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -399,11 +399,11 @@ span.docs.inlineblock {
 
 /* Lower Z index for BlocklyWidgetDiv and grid picker tooltips */
 .blocklyWidgetDiv {
-    z-index: 9;
+    z-index: 105;
 }
 
 .blocklyGridPickerTooltip {
-    z-index: 10;
+    z-index: 106;
 }
 
 /* Set Z index of the Blockly scrollbars to be beneath the BlocklyWidgetDiv */


### PR DESCRIPTION
Fixes #1819 