### PR TITLE
Hide search

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1430,6 +1430,14 @@ namespace pxt.blocks {
         }
     }
 
+    export function removeSearch() {
+        let blocklySearchArea = document.getElementById('blocklySearchArea') as HTMLInputElement;
+
+        if (blocklySearchArea) {
+            blocklySearchArea.parentNode.removeChild(blocklySearchArea);
+        }
+    }
+
     function categoryElement(tb: Element, nameid: string): Element {
         return tb ? getFirstChildWithAttr(tb, "category", "nameid", nameid.toLowerCase()) : undefined;
     }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -29,7 +29,7 @@ namespace pxt.editor {
     export interface IAppState {
         active?: boolean; // is this tab visible at all
         header?: pxt.workspace.Header;
-        filters?: pxt.editor.ProjectFilters;
+        editorState?: EditorState;
         currFile?: IFile;
         fileState?: string;
         showFiles?: boolean;
@@ -55,6 +55,11 @@ namespace pxt.editor {
 
         highContrast?: boolean;
         hideExperimentalBanner?: boolean;
+    }
+
+    export interface EditorState {
+        filters?: pxt.editor.ProjectFilters;
+        searchBar?: boolean; // show the search bar in editor
     }
 
     export interface ProjectCreationOptions {
@@ -112,7 +117,7 @@ namespace pxt.editor {
         saveFileAsync(): Promise<void>;
         loadHeaderAsync(h: pxt.workspace.Header): Promise<void>;
         reloadHeaderAsync(): Promise<void>;
-        importProjectAsync(prj: pxt.workspace.Project, filters?: pxt.editor.ProjectFilters): Promise<void>;
+        importProjectAsync(prj: pxt.workspace.Project, editorState?: pxt.editor.EditorState): Promise<void>;
         overrideTypescriptFile(text: string): void;
 
         exportAsync(): Promise<string>;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -109,6 +109,7 @@ namespace pxt.editor {
     export interface EditorSyncState {
         // (optional) filtering argument
         filters?: pxt.editor.ProjectFilters;
+        // (optional) show or hide the search bar
         searchBar?: boolean;
     }
 

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -109,6 +109,7 @@ namespace pxt.editor {
     export interface EditorSyncState {
         // (optional) filtering argument
         filters?: pxt.editor.ProjectFilters;
+        searchBar?: boolean;
     }
 
     export interface EditorWorkspaceSyncResponse extends EditorMessageResponse {
@@ -134,6 +135,7 @@ namespace pxt.editor {
         project: pxt.workspace.Project;
         // (optional) filtering argument
         filters?: pxt.editor.ProjectFilters;
+        searchBar?: boolean;
     }
 
     export interface EditorMessageRenderBlocksRequest extends EditorMessageRequest {
@@ -225,7 +227,10 @@ namespace pxt.editor {
                     }
                     case "importproject": {
                         const load = data as EditorMessageImportProjectRequest;
-                        p = p.then(() => projectView.importProjectAsync(load.project, load.filters));
+                        p = p.then(() => projectView.importProjectAsync(load.project, {
+                            filters: load.filters,
+                            searchBar: load.searchBar
+                        }));
                         break;
                     }
                     case "proxytosim": {

--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -49,7 +49,7 @@
         }
     }
     var lastSaved;
-    var filter = false;
+    var filter = true;
 
     function toggleFilters() {
         filter = !filter;
@@ -104,7 +104,8 @@
                 // no project
                 msg.projects = projects;
                 if (filter) msg.editor = {
-                    "filters": JSON.parse(JSON.stringify(filters))
+                    "filters": JSON.parse(JSON.stringify(filters)),
+                    "searchBar": false
                 }
                 editor.postMessage(msg, "*")
                 return;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -554,10 +554,10 @@ export class ProjectView
     }
 
     reloadHeaderAsync() {
-        return this.loadHeaderAsync(this.state.header, this.state.filters)
+        return this.loadHeaderAsync(this.state.header, this.state.editorState)
     }
 
-    loadHeaderAsync(h: pxt.workspace.Header, filters?: pxt.editor.ProjectFilters): Promise<void> {
+    loadHeaderAsync(h: pxt.workspace.Header, editorState?: pxt.editor.EditorState): Promise<void> {
         if (!h)
             return Promise.resolve()
 
@@ -567,7 +567,7 @@ export class ProjectView
         logs.clear();
         this.setState({
             showFiles: false,
-            filters: filters,
+            editorState: editorState,
             tutorialOptions: undefined
         })
         return pkg.loadPkgAsync(h.id)
@@ -601,7 +601,7 @@ export class ProjectView
                 }
 
                 pkg.getEditorPkg(pkg.mainPkg).onupdate = () => {
-                    this.loadHeaderAsync(h, this.state.filters).done()
+                    this.loadHeaderAsync(h, this.state.editorState).done()
                 }
 
                 pkg.mainPkg.getCompileOptionsAsync()
@@ -774,7 +774,7 @@ export class ProjectView
         }
     }
 
-    importProjectAsync(project: pxt.workspace.Project, filters?: pxt.editor.ProjectFilters): Promise<void> {
+    importProjectAsync(project: pxt.workspace.Project, editorState?: pxt.editor.EditorState): Promise<void> {
         let h: pxt.workspace.InstallHeader = project.header;
         if (!h) {
             h = {
@@ -787,7 +787,7 @@ export class ProjectView
             }
         }
         return workspace.installAsync(h, project.text)
-            .then(hd => this.loadHeaderAsync(hd, filters));
+            .then(hd => this.loadHeaderAsync(hd, editorState));
     }
 
     initDragAndDrop() {
@@ -882,7 +882,7 @@ export class ProjectView
             pubCurrent: false,
             target: pxt.appTarget.id,
             temporary: options.temporary
-        }, files).then(hd => this.loadHeaderAsync(hd, options.filters))
+        }, files).then(hd => this.loadHeaderAsync(hd, {filters: options.filters}))
     }
 
     switchTypeScript() {
@@ -1478,7 +1478,6 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
     }
 
     openTutorials() {
-//        this.setState({tutorialOptions: undefined});
         pxt.tickEvent("menu.openTutorials");
         this.projects.showOpenTutorials();
     }
@@ -1518,7 +1517,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                     tutorialStep: 0,
                     tutorialSteps: result
                 };
-                this.setState({ tutorialOptions: tutorialOptions, tracing: undefined })
+                this.setState({ tutorialOptions: tutorialOptions, editorState: {searchBar: false}, tracing: undefined })
 
                 let tc = this.refs["tutorialcontent"] as tutorial.TutorialContent;
                 tc.setPath(tutorialId);
@@ -1545,7 +1544,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         } else {
             curr.temporary = false;
         }
-        this.setState({ active: false, filters: undefined });
+        this.setState({ active: false, editorState: undefined });
         return workspace.saveAsync(curr, {})
             .then(() => { return keep ? workspace.installAsync(curr, files) : Promise.resolve(null); })
             .then(() => {
@@ -2272,7 +2271,7 @@ $(document).ready(() => {
         })
         .then((state) => {
             if (state) {
-                theEditor.setState(state);
+                theEditor.setState({editorState: state});
             }
             initSerial();
             initScreenshots();
@@ -2302,7 +2301,7 @@ $(document).ready(() => {
             }
 
             // default handlers
-            if (hd) return theEditor.loadHeaderAsync(hd, theEditor.state.filters)
+            if (hd) return theEditor.loadHeaderAsync(hd, theEditor.state.editorState)
             else theEditor.newProject();
             return Promise.resolve();
         })

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -32,6 +32,7 @@ export class Editor extends srceditor.Editor {
     showToolboxCategories: CategoryMode = CategoryMode.Basic;
     cachedToolbox: string;
     filters: pxt.editor.ProjectFilters;
+    showSearch: boolean;
 
     setVisible(v: boolean) {
         super.setVisible(v);
@@ -82,7 +83,7 @@ export class Editor extends srceditor.Editor {
                 .finally(() => { this.loadingXml = false })
                 .then(bi => {
                     this.blockInfo = bi;
-                    let showSearch = true;
+                    let showSearch = this.showSearch;
                     let toolbox = this.getDefaultToolbox(this.showToolboxCategories);
 
                     // Search needs a toolbox with ALL blocks
@@ -98,6 +99,8 @@ export class Editor extends srceditor.Editor {
                             searchFor => compiler.apiSearchAsync(searchFor)
                                 .then((fns: pxtc.service.SearchInfo[]) => fns),
                             searchTb => this.updateToolbox(searchTb, this.showToolboxCategories, true));
+                    } else {
+                        pxt.blocks.removeSearch();
                     }
                     pxt.blocks.initFlyouts(this.editor);
 
@@ -555,10 +558,15 @@ export class Editor extends srceditor.Editor {
         if (this.currFile && this.currFile != file) {
             this.filterToolbox(null);
         }
-        if (this.parent.state.filters) {
-            this.filterToolbox(this.parent.state.filters);
+        if (this.parent.state.editorState && this.parent.state.editorState.filters) {
+            this.filterToolbox(this.parent.state.editorState.filters);
         } else {
             this.filters = null;
+        }
+        if (this.parent.state.editorState && this.parent.state.editorState.searchBar != undefined) {
+            this.showSearch = this.parent.state.editorState.searchBar;
+        } else {
+            this.showSearch = true;
         }
         this.currFile = file;
         // Clear the search field if a value exists

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -691,7 +691,7 @@ export class Editor extends srceditor.Editor {
         groups?: string[],
         labelLineWidth?: string) {
         // Filter the toolbox
-        let filters = this.parent.state.filters;
+        let filters = this.parent.state.editorState ? this.parent.state.editorState.filters : undefined;
         const categoryState = filters ? (filters.namespaces && filters.namespaces[ns] != undefined ? filters.namespaces[ns] : filters.defaultState) : undefined;
         let hasChild = false;
         if (filters && categoryState !== undefined && fns) {


### PR DESCRIPTION
Option to hide searcher on workspaceSync. Also, hiding search in all tutorials. 

Refactoring editorSyncState to only allow workspaceSync to manipulate the editorState and not the entire appState on sync.