### PR TITLE
Fixed an issue where the focus was moving to some hidden link showing

### DIFF
--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -112,6 +112,14 @@
     </div>
 </aside>
 
+<aside id=top-dropdown-noheading class=toc>
+    <div class="item" title="@TITLE@">
+        <div class="menu">
+            @ITEMS@
+        </div>
+    </div>
+</aside>
+
 <aside id=inner-dropdown class=toc>
     <div class="ui inverted accordion item visible" role="tree" title="@TITLE@">
         <div class="@ACTIVE@ title">

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -211,8 +211,13 @@ namespace pxt.docs {
                 mparams["EXPANDED"] = 'false';
             }
             if (m.subitems && m.subitems.length > 0) {
-                if (lev == 0) templ = toc["top-dropdown"]
-                else if (lev == 1) templ = toc["inner-dropdown"]
+                if (lev == 0) { 
+                    if (m.name !== "") { 
+                        templ = toc["top-dropdown"] 
+                    } else { 
+                        templ = toc["top-dropdown-noHeading"] 
+                    } 
+                } else if (lev == 1) templ = toc["inner-dropdown"]
                 else templ = toc["nested-dropdown"]
                 mparams["ITEMS"] = m.subitems.map(e => recTOC(e, lev + 1)).join("\n")
             } else {


### PR DESCRIPTION
Fixed an issue where the focus was moving to some hidden link showing on left panel on documentation page.

Version for V0 : [https://github.com/Microsoft/pxt/pull/2923](https://github.com/Microsoft/pxt/pull/2923)

Related issue : [https://github.com/Microsoft/pxt/issues/2795](https://github.com/Microsoft/pxt/issues/2795)

![capture](https://user-images.githubusercontent.com/3747805/30341684-d428915e-97ab-11e7-9e78-0371da48d6ce.PNG)

I managed to support those special cases where there is no link for the header of a menu, but that the markdown parser was still generating a href tag.

![capture](https://user-images.githubusercontent.com/3747805/30341741-002c4156-97ac-11e7-8011-61925431cbb8.PNG)