### PR TITLE
Fix scrolling issues with the projects modal

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -512,6 +512,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         let newName = projectName;
 
         const save = () => {
+            this.hide();
             this.props.parent.updateHeaderName(newName);
             this.props.parent.openHome();
         }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -819,6 +819,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
 
     setPosition = () => {
         if (this.ref) {
+            const { dimmer } = this.props;
             const mountNode = this.getMountNode();
             let height: number;
 
@@ -828,6 +829,11 @@ export class Modal extends data.Component<ModalProps, ModalState> {
             }
             else {
                 height = 0;
+            }
+
+            if (dimmer) {
+                mountNode.classList.add('dimmable')
+                mountNode.classList.add('dimmed')
             }
 
             const marginTop = -Math.round(height / 2);
@@ -868,14 +874,17 @@ export class Modal extends data.Component<ModalProps, ModalState> {
             }
         }
 
-        this.setPosition()
+        this.setPosition();
     }
 
     handleRef = (c: any) => (this.ref = c);
 
     handlePortalUnmount = () => {
         const mountNode = this.getMountNode();
-        mountNode.classList.remove('blurring', 'dimmable', 'dimmed', 'scrollable');
+        mountNode.classList.remove('blurring');
+        mountNode.classList.remove('dimmable');
+        mountNode.classList.remove('dimmed');
+        mountNode.classList.remove('scrolling');
 
         if (this.animationId) cancelAnimationFrame(this.animationId);
     }


### PR DESCRIPTION
Fixing a couple of issues here: 
- Exit and save modal was not hiding itself when it was saved. 
- When switching from one modal to another, since everything is async, the first modal would close and cleanup the 'dimmable' 'dimmed' classes from the mountNode (body), and that would break scrolling for the next modal. The fix is to always make sure that the dimmable and dimmed attributes are set when the modal has a dimmer attached.