### PR TITLE
[Accessibility] A set of fixes linked to the screen readers in the Projects modal.

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -23,7 +23,7 @@
     <div id='content'>
     </div>
 
-    <div id='msg'>
+    <div id='msg' aria-live="polite">
         <div id='errmsg' class="ui red inverted segment"></div>
         <div id='warnmsg' class="ui orange inverted segment"></div>
         <div id='infomsg' class="ui teal inverted segment"></div>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1189,8 +1189,8 @@ export class ProjectView
             },
             htmlBody: `<div class="ui form">
   <div class="ui field">
-    <label>${lf("Select a {0} file to open.", ext)}</label>
-    <input type="file" class="ui button blue fluid focused"></input>
+    <label id="selectFileToOpenLabel">${lf("Select a {0} file to open.", ext)}</label>
+    <input type="file" tabindex="0" autofocus aria-describedby="selectFileToOpenLabel" class="ui button blue fluid focused"></input>
   </div>
 </div>`,
         }).done(res => {
@@ -1218,7 +1218,7 @@ export class ProjectView
             htmlBody: `<div class="ui form">
   <div class="ui field">
     <label>${lf("What is the URL of the offensive project?")}</label>
-    <input type="url" placeholder="Enter project URL here..."></input>
+    <input type="url" class="focused" tabindex="0" autofocus placeholder="Enter project URL here..."></input>
   </div>
   <div class="ui field">
     <label>${lf("Why do you find it offensive?")}</label>
@@ -1267,8 +1267,8 @@ export class ProjectView
     </div>
 </div>
   <div class="ui field">
-    <label>${lf("Copy the URL of the project.")}</label>
-    <input type="url" placeholder="${shareUrl}..." class="ui button blue fluid"></input>
+    <label id="selectUrlToOpenLabel">${lf("Copy the URL of the project.")}</label>
+    <input type="url" tabindex="0" autofocus aria-describedby="selectUrlToOpenLabel" placeholder="${shareUrl}..." class="ui button blue fluid"></input>
   </div>
 </div>`,
         }).done(res => {

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -32,7 +32,7 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
             : undefined;
         const sideUrl = url && /^\//.test(url) ? "#doc:" + url : url;
         const className = card.className;
-        const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`} role={card.role} aria-label={card.ariaLabel || card.title} title={card.title} onClick={e => card.onClick ? card.onClick(e) : undefined } tabIndex={card.onClick ? card.tabIndex || 0 : null} onKeyDown={card.onClick ? sui.fireClickOnEnter : null}>
+        const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`} role={card.role} aria-selected={card.role === "option" ? "true" : undefined} aria-label={card.ariaLabel || card.title} title={card.title} onClick={e => card.onClick ? card.onClick(e) : undefined } tabIndex={card.onClick ? card.tabIndex || 0 : null} onKeyDown={card.onClick ? sui.fireClickOnEnter : null}>
             {card.header || card.blocks || card.javascript || card.hardware || card.software || card.any ?
                 <div key="header" className={"ui content " + (card.responsive ? " tall desktop only" : "") }>
                     <div className="right floated meta">

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -104,7 +104,7 @@ export class SideDocs extends data.Component<ISettingsProps, {}> {
             </button>
             <div id="sidedocs">
                 <div id="sidedocsbar">
-                    <h3><a className="ui icon link" data-content={lf("Open documentation in new tab") } aria-label={lf("Open documentation in new tab") } title={lf("Open documentation in new tab") } onClick={() => this.popOut() } >
+                    <h3><a className="ui icon link" role="link" tabIndex={0} data-content={lf("Open documentation in new tab") } aria-label={lf("Open documentation in new tab") } title={lf("Open documentation in new tab") } onClick={() => this.popOut() } >
                         <i className="external icon"></i>
                     </a></h3>
                 </div>

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -194,8 +194,8 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
         .map(logo => `<img class="ui logo" src="${Util.toDataUri(logo)}" />`)
         .join(' ');
     let html = `
-  <div class="ui ${options.size || "small"} modal">
-    <div class="header">
+  <div role="dialog" class="ui ${options.size || "small"} modal">
+    <div role="heading" class="header">
         ${Util.htmlEscape(options.header)}
     </div>
     <div class="content">

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -231,10 +231,10 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 </sui.Segment>
                 {tab == MYSTUFF ? <div className={tabClasses} id={`tab${tab}`} role="tabpanel" aria-labelledby={`${tab}tab`} aria-hidden="false">
                     <div className="group">
-                        <div className="ui cards" role="listbox">
+                        <div className="ui cards">
                             <codecard.CodeCardView
                                 ariaLabel={lf("Creates a new empty project")}
-                                role="option"
+                                role="button"
                                 key={'newproject'}
                                 icon="file outline"
                                 iconColor="primary"
@@ -245,7 +245,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                             {pxt.appTarget.compile ?
                                 <codecard.CodeCardView
                                     ariaLabel={lf("Open files from your computer")}
-                                    role="option"
+                                    role="button"
                                     key={'import'}
                                     icon="upload"
                                     iconColor="secondary"
@@ -256,7 +256,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                             {pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.publishing && pxt.appTarget.cloud.importing ?
                                 <codecard.CodeCardView
                                     ariaLabel={lf("Open a shared project URL")}
-                                    role="option"
+                                    role="button"
                                     key={'importurl'}
                                     icon="cloud download"
                                     iconColor="secondary"
@@ -267,7 +267,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                             { legacyUrl ?
                                 <codecard.CodeCardView
                                     ariaLabel={lf("Import old programs")}
-                                    role="option"
+                                    role="button"
                                     key={'importlegacy'}
                                     icon="archive"
                                     iconColor="secondary"

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -581,7 +581,7 @@ export class MenuItem extends data.Component<MenuItemProps, {}> {
         }
 
         return (
-            <div id={id} tabIndex={active ? 0 : undefined} className={classes} onClick={this.handleClick} role="tab" aria-controls={ariaControls} aria-selected={active} aria-label={content || name}>
+            <div id={id} tabIndex={active ? 0 : -1} className={classes} onClick={this.handleClick} role="tab" aria-controls={ariaControls} aria-selected={active} aria-label={content || name}>
                 {icon ? <i className={`icon ${icon}`} ></i> : undefined}
                 {content || name}
             </div>


### PR DESCRIPTION
- The items of the My Stuff, Projects and Examples are now announced as selected.
- The Create new project and Important project are now announced as button.
- The <input file> are now described correctly by the Narrator.
- The <input file> keep the focus when selecting a file on Edge and IE.
- The messages displayed after a click on the Download button or Import file are now read by the screen readers.
- The "Open documentation in a new tab" is now accessible with the keyboard and readable by the screen reader.
- A minor bug linked to the tabindex of the tablist has been fixed on Edge and IE.

Linked issues : [https://github.com/Microsoft/pxt/issues/2520](https://github.com/Microsoft/pxt/issues/2520), [https://github.com/Microsoft/pxt/issues/2522](https://github.com/Microsoft/pxt/issues/2522), [https://github.com/Microsoft/pxt/issues/2524](https://github.com/Microsoft/pxt/issues/2524), [https://github.com/Microsoft/pxt/issues/2526](https://github.com/Microsoft/pxt/issues/2526), [https://github.com/Microsoft/pxt/issues/2530](https://github.com/Microsoft/pxt/issues/2530), [https://github.com/Microsoft/pxt/issues/2544](https://github.com/Microsoft/pxt/issues/2544), [https://github.com/Microsoft/pxt/issues/2529](https://github.com/Microsoft/pxt/issues/2529)
