### PR TITLE
Fix tutorial rendering. 

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -597,7 +597,7 @@ ${files["main.ts"]}
                         let stepcontent = content.innerHTML.split(/<h3.*\/h3>/gi);
                         for (let i = 0; i < stepcontent.length - 1; i++) {
                             content.innerHTML = stepcontent[i + 1];
-                            stepInfo[i].headerContent = content.firstElementChild.innerHTML;
+                            stepInfo[i].headerContent = `<p>` + content.firstElementChild.innerHTML + `</p>`;
                             stepInfo[i].content = stepcontent[i + 1];
                         }
                         content.innerHTML = '';

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -596,9 +596,11 @@ ${files["main.ts"]}
                         // Split the steps
                         let stepcontent = content.innerHTML.split(/<h3.*\/h3>/gi);
                         for (let i = 0; i < stepcontent.length - 1; i++) {
-                            stepInfo[i].headerContent = stepcontent[i + 1].split(/(<.*?>.*<\/.*?>)/i)[1];
+                            content.innerHTML = stepcontent[i + 1];
+                            stepInfo[i].headerContent = content.firstElementChild.innerHTML;
                             stepInfo[i].content = stepcontent[i + 1];
                         }
+                        content.innerHTML = '';
                         // return the result
                         window.parent.postMessage(<pxsim.TutorialLoadedMessage>{
                             type: "tutorial",


### PR DESCRIPTION
Fix bug in tutorial rendering logic. Fixes #2189

The issue was after the full page was rendered by markdown, I had HTML in string format, and I needed the first element of each step. I was using regex to parse the HTML. I am now using the contentdiv passed in and temporarily setting the HTML of each step, and extracting the first elements HTML. Using the DOM to do the parsing.