### PR TITLE
Filter serial by vendor and product id instead of manufacturer

### DIFF
--- a/cli/serial.ts
+++ b/cli/serial.ts
@@ -16,6 +16,8 @@ export interface SerialPortInfo {
     comName: string;
     pnpId: string;
     manufacturer: string;
+    vendorId: string;
+    productId: string;
 
     opened?: boolean;
     port?: any;
@@ -63,11 +65,17 @@ export function monitorSerial(onData: (info: SerialPortInfo, buffer: Buffer) => 
         });
     }
 
-    const manufacturerRx = pxt.appTarget.serial.manufacturerFilter
-        ? new RegExp(pxt.appTarget.serial.manufacturerFilter, "i")
-        : undefined;
+    const vendorFilter = pxt.appTarget.serial.vendorId ? parseInt(pxt.appTarget.serial.vendorId, 16) : undefined;
+    const productFilter = pxt.appTarget.serial.productId ? parseInt(pxt.appTarget.serial.productId, 16) : undefined;
+
     function filterPort(info: SerialPortInfo): boolean {
-        return manufacturerRx ? manufacturerRx.test(info.manufacturer) : true;
+        console.log(info);
+        let retVal = true;
+        if (vendorFilter)
+            retVal && (vendorFilter == parseInt(info.vendorId, 16));
+        if (productFilter)
+            retVal && (productFilter == parseInt(info.productId, 16));
+        return retVal;
     }
 
     setInterval(() => {

--- a/cli/serial.ts
+++ b/cli/serial.ts
@@ -69,7 +69,6 @@ export function monitorSerial(onData: (info: SerialPortInfo, buffer: Buffer) => 
     const productFilter = pxt.appTarget.serial.productId ? parseInt(pxt.appTarget.serial.productId, 16) : undefined;
 
     function filterPort(info: SerialPortInfo): boolean {
-        console.log(info);
         let retVal = true;
         if (vendorFilter)
             retVal && (vendorFilter == parseInt(info.vendorId, 16));

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -71,7 +71,8 @@ declare namespace pxt {
 
     interface AppSerial {
         useHF2?: boolean;
-        manufacturerFilter?: string; // used by node-serial
+        vendorId?: string; // used by node-serial
+        productId?: string; // used by node-serial
         nameFilter?: string; // regex to match devices
         log?: boolean;
     }


### PR DESCRIPTION
micro:bit on windows serial info: 
```
comName: 'COM18',
  manufacturer: 'mbed',
  serialNumber: undefined,
  pnpId: 'USB\\VID_0D28&PID_0204&MI_01\\9900000040304E4500431003000000150000000097969901',
  locationId: 'mbed Serial Port',
  vendorId: '0D28',
  productId: '0204'
```

on mac: 
```
comName: '/dev/cu.usbmodem1422',
  manufacturer: 'ARM',
  serialNumber: '9900000040304e4500431003000000150000000097969901',
  pnpId: undefined,
  locationId: '0x14200000',
  vendorId: '0x0d28',
  productId: '0x0204' 
```

Changing our serial filter logic to filter by vendor / product id and not manufacturer. 

To test, change serial section of pxtarget.json in pxt-microbit to: 
```
    "serial": {
        "productFilter": "0x0204",
        "vendorFilter": "0x0d28",
        "nameFilter": "^mbed Serial Port",
        "log": true
    },
```