### PR TITLE
File download in extensions

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -190,7 +190,7 @@ namespace ts.pxtc {
         saveOnly?: boolean;
         userContextWindow?: Window;
         downloadFileBaseName?: string;
-        confirmAsync?: (confirmOptions: {}) => Promise<void>;
+        confirmAsync?: (confirmOptions: {}) => Promise<number>;
     }
 
     export interface Breakpoint extends LocationInfo {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -190,6 +190,7 @@ namespace ts.pxtc {
         saveOnly?: boolean;
         userContextWindow?: Window;
         downloadFileBaseName?: string;
+        confirmAsync?: (confirmOptions: {}) => Promise<void>;
     }
 
     export interface Breakpoint extends LocationInfo {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -189,6 +189,7 @@ namespace ts.pxtc {
         // client options
         saveOnly?: boolean;
         userContextWindow?: Window;
+        downloadFileBaseName?: string;
     }
 
     export interface Breakpoint extends LocationInfo {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -965,6 +965,7 @@ export class ProjectView
                 resp.saveOnly = saveOnly
                 resp.userContextWindow = userContextWindow;
                 resp.downloadFileBaseName = pkg.genFileName("");
+                resp.confirmAsync = core.confirmAsync;
                 return pxt.commands.deployCoreAsync(resp)
                     .catch(e => {
                         core.warningNotification(pxt.appTarget.compile.useModulator ? lf("Upload failed, please try again.") : lf(".hex file upload failed, please try again."));

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -964,9 +964,10 @@ export class ProjectView
                 }
                 resp.saveOnly = saveOnly
                 resp.userContextWindow = userContextWindow;
+                resp.downloadFileBaseName = pkg.genFileName("");
                 return pxt.commands.deployCoreAsync(resp)
                     .catch(e => {
-                        core.warningNotification(lf(".hex file upload failed, please try again."));
+                        core.warningNotification(pxt.appTarget.compile.useModulator ? lf("Upload failed, please try again.") : lf(".hex file upload failed, please try again."));
                         pxt.reportException(e);
                         if (userContextWindow)
                             try { userContextWindow.close() } catch (e) { }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -968,7 +968,7 @@ export class ProjectView
                 resp.confirmAsync = core.confirmAsync;
                 return pxt.commands.deployCoreAsync(resp)
                     .catch(e => {
-                        core.warningNotification(pxt.appTarget.compile.useModulator ? lf("Upload failed, please try again.") : lf(".hex file upload failed, please try again."));
+                        core.warningNotification(lf("Upload failed, please try again."));
                         pxt.reportException(e);
                         if (userContextWindow)
                             try { userContextWindow.close() } catch (e) { }


### PR DESCRIPTION
These changes let targets that override `deployCoreAsync()` download files and show confirm dialogs. This is required for targets that use a modulator deployment.