### PR TITLE
Blockly JS tooltip overflow

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -407,6 +407,8 @@ div.simframe > iframe {
     box-shadow: none !important;
     background-color: transparent !important;
     opacity: 1 !important;
+    /* wrap the JS text inside a blockly Tooltip */
+    overflow-wrap: break-word;
 }
 
 .blocklyToolboxDiv, .monacoToolboxDiv {

--- a/theme/common.less
+++ b/theme/common.less
@@ -679,6 +679,9 @@ Avatar
     margin-left: 4em;
     margin-bottom: 1em;
 }
+#docs code.lang-typescript {
+    overflow-wrap: break-word;
+}
 
 @media only screen {
     .avatar .avatar-image {


### PR DESCRIPTION
Fix overflow of JS in blockly tooltip showing a non usable horizontal scrollbar.

Fixes #2247