### PR TITLE
Better search interactions

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -846,6 +846,7 @@ declare namespace Blockly {
             setExpanded(expanded: boolean): void;
             toggle(): void;
             updateRow(): void;
+            onKeyDown(e: any): void;
         }
 
         class TreeControl {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1350,7 +1350,7 @@ namespace pxt.blocks {
         const oldKeyDown = (Blockly as any).Toolbox.TreeNode.prototype.onKeyDown;
         (Blockly as any).Toolbox.TreeNode.prototype.onKeyDown = function(e: any) {
             const x = e.which || e.keyCode;
-            const interceptCharacter = x != 37 && x != 38 && x != 39 && x != 40 // Arrows
+            const interceptCharacter = x != 37 && x != 38 && x != 39 && x != 40 // Arrows (Handled by Blockly)
                 && !e.ctrlKey && !e.metaKey && !e.altKey; // Meta keys
             if (interceptCharacter) {
                 let searchField = document.getElementById('blocklySearchInputField') as HTMLInputElement;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -961,6 +961,7 @@ namespace pxt.blocks {
         // lf("{id:category}Text")
         // lf("{id:category}Math")
         // lf("{id:category}Advanced")
+        // lf("{id:category}Search")
         // lf("{id:category}More\u2026")
 
         // update shadow types
@@ -1241,6 +1242,10 @@ namespace pxt.blocks {
             toolboxDiv.insertBefore(blocklySearchArea, toolboxDiv.firstChild);
         }
 
+        const hasSearchFlyout = () => {
+            return document.getElementsByClassName('blocklyTreeIconsearch').length > 0;
+        }
+
         const showSearchFlyout = () => {
             const tree = (workspace as any).toolbox_.tree_;
             // Show the search flyout
@@ -1269,8 +1274,7 @@ namespace pxt.blocks {
                     let parentCategoryList = searchTb;
 
                     const nsWeight = 101; // Show search category on top
-                    const locCatName = lf("Search");
-                    category = createCategoryElement(locCatName, catName, nsWeight);
+                    category = createCategoryElement(lf("{id:category}Search"), catName, nsWeight);
                     category.setAttribute("colour", '#000');
                     category.setAttribute("iconclass", 'blocklyTreeIconsearch');
                     category.setAttribute("expandedclass", 'blocklyTreeIconsearch');
@@ -1335,7 +1339,11 @@ namespace pxt.blocks {
             let searchField = document.getElementById('blocklySearchInputField') as HTMLInputElement;
             let searchFor = searchField.value.toLowerCase();
             if (searchFor != '') {
-                showSearchFlyout();
+                if (hasSearchFlyout()) showSearchFlyout();
+                else {
+                    previousSearchTerm = '';
+                    searchChangeHandler();
+                }
             }
         }
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1201,7 +1201,8 @@ namespace pxt.blocks {
             let trashIcon = document.createElement('i');
             trashIcon.className = 'trash icon';
             trashDiv.appendChild(trashIcon);
-            document.getElementsByClassName('blocklyToolboxDiv')[0].appendChild(trashDiv);
+            const toolboxDiv = document.getElementsByClassName('blocklyToolboxDiv')[0];
+            if (toolboxDiv) toolboxDiv.appendChild(trashDiv);
         }
 
         return tb;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1347,7 +1347,7 @@ namespace pxt.blocks {
             : blocklySearchInputField.onclick = searchClickHandler;
 
         // Override Blockly's toolbox keydown method to intercept characters typed and move the focus to the search input
-        const oldKeyDown = (Blockly as any).Toolbox.TreeNode.prototype.onKeyDown;
+        const oldKeyDown = Blockly.Toolbox.TreeNode.prototype.onKeyDown;
         (Blockly as any).Toolbox.TreeNode.prototype.onKeyDown = function(e: any) {
             const x = e.which || e.keyCode;
             const interceptCharacter = x != 37 && x != 38 && x != 39 && x != 40 // Arrows (Handled by Blockly)

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -548,6 +548,11 @@ export class Editor extends srceditor.Editor {
             this.filters = null;
         }
         this.currFile = file;
+        // Clear the search field if a value exists
+        let searchField = document.getElementById('blocklySearchInputField') as HTMLInputElement;
+        if (searchField && searchField.value) {
+            searchField.value = '';
+        }
         return Promise.resolve();
     }
 


### PR DESCRIPTION
- 300ms debounce
- No Jquery
- Show flyout after search completes. 
- Show flyout on click, Fixes #2071 
- Intercept Blockly toolbox key down event for valid characters, and switch focus to search input. (If a user is browsing the toolbox, and starts typing, we immediately switch focus to the search input)

![searchinteractions](https://user-images.githubusercontent.com/16690124/27520260-b2a51ef4-59bb-11e7-9bec-485de31d2e96.gif)
