### PR TITLE
[Accessibility] Multiple minor fixes and improvement

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -5,6 +5,15 @@
 /* Reference import */
 @import (reference) "semantic.less";
 
+
+/* Messages */
+#msg .hc {
+    background-color: black !important;
+    border: 1px solid white !important;
+    border-radius: 0em;
+    color: white !important;
+}
+
 .hc {
 
 @selected: #10C8CD;
@@ -18,10 +27,32 @@
     /* Simulator */
     #filelist {
         background: black !important;
+
+        #boardview {
+            background: black !important;
+        }
     }
 
 
     /* Menu bar */
+    #menubar .menu > .item:focus,
+    #menubar #accessibleMenu > .item:focus,
+    #menubar .editor-menuitem > .item:focus {
+        border: 1px solid @selected !important;
+    }
+
+    #menubar .menu > .item:focus > i, 
+    #menubar .menu > .item:focus > span {
+        color: @selected !important;
+    }
+
+    #menubar #accessibleMenu > .item:focus,
+    #menubar .editor-menuitem > .item:focus:not(.active) {
+        i, span {
+            color: @selected !important;
+        }
+    }
+
     #menubar .ui.inverted.menu, #menubar #accessibleMenu .ui.item.link.inverted:hover {
         background: black !important;
         border-bottom: 1px solid white;
@@ -176,14 +207,24 @@
         }
     }
 
+    #cookiemsg {
+        background: black !important;
+        border-radius: 0em;
+        border: 1px solid white !important;
+    }
+
     /* Blockly / Monaco toolbox */
+    .blocklyTreeSelected {
+        background: @selected !important;
+    }
+
     .blocklyToolboxDiv, .monacoToolboxDiv {
         background: black !important;
         border-left: 1px solid white !important; 
         border-right: 1px solid white !important;
     }
 
-    .blocklyTreeLabel {
+    .blocklyTreeLabel, .blocklyTreeIcon {
         color: white !important;
     }
 
@@ -226,5 +267,4 @@
             color: white !important;
         }
     }
-
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1190,7 +1190,7 @@ export class ProjectView
             htmlBody: `<div class="ui form">
   <div class="ui field">
     <label>${lf("Select a {0} file to open.", ext)}</label>
-    <input type="file" class="ui button blue fluid"></input>
+    <input type="file" class="ui button blue fluid focused"></input>
   </div>
 </div>`,
         }).done(res => {
@@ -1531,7 +1531,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         const hc = !this.state.highContrast;
         pxt.tickEvent("menu.highcontrast", { on: hc ? 1 : 0 });
         this.setState({ highContrast: hc }, () => this.restartSimulator());
-        sui.highContrast = hc;
+        core.highContrast = hc;
         if (this.editor && this.editor.isReady) {
             this.editor.setHighContrast(hc);
         }

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -11,6 +11,8 @@ import * as pkg from "./package";
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 
+export let highContrast: boolean;
+
 const lf = Util.lf;
 
 export type Component<S, T> = data.Component<S, T>;
@@ -91,6 +93,22 @@ let lastTime: any = {}
 function htmlmsg(kind: string, msg: string) {
     let now = Date.now()
     let prev = lastTime[kind] || 0
+
+    let msgTag = $('#msg');
+    if (highContrast) {
+        msgTag.children().each((index: number, elem: Element) => {
+            if (!elem.classList.contains('hc')) {
+                elem.classList.add('hc')
+            }
+        });
+    } else {
+        msgTag.children().each((index: number, elem: Element) => {
+            if (!elem.classList.contains('hc')) {
+                elem.classList.remove('hc')
+            }
+        });
+    }
+
     if (now - prev < 100)
         $('#' + kind + 'msg').text(msg);
     else {

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -3,8 +3,6 @@ import * as ReactDOM from "react-dom";
 import * as data from "./data";
 import * as core from "./core";
 
-export let highContrast: boolean;
-
 export interface UiProps {
     icon?: string;
     iconClass?: string;
@@ -96,7 +94,7 @@ export class DropdownMenuItem extends UiElement<DropdownProps> {
     private isOpened = false
     private preventHide = false
 
-    private handleKeyDown = (e: KeyboardEvent) => {
+    private menuItemKeyDown = (e: KeyboardEvent) => {
         let charCode = (typeof e.which == "number") ? e.which : e.keyCode
         if (charCode === 9) {
             this.close()
@@ -107,6 +105,17 @@ export class DropdownMenuItem extends UiElement<DropdownProps> {
         }
     }
 
+    private dropDownKeyDown = (e: JQueryKeyEventObject) => {
+        let charCode = (typeof e.which == "number") ? e.which : e.keyCode
+        if (charCode === 32 || charCode === 13) {
+            if (this.isOpened) {
+                this.child("").dropdown("hide")
+            } else {
+                this.child("").dropdown("show")
+            }
+        }
+    }
+
     private close() {
         this.preventHide = false
         this.child("").dropdown("hide")
@@ -114,7 +123,9 @@ export class DropdownMenuItem extends UiElement<DropdownProps> {
 
     componentDidMount() {
         this.popup()
-        this.child("").dropdown({
+        let dropdowmtag = this.child("")
+        dropdowmtag.on("keydown", this.dropDownKeyDown)
+        dropdowmtag.dropdown({
             action: (text: string, value: any, element: JQuery) => {
                 this.close()
 
@@ -140,7 +151,7 @@ export class DropdownMenuItem extends UiElement<DropdownProps> {
 
                 var menuItems = this.child(".item")
                 menuItems.each((index: number, elem: HTMLElement) => {
-                    elem.onkeydown = this.handleKeyDown
+                    elem.onkeydown = this.menuItemKeyDown
                 })
             },
             onHide: () => {
@@ -905,7 +916,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
         const dimmerClasses = !dimmer
             ? null
             : cx([
-                highContrast ? 'hc' : '', 
+                core.highContrast ? 'hc' : '', 
                 'ui',
                 dimmer === 'inverted' ? 'inverted' : '',
                 pxt.options.light ? '' : "transition",


### PR DESCRIPTION
Multiple bug fix :
- The tab navigation in the Import modal was broken.
- Changed the behavior of the dropdown menu to close/open it by pressing Enter on the menu (but not necessarily a menu item).
- In high contrast mode, the focus was not rendered on the dropdown menu.
- In high contrast mode, the Learn More flyout was not supported.
- In high contrast mode, the info messages like errors for example were not supported.
- In high contrast mode, the background color of the simulator in full screen mode was not supported.
- In high contrast modem, the selected item in the blocky/monaco editor's toolbox was not supported.