### PR TITLE
Fix crowdin early bailout issue

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3495,6 +3495,9 @@ function internalUploadTargetTranslationsAsync(uploadDocs: boolean) {
 function uploadDocsTranslationsAsync(srcDir: string, crowdinDir: string, branch: string, prj: string, key: string): Promise<void> {
     pxt.log(`uploading from ${srcDir} to ${crowdinDir} under project ${prj}/${branch || ""}`)
 
+    let ignoredDirectories: Map<boolean> = {};
+    nodeutil.allFiles(srcDir).filter(d => nodeutil.fileExistsSync(path.join(path.dirname(d), ".crowdinignore"))).forEach(f => ignoredDirectories[path.dirname(f)] = true);
+    const ignoredDirectoriesList = Object.keys(ignoredDirectories);
     const todo = nodeutil.allFiles(srcDir).filter(f => /\.md$/.test(f) && !/_locales/.test(f)).reverse();
     const knownFolders: Map<boolean> = {};
     const ensureFolderAsync = (crowdd: string) => {
@@ -3509,10 +3512,10 @@ function uploadDocsTranslationsAsync(srcDir: string, crowdinDir: string, branch:
         if (!f) return Promise.resolve();
         const crowdf = path.join(crowdinDir, f);
         const crowdd = path.dirname(crowdf);
-        // check if directory has a .crowdinignore file
-        if (nodeutil.fileExistsSync(path.join(path.dirname(f), ".crowdinignore"))) {
+        // check if file should be ignored
+        if (ignoredDirectoriesList.filter(d => path.dirname(f).indexOf(d) == 0).length > 0) {
             pxt.log(`skpping ${f} because of .crowdinignore file`)
-            return Promise.resolve();
+            return nextFileAsync(todo.pop());
         }
 
         const data = fs.readFileSync(f, 'utf8');


### PR DESCRIPTION
Fix crowdin early bailout issue that skips the all folders after seeing a crowdinignore file

I now do a pass and search for the crowdinignore file keeping a list of ignored directories, and checking the directory of the file against those directory.

```
Using target PXT/microbit with build engine yotta
  Target dir:   /Users/sam/pxt-microbit
  PXT Core dir: /Users/sam/pxt
upload microbit/target-strings.json (11 strings) to https://crowdin.com/project/kindscript
upload microbit/sim-strings.json (0 strings) to https://crowdin.com/project/kindscript
uploading 8 files to crowdin
uploading libs/bluetooth/_locales/bluetooth-strings.json to microbit/bluetooth-strings.json
uploading libs/bluetooth/_locales/bluetooth-jsdoc-strings.json to microbit/bluetooth-jsdoc-strings.json
uploading libs/devices/_locales/devices-strings.json to microbit/devices-strings.json
uploading libs/devices/_locales/devices-jsdoc-strings.json to microbit/devices-jsdoc-strings.json
uploading libs/radio/_locales/radio-strings.json to microbit/radio-strings.json
uploading libs/radio/_locales/radio-jsdoc-strings.json to microbit/radio-jsdoc-strings.json
uploading libs/core/_locales/core-strings.json to microbit/core-strings.json
uploading libs/core/_locales/core-jsdoc-strings.json to microbit/core-jsdoc-strings.json
uploading from docs to microbit under project kindscript/
creating folder microbit/docs
uploading docs/SUMMARY.md to microbit/docs/SUMMARY.md
uploading docs/about.md to microbit/docs/about.md
uploading docs/blocks/logic/boolean.md to microbit/docs/blocks/logic/boolean.md
creating folder microbit/docs/blocks/logic
uploading docs/blocks/logic/if.md to microbit/docs/blocks/logic/if.md
uploading docs/blocks/loops/for.md to microbit/docs/blocks/loops/for.md
creating folder microbit/docs/blocks/loops
uploading docs/blocks/loops/while.md to microbit/docs/blocks/loops/while.md
uploading docs/blocks/loops.md to microbit/docs/blocks/loops.md
creating folder microbit/docs/blocks
uploading docs/blocks/math/random-boolean.md to microbit/docs/blocks/math/random-boolean.md
creating folder microbit/docs/blocks/math
uploading docs/blocks/on-start.md to microbit/docs/blocks/on-start.md
uploading docs/blocks/variables/assign.md to microbit/docs/blocks/variables/assign.md
creating folder microbit/docs/blocks/variables
uploading docs/blocks/variables/change.md to microbit/docs/blocks/variables/change.md
uploading docs/blocks/variables/var.md to microbit/docs/blocks/variables/var.md
uploading docs/courses/csintro/SUMMARY.md to microbit/docs/courses/csintro/SUMMARY.md
creating folder microbit/docs/courses/csintro
uploading docs/courses/csintro/about.md to microbit/docs/courses/csintro/about.md
uploading docs/courses/csintro/acknowledgements.md to microbit/docs/courses/csintro/acknowledgements.md
uploading docs/courses/csintro/algorithms/activity.md to microbit/docs/courses/csintro/algorithms/activity.md
creating folder microbit/docs/courses/csintro/algorithms
uploading docs/courses/csintro/algorithms/overview.md to microbit/docs/courses/csintro/algorithms/overview.md
uploading docs/courses/csintro/algorithms/project.md to microbit/docs/courses/csintro/algorithms/project.md
uploading docs/courses/csintro/algorithms/standards.md to microbit/docs/courses/csintro/algorithms/standards.md
uploading docs/courses/csintro/algorithms/unplugged.md to microbit/docs/courses/csintro/algorithms/unplugged.md
uploading docs/courses/csintro/algorithms.md to microbit/docs/courses/csintro/algorithms.md
uploading docs/courses/csintro/arrays/activity.md to microbit/docs/courses/csintro/arrays/activity.md
creating folder microbit/docs/courses/csintro/arrays
uploading docs/courses/csintro/arrays/overview.md to microbit/docs/courses/csintro/arrays/overview.md
uploading docs/courses/csintro/arrays/project.md to microbit/docs/courses/csintro/arrays/project.md
uploading docs/courses/csintro/arrays/standards.md to microbit/docs/courses/csintro/arrays/standards.md
uploading docs/courses/csintro/arrays/unplugged.md to microbit/docs/courses/csintro/arrays/unplugged.md
uploading docs/courses/csintro/arrays.md to microbit/docs/courses/csintro/arrays.md
uploading docs/courses/csintro/binary/activity.md to microbit/docs/courses/csintro/binary/activity.md
creating folder microbit/docs/courses/csintro/binary
uploading docs/courses/csintro/binary/overview.md to microbit/docs/courses/csintro/binary/overview.md
uploading docs/courses/csintro/binary/project.md to microbit/docs/courses/csintro/binary/project.md
uploading docs/courses/csintro/binary/standards.md to microbit/docs/courses/csintro/binary/standards.md
uploading docs/courses/csintro/binary/unplugged.md to microbit/docs/courses/csintro/binary/unplugged.md
uploading docs/courses/csintro/binary.md to microbit/docs/courses/csintro/binary.md
uploading docs/courses/csintro/booleans/activity.md to microbit/docs/courses/csintro/booleans/activity.md
creating folder microbit/docs/courses/csintro/booleans
uploading docs/courses/csintro/booleans/overview.md to microbit/docs/courses/csintro/booleans/overview.md
uploading docs/courses/csintro/booleans/project.md to microbit/docs/courses/csintro/booleans/project.md
uploading docs/courses/csintro/booleans/standards.md to microbit/docs/courses/csintro/booleans/standards.md
uploading docs/courses/csintro/booleans/unplugged.md to microbit/docs/courses/csintro/booleans/unplugged.md
uploading docs/courses/csintro/booleans.md to microbit/docs/courses/csintro/booleans.md
uploading docs/courses/csintro/conditionals/activity.md to microbit/docs/courses/csintro/conditionals/activity.md
creating folder microbit/docs/courses/csintro/conditionals
uploading docs/courses/csintro/conditionals/overview.md to microbit/docs/courses/csintro/conditionals/overview.md
uploading docs/courses/csintro/conditionals/project.md to microbit/docs/courses/csintro/conditionals/project.md
uploading docs/courses/csintro/conditionals/standards.md to microbit/docs/courses/csintro/conditionals/standards.md
uploading docs/courses/csintro/conditionals/unplugged.md to microbit/docs/courses/csintro/conditionals/unplugged.md
uploading docs/courses/csintro/conditionals.md to microbit/docs/courses/csintro/conditionals.md
uploading docs/courses/csintro/coordinates/activity.md to microbit/docs/courses/csintro/coordinates/activity.md
creating folder microbit/docs/courses/csintro/coordinates
uploading docs/courses/csintro/coordinates/overview.md to microbit/docs/courses/csintro/coordinates/overview.md
uploading docs/courses/csintro/coordinates/project.md to microbit/docs/courses/csintro/coordinates/project.md
uploading docs/courses/csintro/coordinates/standards.md to microbit/docs/courses/csintro/coordinates/standards.md
uploading docs/courses/csintro/coordinates/unplugged.md to microbit/docs/courses/csintro/coordinates/unplugged.md
uploading docs/courses/csintro/coordinates.md to microbit/docs/courses/csintro/coordinates.md
uploading docs/courses/csintro/finalproject/examples.md to microbit/docs/courses/csintro/finalproject/examples.md
creating folder microbit/docs/courses/csintro/finalproject
uploading docs/courses/csintro/finalproject/project.md to microbit/docs/courses/csintro/finalproject/project.md
uploading docs/courses/csintro/finalproject/review.md to microbit/docs/courses/csintro/finalproject/review.md
uploading docs/courses/csintro/finalproject/standards.md to microbit/docs/courses/csintro/finalproject/standards.md
uploading docs/courses/csintro/finalproject.md to microbit/docs/courses/csintro/finalproject.md
uploading docs/courses/csintro/introduction.md to microbit/docs/courses/csintro/introduction.md
uploading docs/courses/csintro/iteration/activity.md to microbit/docs/courses/csintro/iteration/activity.md
creating folder microbit/docs/courses/csintro/iteration
uploading docs/courses/csintro/iteration/overview.md to microbit/docs/courses/csintro/iteration/overview.md
uploading docs/courses/csintro/iteration/project.md to microbit/docs/courses/csintro/iteration/project.md
uploading docs/courses/csintro/iteration/standards.md to microbit/docs/courses/csintro/iteration/standards.md
uploading docs/courses/csintro/iteration/unplugged.md to microbit/docs/courses/csintro/iteration/unplugged.md
uploading docs/courses/csintro/iteration.md to microbit/docs/courses/csintro/iteration.md
uploading docs/courses/csintro/making/activity.md to microbit/docs/courses/csintro/making/activity.md
creating folder microbit/docs/courses/csintro/making
uploading docs/courses/csintro/making/introduction.md to microbit/docs/courses/csintro/making/introduction.md
uploading docs/courses/csintro/making/project.md to microbit/docs/courses/csintro/making/project.md
uploading docs/courses/csintro/making/standards.md to microbit/docs/courses/csintro/making/standards.md
uploading docs/courses/csintro/making/unplugged.md to microbit/docs/courses/csintro/making/unplugged.md
uploading docs/courses/csintro/making.md to microbit/docs/courses/csintro/making.md
uploading docs/courses/csintro/miniproject/activity.md to microbit/docs/courses/csintro/miniproject/activity.md
creating folder microbit/docs/courses/csintro/miniproject
uploading docs/courses/csintro/miniproject/project.md to microbit/docs/courses/csintro/miniproject/project.md
uploading docs/courses/csintro/miniproject/review.md to microbit/docs/courses/csintro/miniproject/review.md
uploading docs/courses/csintro/miniproject/standards.md to microbit/docs/courses/csintro/miniproject/standards.md
uploading docs/courses/csintro/miniproject.md to microbit/docs/courses/csintro/miniproject.md
uploading docs/courses/csintro/radio/activity.md to microbit/docs/courses/csintro/radio/activity.md
creating folder microbit/docs/courses/csintro/radio
uploading docs/courses/csintro/radio/overview.md to microbit/docs/courses/csintro/radio/overview.md
uploading docs/courses/csintro/radio/project.md to microbit/docs/courses/csintro/radio/project.md
uploading docs/courses/csintro/radio/standards.md to microbit/docs/courses/csintro/radio/standards.md
uploading docs/courses/csintro/radio/unplugged.md to microbit/docs/courses/csintro/radio/unplugged.md
uploading docs/courses/csintro/radio.md to microbit/docs/courses/csintro/radio.md
uploading docs/courses/csintro/references.md to microbit/docs/courses/csintro/references.md
uploading docs/courses/csintro/variables/activity.md to microbit/docs/courses/csintro/variables/activity.md
creating folder microbit/docs/courses/csintro/variables
uploading docs/courses/csintro/variables/overview.md to microbit/docs/courses/csintro/variables/overview.md
uploading docs/courses/csintro/variables/project.md to microbit/docs/courses/csintro/variables/project.md
uploading docs/courses/csintro/variables/standards.md to microbit/docs/courses/csintro/variables/standards.md
uploading docs/courses/csintro/variables/unplugged.md to microbit/docs/courses/csintro/variables/unplugged.md
uploading docs/courses/csintro/variables.md to microbit/docs/courses/csintro/variables.md
uploading docs/courses/csintro.md to microbit/docs/courses/csintro.md
creating folder microbit/docs/courses
uploading docs/courses.md to microbit/docs/courses.md
uploading docs/device/crocodile-clips.md to microbit/docs/device/crocodile-clips.md
creating folder microbit/docs/device
uploading docs/device/error-codes.md to microbit/docs/device/error-codes.md
uploading docs/device/foil-circuits.md to microbit/docs/device/foil-circuits.md
uploading docs/device/mes-events.md to microbit/docs/device/mes-events.md
uploading docs/device/pins.md to microbit/docs/device/pins.md
uploading docs/device/reactive.md to microbit/docs/device/reactive.md
uploading docs/device/screen.md to microbit/docs/device/screen.md
uploading docs/device/serial.md to microbit/docs/device/serial.md
uploading docs/device/servo.md to microbit/docs/device/servo.md
uploading docs/device/simulator.md to microbit/docs/device/simulator.md
uploading docs/device/usb/mac-chrome.md to microbit/docs/device/usb/mac-chrome.md
creating folder microbit/docs/device/usb
uploading docs/device/usb/mac-firefox.md to microbit/docs/device/usb/mac-firefox.md
uploading docs/device/usb/mac-safari.md to microbit/docs/device/usb/mac-safari.md
uploading docs/device/usb/troubleshooting.md to microbit/docs/device/usb/troubleshooting.md
uploading docs/device/usb/windows-chrome.md to microbit/docs/device/usb/windows-chrome.md
uploading docs/device/usb/windows-edge.md to microbit/docs/device/usb/windows-edge.md
uploading docs/device/usb/windows-firefox.md to microbit/docs/device/usb/windows-firefox.md
uploading docs/device/usb/windows-ie.md to microbit/docs/device/usb/windows-ie.md
uploading docs/device/usb.md to microbit/docs/device/usb.md
uploading docs/device.md to microbit/docs/device.md
uploading docs/docs.md to microbit/docs/docs.md
uploading docs/examples/blinky.md to microbit/docs/examples/blinky.md
creating folder microbit/docs/examples
uploading docs/examples/eddystone-beacon.md to microbit/docs/examples/eddystone-beacon.md
uploading docs/examples/egg-and-spoon.md to microbit/docs/examples/egg-and-spoon.md
uploading docs/examples/gameofLife.md to microbit/docs/examples/gameofLife.md
uploading docs/examples/name-tag.md to microbit/docs/examples/name-tag.md
uploading docs/examples/plot-acceleration.md to microbit/docs/examples/plot-acceleration.md
uploading docs/examples/plot-analog-pin.md to microbit/docs/examples/plot-analog-pin.md
uploading docs/examples/plot-light-level.md to microbit/docs/examples/plot-light-level.md
uploading docs/examples/radio-dashboard.md to microbit/docs/examples/radio-dashboard.md
uploading docs/examples/rando.md to microbit/docs/examples/rando.md
uploading docs/examples/servo-calibrator.md to microbit/docs/examples/servo-calibrator.md
uploading docs/examples/stop-watch.md to microbit/docs/examples/stop-watch.md
uploading docs/examples.md to microbit/docs/examples.md
uploading docs/fcp/ch1.md to microbit/docs/fcp/ch1.md
creating folder microbit/docs/fcp
uploading docs/fcp.md to microbit/docs/fcp.md
skpping docs/lessons/answering-machine/activity.md because of .crowdinignore file
skpping docs/lessons/answering-machine/challenges.md because of .crowdinignore file
skpping docs/lessons/answering-machine/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/answering-machine/quiz.md because of .crowdinignore file
skpping docs/lessons/answering-machine.md because of .crowdinignore file
skpping docs/lessons/beautiful-image/activity.md because of .crowdinignore file
skpping docs/lessons/beautiful-image/challenges.md because of .crowdinignore file
skpping docs/lessons/beautiful-image/tutorial.md because of .crowdinignore file
skpping docs/lessons/beautiful-image.md because of .crowdinignore file
skpping docs/lessons/blink/activity.md because of .crowdinignore file
skpping docs/lessons/blink/challenges.md because of .crowdinignore file
skpping docs/lessons/blink/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/blink/quiz.md because of .crowdinignore file
skpping docs/lessons/blink.md because of .crowdinignore file
skpping docs/lessons/blocks-conditions.md because of .crowdinignore file
skpping docs/lessons/bop-it/activity.md because of .crowdinignore file
skpping docs/lessons/bop-it/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/bop-it/quiz.md because of .crowdinignore file
skpping docs/lessons/catch-the-egg-game/activity.md because of .crowdinignore file
skpping docs/lessons/catch-the-egg-game/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/catch-the-egg-game/quiz.md because of .crowdinignore file
skpping docs/lessons/catch-the-egg-game/tutorial.md because of .crowdinignore file
skpping docs/lessons/catch-the-egg-game.md because of .crowdinignore file
skpping docs/lessons/charting/activity.md because of .crowdinignore file
skpping docs/lessons/charting/challenge.md because of .crowdinignore file
skpping docs/lessons/charting/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/charting/quiz.md because of .crowdinignore file
skpping docs/lessons/charting.md because of .crowdinignore file
skpping docs/lessons/classic-beatbox/activity.md because of .crowdinignore file
skpping docs/lessons/classic-beatbox/challenges.md because of .crowdinignore file
skpping docs/lessons/classic-beatbox.md because of .crowdinignore file
skpping docs/lessons/compass/activity.md because of .crowdinignore file
skpping docs/lessons/compass/challenges.md because of .crowdinignore file
skpping docs/lessons/compass/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/compass/quiz.md because of .crowdinignore file
skpping docs/lessons/compass.md because of .crowdinignore file
skpping docs/lessons/counter/activity.md because of .crowdinignore file
skpping docs/lessons/counter/challenges.md because of .crowdinignore file
skpping docs/lessons/counter/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/counter/quiz.md because of .crowdinignore file
skpping docs/lessons/counter.md because of .crowdinignore file
skpping docs/lessons/dice-roll/activity.md because of .crowdinignore file
skpping docs/lessons/dice-roll/challenges.md because of .crowdinignore file
skpping docs/lessons/dice-roll/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/dice-roll/quiz.md because of .crowdinignore file
skpping docs/lessons/dice-roll.md because of .crowdinignore file
skpping docs/lessons/digi-yoyo/activity.md because of .crowdinignore file
skpping docs/lessons/digi-yoyo/challenges.md because of .crowdinignore file
skpping docs/lessons/digi-yoyo/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/digi-yoyo/quiz.md because of .crowdinignore file
skpping docs/lessons/digi-yoyo.md because of .crowdinignore file
skpping docs/lessons/flashing-heart/activity.md because of .crowdinignore file
skpping docs/lessons/flashing-heart/challenges.md because of .crowdinignore file
skpping docs/lessons/flashing-heart/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/flashing-heart/quiz.md because of .crowdinignore file
skpping docs/lessons/flashing-heart.md because of .crowdinignore file
skpping docs/lessons/game-counter/activity.md because of .crowdinignore file
skpping docs/lessons/game-counter/challenges.md because of .crowdinignore file
skpping docs/lessons/game-counter.md because of .crowdinignore file
skpping docs/lessons/game-of-chance/activity.md because of .crowdinignore file
skpping docs/lessons/game-of-chance/challenges.md because of .crowdinignore file
skpping docs/lessons/game-of-chance.md because of .crowdinignore file
skpping docs/lessons/glowing-pendulum/activity.md because of .crowdinignore file
skpping docs/lessons/glowing-pendulum/challenges.md because of .crowdinignore file
skpping docs/lessons/glowing-pendulum/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/glowing-pendulum/quiz.md because of .crowdinignore file
skpping docs/lessons/glowing-pendulum/tutorial.md because of .crowdinignore file
skpping docs/lessons/glowing-pendulum.md because of .crowdinignore file
skpping docs/lessons/graphics.md because of .crowdinignore file
skpping docs/lessons/guess-the-number/activity.md because of .crowdinignore file
skpping docs/lessons/guess-the-number/challenges.md because of .crowdinignore file
skpping docs/lessons/guess-the-number/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/guess-the-number/quiz.md because of .crowdinignore file
skpping docs/lessons/guess-the-number/tutorial.md because of .crowdinignore file
skpping docs/lessons/guess-the-number.md because of .crowdinignore file
skpping docs/lessons/happy-birthday/activity.md because of .crowdinignore file
skpping docs/lessons/happy-birthday/challenges.md because of .crowdinignore file
skpping docs/lessons/happy-birthday.md because of .crowdinignore file
skpping docs/lessons/headbands/activity.md because of .crowdinignore file
skpping docs/lessons/headbands/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/headbands/quiz.md because of .crowdinignore file
skpping docs/lessons/headbands.md because of .crowdinignore file
skpping docs/lessons/hero/activity.md because of .crowdinignore file
skpping docs/lessons/hero.md because of .crowdinignore file
skpping docs/lessons/looper/activity.md because of .crowdinignore file
skpping docs/lessons/looper/challenges.md because of .crowdinignore file
skpping docs/lessons/looper/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/looper/quiz.md because of .crowdinignore file
skpping docs/lessons/looper.md because of .crowdinignore file
skpping docs/lessons/love-meter/activity.md because of .crowdinignore file
skpping docs/lessons/love-meter/challenges.md because of .crowdinignore file
skpping docs/lessons/love-meter/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/love-meter/quiz.md because of .crowdinignore file
skpping docs/lessons/love-meter.md because of .crowdinignore file
skpping docs/lessons/lucky-7/activity.md because of .crowdinignore file
skpping docs/lessons/lucky-7/challenges.md because of .crowdinignore file
skpping docs/lessons/lucky-7/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/lucky-7/quiz.md because of .crowdinignore file
skpping docs/lessons/lucky-7/tutorial.md because of .crowdinignore file
skpping docs/lessons/lucky-7.md because of .crowdinignore file
skpping docs/lessons/magic-8/activity.md because of .crowdinignore file
skpping docs/lessons/magic-8/challenges.md because of .crowdinignore file
skpping docs/lessons/magic-8/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/magic-8/quiz.md because of .crowdinignore file
skpping docs/lessons/magic-8/tutorial.md because of .crowdinignore file
skpping docs/lessons/magic-8.md because of .crowdinignore file
skpping docs/lessons/magic-logo/activity.md because of .crowdinignore file
skpping docs/lessons/magic-logo/challenges.md because of .crowdinignore file
skpping docs/lessons/magic-logo/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/magic-logo/quiz.md because of .crowdinignore file
skpping docs/lessons/magic-logo.md because of .crowdinignore file
skpping docs/lessons/night-light/activity.md because of .crowdinignore file
skpping docs/lessons/night-light/challenges.md because of .crowdinignore file
skpping docs/lessons/night-light/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/night-light/quiz.md because of .crowdinignore file
skpping docs/lessons/night-light.md because of .crowdinignore file
skpping docs/lessons/pogo/activity.md because of .crowdinignore file
skpping docs/lessons/pogo.md because of .crowdinignore file
skpping docs/lessons/prank-wifi/activity.md because of .crowdinignore file
skpping docs/lessons/prank-wifi/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/prank-wifi/quiz.md because of .crowdinignore file
skpping docs/lessons/prank-wifi.md because of .crowdinignore file
skpping docs/lessons/rotation-animation/activity.md because of .crowdinignore file
skpping docs/lessons/rotation-animation/challenges.md because of .crowdinignore file
skpping docs/lessons/rotation-animation/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/rotation-animation/quiz.md because of .crowdinignore file
skpping docs/lessons/rotation-animation.md because of .crowdinignore file
skpping docs/lessons/screen-wipe/activity.md because of .crowdinignore file
skpping docs/lessons/screen-wipe/challenges.md because of .crowdinignore file
skpping docs/lessons/screen-wipe/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/screen-wipe/quiz.md because of .crowdinignore file
skpping docs/lessons/screen-wipe.md because of .crowdinignore file
skpping docs/lessons/seismograph/activity.md because of .crowdinignore file
skpping docs/lessons/seismograph/challenge.md because of .crowdinignore file
skpping docs/lessons/seismograph.md because of .crowdinignore file
skpping docs/lessons/smiley/activity.md because of .crowdinignore file
skpping docs/lessons/smiley/challenges.md because of .crowdinignore file
skpping docs/lessons/smiley/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/smiley/quiz.md because of .crowdinignore file
skpping docs/lessons/smiley.md because of .crowdinignore file
skpping docs/lessons/snowflake-fall/activity.md because of .crowdinignore file
skpping docs/lessons/snowflake-fall/challenges.md because of .crowdinignore file
skpping docs/lessons/snowflake-fall/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/snowflake-fall/quiz.md because of .crowdinignore file
skpping docs/lessons/snowflake-fall.md because of .crowdinignore file
skpping docs/lessons/speed-button/activity.md because of .crowdinignore file
skpping docs/lessons/speed-button/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/speed-button/quiz.md because of .crowdinignore file
skpping docs/lessons/speed-button.md because of .crowdinignore file
skpping docs/lessons/spinner/activity.md because of .crowdinignore file
skpping docs/lessons/spinner/challenges.md because of .crowdinignore file
skpping docs/lessons/spinner/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/spinner/quiz.md because of .crowdinignore file
skpping docs/lessons/spinner.md because of .crowdinignore file
skpping docs/lessons/stem.md because of .crowdinignore file
skpping docs/lessons/strobe-light/activity.md because of .crowdinignore file
skpping docs/lessons/strobe-light/challenges.md because of .crowdinignore file
skpping docs/lessons/strobe-light/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/strobe-light/quiz.md because of .crowdinignore file
skpping docs/lessons/strobe-light.md because of .crowdinignore file
skpping docs/lessons/teach.md because of .crowdinignore file
skpping docs/lessons/temperature/activity.md because of .crowdinignore file
skpping docs/lessons/temperature/challenges.md because of .crowdinignore file
skpping docs/lessons/temperature.md because of .crowdinignore file
skpping docs/lessons/truth-or-dare/activity.md because of .crowdinignore file
skpping docs/lessons/truth-or-dare/challenges.md because of .crowdinignore file
skpping docs/lessons/truth-or-dare/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/truth-or-dare/quiz.md because of .crowdinignore file
skpping docs/lessons/truth-or-dare/tutorial.md because of .crowdinignore file
skpping docs/lessons/truth-or-dare.md because of .crowdinignore file
skpping docs/lessons/variables.md because of .crowdinignore file
skpping docs/lessons/zoomer/activity.md because of .crowdinignore file
skpping docs/lessons/zoomer/challenges.md because of .crowdinignore file
skpping docs/lessons/zoomer/quiz-answers.md because of .crowdinignore file
skpping docs/lessons/zoomer/quiz.md because of .crowdinignore file
skpping docs/lessons/zoomer.md because of .crowdinignore file
uploading docs/lessons.md to microbit/docs/lessons.md
uploading docs/open-source.md to microbit/docs/open-source.md
uploading docs/packages/approval.md to microbit/docs/packages/approval.md
creating folder microbit/docs/packages
uploading docs/packages.md to microbit/docs/packages.md
uploading docs/projects/atronix-jam.md to microbit/docs/projects/atronix-jam.md
creating folder microbit/docs/projects
uploading docs/projects/banana-keyboard/code.md to microbit/docs/projects/banana-keyboard/code.md
creating folder microbit/docs/projects/banana-keyboard
uploading docs/projects/banana-keyboard/make.md to microbit/docs/projects/banana-keyboard/make.md
uploading docs/projects/banana-keyboard.md to microbit/docs/projects/banana-keyboard.md
uploading docs/projects/coin-flipper.md to microbit/docs/projects/coin-flipper.md
uploading docs/projects/compass.md to microbit/docs/projects/compass.md
uploading docs/projects/fireflies.md to microbit/docs/projects/fireflies.md
uploading docs/projects/flashing-heart.md to microbit/docs/projects/flashing-heart.md
uploading docs/projects/guitar/accelerometer.md to microbit/docs/projects/guitar/accelerometer.md
creating folder microbit/docs/projects/guitar
uploading docs/projects/guitar/displaybuttons.md to microbit/docs/projects/guitar/displaybuttons.md
uploading docs/projects/guitar/lightsensor.md to microbit/docs/projects/guitar/lightsensor.md
uploading docs/projects/guitar/make.md to microbit/docs/projects/guitar/make.md
uploading docs/projects/guitar/pinpress.md to microbit/docs/projects/guitar/pinpress.md
uploading docs/projects/guitar.md to microbit/docs/projects/guitar.md
uploading docs/projects/hack-your-headphones/code.md to microbit/docs/projects/hack-your-headphones/code.md
creating folder microbit/docs/projects/hack-your-headphones
uploading docs/projects/hack-your-headphones/make.md to microbit/docs/projects/hack-your-headphones/make.md
uploading docs/projects/hack-your-headphones.md to microbit/docs/projects/hack-your-headphones.md
uploading docs/projects/hot-or-cold.md to microbit/docs/projects/hot-or-cold.md
uploading docs/projects/inchworm/code.md to microbit/docs/projects/inchworm/code.md
creating folder microbit/docs/projects/inchworm
uploading docs/projects/inchworm/connect.md to microbit/docs/projects/inchworm/connect.md
uploading docs/projects/inchworm/make.md to microbit/docs/projects/inchworm/make.md
uploading docs/projects/inchworm.md to microbit/docs/projects/inchworm.md
uploading docs/projects/infection.md to microbit/docs/projects/infection.md
uploading docs/projects/karel.md to microbit/docs/projects/karel.md
uploading docs/projects/light-monster/code.md to microbit/docs/projects/light-monster/code.md
creating folder microbit/docs/projects/light-monster
uploading docs/projects/light-monster/connect.md to microbit/docs/projects/light-monster/connect.md
uploading docs/projects/light-monster/make.md to microbit/docs/projects/light-monster/make.md
uploading docs/projects/light-monster.md to microbit/docs/projects/light-monster.md
uploading docs/projects/love-meter.md to microbit/docs/projects/love-meter.md
uploading docs/projects/magic-button-trick.md to microbit/docs/projects/magic-button-trick.md
uploading docs/projects/messenger.md to microbit/docs/projects/messenger.md
uploading docs/projects/milk-carton-robot/code.md to microbit/docs/projects/milk-carton-robot/code.md
creating folder microbit/docs/projects/milk-carton-robot
uploading docs/projects/milk-carton-robot/connect.md to microbit/docs/projects/milk-carton-robot/connect.md
uploading docs/projects/milk-carton-robot/make.md to microbit/docs/projects/milk-carton-robot/make.md
uploading docs/projects/milk-carton-robot.md to microbit/docs/projects/milk-carton-robot.md
uploading docs/projects/milk-jar-robot.md to microbit/docs/projects/milk-jar-robot.md
uploading docs/projects/milky-monster/code.md to microbit/docs/projects/milky-monster/code.md
creating folder microbit/docs/projects/milky-monster
uploading docs/projects/milky-monster/connect.md to microbit/docs/projects/milky-monster/connect.md
uploading docs/projects/milky-monster/make.md to microbit/docs/projects/milky-monster/make.md
uploading docs/projects/milky-monster.md to microbit/docs/projects/milky-monster.md
uploading docs/projects/plant-watering/code.md to microbit/docs/projects/plant-watering/code.md
creating folder microbit/docs/projects/plant-watering
uploading docs/projects/plant-watering/make.md to microbit/docs/projects/plant-watering/make.md
uploading docs/projects/plant-watering.md to microbit/docs/projects/plant-watering.md
uploading docs/projects/radio-challenges.md to microbit/docs/projects/radio-challenges.md
uploading docs/projects/railway-crossing.md to microbit/docs/projects/railway-crossing.md
uploading docs/projects/rc-car/code.md to microbit/docs/projects/rc-car/code.md
creating folder microbit/docs/projects/rc-car
uploading docs/projects/rc-car/connect.md to microbit/docs/projects/rc-car/connect.md
uploading docs/projects/rc-car/make.md to microbit/docs/projects/rc-car/make.md
uploading docs/projects/rc-car.md to microbit/docs/projects/rc-car.md
uploading docs/projects/reaction-time/code.md to microbit/docs/projects/reaction-time/code.md
creating folder microbit/docs/projects/reaction-time
uploading docs/projects/reaction-time/make.md to microbit/docs/projects/reaction-time/make.md
uploading docs/projects/reaction-time.md to microbit/docs/projects/reaction-time.md
uploading docs/projects/rock-paper-scissors.md to microbit/docs/projects/rock-paper-scissors.md
uploading docs/projects/rps-teams.md to microbit/docs/projects/rps-teams.md
uploading docs/projects/smiley-buttons.md to microbit/docs/projects/smiley-buttons.md
uploading docs/projects/soil-moisture/code.md to microbit/docs/projects/soil-moisture/code.md
creating folder microbit/docs/projects/soil-moisture
uploading docs/projects/soil-moisture/connect.md to microbit/docs/projects/soil-moisture/connect.md
uploading docs/projects/soil-moisture/make.md to microbit/docs/projects/soil-moisture/make.md
uploading docs/projects/soil-moisture.md to microbit/docs/projects/soil-moisture.md
uploading docs/projects/states-of-matter/code.md to microbit/docs/projects/states-of-matter/code.md
creating folder microbit/docs/projects/states-of-matter
uploading docs/projects/states-of-matter/make.md to microbit/docs/projects/states-of-matter/make.md
uploading docs/projects/states-of-matter.md to microbit/docs/projects/states-of-matter.md
uploading docs/projects/telegraph/code.md to microbit/docs/projects/telegraph/code.md
creating folder microbit/docs/projects/telegraph
uploading docs/projects/telegraph/make.md to microbit/docs/projects/telegraph/make.md
uploading docs/projects/telegraph.md to microbit/docs/projects/telegraph.md
uploading docs/projects/timing-gates.md to microbit/docs/projects/timing-gates.md
uploading docs/projects/voting-machine.md to microbit/docs/projects/voting-machine.md
uploading docs/projects/wallet/code.md to microbit/docs/projects/wallet/code.md
creating folder microbit/docs/projects/wallet
uploading docs/projects/wallet/make.md to microbit/docs/projects/wallet/make.md
uploading docs/projects/wallet.md to microbit/docs/projects/wallet.md
uploading docs/projects/watch/code.md to microbit/docs/projects/watch/code.md
creating folder microbit/docs/projects/watch
uploading docs/projects/watch/digital-watch.md to microbit/docs/projects/watch/digital-watch.md
uploading docs/projects/watch/make.md to microbit/docs/projects/watch/make.md
uploading docs/projects/watch/timer.md to microbit/docs/projects/watch/timer.md
uploading docs/projects/watch.md to microbit/docs/projects/watch.md
uploading docs/projects.md to microbit/docs/projects.md
uploading docs/reference/basic/clear-screen.md to microbit/docs/reference/basic/clear-screen.md
creating folder microbit/docs/reference/basic
uploading docs/reference/basic/forever.md to microbit/docs/reference/basic/forever.md
uploading docs/reference/basic/pause.md to microbit/docs/reference/basic/pause.md
uploading docs/reference/basic/plot-leds.md to microbit/docs/reference/basic/plot-leds.md
uploading docs/reference/basic/show-animation.md to microbit/docs/reference/basic/show-animation.md
uploading docs/reference/basic/show-arrow.md to microbit/docs/reference/basic/show-arrow.md
uploading docs/reference/basic/show-icon.md to microbit/docs/reference/basic/show-icon.md
uploading docs/reference/basic/show-leds.md to microbit/docs/reference/basic/show-leds.md
uploading docs/reference/basic/show-number.md to microbit/docs/reference/basic/show-number.md
uploading docs/reference/basic/show-string.md to microbit/docs/reference/basic/show-string.md
uploading docs/reference/basic.md to microbit/docs/reference/basic.md
creating folder microbit/docs/reference
uploading docs/reference/bluetooth/about-bluetooth.md to microbit/docs/reference/bluetooth/about-bluetooth.md
creating folder microbit/docs/reference/bluetooth
uploading docs/reference/bluetooth/advertise-uid-buffer.md to microbit/docs/reference/bluetooth/advertise-uid-buffer.md
uploading docs/reference/bluetooth/advertise-uid.md to microbit/docs/reference/bluetooth/advertise-uid.md
uploading docs/reference/bluetooth/advertise-url.md to microbit/docs/reference/bluetooth/advertise-url.md
uploading docs/reference/bluetooth/bluetooth-pairing.md to microbit/docs/reference/bluetooth/bluetooth-pairing.md
uploading docs/reference/bluetooth/on-bluetooth-connected.md to microbit/docs/reference/bluetooth/on-bluetooth-connected.md
uploading docs/reference/bluetooth/on-bluetooth-disconnected.md to microbit/docs/reference/bluetooth/on-bluetooth-disconnected.md
uploading docs/reference/bluetooth/on-uart-data-received.md to microbit/docs/reference/bluetooth/on-uart-data-received.md
uploading docs/reference/bluetooth/set-transmit-power.md to microbit/docs/reference/bluetooth/set-transmit-power.md
uploading docs/reference/bluetooth/start-accelerometer-service.md to microbit/docs/reference/bluetooth/start-accelerometer-service.md
uploading docs/reference/bluetooth/start-button-service.md to microbit/docs/reference/bluetooth/start-button-service.md
uploading docs/reference/bluetooth/start-io-pin-service.md to microbit/docs/reference/bluetooth/start-io-pin-service.md
uploading docs/reference/bluetooth/start-led-service.md to microbit/docs/reference/bluetooth/start-led-service.md
uploading docs/reference/bluetooth/start-magnetometer-service.md to microbit/docs/reference/bluetooth/start-magnetometer-service.md
uploading docs/reference/bluetooth/start-temperature-service.md to microbit/docs/reference/bluetooth/start-temperature-service.md
uploading docs/reference/bluetooth/start-uart-service.md to microbit/docs/reference/bluetooth/start-uart-service.md
uploading docs/reference/bluetooth/stop-advertising.md to microbit/docs/reference/bluetooth/stop-advertising.md
uploading docs/reference/bluetooth/uart-read-until.md to microbit/docs/reference/bluetooth/uart-read-until.md
uploading docs/reference/bluetooth/uart-write-number.md to microbit/docs/reference/bluetooth/uart-write-number.md
uploading docs/reference/bluetooth/uart-write-string.md to microbit/docs/reference/bluetooth/uart-write-string.md
uploading docs/reference/bluetooth/uart-write-value.md to microbit/docs/reference/bluetooth/uart-write-value.md
uploading docs/reference/bluetooth.md to microbit/docs/reference/bluetooth.md
uploading docs/reference/control/assert.md to microbit/docs/reference/control/assert.md
creating folder microbit/docs/reference/control
uploading docs/reference/control/device-name.md to microbit/docs/reference/control/device-name.md
uploading docs/reference/control/device-serial-number.md to microbit/docs/reference/control/device-serial-number.md
uploading docs/reference/control/event-source-id.md to microbit/docs/reference/control/event-source-id.md
uploading docs/reference/control/event-timestamp.md to microbit/docs/reference/control/event-timestamp.md
uploading docs/reference/control/event-value-id.md to microbit/docs/reference/control/event-value-id.md
uploading docs/reference/control/event-value.md to microbit/docs/reference/control/event-value.md
uploading docs/reference/control/in-background.md to microbit/docs/reference/control/in-background.md
uploading docs/reference/control/on-event.md to microbit/docs/reference/control/on-event.md
uploading docs/reference/control/panic.md to microbit/docs/reference/control/panic.md
uploading docs/reference/control/raise-event.md to microbit/docs/reference/control/raise-event.md
uploading docs/reference/control/reset.md to microbit/docs/reference/control/reset.md
uploading docs/reference/control/wait-micros.md to microbit/docs/reference/control/wait-micros.md
uploading docs/reference/control.md to microbit/docs/reference/control.md
uploading docs/reference/devices/on-gamepad-button.md to microbit/docs/reference/devices/on-gamepad-button.md
creating folder microbit/docs/reference/devices
uploading docs/reference/devices/on-notified.md to microbit/docs/reference/devices/on-notified.md
uploading docs/reference/devices/on-signal-strength-changed.md to microbit/docs/reference/devices/on-signal-strength-changed.md
uploading docs/reference/devices/raise-alert-to.md to microbit/docs/reference/devices/raise-alert-to.md
uploading docs/reference/devices/signal-strength.md to microbit/docs/reference/devices/signal-strength.md
uploading docs/reference/devices/tell-camera-to.md to microbit/docs/reference/devices/tell-camera-to.md
uploading docs/reference/devices/tell-remote-control-to.md to microbit/docs/reference/devices/tell-remote-control-to.md
uploading docs/reference/devices.md to microbit/docs/reference/devices.md
uploading docs/reference/event-handler.md to microbit/docs/reference/event-handler.md
uploading docs/reference/game/add-score.md to microbit/docs/reference/game/add-score.md
creating folder microbit/docs/reference/game
uploading docs/reference/game/change-score-by.md to microbit/docs/reference/game/change-score-by.md
uploading docs/reference/game/change.md to microbit/docs/reference/game/change.md
uploading docs/reference/game/clear.md to microbit/docs/reference/game/clear.md
uploading docs/reference/game/create-sprite.md to microbit/docs/reference/game/create-sprite.md
uploading docs/reference/game/delete.md to microbit/docs/reference/game/delete.md
uploading docs/reference/game/game-over.md to microbit/docs/reference/game/game-over.md
uploading docs/reference/game/get.md to microbit/docs/reference/game/get.md
uploading docs/reference/game/if-on-edge-bounce.md to microbit/docs/reference/game/if-on-edge-bounce.md
uploading docs/reference/game/is-touching-edge.md to microbit/docs/reference/game/is-touching-edge.md
uploading docs/reference/game/is-touching.md to microbit/docs/reference/game/is-touching.md
uploading docs/reference/game/move.md to microbit/docs/reference/game/move.md
uploading docs/reference/game/pause.md to microbit/docs/reference/game/pause.md
uploading docs/reference/game/position.md to microbit/docs/reference/game/position.md
uploading docs/reference/game/reports.md to microbit/docs/reference/game/reports.md
uploading docs/reference/game/resume.md to microbit/docs/reference/game/resume.md
uploading docs/reference/game/score.md to microbit/docs/reference/game/score.md
uploading docs/reference/game/set-score.md to microbit/docs/reference/game/set-score.md
uploading docs/reference/game/set.md to microbit/docs/reference/game/set.md
uploading docs/reference/game/start-countdown.md to microbit/docs/reference/game/start-countdown.md
uploading docs/reference/game/turn.md to microbit/docs/reference/game/turn.md
uploading docs/reference/game.md to microbit/docs/reference/game.md
uploading docs/reference/images/arrow-image.md to microbit/docs/reference/images/arrow-image.md
creating folder microbit/docs/reference/images
uploading docs/reference/images/arrow-number.md to microbit/docs/reference/images/arrow-number.md
uploading docs/reference/images/create-big-image.md to microbit/docs/reference/images/create-big-image.md
uploading docs/reference/images/create-image.md to microbit/docs/reference/images/create-image.md
uploading docs/reference/images/icon-image.md to microbit/docs/reference/images/icon-image.md
uploading docs/reference/images/image.md to microbit/docs/reference/images/image.md
uploading docs/reference/images/pixel.md to microbit/docs/reference/images/pixel.md
uploading docs/reference/images/plot-frame.md to microbit/docs/reference/images/plot-frame.md
uploading docs/reference/images/plot-image.md to microbit/docs/reference/images/plot-image.md
uploading docs/reference/images/scroll-image.md to microbit/docs/reference/images/scroll-image.md
uploading docs/reference/images/set-pixel.md to microbit/docs/reference/images/set-pixel.md
uploading docs/reference/images/show-frame.md to microbit/docs/reference/images/show-frame.md
uploading docs/reference/images/show-image.md to microbit/docs/reference/images/show-image.md
uploading docs/reference/images/width.md to microbit/docs/reference/images/width.md
uploading docs/reference/images.md to microbit/docs/reference/images.md
uploading docs/reference/input/acceleration.md to microbit/docs/reference/input/acceleration.md
creating folder microbit/docs/reference/input
uploading docs/reference/input/button-is-pressed.md to microbit/docs/reference/input/button-is-pressed.md
uploading docs/reference/input/calibrate-compass.md to microbit/docs/reference/input/calibrate-compass.md
uploading docs/reference/input/compass-heading.md to microbit/docs/reference/input/compass-heading.md
uploading docs/reference/input/light-level.md to microbit/docs/reference/input/light-level.md
uploading docs/reference/input/magnetic-force.md to microbit/docs/reference/input/magnetic-force.md
uploading docs/reference/input/on-button-pressed.md to microbit/docs/reference/input/on-button-pressed.md
uploading docs/reference/input/on-gesture.md to microbit/docs/reference/input/on-gesture.md
uploading docs/reference/input/on-pin-pressed.md to microbit/docs/reference/input/on-pin-pressed.md
uploading docs/reference/input/on-pin-released.md to microbit/docs/reference/input/on-pin-released.md
uploading docs/reference/input/pin-is-pressed.md to microbit/docs/reference/input/pin-is-pressed.md
uploading docs/reference/input/rotation.md to microbit/docs/reference/input/rotation.md
uploading docs/reference/input/running-time.md to microbit/docs/reference/input/running-time.md
uploading docs/reference/input/set-accelerometer-range.md to microbit/docs/reference/input/set-accelerometer-range.md
uploading docs/reference/input/temperature.md to microbit/docs/reference/input/temperature.md
uploading docs/reference/input.md to microbit/docs/reference/input.md
uploading docs/reference/led/brightness.md to microbit/docs/reference/led/brightness.md
creating folder microbit/docs/reference/led
uploading docs/reference/led/enable.md to microbit/docs/reference/led/enable.md
uploading docs/reference/led/fade-in.md to microbit/docs/reference/led/fade-in.md
uploading docs/reference/led/fade-out.md to microbit/docs/reference/led/fade-out.md
uploading docs/reference/led/plot-all.md to microbit/docs/reference/led/plot-all.md
uploading docs/reference/led/plot-bar-graph.md to microbit/docs/reference/led/plot-bar-graph.md
uploading docs/reference/led/plot-brightness.md to microbit/docs/reference/led/plot-brightness.md
uploading docs/reference/led/plot.md to microbit/docs/reference/led/plot.md
uploading docs/reference/led/point.md to microbit/docs/reference/led/point.md
uploading docs/reference/led/screenshot.md to microbit/docs/reference/led/screenshot.md
uploading docs/reference/led/set-brightness.md to microbit/docs/reference/led/set-brightness.md
uploading docs/reference/led/set-display-mode.md to microbit/docs/reference/led/set-display-mode.md
uploading docs/reference/led/stop-animation.md to microbit/docs/reference/led/stop-animation.md
uploading docs/reference/led/toggle-all.md to microbit/docs/reference/led/toggle-all.md
uploading docs/reference/led/toggle.md to microbit/docs/reference/led/toggle.md
uploading docs/reference/led/unplot.md to microbit/docs/reference/led/unplot.md
uploading docs/reference/led.md to microbit/docs/reference/led.md
uploading docs/reference/music/beat.md to microbit/docs/reference/music/beat.md
creating folder microbit/docs/reference/music
uploading docs/reference/music/begin-melody.md to microbit/docs/reference/music/begin-melody.md
uploading docs/reference/music/change-tempo-by.md to microbit/docs/reference/music/change-tempo-by.md
uploading docs/reference/music/on-event.md to microbit/docs/reference/music/on-event.md
uploading docs/reference/music/play-tone.md to microbit/docs/reference/music/play-tone.md
uploading docs/reference/music/rest.md to microbit/docs/reference/music/rest.md
uploading docs/reference/music/ring-tone.md to microbit/docs/reference/music/ring-tone.md
uploading docs/reference/music/set-play-tone.md to microbit/docs/reference/music/set-play-tone.md
uploading docs/reference/music/set-tempo.md to microbit/docs/reference/music/set-tempo.md
uploading docs/reference/music/tempo.md to microbit/docs/reference/music/tempo.md
uploading docs/reference/music.md to microbit/docs/reference/music.md
uploading docs/reference/out-of-bounds.md to microbit/docs/reference/out-of-bounds.md
uploading docs/reference/pins/analog-pitch.md to microbit/docs/reference/pins/analog-pitch.md
creating folder microbit/docs/reference/pins
uploading docs/reference/pins/analog-read-pin.md to microbit/docs/reference/pins/analog-read-pin.md
uploading docs/reference/pins/analog-set-period.md to microbit/docs/reference/pins/analog-set-period.md
uploading docs/reference/pins/analog-set-pitch-pin.md to microbit/docs/reference/pins/analog-set-pitch-pin.md
uploading docs/reference/pins/analog-write-pin.md to microbit/docs/reference/pins/analog-write-pin.md
uploading docs/reference/pins/digital-read-pin.md to microbit/docs/reference/pins/digital-read-pin.md
uploading docs/reference/pins/digital-write-pin.md to microbit/docs/reference/pins/digital-write-pin.md
uploading docs/reference/pins/i2c-read-number.md to microbit/docs/reference/pins/i2c-read-number.md
uploading docs/reference/pins/i2c-write-number.md to microbit/docs/reference/pins/i2c-write-number.md
uploading docs/reference/pins/map.md to microbit/docs/reference/pins/map.md
uploading docs/reference/pins/on-pulsed.md to microbit/docs/reference/pins/on-pulsed.md
uploading docs/reference/pins/pulse-duration.md to microbit/docs/reference/pins/pulse-duration.md
uploading docs/reference/pins/pulse-in.md to microbit/docs/reference/pins/pulse-in.md
uploading docs/reference/pins/servo-set-pulse.md to microbit/docs/reference/pins/servo-set-pulse.md
uploading docs/reference/pins/servo-write-pin.md to microbit/docs/reference/pins/servo-write-pin.md
uploading docs/reference/pins/set-events.md to microbit/docs/reference/pins/set-events.md
uploading docs/reference/pins/set-pull.md to microbit/docs/reference/pins/set-pull.md
uploading docs/reference/pins/spi-format.md to microbit/docs/reference/pins/spi-format.md
uploading docs/reference/pins/spi-frequency.md to microbit/docs/reference/pins/spi-frequency.md
uploading docs/reference/pins/spi-pins.md to microbit/docs/reference/pins/spi-pins.md
uploading docs/reference/pins/spi-write.md to microbit/docs/reference/pins/spi-write.md
uploading docs/reference/pins.md to microbit/docs/reference/pins.md
uploading docs/reference/radio/on-data-packet-received.md to microbit/docs/reference/radio/on-data-packet-received.md
creating folder microbit/docs/reference/radio
uploading docs/reference/radio/on-data-received.md to microbit/docs/reference/radio/on-data-received.md
uploading docs/reference/radio/packet.md to microbit/docs/reference/radio/packet.md
uploading docs/reference/radio/receive-number.md to microbit/docs/reference/radio/receive-number.md
uploading docs/reference/radio/receive-string.md to microbit/docs/reference/radio/receive-string.md
uploading docs/reference/radio/received-signal-strength.md to microbit/docs/reference/radio/received-signal-strength.md
uploading docs/reference/radio/send-number.md to microbit/docs/reference/radio/send-number.md
uploading docs/reference/radio/send-string.md to microbit/docs/reference/radio/send-string.md
uploading docs/reference/radio/send-value.md to microbit/docs/reference/radio/send-value.md
uploading docs/reference/radio/set-group.md to microbit/docs/reference/radio/set-group.md
uploading docs/reference/radio/set-transmit-power.md to microbit/docs/reference/radio/set-transmit-power.md
uploading docs/reference/radio/set-transmit-serial-number.md to microbit/docs/reference/radio/set-transmit-serial-number.md
uploading docs/reference/radio/write-received-packet-to-serial.md to microbit/docs/reference/radio/write-received-packet-to-serial.md
uploading docs/reference/radio/write-value-to-serial.md to microbit/docs/reference/radio/write-value-to-serial.md
uploading docs/reference/radio.md to microbit/docs/reference/radio.md
uploading docs/reference/serial/on-data-received.md to microbit/docs/reference/serial/on-data-received.md
creating folder microbit/docs/reference/serial
uploading docs/reference/serial/read-buffer.md to microbit/docs/reference/serial/read-buffer.md
uploading docs/reference/serial/read-line.md to microbit/docs/reference/serial/read-line.md
uploading docs/reference/serial/read-string.md to microbit/docs/reference/serial/read-string.md
uploading docs/reference/serial/read-until.md to microbit/docs/reference/serial/read-until.md
uploading docs/reference/serial/redirect-to.md to microbit/docs/reference/serial/redirect-to.md
uploading docs/reference/serial/write-buffer.md to microbit/docs/reference/serial/write-buffer.md
uploading docs/reference/serial/write-line.md to microbit/docs/reference/serial/write-line.md
uploading docs/reference/serial/write-number.md to microbit/docs/reference/serial/write-number.md
uploading docs/reference/serial/write-string.md to microbit/docs/reference/serial/write-string.md
uploading docs/reference/serial/write-value.md to microbit/docs/reference/serial/write-value.md
uploading docs/reference/serial.md to microbit/docs/reference/serial.md
uploading docs/reference.md to microbit/docs/reference.md
uploading docs/streaming.md to microbit/docs/streaming.md
uploading docs/support.md to microbit/docs/support.md
uploading docs/tutorials/getting-started.md to microbit/docs/tutorials/getting-started.md
creating folder microbit/docs/tutorials
uploading docs/types/number.md to microbit/docs/types/number.md
creating folder microbit/docs/types
uploading docs/types/string.md to microbit/docs/types/string.md
uploading docs/types/var.md to microbit/docs/types/var.md
uploading docs/uploader.md to microbit/docs/uploader.md
```