### PR TITLE
[Accessibility] Fixed the focus outline of makecode.com

### DIFF
--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -1,4 +1,4 @@
-<footer class="ui inverted accent vertical footer segment hideprint" role="contentinfo">
+<footer class="ui inverted accent vertical footer segment hideprint" role="contentinfo" aria-hidden="false">
     <div class="ui center aligned container">
         <div class="ui horizontal inverted small divided link list">
             <a class="item" href="https://makecode.com/" title="Microsoft MakeCode" target="_blank" rel="noopener">Powered by Microsoft MakeCode</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
 				outline: auto !important; /* initial or inherit has no render on Chrome */
 			}
 
-			.inverted:not(#makecode-resources-container) .ui.card:not([tabindex='-1']):focus,
+			.ui.inverted:not(#makecode-resources-container) .ui.card:not([tabindex='-1']):focus,
 			.ui.button.green:focus {
 				outline: 2px solid white !important;
 			}

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,11 +12,6 @@
 	<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/4.1.0/css/fabric.min.css">
 
 	<style>
-
-		*:focus {
-			outline: 1px solid transparent !important;
-		}
-
 		@media not all and (pointer:coarse) {
 			*:not([tabindex='-1']):focus {
 				outline: 2px solid #4D90FE !important;

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,17 @@
 	<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/4.1.0/css/fabric.min.css">
 
 	<style>
+
+		*:focus {
+			outline: 1px solid transparent !important;
+		}
+
+		@media not all and (pointer:coarse) {
+			*:not([tabindex='-1']):focus {
+				outline: 2px solid #4D90FE !important;
+			}
+		}
+
 		#makecode-fixed-menu {
 			background: #2D404F;
 			background: rgba(45, 64, 79, 0.9);

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,12 @@
 	<style>
 		@media not all and (pointer:coarse) {
 			*:not([tabindex='-1']):focus {
-				outline: 2px solid #4D90FE !important;
+				outline: auto !important; /* initial or inherit has no render on Chrome */
+			}
+
+			.inverted:not(#makecode-resources-container) .ui.card:not([tabindex='-1']):focus,
+			.ui.button.green:focus {
+				outline: 2px solid white !important;
 			}
 		}
 


### PR DESCRIPTION
* Fixed the focus outline of makecode.com
* Fixed an issue where the narrator was outlining a hidden element in the footer.

Related issues : [https://github.com/Microsoft/pxt/issues/2604](https://github.com/Microsoft/pxt/issues/2604), [https://github.com/Microsoft/pxt/issues/2803](https://github.com/Microsoft/pxt/issues/2803)

![capture](https://user-images.githubusercontent.com/3747805/29797494-379afb06-8c0c-11e7-9228-a33e61ded275.PNG)
