### PR TITLE
Preserve embedded pages across reloads

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2094,12 +2094,12 @@ $(document).ready(() => {
         return;
     }
 
-    appcache.init();
     initLogin();
+    const hash = parseHash();
+    appcache.init(hash);
 
     pxt.docs.requireMarked = () => require("marked");
     const ih = (hex: pxt.cpp.HexFile) => theEditor.importHex(hex);
-    const hash = parseHash();
 
     const hm = /^(https:\/\/[^/]+)/.exec(window.location.href)
     if (hm) Cloud.apiRoot = hm[1] + "/api/"

--- a/webapp/src/appcache.ts
+++ b/webapp/src/appcache.ts
@@ -1,9 +1,17 @@
 import * as core from "./core";
 
-export function init() {
+export function init(hash: { cmd: string, arg: string }) {
     let appCache = window.applicationCache;
     appCache.addEventListener('updateready', () => {
-        core.infoNotification(lf("Update download complete. Reloading..."));
-        setTimeout(() => location.reload(), 3000);
+        core.infoNotification(lf("Update download complete. Reloading... "));
+        setTimeout(() => {
+            // On embedded pages, preserve the loaded project
+            if (pxt.BrowserUtils.isIFrame() && hash.cmd === "pub") {
+                location.replace(location.origin + `/#pub:${hash.arg}`)
+            }
+            else {
+                location.reload()
+            }
+        }, 3000);
     }, false);
 }


### PR DESCRIPTION
Fixes the bug where if we publish a release and you navigate to a page with our editor embedded, then the embedded editor will update and the embedded project will be replaced with the template project.