### PR TITLE
[Accessibility] Narrator focus was navigating to hidden element in item mode and reading it as 'simulator'.

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1703,7 +1703,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                 </div>
                 <div id="simulator">
                     <aside id="filelist" className="ui items">
-                        <label htmlFor="boardview" id="boardviewLabel" className="accessible-hidden">{lf("Simulator") }</label>
+                        <label htmlFor="boardview" id="boardviewLabel" className="accessible-hidden" aria-hidden="true">{lf("Simulator") }</label>
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-labelledby="boardviewLabel" tabIndex={0}>
                         </div>
                         { !isHeadless ? <aside className="ui item grid centered portrait hide simtoolbar" role="complementary" aria-label={lf("Simulator toolbar") }>


### PR DESCRIPTION
Fixed an issue where, after a Caps Lock + Right arrow, the narrator was focusing on a hidden element that was describing the simulator. With this fix, the narrator focus on the simulator and describe it, instead of a hidden element and describe it as a simulator.

Related issue : [https://github.com/Microsoft/pxt/issues/2629](https://github.com/Microsoft/pxt/issues/2629)