### PR TITLE
Fixed NL translation issue

### DIFF
--- a/webapp/public/locales/nl/strings.json
+++ b/webapp/public/locales/nl/strings.json
@@ -273,7 +273,7 @@
   "arithmetic operation": "rekenkundige bewerking",
   "assign the value of a variable": "de waarde van een variabele toewijzen",
   "boolean operation": "boolean bewerking",
-  "change %1 by %2": "%1 vervangen door %2",
+  "change %1 by %2": "%1 veranderen met %2",
   "comparing two numbers": "twee getallen vergelijken",
   "conflict on yotta setting {0} between packages {1} and {2}": "conflict op yotta instelling {0} tussen pakketten {1} en {2}",
   "creating new project...": "nieuw project aanmaken...",


### PR DESCRIPTION
In Dutch "vervangen door" translates to "replace by". I recommend to translate it to "veranderen met".