### PR TITLE
Adjust cached block help path for 'number'.

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -163,12 +163,12 @@ namespace pxt.blocks {
             },
             'math_number': {
                 name: Util.lf("{id:block}number"),
-                url: '/blocks/math/random',
+                url: '/types/number',
                 category: 'math'
             },
             'math_number_minmax': {
                 name: Util.lf("{id:block}number"),
-                url: '/blocks/math/random',
+                url: '/blocks/math',
                 category: 'math'
             },
             'math_arithmetic': {


### PR DESCRIPTION
Addresses: https://github.com/Microsoft/pxt/issues/1708.

- [x] Modify help path for 'math_number' and 'math_number_minmax' to go to real places.

