### PR TITLE
Android monaco editor issues

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -361,8 +361,12 @@ file('built/web/vs/editor/editor.main.js', ['node_modules/pxt-monaco-typescript/
     monacoeditor = monacoeditor.replace(/((GoToDefinitionAction|'editor.action.(changeAll|quickOutline|previewDeclaration|referenceSearch.trigger)')[.\s\S]*?)(menuOpts:[.\s\S]*?})/gi, '$1')
     monacoeditor = monacoeditor.replace(/.*define\(\"vs\/language\/typescript\/src\/monaco.contribution\",.*/gi, `${monacotypescriptcontribution}`)
     // Fix for android keyboard issues:
-    monacoeditor = monacoeditor.replace(/this\.textArea\.setAttribute\('autocorrect', 'off'\);/gi,
-                `this.textArea.setAttribute('autocorrect', 'off');\n            this.textArea.setAttribute('autocomplete', 'off');`)
+    // Issue 1: getClientRects issue on Android 5.1 (Chrome 40), monaco-editor/#562
+    monacoeditor = monacoeditor.replace(/FloatHorizontalRange\(Math\.max\(0, clientRect\.left - clientRectDeltaLeft\), clientRect\.width\)/gi,
+                `FloatHorizontalRange(Math.max(0, clientRect.right - clientRectDeltaLeft), clientRect.width)`)
+    // Issue 2: Delete key is a composition input on Android 6+, monaco-editor/#563
+    monacoeditor = monacoeditor.replace(/if \(typeInput\.text !== ''\)/gi,
+                `if (typeInput.text !== '' || typeInput.replaceCharCnt == 1)`)
     fs.writeFileSync("built/web/vs/editor/editor.main.js", monacoeditor)
 
     jake.mkdirP("webapp/public/vs")


### PR DESCRIPTION
Testing monaco-editor on Android versions 5.1 (Chrome 40), 6.0.1 (Chrome 50) and 7.1.1 (Chrome 55) concluded the following: 
- Android 5.1 does not respect the auto-capitalize setting to off, and begins by capitalizing the first character. Most namespaces start with a lowercase character and so this is annoying. No workaround for this.

- Chrome 40 on Android 5.1 returns different values for ranges.getClientRects than monaco expects with later versions of Chrome. This yields to the monaco editor cursor not updating as the user types, and always snapping left. Fixed in this PR by using the getClientRects's right bounds. Filed monaco-editor issue: https://github.com/Microsoft/monaco-editor/issues/562 with video of repro. 

- Android 6.0.1 keyboards return the back (backspace key) on key down as unknown (keycode = 229), and expects that we handle it on input. Workaround for this is to call replacePrevChar [1] with empty text when the input is a backspace. Fixed in this PR and files a monaco-editor issue: https://github.com/Microsoft/monaco-editor/issues/563
This workaround isn't foolproof and wouldn't work if a user is trying to delete a line. Consulting the monaco team for further guidance.

- As part of this PR I also removed the previous workaround that set auto-complete to off, as this is now in the monaco-editor codebase. 

TODO: 
- [x] Android with Gboard ignores auto-complete off and so we must fix the issue around auto complete and composition update.
- [x] Android 7.1 with Chrome 56 is special as there are known issues with monaco editor and Chrome 56. https://github.com/Microsoft/monaco-editor/issues/320
- [x] Android 7.2 with Chrome 60 has different composition update issues with the Gboard
