### PR TITLE
Fix IE 11 scrolling in projects dialog.

### DIFF
--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -838,7 +838,8 @@ export class Modal extends data.Component<ModalProps, ModalState> {
         const mountNode = this.getMountNode();
 
         if (dimmer) {
-            mountNode.classList.add('dimmable', 'dimmed');
+            mountNode.classList.add('dimmable');
+            mountNode.classList.add('dimmed');
 
             if (dimmer === 'blurring' && !pxt.options.light) {
                 mountNode.classList.add('blurring');


### PR DESCRIPTION
IE 11 doesn't like the use of classList.add with multiple classes. 

Fix is to split it up into multiple calls to classList.add

Fixes #2985