### PR TITLE
Disable simulator aspect ratio on smaller screens

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1028,6 +1028,7 @@ Field editors
         display:inline-block;
         width: 10rem;
         margin-right:0.5rem;
+        padding-bottom: 81.96% !important;
     }
     div.simframe:not(:first-child) {
         display:none !important;


### PR DESCRIPTION
This fixes the issue where the simulator overflows the editor toolbar in the tablet and mobile views by overriding the style that is set programmatically by the simdriver. The weird percentage comes from the default value for that padding set elsewhere in `common.less`. Tested across all targets except micro:bit. 