### PR TITLE
Add an option to move APIs after on start

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1471,15 +1471,28 @@ namespace pxt.blocks {
         return tdASTtoTS(e, compiled);
     }
 
+    function eventWeight(b: B.Block, e: Environment) {
+        if (b.type === ts.pxtc.ON_START_TYPE) {
+            return 0;
+        }
+        const api = e.stdCallTable[b.type];
+        if (api && api.attrs.afterOnStart) {
+            return 1;
+        }
+        else {
+            return -1;
+        }
+    }
+
     function compileWorkspace(e: Environment, w: B.Workspace, blockInfo: pxtc.BlocksInfo): JsNode[] {
         try {
             infer(e, w);
 
             const stmtsMain: JsNode[] = [];
 
-            // all compiled top level blocks are event, move on start to bottom
+            // all compiled top level blocks are events
             const topblocks = w.getTopBlocks(true).sort((a, b) => {
-                return (a.type == ts.pxtc.ON_START_TYPE ? 1 : 0) - (b.type == ts.pxtc.ON_START_TYPE ? 1 : 0);
+                return eventWeight(a, e) - eventWeight(b, e)
             });
 
             updateDisabledBlocks(e, w.getAllBlocks(), topblocks);

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -135,6 +135,7 @@ namespace ts.pxtc {
         groups?: string[];
         labelLineWidth?: string;
         handlerStatement?: boolean; // indicates a block with a callback that can be used as a statement
+        afterOnStart?: boolean; // indicates an event that should be compiled after on start when converting to typescript
 
         // on interfaces
         indexerGet?: string;
@@ -356,7 +357,7 @@ namespace ts.pxtc {
     }
 
     const numberAttributes = ["weight", "imageLiteral"]
-    const booleanAttributes = ["advanced", "handlerStatement"]
+    const booleanAttributes = ["advanced", "handlerStatement", "afterOnStart"]
 
     export function parseCommentString(cmt: string): CommentAttrs {
         let res: CommentAttrs = {


### PR DESCRIPTION
The fix discussed in https://github.com/Microsoft/pxt/issues/2385

Needs to be moved to V0 as well.