### PR TITLE
Fix Diagnostics error

### DIFF
--- a/pxtlib/typescript.ts
+++ b/pxtlib/typescript.ts
@@ -229,4 +229,10 @@ namespace ts.pxtc {
 
         return false;
     }
+
+    export enum DiagnosticCategory {
+        Warning = 0,
+        Error = 1,
+        Message = 2,
+    }
 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -537,10 +537,10 @@ export class Editor extends srceditor.Editor {
         if (!tsfile || !tsfile.diagnostics) return;
 
         // only show errors
-        let diags = tsfile.diagnostics.filter(d => d.category == ts.DiagnosticCategory.Error);
+        let diags = tsfile.diagnostics.filter(d => d.category == ts.pxtc.DiagnosticCategory.Error);
         let sourceMap = this.compilationResult.sourceMap;
 
-        diags.filter(diag => diag.category == ts.DiagnosticCategory.Error).forEach(diag => {
+        diags.filter(diag => diag.category == ts.pxtc.DiagnosticCategory.Error).forEach(diag => {
             let bid = pxt.blocks.findBlockId(sourceMap, { start: diag.line, length: diag.endLine - diag.line });
             if (bid) {
                 let b = this.editor.getBlockById(bid)

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -25,13 +25,13 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[]) {
 
     for (let diagnostic of diagnostics) {
         if (diagnostic.fileName) {
-            output += `${diagnostic.category == ts.DiagnosticCategory.Error ? lf("error") : diagnostic.category == ts.DiagnosticCategory.Warning ? lf("warning") : lf("message")}: ${diagnostic.fileName}(${diagnostic.line + 1},${diagnostic.column + 1}): `;
+            output += `${diagnostic.category == ts.pxtc.DiagnosticCategory.Error ? lf("error") : diagnostic.category == ts.pxtc.DiagnosticCategory.Warning ? lf("warning") : lf("message")}: ${diagnostic.fileName}(${diagnostic.line + 1},${diagnostic.column + 1}): `;
             let f = mainPkg.filterFiles(f => f.getTypeScriptName() == diagnostic.fileName)[0]
             if (f)
                 f.diagnostics.push(diagnostic)
         }
 
-        const category = ts.DiagnosticCategory[diagnostic.category].toLowerCase();
+        const category = ts.pxtc.DiagnosticCategory[diagnostic.category].toLowerCase();
         output += `${category} TS${diagnostic.code}: ${ts.pxtc.flattenDiagnosticMessageText(diagnostic.messageText, "\n")}\n`;
     }
 
@@ -41,7 +41,7 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[]) {
 
     let f = mainPkg.outputPkg.setFile("output.txt", output)
     // display total number of errors on the output file
-    f.numDiagnosticsOverride = diagnostics.filter(d => d.category == ts.DiagnosticCategory.Error).length
+    f.numDiagnosticsOverride = diagnostics.filter(d => d.category == ts.pxtc.DiagnosticCategory.Error).length
 }
 
 let hang = new Promise<any>(() => { })


### PR DESCRIPTION
Running into this error when there is a Diagnostics message: 
<img width="1248" alt="screen shot 2017-05-05 at 12 36 38 am" src="https://cloud.githubusercontent.com/assets/16690124/25737134/f534e394-312a-11e7-8884-9c03aaf056d9.png">



missing ts.DiagnosticsCategory enum in compiler.ts

It looks like parts of the compiler that call setDiagnostics don't run in the web worker and thus don't have the ts definitions for the DiagnosticsCategory enum. 
