### PR TITLE
Add group label to monaco blocks

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -264,6 +264,12 @@ namespace pxt.editor {
         snippet: string;
 
         /**
+         * Group label used to categorize block.  Blocks are arranged with other
+         * blocks that share the same group.
+         */
+        group?: string,
+
+        /**
          * Description of code to appear in the hover text
          */
         jsDoc?: string

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -462,6 +462,7 @@ export function overrideCategory(ns: string, def: pxt.editor.MonacoToolboxCatego
                             weight: currentWeight,
                             advanced: b.advanced,
                             jsDoc: b.jsDoc,
+                            group: b.group,
                         },
                         noNamespace: true
                     }
@@ -484,6 +485,7 @@ export function overrideCategory(ns: string, def: pxt.editor.MonacoToolboxCatego
                             weight: currentWeight,
                             advanced: b.advanced,
                             jsDoc: b.jsDoc,
+                            group: b.group,
                         },
                         noNamespace: true
                     }


### PR DESCRIPTION
The comments here weren't entirely true: https://github.com/playi/pxt-wonder/issues/74

They're closer now, but `MonacoToolboxBlockDefinition` still isn't quite the same as `MonacoBlockDefinition`, as the former doesn't have a nested `attributes`.