### PR TITLE
Examples that compile to blocks

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -78,7 +78,7 @@ declare namespace pxt {
         time?: number;
         url?: string;
         responsive?: boolean;
-        cardType?: "example" | "tutorial" | "project";
+        cardType?: "example" | "blocksExample" | "tutorial" | "project";
 
         header?: string;
         any?: number;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -9,6 +9,7 @@ import * as data from "./data";
 import * as sui from "./sui";
 import * as pkg from "./package";
 import * as core from "./core";
+import * as compiler from "./compiler";
 
 import * as codecard from "./codecard"
 import * as gallery from "./gallery";
@@ -122,6 +123,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             this.hide();
             switch (scr.cardType) {
                 case "example": chgCode(scr); break;
+                case "blocksExample": chgCode(scr, true); break;
                 case "tutorial": this.props.parent.startTutorial(scr.url); break;
                 default:
                     const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(scr.url);
@@ -130,13 +132,24 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             }
         }
 
-        const chgCode = (scr: pxt.CodeCard) => {
+        const chgCode = (scr: pxt.CodeCard, loadBlocks?: boolean) => {
             core.showLoading(lf("Loading..."));
             gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
                 .done(opts => {
                     core.hideLoading();
-                    if (opts)
-                        this.props.parent.newProject(opts);
+                    if (opts) {
+                        if (loadBlocks) {
+                            const ts = opts.filesOverride["main.ts"]
+                            compiler.getBlocksAsync()
+                                .then(blocksInfo => compiler.decompileSnippetAsync(ts, blocksInfo))
+                                .then(resp => {
+                                    opts.filesOverride["main.blocks"] = resp
+                                    this.props.parent.newProject(opts);
+                                })
+                        } else {
+                            this.props.parent.newProject(opts);
+                        }
+                    }
                 });
         }
         const upd = (v: any) => {


### PR DESCRIPTION
Support examples that compile to blocks, using the cardType: blocksExample.
eg: 

```
{
  "name": "Blinky",
  "url":"/examples/basics/blinky",
  "cardType": "blocksExample"
},
```