### PR TITLE
Change reserved and already taken names when compiling blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -10,6 +10,18 @@ import B = Blockly;
 let iface: pxt.worker.Iface
 
 namespace pxt.blocks {
+    export const reservedWords = [ "abstract", "any", "as", "break",
+    "case", "catch", "class", "continue", "const", "constructor", "debugger",
+    "declare", "default", "delete", "do", "else", "enum", "export", "extends",
+    "false", "finally", "for", "from", "function", "get", "if", "implements",
+    "import", "in", "instanceof", "interface", "is", "let", "module", "namespace",
+    "new", "null", "package", "private", "protected", "public",
+    "require", "global", "return", "set", "static", "super", "switch",
+    "symbol", "this", "throw", "true", "try", "type", "typeof", "var", "void",
+    "while", "with", "yield", "async", "await", "of",
+
+    // PXT Specific
+    "Math"];
 
     export function initWorker() {
         if (!iface) {
@@ -981,7 +993,7 @@ namespace pxt.blocks {
         let n = name.replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_$]/g, a =>
             ts.pxtc.isIdentifierPart(a.charCodeAt(0), ts.pxtc.ScriptTarget.ES5) ? a : "");
 
-        if (!n || !ts.pxtc.isIdentifierStart(n.charCodeAt(0), ts.pxtc.ScriptTarget.ES5)) {
+        if (!n || !ts.pxtc.isIdentifierStart(n.charCodeAt(0), ts.pxtc.ScriptTarget.ES5) || reservedWords.indexOf(n) !== -1) {
             n = "_" + n;
         }
 
@@ -1340,13 +1352,23 @@ namespace pxt.blocks {
         let e = emptyEnv(w);
 
         // append functions in stdcalltable
-        if (blockInfo)
+        if (blockInfo) {
+            // Enums are not enclosed in namespaces, so add them to the taken names
+            // to avoid collision
+            Object.keys(blockInfo.apis.byQName).forEach(name => {
+                const info = blockInfo.apis.byQName[name];
+                if (info.kind === pxtc.SymbolKind.Enum) {
+                    e.renames.takenNames[info.qName] = true;
+                }
+            });
+
             blockInfo.blocks
                 .forEach(fn => {
                     if (e.stdCallTable[fn.attributes.blockId]) {
                         pxt.reportError("blocks", "function already defined", { "details": fn.attributes.blockId });
                         return;
                     }
+                    e.renames.takenNames[fn.namespace] = true;
                     let fieldMap = pxt.blocks.parameterNames(fn);
                     let instance = fn.kind == pxtc.SymbolKind.Method || fn.kind == pxtc.SymbolKind.Property;
                     let args = (fn.parameters || []).map(p => {
@@ -1373,6 +1395,7 @@ namespace pxt.blocks {
                         isIdentity: fn.attributes.shim == "TD_ID"
                     }
                 })
+        }
 
         if (skipVariables) return e;
 

--- a/tests/blocklycompiler-test/baselines/variables_reserved_names.ts
+++ b/tests/blocklycompiler-test/baselines/variables_reserved_names.ts
@@ -1,0 +1,10 @@
+let _Math = 0
+let _let = 0
+let string = 0
+let Number = 0
+let boolean = 0
+boolean = 0
+Number = 0
+string = 0
+_let = 0
+_Math = 0

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -285,5 +285,9 @@ describe("blockly compiler", () => {
         it("should change invalid names and preserve unicode names", done => {
             blockTestAsync("variables_names").then(done, done);
         });
+
+        it("should change reserved names", done => {
+            blockTestAsync("variables_reserved_names").then(done, done);
+        });
     });
 });

--- a/tests/blocklycompiler-test/variables_reserved_names.blocks
+++ b/tests/blocklycompiler-test/variables_reserved_names.blocks
@@ -1,0 +1,54 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block id="I{9zVw/0]icrkq4+E=y%" type="pxt-on-start" x="90" y="50">
+    <statement name="HANDLER">
+      <block id="}yM{9kafDVMJEsiApt+j" type="variables_set">
+        <field name="VAR">boolean</field>
+        <value name="VALUE">
+          <shadow id="[M)fd/.RgR5`62;DNrWo" type="math_number">
+            <field name="NUM">0</field>
+          </shadow>
+        </value>
+        <next>
+          <block id="^qR=/8m(Nm^~2*r2Le6$" type="variables_set">
+            <field name="VAR">Number</field>
+            <value name="VALUE">
+              <shadow id="+XgCh_f0q_a9nlty.f?=" type="math_number">
+                <field name="NUM">0</field>
+              </shadow>
+            </value>
+            <next>
+              <block id=";m;Jjy/;0/StgX-.-Ksx" type="variables_set">
+                <field name="VAR">string</field>
+                <value name="VALUE">
+                  <shadow id="Kf%!)k:Lt#Nt9W8BFp_6" type="math_number">
+                    <field name="NUM">0</field>
+                  </shadow>
+                </value>
+                <next>
+                  <block id="d2oQl}{%L-u0UspURFg0" type="variables_set">
+                    <field name="VAR">let</field>
+                    <value name="VALUE">
+                      <shadow id=":a^/a{E[;b4x8PcQgeBV" type="math_number">
+                        <field name="NUM">0</field>
+                      </shadow>
+                    </value>
+                    <next>
+                      <block id="(*wxevnjAR[jj4o`b`}L" type="variables_set">
+                        <field name="VAR">Math</field>
+                        <value name="VALUE">
+                          <shadow id="DmY1=@uE)4$WRAUw,zW8" type="math_number">
+                            <field name="NUM">0</field>
+                          </shadow>
+                        </value>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+</xml>


### PR DESCRIPTION
Fixes #2142 

Fixes variable name collisions with reserved TS words, namespaces, and enum names. Let me know if I forgot anything.