### PR TITLE
Better handling of save vs download buttons

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -42,6 +42,7 @@ namespace pxt.editor {
 
         running?: boolean;
         compiling?: boolean;
+        isSaving?: boolean;
         publishing?: boolean;
         hideEditorFloats?: boolean;
         collapseEditorTools?: boolean;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -932,6 +932,7 @@ export class ProjectView
 
     saveAndCompile() {
         if (!this.state.header) return;
+        this.setState({isSaving: true});
 
         return (this.state.projectName !== lf("Untitled")
             ? Promise.resolve(true) : this.promptRenameProjectAsync())
@@ -939,7 +940,11 @@ export class ProjectView
             .then(() => this.saveFileAsync())
             .then(() => {
                 if (!pxt.appTarget.compile.hasHex) {
-                    this.saveProjectToFileAsync().done();
+                    this.saveProjectToFileAsync()
+                        .finally(() => {
+                            this.setState({isSaving: false});
+                        })
+                        .done();
                 }
                 else {
                     this.compile(true);
@@ -1000,7 +1005,7 @@ export class ProjectView
                 if (userContextWindow)
                     try { userContextWindow.close() } catch (e) { }
             }).finally(() => {
-                this.setState({ compiling: false });
+                this.setState({ compiling: false, isSaving: false });
                 if (simRestart) this.runSimulator();
             })
             .done();

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -80,7 +80,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     }
 
     render() {
-        const { tutorialOptions, hideEditorFloats, collapseEditorTools, projectName, showParts, compiling, running } = this.props.parent.state;
+        const { tutorialOptions, hideEditorFloats, collapseEditorTools, projectName, showParts, compiling, isSaving, running } = this.props.parent.state;
 
         const sandbox = pxt.shell.isSandboxMode();
         const readOnly = pxt.shell.isReadOnly();
@@ -118,6 +118,16 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const downloadIcon = pxt.appTarget.appTheme.downloadIcon || "download";
         const downloadText = pxt.appTarget.appTheme.useUploadMessage ? lf("Upload") : lf("Download");
 
+        let downloadButtonClasses = "";
+        let saveButtonClasses = "";
+        if (isSaving) {
+            downloadButtonClasses = "disabled";
+            saveButtonClasses = "loading disabled";
+        } else if (compileLoading) {
+            downloadButtonClasses = "loading disabled";
+            saveButtonClasses = "disabled";
+        }
+
         return <div className="ui equal width grid right aligned padded">
             <div className="column mobile only">
                 {collapsed ?
@@ -128,13 +138,13 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 {headless && run ? <sui.Button class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('mobile') } /> : undefined }
                                 {headless && restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('mobile') } /> : undefined }
                                 {headless && trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('mobile') } /> : undefined }
-                                {compileBtn ? <sui.Button class={`primary download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
+                                {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
                             </div>
                         </div>
                         <div className="right aligned column">
                             {!readOnly ?
                                 <div className="ui icon small buttons">
-                                    <sui.Button icon='save' class="editortools-btn save-editortools-btn" title={lf("Save") } onClick={() => this.saveFile('mobile') } />
+                                    <sui.Button icon='save' class={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } onClick={() => this.saveFile('mobile') } />
                                     {showUndoRedo ? <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo") } onClick={() => this.undo('mobile') } /> : undefined }
                                 </div> : undefined }
                         </div>
@@ -153,11 +163,11 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('mobile') } /> : undefined }
                             </div>
                             {showCollapsed ?
-                            <div className="row" style={{ paddingTop: "1rem" }}>
-                                <div className="ui vertical icon small buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('mobile') } />
-                                </div>
-                            </div> : undefined }
+                                <div className="row" style={{ paddingTop: "1rem" }}>
+                                    <div className="ui vertical icon small buttons">
+                                        <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('mobile') } />
+                                    </div>
+                                </div> : undefined }
                         </div>
                         <div className="three wide column">
                         </div>
@@ -174,7 +184,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 <div className="column">
                                     <div className="ui icon large buttons">
                                         {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('mobile') } /> : undefined }
-                                        {compileBtn ? <sui.Button class={`primary download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
+                                        {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
                                     </div>
                                 </div>
                             </div>
@@ -191,18 +201,18 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     {run ? <sui.Button role="menuitem" class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('tablet') } /> : undefined }
                                     {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('tablet') } /> : undefined }
                                     {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('tablet') } /> : undefined }
-                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
+                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
                                 </div>
                             </div> :
                             <div className="left aligned six wide column">
                                 <div className="ui icon buttons">
                                     <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
-                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon={downloadIcon} text={downloadText} title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
+                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} text={downloadText} title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
                                 </div>
                             </div> }
                         <div className="column four wide">
                             {readOnly ? undefined :
-                                <sui.Button icon='save' class="small editortools-btn save-editortools-btn" title={lf("Save") } onClick={() => this.saveFile('tablet') } /> }
+                                <sui.Button icon='save' class={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } onClick={() => this.saveFile('tablet') } /> }
                         </div>
                         <div className="column six wide right aligned">
                             {showUndoRedo ?
@@ -224,19 +234,19 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('tablet') } /> : undefined }
                             </div>
                             {showCollapsed ?
-                            <div className="row" style={{ paddingTop: "1rem" }}>
-                                <div className="ui vertical icon small buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
-                                </div>
-                            </div> : undefined }
+                                <div className="row" style={{ paddingTop: "1rem" }}>
+                                    <div className="ui vertical icon small buttons">
+                                        <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
+                                    </div>
+                                </div> : undefined }
                         </div>
                         <div className="three wide column">
                         </div>
                         <div className="five wide column">
                             <div className="ui grid right aligned">
-                                 {compileBtn ? <div className="row">
+                                {compileBtn ? <div className="row">
                                     <div className="column">
-                                       <sui.Button role="menuitem" class={`primary large fluid download-button download-button-full ${compileLoading ? 'loading' : ''}`} icon={downloadIcon} text={downloadText} title={compileTooltip} onClick={() => this.compile('tablet') } />
+                                        <sui.Button role="menuitem" class={`primary large fluid download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} text={downloadText} title={compileTooltip} onClick={() => this.compile('tablet') } />
                                     </div>
                                 </div> : undefined }
                                 {showProjectRename ?
@@ -249,7 +259,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                                     value={projectName || ''}
                                                     onChange={(e) => this.saveProjectName((e.target as any).value, 'tablet') }>
                                                 </input>
-                                                <sui.Button icon='save' class="large right attached editortools-btn save-editortools-btn" title={lf("Save") } onClick={() => this.saveFile('tablet') } />
+                                                <sui.Button icon='save' class={`large right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } onClick={() => this.saveFile('tablet') } />
                                             </div>
                                         </div>
                                     </div> : undefined }
@@ -258,20 +268,20 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         <div className="six wide column right aligned">
                             <div className="ui grid right aligned">
                                 { showUndoRedo || showZoomControls ?
-                                <div className="row">
-                                    <div className="column">
-                                    {showUndoRedo ?
-                                        <div className="ui icon large buttons">
-                                            <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo") } onClick={() => this.undo() } />
-                                            <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn} ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo") } onClick={() => this.redo() } />
-                                        </div> : undefined }
-                                    {showZoomControls ?
-                                        <div className="ui icon large buttons">
-                                            <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={() => this.zoomIn() } />
-                                            <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={() => this.zoomOut() } />
-                                        </div> : undefined }
-                                    </div>
-                                </div> : undefined }
+                                    <div className="row">
+                                        <div className="column">
+                                            {showUndoRedo ?
+                                                <div className="ui icon large buttons">
+                                                    <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo") } onClick={() => this.undo() } />
+                                                    <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn} ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo") } onClick={() => this.redo() } />
+                                                </div> : undefined }
+                                            {showZoomControls ?
+                                                <div className="ui icon large buttons">
+                                                    <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={() => this.zoomIn() } />
+                                                    <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={() => this.zoomOut() } />
+                                                </div> : undefined }
+                                        </div>
+                                    </div> : undefined }
                                 {trace ?
                                     <div className="row" style={showUndoRedo || showZoomControls ? { paddingTop: 0 } : {}}>
                                         <div className="column">
@@ -285,20 +295,20 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             <div className="column computer only">
                 <div className="ui grid equal width">
                     <div id="downloadArea" className="ui column items">{headless ?
-                            <div className="ui item">
-                                <div className="ui icon large buttons">
-                                    {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} class={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } /> : undefined }
-                                    {run ? <sui.Button role="menuitem" class={`large play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('computer') } /> : undefined }
-                                    {restart ? <sui.Button key='restartbtn' class={`large restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('computer') } /> : undefined }
-                                    {trace ? <sui.Button key='tracebtn' class={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('computer') } /> : undefined }
-                                    {compileBtn ? <sui.Button icon={downloadIcon} class={`primary large download-button ${compileLoading ? 'loading' : ''}`} title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
-                                </div>
-                            </div> :
-                            <div className="ui item">
+                        <div className="ui item">
+                            <div className="ui icon large buttons">
                                 {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} class={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } /> : undefined }
-                                {compileBtn ? <sui.Button icon={downloadIcon} class={`primary huge fluid download-button ${compileLoading ? 'loading' : ''}`} text={downloadText} title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
+                                {run ? <sui.Button role="menuitem" class={`large play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('computer') } /> : undefined }
+                                {restart ? <sui.Button key='restartbtn' class={`large restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('computer') } /> : undefined }
+                                {trace ? <sui.Button key='tracebtn' class={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('computer') } /> : undefined }
+                                {compileBtn ? <sui.Button icon={downloadIcon} class={`primary large download-button ${downloadButtonClasses}`} title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
                             </div>
-                        }
+                        </div> :
+                        <div className="ui item">
+                            {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} class={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } /> : undefined }
+                            {compileBtn ? <sui.Button icon={downloadIcon} class={`primary huge fluid download-button ${downloadButtonClasses}`} text={downloadText} title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
+                        </div>
+                    }
                     </div>
                     {showProjectRename ?
                         <div className="column left aligned">
@@ -309,7 +319,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     value={projectName || ''}
                                     onChange={(e) => this.saveProjectName((e.target as any).value, 'computer') }>
                                 </input>
-                                <sui.Button icon='save' class="small right attached editortools-btn save-editortools-btn" title={lf("Save") } onClick={() => this.saveFile('computer') } />
+                                <sui.Button icon='save' class={`small right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } onClick={() => this.saveFile('computer') } />
                             </div>
                         </div> : undefined }
                     <div className="column right aligned">


### PR DESCRIPTION
New behavior: When one of the 2 buttons is clicked, it starts spinning, and both buttons are disabled during the operation

Current behavior: Only "download" spins, and neither buttons are ever disabled

Fixes https://github.com/Microsoft/pxt-adafruit/issues/244

![save](https://user-images.githubusercontent.com/14299377/28228138-029c8642-6892-11e7-8395-30368feebc12.gif)
