### PR TITLE
Separate the two length blocks

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1482,6 +1482,25 @@ namespace pxt.blocks {
         const listsLengthId = "lists_length";
         const listsLengthDef = pxt.blocks.getBlockDefinition(listsLengthId);
         msg.LISTS_LENGTH_TITLE = listsLengthDef.block["LISTS_LENGTH_TITLE"];
+
+        // We have to override this block definition because the builtin block
+        // allows both Strings and Arrays in its input check and that confuses
+        // our Blockly compiler
+        let block = Blockly.Blocks[listsLengthId];
+        block.init = function() {
+            this.jsonInit({
+            "message0": msg.LISTS_LENGTH_TITLE,
+            "args0": [
+                {
+                "type": "input_value",
+                "name": "VALUE",
+                "check": ['Array']
+                }
+            ],
+            "output": 'Number'
+            });
+        }
+
         installBuiltinHelpInfo(listsLengthId);
     }
 
@@ -2745,6 +2764,24 @@ namespace pxt.blocks {
         const textLengthId = "text_length";
         const textLengthDef = pxt.blocks.getBlockDefinition(textLengthId);
         msg.TEXT_LENGTH_TITLE = textLengthDef.block["TEXT_LENGTH_TITLE"];
+
+        // We have to override this block definition because the builtin block
+        // allows both Strings and Arrays in its input check and that confuses
+        // our Blockly compiler
+        let block = Blockly.Blocks[textLengthId];
+        block.init = function() {
+            this.jsonInit({
+            "message0": msg.TEXT_LENGTH_TITLE,
+            "args0": [
+                {
+                "type": "input_value",
+                "name": "VALUE",
+                "check": ['String']
+                }
+            ],
+            "output": 'Number'
+            });
+        }
         installBuiltinHelpInfo(textLengthId);
 
         // builtin text_join

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -261,7 +261,7 @@ namespace pxt.blocks {
                 url: '/blocks/arrays/length',
                 category: 'arrays',
                 block: {
-                    LISTS_LENGTH_TITLE: Util.lf("length of %1")
+                    LISTS_LENGTH_TITLE: Util.lf("length of array %1")
                 }
             },
             'lists_index_get': {
@@ -345,7 +345,7 @@ namespace pxt.blocks {
                 url: 'types/string/length',
                 category: 'text',
                 block: {
-                    TEXT_LENGTH_TITLE: Util.lf("length of %1")
+                    TEXT_LENGTH_TITLE: Util.lf("length of text %1")
                 }
             },
             'text_join': {

--- a/tests/blocklycompiler-test/baselines/lists_empty_inputs2.ts
+++ b/tests/blocklycompiler-test/baselines/lists_empty_inputs2.ts
@@ -2,6 +2,6 @@ let item = 0;
 [0][0] = 0
 
 item = [0][0]
-item = "".length
+item = [0].length
 item = [0].pop();
 [0].push(0)

--- a/tests/blocklycompiler-test/baselines/lists_length_with_for_of.ts
+++ b/tests/blocklycompiler-test/baselines/lists_length_with_for_of.ts
@@ -1,0 +1,5 @@
+let item = 0
+let list: number[] = []
+for (let value of list) {
+    item = list.length
+}

--- a/tests/blocklycompiler-test/cases/lists_length_with_for_of.blocks
+++ b/tests/blocklycompiler-test/cases/lists_length_with_for_of.blocks
@@ -1,0 +1,31 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block id="]exU%DBA`~5*jpXI%+?z" type="pxt-on-start" x="50" y="130">
+    <statement name="HANDLER">
+      <block id="$ek^,L#29xpgQR_U+rv*" type="controls_for_of">
+        <field name="VAR">value</field>
+        <value name="LIST">
+          <shadow id="xM-4ZoiP1T]?(++ydg?#" type="variables_get">
+            <field name="VAR">list</field>
+          </shadow>
+        </value>
+        <statement name="DO">
+          <block id="tl_-%xivc_@^YxNnudmX" type="variables_set">
+            <field name="VAR">item</field>
+            <value name="VALUE">
+              <shadow id="D75K(TFB~I+;CzZGC-7," type="math_number">
+                <field name="NUM">0</field>
+              </shadow>
+              <block id="+-tXpBk7^J{~BR$p__/X" type="lists_length">
+                <value name="VALUE">
+                  <block id="$^,h%p-$J[d_){{kjs%!" type="variables_get">
+                    <field name="VAR">list</field>
+                  </block>
+                </value>
+              </block>
+            </value>
+          </block>
+        </statement>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -235,6 +235,10 @@ describe("blockly compiler", () => {
         it("should not infinitely recurse for unininitialized arrays used in a for of loop", done => {
             blockTestAsync("lists_infinite2").then(done, done);
         });
+
+        it("should not declare lists as strings when using the length block", done => {
+            blockTestAsync("lists_length_with_for_of").then(done, done);
+        });
     });
 
     describe("compiling logic", () => {


### PR DESCRIPTION
Fixes #2374 

We have two length blocks (one for strings and one for arrays) that up until now have been interchangeable. Unfortunately, our compiler doesn't support that and it caused type inference issues where arrays would occasionally be declared as strings. This PR makes them explicitly separate and alters the checks in the block definition so that they only accept either strings or arrays but not both.

Before:

![length_before](https://user-images.githubusercontent.com/13754588/27752810-bc67e3b0-5d97-11e7-9350-03b7fca0dac1.PNG)

After:

![length_after](https://user-images.githubusercontent.com/13754588/27752812-c0aab510-5d97-11e7-8894-eb41173d6690.PNG)

I'll need to cherry-pick this into V0 once merged. This might be a minor breaking change...
