### PR TITLE
Change grid picker looks for text items

### DIFF
--- a/pxtblocks/fields/field_gridpicker.ts
+++ b/pxtblocks/fields/field_gridpicker.ts
@@ -30,6 +30,7 @@ namespace pxtblockly {
 
         private backgroundColour_: string;
         private itemColour_: string;
+        private borderColour_: string;
 
         private tooltipConfig_: FieldGridPickerToolTipConfig;
 
@@ -43,8 +44,9 @@ namespace pxtblockly {
             this.width_ = parseInt(options.width) || 400;
 
             this.backgroundColour_ = pxtblockly.parseColour(options.colour);
+            this.itemColour_ = options.itemColour || "rgba(255, 255, 255, 0.6)";
+            this.borderColour_ = Blockly.PXTUtils.fadeColour(this.backgroundColour_, 0.4, false);
 
-            this.itemColour_ = options.itemColour || '#fff';
             let tooltipCfg: FieldGridPickerToolTipConfig = {
                 xOffset: parseInt(options.tooltipsXOffset) || 15,
                 yOffset: parseInt(options.tooltipsYOffset) || -10
@@ -100,6 +102,7 @@ namespace pxtblockly {
             scrollContainer.addChild(tableContainer, true);
             paddingContainer.addChild(scrollContainer, true);
             paddingContainer.render(div);
+            (paddingContainer.getElement() as HTMLElement).style.border = `solid 1px ${this.borderColour_}`;
 
             const paddingContainerDom = paddingContainer.getElement() as HTMLElement;
             const scrollContainerDom = scrollContainer.getElement() as HTMLElement;
@@ -118,14 +121,14 @@ namespace pxtblockly {
             scrollContainerDom.className = 'blocklyGridPickerScroller';
             paddingContainerDom.className = 'blocklyGridPickerPadder';
 
-            // Add the tooltips
+            // Add the tooltips and style the items
             const menuItemsDom = tableContainerDom.getElementsByClassName('goog-menuitem');
+            let largestTextItem = -1;
 
             for (let i = 0; i < menuItemsDom.length; ++i) {
                 const elem = menuItemsDom[i] as HTMLElement;
                 elem.style.borderColor = this.backgroundColour_;
                 elem.style.backgroundColor = this.itemColour_;
-
                 elem.parentElement.className = 'blocklyGridPickerRow';
 
                 const tooltipText = (options[i] as any)[0].alt;
@@ -146,6 +149,19 @@ namespace pxtblockly {
                         tooltip.setPosition(newPos);
                     });
                     this.tooltips_.push(tooltip);
+                } else {
+                    const elemWidth = goog.style.getSize(elem).width;
+                    if (elemWidth > largestTextItem) {
+                        largestTextItem = elemWidth;
+                    }
+                }
+            }
+
+            // Resize text items so they have a uniform width
+            if (largestTextItem > -1) {
+                for (let i = 0; i < menuItemsDom.length; ++i) {
+                    const elem = menuItemsDom[i] as HTMLElement;
+                    goog.style.setWidth(elem, largestTextItem);
                 }
             }
 


### PR DESCRIPTION
- Item background color is now slightly faded instead of pure white
- Column widths are now uniform

Before:
![image](https://cloud.githubusercontent.com/assets/14299377/26118644/859ffbec-3a1f-11e7-849a-211d6d7e6d1a.png)

After:
![image](https://cloud.githubusercontent.com/assets/14299377/26118717/b745d932-3a1f-11e7-9cff-868f7f38fae6.png)