### PR TITLE
Fix modulus op in monaco flyout

### DIFF
--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -136,7 +136,7 @@ export const maths: BuiltinCategoryDefinition = {
             snippet: `1 / 1`,
             snippetOnly: true,
             attributes: {
-                jsDoc: lf("Returns the remainder of one number divided by another")
+                jsDoc: lf("Returns the quotient of one number divided by another")
             }
         },
         {


### PR DESCRIPTION
Looks like if there's two blocks with the same jsDoc, they get merged with some odd behavior.  There should be a modulus operator, but it just shows up as a block with just "0".  I've always assumed that this was a simple number block, but it's the broken modulus block.

![image](https://user-images.githubusercontent.com/1227186/28229106-49bbf356-6896-11e7-9d86-671be5bd54a5.png)

Fixing the jsDoc makes this turn into the modulus block.