### PR TITLE
Conservatively decompile variables referenced inside grey blocks

### DIFF
--- a/tests/decompile-test/baselines/always_local_variable.blocks
+++ b/tests/decompile-test/baselines/always_local_variable.blocks
@@ -1,13 +1,8 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
 <block type="pxt-on-start">
 <statement name="HANDLER">
-<block type="variables_set">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">0</field>
-</shadow>
-</value>
+<block type="typescript_statement">
+<mutation declaredvars="x" numlines="1" line0="x &#61; 0" />
 <next>
 <block type="typescript_statement">
 <mutation numlines="3" line0="for &#40;&#59;&#59;&#41; &#123;" line1="    x&#43;&#43;&#59;" line2="&#125;" />

--- a/tests/decompile-test/baselines/always_null_and_undefined.blocks
+++ b/tests/decompile-test/baselines/always_null_and_undefined.blocks
@@ -1,21 +1,11 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
 <block type="pxt-on-start">
 <statement name="HANDLER">
-<block type="variables_set">
-<field name="VAR">y</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">0</field>
-</shadow>
-</value>
+<block type="typescript_statement">
+<mutation declaredvars="y" numlines="1" line0="y &#61; 0" />
 <next>
-<block type="variables_set">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">0</field>
-</shadow>
-</value>
+<block type="typescript_statement">
+<mutation declaredvars="x" numlines="1" line0="x &#61; 0" />
 <next>
 <block type="typescript_statement">
 <mutation numlines="1" line0="x &#61; null&#59;" />

--- a/tests/decompile-test/baselines/no_nested_events.blocks
+++ b/tests/decompile-test/baselines/no_nested_events.blocks
@@ -16,4 +16,11 @@
 </block>
 </statement>
 </block>
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="typescript_statement">
+<mutation declaredvars="i" numlines="1" line0="i &#61; 0" />
+</block>
+</statement>
+</block>
 </xml>


### PR DESCRIPTION
Part of the fix for #2860 

If a variable is referenced in a grey block and the declaration looks like one we auto-generated, then emit the declaration as a grey block