### PR TITLE
Normalizing and validating loc strings

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -8,6 +8,17 @@ namespace pxt.blocks {
         shadowValue?: string;
     }
 
+    export function normalizeBlock(b: string): string {
+        if (!b) return b;
+        // normalize and validate common errors
+        // made while translating
+        let nb = b.replace(/%\s+/g, '%');
+        if (nb != b)
+            pxt.log(`block has extra spaces: ${b}`);
+        nb = nb.replace(/\s*\|\s*/g, '|');
+        return nb;
+    }
+
     export function parameterNames(fn: pxtc.SymbolInfo): Map<BlockParameter> {
         // collect blockly parameter name mapping
         const instance = (fn.kind == ts.pxtc.SymbolKind.Method || fn.kind == ts.pxtc.SymbolKind.Property) && !fn.attributes.defaultInstance;
@@ -51,14 +62,7 @@ namespace pxt.blocks {
     export function parseFields(b: string): FieldDescription[] {
         // normalize and validate common errors
         // made while translating
-        let nb = b.replace(/%\s+/g, '%');
-        if (nb != b)
-            pxt.log(`block has extra spaces: ${b}`);
-        if (nb[0] == nb[0].toLocaleUpperCase() && nb[0] != nb[0].toLowerCase())
-            pxt.log(`block is capitalized: ${b}`);
-
-        nb = nb.replace(/\s*\|\s*/g, '|');
-        return nb.split('|').map((n, ni) => {
+        return b.split('|').map((n, ni) => {
             let m = /([^%]*)\s*%([a-zA-Z0-9_]+)/.exec(n);
             if (!m) return { n, ni };
 

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -13,8 +13,10 @@ namespace pxt.blocks {
         // normalize and validate common errors
         // made while translating
         let nb = b.replace(/%\s+/g, '%');
-        if (nb != b)
+        if (nb != b) {
             pxt.log(`block has extra spaces: ${b}`);
+            return b;
+        }
         nb = nb.replace(/\s*\|\s*/g, '|');
         return nb;
     }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -297,7 +297,16 @@ namespace ts.pxtc {
                     }
                 }
                 else if (fn.attributes.block && locBlock) {
+                    const ps = pxt.blocks.parameterNames(fn);
+                    const oldBlock = fn.attributes.block;
                     fn.attributes.block = pxt.blocks.normalizeBlock(locBlock);
+                    if (oldBlock != fn.attributes.block) {
+                        const locps = pxt.blocks.parameterNames(fn);
+                        if (JSON.stringify(ps) != JSON.stringify(locps)) {
+                            pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`)
+                            fn.attributes.block = oldBlock;
+                        }
+                    }
                 }
             }))
             .then(() => apis);

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -297,7 +297,7 @@ namespace ts.pxtc {
                     }
                 }
                 else if (fn.attributes.block && locBlock) {
-                    fn.attributes.block = locBlock;
+                    fn.attributes.block = pxt.blocks.normalizeBlock(locBlock);
                 }
             }))
             .then(() => apis);


### PR DESCRIPTION
Don't load loc strings is invalid spaces or invalid parameter names.