### PR TITLE
Initial service worker work

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -883,6 +883,7 @@ function uploadCoreAsync(opts: UploadOptions) {
         "var pxtConfig = null": "var pxtConfig = @cfg@",
         "@defaultLocaleStrings@": defaultLocale ? "@commitCdnUrl@" + "locales/" + defaultLocale + "/strings.json" : "",
         "@cachedHexFiles@": hexFiles.length ? hexFiles.join("\n") : "",
+        "@cachedHexFilesArray@": hexFiles.length ? hexFiles.join(`",\n"`) : "",
         "@targetEditorJs@": targetEditorJs
     }
 
@@ -930,6 +931,7 @@ function uploadCoreAsync(opts: UploadOptions) {
         "docs.html",
         "siminstructions.html",
         "release.manifest",
+        "serviceworker.js",
         "worker.js",
         "tdworker.js",
         "monacoworker.js",

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -822,6 +822,11 @@ export function serveAsync(options: ServeOptions) {
             return
         }
 
+        if (pathname == "/--serviceworker") {
+            sendFile(path.join(publicDir, 'serviceworker.js'));
+            return
+        }
+
         if (pathname == "/--docs") {
             sendFile(path.join(publicDir, 'docs.html'));
             return

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -184,6 +184,6 @@ function registerServiceWorker() {
 }
 
 $(document).ready(function () {
-    registerServiceWorker();
+    //registerServiceWorker();
     renderSnippets();
 });

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -166,6 +166,24 @@ function renderSnippets() {
     });
 }
 
+function registerServiceWorker() {
+    if (pxt.Cloud.isLocalhost()) return;
+    if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function() {
+            navigator.serviceWorker.register('/sw.js').then(function(registration) {
+                // Registration was successful
+                console.log('ServiceWorker registration successful with scope: ', registration.scope);
+                // Abort app cache if service worker is loaded
+                window.applicationCache.abort();
+            }, function(err) {
+                // registration failed :(
+                console.log('ServiceWorker registration failed: ', err);
+            });
+        });
+    }
+}
+
 $(document).ready(function () {
+    registerServiceWorker();
     renderSnippets();
 });

--- a/webapp/public/serviceworker.js
+++ b/webapp/public/serviceworker.js
@@ -1,0 +1,149 @@
+var CACHE_NAME = 'pxt-cache-v2';
+
+
+
+// keep in sync with release.manifest
+var urlsToCache = [
+  // docs
+  '/doccdn/jquery.js',
+  '/doccdn/semantic.css',
+  '/doccdn/blockly.css',
+  '/docfiles/docs.js',
+  '/docfiles/target.js',
+  '/docfiles/style.css',
+  '/docfiles/target.css',
+  '/docfiles/vs.css',
+  '/--embed',
+  "https://az742082.vo.msecnd.net/pub/psopafpj",
+
+  // editor
+  "/blb/semantic.js",
+  "/blb/main.js",
+  "/blb/typescript.js",
+  "/blb/marked/marked.min.js",
+  "/blb/highlight.js/highlight.pack.js",
+  "/blb/lzma/lzma_worker-min.js",
+  "/blb/fuse.min.js",
+  "/blb/jquery.js",
+  "/blb/pxtlib.js",
+  "/blb/pxtcompiler.js",
+  "/blb/pxtblocks.js",
+  "/blb/pxtwinrt.js",
+  "/blb/pxteditor.js",
+  "/blb/pxtsim.js",
+  "/blb/blockly.css",
+  "/blb/semantic.css",
+  "/blb/rtlsemantic.css",
+  "/blb/custom.css",
+  "/blb/icons.css",
+  "@defaultLocaleStrings@",
+  "@cachedHexFilesArray@",
+  "@targetEditorJs@",
+
+  // Blockly
+  "/blb/blockly/blockly_compressed.js",
+  "/blb/blockly/blocks_compressed.js",
+  "/blb/blockly/msg/js/en.js",
+  "/cdn/blockly/media/sprites.png",
+  "/cdn/blockly/media/click.mp3",
+  "/cdn/blockly/media/disconnect.wav",
+  "/cdn/blockly/media/delete.mp3",
+
+  // monaco
+  "/blb/vs/loader.js",
+  "/blb/vs/base/worker/workerMain.js",
+  "/blb/vs/basic-languages/src/bat.js",
+  "/blb/vs/basic-languages/src/cpp.js",
+  "/blb/vs/editor/editor.main.css",
+  "/blb/vs/editor/editor.main.js",
+  "/blb/vs/editor/editor.main.nls.js",
+  "/blb/vs/language/json/jsonMode.js",
+  "/blb/vs/language/json/jsonWorker.js",
+  "/blb/vs/language/typescript/lib/typescriptServices.js",
+  "/blb/vs/language/typescript/src/mode.js",
+  "/blb/vs/language/typescript/src/worker.js",
+
+  // AI
+  "https://az416426.vo.msecnd.net/scripts/a/ai.0.js"
+];
+
+self.addEventListener('install', function (event) {
+  // Perform install step:  loading each required file into cache
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(function (cache) {
+      // Add all offline dependencies to the cache
+      return cache.addAll(urlsToCache);
+    })
+    .then(function() {
+      // At this point everything has been cached
+      return self.skipWaiting();
+    })
+  );
+})
+self.addEventListener('activate', function(event) {
+  var cacheWhitelist = [CACHE_NAME];
+  event.waitUntil(
+    caches.keys().then(function(cacheNames) {
+      return Promise.all(
+        cacheNames.map(function(cacheName) {
+          if (cacheWhitelist.indexOf(cacheName) === -1) {
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    }).then(function () {
+      // Calling claim() to force a "controllerchange" event on navigator.serviceWorker
+      event.waitUntil(self.clients.claim());
+    })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    (event.request.url.indexOf('/api/') >= 0) ?
+      fetch(event.request)
+    : caches.match(event.request).then(function (response) {
+      // Cache hit - return response
+      if (response) {
+        console.log("Cache response hit")
+        console.log(response);
+        return response;
+      }
+      // IMPORTANT: Clone the request. A request is a stream and
+      // can only be consumed once. Since we are consuming this
+      // once by cache and once by the browser for fetch, we need
+      // to clone the response.
+      var fetchRequest = event.request.clone();
+      
+      return fetch(fetchRequest).then(
+        function(response) {
+          // Check if we received a valid response
+          if(!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
+
+          // IMPORTANT: Clone the response. A response is a stream
+          // and because we want the browser to consume the response
+          // as well as the cache consuming the response, we need
+          // to clone it so we have two streams.
+          var responseToCache = response.clone();
+
+          caches.open(CACHE_NAME)
+            .then(function(cache) {
+              cache.put(event.request, responseToCache);
+            });
+
+          return response;
+        }
+      ).catch(function () {
+        console.log("failed with request.. ")
+        console.log(event.request)
+        if (event.request.url.indexOf('/api/') >= 0) {
+          console.log("Trying to find API")
+        }
+      });
+    })
+  );
+});
+
+// v1

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2137,7 +2137,8 @@ $(document).ready(() => {
 
     initLogin();
     const hash = parseHash();
-    appcache.init(hash);
+    appcache.initAppCache(hash);
+    appcache.initWebWorker();
 
     pxt.docs.requireMarked = () => require("marked");
     const ih = (hex: pxt.cpp.HexFile) => theEditor.importHex(hex);

--- a/webapp/src/appcache.ts
+++ b/webapp/src/appcache.ts
@@ -1,6 +1,9 @@
+/// <reference path="../../built/pxtlib.d.ts"/>
 import * as core from "./core";
 
-export function init(hash: { cmd: string, arg: string }) {
+import Cloud = pxt.Cloud;
+
+export function initAppCache(hash: { cmd: string, arg: string }) {
     let appCache = window.applicationCache;
     appCache.addEventListener('updateready', () => {
         core.infoNotification(lf("Update download complete. Reloading... "));
@@ -14,4 +17,23 @@ export function init(hash: { cmd: string, arg: string }) {
             }
         }, 5000);
     }, false);
+}
+
+
+export function initWebWorker() {
+    if (Cloud.isLocalHost()) return;
+    if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+            const cdn = pxt.webConfig.commitCdnUrl;
+            (navigator as any).serviceWorker.register(`--serviceworker`).then((registration: any) => {
+                // Registration was successful
+                console.log('ServiceWorker registration successful with scope: ', registration.scope);
+                // Abort app cache if service worker is loaded
+                window.applicationCache.abort();
+            }, (err: any) => {
+                // registration failed :(
+                console.log('ServiceWorker registration failed: ', err);
+            });
+        });
+    }
 }


### PR DESCRIPTION
This PR is by far not ready. 

Beginning initial service worker work to support better caching of editor and doc pages for browsers that support it.
Right now, roughly 63% of our users are on a browser that supports service workers. 

Service workers allow us to do better than just cache static files (like application cache), it allows us to cache page requests, images, and perhaps do more complicated caching with blocks / packages for a better offline scenario.

We will still keep the appcache as a fallback.

Some resources RE service workers: 
- Udacity course: https://classroom.udacity.com/courses/ud899
- https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook
- https://developers.google.com/web/fundamentals/getting-started/primers/service-workers