### PR TITLE
Fix monaco editor error markers, line number's off by 1.

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1191,9 +1191,9 @@ export class Editor extends srceditor.Editor {
                     monacoErrors.push({
                         severity: monaco.Severity.Error,
                         message: message,
-                        startLineNumber: d.line,
+                        startLineNumber: d.line + 1,
                         startColumn: d.column,
-                        endLineNumber: d.endLine || endPos.lineNumber,
+                        endLineNumber: (d.endLine || endPos.lineNumber) + 1,
                         endColumn: d.endColumn || endPos.column
                     })
                 }


### PR DESCRIPTION
Not sure if this is the right place for this fix.
I'm able to add 1 to the line number to avoid the off by 1 issue, but the monaco editor is just surfacing what is returned inside file.diagnostics. 

@mmoskal should this fix be done in the compiler?