### PR TITLE
[Accessibility] Fixed Close button alignment

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -417,13 +417,16 @@ div.simframe > iframe {
 *******************************/
 
 .ui.modal .closeIcon {
-    position: absolute;
+    position: relative;
     top: 0; 
     right: 0;
+    z-index: 1002;
 }
 .ui.modal.projectsdialog .closeIcon {
-    top: 0.4rem;
-    right: 0.2rem;
+    position: absolute;
+    color: white;
+    padding: 1.75rem;
+    margin-right: 0px;
 }
 
 .ui.button.icon.clear {

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -887,6 +887,12 @@ export class Modal extends data.Component<ModalProps, ModalState> {
 
         const modalJSX = (
             <div className={classes} style={{ marginTop }} ref={this.handleRef} role="dialog" aria-labelledby={this.props.header ? this.id + 'title' : undefined} aria-describedby={this.props.description ? this.id + 'description' : this.id + 'desc'} >
+                {this.props.closeIcon ? <Button
+                    icon={closeIconName}
+                    class={`huge clear right floated closeIcon focused`}
+                    onClick={() => this.handleClose(null) }
+                    tabIndex={0}
+                    ariaLabel={lf("Close dialog")} /> : undefined }
                 {this.props.header ? <div id={this.id + 'title'} className={"header " + (this.props.headerClass || "") }>
                     {this.props.header}
                     {this.props.helpUrl ?
@@ -908,12 +914,6 @@ export class Modal extends data.Component<ModalProps, ModalState> {
                                 this.props.actionClick();
                             } } />
                     </div> : undefined }
-                {this.props.closeIcon ? <Button
-                    icon={closeIconName}
-                    class={`huge clear right floated closeIcon focused`}
-                    onClick={() => this.handleClose(null) }
-                    tabIndex={0}
-                    ariaLabel={lf("Close dialog")} /> : undefined }
             </div>
         )
 


### PR DESCRIPTION
Fixed an issue where the close button on the modals was not positioned correctly on Safari and iOS.

On left, Safari, on right Google Chrome.

<img width="1680" alt="screen shot 2017-08-17 at 3 45 55 pm" src="https://user-images.githubusercontent.com/3747805/29438346-f1e40b60-836a-11e7-8288-46da9786e461.png">
<img width="1679" alt="screen shot 2017-08-17 at 3 46 07 pm" src="https://user-images.githubusercontent.com/3747805/29438347-f1e507ae-836a-11e7-9da4-b83ee1709100.png">
<img width="1680" alt="screen shot 2017-08-17 at 3 46 24 pm" src="https://user-images.githubusercontent.com/3747805/29438348-f1e5176c-836a-11e7-9cf3-2c68e9467fbe.png">
<img width="1680" alt="screen shot 2017-08-17 at 3 46 43 pm" src="https://user-images.githubusercontent.com/3747805/29438349-f1e56fd2-836a-11e7-8131-0cae3d99c545.png">

