### PR TITLE
[Accessibility] Color contrast and focus visual render fixed

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -412,6 +412,18 @@ div.simframe > iframe {
     background: white !important;
 }
 
+.ui.secondary.inverted.menu .link.item, .ui.secondary.inverted.menu a.item {
+    color: rgba(255, 255, 255, 0.9) !important;
+}
+
+.ui.disabled.header {
+    opacity: 0.80;
+}
+
+.ui.cards > .card .meta,
+.ui.card .meta {
+    color: rgba(0, 0, 0, 0.68);
+}
 
 /*******************************
         Modal Close Icon

--- a/theme/common.less
+++ b/theme/common.less
@@ -412,6 +412,7 @@ div.simframe > iframe {
     background: white !important;
 }
 
+
 /*******************************
         Modal Close Icon
 *******************************/

--- a/theme/common.less
+++ b/theme/common.less
@@ -412,19 +412,6 @@ div.simframe > iframe {
     background: white !important;
 }
 
-.ui.secondary.inverted.menu .link.item, .ui.secondary.inverted.menu a.item {
-    color: rgba(255, 255, 255, 0.9) !important;
-}
-
-.ui.disabled.header {
-    opacity: 0.80;
-}
-
-.ui.cards > .card .meta,
-.ui.card .meta {
-    color: rgba(0, 0, 0, 0.68);
-}
-
 /*******************************
         Modal Close Icon
 *******************************/

--- a/theme/sidedoc.less
+++ b/theme/sidedoc.less
@@ -44,7 +44,12 @@
   margin: 0;
   background: grey;
   box-shadow: none !important;
-   transition: none;
+  transition: none;
+
+  &:hover,
+  &:focus {
+    background: #5A5A5A;
+  }
 }
 
 .sideDocs #sidedocsframe {

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -50,6 +50,13 @@
     background: rgba(255, 255, 255, 0.30);
 }
 
+.ui.vertical.menu .item > .label {
+    &:hover,
+    &:focus {
+        background: #6C6C6C;
+    }
+}
+
 /* Tutorial mode */
 .tutorial .ui.inverted.menu {
     background: @mainMenuTutorialBackground !important;

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -44,6 +44,24 @@
 @tallEditorBreakpoint: 44rem;
 @thinEditorBreakpoint: 24rem;
 
+/*-------------------
+     Neutral Text
+--------------------*/
+
+@lightTextColor              : rgba(0, 0, 0, 0.68);
+@invertedLightTextColor      : rgba(255, 255, 255, 0.9);
+
+
+/*******************************
+             States
+*******************************/
+
+/*-------------------
+      Disabled
+--------------------*/
+
+@disabledOpacity: 0.80;
+
 /*******************************
      PXT Variables
 *******************************/

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -30,6 +30,12 @@
 @docsPageFont: @pageFont;
 
 /*-------------------
+   Links
+--------------------*/
+
+@linkColor           : #0F6C9B;
+
+/*-------------------
    Breakpoints
 --------------------*/
 
@@ -47,8 +53,7 @@
 /*-------------------
      Neutral Text
 --------------------*/
-
-@lightTextColor              : rgba(0, 0, 0, 0.68);
+ 
 @invertedLightTextColor      : rgba(255, 255, 255, 0.9);
 
 


### PR DESCRIPTION
Fixed the color contrast of tab items, disabled headers and item description.
Also added a darker hover and focus color for the Side Documentation button and the buttons in the toolbox.

![capture](https://user-images.githubusercontent.com/3747805/28696730-481611c0-72ec-11e7-9578-116aa140ab61.PNG)

![capture](https://user-images.githubusercontent.com/3747805/28798128-702c6f06-75f8-11e7-9dc1-0c12a55d9843.PNG)

![capture](https://user-images.githubusercontent.com/3747805/28798215-ade2ecb2-75f8-11e7-9f71-2a32919b8257.PNG)




Related issues : [https://github.com/Microsoft/pxt/issues/2519](https://github.com/Microsoft/pxt/issues/2519), [https://github.com/Microsoft/pxt/issues/2534](https://github.com/Microsoft/pxt/issues/2534), [https://github.com/Microsoft/pxt/issues/2499](https://github.com/Microsoft/pxt/issues/2499), [https://github.com/Microsoft/pxt/issues/2525](https://github.com/Microsoft/pxt/issues/2525)