### PR TITLE
Fixing array inference with the create_empty block

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -203,7 +203,7 @@ namespace pxt.blocks {
                     }
                 }
             }
-            return tp || ground("number[]");
+            return tp || ground("Array");
         }
         else if (check === "T") {
             const func = e.stdCallTable[b.type];

--- a/tests/blocklycompiler-test/baselines/lists_empty_arrays.ts
+++ b/tests/blocklycompiler-test/baselines/lists_empty_arrays.ts
@@ -1,0 +1,3 @@
+let item: string[] = []
+item = []
+item.push("")

--- a/tests/blocklycompiler-test/cases/lists_empty_arrays.blocks
+++ b/tests/blocklycompiler-test/cases/lists_empty_arrays.blocks
@@ -1,0 +1,31 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <block id="Nh(7^jG~J4PH9{x.tyHH" type="pxt-on-start" x="-130" y="70">
+    <statement name="HANDLER">
+      <block id="/V7!|zCEy~o+IxFgv3Tq" type="variables_set">
+        <field name="VAR">item</field>
+        <value name="VALUE">
+          <shadow id="h3hiyq|zoi+;h7,7P|3," type="math_number">
+            <field name="NUM">0</field>
+          </shadow>
+          <block id="O*9CYEB4Wq%@?BYFgF43" type="lists_create_with">
+            <mutation items="0"></mutation>
+          </block>
+        </value>
+        <next>
+          <block id="(q*LdlqFDeaAl;v|kLGP" type="array_push">
+            <value name="list">
+              <block id="8J%yx/s%yO{-HRZ7@y.|" type="variables_get">
+                <field name="VAR">item</field>
+              </block>
+            </value>
+            <value name="value">
+              <block id="OBB1*ax6?k`fSVnPTA_Q" type="text">
+                <field name="TEXT"></field>
+              </block>
+            </value>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -239,6 +239,10 @@ describe("blockly compiler", () => {
         it("should not declare lists as strings when using the length block", done => {
             blockTestAsync("lists_length_with_for_of").then(done, done);
         });
+
+        it("should handle empty array blocks", done => {
+            blockTestAsync("lists_empty_arrays").then(done, done);
+        });
     });
 
     describe("compiling logic", () => {


### PR DESCRIPTION
Fixes #2451 