### PR TITLE
Better support for printed images in docs

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -390,5 +390,9 @@ print only stuff
     ul, ol, img, h2, h3 {
         page-break-inside: avoid;
     }
+    /* images */
+    .ui.image {
+        max-width: 60%;
+    }
     /* headers, footers */ 
 }

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -418,7 +418,7 @@ namespace pxt.docs {
             marked = requireMarked();
             let renderer = new marked.Renderer()
             renderer.image = function (href: string, title: string, text: string) {
-                let out = '<img class="ui image" src="' + href + '" alt="' + text + '"';
+                let out = '<img class="ui centered image" src="' + href + '" alt="' + text + '"';
                 if (title) {
                     out += ' title="' + title + '"';
                 }
@@ -541,7 +541,7 @@ ${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}#${opts.repo.
 
         // try getting a better custom image for twitter
         const imgM = /<div class="ui embed mdvid"[^<>]+?data-placeholder="([^"]+)"[^>]*\/?>/i.exec(html)
-            || /<img class="ui image" src="([^"]+)"[^>]*\/?>/i.exec(html);
+            || /<img class="ui [^"]*image" src="([^"]+)"[^>]*\/?>/i.exec(html);
         if (imgM)
             pubinfo["cardLogo"] = html2Quote(imgM[1]);
 


### PR DESCRIPTION
Images tend to be too large in docs and incur a lot of paginations.

- [x] restricts to 60% width on images (heuristic)
- [x] centering images which is more common in docs