### PR TITLE
[Accessibility] Fixed the color contrast issue in the documentation

### DIFF
--- a/theme/_theme/theme.config
+++ b/theme/_theme/theme.config
@@ -43,7 +43,7 @@
 @form       : 'default';
 @grid       : 'pxt';
 @menu       : 'pxt';
-@message    : 'default';
+@message    : 'pxt';
 @table      : 'default';
 
 /* Modules */

--- a/theme/theme.config
+++ b/theme/theme.config
@@ -43,7 +43,7 @@
 @form       : 'default';
 @grid       : 'pxt';
 @menu       : 'pxt';
-@message    : 'default';
+@message    : 'pxt';
 @table      : 'default';
 
 /* Modules */

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -17,7 +17,7 @@
 @brown:#00BCF2;
 @grey:#505050;
 
-@greenTextColor: #107C10;
+@greenTextColor: darken(@green, 5);
 
 @lightTextColor              : rgba(0, 0, 0, 0.68);
 @invertedUnselectedTextColor : rgba(255, 255, 255, 0.8); 


### PR DESCRIPTION
Fixed an issue where the color contrast of the green text in the documentation was not correct.

Related issue : [https://github.com/Microsoft/pxt/issues/2528](https://github.com/Microsoft/pxt/issues/2528)
Related PR : [https://github.com/Microsoft/pxt-microbit/pull/536](https://github.com/Microsoft/pxt-microbit/pull/536), [https://github.com/Microsoft/pxt-sparkfun/pull/47](https://github.com/Microsoft/pxt-sparkfun/pull/47), [https://github.com/Microsoft/pxt-minecraft/pull/322](https://github.com/Microsoft/pxt-minecraft/pull/322), [https://github.com/Microsoft/pxt-adafruit/pull/323](https://github.com/Microsoft/pxt-adafruit/pull/323), [https://github.com/Microsoft/pxt-chibitronics/pull/68](https://github.com/Microsoft/pxt-chibitronics/pull/68)

For some reason, this issue was fixed by the past but has been reverted at a moment. I think it's when we moved some changes to PXT instead of PXT-microbit.

![untitled](https://user-images.githubusercontent.com/3747805/30338623-1b3ca55e-97a1-11e7-9458-dddea8f656f0.png)
