### PR TITLE
Add a event order note replacement tag in `on-start.md`.

### DIFF
--- a/common-docs/blocks/on-start.md
+++ b/common-docs/blocks/on-start.md
@@ -27,4 +27,6 @@ before launching the ``on start`` code.
 
 If a block from ``on start`` pauses, other registered events will have the opportunity to run as well.
 
+## #eventsnote
+
 ## #examples

--- a/common-docs/blocks/on-start.md
+++ b/common-docs/blocks/on-start.md
@@ -27,6 +27,6 @@ before launching the ``on start`` code.
 
 If a block from ``on start`` pauses, other registered events will have the opportunity to run as well.
 
-## #eventsnote
+## #eventorder
 
 ## #examples


### PR DESCRIPTION
RE: https://github.com/Microsoft/pxt/issues/2385 and https://github.com/Microsoft/pxt/pull/2940.

The idea here is that the targets will include in their own _on-start.md_ a note about event registration order. This allows for api differences in support for 'late registration' of things like **forever** and **runInBackground** which can be target specific.

The target's version of _on-start.md_ can include a note which might look like:

```markdown
## #eventorder

## ~hint
**Who goes first?**

All events are registered before the **onStart** block runs. If your program has a
**[forever](/reference/loops/forever)** loop or a
**[runInBackground](/reference/control/run-in-background)** block, these will not
start until after the code in **onStart** begins.
## ~
```

![image](https://user-images.githubusercontent.com/27789908/30612318-f824fccc-9d38-11e7-822c-c95703c2c789.png)
