### PR TITLE
Home screen accessibility fixes

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -39,6 +39,7 @@
         padding: 0;
         padding-top: calc(@mainMenuHeight + 2rem) !important;
         margin: 0;
+        border: 0;
         width: 100%;
         min-height: 100%;
         background: @homeScreenBackground;
@@ -74,6 +75,7 @@
         }
     }
     .ui.card {
+        margin-right: 5px;
         border-radius: 0px;
     }
     .header {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1724,12 +1724,12 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
 
                         <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar" aria-label={lf("Main menu") }>
                             {!sandbox ? <div className="left menu">
-                                <span className="ui item logo brand">
+                                <a href={targetTheme.logoUrl} aria-label={lf("{0} Logo", targetTheme.boardName) } role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => pxt.tickEvent("menu.brand") }>
                                     {targetTheme.logo || targetTheme.portraitLogo
-                                        ? <a className="ui image landscape only" target="_blank" rel="noopener" href={targetTheme.logoUrl}><img className={`ui logo ${targetTheme.portraitLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo) } alt={`${targetTheme.boardName} Logo`} /></a>
-                                        : <span className="name">{targetTheme.name}</span>}
-                                    {targetTheme.portraitLogo ? (<a className="ui portrait only" target="_blank" rel="noopener" href={targetTheme.logoUrl}><img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo) } alt={`${targetTheme.boardName} Logo`} /></a>) : null}
-                                </span>
+                                        ? <img className={`ui logo ${targetTheme.logo ? " portrait hide" : ''}`}  src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo) } alt={lf("{0} Logo", targetTheme.boardName) } />
+                                        : <span className="name">{targetTheme.boardName}</span>}
+                                    {targetTheme.portraitLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo) } alt={lf("{0} Logo", targetTheme.boardName) } />) : null}
+                                </a>
                                 {betaUrl ? <a href={`${betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta") }</a> : undefined}
                                 {!inTutorial ? <sui.Item class="icon openproject" role="menuitem" textClass="landscape only" icon="home large" ariaLabel={lf("Home screen") } text={lf("Home") } onClick={() => this.exitAndSave() } /> : null}
                                 {!inTutorial && this.state.header && sharingEnabled ? <sui.Item class="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project") } text={lf("Share") } icon="share alternate large" onClick={() => this.embed() } /> : null}
@@ -1777,9 +1777,9 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
 
                                 {!sandbox ? <a href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization) } role="menuitem" target="blank" rel="noopener" className="ui item logo organization" onClick={() => pxt.tickEvent("menu.org") }>
                                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo
-                                        ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo) } alt={`${targetTheme.organization} Logo`} />
+                                        ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo) } alt={lf("{0} Logo", targetTheme.organization) } />
                                         : <span className="name">{targetTheme.organization}</span>}
-                                    {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo) } alt={`${targetTheme.organization} Logo`} />) : null}
+                                    {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo) } alt={lf("{0} Logo", targetTheme.organization) } />) : null}
                                 </a> : undefined}
                             </div>
                         </div>

--- a/webapp/src/carousel.tsx
+++ b/webapp/src/carousel.tsx
@@ -42,7 +42,7 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
         this.arrows = [];
         const { rightDisabled, leftDisabled } = this.state || {} as any;
         return <div className="ui carouselouter">
-            <span className={"carouselarrow left aligned" + (leftDisabled ? " arrowdisabled" : "")} tabIndex={0} onClick={() => this.onArrowClick(true)} ref={r => this.arrows.push(r)}>
+            <span className={"carouselarrow left aligned" + (leftDisabled ? " arrowdisabled" : "")} tabIndex={leftDisabled ? -1 : 0} onClick={() => this.onArrowClick(true)} ref={r => this.arrows.push(r)}>
                 <i className="icon circle angle left"/>
             </span>
             <div className="carouselcontainer" ref={r => this.container = r}>
@@ -54,7 +54,7 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
                 }
                 </div>
             </div>
-            <span className={"carouselarrow right aligned" + (rightDisabled ? " arrowdisabled" : "")} tabIndex={0} onClick={() => this.onArrowClick(false)} ref={r => this.arrows.push(r)}>
+            <span className={"carouselarrow right aligned" + (rightDisabled ? " arrowdisabled" : "")} tabIndex={rightDisabled ? -1 : 0} onClick={() => this.onArrowClick(false)} ref={r => this.arrows.push(r)}>
                 <i className="icon circle angle right"/>
             </span>
         </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -200,20 +200,20 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                 <div id="menubar" role="banner">
                     <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">
                         <div className="left menu">
-                            <span className="ui item logo brand">
+                            <a href={targetTheme.logoUrl} aria-label={lf("{0} Logo", targetTheme.boardName) } role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => pxt.tickEvent("menu.brand") }>
                                 {targetTheme.logo || targetTheme.portraitLogo
-                                    ? <a className="ui image landscape only" target="_blank" rel="noopener" href={targetTheme.logoUrl}><img className={`ui logo ${targetTheme.portraitLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo) } alt={`${targetTheme.boardName} Logo`} /></a>
-                                    : <span className="name">{targetTheme.name}</span>}
-                                {targetTheme.portraitLogo ? (<a className="ui portrait only" target="_blank" rel="noopener" href={targetTheme.logoUrl}><img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo) } alt={`${targetTheme.boardName} Logo`} /></a>) : null}
-                            </span>
+                                    ? <img className={`ui logo ${targetTheme.logo ? " portrait hide" : ''}`}  src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo) } alt={lf("{0} Logo", targetTheme.boardName) } />
+                                    : <span className="name">{targetTheme.boardName}</span>}
+                                {targetTheme.portraitLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo) } alt={lf("{0} Logo", targetTheme.boardName) } />) : null}
+                            </a>
                         </div>
                         <div className="ui item">{tabIcon ? <i className={`icon ${tabIcon}`} aria-hidden={true}/> : undefined} {tabName}</div>
                         <div className="right menu">
                             <a href={targetTheme.organizationUrl} target="blank" rel="noopener" className="ui item logo organization" onClick={() => pxt.tickEvent("menu.org") }>
                                 {targetTheme.organizationWideLogo || targetTheme.organizationLogo
-                                    ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo) } alt={`${targetTheme.organization} Logo`} />
+                                    ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo) } alt={lf("{0} Logo", targetTheme.organization) } />
                                     : <span className="name">{targetTheme.organization}</span>}
-                                {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo) } alt={`${targetTheme.organization} Logo`} />) : null}
+                                {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo) } alt={lf("{0} Logo", targetTheme.organization) } />) : null}
                             </a>
                         </div>
                     </div>
@@ -225,7 +225,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                                 <div className="column right aligned">
                                     <div className="getting-started">
                                         <h2 className="getting-started-header">{lf("First time here?") }</h2>
-                                        <div className="ui huge primary button" onClick={gettingStarted}>{lf("Get Started") }<i className="right arrow icon"></i></div>
+                                        <sui.Button icon="right arrow" rightIcon class="huge primary focused" text={lf("Get Started") } title={lf("Getting started tutorial") } onClick={gettingStarted} />
                                     </div>
                                 </div>
                             </div>
@@ -253,9 +253,9 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                         </div>
                     ) }
                     {targetTheme.organizationUrl || targetTheme.organizationUrl || targetTheme.privacyUrl ? <div className="ui horizontal small divided link list homefooter">
-                        {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" rel="noopener" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
-                        {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use") }</a> : undefined }
-                        {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy") }</a> : undefined }
+                        {targetTheme.organizationUrl && targetTheme.organization ? <a className="item focused" target="_blank" rel="noopener" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
+                        {targetTheme.termsOfUseUrl ? <a target="_blank" className="item focused" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use") }</a> : undefined }
+                        {targetTheme.privacyUrl ? <a target="_blank" className="item focused" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy") }</a> : undefined }
                     </div> : undefined }
                 </div> : undefined }
             </sui.Modal >
@@ -290,11 +290,11 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
     }
 
     componentDidMount() {
-       if (this.props.parent.state.header) {
-           if (this.latestProject && this.latestProject.element) {
-               this.latestProject.element.focus()
-           }
-       }
+        if (this.props.parent.state.header) {
+            if (this.latestProject && this.latestProject.element) {
+                this.latestProject.element.focus()
+            }
+        }
     }
 
     fetchGallery(path: string): pxt.CodeCard[] {
@@ -371,7 +371,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                                 </div>
                                 :
                                 <codecard.CodeCardView
-                                    ref={(view) => {if (index === 1) this.latestProject = view }}
+                                    ref={(view) => { if (index === 1) this.latestProject = view } }
                                     cardType="file"
                                     className="file"
                                     key={'local' + scr.id}
@@ -438,6 +438,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                     {pxt.appTarget.compile ?
                         <codecard.CodeCardView
                             ariaLabel={lf("Open files from your computer") }
+                            className="focused"
                             role="button"
                             key={'import'}
                             icon="upload"
@@ -449,6 +450,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                     {pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.publishing && pxt.appTarget.cloud.importing ?
                         <codecard.CodeCardView
                             ariaLabel={lf("Open a shared project URL") }
+                            className="focused"
                             role="button"
                             key={'importurl'}
                             icon="cloud download"
@@ -512,18 +514,20 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         const cancel = () => {
             this.hide();
         }
-        const onChange = (name : string) => {
+        const onChange = (name: string) => {
             newName = name;
         };
 
         const actions = [{
             label: lf("Save"),
             onClick: save,
+            icon: 'check',
             className: 'positive'
-        },{
-            label: lf("Cancel"),
-            onClick: cancel
-        }]
+        }, {
+                label: lf("Cancel"),
+                icon: 'cancel',
+                onClick: cancel
+            }]
 
         return (
             <sui.Modal open={visible} className="exitandsave" header={lf("Save and Exit?") } size="small"
@@ -532,7 +536,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 closeIcon={true}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 >
-                <div className="ui segment form text">
+                <div className="ui form">
                     <sui.Input id={"projectNameInput"} class="focused" label={lf("Project Name") } ariaLabel={lf("Type a name for your project") } value={projectName} onChange={onChange}/>
                 </div>
             </sui.Modal>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -363,7 +363,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                     ) : headers.map((scr, index) =>
                         <div key={'local' + scr.id}>
                             {scr.id == 'new' ?
-                                <div className="ui card link newprojectcard" tabIndex={0} title={lf("Creates a new empty project") } onClick={() => this.newProject() }>
+                                <div className="ui card link newprojectcard" tabIndex={0} title={lf("Creates a new empty project") } onClick={() => this.newProject() } onKeyDown={sui.fireClickOnEnter} >
                                     <div className="content">
                                         <i className="icon huge add circle"></i>
                                         <span className="header">{scr.name}</span>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -198,6 +198,7 @@ pxt extract ${url}`;
             actions.push({
                 label: action,
                 onClick: publish,
+                icon: 'share alternate',
                 loading: actionLoading,
                 className: 'primary'
             })

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -14,6 +14,7 @@ export interface UiProps {
     title?: string;
     ariaLabel?: string;
     tabIndex?: number;
+    rightIcon?: boolean;
 }
 
 export interface WithPopupProps extends UiProps {
@@ -40,10 +41,12 @@ function genericClassName(cls: string, props: UiProps, ignoreIcon: boolean = fal
 }
 
 function genericContent(props: UiProps) {
-    return [
+    let retVal = [
         props.icon ? (<i key='iconkey' aria-hidden="true" role="presentation" className={props.icon + " icon " + (props.text ? " icon-and-text " : "") + (props.iconClass ? " " + props.iconClass : '') }></i>) : null,
         props.text ? (<span key='textkey' className={'ui text' + (props.textClass ? ' ' + props.textClass : '') }>{props.text}</span>) : null,
     ]
+    if (props.icon && props.rightIcon) retVal = retVal.reverse();
+    return retVal;
 }
 
 export function popupWindow(url: string, title: string, width: number, height: number) {
@@ -384,7 +387,7 @@ export class Input extends data.Component<{
                         placeholder={p.placeholder} value={value}
                         readOnly={!!p.readOnly}
                         onClick={(e) => p.selectOnClick ? (e.target as any).setSelectionRange(0, 9999) : undefined}
-                        onChange={v => onChange((v.target as any).value)}/>
+                        onChange={v => onChange((v.target as any).value) }/>
                         : <textarea
                             id={p.id}
                             className={"ui input " + (p.class || "") + (p.inputLabel ? " labelled" : "") }
@@ -393,7 +396,7 @@ export class Input extends data.Component<{
                             value={value}
                             readOnly={!!p.readOnly}
                             onClick={(e) => p.selectOnClick ? (e.target as any).setSelectionRange(0, 9999) : undefined}
-                            onChange={v => onChange((v.target as any).value)}>
+                            onChange={v => onChange((v.target as any).value) }>
                         </textarea>}
                     {copyBtn}
                 </div>
@@ -728,6 +731,7 @@ export interface ModalAction {
     onClick: () => void;
     className?: string;
     loading?: boolean;
+    icon?: string;
 }
 
 export interface ModalProps {
@@ -912,7 +916,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
                         <a className={`ui huge icon clear focused`} href={this.props.helpUrl} target="_docs" role="button" aria-label={lf("Help on {0} dialog", this.props.header) }>
                             <i className="help icon"></i>
                         </a>
-                        : undefined}
+                        : undefined }
                 </div> : undefined }
                 {this.props.description ? <label id={this.id + 'description'} className="accessible-hidden">{this.props.description}</label> : undefined}
                 <div id={this.id + 'desc'} className="content">
@@ -923,11 +927,13 @@ export class Modal extends data.Component<ModalProps, ModalState> {
                         {this.props.actions.map(action =>
                             <Button
                                 key={`action_${action.label}`}
+                                icon={action.icon}
                                 text={action.label}
-                                class={`approve ${action.className || ''} ${action.loading ? "loading disabled" : ""} focused`}
+                                class={`approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""} focused`}
                                 onClick={() => {
                                     action.onClick();
-                                } } />
+                                } }
+                                onKeyDown={fireClickOnEnter} />
                         ) }
                     </div> : undefined }
                 {closeIcon ? <Button

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -126,15 +126,20 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
         // TODO: Use step name instead of tutorial Name in full screen mode.
         const header = tutorialFullscreen ? tutorialName : lf("Hint");
 
+        const hide = () => this.setState({ visible: false });
+
+        const actions = [{
+            label: lf("Ok"),
+            onClick: hide,
+            icon: 'check',
+            className: 'green'
+        }]
+
         return <sui.Modal open={visible} className="hintdialog" size="small" header={header} closeIcon={true}
                 onClose={() => this.setState({ visible: false })} dimmer={true}
+                actions={actions}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>
-                    <div className="content">
-                        <div dangerouslySetInnerHTML={{__html: tutorialHint}} />
-                    </div>
-                    <div className="actions" style={{textAlign: "right"}}>
-                        <sui.Button class="green focused" icon={`check`} text={lf("Ok") } onClick={() => this.setState({ visible: false }) } onKeyDown={sui.fireClickOnEnter} />
-                    </div>
+                    <div dangerouslySetInnerHTML={{__html: tutorialHint}} />
             </sui.Modal>;
     }
 }


### PR DESCRIPTION
Mostly accessibility fixes.
- [x] All items in home screen tabbable
- [x] Enter and Space handled for button elements
- [x] Fixed brand logo logic (same as org logo fix)

Also fixed: 
- Margin between home screen cards
- Margin in hint card. Fixes https://github.com/Microsoft/pxt/issues/2901
