### PR TITLE
Translucent blocks during drag

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -252,6 +252,11 @@ div.blocklyTreeRow {
     height: 100%;
 }
 
+/* Transulcent blocks when dragging */
+.blocklyDraggable.blocklyDragging {
+   opacity: 0.7;
+}  
+
 /*******************************
         Media Adjustments
 *******************************/


### PR DESCRIPTION
Make blocks a little translucent while dragging so you can see what's behind them.

![opacity7](https://user-images.githubusercontent.com/16690124/30784551-4e1e6c68-a125-11e7-9bb1-ed7d4f0447d5.gif)

<img width="564" alt="screen shot 2017-09-23 at 7 09 45 pm" src="https://user-images.githubusercontent.com/16690124/30784553-54623640-a125-11e7-9790-b2acea500a10.png">
