### PR TITLE
[Accessibility] Multiple minor fixes

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -211,10 +211,6 @@ div.simframe > iframe {
     .ui.item.link:focus {
         top:20em;
     }
-
-    .ui.item.link:hover {
-        top:20em;
-    }
 }
 
 #menubar .ui.menu .item.editor-menuitem {

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -93,13 +93,32 @@
         }
     }
 
-    .ui.button.download-button:hover > span, i {
+    .ui.button.download-button:hover > span, 
+    .ui.button.download-button:hover > i {
         color: white !important;
     }
 
     /* Hyperlinks */
     a {
         color: yellow !important;
+    }
+
+    #sidedocsbar {
+        background-color: black !important;
+
+        a {
+            color: white !important;
+            outline: 1px solid white;
+
+            &:focus {
+                outline: 1px solid @selected;
+                color: @selected !important;
+
+                i, span {
+                    color: @selected !important;
+                }
+            }
+        }
     }
 
     /* Items */

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -127,7 +127,7 @@ export class SideDocs extends data.Component<ISettingsProps, {}> {
             <div id="sidedocs">
                 <iframe id="sidedocsframe" src={docsUrl} title={lf("Documentation")} aria-atomic="true" aria-live="assertive" sandbox="allow-scripts allow-same-origin allow-forms allow-popups" />
                 <div id="sidedocsbar">
-                    <a className="ui icon link" role="link" tabIndex={0} data-content={lf("Open documentation in new tab") } aria-label={lf("Open documentation in new tab") } onClick={() => this.popOut() } >
+                    <a className="ui icon link" role="link" tabIndex={0} data-content={lf("Open documentation in new tab") } aria-label={lf("Open documentation in new tab") } onClick={() => this.popOut() } onKeyDown={sui.fireClickOnEnter} >
                         <i className="external icon"></i>
                     </a>
                 </div>

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -292,7 +292,7 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
                 }
             },
             onVisible: () => {
-                initializeFocusTabIndex(mo.get(0));
+                initializeFocusTabIndex(mo.get(0), true);
             }
         });
         mo.modal("show")

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -777,11 +777,11 @@ export class Modal extends data.Component<ModalProps, ModalState> {
     getMountNode = () => this.props.mountNode || document.body;
 
     handleClose = (e: Event) => {
-        const { onClose } = this.props;
-        if (onClose) onClose(e, this.props);
-
         if (this.state.open != false)
             this.setState({open: false})
+
+        const { onClose } = this.props;
+        if (onClose) onClose(e, this.props);
     }
 
     handleOpen = (e: Event) => {
@@ -1032,11 +1032,11 @@ export class Portal extends data.Component<PortalProps, PortalState> {
     }
 
     close = (e: Event) => {
-        const { onClose } = this.props;
-        if (onClose) onClose(e);
-
         if (this.state.open != false)
             this.setState({open: false})
+
+        const { onClose } = this.props;
+        if (onClose) onClose(e);
     }
 
     open = (e: Event) => {


### PR DESCRIPTION
- Fixed an issue where the hidden menu was staying opened when it was loosing the focus but has the mouse hover.
- Fixed an issue that was generating a warning in the console after closing a modal with the Escape key because of a bad state in React.
- Fixed an issue where the focus was not trapped in the Import modal when we closed another modal before the Project modal (for i.e : the issue was appearing after using the Language modal, and then the Projects/Import).
- Fixed an issue where, in High contrast mode, the Open documentation in a new tab button was not clearly visible (yellow color on white background when the High Contrast of the system was not enabled). I changed the color and put the background to black so it's visible even if the background color of the documentation is white (when the High Contrast of the operating system is disabled).
- Fixed an issue where the Open documentation in a new tab button was not working with the Space/Enter key.

Tested on IE, Chrome, FireFox, Safari with Narrator, Jaws and Voice Over. NVDA is buggy on my machine right now, I will reinstall it.

Without the High Contrast OS's setting enabled.
![2](https://user-images.githubusercontent.com/3747805/29321800-736a6e68-8190-11e7-9076-a545e9fa21c6.PNG)

With the High Contrast OS's setting enabled.
![1](https://user-images.githubusercontent.com/3747805/29321825-8829b5f2-8190-11e7-810f-3208fb80df98.PNG)

