### PR TITLE
Apply filters that are passed in with workspacesync

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2166,7 +2166,7 @@ $(document).ready(() => {
             let ent = theEditor.settings.fileHistory.filter(e => !!workspace.getHeader(e.id))[0]
             let hd = workspace.getHeaders()[0]
             if (ent) hd = workspace.getHeader(ent.id)
-            if (hd) return theEditor.loadHeaderAsync(hd, null)
+            if (hd) return theEditor.loadHeaderAsync(hd, theEditor.state.filters)
             else theEditor.newProject();
             return Promise.resolve();
         }).then(() => workspace.importLegacyScriptsAsync())


### PR DESCRIPTION
While we set the filters on theEditor.state.filters on workspacesync,
we end up overwriting them when theEditor.loadHeaderAsync(*, null) is called.