### PR TITLE
Fixing NaN appearing in block fields that use a slider

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -516,7 +516,7 @@ namespace pxt.blocks {
     }
 
     function checkNumber(n: number) {
-        if (n === Infinity || n === NaN) {
+        if (n === Infinity || isNaN(n)) {
             U.userError(lf("Number entered is either too large or too small"));
         }
     }

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -509,7 +509,7 @@ namespace pxt.blocks {
     ///////////////////////////////////////////////////////////////////////////////
 
     function extractNumber(b: B.Block): number {
-        let v = b.getFieldValue("NUM");
+        let v = b.getFieldValue(b.type === "math_number_minmax" ? "SLIDER" : "NUM");
         const parsed = parseFloat(v);
         checkNumber(parsed);
         return parsed;


### PR DESCRIPTION
Not sure how this broke (or rather, not sure how this ever worked).