### PR TITLE
Autogenerate tsprj from blocksprj if needed. Remove *prj from bundled pkgs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1216,8 +1216,8 @@ export function buildTargetAsync(): Promise<void> {
         .then(() => buildFolderAsync('cmds', true))
         .then(buildSemanticUIAsync)
         .then(() => {
-            if (fs.existsSync(path.join("editor","tsconfig.json"))) {
-                const tsConfig = JSON.parse(fs.readFileSync(path.join("editor","tsconfig.json"), "utf8"));
+            if (fs.existsSync(path.join("editor", "tsconfig.json"))) {
+                const tsConfig = JSON.parse(fs.readFileSync(path.join("editor", "tsconfig.json"), "utf8"));
                 if (tsConfig.compilerOptions.module)
                     return buildFolderAndBrowserifyAsync('editor', true, 'editor');
                 else
@@ -1569,6 +1569,16 @@ function updateDefaultProjects(cfg: pxt.TargetBundle) {
 
             (<any>cfg)[projectId] = newProject;
         });
+
+    if (!cfg.tsprj && cfg.blocksprj) {
+        let notBlock = (s: string) => !U.endsWith(s, ".blocks")
+        cfg.tsprj = U.clone(cfg.blocksprj)
+        cfg.tsprj.id = "tsprj"
+        cfg.tsprj.config.files = cfg.tsprj.config.files.filter(notBlock)
+        for (let k of Object.keys(cfg.tsprj.files)) {
+            if (!notBlock(k)) delete cfg.tsprj.files[k]
+        }
+    }
 }
 
 function updateTOC(cfg: pxt.TargetBundle) {
@@ -1621,7 +1631,8 @@ function buildTargetCoreAsync() {
 
         return pkg.filesToBePublishedAsync(true)
             .then(res => {
-                cfg.bundledpkgs[path.basename(dirname)] = res
+                if (!isPrj)
+                    cfg.bundledpkgs[path.basename(dirname)] = res
             })
             .then(() => testForBuildTargetAsync(isPrj))
             .then((compileOpts) => {

--- a/docs/target-creation.md
+++ b/docs/target-creation.md
@@ -67,9 +67,7 @@ Graphical assets are located under ``/docs/static``.
 
 Templates are the default projects for your target. There is one default blocks project, and one default JavaScript project.
 The initial templates are empty projects.
-
-* To change the default blocks project, modify the package under ``libs/blocksprj``
-* To change the default JavaScript project, modify the package under ``libs/tsprj``
+To change the default project, modify the package under ``libs/blocksprj``
 
 ### Testing the target locally
 


### PR DESCRIPTION
If there is no tsprj we now generate it from blocksprj.

This also removes the *prj from bundledpkgs in appTarget. If you know any reason it's needed there, please shout! @pelikhan @microsoftsam @riknoll 
