### PR TITLE
Select all input on click in share dialog

### DIFF
--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -172,7 +172,7 @@ pxt extract ${url}`;
                         : undefined }
                     { url && ready ? <div>
                         <p>{lf("Your project is ready! Use the address below to share your projects.") }</p>
-                        <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} />
+                        <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} selectOnClick={true}/>
                     </div>
                         : undefined }
                     { ready ? <div>
@@ -185,7 +185,7 @@ pxt extract ${url}`;
                             </sui.Menu> : undefined }
                         { advancedMenu ?
                             <sui.Field>
-                                <sui.Input class="mini" readOnly={true} lines={4} value={embed} copy={ready} disabled={!ready} />
+                                <sui.Input class="mini" readOnly={true} lines={4} value={embed} copy={ready} disabled={!ready} selectOnClick={true}/>
                             </sui.Field> : null }
                     </div> : undefined }
                 </div>

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -216,6 +216,7 @@ export class Input extends data.Component<{
     lines?: number;
     readOnly?: boolean;
     copy?: boolean;
+    selectOnClick?: boolean;
 }, {}> {
 
     copy() {
@@ -252,6 +253,7 @@ export class Input extends data.Component<{
                         type={p.type || "text"}
                         placeholder={p.placeholder} value={p.value}
                         readOnly={!!p.readOnly}
+                        onClick={(e) => p.selectOnClick ? (e.target as any).select() : undefined}
                         onChange={v => p.onChange((v.target as any).value) }/>
                         : <textarea
                             className={"ui input " + (p.class || "") + (p.inputLabel ? " labelled" : "") }
@@ -259,6 +261,7 @@ export class Input extends data.Component<{
                             placeholder={p.placeholder}
                             value={p.value}
                             readOnly={!!p.readOnly}
+                            onClick={(e) => p.selectOnClick ? (e.target as any).select() : undefined}
                             onChange={v => p.onChange((v.target as any).value) }>
                         </textarea>}
                     {copyBtn}


### PR DESCRIPTION
In order to make sure we don't select part of the share URl. This ensures whenever we click or focus on the field, it selects the entire share URL string. Same for advanced sharing.

![selectonclick](https://user-images.githubusercontent.com/16690124/27510690-4fc7f964-58cb-11e7-8610-0f03667cd213.gif)
 