### PR TITLE
cdn Url now passed to the sim run message

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -13,6 +13,7 @@ namespace pxsim {
         code: string;
         mute?: boolean;
         highContrast?: boolean;
+        cdnUrl?: string;
     }
 
     export interface SimulatorMuteMessage extends SimulatorMessage {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -37,6 +37,7 @@ namespace pxsim {
         partDefinitions?: pxsim.Map<PartDefinition>;
         mute?: boolean;
         highContrast?: boolean;
+        cdnUrl?: string;
     }
 
     export interface HwDebugger {
@@ -233,7 +234,8 @@ namespace pxsim {
                 code: js,
                 partDefinitions: opts.partDefinitions,
                 mute: opts.mute,
-                highContrast: opts.highContrast
+                highContrast: opts.highContrast,
+                cdnUrl: opts.cdnUrl
             }
 
             this.applyAspectRatio();

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -183,7 +183,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResul
         fnArgs,
         highContrast,
         aspectRatio: parts.length ? pxt.appTarget.simulator.partsAspectRatio : pxt.appTarget.simulator.aspectRatio,
-        partDefinitions: pkg.computePartDefinitions(parts)
+        partDefinitions: pkg.computePartDefinitions(parts),
+        cdnUrl: pxt.webConfig.commitCdnUrl
     }
     postSimEditorEvent("started");
 


### PR DESCRIPTION
Guillaume and I pair programmed a solution for pxt targets to be able to access the cdn url. That way targets can use the same generic url to load files locally and remotely. Now the simulator run message passes along the cdn url so that it can be accessed in the initAsync() function.