### PR TITLE
Fix regression in adding packages with no namespace color set. 

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -318,6 +318,7 @@ namespace pxt.blocks {
     let namespaceStyleBuffer: string = '';
     export function appendNamespaceCss(namespace: string, color: string) {
         const ns = namespace.toLowerCase();
+        color = color || '#dddddd'; // Default toolbox color
         if (namespaceStyleBuffer.indexOf(ns) > -1) return;
         namespaceStyleBuffer += `
             span.docs.${ns} {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -275,7 +275,7 @@ namespace pxt.runner {
                 });
                 let nsStyleBuffer = '';
                 Object.keys(res).forEach(ns => {
-                    const color = res[ns];
+                    const color = res[ns] || '#dddddd';
                     nsStyleBuffer += `
                         span.docs.${ns.toLowerCase()} {
                             background-color: ${color} !important;


### PR DESCRIPTION
Use default color if color is null.
Fixes #2716
