### PR TITLE
[Accessibility] Made the simulator frame not focusable with the keyboard.

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1708,7 +1708,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                 <div id="simulator">
                     <aside id="filelist" className="ui items">
                         <label htmlFor="boardview" id="boardviewLabel" className="accessible-hidden" aria-hidden="true">{lf("Simulator") }</label>
-                        <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-labelledby="boardviewLabel" tabIndex={0}>
+                        <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-labelledby="boardviewLabel">
                         </div>
                         { !isHeadless ? <aside className="ui item grid centered portrait hide simtoolbar" role="complementary" aria-label={lf("Simulator toolbar") }>
                             <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>


### PR DESCRIPTION
Impact on the Screen Reader : 
- On Edge with the Narrator : once focused on a button of the simulator, instead of announcing "Simulator region, A button",  it announces the title of the page in the iframe, which is something like "BBC micro:bit simulator, A button".
- On Firefox and Chrome with NVDA and JAWS, the behavior doesn't change, it still announce "Simulator region, A button".