### PR TITLE
Fixing placement of errors in monaco editor

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1208,8 +1208,8 @@ export class Editor extends srceditor.Editor {
                         message: message,
                         startLineNumber: d.line + 1,
                         startColumn: d.column,
-                        endLineNumber: (d.endLine || endPos.lineNumber) + 1,
-                        endColumn: d.endColumn || endPos.column
+                        endLineNumber: d.endLine == undefined ? endPos.lineNumber : d.endLine + 1,
+                        endColumn: d.endColumn == undefined ? endPos.column : d.endColumn
                     })
                 }
             }


### PR DESCRIPTION
Fixes #2867 
The line numbers in out diagnostics are off by one, but Monaco's are not. We were adding one where we shouldn't be. I think the issue might be slightly different in V0; I'll take a look after this is merged.