### PR TITLE
chrome extension is now specified via config

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -86,6 +86,7 @@ declare namespace pxt {
         productId?: string; // used by node-serial
         nameFilter?: string; // regex to match devices
         log?: boolean;
+        chromeExtension?: string; // unique identifier of the chrome extension
     }
 
     interface AppCloud {

--- a/pxtsim/logs.ts
+++ b/pxtsim/logs.ts
@@ -1,5 +1,6 @@
 namespace pxsim.logs {
     export interface ILogProps {
+        chromeExtension?: string;
         maxEntries?: number;
         maxLineLength?: number;
         maxAccValues?: number;
@@ -149,10 +150,14 @@ namespace pxsim.logs {
         }
 
         registerChromeSerial() {
+            const extensionId = this.props.chromeExtension;
+            if (!extensionId) return;
+
             let buffers: pxsim.Map<string> = {};
             let chrome = (window as any).chrome;
             if (chrome && chrome.runtime) {
-                let port = chrome.runtime.connect("cihhkhnngbjlhahcfmhekmbnnjcjdbge", { name: "micro:bit" });
+                // "cihhkhnngbjlhahcfmhekmbnnjcjdbge"
+                let port = chrome.runtime.connect(extensionId, { name: "serial" });
                 port.onMessage.addListener((msg: { type: string; id: string; data: string; }) => {
                     if (msg.type == "serial") {
                         if (!this.dropSim) {

--- a/webapp/src/logview.tsx
+++ b/webapp/src/logview.tsx
@@ -17,11 +17,17 @@ export class LogView extends React.Component<{}, LogViewState> {
 
     constructor(props: any) {
         super(props);
+        let chromeExtension = pxt.appTarget.serial ? pxt.appTarget.serial.chromeExtension : undefined;
+        if (!chromeExtension) {
+            const m = /chromeserial=([a-z]+)/i.exec(window.location.href);
+            if (m) chromeExtension = m[1];
+        }
         this.view = new pxsim.logs.LogViewElement({
             maxEntries: 80,
             maxAccValues: 500,
             onClick: (es) => this.onClick(es),
-            onTrendChartChanged: () => this.setState({ trends: this.view.hasTrends() })
+            onTrendChartChanged: () => this.setState({ trends: this.view.hasTrends() }),
+            chromeExtension
         })
         this.state = {};
     }


### PR DESCRIPTION
The Chrome extension of micro:bit is still link in PXT. Refactoring this out to allow 3rd party extensions using the ``?chromeserial=...`` href flag