### PR TITLE
Allow query argument to override chrome extension for serial

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -85,7 +85,7 @@ declare namespace pxt {
         vendorId?: string; // used by node-serial
         productId?: string; // used by node-serial
         nameFilter?: string; // regex to match devices
-        log?: boolean;
+        log?: boolean; // pipe messages to log
         chromeExtension?: string; // unique identifier of the chrome extension
     }
 

--- a/webapp/src/logview.tsx
+++ b/webapp/src/logview.tsx
@@ -17,11 +17,16 @@ export class LogView extends React.Component<{}, LogViewState> {
 
     constructor(props: any) {
         super(props);
-        let chromeExtension = pxt.appTarget.serial ? pxt.appTarget.serial.chromeExtension : undefined;
+
+        // resolve chrome extension info
+        let chromeExtension: string = undefined;
         if (!chromeExtension) {
             const m = /chromeserial=([a-z]+)/i.exec(window.location.href);
             if (m) chromeExtension = m[1];
         }
+        if (!chromeExtension) chromeExtension = pxt.appTarget.serial ? pxt.appTarget.serial.chromeExtension : undefined;
+
+        // init view
         this.view = new pxsim.logs.LogViewElement({
             maxEntries: 80,
             maxAccValues: 500,
@@ -42,7 +47,7 @@ export class LogView extends React.Component<{}, LogViewState> {
     }
 
     render() {
-        return <div/>
+        return <div />
     }
 
     componentDidUpdate() {

--- a/webapp/src/logview.tsx
+++ b/webapp/src/logview.tsx
@@ -19,12 +19,10 @@ export class LogView extends React.Component<{}, LogViewState> {
         super(props);
 
         // resolve chrome extension info
-        let chromeExtension: string = undefined;
-        if (!chromeExtension) {
-            const m = /chromeserial=([a-z]+)/i.exec(window.location.href);
-            if (m) chromeExtension = m[1];
-        }
-        if (!chromeExtension) chromeExtension = pxt.appTarget.serial ? pxt.appTarget.serial.chromeExtension : undefined;
+        const serial = pxt.appTarget.serial || {};
+        let chromeExtension = serial.chromeExtension;
+        const m = /chromeserial=([a-z]+)/i.exec(window.location.href);
+        if (m) chromeExtension = m[1];
 
         // init view
         this.view = new pxsim.logs.LogViewElement({
@@ -32,7 +30,11 @@ export class LogView extends React.Component<{}, LogViewState> {
             maxAccValues: 500,
             onClick: (es) => this.onClick(es),
             onTrendChartChanged: () => this.setState({ trends: this.view.hasTrends() }),
-            chromeExtension
+            chromeExtension,
+            useHF2: serial.useHF2,
+            productId: serial.productId,
+            vendorId: serial.vendorId,
+            nameFilter: serial.nameFilter
         })
         this.state = {};
     }


### PR DESCRIPTION
Allow ``?chromeserial=...`` to use another extension