### PR TITLE
Reorder loops

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -13,7 +13,7 @@ interface Array<T> {
       * @param items New elements of the Array.
       */
     //% help=arrays/push
-    //% shim=Array_::push weight=75
+    //% shim=Array_::push weight=49
     //% blockId="array_push" block="%list| add value %value| to end" blockNamespace="arrays"
     push(item: T): void;
 
@@ -21,7 +21,7 @@ interface Array<T> {
       * Removes the last element from an array and returns it.
       */
     //% help=arrays/pop
-    //% shim=Array_::pop weight=74
+    //% shim=Array_::pop weight=48
     //% blockId="array_pop" block="get and remove last value from %list" blockNamespace="arrays"
     pop(): T;
 
@@ -155,7 +155,7 @@ declare interface String {
      * Returns a string that contains the concatenation of two or more strings.
      * @param other The string to append to the end of the string.
      */
-    //% shim=String_::concat weight=80
+    //% shim=String_::concat weight=49
     //% blockId="string_concat" blockNamespace="text"
     // block="join %list=text|%other"
     concat(other: string): string;
@@ -164,12 +164,12 @@ declare interface String {
      * Returns the character at the specified index.
      * @param index The zero-based index of the desired character.
      */
-    //% shim=String_::charAt weight=77
+    //% shim=String_::charAt weight=48
     //% blockId="string_get" block="char from %this=text|at %pos" blockNamespace="text"
     charAt(index: number): string;
 
     /** Returns the length of a String object. */
-    //% property shim=String_::length weight=75
+    //% property shim=String_::length weight=47
     //% blockId="text_length" block="length of %VALUE" blockBuiltin=true blockNamespace="text"
     length: number;
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -249,10 +249,10 @@ namespace pxt.blocks {
             if (fn.attributes.mutateDefaults) {
                 const mutationValues = fn.attributes.mutateDefaults.split(";");
                 mutationValues.forEach(mutation => {
-                    const mutatedBlock = block.cloneNode(true);
+                    const mutatedBlock = block.cloneNode(true) as HTMLElement;
                     mutateToolboxBlock(mutatedBlock, fn.attributes.mutate, mutation);
                     if (showCategories !== CategoryMode.None) {
-                        category.appendChild(mutatedBlock);
+                        insertBlock(mutatedBlock, category, fn.attributes.weight);
                     } else {
                         tb.appendChild(mutatedBlock);
                     }
@@ -260,12 +260,39 @@ namespace pxt.blocks {
             }
             else {
                 if (showCategories !== CategoryMode.None && !(showCategories === CategoryMode.Basic && isAdvanced)) {
-                    category.appendChild(block);
+                    insertBlock(block, category, fn.attributes.weight);
                     injectToolboxIconCss();
                 } else if (showCategories === CategoryMode.None) {
                     tb.appendChild(block);
                 }
             }
+        }
+
+    }
+
+    function insertBlock(bl: Element, cat: Element, weight?: number) {
+        const isBuiltin = !!blockColors[cat.getAttribute("nameid")];
+        if (isBuiltin && weight > 50) {
+            bl.setAttribute("loaded", "true")
+
+            let first: Element;
+            for (let i = 0; i < cat.childNodes.length; i++) {
+                const n = cat.childNodes.item(i) as Element;
+                if (n.tagName === "block" && !n.getAttribute("loaded")) {
+                    first = n;
+                    break;
+                }
+            }
+
+            if (first) {
+                cat.insertBefore(bl, first);
+            }
+            else {
+                cat.appendChild(bl);
+            }
+        }
+        else {
+            cat.appendChild(bl)
         }
     }
 
@@ -818,7 +845,7 @@ namespace pxt.blocks {
                 if (showCategories !== CategoryMode.None) {
                     let cat = categoryElement(tb, eb.namespace);
                     if (cat) {
-                        cat.appendChild(el);
+                        insertBlock(el, cat, eb.weight)
                     } else {
                         console.error(`trying to add block ${eb.type} to unknown category ${eb.namespace}`)
                     }


### PR DESCRIPTION
Our loader currently only ever appends blocks to the end of a category which means that you can't have dynamically loaded blocks appear before ones hard-coded in the toolbox definition. This hack makes it so that any block with a weight greater than 50 will appear above those blocks. Not ideal, but I'm concerned that the other option of storing the weights in the DOM and sorting as blocks are inserted would impact performance.

Fixes #2115 