### PR TITLE
Fix editor floats and bring it to the monaco toolbox

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -406,6 +406,7 @@ export class Editor extends srceditor.Editor {
                 pxt.tickActivity("blocks.create", "blocks.create." + blockId);
                 if (ev.xml.tagName == 'SHADOW')
                     this.cleanUpShadowBlocks();
+                this.parent.setState({ hideEditorFloats: false });
             }
             if (ev.type == 'ui') {
                 if (ev.element == 'category') {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -525,6 +525,8 @@ export class Editor extends srceditor.Editor {
             this.selectedCategoryRow.className = 'blocklyTreeRow';
         }
 
+        this.parent.setState({ hideEditorFloats: !clear });
+
         if (clear) {
             this.selectedCategoryRow = null;
         }
@@ -567,6 +569,7 @@ export class Editor extends srceditor.Editor {
             false, null, () => {
                 this.showAdvanced = !this.showAdvanced;
                 this.updateToolbox();
+                this.parent.setState({ hideEditorFloats: false });
             }, lf("{id:category}Advanced")))
         }
 
@@ -711,6 +714,8 @@ export class Editor extends srceditor.Editor {
                 monacoFlyout.style.display = 'none';
 
                 treerow.className = 'blocklyTreeRow';
+
+                this.parent.setState({ hideEditorFloats: false });
                 return;
             } else {
                 // Selected category


### PR DESCRIPTION
Since the latest Blockly release (April), Blockly changes some of the ui events that are called and we no longer get a category close event when a new Block is created.

This meant that we need to explicitly change the state of the editor floats after creating a block.

Also enabled the whole scenario for the monaco toolbox as well.

Fixes #2643