### PR TITLE
Minor tutorial authoring fixes

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -611,7 +611,7 @@ ${files["main.ts"]}
                         let uptoSteps = steps.join();
                         uptoSteps = uptoSteps.replace(/((?!.)\s)+/g, "\n");
 
-                        let regex = /```(sim|block|blocks|shuffle|filterblocks)\n([\s\S]*?)\n```/gmi;
+                        let regex = /```(sim|block|blocks|shuffle|filterblocks)\s*\n([\s\S]*?)\n```/gmi;
                         let match: RegExpExecArray;
                         let code = '';
                         while ((match = regex.exec(uptoSteps)) != null) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -526,7 +526,8 @@ export class ProjectView
                 switch (t.subtype) {
                     case 'loaded':
                         let tt = msg as pxsim.TutorialLoadedMessage;
-                        this.editor.filterToolbox({ blocks: tt.toolboxSubset, defaultState: pxt.editor.FilterState.Hidden }, CategoryMode.Basic);
+                        if (tt.toolboxSubset && Object.keys(tt.toolboxSubset).length > 0)
+                            this.editor.filterToolbox({ blocks: tt.toolboxSubset, defaultState: pxt.editor.FilterState.Hidden }, CategoryMode.Basic);
                         let tutorialOptions = this.state.tutorialOptions;
                         tutorialOptions.tutorialReady = true;
                         tutorialOptions.tutorialStepInfo = tt.stepInfo;


### PR DESCRIPTION
Allow tutorials to load if they don't have any filters.
Fix tutorial code regex to support whitespace after ```blocks