### PR TITLE
Fix interference of react, semantic ui and tutorial dimmers

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -66,7 +66,7 @@ body#docs.tutorial {
     box-shadow: none;
     border: none;
 }
-#docs.tutorial #content{
+#docs.tutorial #root{
     margin-bottom: 0.5rem !important;
 }
 
@@ -127,8 +127,8 @@ body#docs.tutorial {
     margin-bottom: 1rem;
 }
 
-#root.dimmable.dimmed #tutorialcard .tutorialmessage {
-    border: solid white 2px;
+#root.dimmable.dimmed .ui.segment.message {
+    border-radius: 5px;
 }
 
 /* Show / Hide in dimmer */

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -21,7 +21,7 @@
         <div class="ui large loader"></div>
     </div>
 
-    <div id='content'>
+    <div id='content' class="ui dimmable full-abs">
     </div>
 
     <div id='msg'>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1609,7 +1609,8 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
             hideMenuBar ? 'hideMenuBar' : '',
             hideEditorToolbar ? 'hideEditorToolbar' : '',
             sandbox && simActive ? 'simView' : '',
-            'full-abs'
+            'full-abs',
+            'dimmable'
         ]);
 
         return (

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -537,7 +537,8 @@ export class ProjectView
         logs.clear();
         this.setState({
             showFiles: false,
-            filters: filters
+            filters: filters,
+            tutorialOptions: undefined
         })
         return pkg.loadPkgAsync(h.id)
             .then(() => {
@@ -1434,6 +1435,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
     }
 
     openTutorials() {
+//        this.setState({tutorialOptions: undefined});
         pxt.tickEvent("menu.openTutorials");
         this.projects.showOpenTutorials();
     }
@@ -1463,6 +1465,10 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                 }
                 //TODO: parse for tutorial options, mainly initial blocks
             }).then(() => {
+                return this.createProjectAsync({
+                    name: title
+                });
+            }).then(() => {
                 let tutorialOptions: pxt.editor.TutorialOptions = {
                     tutorial: tutorialId,
                     tutorialName: title,
@@ -1473,10 +1479,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
 
                 let tc = this.refs["tutorialcontent"] as tutorial.TutorialContent;
                 tc.setPath(tutorialId);
-            }).then(() => {
-                return this.createProjectAsync({
-                    name: title
-                });
             });
     }
 
@@ -1523,6 +1525,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
     }
 
     completeTutorial() {
+//        this.setState({tutorialOptions: undefined});
         pxt.tickEvent("tutorial.complete");
         this.tutorialComplete.show();
     }

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -18,32 +18,32 @@ export type Component<S, T> = data.Component<S, T>;
 let dimmerInitialized = false;
 
 export function isLoading() {
-    return !!$('.ui.page.dimmer .loadingcontent')[0];
+    return !!$('.ui.loading.dimmer .loadingcontent')[0];
 }
 
 export function hideLoading() {
-    $('.ui.page.dimmer .loadingcontent').remove();
-    $('body.main').dimmer('hide');
+    $('.ui.loading.dimmer .loadingcontent').remove();
+    $('.ui.loading.dimmer').dimmer('hide');
 
     if (!dimmerInitialized) {
         initializeDimmer();
     }
-    $('body.main').dimmer('hide');
+    $('.ui.loading.dimmer').dimmer('hide');
 }
 
 export function showLoading(msg: string) {
     initializeDimmer();
-    $('body.main').dimmer('show');
-    $('.ui.page.dimmer').html(`
+    $('.ui.loading.dimmer').dimmer('show');
+    $('.ui.loading.dimmer').html(`
   <div class="content loadingcontent">
-    <div class="ui text large loader msg">{lf("Please wait")}</div>
+    <div class="ui text large loader msg">${lf("Please wait")}</div>
   </div>
 `)
-    $('.ui.page.dimmer .msg').text(msg)
+    $('.ui.loading.dimmer .msg').text(msg)
 }
 
 function initializeDimmer() {
-    $('body.main').dimmer({
+    $('body.main').dimmer({'dimmerName': 'loading'}).dimmer({
         closable: false
     });
     dimmerInitialized = true;

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -22,28 +22,29 @@ export function isLoading() {
 }
 
 export function hideLoading() {
-    $('.ui.loading.dimmer .loadingcontent').remove();
-    $('.ui.loading.dimmer').dimmer('hide');
-
+    $('.ui.dimmer.loading .loadingcontent').remove();
+    $('.ui.dimmer.loading').dimmer('hide');
     if (!dimmerInitialized) {
         initializeDimmer();
     }
-    $('.ui.loading.dimmer').dimmer('hide');
+    setTimeout(function () {
+        $('.ui.dimmer.loading').dimmer('hide');
+    }, 200);
 }
 
 export function showLoading(msg: string) {
     initializeDimmer();
-    $('.ui.loading.dimmer').dimmer('show');
-    $('.ui.loading.dimmer').html(`
+    $('.ui.dimmer.loading').dimmer('show');
+    $('.ui.dimmer.loading').html(`
   <div class="content loadingcontent">
     <div class="ui text large loader msg">${lf("Please wait")}</div>
   </div>
 `)
-    $('.ui.loading.dimmer .msg').text(msg)
+    $('.ui.dimmer.loading .msg').text(msg);
 }
 
 function initializeDimmer() {
-    $('body.main').dimmer({'dimmerName': 'loading'}).dimmer({
+    $('#content').dimmer({'dimmerName': 'loading'}).dimmer({
         closable: false
     });
     dimmerInitialized = true;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -137,7 +137,6 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             core.showLoading(lf("Loading..."));
             gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
                 .done(opts => {
-                    core.hideLoading();
                     if (opts) {
                         if (loadBlocks) {
                             const ts = opts.filesOverride["main.ts"]


### PR DESCRIPTION
Each of these components use dimmers and they interfere with each other's click events causing unexpected behaviour. 

Clearing tutorial mode when creating a new project of any kind. #2120 

Fixes #1803 
Fixes #2120
Fixes #2013
Fixes #2101

I have designated the
body.dimmable area for react dimmers and modals 
#content.dimmable area for the loading dimmer
#root.dimmable area for other semantic dimmers and modals

This way they won't interfere with each other.