### PR TITLE
[Accessibility] Hidden tab menu - focus on Monaco editor

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -208,6 +208,9 @@ export class ProjectView
             if (this.state.embedSimView) this.setState({ embedSimView: false });
             return;
         }
+        if (this.textEditor && !this.textEditor.giveFocusOnLoading) {
+            this.textEditor.giveFocusOnLoading = true;
+        }
         if (this.isBlocksActive()) {
             this.blocksEditor.openTypeScript();
         }
@@ -443,6 +446,10 @@ export class ProjectView
                 });
             }
         } else {
+            if (this.isTextEditor() || this.isPxtJsonEditor()) {
+                this.textEditor.giveFocusOnLoading = false
+            }
+
             this.setFile(fn)
         }
     }
@@ -1371,6 +1378,10 @@ export class ProjectView
 
     isTextEditor(): boolean {
         return this.editor == this.textEditor;
+    }
+
+    isPxtJsonEditor(): boolean {
+        return this.editor == this.pxtJsonEditor;
     }
 
     isBlocksEditor(): boolean {

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -354,8 +354,14 @@ export function promptAsync(options: PromptOptions): Promise<string> {
     options.onLoaded = () => {
         let dialogInput = document.getElementById('promptDialogInput') as HTMLInputElement;
         if (dialogInput) {
-            dialogInput.focus();
             dialogInput.setSelectionRange(0, 9999);
+            dialogInput.onkeyup = (e: KeyboardEvent) => {
+                let charCode = (typeof e.which == "number") ? e.which : e.keyCode
+                if (charCode === 13 || charCode === 32) {
+                    e.preventDefault();
+                    (document.getElementsByClassName("approve positive").item(0) as HTMLElement).click();
+                }
+            }
         }
     };
 

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -348,7 +348,7 @@ export function promptAsync(options: PromptOptions): Promise<string> {
     }
 
     options.htmlBody = `<div class="ui fluid icon input">
-                            <input type="text" id="promptDialogInput" value="${options.defaultValue}">
+                            <input class="focused" type="text" id="promptDialogInput" value="${options.defaultValue}">
                         </div>`;
 
     options.onLoaded = () => {

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -293,7 +293,7 @@ export function confirmAsync(options: ConfirmOptions): Promise<number> {
     if (!options.hideAgree) {
         options.buttons.push({
             label: options.agreeLbl || lf("Go ahead!"),
-            class: options.agreeClass,
+            class: options.agreeClass + " focused",
             icon: options.agreeIcon,
             onclick: () => {
                 result = 1

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -54,6 +54,7 @@ export class Editor extends srceditor.Editor {
     nsMap: pxt.Map<MonacoBlockDefinition[]>;
     loadingMonaco: boolean;
     showAdvanced: boolean;
+    giveFocusOnLoading: boolean = true;
 
     hasBlocks() {
         if (!this.currFile) return true
@@ -1018,6 +1019,12 @@ export class Editor extends srceditor.Editor {
 
                 this.resize();
                 this.resetFlyout(true);
+
+                if (this.giveFocusOnLoading) {
+                    this.editor.focus();
+                }
+
+                this.giveFocusOnLoading = true;
             }).finally(() => {
                 editorArea.removeChild(loading);
             });


### PR DESCRIPTION
Original PR merged to anticipate an Accessibility meeting => [https://github.com/Microsoft/pxt/pull/2426](https://github.com/Microsoft/pxt/pull/2426)

Adding a hidden menu displayed only when the user starts to use tab in the page.
Give the focus to the JS editor when using the "Skip to JS" menu. Give it too when the page load and that we are in JS mode. But don't give the focus when using the Explorer menu.

To reach this last goal, I had to edit app.tsx because of a specific situation : 
1. Create a new project in MakeCode
2. Switch to JavaScript
3. In Explorer, switch to pxt.json
4. Switch back to JS by using the "JavaScript" button or hidden menu (not the Explorer).

As I've made a system that prevent to give the focus if we click on an Explorer item, in this specific case, without editing app.tsx, I think it might be impossible to know if we opened the pxt.json from the Explorer or from the More menu. Because of that, the focus was not given back to the editor if at this specific moment we were clicking on the JavaScript button.

