### PR TITLE
Fixed a bug where pressing Enter was not validating a Modal.

### DIFF
--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -347,8 +347,14 @@ export function promptAsync(options: PromptOptions): Promise<string> {
     options.onLoaded = () => {
         let dialogInput = document.getElementById('promptDialogInput') as HTMLInputElement;
         if (dialogInput) {
-            dialogInput.focus();
             dialogInput.setSelectionRange(0, 9999);
+            dialogInput.onkeyup = (e: KeyboardEvent) => {
+                let charCode = (typeof e.which == "number") ? e.which : e.keyCode
+                if (charCode === 13 || charCode === 32) {
+                    e.preventDefault();
+                    (document.getElementsByClassName("approve positive").item(0) as HTMLElement).click();
+                }
+            }
         }
     };
 


### PR DESCRIPTION
Fixed a bug where pressing Enter in the input field of Make a Variable and Make a function modals was not doing the behavior of a click on the OK button.

Original issue : [https://github.com/Microsoft/pxt/issues/2459](https://github.com/Microsoft/pxt/issues/2459)