### PR TITLE
Filter out errors in sim implementation check

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2730,7 +2730,10 @@ function simulatorCoverage(pkgCompileRes: pxtc.CompileResult, pkgOpts: pxtc.Comp
     }
 
     let simDeclRes = pxtc.compile(opts)
-    reportDiagnostics(simDeclRes.diagnostics);
+
+    // The program we compiled was missing files, so filter out those errors
+    reportDiagnostics(simDeclRes.diagnostics.filter(d => d.code != 5012 /* file not found */ && d.code != 2318/* missing global type */));
+
     let typechecker = simDeclRes.ast.getTypeChecker()
     let doSymbol = (sym: ts.Symbol) => {
         if (sym.getFlags() & ts.SymbolFlags.HasExports) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt/issues/2954

The solution was to just filter out those errors; the sim implementation check still works. The only other option was to compile a complete program, which would include all of the dependencies in the built folder and ends up being a maintenance nightmare. I started down that path but gave up.