### PR TITLE
Bug 395 fix v0

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -37,6 +37,16 @@ namespace pxsim {
             return Date.now();
         }
 
+        export function perfNow(): number {
+            const perf = typeof performance != "undefined" ?
+                performance.now ||
+                (performance as any).moznow ||
+                (performance as any).msNow ||
+                (performance as any).oNow ||
+                Date.now : Date.now;
+            return perf.bind(performance)();
+        }
+
         export function nextTick(f: () => void) {
             (<any>Promise)._async._schedule(f)
         }
@@ -229,6 +239,7 @@ namespace pxsim {
         dead = false;
         running = false;
         startTime = 0;
+        startTimeUs = 0;
         id: string;
         globals: any = {};
         currFrame: StackFrame;
@@ -293,6 +304,7 @@ namespace pxsim {
                 this.running = r;
                 if (this.running) {
                     this.startTime = U.now();
+                    this.startTimeUs = U.perfNow();
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'running' });
                 } else {
                     Runtime.postMessage(<SimulatorStateMessage>{ type: 'status', runtimeid: this.id, state: 'killed' });

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -39,12 +39,13 @@ namespace pxsim {
 
         export function perfNow(): number {
             const perf = typeof performance != "undefined" ?
-                performance.now ||
-                (performance as any).moznow ||
-                (performance as any).msNow ||
-                (performance as any).oNow ||
-                Date.now : Date.now;
-            return perf.bind(performance)();
+                performance.now.bind(performance)                 ||
+                (performance as any).moznow.bind(performance)     ||
+                (performance as any).msNow.bind(performance)      ||
+                (performance as any).webkitNow.bind(performance)  ||
+                (performance as any).oNow.bind(performance)       :
+                Date.now;
+            return perf();
         }
 
         export function nextTick(f: () => void) {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -58,9 +58,7 @@ namespace pxsim {
         }
 
         getLastEventTime() {
-            let startTime = runtime.startTimeUs;
-            let lastEventTime = this.lastEventTimestamp;
-            return Math.floor((lastEventTime - startTime) * 1000);
+            return Math.floor(this.lastEventTimestamp - runtime.startTimeUs)*1000;
         }
     }
 

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -31,7 +31,7 @@ namespace pxsim {
 
     export class EventBus {
         private queues: Map<EventQueue<number>> = {};
-        private lastEvent: number | string;
+        private lastEventValue: string | number;
         private lastEventTimestamp: number;
 
         constructor(private runtime: Runtime) { }
@@ -44,21 +44,24 @@ namespace pxsim {
         }
 
         queue(id: number | string, evid: number | string, value: number = 0) {
+            //id: event source, e.g., MICROBIT_ID_BUTTON_A
+            //evid: event value, e.g., MICROBIT_BUTTON_EVT_CLICK
+            //value: mysterious optional parameter
             let k = id + ":" + evid;
             let queue = this.queues[k];
             if (queue) {
-                this.lastEvent = evid;
+                this.lastEventValue = evid;
                 this.lastEventTimestamp = U.perfNow();
                 queue.push(value);
             }
         }
 
-        getLastEvent() {
-            return this.lastEvent;
+        getLastEventValue() {
+            return this.lastEventValue;
         }
 
         getLastEventTime() {
-            return Math.floor(this.lastEventTimestamp - runtime.startTimeUs)*1000;
+            return Math.floor(this.lastEventTimestamp - runtime.startTimeUs) * 1000;
         }
     }
 

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -31,6 +31,8 @@ namespace pxsim {
 
     export class EventBus {
         private queues: Map<EventQueue<number>> = {};
+        private lastEvent: number | string;
+        private lastEventTimestamp: number;
 
         constructor(private runtime: Runtime) { }
 
@@ -44,7 +46,21 @@ namespace pxsim {
         queue(id: number | string, evid: number | string, value: number = 0) {
             let k = id + ":" + evid;
             let queue = this.queues[k];
-            if (queue) queue.push(value);
+            if (queue) {
+                this.lastEvent = evid;
+                this.lastEventTimestamp = U.perfNow();
+                queue.push(value);
+            }
+        }
+
+        getLastEvent() {
+            return this.lastEvent;
+        }
+
+        getLastEventTime() {
+            let startTime = runtime.startTimeUs;
+            let lastEventTime = this.lastEventTimestamp;
+            return Math.floor((lastEventTime - startTime) * 1000);
         }
     }
 


### PR DESCRIPTION
Implements pxsim.control.eventTimestamp and eventValue.  Resolves https://github.com/Microsoft/pxt/issues/395.