### PR TITLE
Unhighlight blocks on save

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -47,6 +47,7 @@ export class Editor extends srceditor.Editor {
 
     saveToTypeScript(): Promise<string> {
         if (!this.typeScriptSaveable) return Promise.resolve('');
+        this.clearHighlightedStatements();
         try {
             return pxt.blocks.compileAsync(this.editor, this.blockInfo)
                 .then((compilationResult) => {


### PR DESCRIPTION
When in snail mode, if you remove a block it remains highlighted even if the program is not running. This fixes that by clearing the highlight on save.