### PR TITLE
Don't always filter out the variables category in tutorials

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1006,6 +1006,15 @@ namespace pxt.blocks {
                         continue;
                     }
 
+                    // The variables category is special and won't have any children so we
+                    // need to check manually
+                    if (catName === "variables" && (!filters.blocks ||
+                        filters.blocks["variables_set"] ||
+                        filters.blocks["variables_get"] ||
+                        filters.blocks["variables_change"])) {
+                        continue;
+                    }
+
                     let categoryState = filters.namespaces && filters.namespaces[catName] != undefined ? filters.namespaces[catName] : filters.defaultState;
                     let blocks = cat.getElementsByTagName(`block`);
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1011,7 +1011,8 @@ namespace pxt.blocks {
                     if (catName === "variables" && (!filters.blocks ||
                         filters.blocks["variables_set"] ||
                         filters.blocks["variables_get"] ||
-                        filters.blocks["variables_change"])) {
+                        filters.blocks["variables_change"]) &&
+                        (!filters.namespaces || filters.namespaces["variables"] !== FilterState.Disabled)) {
                         continue;
                     }
 


### PR DESCRIPTION
In tutorial mode, we always remove the variables category even if you use variable blocks in your code because the category itself doesn't have any child blocks in its definition. This fixes that bug.