### PR TITLE
Do not download tutorial markdown in client, use step length returned by runner

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -90,7 +90,6 @@ namespace pxt.editor {
     export interface TutorialOptions {
         tutorial?: string; // tutorial
         tutorialName?: string; // tutorial title
-        tutorialSteps?: string[]; // tutorial steps
         tutorialStepInfo?: TutorialStepInfo[];
         tutorialStep?: number; // current tutorial page
         tutorialReady?: boolean; // current tutorial page

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -569,7 +569,7 @@ ${files["main.ts"]}
             .then(tutorialmd => {
                 let steps = tutorialmd.split(/^##[^#].*$/gmi);
                 let stepInfo: editor.TutorialStepInfo[] = [];
-                tutorialmd.replace(/##[^#](.*)/g, (f, s) => {
+                tutorialmd.replace(/^##[^#](.*)$/gmi, (f, s) => {
                     let info: editor.TutorialStepInfo = {
                         fullscreen: s.indexOf('@fullscreen') > -1,
                         hasHint: s.indexOf('@nohint') < 0

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1458,7 +1458,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
     }
 
     openTutorials() {
-//        this.setState({tutorialOptions: undefined});
         pxt.tickEvent("menu.openTutorials");
         this.projects.showOpenTutorials();
     }
@@ -1475,7 +1474,23 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         let result: string[] = [];
 
         sounds.initTutorial(); // pre load sounds
-        return pxt.Cloud.downloadMarkdownAsync(tutorialId)
+        return Promise.resolve().then(() => {
+                return this.createProjectAsync({
+                    name: title
+                });
+            }).then(() => {
+                let tutorialOptions: pxt.editor.TutorialOptions = {
+                    tutorial: tutorialId,
+                    tutorialName: title,
+                    tutorialStep: 0
+                };
+                this.setState({ tutorialOptions: tutorialOptions, tracing: undefined })
+
+                let tc = this.refs["tutorialcontent"] as tutorial.TutorialContent;
+                tc.setPath(tutorialId);
+            });
+
+            /*pxt.Cloud.downloadMarkdownAsync(tutorialId)
             .then(md => {
                 let titleRegex = /^#\s*(.*)/g.exec(md);
                 if (!titleRegex || titleRegex.length < 1) return;
@@ -1487,22 +1502,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                     result.push(stepmd);
                 }
                 //TODO: parse for tutorial options, mainly initial blocks
-            }).then(() => {
-                return this.createProjectAsync({
-                    name: title
-                });
-            }).then(() => {
-                let tutorialOptions: pxt.editor.TutorialOptions = {
-                    tutorial: tutorialId,
-                    tutorialName: title,
-                    tutorialStep: 0,
-                    tutorialSteps: result
-                };
-                this.setState({ tutorialOptions: tutorialOptions, tracing: undefined })
-
-                let tc = this.refs["tutorialcontent"] as tutorial.TutorialContent;
-                tc.setPath(tutorialId);
-            });
+            }).*/
     }
 
     exitTutorial(keep?: boolean) {
@@ -1550,7 +1550,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
     }
 
     completeTutorial() {
-//        this.setState({tutorialOptions: undefined});
         pxt.tickEvent("tutorial.complete");
         this.tutorialComplete.show();
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1489,20 +1489,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                 let tc = this.refs["tutorialcontent"] as tutorial.TutorialContent;
                 tc.setPath(tutorialId);
             });
-
-            /*pxt.Cloud.downloadMarkdownAsync(tutorialId)
-            .then(md => {
-                let titleRegex = /^#\s*(.*)/g.exec(md);
-                if (!titleRegex || titleRegex.length < 1) return;
-                title = titleRegex[1].trim();
-
-                let steps = md.split(/^##[^#].*$/gmi);
-                for (let step = 1; step < steps.length; step++) {
-                    let stepmd = `##${steps[step]}`;
-                    result.push(stepmd);
-                }
-                //TODO: parse for tutorial options, mainly initial blocks
-            }).*/
     }
 
     exitTutorial(keep?: boolean) {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -26,14 +26,15 @@ export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
     }
 
     render() {
-        const { tutorialReady, tutorialSteps, tutorialStep, tutorialName } = this.props.parent.state.tutorialOptions;
+        const { tutorialReady, tutorialStepInfo, tutorialStep, tutorialName } = this.props.parent.state.tutorialOptions;
         const state = this.props.parent.state;
         const targetTheme = pxt.appTarget.appTheme;
         const currentStep = tutorialStep;
+        if (!tutorialReady) return <div />;
 
         return <div className="ui item">
             <div className="ui item tutorial-menuitem" role="menubar">
-                {tutorialSteps.map((step, index) =>
+                {tutorialStepInfo.map((step, index) =>
                     (index == currentStep) ?
                         <span className="step-label" key={'tutorialStep' + index}>
                             <a className={`ui circular label ${currentStep == index ? 'blue selected' : 'inverted'} ${!tutorialReady ? 'disabled' : ''}`} role="menuitem" aria-label={lf("Tutorial step {0}. This is the current step", index + 1)} tabIndex={0} onClick={() => this.openTutorialStep(index) } onKeyDown={sui.fireClickOnEnter}>{index + 1}</a>
@@ -216,13 +217,13 @@ export class TutorialCard extends data.Component<ISettingsProps, {}> {
 
     render() {
         const options = this.props.parent.state.tutorialOptions;
-        const { tutorialReady, tutorialStepInfo, tutorialStep, tutorialSteps } = options;
+        const { tutorialReady, tutorialStepInfo, tutorialStep } = options;
         if (!tutorialReady) return <div />
         const tutorialHeaderContent = tutorialStepInfo[tutorialStep].headerContent;
         let tutorialAriaLabel = tutorialStepInfo[tutorialStep].ariaLabel;
 
         const currentStep = tutorialStep;
-        const maxSteps = tutorialSteps.length;
+        const maxSteps = tutorialStepInfo.length;
         const hasPrevious = tutorialReady && currentStep != 0;
         const hasNext = tutorialReady && currentStep != maxSteps - 1;
         const hasFinish = currentStep == maxSteps - 1;


### PR DESCRIPTION
Workaround to not download the tutorial markdown for tutorial step lookahead, and use the values returned once the steps are rendered.