### PR TITLE
Fixing the input in the save and exit dialog

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -533,23 +533,9 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 >
                 <div className="ui segment form text">
-                    <ExitAndSaveInput onChange={onChange} initialName={projectName}/>
+                    <sui.Input id={"projectNameInput"} class="focused" label={lf("Project Name") } ariaLabel={lf("Type a name for your project") } value={projectName} onChange={onChange}/>
                 </div>
             </sui.Modal>
         )
-    }
-}
-
-class ExitAndSaveInput extends React.Component<{ onChange: (name: string) => void, initialName: string }, { value: string }> {
-    render() {
-        const onChange = (name: string) => {
-            if (!this.state|| this.state.value !== name) {
-                this.setState({ value: name });
-            }
-            this.props.onChange(name);
-        };
-
-        const value = this.state ? this.state.value : this.props.initialName;
-        return <sui.Input id={"projectNameInput"} class="focused" label={lf("Project Name") } ariaLabel={lf("Type a name for your project") } value={value} onChange={onChange}/>
     }
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -503,16 +503,18 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
     renderCore() {
         const { visible } = this.state;
         const { projectName } = this.props.parent.state;
-        const setFileName = (name: string) => {
-            this.props.parent.updateHeaderName(name);
-        }
+        let newName = projectName;
 
         const save = () => {
+            this.props.parent.updateHeaderName(newName);
             this.props.parent.openHome();
         }
         const cancel = () => {
             this.hide();
         }
+        const onChange = (name : string) => {
+            newName = name;
+        };
 
         const actions = [{
             label: lf("Save"),
@@ -531,9 +533,23 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 >
                 <div className="ui segment form text">
-                    <sui.Input id={"projectNameInput"} class="focused" label={lf("Project Name") } ariaLabel={lf("Type a name for your project") } value={projectName} onChange={setFileName}/>
+                    <ExitAndSaveInput onChange={onChange} initialName={projectName}/>
                 </div>
             </sui.Modal>
         )
+    }
+}
+
+class ExitAndSaveInput extends React.Component<{ onChange: (name: string) => void, initialName: string }, { value: string }> {
+    render() {
+        const onChange = (name: string) => {
+            if (!this.state|| this.state.value !== name) {
+                this.setState({ value: name });
+            }
+            this.props.onChange(name);
+        };
+
+        const value = this.state ? this.state.value : this.props.initialName;
+        return <sui.Input id={"projectNameInput"} class="focused" label={lf("Project Name") } ariaLabel={lf("Type a name for your project") } value={value} onChange={onChange}/>
     }
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -333,7 +333,7 @@ export class Input extends data.Component<{
     selectOnClick?: boolean;
     id?: string;
     ariaLabel?: string;
-}, {}> {
+}, { value: string }> {
 
     copy() {
         const p = this.props
@@ -362,6 +362,17 @@ export class Input extends data.Component<{
             ? <Button class="ui right labeled primary icon button" text={lf("Copy") } icon="copy" onClick={() => this.copy() } />
             : null;
 
+        let value = (this.state && this.state.value) ? this.state.value : p.value;
+
+        const onChange = (newValue: string) => {
+            if (!p.readOnly && (!this.state || this.state.value !== newValue)) {
+                this.setState({ value: newValue })
+            }
+            if (p.onChange) {
+                p.onChange(newValue);
+            }
+        };
+
         return (
             <Field ariaLabel={p.ariaLabel} htmlFor={p.id} label={p.label}>
                 <div className={"ui input" + (p.inputLabel ? " labelled" : "") + (p.copy ? " action fluid" : "") + (p.disabled ? " disabled" : "") }>
@@ -370,19 +381,19 @@ export class Input extends data.Component<{
                         id={p.id}
                         className={p.class || ""}
                         type={p.type || "text"}
-                        placeholder={p.placeholder} value={p.value}
+                        placeholder={p.placeholder} value={value}
                         readOnly={!!p.readOnly}
                         onClick={(e) => p.selectOnClick ? (e.target as any).setSelectionRange(0, 9999) : undefined}
-                        onChange={v => p.onChange((v.target as any).value) }/>
+                        onChange={v => onChange((v.target as any).value)}/>
                         : <textarea
                             id={p.id}
                             className={"ui input " + (p.class || "") + (p.inputLabel ? " labelled" : "") }
                             rows={p.lines}
                             placeholder={p.placeholder}
-                            value={p.value}
+                            value={value}
                             readOnly={!!p.readOnly}
                             onClick={(e) => p.selectOnClick ? (e.target as any).setSelectionRange(0, 9999) : undefined}
-                            onChange={v => p.onChange((v.target as any).value) }>
+                            onChange={v => onChange((v.target as any).value)}>
                         </textarea>}
                     {copyBtn}
                 </div>


### PR DESCRIPTION
Basically, the issue was that every time you type a letter into the project name we would save it. When we save the name it changes the state of the ProjectView which causes the Modal to re-render. Then, the accessibility code that controls the focus of the elements tries to focus the first input in the dialog and messes up the typing.

The solution was to make it so that we only save the name when the user selects save. I had to rework the input class so that it actually updates its text when you type. Previously it did not do that and we were relying on the parent to update the text by passing it as a property.