### PR TITLE
Fixing appcache for target editor extensions using staticpkg

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -925,7 +925,7 @@ function uploadCoreAsync(opts: UploadOptions) {
             "var pxtConfig = null": "var pxtConfig = " + JSON.stringify(cfg, null, 4),
             "@defaultLocaleStrings@": "",
             "@cachedHexFiles@": "",
-            "@targetEditorJs@": ""
+            "@targetEditorJs@": targetEditorJs ? opts.localDir + "editor.js" : ""
         }
     }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -925,7 +925,7 @@ function uploadCoreAsync(opts: UploadOptions) {
             "var pxtConfig = null": "var pxtConfig = " + JSON.stringify(cfg, null, 4),
             "@defaultLocaleStrings@": "",
             "@cachedHexFiles@": "",
-            "@targetEditorJs@": targetEditorJs ? opts.localDir + "editor.js" : ""
+            "@targetEditorJs@": targetEditorJs ? `${opts.localDir}editor.js` : ""
         }
     }
 


### PR DESCRIPTION
editor.js was not being appended to the release manifest when building with staticpkg.