### PR TITLE
Use function keyword for blocks instead of arrow functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "monaco-editor": "0.8.1",
-    "pxt-monaco-typescript": "2.1.7",
+    "pxt-monaco-typescript": "2.1.9",
     "jake": "^8.0.12",
     "jquery": "^2.2.0",
     "karma": "^1.7.0",

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1129,7 +1129,7 @@ namespace pxt.blocks {
             callback = mkGroup([argumentDeclaration, body]);
         }
         else {
-            callback = mkGroup([mkText("() =>"), body]);
+            callback = mkGroup([mkText("function ()"), body]);
         }
 
         if (isExtension)

--- a/pxtblocks/blocklymutators.ts
+++ b/pxtblocks/blocklymutators.ts
@@ -282,7 +282,7 @@ namespace pxt.blocks {
                 return escapedParam;
             }).join(", ");
 
-            const lambdaString = ` ({ ${declarationString} }) => `;
+            const lambdaString = `function ({ ${declarationString} })`;
 
             if (this.info.attributes.mutatePropertyEnum) {
                 return mkText(` [${this.parameters.map(p => `${this.info.attributes.mutatePropertyEnum}.${p}`).join(", ")}],${lambdaString}`)

--- a/pxtblocks/blocklymutators.ts
+++ b/pxtblocks/blocklymutators.ts
@@ -282,13 +282,13 @@ namespace pxt.blocks {
                 return escapedParam;
             }).join(", ");
 
-            const lambdaString = `function ({ ${declarationString} })`;
+            const functionString = `function ({ ${declarationString} })`;
 
             if (this.info.attributes.mutatePropertyEnum) {
-                return mkText(` [${this.parameters.map(p => `${this.info.attributes.mutatePropertyEnum}.${p}`).join(", ")}],${lambdaString}`)
+                return mkText(` [${this.parameters.map(p => `${this.info.attributes.mutatePropertyEnum}.${p}`).join(", ")}],${functionString}`)
             }
             else {
-                return mkText(lambdaString);
+                return mkText(functionString);
             }
         }
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -794,6 +794,7 @@ ${output}</xml>`;
                         return getStatementBlock((node as ts.ExpressionStatement).expression, next, parent || node, asExpression, topLevel);
                     case SK.VariableStatement:
                         return codeBlock((node as ts.VariableStatement).declarationList.declarations, next, false, parent || node);
+                    case SK.FunctionExpression:
                     case SK.ArrowFunction:
                         return getArrowFunctionStatement(node as ts.ArrowFunction, next);
                     case SK.BinaryExpression:
@@ -1195,6 +1196,7 @@ ${output}</xml>`;
                 }
 
                 switch (e.kind) {
+                    case SK.FunctionExpression:
                     case SK.ArrowFunction:
                         const m = getDestructuringMutation(e as ArrowFunction);
                         if (m) {
@@ -1478,6 +1480,7 @@ ${output}</xml>`;
             case SK.PostfixUnaryExpression:
             case SK.PrefixUnaryExpression:
                 return checkIncrementorExpression(node as (ts.PrefixUnaryExpression | ts.PostfixUnaryExpression));
+            case SK.FunctionExpression:
             case SK.ArrowFunction:
                 return checkArrowFunction(node as ts.ArrowFunction);
             case SK.BinaryExpression:
@@ -1729,7 +1732,7 @@ ${output}</xml>`;
                     const arrayArg = info.args[info.args.length - 2] as ArrayLiteralExpression;
                     const callbackArg = info.args[info.args.length - 1] as ArrowFunction;
 
-                    if (arrayArg.kind === SK.ArrayLiteralExpression && callbackArg.kind === SK.ArrowFunction) {
+                    if (arrayArg.kind === SK.ArrayLiteralExpression && isFunctionExpression(callbackArg)) {
                         const propNames: string[] = [];
 
                         // Make sure that all elements in the array literal are enum values
@@ -1959,7 +1962,7 @@ ${output}</xml>`;
 
     function hasArrowFunction(info: CallInfo): boolean {
         const parameters = (info.decl as FunctionLikeDeclaration).parameters;
-        return info.args.some((arg, index) => arg && arg.kind === SK.ArrowFunction);
+        return info.args.some((arg, index) => arg && isFunctionExpression(arg));
     }
 
     function isLiteralNode(node: ts.Node): boolean {
@@ -2026,5 +2029,9 @@ ${output}</xml>`;
 
             return res;
         });
+    }
+
+    function isFunctionExpression(node: Node) {
+        return node.kind === SK.ArrowFunction || node.kind === SK.FunctionExpression;
     }
 }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -927,7 +927,7 @@ namespace ts.pxtc.service {
                     if (functionSignature) {
                         return getFunctionString(functionSignature);
                     }
-                    return `() => {}`;
+                    return `function () {}`;
             }
 
             const type = checker ? checker.getTypeAtLocation(param) : undefined;
@@ -937,7 +937,7 @@ namespace ts.pxtc.service {
                     if (sigs.length) {
                         return getFunctionString(sigs[0]);
                     }
-                    return `() => {}`;
+                    return `function () {}`;
                 }
             }
             return "null";
@@ -966,7 +966,7 @@ namespace ts.pxtc.service {
             let displayPartsStr = ts.displayPartsToString(displayParts);
             functionArgument = displayPartsStr.substr(0, displayPartsStr.lastIndexOf(":"));
 
-            return `${functionArgument} => {\n    ${returnValue}\n}`
+            return `function ${functionArgument} {\n    ${returnValue}\n}`
         }
     }
 }

--- a/tests/decompile-test/baselines/functions_callbacks2.blocks
+++ b/tests/decompile-test/baselines/functions_callbacks2.blocks
@@ -1,0 +1,35 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_callback">
+<statement name="HANDLER">
+</statement>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+<block type="test_callback">
+<statement name="HANDLER">
+<block type="test_no_argument">
+</block>
+</statement>
+</block>
+<block type="test_callback">
+<statement name="HANDLER">
+<block type="test_no_argument">
+<next>
+<block type="test_no_argument">
+</block>
+</next>
+</block>
+</statement>
+</block>
+<block type="test_callback_with_argument">
+<field name="arg1">TestEnum.testValue2</field>
+<value name="arg2">
+<shadow type="math_number">
+<field name="NUM">10</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+<block type="test_no_argument">
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/functions_callbacks2.ts
+++ b/tests/decompile-test/cases/functions_callbacks2.ts
@@ -1,0 +1,14 @@
+/// <reference path="./testBlocks/basic.ts" />
+
+testNamespace.withCallback(function () {})
+
+testNamespace.withCallback(function () { testNamespace.noArgument() })
+
+testNamespace.withCallback(function() {
+    testNamespace.noArgument();
+    testNamespace.noArgument();
+})
+
+testNamespace.withCallbackAndArguments(TestEnum.testValue2, 10, function() {
+    testNamespace.noArgument();
+})


### PR DESCRIPTION
Fixes #1676 

This is a big change to our generated TypeScript, so let's make sure we're all on the same page before merging. Instead of compiling event handlers to arrow functions, we will instead compile to function expressions because the keyword makes it easier to understand.

In other words, this:

![simple_button](https://user-images.githubusercontent.com/13754588/27889942-93d4bf8e-61a4-11e7-95a7-c00791aed692.PNG)


Will now compile to this:

```typescript
input.buttonA.onEvent(ButtonEvent.Click, function () {
})
```

Instead of this:

```typescript
input.buttonA.onEvent(ButtonEvent.Click, () => {
})
```