### PR TITLE
Clear 'tracing' state when switching between normal and tutorial modes

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1469,7 +1469,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                     tutorialStep: 0,
                     tutorialSteps: result
                 };
-                this.setState({ tutorialOptions: tutorialOptions })
+                this.setState({ tutorialOptions: tutorialOptions, tracing: undefined })
 
                 let tc = this.refs["tutorialcontent"] as tutorial.TutorialContent;
                 tc.setPath(tutorialId);
@@ -1509,7 +1509,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
             })
             .finally(() => {
                 core.hideLoading()
-                this.setState({ active: true, tutorialOptions: undefined });
+                this.setState({ active: true, tutorialOptions: undefined, tracing: undefined });
             });
     }
 


### PR DESCRIPTION
Resolves https://github.com/Microsoft/pxt/issues/1918

Slow-mo is selected in normal editor...
![f1](https://user-images.githubusercontent.com/16658549/28697317-c54193a6-72ef-11e7-95cf-b6cb3af1ef17.PNG)

...but when we switch to tutorial mode, it's gone.
![f2](https://user-images.githubusercontent.com/16658549/28697330-e53158a4-72ef-11e7-8c81-3b0f3a924572.PNG)

This state is also cleared when switching _from_ the tutorial _to_ the normal editor.