### PR TITLE
Replace incorrect 'define.md' for function type docs

### DIFF
--- a/common-docs/types/function/define.md
+++ b/common-docs/types/function/define.md
@@ -1,30 +1,75 @@
-# Function
+# Function definition
 
-A function is some amount of code you can reuse in your program. You create a function using a
-function _definition_ which names the function and has its code. A function _call_ is when you use a
-function by its name somewhere in your program.
-
-## Defining a function
-
-A function [**definition**](/types/function/define) is a block that has the name of the function and its code.
+The name, arguments, and code for a function.
 
 ```block
-function doSomething() {
+function doSomething(){}
+```
+
+A function lets you create a portion of code that you can reuse in your program. This is handy because
+you can put code that you want to use over again in a function. Instead of copying the same code to many
+places in your program, you can just use a function you made and all the code inside is used as a single
+block.
+
+## The _function_ word
+
+All functions definitions begin with the word **function**. This means that the definition will start.
+
+```typescript
+function myFunction() {
 }
 ```
 
-## Calling a function
+## Name
 
-A function [**call**](/types/function/call) is when you want to use the code in the function at some place in your program.
+A function has a _name_ that is unique. You also give a name to a function which gives an idea about what
+the code in the function does. If you want to make a function to set all LEDs to green, then you might call
+the function, **setAllGreen**. This gives you and anyone else looking at your code an idea of what
+the function will do.
 
-```sig
-function doSomething() {
+```block
+function setAllGreen() {
+    let lightsOn = true;
 }
-doSomething();
+```
+If you had some functions with the names **function1**, **function2**, and **function3**, they would be unique but
+you probably wouldn't remember what each one does the next time you looked at your code. That's why it's
+best to give your functions names that tell you what the code inside is going to accomplish.
+
+## Agruments
+
+After you make the name of the function, you add the _argument list_. In JavaScript, the argument list is inside two **(** **)** braces. Right now, your functions don't use any arguments.
+
+## Body
+
+The _body_ of the function is the code inside of the function block. In JavaScript, it is what goes between braces **{** **}** of the function. The work of the function happens here.
+
+```blocks
+let side = 25;
+let square = 0;
+
+function squared( ) {
+    square = side * side;
+}
 ```
 
-### #specific
+## Example
 
-## See also
+Make a function to calculate the average of score of quiz scores in a list.
 
-[define](/types/function/define), [call](/types/function/call)
+```blocks
+let scores = [9, 5, 3, 1, 6, 3, 5, 7];
+let average = 0;
+
+function averageScore( ) {
+    let count = 0;
+    for (let score of scores) {
+        count += score;
+    }
+    average = count / scores.length;
+}
+```
+
+## See also #seealso
+ 
+[call](/types/function/call)


### PR DESCRIPTION
The wrong doc was copied as _define.md_ on the back merge for the function type docs from `master`. This is the correct one.

RE: https://github.com/Microsoft/pxt/commit/5e3aa630d813e9078d604ddf7050f36dfa2347df