### PR TITLE
[Accessibility] Updated the accessibility helper of the simulator for Adafruit

### DIFF
--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -7,11 +7,17 @@ namespace pxsim.accessibility {
         elem.setAttribute("tabindex", "0");
     }
 
-    export function enableKeyboardInteraction(elem: Element, handler?: () => void): void {
+    export function enableKeyboardInteraction(elem: Element, handlerKeyDown?: () => void, handlerKeyUp?: () => void): void {
+        elem.addEventListener('keydown', (e: KeyboardEvent) => {
+            let charCode = (typeof e.which == "number") ? e.which : e.keyCode
+            if ((charCode === 32 || charCode === 13) && handlerKeyDown) {
+                handlerKeyDown();
+            }
+        });
         elem.addEventListener('keyup', (e: KeyboardEvent) => {
             let charCode = (typeof e.which == "number") ? e.which : e.keyCode
-            if (charCode === 32 || charCode === 13) {
-                handler();
+            if ((charCode === 32 || charCode === 13) && handlerKeyUp) {
+                handlerKeyUp();
             }
         });
     }


### PR DESCRIPTION
Edited the enableKeyboardInteraction method to support the keydown and keyup. It is useful for the Adafruit simulator ([https://github.com/Microsoft/pxt-adafruit/pull/287](https://github.com/Microsoft/pxt-adafruit/pull/287)).
This change will be required to support the Adafruit simulator accessibility features.
This change imply another PR that updates the micro:bit simulator to support this change : [https://github.com/Microsoft/pxt-microbit/pull/508](https://github.com/Microsoft/pxt-microbit/pull/508)