### PR TITLE
Give better control over inline inputs

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -761,7 +761,15 @@ namespace pxt.blocks {
             }
         }
 
-        block.setInputsInline(!fn.attributes.blockExternalInputs && fn.parameters.length < 4 && !fn.attributes.imageLiteral);
+        if (fn.attributes.inlineInputMode === "external") {
+            block.setInputsInline(false);
+        }
+        else if (fn.attributes.inlineInputMode === "internal") {
+            block.setInputsInline(true);
+        }
+        else {
+            block.setInputsInline(fn.parameters.length < 4 && !fn.attributes.imageLiteral);
+        }
 
         switch (fn.retType) {
             case "number": block.setOutput(true, "Number"); break;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -100,7 +100,7 @@ namespace ts.pxtc {
         block?: string; // format of the block, used at namespace level for category name
         blockId?: string; // unique id of the block
         blockGap?: string; // pixels in toolbox after the block is inserted
-        blockExternalInputs?: boolean; // force external inputs
+        blockExternalInputs?: boolean; // force external inputs. Deprecated; see inlineInputMode.
         blockImportId?: string;
         blockBuiltin?: boolean;
         blockNamespace?: string;
@@ -141,6 +141,7 @@ namespace ts.pxtc {
         mutatePrefix?: string;
         mutateDefaults?: string;
         mutatePropertyEnum?: string;
+        inlineInputMode?: string; // can be inline, external, or auto
 
         _name?: string;
         _source?: string;
@@ -401,6 +402,10 @@ namespace ts.pxtc {
 
         if (res.trackArgs) {
             res.trackArgs = ((res.trackArgs as any) as string).split(/[ ,]+/).map(s => parseInt(s) || 0)
+        }
+
+        if (res.blockExternalInputs && !res.inlineInputMode) {
+            res.inlineInputMode = "external";
         }
 
         res.paramHelp = {}


### PR DESCRIPTION
Fixes #2471 

I'm soft-deprecating the old comment attribute in favor of this new one. Gives three modes "inline", "external" and "auto".