### PR TITLE
Adding simulator editor events

### DIFF
--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -52,6 +52,7 @@ namespace pxt.editor {
         | "workspacesave" // EditorWorkspaceSaveRequest
 
         | "event"
+        | "simevent"
         ;
     }
 
@@ -96,7 +97,7 @@ namespace pxt.editor {
 
     export interface EditorWorkspaceSyncRequest extends EditorMessageRequest {
         /**
-         * Synching projects from host into 
+         * Synching projects from host into
          */
         action: "workspacesync" | "workspacereset";
     }
@@ -143,16 +144,26 @@ namespace pxt.editor {
         data: string;
     }
 
+    export interface EditorSimulatorEvent extends EditorMessageRequest {
+        action: "simevent";
+        subtype: "toplevelfinished" | "started" | "stopped" | "resumed"
+    }
+
+    export interface EditorSimulatorStoppedEvent extends EditorSimulatorEvent {
+        subtype: "stopped";
+        exception?: string;
+    }
+
     const pendingRequests: pxt.Map<{
         resolve: (res?: EditorMessageResponse | PromiseLike<EditorMessageResponse>) => void;
         reject: (err: any) => void;
     }> = {};
     /**
-     * Binds incoming window messages to the project view. 
+     * Binds incoming window messages to the project view.
      * Requires the "allowParentController" flag in the pxtarget.json/appTheme object.
-     * 
-     * When the project view receives a request (EditorMessageRequest), 
-     * it starts the command and returns the result upon completion. 
+     *
+     * When the project view receives a request (EditorMessageRequest),
+     * it starts the command and returns the result upon completion.
      * The response (EditorMessageResponse) contains the request id and result.
      * Some commands may be async, use the ``id`` field to correlate to the original request.
      */

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -37,6 +37,10 @@ namespace pxsim {
         frameid: string;
     }
 
+    export interface SimulatorTopLevelCodeFinishedMessage extends SimulatorMessage {
+        type: "toplevelcodefinished";
+    }
+
     export interface SimulatorDocsReadyMessage extends SimulatorMessage {
     }
 
@@ -170,6 +174,7 @@ namespace pxsim {
                 .done(() => {
                     runtime.run((v) => {
                         pxsim.dumpLivePointers();
+                        Runtime.postMessage({ type: "toplevelcodefinished" })
                     })
                 })
         }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -9,6 +9,7 @@ namespace pxsim {
         onDebuggerResume?: () => void;
         onStateChanged?: (state: SimulatorState) => void;
         onSimulatorCommand?: (msg: pxsim.SimulatorCommandMessage) => void;
+        onTopLevelCodeEnd?: () => void;
         simUrl?: string;
     }
 
@@ -290,6 +291,7 @@ namespace pxsim {
                 case 'custom':
                     break; //handled elsewhere
                 case 'debugger': this.handleDebuggerMessage(msg as DebuggerMessage); break;
+                case 'toplevelcodefinished': if (this.options.onTopLevelCodeEnd) this.options.onTopLevelCodeEnd(); break;
                 default:
                     if (msg.type == 'radiopacket') {
                         // assign rssi noisy?

--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -8,7 +8,7 @@
 <style type="text/css">
     @import "/blb/semantic.css";
 </style>
-<style>    
+<style>
     #logs {
         position: absolute;
         left: 0;
@@ -18,7 +18,7 @@
         border: 0;
         font-size: 0.6rem;
     }
-    
+
     #logs img {
         max-width:18rem;
     }
@@ -51,11 +51,11 @@
     let filter = false;
 
     function toggleFilters() {
-        filter = !filter;        
+        filter = !filter;
         var logs = document.getElementById("logs");
         logs.innerText += "filter: " + filter + "\n";
     }
-    
+
     var pendingMsgs = {};
     function sendMessage(action) {
         console.log('send ' + action)
@@ -87,7 +87,12 @@
         console.log('received...')
         console.log(msg)
         var logs = document.getElementById("logs");
-        logs.innerText += "< " + msg.type +(msg.action ? " " + msg.action : "" ) + "\n";
+        if (msg.action === "simevent") {
+            logs.innerText += "< " + msg.type + " " + msg.action + " (" + msg.subtype + ")\n";
+        }
+        else {
+            logs.innerText += "< " + msg.type +(msg.action ? " " + msg.action : "" ) + "\n";
+        }
         if(msg.resp)
             console.log(JSON.stringify(msg.resp, null, 2))
 

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -188,6 +188,13 @@ export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResul
         partDefinitions: pkg.computePartDefinitions(parts)
     }
 
+
+    pxt.editor.postHostMessageAsync({
+        type: "pxthost",
+        action: "simevent",
+        subtype: "started",
+    } as pxt.editor.EditorSimulatorEvent);
+
     driver.run(js, opts);
 }
 

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -69,6 +69,12 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
             if (brk.exceptionMessage) {
                 core.errorNotification(lf("Program Error: {0}", brk.exceptionMessage))
             }
+            pxt.editor.postHostMessageAsync({
+                type: "pxthost",
+                action: "simevent",
+                subtype: "stopped",
+                exception: brk.exceptionMessage
+            } as pxt.editor.EditorSimulatorStoppedEvent);
         },
         onTraceMessage: function (msg) {
             let brkInfo = lastCompileResult.breakpoints[msg.breakpointId]
@@ -86,6 +92,11 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
             }
         },
         onDebuggerResume: function () {
+            pxt.editor.postHostMessageAsync({
+                type: "pxthost",
+                action: "simevent",
+                subtype: "resumed"
+            } as pxt.editor.EditorSimulatorEvent)
             config.highlightStatement(null)
             updateDebuggerButtons()
         },
@@ -126,6 +137,13 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
                     }
                     break;
             }
+        },
+        onTopLevelCodeEnd: () => {
+            pxt.editor.postHostMessageAsync({
+                type: "pxthost",
+                action: "simevent",
+                subtype: "toplevelfinished"
+            } as pxt.editor.EditorSimulatorEvent)
         }
     };
     driver = new pxsim.SimulatorDriver($('#simulators')[0], options);


### PR DESCRIPTION
Adds simulator events for the editor including the usual start, stop, resume, exception, and a new one for when the top level code has finished executing.