### PR TITLE
No localhost banner

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1635,9 +1635,10 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
 
         // For apps, if the user is not on the live website, display a warning banner
         const isApp = electron.isElectron || pxt.winrt.isWinRT() || !!(window as any).ipcRenderer;
+        const isLocalServe = location.hostname === "localhost";
         const isExperimentalUrlPath = location.pathname !== "/"
             && (targetTheme.appPathNames || []).indexOf(location.pathname) === -1;
-        const showExperimentalBanner = !Cloud.isLocalHost() && isApp && !this.state.hideExperimentalBanner && isExperimentalUrlPath;
+        const showExperimentalBanner = !isLocalServe && isApp && !this.state.hideExperimentalBanner && isExperimentalUrlPath;
         const liveUrl = pxt.appTarget.appTheme.homeUrl + location.search + location.hash;
 
         // update window title

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1637,7 +1637,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         const isApp = electron.isElectron || pxt.winrt.isWinRT() || !!(window as any).ipcRenderer;
         const isExperimentalUrlPath = location.pathname !== "/"
             && (targetTheme.appPathNames || []).indexOf(location.pathname) === -1;
-        const showExperimentalBanner = isApp && !this.state.hideExperimentalBanner && isExperimentalUrlPath;
+        const showExperimentalBanner = !Cloud.isLocalHost() && isApp && !this.state.hideExperimentalBanner && isExperimentalUrlPath;
         const liveUrl = pxt.appTarget.appTheme.homeUrl + location.search + location.hash;
 
         // update window title


### PR DESCRIPTION
Small fix to not show the "This is an experimental version of the editor" when doing local development.

Using `location.hostname` instead of `cloud.isLocalHost()` to also support `?nolocalhost=1` in the URL (for which `cloud.isLocalHost()` returns false)