### PR TITLE
Fix undefined error when home screen hero is not defined.

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -220,7 +220,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                 </div>
                 {tab == HOME ? <div className={tabClasses}>
                     {hasGettingStarted ?
-                        <div className="ui segment getting-started-segment" style={{ backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` }}>
+                        <div className="ui segment getting-started-segment" style={targetTheme.homeScreenHero ? { backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` } : {}}>
                             <div className="ui grid equal width padded">
                                 <div className="column right aligned">
                                     <div className="getting-started">


### PR DESCRIPTION
In console, we see the following message when the homescreenhero image is not defined in the pxtarget:
```
Failed to load resource: the server responded with a status of 404 (Not Found)
```