### PR TITLE
Adding optional comments for empty event handlers

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -256,6 +256,7 @@ declare namespace ts.pxtc {
         flashChecksumAddr?: number;
         onStartText?: boolean;
         hidSelectors?: HidSelector[];
+        emptyEventHandlerComments?: boolean; // true adds a comment for empty event handlers
     }
 
     interface CompileOptions {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1160,6 +1160,11 @@ namespace pxt.blocks {
         const compiledArgs: JsNode[] = args.map(arg => compileArg(e, b, arg, comments));
         const bBody = getInputTargetBlock(b, "HANDLER");
         const body = compileStatements(e, bBody);
+
+        if (pxt.appTarget.compile && pxt.appTarget.compile.emptyEventHandlerComments && body.children.length === 0) {
+            body.children.unshift(mkStmt(mkText(`// ${pxtc.HANDLER_COMMENT}`)))
+        }
+
         let argumentDeclaration: JsNode;
 
         if (isMutatingBlock(b) && b.mutation.getMutationType() === MutatorTypes.ObjectDestructuringMutator) {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1435,7 +1435,7 @@ ${output}</xml>`;
                 if (match) {
                     const matched = match[1].trim()
 
-                    if (matched === ON_START_COMMENT) {
+                    if (matched === ON_START_COMMENT || matched === HANDLER_COMMENT) {
                         return;
                     }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -8,6 +8,7 @@ namespace ts.pxtc {
 
     export const ON_START_TYPE = "pxt-on-start";
     export const ON_START_COMMENT = U.lf("on start");
+    export const HANDLER_COMMENT = U.lf("code goes here");
     export const TS_STATEMENT_TYPE = "typescript_statement";
     export const TS_OUTPUT_TYPE = "typescript_expression";
     export const BINARY_JS = "binary.js";


### PR DESCRIPTION
Adds a feature where empty event handlers are marked with a comment, like this:

```typescript
input.buttonA.onEvent(ButtonEvent.Click, function () {
    // code goes here
})
```

As a result, the decompiler will ignore any comment with the text "code goes here". I'd make that text configurable but we don't have a good way to localize string in `pxtarget.json`
