### PR TITLE
Adding test extension and more protocol work

### DIFF
--- a/pxteditor/extension.ts
+++ b/pxteditor/extension.ts
@@ -73,12 +73,9 @@ namespace pxt.editor {
      */
     export type ExtInitializeType = "extinit";
 
-    export interface InitializeEvent extends ExtensionEvent {
-        event: ExtInitializeType;
-    }
-
     export interface InitializeRequest extends ExtensionRequest {
         action: ExtInitializeType;
+        body: string;
     }
 
     export interface InitializeResponse extends ExtensionResponse {

--- a/webapp/public/extension.html
+++ b/webapp/public/extension.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en" data-manifest="" data-framework="typescript">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+</head>
+<style type="text/css">
+    @import "/blb/semantic.css";
+</style>
+<style>
+    #logs {
+        position: absolute;
+        left: 0;
+        width: 100%;
+        border: 0;
+        font-size: 0.6rem;
+    }
+
+    #logs img {
+        max-width:18rem;
+    }
+</style>
+
+<script>
+    var extId;
+    var logs;
+    var idToType = {};
+    function receiveMessage(ev) {
+        var msg = ev.data;
+        logs.innerText += formatResponse(msg);
+        var action = idToType[msg.id];
+        if (action === "extinit") {
+            handleInit(msg);
+        }
+        delete idToType[msg.id];
+    }
+
+    function formatResponse(resp) {
+        var action = idToType[resp.id];
+        return "\n< " + action + " (response) s=" + resp.success + " "
+            + (resp.error ? resp.error : "") + (resp.body ? JSON.stringify(resp.body) : "");
+    }
+
+    function handleInit(msg) {
+        extId = msg.extId;
+        logs.innerText += "\n<< got id " + extId;
+    }
+
+    function sendRequest(action) {
+        var msg = mkRequest(action);
+        switch (action) {
+            case "extdatastream":
+                msg.body = {
+                    serial: true
+                };
+                break;
+            case "extquerypermission":
+            break;
+            case "extrequestpermission":
+                msg.body = {
+                    serial: true
+                };
+                break;
+            case "extusercode":
+            break;
+            case "extreadcode":
+            break;
+            case "extwritecode":
+                msg.body = {
+                    code: "let x = 0;",
+                    json: '{ "whatever": "sure" }'
+                }
+                break;
+            case "extinit":
+                msg.body = "neoanim"
+            break;
+        }
+        logs.innerText += "\n> " + msg.action;
+        window.parent.postMessage(msg, "*");
+    }
+
+    function mkRequest(action) {
+        var id = Math.random().toString();
+        idToType[id] = action;
+        return {
+            type: "pxtpkgext",
+            action: action,
+            extId: extId,
+            response: true,
+            id: id
+        }
+    }
+
+    function bindButtons() {
+        var elt = document.getElementById("buttons");
+
+        for (let i = 0; i < elt.childNodes.length; i++) {
+            var btn = elt.childNodes.item(i);
+            
+            if (btn.nodeType === Node.ELEMENT_NODE) {
+                let action = btn.getAttribute("action");
+                if (action) {
+                    btn.addEventListener("click", function() {
+                        sendRequest(action);
+                    });
+                }
+            }
+        }
+    }
+
+    window.addEventListener("message", receiveMessage, false);
+    window.onload = function() {
+        bindButtons();
+        logs = document.getElementById("logs");
+        this.sendRequest("extinit");
+    }
+</script>
+
+<body>
+    <h1>Test Extension</h1>
+    <div id="buttons" class="ui buttons">
+        <button class="ui button" action="extrequestpermission">ask permission</button>
+        <button class="ui button" action="extquerypermission">query permissions</button>
+        <button class="ui button" action="extreadcode">read code</button>
+        <button class="ui button" action="extwritecode">write code</button>
+        <button class="ui button" action="extdatastream">serial</button>
+        <button class="ui button" action="extusercode">user code</button>
+    </div>
+    <pre id="logs" class="ui"></pre>
+</body>
+</html>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -360,7 +360,7 @@ export class ProjectView
             },
             editor: this.state.header ? this.state.header.editor : ''
         })
-        if (pxt.appTarget.appTheme.allowParentController)
+        if (pxt.appTarget.appTheme.allowParentController || pxt.appTarget.appTheme.allowPackageExtensions)
             pxt.editor.bindEditorMessages(this);
         this.forceUpdate(); // we now have editors prepared
     }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -104,11 +104,12 @@ export class Editor extends srceditor.Editor {
                     pxt.blocks.initExtensions(this.editor, this.extensions, (extensionName) => {
                         const extension = this.extensions.filter(c => c.name == extensionName)[0];
                         const parsedRepo = pxt.github.parseRepoId(extension.installedVersion);
+                        const debug = pxt.Cloud.isLocalHost() && /debugExtensions/i.test(window.location.href);
                         pxt.packagesConfigAsync()
                             .then((config) => {
                                 const repoStatus = pxt.github.repoStatus(parsedRepo, config);
                                 const repoName = parsedRepo.fullName.substr(parsedRepo.fullName.indexOf(`/`) + 1);
-                                const url = `https://${parsedRepo.owner}.github.io/${repoName}/`;
+                                const url = debug ? "http://localhost:3232/extension.html" : `https://${parsedRepo.owner}.github.io/${repoName}/`;
                                 this.parent.openExtension(extension.name, url, repoStatus == 0); // repoStatus can only be APPROVED or UNKNOWN at this point
                             });
                     })

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -48,19 +48,22 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
     }
 
     showExtension(extension: string, url: string, consentRequired: boolean) {
-        let consent = consentRequired ? this.manager.hasConsent(extension) : true;
+        let consent = consentRequired ? this.manager.hasConsent(this.manager.getExtId(extension)) : true;
         this.setState({ visible: true, extension: extension, url: url, consent: consent});
     }
 
     submitConsent() {
-        this.manager.setConsent(this.state.extension, true);
+        this.manager.setConsent(this.manager.getExtId(this.state.extension), true);
         this.setState({consent: true});
     }
 
     initializeFrame() {
+        this.manager.setConsent(this.manager.getExtId(this.state.extension), true);
         const frame = Extensions.getFrame(this.state.extension);
         frame.style.display = 'block';
-        if (!frame.src) frame.src = this.state.url;
+        if (!frame.src) {
+            frame.src = this.state.url;
+        }
     }
 
     shouldComponentUpdate(nextProps: ISettingsProps, nextState: ExtensionsState, nextContext: any): boolean {
@@ -103,13 +106,13 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
         this.manager.handleExtensionMessage(request);
     }
 
-    send(extId: string, editorMessage: pxt.editor.ExtensionMessage) {
-        const frame = Extensions.getFrame(extId)
+    send(name: string, editorMessage: pxt.editor.ExtensionMessage) {
+        const frame = Extensions.getFrame(name);
         if (frame) {
             frame.contentWindow.postMessage(editorMessage, "*");
         }
         else {
-            console.warn(`Attempting to post message to unloaded extesnion ${extId}`);
+            console.warn(`Attempting to post message to unloaded extesnion ${name}`);
         }
     }
 


### PR DESCRIPTION
Adds the initial handshake for extensions, support for the extensions reading an writing code to their packages, and a test extension. To use the test extension:

1. Add `#debugExtensions` to your URL
2. Add the pxt-neoanim package to your project
3. Open the lights category and click the button. The test extension will load instead of pxt-neoanim.