### PR TITLE
Facebook and Twitter social icons in the share dialog

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -196,9 +196,14 @@ declare namespace pxt {
         useUploadMessage?: boolean; // change "Download" text to "Upload"
         downloadIcon?: string; // which icon io use for download
         blockColors?: Map<string>; // block namespace colors, used for build in categories
-        showSocialIcons?: boolean; // show social icons in share dialog
+        socialOptions?: SocialOptions; // show social icons in share dialog, options like twitter handle and org handle
+    }
+
+    interface SocialOptions {
         twitterHandle?: string;
         orgTwitterHandle?: string;
+        hashtags?: string;
+        related?: string;
     }
 
     interface DocMenuEntry {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -196,6 +196,9 @@ declare namespace pxt {
         useUploadMessage?: boolean; // change "Download" text to "Upload"
         downloadIcon?: string; // which icon io use for download
         blockColors?: Map<string>; // block namespace colors, used for build in categories
+        showSocialIcons?: boolean; // show social icons in share dialog
+        twitterHandle?: string;
+        orgTwitterHandle?: string;
     }
 
     interface DocMenuEntry {

--- a/theme/common.less
+++ b/theme/common.less
@@ -780,6 +780,19 @@ Field editors
 }
 
 /*******************************
+        Social Buttons
+*******************************/
+
+.social-icons a.facebook {
+    color: white;
+    background-color: #3b5998;
+}
+.social-icons a.twitter {
+    color: white;
+    background-color: #00aced;
+}
+
+/*******************************
         Layout Variables
 *******************************/
 

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -175,6 +175,14 @@ pxt extract ${url}`;
                 (socialOptions.hashtags ? `&hashtags=${encodeURIComponent(socialOptions.hashtags)}` : '');
                 (socialOptions.related ? `&related=${encodeURIComponent(socialOptions.related)}` : '');
         }
+        const showFbPopup = () => {
+            pxt.tickEvent('share.facebook')
+            sui.popupWindow(fbUrl, lf("Share on Facebook"), 600, 600);
+        }
+        const showTwtPopup = () => {
+            pxt.tickEvent('share.twitter')
+            sui.popupWindow(twitterUrl, lf("Share on Twitter"), 600, 600);
+        }
 
         return (
             <sui.Modal open={this.state.visible} className="sharedialog" header={lf("Share Project") } size="small"
@@ -194,8 +202,8 @@ pxt extract ${url}`;
                         <p>{lf("Your project is ready! Use the address below to share your projects.") }</p>
                         <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} selectOnClick={true}/>
                         {showSocialIcons ? <div className="social-icons">
-                            <a className="ui button large icon facebook" onClick={(e) => {sui.popupWindow(fbUrl, lf("Share on Facebook"), 600, 600); e.preventDefault(); return false;}}><i className="icon facebook"></i></a>
-                            <a className="ui button large icon twitter" onClick={(e) => {sui.popupWindow(twitterUrl, lf("Share on Twitter"), 600, 600); e.preventDefault(); return false;}}><i className="icon twitter"></i></a>
+                            <a className="ui button large icon facebook" onClick={(e) => {showFbPopup(); e.preventDefault(); return false;}}><i className="icon facebook"></i></a>
+                            <a className="ui button large icon twitter" onClick={(e) => {showTwtPopup(); e.preventDefault(); return false;}}><i className="icon twitter"></i></a>
                         </div> : undefined}
                     </div>
                         : undefined }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -64,6 +64,7 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
         const embedding = !!cloud.embedding;
         const header = this.props.parent.state.header;
         const advancedMenu = !!this.state.advancedMenu;
+        const showSocialIcons = pxt.appTarget.appTheme.showSocialIcons;
 
         let ready = false;
         let mode = this.state.mode;
@@ -156,6 +157,28 @@ pxt extract ${url}`;
         const action = !ready ? lf("Publish project") : undefined;
         const actionLoading = this.props.parent.state.publishing;
 
+        let fbUrl = '';
+        let twitterUrl = '';
+        if (showSocialIcons) {
+            let twitterText = lf("Check out what I made!");
+            const twitterHandle = pxt.appTarget.appTheme.orgTwitterHandle;
+            const orgTwitterHandle = pxt.appTarget.appTheme.orgTwitterHandle;
+            if (twitterHandle && orgTwitterHandle) {
+                twitterText = lf("Check out what I made with {0} and {1}!", twitterHandle, orgTwitterHandle);
+            } else if (twitterHandle) {
+                twitterText = lf("Check out what I made with {0}!", twitterHandle);
+            } else if (orgTwitterHandle) {
+                twitterText = lf("Check out what I made with {0}!", orgTwitterHandle);
+            }
+            fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+            twitterUrl = `https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(twitterText)}`;
+        }
+
+        const popupWindow = (url: string, title: string, width: number, height: number) => {
+            return window.open(url, title, `resizable=no, copyhistory=no, ` +
+                `width=${width}, height=${height}, top=${(screen.height / 2) - (height / 2)}, left=${(screen.width / 2) - (width / 2)}`);
+        }
+
         return (
             <sui.Modal open={this.state.visible} className="sharedialog" header={lf("Share Project") } size="small"
                 onClose={() => this.setState({ visible: false }) } dimmer={true}
@@ -173,6 +196,10 @@ pxt extract ${url}`;
                     { url && ready ? <div>
                         <p>{lf("Your project is ready! Use the address below to share your projects.") }</p>
                         <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} selectOnClick={true}/>
+                        {showSocialIcons ? <div className="social-icons">
+                            <a className="ui button large icon facebook" onClick={(e) => {popupWindow(fbUrl, lf("Share on Facebook"), 500, 500); e.preventDefault(); return false;}}><i className="icon facebook"></i></a>
+                            <a className="ui button large icon twitter" onClick={(e) => {popupWindow(twitterUrl, lf("Share on Twitter"), 500, 500); e.preventDefault(); return false;}}><i className="icon twitter"></i></a>
+                        </div> : undefined}
                     </div>
                         : undefined }
                     { ready ? <div>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -161,7 +161,7 @@ pxt extract ${url}`;
         let twitterUrl = '';
         if (showSocialIcons) {
             let twitterText = lf("Check out what I made!");
-            const twitterHandle = pxt.appTarget.appTheme.orgTwitterHandle;
+            const twitterHandle = pxt.appTarget.appTheme.twitterHandle;
             const orgTwitterHandle = pxt.appTarget.appTheme.orgTwitterHandle;
             if (twitterHandle && orgTwitterHandle) {
                 twitterText = lf("Check out what I made with {0} and {1}!", twitterHandle, orgTwitterHandle);

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -197,8 +197,8 @@ pxt extract ${url}`;
                         <p>{lf("Your project is ready! Use the address below to share your projects.") }</p>
                         <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} selectOnClick={true}/>
                         {showSocialIcons ? <div className="social-icons">
-                            <a className="ui button large icon facebook" onClick={(e) => {popupWindow(fbUrl, lf("Share on Facebook"), 500, 500); e.preventDefault(); return false;}}><i className="icon facebook"></i></a>
-                            <a className="ui button large icon twitter" onClick={(e) => {popupWindow(twitterUrl, lf("Share on Twitter"), 500, 500); e.preventDefault(); return false;}}><i className="icon twitter"></i></a>
+                            <a className="ui button large icon facebook" onClick={(e) => {popupWindow(fbUrl, lf("Share on Facebook"), 600, 600); e.preventDefault(); return false;}}><i className="icon facebook"></i></a>
+                            <a className="ui button large icon twitter" onClick={(e) => {popupWindow(twitterUrl, lf("Share on Twitter"), 600, 600); e.preventDefault(); return false;}}><i className="icon twitter"></i></a>
                         </div> : undefined}
                     </div>
                         : undefined }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -64,7 +64,7 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
         const embedding = !!cloud.embedding;
         const header = this.props.parent.state.header;
         const advancedMenu = !!this.state.advancedMenu;
-        const showSocialIcons = pxt.appTarget.appTheme.showSocialIcons;
+        const showSocialIcons = !!pxt.appTarget.appTheme.socialOptions;
 
         let ready = false;
         let mode = this.state.mode;
@@ -161,22 +161,19 @@ pxt extract ${url}`;
         let twitterUrl = '';
         if (showSocialIcons) {
             let twitterText = lf("Check out what I made!");
-            const twitterHandle = pxt.appTarget.appTheme.twitterHandle;
-            const orgTwitterHandle = pxt.appTarget.appTheme.orgTwitterHandle;
-            if (twitterHandle && orgTwitterHandle) {
-                twitterText = lf("Check out what I made with {0} and {1}!", twitterHandle, orgTwitterHandle);
-            } else if (twitterHandle) {
-                twitterText = lf("Check out what I made with {0}!", twitterHandle);
-            } else if (orgTwitterHandle) {
-                twitterText = lf("Check out what I made with {0}!", orgTwitterHandle);
+            const socialOptions =  pxt.appTarget.appTheme.socialOptions;
+            if (socialOptions.twitterHandle && socialOptions.orgTwitterHandle) {
+                twitterText = lf("Check out what I made with @{0} and @{1}!", socialOptions.twitterHandle, socialOptions.orgTwitterHandle);
+            } else if (socialOptions.twitterHandle) {
+                twitterText = lf("Check out what I made with @{0}!", socialOptions.twitterHandle);
+            } else if (socialOptions.orgTwitterHandle) {
+                twitterText = lf("Check out what I made with @{0}!", socialOptions.orgTwitterHandle);
             }
-            fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
-            twitterUrl = `https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(twitterText)}`;
-        }
-
-        const popupWindow = (url: string, title: string, width: number, height: number) => {
-            return window.open(url, title, `resizable=no, copyhistory=no, ` +
-                `width=${width}, height=${height}, top=${(screen.height / 2) - (height / 2)}, left=${(screen.width / 2) - (width / 2)}`);
+            fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+            twitterUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}` +
+                `&text=${encodeURIComponent(twitterText)}` +
+                (socialOptions.hashtags ? `&hashtags=${encodeURIComponent(socialOptions.hashtags)}` : '');
+                (socialOptions.related ? `&related=${encodeURIComponent(socialOptions.related)}` : '');
         }
 
         return (
@@ -197,8 +194,8 @@ pxt extract ${url}`;
                         <p>{lf("Your project is ready! Use the address below to share your projects.") }</p>
                         <sui.Input class="mini" readOnly={true} lines={1} value={url} copy={true} selectOnClick={true}/>
                         {showSocialIcons ? <div className="social-icons">
-                            <a className="ui button large icon facebook" onClick={(e) => {popupWindow(fbUrl, lf("Share on Facebook"), 600, 600); e.preventDefault(); return false;}}><i className="icon facebook"></i></a>
-                            <a className="ui button large icon twitter" onClick={(e) => {popupWindow(twitterUrl, lf("Share on Twitter"), 600, 600); e.preventDefault(); return false;}}><i className="icon twitter"></i></a>
+                            <a className="ui button large icon facebook" onClick={(e) => {sui.popupWindow(fbUrl, lf("Share on Facebook"), 600, 600); e.preventDefault(); return false;}}><i className="icon facebook"></i></a>
+                            <a className="ui button large icon twitter" onClick={(e) => {sui.popupWindow(twitterUrl, lf("Share on Twitter"), 600, 600); e.preventDefault(); return false;}}><i className="icon twitter"></i></a>
                         </div> : undefined}
                     </div>
                         : undefined }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -42,6 +42,11 @@ function genericContent(props: UiProps) {
     ]
 }
 
+export function popupWindow(url: string, title: string, width: number, height: number) {
+    return window.open(url, title, `resizable=no, copyhistory=no, ` +
+        `width=${width}, height=${height}, top=${(screen.height / 2) - (height / 2)}, left=${(screen.width / 2) - (width / 2)}`);
+}
+
 export class UiElement<T extends WithPopupProps> extends data.Component<T, {}> {
     popup() {
         if (this.props.popup) {


### PR DESCRIPTION
Simple Facebook and Twitter social icons in the share dialog that open up new popups into the Facebook sharer / Twitter inject pages: 

![socialicons](https://user-images.githubusercontent.com/16690124/27511327-3c1e998a-58d6-11e7-8834-9ce5f0e363b2.gif)

Twitter message: "Check out what I made with @twitterHandle and @orgTwitterHandle! LINK" 