### PR TITLE
Fix a couple of monaco editor filter bugs.

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -611,7 +611,7 @@ export class Editor extends srceditor.Editor {
                     if (monacoEditor.nsMap[ns.toLowerCase()]) blocks = blocks.concat(monacoEditor.nsMap[ns.toLowerCase()].filter(block => !(block.attributes.blockHidden || block.attributes.deprecated)));
                     el = monacoEditor.createCategoryElement(ns, md.color, md.icon, false, blocks, null, name);
                 }
-                group.appendChild(el);
+                if (el) group.appendChild(el);
             });
         }
     }
@@ -674,7 +674,7 @@ export class Editor extends srceditor.Editor {
         let filters = this.parent.state.filters;
         const categoryState = filters ? (filters.namespaces && filters.namespaces[ns] != undefined ? filters.namespaces[ns] : filters.defaultState) : undefined;
         let hasChild = false;
-        if (filters) {
+        if (filters && categoryState !== undefined && fns) {
             Object.keys(fns).forEach((fn) => {
                 const fnState = filters.fns && filters.fns[fn] != undefined ? filters.fns[fn] : (categoryState != undefined ? categoryState : filters.defaultState);
                 if (fnState == pxt.editor.FilterState.Disabled || fnState == pxt.editor.FilterState.Visible) hasChild = true;


### PR DESCRIPTION
- If no defaultState is specified, the default is effectively VISIBLE in Blocks mode. This appears to be because the Block creation generates the entire list of blocks, then filters them out in filterBlocks(). Because there's no default case statement to handle the case where defaultState is undefined, blocks are NOT removed.
https://github.com/Microsoft/pxt/blob/master/pxtblocks/blocklyloader.ts#L1107
However in text mode, it's the opposite. If the defaultState is not specified, the block is excluded:
https://github.com/Microsoft/pxt/blob/master/webapp/src/monaco.tsx#L680

- There's an uncaught exception here that prevents blocks from loading if el==undefined
https://github.com/Microsoft/pxt/blob/master/webapp/src/monaco.tsx#L614

- There's an uncaught exception if an advanced category is filtered out:
https://github.com/Microsoft/pxt/blob/master/webapp/src/monaco.tsx#L558