### PR TITLE
No more querySelectors 

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -8,6 +8,30 @@ namespace pxt.blocks {
         return text;
     }
 
+    export function getDirectChildren(parent: Element, tag: string) {
+        const res: Element[] = [];
+        for (let i = 0; i < parent.childNodes.length; i++) {
+            const n = parent.childNodes.item(i) as Element;
+            if (n.tagName === tag) {
+                res.push(n);
+            }
+        }
+        return res;
+    }
+
+    export function getBlocksWithType(parent: Document | Element, type: string) {
+        return getChildrenWithAttr(parent, "block", "type", type);
+    }
+
+    export function getChildrenWithAttr(parent:  Document | Element, tag: string, attr: string, value: string) {
+        return Util.toArray(parent.getElementsByTagName(tag)).filter(b => b.getAttribute(attr) === value);
+    }
+
+    export function getFirstChildWithAttr(parent:  Document | Element, tag: string, attr: string, value: string) {
+        const res = getChildrenWithAttr(parent, tag, attr, value);
+        return res.length ? res[0] : undefined;
+    }
+
     /**
      * Loads the xml into a off-screen workspace (not suitable for size computations)
      */
@@ -25,7 +49,8 @@ namespace pxt.blocks {
     }
 
     function patchFloatingBlocks(dom: Element, info: pxtc.BlocksInfo) {
-        let onstart = dom.querySelector(`block[type=${ts.pxtc.ON_START_TYPE}]`)
+        const onstarts = getBlocksWithType(dom, ts.pxtc.ON_START_TYPE);
+        let onstart = onstarts.length ? onstarts[0] : undefined;
         if (onstart) { // nothing to do
             onstart.removeAttribute("deletable");
             return;
@@ -43,7 +68,7 @@ namespace pxt.blocks {
             const nextNode = node.nextElementSibling;
             // does this block is disable or have s nested statement block?
             const nodeType = node.getAttribute("type");
-            if (!node.getAttribute("disabled") && !node.querySelector("statement")
+            if (!node.getAttribute("disabled") && !node.getElementsByTagName("statement").length
                 && (pxt.blocks.buildinBlockStatements[nodeType] ||
                     (blocks[nodeType] && blocks[nodeType].retType == "void" && !hasArrowFunction(blocks[nodeType])))
             ) {
@@ -88,7 +113,7 @@ namespace pxt.blocks {
                 // patch block types
                 upgrades.filter(up => up.type == "blockId")
                     .forEach(up => Object.keys(up.map).forEach(type => {
-                        Util.toArray(doc.querySelectorAll(`block[type=${type}]`))
+                        getBlocksWithType(doc, type)
                             .forEach(blockNode => {
                                 blockNode.setAttribute("type", up.map[type]);
                                 pxt.debug(`patched block ${type} -> ${up.map[type]}`);
@@ -101,7 +126,8 @@ namespace pxt.blocks {
                         const m = k.split('.');
                         const type = m[0];
                         const name = m[1];
-                        Util.toArray(doc.querySelectorAll(`block[type=${type}]>value[name=${name}]`))
+                        getBlocksWithType(doc, type)
+                            .reduce<Element[]>((prev, current) => prev.concat(getDirectChildren(current, "value")), [])
                             .forEach(blockNode => {
                                 blockNode.setAttribute("name", up.map[k]);
                                 pxt.debug(`patched block value ${k} -> ${up.map[k]}`);
@@ -146,7 +172,7 @@ namespace pxt.blocks {
         symbol.parameters.forEach((p, i) => {
             let ptype = info.apis.byQName[p.type];
             if (ptype && ptype.kind == pxtc.SymbolKind.Enum) {
-                let field = block.querySelector(`field[name=${params[p.name].name}]`);
+                let field = getFirstChildWithAttr(block, "field", "name", params[p.name].name);
                 if (field) {
                     let en = enums[ptype.name + '.' + field.textContent];
                     if (en) field.textContent = en;

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -51,7 +51,7 @@ namespace pxt.blocks.layout {
         blocks.forEach(block => {
             block.moveBy(0, y)
             y += block.getHeightWidth().height
-            y += emPixels; //buffer            
+            y += emPixels; //buffer
         })
     };
 
@@ -121,7 +121,7 @@ namespace pxt.blocks.layout {
 }
 
 .blocklyTreeLabel, .blocklyText, .blocklyHtmlInput {
-    font-family:'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace !important;   
+    font-family:'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace !important;
 }
 
 .rtl .blocklyText {
@@ -187,7 +187,7 @@ namespace pxt.blocks.layout {
     function expandImagesAsync(xsg: Document): Promise<void> {
         if (!imageXLinkCache) imageXLinkCache = {};
 
-        const images = xsg.querySelectorAll("image");
+        const images = xsg.getElementsByTagName("image") as NodeListOf<Element>;
         const p = pxt.Util.toArray(images)
             .filter(image => !/^data:/.test(image.getAttributeNS(XLINK_NAMESPACE, "href")))
             .map((image: HTMLImageElement) => {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -334,7 +334,7 @@ namespace pxt.blocks {
     }
 
     function getChildCategories(parent: Element) {
-        const elements = parent.querySelectorAll("category");
+        const elements = parent.getElementsByTagName("category");
         const result: Element[] = [];
 
         for (let i = 0; i < elements.length; i++) {
@@ -378,13 +378,14 @@ namespace pxt.blocks {
     }
 
     function getOrAddSubcategoryByWeight(parent: Element, name: string, nameid: string, weight: number, colour?: string, iconClass?: string) {
-        const existing = parent.querySelector(`category[nameid="${nameid.toLowerCase()}"]`);
+        const existing = getFirstChildWithAttr(parent, "category", "nameid", nameid.toLowerCase())
+
         if (existing) {
             return existing;
         }
 
         const newCategory = createCategoryElement(name, nameid, weight, colour, iconClass);
-        const siblings = parent.querySelectorAll("category");
+        const siblings = parent.getElementsByTagName("category");
 
         let ci = 0;
         for (ci = 0; ci < siblings.length; ++ci) {
@@ -401,14 +402,14 @@ namespace pxt.blocks {
     }
 
     function getOrAddSubcategoryByName(parent: Element, name: string, nameid: string, colour?: string, iconClass?: string) {
-        const existing = parent.querySelector(`category[nameid="${nameid.toLowerCase()}"]`);
+        const existing = getFirstChildWithAttr(parent, "category", "nameid", nameid.toLowerCase())
         if (existing) {
             return existing;
         }
 
         const newCategory = createCategoryElement(name, nameid, 100, colour, iconClass);
 
-        const siblings = parent.querySelectorAll("category");
+        const siblings = parent.getElementsByTagName("category");
         const filtered: Element[] = [];
 
         let ci = 0;
@@ -768,7 +769,7 @@ namespace pxt.blocks {
         const dbg = pxt.options.debug;
         // create new toolbox and update block definitions
         blockInfo.blocks
-            .filter(fn => !tb || !tb.querySelector(`block[type='${fn.attributes.blockId}']`))
+            .filter(fn => !tb || !getFirstChildWithAttr(tb, "block", "type", fn.attributes.blockId))
             .forEach(fn => {
                 if (fn.attributes.blockBuiltin) {
                     Util.assert(!!builtinBlocks[fn.attributes.blockId]);
@@ -844,7 +845,7 @@ namespace pxt.blocks {
                 showAdvanced = true;
                 const cat = categoryElement(tb, "Text");
                 if (cat) {
-                    const blockElements = cat.querySelectorAll("block");
+                    const blockElements = cat.getElementsByTagName("block");
                     for (let i = 0; i < blockElements.length; i++) {
                         const b = blockElements.item(i);
                         usedBlocks[b.getAttribute("type")] = true;
@@ -859,14 +860,14 @@ namespace pxt.blocks {
                 removeCategory(tb, "Arrays");
                 if (config.loopsBlocks) {
                     const cat = categoryElement(tb, "Loops");
-                    cat.removeChild(cat.querySelector('block[type="controls_for_of"]'))
+                    cat.removeChild(getFirstChildWithAttr(cat, "block", "type", "controls_for_of"))
                 }
             }
             else {
                 showAdvanced = true;
                 const cat = categoryElement(tb, "Arrays");
                 if (cat) {
-                    const blockElements = cat.querySelectorAll("block");
+                    const blockElements = cat.getElementsByTagName("block");
                     for (let i = 0; i < blockElements.length; i++) {
                         const b = blockElements.item(i);
                         usedBlocks[b.getAttribute("type")] = true;
@@ -878,20 +879,21 @@ namespace pxt.blocks {
             }
 
             // Load localized names for default categories
-            let cats = tb.querySelectorAll('category');
+            let cats = tb.getElementsByTagName('category');
             for (let i = 0; i < cats.length; i++) {
                 cats[i].setAttribute('name',
                     Util.rlf(`{id:category}${cats[i].getAttribute('name')}`, []));
             }
 
             // update category colors
-            let topCats = tb.querySelectorAll(`#${tb.id} > category`);
+            let topCats = getDirectChildren(tb, "category")
+
             for (let i = 0; i < topCats.length; i++) {
                 const nsColor = getNamespaceColor(topCats[i].getAttribute('nameid'));
                 if (nsColor && nsColor != "") {
                     topCats[i].setAttribute('colour', nsColor);
                     // update children colors
-                    const childCats = topCats[i].querySelectorAll('category');
+                    const childCats = topCats[i].getElementsByTagName('category');
                     for (let j = 0; j < childCats.length; j++) {
                         childCats[j].setAttribute('colour', nsColor);
                     }
@@ -935,7 +937,7 @@ namespace pxt.blocks {
         }
 
         if (tb) {
-            const blocks = tb.querySelectorAll("block");
+            const blocks = tb.getElementsByTagName("block");
 
             for (let i = 0; i < blocks.length; i++) {
                 usedBlocks[blocks.item(i).getAttribute("type")] = true;
@@ -966,12 +968,17 @@ namespace pxt.blocks {
 
             if (showCategories !== CategoryMode.None) {
                 // Go through namespaces and keep the ones with an override
-                let categories = tb.querySelectorAll(`category:not([nameid="more"]):not([nameid="advanced"])`);
+                let categories = tb.getElementsByTagName(`category`);
                 for (let ci = 0; ci < categories.length; ++ci) {
                     let cat = categories.item(ci);
                     let catName = cat.getAttribute("nameid");
+
+                    if (catName === "more" || catName === "advanced") {
+                        continue;
+                    }
+
                     let categoryState = filters.namespaces && filters.namespaces[catName] != undefined ? filters.namespaces[catName] : filters.defaultState;
-                    let blocks = cat.querySelectorAll(`block`);
+                    let blocks = cat.getElementsByTagName(`block`);
 
                     let hasVisibleChildren = filterBlocks(blocks, categoryState);
                     switch (categoryState) {
@@ -979,7 +986,7 @@ namespace pxt.blocks {
                             if (!hasVisibleChildren) {
                                 cat.setAttribute("disabled", "true");
                                 // disable sub categories
-                                let subcategories = cat.querySelectorAll(`category`);
+                                let subcategories = cat.getElementsByTagName(`category`);
                                 for (let si = 0; si < subcategories.length; ++si) {
                                     subcategories.item(si).setAttribute("disabled", "true");
                                 }
@@ -990,19 +997,19 @@ namespace pxt.blocks {
                     }
                 }
             } else {
-                let blocks = tb.querySelectorAll(`block`);
+                let blocks = tb.getElementsByTagName(`block`);
                 filterBlocks(blocks);
             }
 
             if (showCategories !== CategoryMode.None) {
                 // Go through all categories, hide the ones that have no blocks inside
-                let categories = tb.querySelectorAll(`category:not([nameid="advanced"])`);
+                let categories = tb.getElementsByTagName(`category`);
                 for (let ci = 0; ci < categories.length; ++ci) {
                     let cat = categories.item(ci);
                     let catName = cat.getAttribute("nameid");
                     // Don't do this for special blockly categories
-                    if (catName == "variables" || catName == "functions") continue;
-                    let blockCount = cat.querySelectorAll(`block`);
+                    if (catName == "variables" || catName == "functions" || catName == "advanced") continue;
+                    let blockCount = cat.getElementsByTagName(`block`);
                     if (blockCount.length == 0) {
                         if (cat.parentNode) cat.parentNode.removeChild(cat);
                     }
@@ -1121,7 +1128,7 @@ namespace pxt.blocks {
                             let block = searchElementCache[type];
                             if (!block) {
                                 // Catches built-in blocks that aren't loaded dynamically
-                                const existing = tb.querySelector(`block[type="${type}"]`);
+                                const existing = getFirstChildWithAttr(tb, "block", "type", type);
                                 if (existing) {
                                     block = (searchElementCache[type] = existing.cloneNode(true));
                                 }
@@ -1155,7 +1162,7 @@ namespace pxt.blocks {
     }
 
     function categoryElement(tb: Element, nameid: string): Element {
-        return tb ? tb.querySelector(`category[nameid="${nameid.toLowerCase()}"]`) : undefined;
+        return tb ? getFirstChildWithAttr(tb, "category", "nameid", nameid.toLowerCase()) : undefined;
     }
 
     export function cleanBlocks() {
@@ -1217,7 +1224,7 @@ namespace pxt.blocks {
         if (colour) block.setColour(colour);
 
         let tb = document.getElementById('blocklyToolboxDefinition');
-        let xml: HTMLElement = tb ? tb.querySelector(`category block[type~='${id}']`) as HTMLElement : undefined;
+        let xml: HTMLElement = tb ? getFirstChildWithAttr(tb, "block", "type", id) as HTMLElement : undefined;
         block.codeCard = <pxt.CodeCard>{
             header: name,
             name: name,

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -146,7 +146,7 @@ namespace pxt.runner {
         if (options.downloadScreenshots && woptions.hexname) {
             pxt.debug("Downloading screenshot for: " + woptions.hexname);
             let filename = woptions.hexname.substr(0, woptions.hexname.lastIndexOf('.'));
-            let fontSize = window.getComputedStyle($svg.get(0).querySelector(".blocklyText")).getPropertyValue("font-size");
+            let fontSize = window.getComputedStyle($svg.get(0).getElementsByClassName("blocklyText").item(0)).getPropertyValue("font-size");
             const customCss = `
 .blocklyMainBackground {
     stroke:none !important;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -239,7 +239,7 @@ namespace pxsim {
             this.scheduleFrameCleanup();
 
             // first frame
-            let frame = this.container.querySelector("iframe") as HTMLIFrameElement;
+            let frame = this.container.getElementsByTagName("iframe").item(0) as HTMLIFrameElement;
             // lazy allocate iframe
             if (!frame) {
                 let wrapper = this.createFrame();

--- a/pxtsim/svg.ts
+++ b/pxtsim/svg.ts
@@ -1,6 +1,6 @@
 namespace pxsim.svg {
     export function parseString(xml: string): SVGSVGElement {
-        return new DOMParser().parseFromString(xml, "image/svg+xml").querySelector("svg") as SVGSVGElement;
+        return new DOMParser().parseFromString(xml, "image/svg+xml").getElementsByTagName("svg").item(0) as SVGSVGElement;
     }
 
     export function toDataUri(xml: string): string {
@@ -86,7 +86,7 @@ namespace pxsim.svg {
 
     export function isTouchEnabled(): boolean {
         return typeof window !== "undefined" &&
-            ('ontouchstart' in window               // works on most browsers 
+            ('ontouchstart' in window               // works on most browsers
                 || navigator.maxTouchPoints > 0);       // works on IE10/11 and Surface);
     }
 

--- a/pxtsim/visuals/microservo.ts
+++ b/pxtsim/visuals/microservo.ts
@@ -47,7 +47,7 @@ namespace pxsim.visuals {
       <circle id="path8216" cx="56.661" cy="899.475" r="8.972" fill="gray" stroke-width="2"/>
     </g>
   </g>
-</svg>            
+</svg>
             `).firstElementChild as SVGGElement;
             this.crankEl = this.element.querySelector("#crank") as SVGGElement;
             this.crankTransform = this.crankEl.getAttribute("transform");

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1925,7 +1925,8 @@ function initTheme() {
         document.body.style.direction = "rtl";
 
         // replace semantic.css with rtlsemantic.css
-        const semanticLink = document.head.querySelector('link[href$="semantic.css"]');
+        const links = Util.toArray(document.head.getElementsByTagName("link"));
+        const semanticLink = links.filter(l => Util.endsWith(l.getAttribute("href"), "semantic.css"))[0];
         const semanticHref = semanticLink.getAttribute("data-rtl");
         if (semanticHref) {
             pxt.debug(`swapping to ${semanticHref}`)


### PR DESCRIPTION
Removing all references to querySelector and querySelectorAll (well, except one in the servo part that should be safe). IE11 does not like CSS selectors, so this fixes a bunch of issues.

Fixes #2116 