### PR TITLE
[Accessibility] Documentation menu accessible with keyboard and screen reader

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,8 @@
 			"request": "launch",
 			"program": "${workspaceRoot}/built/pxt.js",
 			"stopOnEntry": false,
-			"args": ["build"],
-			"cwd": "${workspaceRoot}/../pxt-calliope/libs/core",
+			"args": ["serve", "--cloud"],
+			"cwd": "${workspaceRoot}/../pxt-microbit",
 			"runtimeExecutable": null,
 			"runtimeArgs": [
 				"--nolazy"

--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -14,7 +14,7 @@
 <body id='root' class='root'>
 
 <div id="accessibleMenu" role="menubar">
-    <a href="#mainContentArticle" tabindex="0" role="menuitem">Skip to the main content</a>
+    <a href="#mainContentArticle" class="ui item link" tabindex="0" role="menuitem">Skip to the main content</a>
 </div>
 
 <!-- @include tocheader.html -->

--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -13,6 +13,10 @@
 
 <body id='root' class='root'>
 
+<div id="accessibleMenu" role="menubar">
+    <a href="#mainContentArticle" tabindex="0" role="menuitem">Skip to the main content</a>
+</div>
+
 <!-- @include tocheader.html -->
 
 <div class="pusher">
@@ -21,12 +25,12 @@
 
     <!-- @include toc.html -->
     
-    <div class="article">
+    <div class="article" id="mainContentArticle">
         
         <!-- @include header.html -->
 
         <div id="docs" class="main ui container mainbody">
-            <button id="printbtn" class="circular ui icon right floated button hideprint">
+            <button id="printbtn" class="circular ui icon right floated button hideprint" title="Print this page">
                 <i class="icon print"></i>
             </button>
             @body@

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -1,3 +1,10 @@
+function handleEnterKey(e) {
+    let charCode = (typeof e.which == "number") ? e.which : e.keyCode
+    if (charCode === 13 || charCode === 32) {
+        e.preventDefault();
+        e.currentTarget.click();
+    }
+}
 function describePlural(value, unit) {
     return value + " " + unit + (value == 1 ? "" : "s")
 }
@@ -47,8 +54,21 @@ function searchSubmit(form) {
 }
 
 function setupSidebar() {
+    let togglesidebar = document.getElementById("togglesidebar");
+    togglesidebar.onkeydown = handleEnterKey;
+
+
     $('.ui.sidebar')
-        .sidebar({ dimPage: false })
+        .sidebar({ 
+            dimPage: false,
+            onShow: () => {
+                togglesidebar.setAttribute("aria-expanded", "true");
+                document.getElementsByClassName("sidebar").item(0).getElementsByClassName("focused").item(0).focus();
+            },
+            onHidden: () => {
+                togglesidebar.setAttribute("aria-expanded", "false");
+            }
+        })
         .sidebar(
         'attach events', '#togglesidebar'
         );
@@ -68,16 +88,31 @@ function setupSidebar() {
     for (let i = 0; i < accordions.length; i++) {
         let nodes = accordions.item(i).getElementsByClassName("title");
         for (let j = 0; j < nodes.length; j++) {
-            let node = nodes.item(j);
-            node.getElementsByTagName("a").item(0).onkeydown = (e) => {
+            let hrefNode = nodes.item(j).getElementsByTagName("a").item(0);
+            let iNode = nodes.item(j).getElementsByTagName("i").item(0);
+            iNode.onclick = (e) => {
+                if (hrefNode.hasAttribute("aria-expanded") && hrefNode.getAttribute("aria-expanded") === "true") {
+                    hrefNode.setAttribute("aria-expanded", "false");
+                } else {
+                    hrefNode.setAttribute("aria-expanded", "true");
+                }
+            };
+            hrefNode.onkeydown = (e) => {
                 let charCode = (typeof e.which == "number") ? e.which : e.keyCode
                 if (charCode === 39) {
                     $(e.target.parentElement.parentElement).accordion("open", 0);
+                    e.target.setAttribute("aria-expanded", "true");
                 } else if (charCode === 37) {
                     $(e.target.parentElement.parentElement).accordion("close", 0);
+                    e.target.setAttribute("aria-expanded", "false");
                 }
             };
         }
+    }
+
+    let searchIcons = document.getElementsByClassName("search link icon");
+    for (let i = 0; i < searchIcons.length; i++) {
+        searchIcons.item(i).onkeydown = handleEnterKey;
     }
 }
 

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -63,6 +63,22 @@ function setupSidebar() {
                 trigger: '.title .icon'
             }
         });
+
+    let accordions = document.getElementsByClassName("ui accordion");
+    for (let i = 0; i < accordions.length; i++) {
+        let nodes = accordions.item(i).getElementsByClassName("title");
+        for (let j = 0; j < nodes.length; j++) {
+            let node = nodes.item(j);
+            node.getElementsByTagName("a").item(0).onkeydown = (e) => {
+                let charCode = (typeof e.which == "number") ? e.which : e.keyCode
+                if (charCode === 39) {
+                    $(e.target.parentElement.parentElement).accordion("open", 0);
+                } else if (charCode === 37) {
+                    $(e.target.parentElement.parentElement).accordion("close", 0);
+                }
+            };
+        }
+    }
 }
 
 function setupSemantic() {
@@ -127,7 +143,7 @@ function setupSemantic() {
         }).appendTo(outer);
     });
 
-    $('#printbtn').on("click", function() {
+    $('#printbtn').on("click", function () {
         window.print();
     })
 

--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -10,6 +10,6 @@
                 <!-- we need to force the browser to load this font -->
                 <div style='font-family: Icons; color: #010101;' aria-hidden="true">.</div>
             </div>
-            <a class="item" href="https://www.microsoft.com/" target="_blank" rel="noopener" aria-label="Microsoft website"><img class="ui centered image" src="https://az851932.vo.msecnd.net/pub/pmapoirq" /></a>
+            <a class="item" href="https://www.microsoft.com/" target="_blank" rel="noopener" aria-label="Microsoft Home Page"><img class="ui centered image" src="https://az851932.vo.msecnd.net/pub/pmapoirq" /></a>
         </div>
     </div>

--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -10,6 +10,6 @@
                 <!-- we need to force the browser to load this font -->
                 <div style='font-family: Icons; color: #010101;' aria-hidden="true">.</div>
             </div>
-            <a class="item" href="https://www.microsoft.com/" target="_blank" rel="noopener"><img class="ui centered image" src="https://az851932.vo.msecnd.net/pub/pmapoirq" /></a>
+            <a class="item" href="https://www.microsoft.com/" target="_blank" rel="noopener" aria-label="Microsoft website"><img class="ui centered image" src="https://az851932.vo.msecnd.net/pub/pmapoirq" /></a>
         </div>
     </div>

--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -75,28 +75,28 @@
 </aside>
 
 <aside id=top-dropdown class=menu>
-    <div class="ui simple dropdown item" title="@TITLE@">
+    <nav div class="ui simple dropdown item" title="@TITLE@">
         @NAME@
         <i class="dropdown icon"></i>
         <div class="menu">
             @ITEMS@
         </div>
-    </div>
+    </nav>
 </aside>
 
 <aside id=inner-dropdown class=menu>
-    <div class="item" title="@TITLE@">
+    <nav class="item" title="@TITLE@">
         <i class="dropdown icon"></i> @NAME@
         <div class="menu">
             @ITEMS@
         </div>
-    </div>
+    </nav>
 </aside>
 
 
 <!-- TOC in the sidebar -->
 <aside id=item class=toc>
-    <a class="item @ACTIVE@" href="@LINK@">@NAME@</a>
+    <a class="item @ACTIVE@" href="@LINK@" role="menuitem">@NAME@</a>
 </aside>
 
 <aside id=divider class=toc>
@@ -105,7 +105,7 @@
 
 <aside id=top-dropdown class=toc>
     <div class="item" title="@TITLE@">
-        <a class="header @ACTIVE@" href="@LINK@">@NAME@</a>
+        <a class="header @ACTIVE@" href="@LINK@" role="menu">@NAME@</a>
         <div class="menu">
             @ITEMS@
         </div>

--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -113,10 +113,10 @@
 </aside>
 
 <aside id=inner-dropdown class=toc>
-    <div class="ui inverted accordion item visible" title="@TITLE@">
+    <div class="ui inverted accordion item visible" role="tree" title="@TITLE@">
         <div class="@ACTIVE@ title">
             <i class="dropdown icon"></i>
-            <a class="header" href="@LINK@">@NAME@</a>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@" href="@LINK@">@NAME@</a>
         </div>
         <div class="@ACTIVE@ content">
             @ITEMS@
@@ -128,7 +128,7 @@
     <div class="inverted accordion item visible" title="@TITLE@">
         <div class="@ACTIVE@ title">
             <i class="dropdown icon"></i>
-            <a class="header" href="@LINK@">@NAME@</a>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@" href="@LINK@">@NAME@</a>
         </div>
         <div class="@ACTIVE@ content">
             @ITEMS@

--- a/docfiles/pageheader.html
+++ b/docfiles/pageheader.html
@@ -1,7 +1,7 @@
 <div id="pagemenu" class="ui accent borderless menu inverted hideprint">
     <div class="ui container">
         <div class="ui item">
-            <a href="/" class="header item focused" tabindex="0" title="Go back to the editor">
+            <a href="/" class="header item focused" tabindex="0" title="Go to editor">
             @targetlogo@		
          </a>
         </div>

--- a/docfiles/pageheader.html
+++ b/docfiles/pageheader.html
@@ -1,7 +1,7 @@
 <div id="pagemenu" class="ui accent borderless menu inverted hideprint">
     <div class="ui container">
         <div class="ui item">
-            <a href="/" class="header item">
+            <a href="/" class="header item focused" tabindex="0" title="Go back to the editor">
             @targetlogo@		
          </a>
         </div>

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -186,6 +186,30 @@ svg {
     padding-bottom: 3em;
 }
 
+#accessibleMenu {
+    position: absolute;
+    z-index: 1001;
+    top: -20em;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+}
+
+#accessibleMenu a {
+    position: absolute;
+    width: 100%;
+    height: 4em;
+    line-height: 4em;
+    font-size: 1em;
+    text-align: center;
+    color: white;
+}
+
+#accessibleMenu a:focus,
+#accessibleMenu a:hover {
+    top:20em;
+}
+
 /* Styling the table of contents much like the Semantic UI documentation site: http://semantic-ui.com/introduction/getting-started.html */
 .pusher > .full.height {
   display: -webkit-box;

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -186,28 +186,12 @@ svg {
     padding-bottom: 3em;
 }
 
-#accessibleMenu {
-    position: absolute;
-    z-index: 1001;
-    top: -20em;
-    padding: 0;
-    margin: 0;
-    width: 100%;
-}
-
-#accessibleMenu a {
-    position: absolute;
-    width: 100%;
+#accessibleMenu .ui.item.link {
     height: 4em;
     line-height: 4em;
     font-size: 1em;
     text-align: center;
     color: white;
-}
-
-#accessibleMenu a:focus,
-#accessibleMenu a:hover {
-    top:20em;
 }
 
 /* Styling the table of contents much like the Semantic UI documentation site: http://semantic-ui.com/introduction/getting-started.html */

--- a/docfiles/toc.html
+++ b/docfiles/toc.html
@@ -1,6 +1,6 @@
 <div class="toc ui accent inverted hideprint">
     <div class="ui vertical accent inverted sticky menu tocmenu">
-        <a href="/" class="header item focused" tabindex="0" title="Go back to the editor">
+        <a href="/" class="header item focused" tabindex="0" title="Go to editor">
             @targetlogo@
             &nbsp; &nbsp;
             Documentation

--- a/docfiles/toc.html
+++ b/docfiles/toc.html
@@ -1,6 +1,6 @@
 <div class="toc ui accent inverted hideprint">
     <div class="ui vertical accent inverted sticky menu tocmenu">
-        <a href="/" class="header item">
+        <a href="/" class="header item focused" tabindex="0" title="Go back to the editor">
             @targetlogo@
             &nbsp; &nbsp;
             Documentation
@@ -10,7 +10,7 @@
                 <div class="ui fluid icon input">
                     <input type="hidden" name="q1" value="site:@homeurl@" />
                     <input type="search" name="q" placeholder="Search...">
-                    <i onclick="document.getElementById('tocsearch2').submit();" class="search link icon"></i>
+                    <i onclick="document.getElementById('tocsearch2').submit();" tabindex="0" class="search link icon" aria-label="Search" role="button"></i>
                 </div>
             </form>
         </div>

--- a/docfiles/tocheader.html
+++ b/docfiles/tocheader.html
@@ -1,5 +1,5 @@
 <div class="ui vertical accent inverted sidebar menu left hideprint">
-    <a href="/" class="header item">
+    <a href="/" class="header item focused" tabindex="0" title="Go back to the editor">
         @targetlogo@
         &nbsp; &nbsp;
         Documentation
@@ -9,7 +9,7 @@
             <div class="ui fluid icon input">
                 <input type="hidden" name="q1" value="site:@homeurl@" />
                 <input type="search" name="q" placeholder="Search...">
-                <i onclick="document.getElementById('tocsearch1').submit();" class="search link icon"></i>
+                <i onclick="document.getElementById('tocsearch1').submit();" tabindex="0" class="search link icon" aria-label="Search" role="button"></i>
             </div>
         </form>
     </div>
@@ -22,7 +22,7 @@
 
 <div class="ui fixed accent borderless inverted main menu hideprint">
   <div class="ui container">
-    <a id="togglesidebar" class="launch icon item">
+    <a id="togglesidebar" class="launch icon item" tabindex="0" title="Side menu" aria-label="Side menu" role="menu" aria-expanded="false">
       <i class="content icon"></i>
     </a>
 
@@ -31,7 +31,7 @@
     </div>
     
     <div class="right menu">
-        <a href="/" class="header item">
+        <a href="/" class="header item" tabindex="0" title="Go back to the editor">
             @targetlogo@
         </a>
     </div>

--- a/docfiles/tocheader.html
+++ b/docfiles/tocheader.html
@@ -1,5 +1,5 @@
 <div class="ui vertical accent inverted sidebar menu left hideprint">
-    <a href="/" class="header item focused" tabindex="0" title="Go back to the editor">
+    <a href="/" class="header item focused" tabindex="0" title="Go to editor">
         @targetlogo@
         &nbsp; &nbsp;
         Documentation
@@ -31,7 +31,7 @@
     </div>
     
     <div class="right menu">
-        <a href="/" class="header item" tabindex="0" title="Go back to the editor">
+        <a href="/" class="header item" tabindex="0" title="Go to editor">
             @targetlogo@
         </a>
     </div>

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -200,7 +200,8 @@ namespace pxt.docs {
                 return error("Invalid link: " + m.path)
             mparams["LINK"] = m.path
             if (tocPath.indexOf(m) >= 0) {
-                mparams["ACTIVE"] = 'active';
+                mparams["ACTIVE"] = "active";
+                mparams["EXPANDED"] = "true";
                 currentTocEntry = m;
                 breadcrumb.push({
                     name: m.name,

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -200,13 +200,15 @@ namespace pxt.docs {
                 return error("Invalid link: " + m.path)
             mparams["LINK"] = m.path
             if (tocPath.indexOf(m) >= 0) {
-                mparams["ACTIVE"] = "active";
-                mparams["EXPANDED"] = "true";
+                mparams["ACTIVE"] = 'active';
+                mparams["EXPANDED"] = 'true';
                 currentTocEntry = m;
                 breadcrumb.push({
                     name: m.name,
                     href: m.path
                 })
+            } else {
+                mparams["EXPANDED"] = 'false';
             }
             if (m.subitems && m.subitems.length > 0) {
                 if (lev == 0) templ = toc["top-dropdown"]
@@ -230,12 +232,12 @@ namespace pxt.docs {
         let breadcrumbHtml = '';
         if (breadcrumb.length > 1) {
             breadcrumbHtml = `
-            <div class="ui breadcrumb">
+            <nav class="ui breadcrumb" aria-label="Breadcrumb">
                 ${breadcrumb.map((b, i) =>
                     `<a class="${i == breadcrumb.length - 1 ? "active" : ""} section"
-                        href="${html2Quote(b.href)}">${html2Quote(b.name)}</a>`)
+                        href="${html2Quote(b.href)}" aria-current="${i == breadcrumb.length - 1 ? "page" : ""}">${html2Quote(b.name)}</a>`)
                     .join('<i class="right chevron icon divider"></i>')}
-            </div>`;
+            </nav>`;
         }
 
         params["breadcrumb"] = breadcrumbHtml;
@@ -261,7 +263,7 @@ namespace pxt.docs {
             params["homeurl"] = html2Quote(theme.homeUrl);
         params["targetid"] = theme.id || "???";
         params["targetname"] = theme.name || "Microsoft MakeCode";
-        params["targetlogo"] = theme.docsLogo ? `<img class="ui mini image" src="${U.toDataUri(theme.docsLogo)}" />` : ""
+        params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui mini image" src="${U.toDataUri(theme.docsLogo)}" />` : ""
         let ghURLs = d.ghEditURLs || []
         if (ghURLs.length) {
             let ghText = `<p style="margin-top:1em">\n`
@@ -280,6 +282,7 @@ namespace pxt.docs {
         if (theme.accentColor) style += `
 .ui.accent { color: ${theme.accentColor}; }
 .ui.inverted.accent { background: ${theme.accentColor}; }
+#accessibleMenu a { background: ${theme.accentColor}; }
 `
         params["targetstyle"] = style;
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -194,7 +194,7 @@ div.simframe > iframe {
 }
 
 /* Menu */
-#menubar #accessibleMenu {
+#accessibleMenu {
     position: absolute;
     z-index: 1001;
     top: -20em;


### PR DESCRIPTION
- Made the tree view in the side bar accessible with the keyboard and screen reader.
- Made the breadcrumb accessible by the screen reader.
- Added a hidden menu to skip the side menu.
- Changed the behavior of the hamburger menu to give the focus to the side menu once opened.
- Made the menu descriptive for the screen reader in general.

Related issues : [https://github.com/Microsoft/pxt/issues/2625](https://github.com/Microsoft/pxt/issues/2625), [https://github.com/Microsoft/pxt/issues/2623](https://github.com/Microsoft/pxt/issues/2623), [https://github.com/Microsoft/pxt/issues/2648](https://github.com/Microsoft/pxt/issues/2648), [https://github.com/Microsoft/pxt/issues/2626](https://github.com/Microsoft/pxt/issues/2626)