### PR TITLE
[Accessibility] Fixed an issue where the accessibility of the Pin was broken and was breaking the simulator.

### DIFF
--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -28,12 +28,26 @@ namespace pxsim.accessibility {
 
     export function setLiveContent(value: string): void {
         if (!liveRegion) {
+            let style = "position: absolute !important;" +
+                        "display: block;" +
+                        "visibility: visible;" +
+                        "overflow: hidden;" +
+                        "width: 1px;" +
+                        "height: 1px;" +
+                        "margin: -1px;" +
+                        "border: 0;" +
+                        "padding: 0;" +
+                        "clip: rect(0 0 0 0);";
             liveRegion = document.createElement("div");
             liveRegion.setAttribute("role", "status");
             liveRegion.setAttribute("aria-live", "polite");
+            liveRegion.setAttribute("aria-hidden", "false");
+            liveRegion.setAttribute("style", style);
             document.body.appendChild(liveRegion);
         }
 
-        liveRegion.textContent = value;
+        if (liveRegion.textContent !== value) {
+            liveRegion.textContent = value;
+        }
     }
 }


### PR DESCRIPTION
Fixed an issue where while using only the A, B button and Pin (but no thermometer or light level) in the microbit simulator, a space/padding was moving the simulator.
After fixing this issue, the tag used as an aria-live was visible, so I hidden it too.
Finally, I fixed an issue where the simulator's UI was not correctly displayed at loading on FireFox while using only the A, B button and Pin (but no thermometer or light level). It had an impact on tabbing into the Pin.

This fix is linked to pxt-microbit [https://github.com/Microsoft/pxt-microbit/pull/471](https://github.com/Microsoft/pxt-microbit/pull/471)