### PR TITLE
Support for decompiling field editors when they are on the block

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1009,7 +1009,7 @@ namespace pxt.blocks {
         if (lit)
             return lit instanceof String ? H.mkStringLiteral(<string>lit) : H.mkNumberLiteral(<number>lit);
         let f = b.getFieldValue(p.field);
-        if (f)
+        if (f != null)
             return mkText(f);
         else
             return compileExpression(e, getInputTargetBlock(b, p.field), comments)

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1178,8 +1178,8 @@ ${output}</xml>`;
                             } else if (info.attrs && info.attrs.paramFieldEditor && info.attrs.paramFieldEditorOptions) {
                                 if (info.attrs.paramFieldEditorOptions[vName] && info.attrs.paramFieldEditorOptions[vName]['onParentBlock']) {
                                     (r.fields || (r.fields = [])).push(getField(vName, e.getText()));
+                                    return;
                                 }
-                                return;
                             }
                         }
                         if (defaultV) {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1176,17 +1176,10 @@ ${output}</xml>`;
                                     }
                                 }
                             } else if (info.attrs && info.attrs.paramFieldEditor && info.attrs.paramFieldEditorOptions) {
-                                let onBlockFieldName = '';
-                                info.attrs.block.replace(/%(\w+)/g, (f, n) => {
-                                    onBlockFieldName = n;
-                                    return "";
-                                });
-                                if (onBlockFieldName) {
-                                    if (info.attrs.paramFieldEditorOptions[onBlockFieldName]['onParentBlock']) {
-                                        (r.fields || (r.fields = [])).push(getField(vName, e.getText()));
-                                    }
-                                    return;
+                                if (info.attrs.paramFieldEditorOptions[vName] && info.attrs.paramFieldEditorOptions[vName]['onParentBlock']) {
+                                    (r.fields || (r.fields = [])).push(getField(vName, e.getText()));
                                 }
+                                return;
                             }
                         }
                         if (defaultV) {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1150,29 +1150,42 @@ ${output}</xml>`;
                             || (e.kind == SK.PrefixUnaryExpression
                                 && ((e as PrefixUnaryExpression).operator == SK.PlusToken
                                     || (e as PrefixUnaryExpression).operator == SK.MinusToken)
-                                && ((e as PrefixUnaryExpression).operand.kind == SK.NumericLiteral)))
-                            && argNames[i][1]) {
+                                && ((e as PrefixUnaryExpression).operand.kind == SK.NumericLiteral)))) {
                             // Literal
                             const shadowName = argNames[i][0];
                             const shadowType = argNames[i][1];
-                            const shadowBlock = blocksInfo.blocksById[shadowType];
-                            if (shadowBlock) {
-                                let fieldName = '';
-                                blocksInfo.blocksById[shadowType].attributes.block.replace(/%(\w+)/g, (f, n) => {
-                                    fieldName = n;
+                            if (shadowName && shadowType) {
+                                const shadowBlock = blocksInfo.blocksById[shadowType];
+                                if (shadowBlock) {
+                                    let fieldName = '';
+                                    blocksInfo.blocksById[shadowType].attributes.block.replace(/%(\w+)/g, (f, n) => {
+                                        fieldName = n;
+                                        return "";
+                                    });
+                                    if (shadowBlock.attributes && shadowBlock.attributes.paramFieldEditor && shadowBlock.attributes.paramFieldEditor[fieldName]) {
+                                        let fieldBlock = getFieldBlock(shadowType, fieldName, e.getText(), true);
+                                        if (info.attrs.paramShadowOptions && info.attrs.paramShadowOptions[shadowName]) {
+                                            fieldBlock.mutation = {"customfield": Util.htmlEscape(JSON.stringify(info.attrs.paramShadowOptions[shadowName]))}
+                                        }
+                                        v = {
+                                            kind: "value",
+                                            name: vName,
+                                            value: fieldBlock
+                                        };
+                                        defaultV = false;
+                                    }
+                                }
+                            } else if (info.attrs && info.attrs.paramFieldEditor && info.attrs.paramFieldEditorOptions) {
+                                let onBlockFieldName = '';
+                                info.attrs.block.replace(/%(\w+)/g, (f, n) => {
+                                    onBlockFieldName = n;
                                     return "";
                                 });
-                                if (shadowBlock.attributes && shadowBlock.attributes.paramFieldEditor && shadowBlock.attributes.paramFieldEditor[fieldName]) {
-                                    let fieldBlock = getFieldBlock(shadowType, fieldName, e.getText(), true);
-                                    if (info.attrs.paramShadowOptions && info.attrs.paramShadowOptions[shadowName]) {
-                                        fieldBlock.mutation = {"customfield": Util.htmlEscape(JSON.stringify(info.attrs.paramShadowOptions[shadowName]))}
+                                if (onBlockFieldName) {
+                                    if (info.attrs.paramFieldEditorOptions[onBlockFieldName]['onParentBlock']) {
+                                        (r.fields || (r.fields = [])).push(getField(vName, e.getText()));
                                     }
-                                    v = {
-                                        kind: "value",
-                                        name: vName,
-                                        value: fieldBlock
-                                    };
-                                    defaultV = false;
+                                    return;
                                 }
                             }
                         }

--- a/tests/decompile-test/baselines/custom_field_editors.blocks
+++ b/tests/decompile-test/baselines/custom_field_editors.blocks
@@ -15,6 +15,11 @@
 <field name="value">100</field>
 </shadow>
 </value>
+<next>
+<block type="test_customFieldEditorOnParentBlock">
+<field name="value">100</field>
+</block>
+</next>
 </block>
 </next>
 <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>

--- a/tests/decompile-test/custom_field_editors.ts
+++ b/tests/decompile-test/custom_field_editors.ts
@@ -3,3 +3,5 @@
 testNamespace.customFieldEditor(100);
 
 testNamespace.customFieldEditorWithMutation(100);
+
+testNamespace.customFieldEditorOnParentBlock(100);

--- a/tests/decompile-test/testBlocks/basic.ts
+++ b/tests/decompile-test/testBlocks/basic.ts
@@ -161,6 +161,10 @@ namespace testNamespace {
     //% value.shadowOptions.test=0
     export function customFieldEditorWithMutation(value: number): void { }
 
+    //% blockId=test_customFieldEditorOnParentBlock block="%value"
+    //% value.fieldEditor="note" value.fieldOptions.onParentBlock=true
+    export function customFieldEditorOnParentBlock(value: number): void { }
+
     //% blockId=test_customShadowField block="%value"
     //% value.fieldEditor="note"
     export function customShadowField(value: number): number { return value; }


### PR DESCRIPTION
If a block has a field editor inline, we need a way to decompile literals into a field with that value passed to the field editor.