### PR TITLE
Start page: fix mobile layout for ios / electron; greatly improve tablet layout

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -407,15 +407,24 @@ div.simframe > iframe {
     min-height: 4em;
 }
 
-.ui.modal.projectsdialog h2 {
-    width: 100%;
-    text-align: center;
-}
-
-.ui.modal.projectsdialog .loader {
+.ui.modal.projectsdialog .labelsgroup {
     display: block;
     position: relative;
-    top: 35%;
+    min-height: 18em;
+}
+
+.ui.modal.projectsdialog h2.editorname {
+    top: 20%;
+    width: calc(100% - 2rem);
+    text-align: center;
+    position: absolute;
+    display: block;
+}
+
+.ui.modal.projectsdialog .loader.editoravatar {
+    display: block;
+    position: absolute;
+    top: 50%;
 }
 
 .ui.modal.projectsdialog > .content {
@@ -1215,6 +1224,17 @@ Field editors
     }
 }
 
+/* Custom width treshold to force vertical stacking on the start page */
+@media only screen and (max-width: 1095px) {
+    .ui.modal.projectsdialog h2.editorname {
+        top: 5%;
+    }
+
+    .ui.modal.projectsdialog .loader.editoravatar {
+        top: 60%;
+    }
+}
+
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
     /* Blockly */
@@ -1245,6 +1265,10 @@ Field editors
     }
     .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor {
         bottom: @editorToolsCollapsedHeight;
+    }
+
+    .ui.modal.projectsdialog h2.editorname {
+        font-size: 1.2rem;
     }
 }
 

--- a/theme/themes/pxt/collections/grid.overrides
+++ b/theme/themes/pxt/collections/grid.overrides
@@ -1,3 +1,42 @@
 /*******************************
          Site Overrides
 *******************************/
+
+/* Force the grid in the start page to stack vertically as soon as 2 cards don't fit horizontally */
+@media only screen and (max-width: 1095px) {
+  .ui.welcomegrid.stackable.grid {
+    width: auto;
+    margin-left: 0em !important;
+    margin-right: 0em !important;
+  }
+  .ui.welcomegrid.stackable.grid > .row > .wide.column,
+  .ui.welcomegrid.stackable.grid > .wide.column,
+  .ui.welcomegrid.stackable.grid > .column.grid > .column,
+  .ui.welcomegrid.stackable.grid > .column.row > .column,
+  .ui.welcomegrid.stackable.grid > .row > .column,
+  .ui.welcomegrid.stackable.grid > .column:not(.row),
+  .ui.welcomegrid.grid > .stackable.stackable.row > .column {
+    width: 100% !important;
+    margin: 0em 0em !important;
+    box-shadow: none !important;
+    padding: (@stackableRowSpacing / 2) (@stackableGutter / 2) !important;
+  }
+  .ui.welcomegrid.stackable.grid:not(.vertically) > .row {
+    margin: 0em;
+    padding: 0em;
+  }
+
+  /* Coupling */
+  .ui.container > .ui.welcomegrid.stackable.grid > .column,
+  .ui.container > .ui.welcomegrid.stackable.grid > .row > .column {
+    padding-left: 0em !important;
+    padding-right: 0em !important;
+  }
+
+  /* Don't pad inside segment or nested grid */
+  .ui.grid .ui.welcomegrid.stackable.grid,
+  .ui.segment:not(.vertical) .ui.welcomegrid.stackable.page.grid {
+    margin-left: -(@stackableGutter / 2) !important;
+    margin-right: -(@stackableGutter / 2) !important;
+  }
+}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -312,10 +312,10 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                     </sui.Menu>
                 </sui.Segment>
                 {tab == WELCOME ? <div className={tabClasses}>
-                    <div className="ui stackable two column grid">
-                        <div className="six wide column">
-                            <h2 className="row">{pxt.appTarget.name}</h2>
-                            <div className={"row large ui loader"}></div>
+                    <div className="ui stackable two column grid welcomegrid">
+                        <div className="six wide column labelsgroup">
+                            <h2 className="editorname">{pxt.appTarget.name}</h2>
+                            <div className={"large ui loader editoravatar"}></div>
                         </div>
                         <div className="group ten wide column">
                             <div className="ui cards centered">
@@ -327,12 +327,12 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                                     onClick={() => resume() }
                                     /> : undefined}
                                 {pxt.appTarget.appTheme.sideDoc ? <codecard.CodeCardView
-                                        key={'gettingstarted'}
-                                        iconColor="green"
-                                        iconContent={lf("Getting started") }
-                                        description={lf("Create a fun, beginner project in a guided tutorial") }
-                                        onClick={() => gettingStarted() }
-                                        /> : undefined}
+                                    key={'gettingstarted'}
+                                    iconColor="green"
+                                    iconContent={lf("Getting started") }
+                                    description={lf("Create a fun, beginner project in a guided tutorial") }
+                                    onClick={() => gettingStarted() }
+                                    /> : undefined}
                                 <codecard.CodeCardView
                                     key={'newproject'}
                                     iconColor="brown"


### PR DESCRIPTION
Tablet layout before:

![image](https://user-images.githubusercontent.com/14299377/28981286-fb0038c8-7905-11e7-9239-5db539c12282.png)

With these changes:

![image](https://user-images.githubusercontent.com/14299377/28981317-17125348-7906-11e7-8a93-525c83232f4d.png)
