### PR TITLE
Fixing variable auto declarations in grey blocks

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -936,7 +936,7 @@ ${output}</xml>`;
             }
         }
 
-        function getTypeScriptStatementBlock(node: ts.Node): StatementNode {
+        function getTypeScriptStatementBlock(node: ts.Node, prefix?: string): StatementNode {
             const r = mkStmt(pxtc.TS_STATEMENT_TYPE);
             r.mutation = {}
 
@@ -947,6 +947,11 @@ ${output}</xml>`;
             const end = node.getEnd();
 
             text = applyRenamesInRange(text, start, end);
+
+
+            if (prefix) {
+                text = prefix + text;
+            }
 
             const declaredVariables: string[] = [];
             if (node.kind === SK.VariableStatement) {
@@ -1411,7 +1416,7 @@ ${output}</xml>`;
                             // If a variable is referenced inside a "grey" block, we need
                             // to be conservative because our type inference might not work
                             // on the round trip
-                            v = getTypeScriptStatementBlock(node);
+                            v = getTypeScriptStatementBlock(node, "let ");
                         }
                         else {
                             v = getVariableSetOrChangeBlock((node as ts.VariableDeclaration).name as ts.Identifier, (node as ts.VariableDeclaration).initializer, false, true);

--- a/tests/decompile-test/baselines/always_local_variable.blocks
+++ b/tests/decompile-test/baselines/always_local_variable.blocks
@@ -2,7 +2,7 @@
 <block type="pxt-on-start">
 <statement name="HANDLER">
 <block type="typescript_statement">
-<mutation declaredvars="x" numlines="1" line0="x &#61; 0" />
+<mutation declaredvars="x" numlines="1" line0="let x &#61; 0" />
 <next>
 <block type="typescript_statement">
 <mutation numlines="3" line0="for &#40;&#59;&#59;&#41; &#123;" line1="    x&#43;&#43;&#59;" line2="&#125;" />

--- a/tests/decompile-test/baselines/always_null_and_undefined.blocks
+++ b/tests/decompile-test/baselines/always_null_and_undefined.blocks
@@ -2,10 +2,10 @@
 <block type="pxt-on-start">
 <statement name="HANDLER">
 <block type="typescript_statement">
-<mutation declaredvars="y" numlines="1" line0="y &#61; 0" />
+<mutation declaredvars="y" numlines="1" line0="let y &#61; 0" />
 <next>
 <block type="typescript_statement">
-<mutation declaredvars="x" numlines="1" line0="x &#61; 0" />
+<mutation declaredvars="x" numlines="1" line0="let x &#61; 0" />
 <next>
 <block type="typescript_statement">
 <mutation numlines="1" line0="x &#61; null&#59;" />

--- a/tests/decompile-test/baselines/grey_blocks_multi_declarations.blocks
+++ b/tests/decompile-test/baselines/grey_blocks_multi_declarations.blocks
@@ -1,0 +1,19 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="typescript_statement">
+<mutation declaredvars="two" numlines="1" line0="let two &#61; 0" />
+<next>
+<block type="typescript_statement">
+<mutation declaredvars="one" numlines="1" line0="let one &#61; 0" />
+<next>
+<block type="typescript_statement">
+<mutation numlines="1" line0="one &#38;&#61; two" />
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/baselines/no_nested_events.blocks
+++ b/tests/decompile-test/baselines/no_nested_events.blocks
@@ -19,7 +19,7 @@
 <block type="pxt-on-start">
 <statement name="HANDLER">
 <block type="typescript_statement">
-<mutation declaredvars="i" numlines="1" line0="i &#61; 0" />
+<mutation declaredvars="i" numlines="1" line0="let i &#61; 0" />
 </block>
 </statement>
 </block>

--- a/tests/decompile-test/cases/grey_blocks_multi_declarations.ts
+++ b/tests/decompile-test/cases/grey_blocks_multi_declarations.ts
@@ -1,0 +1,3 @@
+let one = 0, two = 0
+
+one &= two


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt/issues/2964

Stupid mistake on my part. I'm going to try and add stricter tests for the decompiler and documentation soon.