### PR TITLE
Render changes for namespace aliasing.

### DIFF
--- a/common-docs/blocks.md
+++ b/common-docs/blocks.md
@@ -7,13 +7,25 @@ Blocks snap into each other to define the program that your @boardname@ will run
 Blocks can be event (buttons, shake, ...) or need to be snapped into an event to run.
 The [on-start](/blocks/on-start) event runs first.
 
+## Blocks
+
 ```namespaces
 for (let i = 0;i<5;++i) {}
 if (true){}
 let x = 0;
+```
+
+## Built-in objects
+
+```namespaces
 Math.randomRange(0,5);
+"".compare("");
+[0].push(0);
 ```
 
 ## See Also
 
-[logic](/blocks/logic), [loops](/blocks/loops), [math](/blocks/math), [variables](/blocks/variables), [on-start](/blocks/on-start), [javascript blocks](/blocks/javascript-blocks), [custom blocks](blocks/custom)
+[logic](/blocks/logic), [loops](/blocks/loops), [variables](/blocks/variables),
+[math](/reference/math), [text](/reference/text), [arrays](/reference/arrays)
+
+[on-start](/blocks/on-start), [javascript blocks](/blocks/javascript-blocks), [custom blocks](blocks/custom)

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -241,6 +241,10 @@ declare interface Boolean {
     toString(): string;
 }
 
+/**
+ * Combine, split, and search text strings.
+*/
+//% blockNamespace="Text"
 declare namespace String {
 
     /**
@@ -261,6 +265,16 @@ declare interface Number {
     toString(): string;
 }
 
+/**
+ * Add, remove, and replace items in lists.
+*/
+//% blockNamespace="Arrays"
+declare namespace Array {
+}
+
+/**
+ * More complex operations with numbers.
+*/
 declare namespace Math {
     /**
      * Returns the value of a base expression taken to a specified power.

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -366,8 +366,8 @@ namespace pxt.runner {
                         let ii = r.compileBlocks.blocksInfo.apis.byQName[info.qName];
                         let nsi = r.compileBlocks.blocksInfo.apis.byQName[ii.namespace];
                         addItem({
-                            name: nsi.name,
-                            url: nsi.attributes.help || ("reference/" + nsi.name.toLowerCase()),
+                            name: nsi.attributes.blockNamespace || nsi.name,
+                            url: nsi.attributes.help || ("reference/" + (nsi.attributes.blockNamespace || nsi.name).toLowerCase()),
                             description: nsi.attributes.jsDoc,
                             blocksXml: block && block.codeCard
                                 ? block.codeCard.blocksXml


### PR DESCRIPTION
Namespaces for some built-ins don't match block naming, such as **Array** to **arrays** and **String** to **text**. So, the help urls are formed like _/reference/String/char-at_ instead of _/reference/text/char-at_. These don't match editor block groups or the doc tree. Here's a proposed fix:

- [x] Use the **blockNamespace** attribute in the namespace jsDoc to alias/map the namespace name (renderer.ts).
- [x] Add a ```declare namespace Array {}``` to inject jsDoc for the **arrays** alias (pxt-core.d.ts ).
- [x] Add descriptions and ```//% blockNamespace="xxx"``` for aliases on **Array** and **String** namespaces (pxt-core.d.ts).
- [x] Include a modified _blocks.md_ for context.

Be careful of the new ```declare namespace Array{}``` since I broke **String** doing this once before :-(

This is related to https://github.com/Microsoft/pxt/pull/2657.