### PR TITLE
Mobile Safari input copy fix

### DIFF
--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -348,7 +348,7 @@ export function promptAsync(options: PromptOptions): Promise<string> {
         let dialogInput = document.getElementById('promptDialogInput') as HTMLInputElement;
         if (dialogInput) {
             dialogInput.focus();
-            dialogInput.select();
+            dialogInput.setSelectionRange(0, 9999);
         }
     };
 

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -225,10 +225,10 @@ export class Input extends data.Component<{
 
         if (!p.lines || p.lines == 1) {
             const inp = el.getElementsByTagName("input")[0] as HTMLInputElement;
-            inp.select();
+            inp.setSelectionRange(0, 9999);
         } else {
             const inp = el.getElementsByTagName("textarea")[0] as HTMLTextAreaElement;
-            inp.select();
+            inp.setSelectionRange(0, 9999);
         }
 
         try {
@@ -253,7 +253,7 @@ export class Input extends data.Component<{
                         type={p.type || "text"}
                         placeholder={p.placeholder} value={p.value}
                         readOnly={!!p.readOnly}
-                        onClick={(e) => p.selectOnClick ? (e.target as any).select() : undefined}
+                        onClick={(e) => p.selectOnClick ? (e.target as any).setSelectionRange(0, 9999) : undefined}
                         onChange={v => p.onChange((v.target as any).value) }/>
                         : <textarea
                             className={"ui input " + (p.class || "") + (p.inputLabel ? " labelled" : "") }
@@ -261,7 +261,7 @@ export class Input extends data.Component<{
                             placeholder={p.placeholder}
                             value={p.value}
                             readOnly={!!p.readOnly}
-                            onClick={(e) => p.selectOnClick ? (e.target as any).select() : undefined}
+                            onClick={(e) => p.selectOnClick ? (e.target as any).setSelectionRange(0, 9999) : undefined}
                             onChange={v => p.onChange((v.target as any).value) }>
                         </textarea>}
                     {copyBtn}


### PR DESCRIPTION
Fix issue with Mobile Safari where copy doesn't work in the share dialog.

Element.select() doesn't work in Mobile Safari. Using setSelectionRange instead: 
https://stackoverflow.com/questions/3272089/programmatically-selecting-text-in-an-input-field-on-ios-devices-mobile-safari
