### PR TITLE
Friendlier layout of blocks in portrait mode

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -1,5 +1,10 @@
 
 namespace pxt.blocks.layout {
+    export interface FlowOptions {
+        ratio?: number;
+        maxWidth?: number;
+    }
+
     export function patchBlocksFromOldWorkspace(blockInfo: ts.pxtc.BlocksInfo, oldWs: B.Workspace, newXml: string): string {
         const newWs = pxt.blocks.loadWorkspaceXml(newXml, true);
         // position blocks
@@ -66,8 +71,8 @@ namespace pxt.blocks.layout {
         flowBlocks(blocks, ratio);
     }
 
-    export function flow(ws: B.Workspace, ratio?: number) {
-        flowBlocks(ws.getTopBlocks(true), ratio);
+    export function flow(ws: B.Workspace, opts?: FlowOptions) {
+        flowBlocks(ws.getTopBlocks(true), opts.ratio, opts.maxWidth);
     }
 
     export function screenshotEnabled(): boolean {
@@ -213,18 +218,24 @@ namespace pxt.blocks.layout {
         return Promise.all(p).then(() => { })
     }
 
-    function flowBlocks(blocks: Blockly.Block[], ratio: number = 1.62) {
+    function flowBlocks(blocks: Blockly.Block[], ratio: number = 1.62, maxWidth?: number) {
         const gap = 16;
         const marginx = 20;
         const marginy = 20;
 
-        // compute total block surface and infer width
-        let surface = 0;
-        for (let block of blocks) {
-            let s = block.getHeightWidth();
-            surface += s.width * s.height;
+        let maxx: number;
+        if (maxWidth > marginx) {
+            maxx = maxWidth - marginx;
         }
-        const maxx = Math.sqrt(surface) * ratio;
+        else {
+            // compute total block surface and infer width
+            let surface = 0;
+            for (let block of blocks) {
+                let s = block.getHeightWidth();
+                surface += s.width * s.height;
+            }
+            maxx = Math.sqrt(surface) * ratio;
+        }
 
         let insertx = marginx;
         let inserty = marginy;

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -72,7 +72,12 @@ namespace pxt.blocks.layout {
     }
 
     export function flow(ws: B.Workspace, opts?: FlowOptions) {
-        flowBlocks(ws.getTopBlocks(true), opts.ratio, opts.maxWidth);
+        if (opts) {
+            flowBlocks(ws.getTopBlocks(true), opts.ratio, opts.maxWidth);
+        }
+        else {
+            flowBlocks(ws.getTopBlocks(true));
+        }
     }
 
     export function screenshotEnabled(): boolean {

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -63,7 +63,7 @@ namespace pxt.blocks {
                 case BlockLayout.Shuffle:
                     pxt.blocks.layout.shuffle(workspace, options.aspectRatio); break;
                 case BlockLayout.Flow:
-                    pxt.blocks.layout.flow(workspace, options.aspectRatio); break;
+                    pxt.blocks.layout.flow(workspace, { ratio: options.aspectRatio }); break;
                 case BlockLayout.Clean:
                     if ((<any>workspace).cleanUp_)
                         (<any>workspace).cleanUp_();

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -185,8 +185,9 @@ export class Editor extends srceditor.Editor {
         });
 
         if (needsLayout) {
+            const metrics = this.editor.getMetrics();
             // If the blocks file has no location info (e.g. it's from the decompiler), format the code
-            pxt.blocks.layout.flow(this.editor);
+            pxt.blocks.layout.flow(this.editor, { maxWidth: metrics.viewWidth });
         }
         else {
             // Otherwise translate the blocks so that they are positioned on the top left

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -186,8 +186,9 @@ export class Editor extends srceditor.Editor {
 
         if (needsLayout) {
             const metrics = this.editor.getMetrics();
-            // If the blocks file has no location info (e.g. it's from the decompiler), format the code
-            pxt.blocks.layout.flow(this.editor, { maxWidth: metrics.viewWidth });
+            // If the blocks file has no location info (e.g. it's from the decompiler), format the code.
+            // Only limit the width if the editor is in portrait
+            pxt.blocks.layout.flow(this.editor, metrics.viewWidth < metrics.viewHeight ? { maxWidth: metrics.viewWidth } : undefined);
         }
         else {
             // Otherwise translate the blocks so that they are positioned on the top left


### PR DESCRIPTION
Every time we decompile, we lose the block location information and so we format the user's block code. If the Blockly workspace's height is greater than its width, then we should format the blocks so that they are arranged vertically rather than horizontally. This fixes that.