### PR TITLE
Decompiler should respect the undeletable onstart flag

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -272,6 +272,8 @@ declare namespace ts.pxtc {
         justMyCode?: boolean;
         computeUsedSymbols?: boolean;
 
+        alwaysDecompileOnStart?: boolean; // decompiler only
+
         embedMeta?: string;
         embedBlob?: string; // base64
     }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -279,6 +279,7 @@ namespace ts.pxtc.decompiler {
 
     export interface DecompileBlocksOptions {
         snippetMode?: boolean; // do not emit "on start"
+        alwaysEmitOnStart?: boolean; // emit "on start" even if empty
     }
 
     export function decompileToBlocks(blocksInfo: pxtc.BlocksInfo, file: ts.SourceFile, options: DecompileBlocksOptions, renameMap?: RenameMap): pxtc.CompileResult {
@@ -1382,11 +1383,23 @@ ${output}</xml>`;
                             }]
                         } as StatementNode;
                     }
+                    else {
+                        maybeEmitEmptyOnStart();
+                    }
                 }
                 return stmt;
             }
+            else {
+                maybeEmitEmptyOnStart();
+            }
 
             return undefined;
+        }
+
+        function maybeEmitEmptyOnStart() {
+            if (options.alwaysEmitOnStart) {
+                write(`<block type="${ts.pxtc.ON_START_TYPE}"></block>`);
+            }
         }
 
         /**

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1357,10 +1357,10 @@ ${output}</xml>`;
 
             eventStatements.map(n => getStatementBlock(n, undefined, undefined, false, topLevel)).forEach(emitStatementNode);
 
+            const emitOnStart = topLevel && !options.snippetMode;
             if (blockStatements.length) {
                 // wrap statement in "on start" if top level
                 const stmt = getStatementBlock(blockStatements.shift(), blockStatements, parent, false, topLevel);
-                const emitOnStart = topLevel && !options.snippetMode;
                 if (emitOnStart) {
                     // Preserve any variable edeclarations that were never used
                     let current = stmt;
@@ -1389,7 +1389,7 @@ ${output}</xml>`;
                 }
                 return stmt;
             }
-            else {
+            else if (emitOnStart) {
                 maybeEmitEmptyOnStart();
             }
 

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -194,7 +194,7 @@ namespace ts.pxtc {
         let file = resp.ast.getSourceFile(fileName);
         const apis = getApiInfo(resp.ast);
         const blocksInfo = pxtc.getBlocksInfo(apis);
-        const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, { snippetMode: false }, pxtc.decompiler.buildRenameMap(resp.ast, file))
+        const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, { snippetMode: false, alwaysEmitOnStart: opts.alwaysDecompileOnStart }, pxtc.decompiler.buildRenameMap(resp.ast, file))
         return bresp;
     }
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -140,6 +140,7 @@ export function decompileAsync(fileName: string, blockInfo?: ts.pxtc.BlocksInfo,
     return pkg.mainPkg.getCompileOptionsAsync(trg)
         .then(opts => {
             opts.ast = true;
+            opts.alwaysDecompileOnStart = pxt.appTarget.runtime && pxt.appTarget.runtime.onStartUnDeletable;
             return decompileCoreAsync(opts, fileName)
         })
         .then(resp => {


### PR DESCRIPTION
We support a flag in `pxtarget.json` that makes it so the "on start" block can't be deleted. However, we had a bug where you could still delete that block if you switch to JavaScript because the decompiler would not emit it. This fixes the decompiler so that we respect that flag.