### PR TITLE
Adding target initialization on static packages to ge the telemetry

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3584,6 +3584,7 @@ function internalStaticPkgAsync(builtPackaged: string, label: string, minify: bo
         pkgversion: "0.0.0",
         fileList: pxtFileList("node_modules/pxt-core/").concat(targetFileList()),
         localDir,
+        target: pxt.appTarget.id,
         builtPackaged,
         minify
     }).then(() => renderDocs(builtPackaged, localDir))

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3584,7 +3584,7 @@ function internalStaticPkgAsync(builtPackaged: string, label: string, minify: bo
         pkgversion: "0.0.0",
         fileList: pxtFileList("node_modules/pxt-core/").concat(targetFileList()),
         localDir,
-        target: pxt.appTarget.id,
+        target: (pxt.appTarget.id || "unknownstatic"),
         builtPackaged,
         minify
     }).then(() => renderDocs(builtPackaged, localDir))


### PR DESCRIPTION
Static packages didn't add the target information in the pxtConfig. This prevented the telemetry from them adding it. 