### PR TITLE
Bug 2516 fix v0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "0.12.100",
+  "version": "0.12.101",
   "description": "Microsoft MakeCode, also known as Programming Experience Toolkit (PXT), provides Blocks / JavaScript tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -237,7 +237,7 @@ namespace pxtblockly {
         setValue(note: string) {
             let regex: RegExp = new RegExp("Note.(.*)");
             let match = regex.exec(note);
-            let noteName: any = (match && match.length) > 1 ? match[1] : null;
+            let noteName: any = (match && match.length > 1) ? match[1] : null;
             note = Note[noteName] ? String(parseFloat(Note[noteName])) : String(parseFloat(note || "0"));
             if (isNaN(Number(note)) || Number(note) < 0)
                 return;

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../localtypings/blockly.d.ts" />
 
 namespace pxtblockly {
-        enum Note {
+    enum Note {
         C = 262,
         CSharp = 277,
         D = 294,
@@ -236,9 +236,9 @@ namespace pxtblockly {
          */
         setValue(note: string) {
             let regex: RegExp = new RegExp("Note.(.*)");
-            let match = regex.exec(note);
+            let match: Array<String> = regex.exec(note);
             let noteName: any = (match && match.length > 1) ? match[1] : null;
-            note = Note[noteName] ? String(parseFloat(Note[noteName])) : String(parseFloat(note || "0"));
+            note = Note[noteName] ? Note[noteName] : String(parseFloat(note || "0"));
             if (isNaN(Number(note)) || Number(note) < 0)
                 return;
             if (this.sourceBlock_ && Blockly.Events.isEnabled() &&

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -1,6 +1,56 @@
 /// <reference path="../../localtypings/blockly.d.ts" />
 
 namespace pxtblockly {
+        enum Note {
+        C = 262,
+        CSharp = 277,
+        D = 294,
+        Eb = 311,
+        E = 330,
+        F = 349,
+        FSharp = 370,
+        G = 392,
+        GSharp = 415,
+        A = 440,
+        Bb = 466,
+        B = 494,
+        C3 = 131,
+        CSharp3 = 139,
+        D3 = 147,
+        Eb3 = 156,
+        E3 = 165,
+        F3 = 175,
+        FSharp3 = 185,
+        G3 = 196,
+        GSharp3 = 208,
+        A3 = 220,
+        Bb3 = 233,
+        B3 = 247,
+        C4 = 262,
+        CSharp4 = 277,
+        D4 = 294,
+        Eb4 = 311,
+        E4 = 330,
+        F4 = 349,
+        FSharp4 = 370,
+        G4 = 392,
+        GSharp4 = 415,
+        A4 = 440,
+        Bb4 = 466,
+        B4 = 494,
+        C5 = 523,
+        CSharp5 = 555,
+        D5 = 587,
+        Eb5 = 622,
+        E5 = 659,
+        F5 = 698,
+        FSharp5 = 740,
+        G5 = 784,
+        GSharp5 = 831,
+        A5 = 880,
+        Bb5 = 932,
+        B5 = 988
+    }
 
     enum PianoSize {
         small = 12,
@@ -185,7 +235,10 @@ namespace pxtblockly {
          * @param {string} note The new note in string format.
          */
         setValue(note: string) {
-            note = String(parseFloat(note || "0"));
+            let regex: RegExp = new RegExp("Note.(.*)");
+            let match = regex.exec(note);
+            let noteName: any = (match && match.length) > 1 ? match[1] : null;
+            note = Note[noteName] ? String(parseFloat(Note[noteName])) : String(parseFloat(note || "0"));
             if (isNaN(Number(note)) || Number(note) < 0)
                 return;
             if (this.sourceBlock_ && Blockly.Events.isEnabled() &&

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -58,6 +58,8 @@ namespace pxtblockly {
         large = 60
     }
 
+    let regex: RegExp = /^Note\.(.+)$/
+
     //  Class for a note input field.
     export class FieldNote extends Blockly.FieldNumber implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
@@ -93,7 +95,6 @@ namespace pxtblockly {
          * @private
          */
         private noteName_: Array<string> = [];
-
 
         constructor(text: string, options: Blockly.FieldCustomOptions, validator?: Function) {
             super(text);
@@ -235,8 +236,8 @@ namespace pxtblockly {
          * @param {string} note The new note in string format.
          */
         setValue(note: string) {
-            let regex: RegExp = new RegExp("Note.(.*)");
-            let match: Array<String> = regex.exec(note);
+            // accommodate note strings like "Note.GSharp5" as well as numbers
+            let match: Array<string> = regex.exec(note);
             let noteName: any = (match && match.length > 1) ? match[1] : null;
             note = Note[noteName] ? Note[noteName] : String(parseFloat(note || "0"));
             if (isNaN(Number(note)) || Number(note) < 0)


### PR DESCRIPTION
Allows blocks to be built from Javascript syntax like `music.ringTone(music.noteFrequency(Note.D));` 

See https://github.com/Microsoft/pxt/issues/2516