### PR TITLE
Editor load telemetry with actual window width and height

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1884,6 +1884,8 @@ function enableAnalytics() {
         stats["screen.height"] = screen.height;
         stats["screen.availwidth"] = screen.availWidth;
         stats["screen.availheight"] = screen.availHeight;
+        stats["window.innerWidth"] = window.innerWidth;
+        stats["window.innerHeight"] = window.innerHeight;
         stats["screen.devicepixelratio"] = pxt.BrowserUtils.devicePixelRatio();
     }
     pxt.tickEvent("editor.loaded", stats);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1884,8 +1884,8 @@ function enableAnalytics() {
         stats["screen.height"] = screen.height;
         stats["screen.availwidth"] = screen.availWidth;
         stats["screen.availheight"] = screen.availHeight;
-        stats["window.innerWidth"] = window.innerWidth;
-        stats["window.innerHeight"] = window.innerHeight;
+        stats["screen.innerWidth"] = window.innerWidth;
+        stats["screen.innerHeight"] = window.innerHeight;
         stats["screen.devicepixelratio"] = pxt.BrowserUtils.devicePixelRatio();
     }
     pxt.tickEvent("editor.loaded", stats);


### PR DESCRIPTION
Fix editor load telemetry to use actual window width and height.

screen.width = width of the screen
screen.availWidth = width of the screen - scrollbars / toolbars
window.innerWidth = width of the browser

