### PR TITLE
[Accessibility] Fixed the color contrast of the side menu

### DIFF
--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -20,6 +20,7 @@
 @greenTextColor: #107C10;
 
 @lightTextColor              : rgba(0, 0, 0, 0.68);
+@invertedUnselectedTextColor : rgba(255, 255, 255, 0.8); 
 
 @pageBackground: #ffffff;
 


### PR DESCRIPTION
Fixed the luminosity of the menu items in the side menu.

Related issue : [https://github.com/Microsoft/pxt/issues/2797](https://github.com/Microsoft/pxt/issues/2797)

![untitled](https://user-images.githubusercontent.com/3747805/29689021-9087a63a-88d6-11e7-8770-6acbca405903.png)

I did not found any visual impact for real on the rest of MakeCode even if this color is used at several places in Semantic UI.

I opened this PR following our discussion on pxt-microbit with @pelikhan  : [https://github.com/Microsoft/pxt-microbit/pull/517](https://github.com/Microsoft/pxt-microbit/pull/517)