### PR TITLE
[Accessibility] Fixed hidden menu position on Chibitronics

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1681,8 +1681,6 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                         <a href={liveUrl}>{lf("Take me back") }</a>
                     </div>
                 </div> : undefined}
-                {useModulator ? <audio id="modulatorAudioOutput" controls></audio> : undefined}
-                {useModulator ? <div id="modulatorWrapper"><div id="modulatorBubble"><canvas id="modulatorWavStrip"></canvas></div></div> : undefined}
                 {hideMenuBar ? undefined :
                     <header id="menubar" role="banner" className={"ui menu"}>
                         <div id="accessibleMenu" role="menubar">
@@ -1753,6 +1751,8 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                             </div>
                         </div>
                     </header> }
+                {useModulator ? <audio id="modulatorAudioOutput" controls></audio> : undefined}
+                {useModulator ? <div id="modulatorWrapper"><div id="modulatorBubble"><canvas id="modulatorWavStrip"></canvas></div></div> : undefined}
                 {gettingStarted ?
                     <div id="getting-started-btn">
                         <sui.Button class="portrait hide bottom attached small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started")} onClick={() => this.gettingStarted()} />


### PR DESCRIPTION
Fixed an issue where the hidden menu was missed positioned in Chibitronics.

Related issue : [https://github.com/Microsoft/pxt-chibitronics/issues/67](https://github.com/Microsoft/pxt-chibitronics/issues/67)

![capture](https://user-images.githubusercontent.com/3747805/30297649-50284308-96fd-11e7-8ddc-6656b692e07b.PNG)

There was no CSS solution. Setting the display to none, visibility to hidden/collapse, position absolute and negative top were not fixing the issue. So I just moved the DOM and it fix the issue without creating marge somewhere else.