### PR TITLE
Force scroll of workspace in addition to translating block positions

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -341,7 +341,7 @@ declare namespace Blockly {
     function prompt(message: string, defaultValue: string, callback: (response: string) => void): void;
 
     let ALIGN_RIGHT: number;
-    
+
     let VARIABLE_CATEGORY_NAME: string;
 
     namespace utils {
@@ -429,9 +429,9 @@ declare namespace Blockly {
     }
 
     class FieldGridPicker extends FieldDropdown {
-        constructor(menuGenerator: ({ src: string; alt: string; width: number; height: number; } | string)[][], colour?: string | number, params?: pxt.Map<string> ); 
+        constructor(menuGenerator: ({ src: string; alt: string; width: number; height: number; } | string)[][], colour?: string | number, params?: pxt.Map<string> );
     }
-    
+
     class FieldSlider extends FieldNumber {
     }
 
@@ -646,6 +646,9 @@ declare namespace Blockly {
         scrollbar: ScrollbarPair;
         svgBlockCanvas_: SVGGElement;
 
+        scrollX: number;
+        scrollY: number;
+
         undoStack_: Blockly.Events.Abstract[];
         redoStack_: Blockly.Events.Abstract[];
 
@@ -686,6 +689,8 @@ declare namespace Blockly {
 
         registerButtonCallback(key: string, func: (button: Blockly.FlyoutButton) => void): void;
         registerToolboxCategoryCallback(a: string, b: Function): void;
+
+        resizeContents(): void;
     }
 
     class WorkspaceSvg {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -190,7 +190,12 @@ export class Editor extends srceditor.Editor {
         }
         else {
             // Otherwise translate the blocks so that they are positioned on the top left
-            this.editor.getTopBlocks(false).forEach(b => b.moveBy(-minX, -minY))
+            this.editor.getTopBlocks(false).forEach(b => b.moveBy(-minX, -minY));
+            this.editor.scrollX = 10;
+            this.editor.scrollY = 10;
+
+            // Forces scroll to take effect
+            this.editor.resizeContents();
         }
     }
 


### PR DESCRIPTION
Should fix the bug where sometimes it scrolls to the center instead of the top left after translating the blocks.