### PR TITLE
[Accessibility] Fix narrator hidden focus documentation

### DIFF
--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -1,4 +1,4 @@
-    <div class="ui inverted accent vertical footer segment hideprint">
+    <footer class="ui inverted accent vertical footer segment hideprint" aria-hidden="false">
         <div class="ui center aligned container">
             <div class="ui horizontal inverted small divided link list">
                 <a class="item" href="https://makecode.com/" title="Microsoft MakeCode" target="_blank" rel="noopener">Powered by Microsoft MakeCode</a>
@@ -12,4 +12,4 @@
             </div>
             <a class="item" href="https://www.microsoft.com/" target="_blank" rel="noopener" aria-label="Microsoft Home Page"><img class="ui centered image" src="https://az851932.vo.msecnd.net/pub/pmapoirq" /></a>
         </div>
-    </div>
+    </footer>


### PR DESCRIPTION
Fixed an issue where the Narrator in Edge was focusing on a hidden element in reading mode.

Related issue : [https://github.com/Microsoft/pxt/issues/2803](https://github.com/Microsoft/pxt/issues/2803)