### PR TITLE
Create a project before trying to decompile

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -607,10 +607,6 @@ export class ProjectView
                 if (pkg.File.blocksFileNameRx.test(file.getName()) && file.getVirtualFileName()) {
                     if (!file.content) // empty blocks file, open javascript editor
                         file = main.lookupFile("this/" + file.getVirtualFileName()) || file
-                    else this.textEditor.decompileAsync(file.getVirtualFileName()).then(resp => {
-                        if (!resp.success)
-                            file = main.lookupFile("this/" + file.getVirtualFileName()) || file
-                    });
                 }
                 this.setState({
                     header: h,

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -161,11 +161,14 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                     if (opts) {
                         if (loadBlocks) {
                             const ts = opts.filesOverride["main.ts"]
-                            compiler.getBlocksAsync()
-                                .then(blocksInfo => compiler.decompileSnippetAsync(ts, blocksInfo))
-                                .then(resp => {
-                                    opts.filesOverride["main.blocks"] = resp
-                                    this.props.parent.newProject(opts);
+                            this.props.parent.createProjectAsync(opts)
+                                .then(() => {
+                                    return compiler.getBlocksAsync()
+                                        .then(blocksInfo => compiler.decompileSnippetAsync(ts, blocksInfo))
+                                        .then(resp => this.props.parent.updateFileAsync("main.blocks", resp, true))
+                                    })
+                                .done(() => {
+                                    core.hideLoading();
                                 })
                         } else {
                             this.props.parent.newProject(opts);


### PR DESCRIPTION
If you're on the home screen after loading the editor and you select an example, it will fail to load. The error was that we were trying to decompile before a project was loaded and an exception was being thrown. It has been masked up until now because before the home screen we always had a project loaded in the editor.

Scenarios to test:
- [x] edit javascript with syntax errors, reload editor -> it should go back to JS
- [x] edit javascript correct code, reload editor -> goes back to JS
- [x] edit blocks correct code, reload editor -> goes back to blocks
- [x] edit blocks, invalid syntax (like a type error) - goes back to blocks