### PR TITLE
browserify bundle ignores non-js files

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1308,7 +1308,9 @@ function buildFolderAndBrowserifyAsync(p: string, optional?: boolean, outputName
         const browserify = require('browserify');
         let b = browserify();
         nodeutil.allFiles(`built/${outputName}`).forEach((f) => {
-            b.add(f);
+            if (f.match(/\.js$/)) {
+                b.add(f);
+            }
         });
 
         let outFile = fs.createWriteStream(`built/${outputName}.js`, 'utf8');


### PR DESCRIPTION
This allows us to generate type declaration files. Otherwise, browserify will error because `.d.ts` files fail to compile.