### PR TITLE
Add support for "hex `01FF00`" - Buffer literals

### DIFF
--- a/cli/pyconv.ts
+++ b/cli/pyconv.ts
@@ -1745,7 +1745,6 @@ const exprMap: Map<(v: py.Expr) => B.JsNode> = {
     FormattedValue: (n: py.FormattedValue) => exprTODO(n),
     JoinedStr: (n: py.JoinedStr) => exprTODO(n),
     Bytes: (n: py.Bytes) => {
-        let hex = B.stringLit()
         return B.mkText(`hex \`${U.toHex(new Uint8Array(n.s))}\``)
     },
     NameConstant: (n: py.NameConstant) => {

--- a/cli/pyconv.ts
+++ b/cli/pyconv.ts
@@ -1745,8 +1745,8 @@ const exprMap: Map<(v: py.Expr) => B.JsNode> = {
     FormattedValue: (n: py.FormattedValue) => exprTODO(n),
     JoinedStr: (n: py.JoinedStr) => exprTODO(n),
     Bytes: (n: py.Bytes) => {
-        let hex = B.stringLit(U.toHex(new Uint8Array(n.s)))
-        return B.H.mkCall("pins.createBufferFromHex", [B.mkText(hex)])
+        let hex = B.stringLit()
+        return B.mkText(`hex \`${U.toHex(new Uint8Array(n.s))}\``)
     },
     NameConstant: (n: py.NameConstant) => {
         if (n.value != null)

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -76,6 +76,9 @@ namespace ts.pxtc {
         jssource += "\npxsim.setupStringLiterals(" +
             JSON.stringify(U.mapMap(bin.strings, (k, v) => 1), null, 1) +
             ")\n"
+        U.iterMap(bin.hexlits, (k, v) => {
+            jssource += `var ${v} = pxsim.BufferMethods.createBufferFromHex("${k}")\n`
+        })
         bin.writeFile(BINARY_JS, jssource)
     }
 

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -618,6 +618,15 @@ ${lbl}: .short 0xffff, ${pxt.REF_TAG_NUMBER}
         .hex ${data}
 `)
         }
+
+        for (let data of Object.keys(bin.hexlits)) {
+            let lbl = bin.hexlits[data]
+            bin.otherLiterals.push(`
+.balign 4
+${lbl}: .short 0xffff, ${pxt.REF_TAG_BUFFER}, ${data.length >> 1}
+        .hex ${data}${data.length % 4 == 0 ? "" : "00"}
+`)
+        }
     }
 
     function vtableToAsm(info: ClassInfo) {

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -429,6 +429,13 @@ namespace pxsim {
             return new RefBuffer(new Uint8Array(size));
         }
 
+        export function createBufferFromHex(hex: string) {
+            let r = createBuffer(hex.length >> 1)
+            for (let i = 0; i < hex.length; i += 2)
+                r.data[i >> 1] = parseInt(hex.slice(i, i + 2), 16)
+            return r
+        }
+
         export function getBytes(buf: RefBuffer) {
             // not sure if this is any useful...
             return buf.data;

--- a/test-errors/tagged-templates.ts
+++ b/test-errors/tagged-templates.ts
@@ -1,5 +1,5 @@
 let place = 'world'
-let str = tag `Hello ${place}` // TS9202 tagged templates
+let str = tag `Hello ${place}` // TS9265 tagged templates
 
 function tag(literals: string[], placeholders: string) {
     return literals[0]


### PR DESCRIPTION
This might be useful if we want to embed some data in sources - compact representation in sources and doesn't take any RAM (literals go into flash)

```
const sound = hex `FE01DD...`
```

Whitespace is allowed in the hex literal.
