### PR TITLE
V0 Fixing placement of errors in monaco editor

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1109,10 +1109,10 @@ export class Editor extends srceditor.Editor {
                     monacoErrors.push({
                         severity: monaco.Severity.Error,
                         message: message,
-                        startLineNumber: d.line,
+                        startLineNumber: d.line + 1,
                         startColumn: d.column,
-                        endLineNumber: d.endLine || endPos.lineNumber,
-                        endColumn: d.endColumn || endPos.column
+                        endLineNumber: d.endLine == undefined ? endPos.lineNumber : d.endLine + 1,
+                        endColumn: d.endColumn == undefined ? endPos.column : d.endColumn
                     })
                 }
             }


### PR DESCRIPTION
Slightly different than the fix for master. This fixes the placement of the red squiggles in the Monaco editor.