### PR TITLE
Mostly cleanup, adding focus outline

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1245,7 +1245,8 @@ namespace pxt.blocks {
         (Blockly as any).Toolbox.TreeNode.prototype.onKeyDown = function(e: any) {
             const x = e.which || e.keyCode;
             const interceptCharacter = x != 37 && x != 38 && x != 39 && x != 40 // Arrows (Handled by Blockly)
-                && !e.ctrlKey && !e.metaKey && !e.altKey; // Meta keys
+                && !e.ctrlKey && !e.metaKey && !e.altKey // Meta keys
+                && x != 9; // Don't capture the tab key
             if (interceptCharacter) {
                 let searchField = document.getElementById('blocklySearchInputField') as HTMLInputElement;
                 if (x == 8) { // Backspace

--- a/theme/accessibility.less
+++ b/theme/accessibility.less
@@ -11,6 +11,7 @@
 
 *:focus{
     outline: 2px dotted black !important;
+    z-index: 1000;
 }
 
 .accessible-hidden {

--- a/theme/accessibility.less
+++ b/theme/accessibility.less
@@ -1,0 +1,54 @@
+/* Import all components */
+@import 'themes/default/globals/site.variables';
+@import 'themes/pxt/globals/site.variables';
+
+/* Reference import */
+@import (reference) "semantic.less";
+
+/*******************************
+          Accessibility
+*******************************/
+
+*:focus{
+    outline: 2px dotted black !important;
+}
+
+.accessible-hidden {
+    position: absolute !important;
+    display: block;
+    visibility: visible;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    border: 0;
+    padding: 0;
+    clip: rect(0 0 0 0);
+}
+
+#accessibleMenu {
+    position: absolute;
+    z-index: 1001;
+    top: -20em;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+
+    .ui.item.link {
+        position: absolute;
+        width: 100%;
+        color: rgba(255, 255, 255, 0.9);
+    }
+
+    .ui.item.link:focus {
+        top:20em;
+    }
+}
+
+/* <= Tablet (Mobile + Tablet) */
+@media only screen and (max-width: @largestTabletScreen) {
+    #menubar #accessibleMenu {
+        height: @mobileMenuHeight !important;
+        min-height: @mobileMenuHeight !important;
+    }
+}

--- a/theme/common.less
+++ b/theme/common.less
@@ -40,19 +40,6 @@ html, body {
     right: 0;
 }
 
-.accessible-hidden {
-    position: absolute !important;
-    display: block;
-    visibility: visible;
-    overflow: hidden;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    border: 0;
-    padding: 0;
-    clip: rect(0 0 0 0);
-}
-
 /* Main Editor layout */
 #maineditor {
     left: @simulatorWidth;
@@ -194,25 +181,6 @@ div.simframe > iframe {
 }
 
 /* Menu */
-#accessibleMenu {
-    position: absolute;
-    z-index: 1001;
-    top: -20em;
-    padding: 0;
-    margin: 0;
-    width: 100%;
-
-    .ui.item.link {
-        position: absolute;
-        width: 100%;
-        color: rgba(255, 255, 255, 0.9);
-    }
-
-    .ui.item.link:focus {
-        top:20em;
-    }
-}
-
 #menubar .ui.menu .item.editor-menuitem {
     margin: calc(@mainMenuHeight/10);
     padding: calc(@mainMenuHeight/10);
@@ -880,10 +848,6 @@ Avatar
     }
     .active.item.javascript-menuitem ~ .toggle {
         margin-left: 40px !important;
-    }
-    #menubar #accessibleMenu {
-        height: @mobileMenuHeight !important;
-        min-height: @mobileMenuHeight !important;
     }
     /* Top Menu */
     #maineditor {

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -5,6 +5,9 @@
 /* Reference import */
 @import (reference) "semantic.less";
 
+/*******************************
+        High Contrast
+*******************************/
 
 /* Messages */
 #msg .hc {

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -10,6 +10,7 @@
 @import 'fieldeditors';
 
 @import 'highcontrast';
+@import 'accessibility';
 
 /* Reference import */
 @import (reference) "semantic.less";

--- a/theme/sidedoc.less
+++ b/theme/sidedoc.less
@@ -5,6 +5,9 @@
 /* Reference import */
 @import (reference) "semantic.less";
 
+/*******************************
+         Side docs
+*******************************/
 
 /* Side Docs layout */
 #sidedocs {

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -6,7 +6,7 @@
 @import (reference) "semantic.less";
 
 /*******************************
-             Layout
+      Tutorial mode
 *******************************/
 
 .tutorial #maineditor .full-abs {


### PR DESCRIPTION
Mostly cleaning up CSS. 

Adding a focus outline like so: 
```
*:focus{
    outline: 2px dotted black !important;
    z-index: 1000;
}
```

TODO:
- [ ] Need to make sure the blocklySVG doesn't capture focus
- [x] Need to make sure the search field doesn't capture tabs
