### PR TITLE
[Mobile] Disable the default scrolling behaviour of touch scroll on iOS devices.

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2090,6 +2090,11 @@ function initExtensionsAsync(): Promise<void> {
         });
 }
 
+$('#content').bind("touchmove", (e: any) => {
+  //Disable scrolling on IOS
+  e.preventDefault();
+});
+
 $(document).ready(() => {
     pxt.setupWebConfig((window as any).pxtConfig);
     const config = pxt.webConfig


### PR DESCRIPTION
Disable the default scrolling behaviour of touch scroll on iOS devices.

This needs to be tested on a Surface Book, and make sure scrolling still works in the Modals, and side bar.