### PR TITLE
fix compile order problem

### DIFF
--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -137,7 +137,7 @@ namespace ts.pxtc {
 
         let tsFiles = opts.sourceFiles.filter(f => U.endsWith(f, ".ts"))
         // ensure that main.ts is last of TS files
-        let tsFilesNoMain = tsFiles.filter(f => !f.match("^main.ts$"))
+        let tsFilesNoMain = tsFiles.filter(f => f != "main.ts")
         if (tsFiles.length > tsFilesNoMain.length) {
             tsFiles = tsFilesNoMain
             tsFiles.push("main.ts")

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -136,6 +136,13 @@ namespace ts.pxtc {
             opts.sourceFiles = Object.keys(opts.fileSystem)
 
         let tsFiles = opts.sourceFiles.filter(f => U.endsWith(f, ".ts"))
+        // ensure that main.ts is last of TS files
+        let tsFilesNoMain = tsFiles.filter(f => !f.match("^main.ts$"))
+        if (tsFiles.length > tsFilesNoMain.length) {
+            tsFiles = tsFilesNoMain
+            tsFiles.push("main.ts")
+        }
+        // TODO: ensure that main.ts is last???
         let program = createProgram(tsFiles, options, host);
 
         // First get and report any syntactic errors.


### PR DESCRIPTION
The introduction of the custom,.ts file for blocks created a problem, as the custom.ts file was ordered after main.ts, resulting in issues like:

https://github.com/Microsoft/pxt/issues/2308

This PR fixes the problem by ensuring that main.ts is the last file in the compilation order.
