### PR TITLE
Fix execution trace for statements with comments

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1262,15 +1262,15 @@ namespace pxt.blocks {
         }
         let l = r[r.length - 1]; if (l) l.id = b.id;
 
-        r.forEach(l => {
-            if (l.type === NT.Block) {
-                l.id = b.id
-            }
-        });
-
         if (comments.length) {
             addCommentNodes(comments, r)
         }
+
+        r.forEach(l => {
+            if (l.type === NT.Block || l.type === NT.Prefix && Util.startsWith(l.op, "//")) {
+                l.id = b.id
+            }
+        });
 
         return r;
     }

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -28,11 +28,12 @@ namespace ts.pxtc {
 
     export function nodeLocationInfo(node: ts.Node) {
         let file = getSourceFileOfNode(node)
-        const { line, character } = ts.getLineAndCharacterOfPosition(file, node.pos);
+        const nodeStart = node.getStart ? node.getStart() : node.pos;
+        const { line, character } = ts.getLineAndCharacterOfPosition(file, nodeStart);
         const { line: endLine, character: endChar } = ts.getLineAndCharacterOfPosition(file, node.end);
         let r: LocationInfo = {
-            start: node.pos,
-            length: node.end - node.pos,
+            start: nodeStart,
+            length: node.end - nodeStart,
             line: line,
             column: character,
             endLine: endLine,

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -348,7 +348,7 @@ namespace pxt.blocks {
 
             let end = getCurrentLine();
 
-            if (n.id && start != end) {
+            if (n.id) {
                 if (sourceMapById[n.id]) {
                     const node = sourceMapById[n.id];
                     node.start = Math.min(node.start, start);

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1114,10 +1114,11 @@ export class Editor extends srceditor.Editor {
     highlightStatement(brk: pxtc.LocationInfo) {
         if (!brk || !this.currFile || this.currFile.name != brk.fileName || !this.editor) return;
         let position = this.editor.getModel().getPositionAt(brk.start);
-        if (!position) return;
+        let end = this.editor.getModel().getPositionAt(brk.start + brk.length);
+        if (!position || !end) return;
         this.highlightDecorations = this.editor.deltaDecorations(this.highlightDecorations, [
             {
-                range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column + brk.length),
+                range: new monaco.Range(position.lineNumber, position.column, end.lineNumber, end.column),
                 options: { inlineClassName: 'highlight-statement' }
             },
         ]);


### PR DESCRIPTION
Fixes #2224 

This changes the behavior in Monaco so that multi-line statements (e.g. if-statements) get highlighted in their entirety instead of just the first line during slow-mo. It looks like this:

![slow_mo_comments](https://user-images.githubusercontent.com/13754588/26893058-17551076-4b6f-11e7-81e9-8cd2a3523d90.gif)

This also fixes the highlighting in blocks for code with comments, which was previously broken.
