### PR TITLE
Fix parameter defaults in blocks and monaco

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -102,7 +102,18 @@ namespace pxt.blocks {
         if (typeInfo) {
             const field = document.createElement("field");
             shadow.appendChild(field);
-            field.setAttribute("name", shadowType == "variables_get" ? "VAR" : typeInfo.field);
+
+            let fieldName: string;
+            switch (shadowType) {
+                case "variables_get":
+                    fieldName = "VAR"; break;
+                case "math_number_minmax":
+                    fieldName = "SLIDER"; break;
+                default:
+                    fieldName = typeInfo.field; break;
+            }
+
+            field.setAttribute("name", fieldName);
 
             let value: Text;
             if (type == "boolean") {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -13,7 +13,7 @@ namespace ts.pxtc {
 
     function renderDefaultVal(apis: pxtc.ApisInfo, p: pxtc.ParameterDesc, imgLit: boolean, cursorMarker: string): string {
         if (p.initializer) return p.initializer
-        if (p.defaults) return p.defaults[0]
+        if (p.default) return p.default
         if (p.type == "number") return "0"
         if (p.type == "boolean") return "false"
         else if (p.type == "string") {
@@ -202,7 +202,7 @@ namespace ts.pxtc {
                         description: desc,
                         type: typeOf(p.type, p),
                         initializer: p.initializer ? p.initializer.getText() : attributes.paramDefl[n],
-                        defaults: m && m[1].trim() ? m[1].split(/,\s*/).map(e => e.trim()) : undefined,
+                        default: attributes.paramDefl[n],
                         properties: props,
                         options: options,
                         isEnum

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -18,7 +18,7 @@ namespace pxt.blocks {
             fn.parameters.forEach(pr => attrNames[pr.name] = {
                 name: pr.name,
                 type: pr.type,
-                shadowValue: pr.defaults ? pr.defaults[0] : undefined
+                shadowValue: pr.default || undefined
             });
         if (fn.attributes.block) {
             Object.keys(attrNames).forEach(k => attrNames[k].name = "");

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -20,7 +20,7 @@ namespace ts.pxtc {
         description: string;
         type: string;
         initializer?: string;
-        defaults?: string[];
+        default?: string;
         properties?: PropertyDesc[];
         options?: pxt.Map<PropertyOption>;
         isEnum?: boolean;
@@ -401,6 +401,12 @@ namespace ts.pxtc {
             doccmt = doccmt.replace(/\n\s*(\*\s*)?/g, "\n")
             doccmt = doccmt.replace(/^\s*@param\s+(\w+)\s+(.*)$/mg, (full: string, name: string, desc: string) => {
                 res.paramHelp[name] = desc
+                if (!res.paramDefl[name]) {
+                    let m = /\beg\.?:\s*(.+)/.exec(desc);
+                    if (m) {
+                        res.paramDefl[name] = m[1].trim() ? m[1].split(/,\s*/).map(e => e.trim())[0] : undefined;
+                    }
+                }
                 return ""
             })
             res.jsDoc += doccmt


### PR DESCRIPTION
This fixes two issues:

1. We were parsing the default values for parameters in two places which led to the Monaco toolbox not picking up the ones set with the `eg.` syntax
2. The name of the field for the slider block changed at some point and we didn't patch blocklyloader (so blocks with slider inputs didn't have default values set)
