### PR TITLE
[Accessibility] Fixed an accessibility issue related to the virtual keyboard on a Smartphone.

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -202,14 +202,14 @@ export class ProjectView
             && this.editorFile && !this.editorFile.isReadonly() && /(\.ts|pxt.json)$/.test(this.editorFile.name);
     }
 
-    openJavaScript() {
+    openJavaScript(giveFocusOnLoading = true) {
         pxt.tickEvent("menu.javascript");
         if (this.isJavaScriptActive()) {
             if (this.state.embedSimView) this.setState({ embedSimView: false });
             return;
         }
-        if (this.textEditor && !this.textEditor.giveFocusOnLoading) {
-            this.textEditor.giveFocusOnLoading = true;
+        if (this.textEditor) {
+            this.textEditor.giveFocusOnLoading = giveFocusOnLoading;
         }
         if (this.isBlocksActive()) {
             this.blocksEditor.openTypeScript();
@@ -1654,7 +1654,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                 <div className="ui grid padded">
                                     {sandbox ? <sui.Item class="sim-menuitem thin portrait only" role="menuitem" textClass="landscape only" text={lf("Simulator") } icon={simActive && this.state.running ? "stop" : "play"} active={simActive} onClick={() => this.openSimView() } title={!simActive ? lf("Show Simulator") : runTooltip} /> : undefined }
                                     <sui.Item class="blocks-menuitem" role="menuitem" textClass="landscape only" text={lf("Blocks") } icon="xicon blocks" active={blockActive} onClick={() => this.openBlocks() } title={lf("Convert code to Blocks") } />
-                                    <sui.Item class="javascript-menuitem" role="menuitem" textClass="landscape only" text={lf("JavaScript") } icon="xicon js" active={javascriptActive} onClick={() => this.openJavaScript() } title={lf("Convert code to JavaScript") } />
+                                    <sui.Item class="javascript-menuitem" role="menuitem" textClass="landscape only" text={lf("JavaScript") } icon="xicon js" active={javascriptActive} onClick={() => this.openJavaScript(false) } title={lf("Convert code to JavaScript") } />
                                     <div className="ui item toggle"></div>
                                 </div>
                             </div> : undefined}


### PR DESCRIPTION
Fixed an issue where the virtual keyboard on smartphone was not appearing properly after clicking on the JavaScript button.

**Previously :** 
We were giving the focus to the Monaco editor once clicked on the JavaScript button, and the virtual keyboard was not appearing.

**Now :** 
We dont' give the focus anymore with this button. We continue to give the focus to Monaco with the hidden menu.
