### PR TITLE
Resize the monaco editor after clicking Advanced 

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -563,6 +563,7 @@ export class Editor extends srceditor.Editor {
             false, null, () => {
                 this.showAdvanced = !this.showAdvanced;
                 this.updateToolbox();
+                this.resize();
             }, lf("{id:category}Advanced")))
         }
 


### PR DESCRIPTION
In case the Advanced section introduces categories with greater length like in #2582

Fixes 2582