### PR TITLE
Fixing nested toc accordions in the docs

### DIFF
--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -1,13 +1,13 @@
 <aside id=button class=box>
    <a class="ui primary button docbutton" href="@ARGS@">@BODY@</a>
-</aside>   
+</aside>
 
 <aside id=vimeo>
 <div class="ui two column stackable grid container">
 <div class="column">
     <div class="ui embed mdvid" data-source="vimeo" data-id="@ARGS@" data-placeholder="/thumbnail/1024/vimeo/@ARGS@" data-icon="video play">
     </div>
-</div></div>    
+</div></div>
 </aside>
 
 <aside id=youtube>
@@ -15,7 +15,7 @@
 <div class="ten wide column">
     <div class="ui embed mdvid" data-source="youtube" data-id="@ARGS@" data-placeholder="https://img.youtube.com/vi/@ARGS@/maxresdefault.jpg">
     </div>
-</div></div>    
+</div></div>
 </aside>
 
 <aside id=section>
@@ -114,6 +114,18 @@
 
 <aside id=inner-dropdown class=toc>
     <div class="ui inverted accordion item visible" title="@TITLE@">
+        <div class="@ACTIVE@ title">
+            <i class="dropdown icon"></i>
+            <a class="header" href="@LINK@">@NAME@</a>
+        </div>
+        <div class="@ACTIVE@ content">
+            @ITEMS@
+        </div>
+    </div>
+</aside>
+
+<aside id=nested-dropdown class=toc>
+    <div class="inverted accordion item visible" title="@TITLE@">
         <div class="@ACTIVE@ title">
             <i class="dropdown icon"></i>
             <a class="header" href="@LINK@">@NAME@</a>

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -209,7 +209,8 @@ namespace pxt.docs {
             }
             if (m.subitems && m.subitems.length > 0) {
                 if (lev == 0) templ = toc["top-dropdown"]
-                else templ = toc["inner-dropdown"]
+                else if (lev == 1) templ = toc["inner-dropdown"]
+                else templ = toc["nested-dropdown"]
                 mparams["ITEMS"] = m.subitems.map(e => recTOC(e, lev + 1)).join("\n")
             } else {
                 if (/^-+$/.test(m.name)) {
@@ -230,7 +231,7 @@ namespace pxt.docs {
             breadcrumbHtml = `
             <div class="ui breadcrumb">
                 ${breadcrumb.map((b, i) =>
-                    `<a class="${i == breadcrumb.length - 1 ? "active" : ""} section" 
+                    `<a class="${i == breadcrumb.length - 1 ? "active" : ""} section"
                         href="${html2Quote(b.href)}">${html2Quote(b.name)}</a>`)
                     .join('<i class="right chevron icon divider"></i>')}
             </div>`;


### PR DESCRIPTION
You can see the issue this fixes [here](https://makecode.microbit.org/docs). Try to expand the nested accordions under the courses heading and they collapse immediately. The fix is that only top-level accordions should have the `ui` class added to them