### PR TITLE
Add initial 'text' docs and rendering support.

### DIFF
--- a/common-docs/reference/string.md
+++ b/common-docs/reference/string.md
@@ -1,0 +1,15 @@
+# Text
+
+Functions to combine, split, and search text strings.
+
+```cards
+"".charAt(0);
+"".compare("");
+"".substr(0, 0);
+parseInt("");
+```
+
+## See also
+
+[char at](/reference/text/char-at), [compare](/reference/text/compare),
+[substr](/reference/text/substr), [parse int](/reference/text/parse-int)

--- a/common-docs/reference/text/char-at.md
+++ b/common-docs/reference/text/char-at.md
@@ -1,0 +1,40 @@
+# char At
+
+Get a character (letter, number, or symbol) from a place in the text string.
+
+```sig
+"".charAt(0);
+```
+
+You can find out which character is at any place in some text. You might have text thats says `"Hello there!"`. The character at position 6 is `'t'`. The word "Hello" plus the space have positions 0 - 5, so, 't' is at position 6. To get the character at this position, the letter `'t'`, you could use a blocks like this:
+
+```block
+let greeting = "Hello there!";
+let tee = greeting.charAt(6);
+```
+
+## Parameters
+
+* **index**: the [number](/types/number) for the position in the text string to return a character for.
+
+## Returns
+
+* a single character [string](/types/string) that is from the selected position in the text string.
+
+## Example
+
+Make a funny new sentence from an existing sentence by choosing every other letter.
+
+```blocks
+let sentence = "Cinnamon vanilla latte";
+let funnySentence = "";
+for (let i = 0; i < sentence.length; i++) {
+    if (i % 2 > 0) {
+        funnySentence = funnySentence + sentence.charAt(i);
+    }
+}
+```
+
+## See also
+
+[substr](/reference/text/substr)

--- a/common-docs/reference/text/compare.md
+++ b/common-docs/reference/text/compare.md
@@ -1,0 +1,73 @@
+# compare
+
+See how two text strings compare based on which characters are first.
+
+```sig
+"".compare("");
+```
+Two strings are compared based on the order of their characters. If string `A` has `"111"` it will
+be less than a string with `"512"`. A string with `"Everthing"` is less than `"Nothing"` because
+`'N'` comes after `'E'` in the alphabet.
+
+The string `"abcdefg"` is greater than `"abcdefa"`. They are almost the same but the last letter of the second string is less than the last letter of the first one. This makes the whole second string compare as less. In blocks, the comparison of these strings looks like:
+
+```block
+let iamGreater = false;
+if ("abcdefg".compare("abcdefa") > 0) {
+    iamGreater = true;
+}
+```
+
+## Parameters
+
+* **that**: the [string](/types/string) that compares to this string.
+
+## Returns
+
+* a [number](/types/number) that is -1, 0, or 1. These numbers mean that this string is:
+
+>**-1**: this string is less than the compared string.<br/>
+**0**: this string is equal to the compared string.<br/>
+**1**: this string is greater than the compared string.
+
+## Examples #exsection
+
+### Which bird is the same as a duck #ex1
+
+See which bird is the same as a `"duck"`.
+
+```blocks
+let match = false;
+let bird = "duck";
+if (bird.compare("crow") == 0) {
+    match = true;
+} else if (bird.compare("goose") == 0) {
+    match = true;
+} else if (bird.compare("duck") == 0) {
+    match = true;
+}
+```
+
+### Compare the birds #ex2
+
+See how other birds compare to a `"duck"`.
+
+```blocks
+let birds = ["crow", "DUCK", "goose", "Duck", "eagle", "osprey"];
+let lesserBirds = 0;
+let greaterBirds = 0;
+let ducks = 0;
+
+for (let bird of birds) {
+    let result = bird.compare("duck");
+    if (result < 0) {
+        lesserBirds++;
+    } else if (result > 0) {
+        greaterBirds++;
+    } else {
+        ducks++;
+    }
+}
+```
+
+

--- a/common-docs/reference/text/parse-int.md
+++ b/common-docs/reference/text/parse-int.md
@@ -1,0 +1,26 @@
+# parse Int
+
+Turn text that has just number characters into a real number value. The number is an integer.
+
+```sig
+parseInt("0");
+```
+
+The text needs to have only number characters. This can also include the `'-'` and the `'.'`
+symbols though. But, only the _integer_ part (left of the decimal point) is converted to a number.
+
+If the text has other characters, like `"-2g5u7"`, only `-2` is returned since it is the best
+attempt at converting to a number. So, try not to mix number characters with letters or other symbols.
+
+## Returns
+
+* a [number](/types/string) value for the text number in the string.
+
+## Example #exsection
+
+Take the temperature text from the sentence and turn it into a number.
+
+```blocks
+let frozenWater = "The freezing temprature of water is 32 degrees Fahrenheit.";
+let freezing = parseInt(frozenWater.substr(36, 2));
+```

--- a/common-docs/reference/text/substr.md
+++ b/common-docs/reference/text/substr.md
@@ -1,0 +1,47 @@
+# substr
+
+Take some part of the this string to make a smaller string (substring).
+
+```sig
+"".substr(0,0);
+```
+
+If a string has a part of it copied as another string, it is called a _substring_. A new 
+substring is made by copying from the first string at some starting place. Also, the substring
+copies just the amount of characters you want from the first string.
+
+You could make a new string that just has the word `"there"` from a bigger string that
+says `"Hello there!!!"`. To do that, the substring is copied from the character position of `6` in the first string and `5` characters are copied. It's done like this:
+
+```block
+let there = "Hello there!!!".substr(6, 5);
+```
+If you want to have the substring copy to the end of the first string, you just use the starting
+position without any length number. This will copy all of the first string beginning at position `6`. The substring will say `"there!!!"` in this case.
+
+```block
+let there = "Hello there!!!".substr(6);
+```
+
+## Parameters
+
+* **start**: a [number](/types/number) which is the position to start copying from in this string. 
+* **length**: a [number](/types/number) which is the amount of characters to copy from this string. If _length_ is left out, the rest of this string is copied beginning at _start_. If _length_ is `0` or less, a string with nothing in it is made.
+
+## Returns
+
+* a new [string](/types/string) which is some part of the this string.
+
+## Example
+
+Copy the nouns from the sentence into two smaller strings.
+
+```block
+let sentence = "The mountains have snow.";
+let mountains = sentence.substr(4, 9);
+let snow = sentence.substr(19, 4);
+```
+
+## See also
+
+[char at](/reference/text/char-at)

--- a/libs/pxt-common/ns.ts
+++ b/libs/pxt-common/ns.ts
@@ -1,0 +1,5 @@
+/**
+ * Functions to combine, split, and search text strings.
+ */
+declare namespace String {
+}

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -165,6 +165,7 @@ declare interface String {
      * @param index The zero-based index of the desired character.
      */
     //% shim=String_::charAt weight=48
+    //% help=text/char-at
     //% blockId="string_get" block="char from %this=text|at %pos" blockNamespace="text"
     charAt(index: number): string;
 
@@ -185,6 +186,7 @@ declare interface String {
      * @param that String to compare to target string
      */
     //% shim=String_::compare
+    //% help=text/compare
     //% blockId="string_compare" block="compare %this=text| to %that" blockNamespace="text"
     compare(that: string): number;
 
@@ -194,6 +196,7 @@ declare interface String {
      * @param length number of characters to extract
      */
     //% shim=String_::substr length.defl=1000000
+    //% help=text/substr
     //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
     substr(start: number, length?: number): string;
 
@@ -209,10 +212,11 @@ declare interface String {
 }
 
 /**
-  * Converts A string to an integer.
+  * Convert a string to an integer.
   * @param s A string to convert into a number.
   */
 //% shim=String_::toNumber
+//% help=text/parse-int
 //% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
 declare function parseInt(text: string): number;
 
@@ -248,7 +252,6 @@ declare namespace String {
     //% blockNamespace="Math" blockId="stringFromCharCode" block="text from char code %code" weight=1
     function fromCharCode(code: number): string;
 }
-
 
 declare interface Number {
     /**

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -367,7 +367,7 @@ namespace pxt.runner {
                         let nsi = r.compileBlocks.blocksInfo.apis.byQName[ii.namespace];
                         addItem({
                             name: nsi.name,
-                            url: nsi.attributes.help || ("reference/" + nsi.name),
+                            url: nsi.attributes.help || ("reference/" + nsi.name.toLowerCase()),
                             description: nsi.attributes.jsDoc,
                             blocksXml: block && block.codeCard
                                 ? block.codeCard.blocksXml


### PR DESCRIPTION
* The four methods currently exposed in the editor.
* adjust _renderer.ts_ to use lower case for "/string" rather than "/String" to match our pathing convention from ns names.
* Add the help paths to pxt-core.
----
Ok, so _renderer_ is currently setup to make non-statements/non-block items go to "/reference". I put the 'text' docs under "/reference/text" for now. Fix this or leave it and put stuff in "/reference"? This will also apply to Arrays later.

Also, I don't know how to alias 'text' for 'String' so there's a namespace switch requiring a _string.md_, and not a _text.md_, to then contain cards for docs in _/text/file-name.md_.
