### PR TITLE
Build common sim as part of the target build

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1268,9 +1268,8 @@ function buildCommonSim() {
             cwd: p
         })
         .then(() => {
-            if (fs.existsSync("built")) {
-                nodeutil.cpR(path.join(p, "built"), "built");
-            }
+            nodeutil.cp(path.join(p, "built", "common-sim.js"), "built");
+            nodeutil.cp(path.join(p, "built", "common-sim.d.ts"), "built");
         })
     }
     else {

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -311,6 +311,13 @@ export function cpR(src: string, dst: string, maxDepth = 8) {
     }
 }
 
+export function cp(srcFile: string, destDirectory: string) {
+    mkdirP(destDirectory);
+    let dest = path.resolve(destDirectory, path.basename(srcFile));
+    let buf = fs.readFileSync(path.resolve(srcFile));
+    fs.writeFileSync(dest, buf);
+}
+
 export function allFiles(top: string, maxDepth = 8, allowMissing = false, includeDirs = false): string[] {
     let res: string[] = []
     if (allowMissing && !fs.existsSync(top)) return res


### PR DESCRIPTION
See https://github.com/Microsoft/pxt-common-packages/pull/63

This builds the simulator code in pxt-common-packages and copies it into the target's built directory. If you have a better idea for how the build should work, let me know.