### PR TITLE
More robust tutorials. Loading queue.

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -70,6 +70,7 @@ namespace pxt.editor {
         filesOverride?: pxt.Map<string>;
         filters?: ProjectFilters;
         temporary?: boolean;
+        inTutorial?: boolean;
     }
 
     export interface ProjectFilters {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -146,7 +146,7 @@ namespace pxt.editor {
 
         openHome(): void;
         setTutorialStep(step: number): void;
-        exitTutorial(keep?: boolean): void;
+        exitTutorial(): void;
         completeTutorial(): void;
         showTutorialHint(): void;
         gettingStarted(): void;

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -20,6 +20,10 @@ namespace pxt.BrowserUtils {
         return hasNavigator() && /mobi/i.test(navigator.userAgent);
     }
 
+    export function isOnline(): boolean {
+        return navigator.onLine;;
+    }
+
     //MacIntel on modern Macs
     export function isMac(): boolean {
         return hasNavigator() && /Mac/i.test(navigator.platform);

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -20,10 +20,6 @@ namespace pxt.BrowserUtils {
         return hasNavigator() && /mobi/i.test(navigator.userAgent);
     }
 
-    export function isOnline(): boolean {
-        return navigator.onLine;;
-    }
-
     //MacIntel on modern Macs
     export function isMac(): boolean {
         return hasNavigator() && /Mac/i.test(navigator.platform);

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -94,7 +94,7 @@ namespace pxt.Cloud {
 
     export function isLoggedIn() { return !!accessToken }
 
-    function isNavigatorOnline() {
+    export function isNavigatorOnline() {
         return navigator && navigator.onLine;
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -351,6 +351,7 @@ namespace pxt.runner {
                         case "tutorial":
                             let body = $('body');
                             body.addClass('tutorial');
+                            $(loading).hide();
                             return renderTutorialAsync(content, src);
                         case "book":
                             return renderBookAsync(content, src);
@@ -617,6 +618,7 @@ ${files["main.ts"]}
                 // Extract toolbox block ids
                 let toolboxSubset: { [index: string]: number } = {};
                 return Promise.resolve()
+                    .then(() => renderMarkdownAsync(content, tutorialmd, { tutorial: true }))
                     .then(() => {
                         let uptoSteps = steps.join();
                         uptoSteps = uptoSteps.replace(/((?!.)\s)+/g, "\n");
@@ -650,7 +652,6 @@ ${files["main.ts"]}
                         }
                         return Promise.resolve();
                     })
-                    .then(() => renderMarkdownAsync(content, tutorialmd, { tutorial: true }))
                     .then(() => {
                         // Split the steps
                         let stepcontent = content.innerHTML.split(newAuthoring ? /<h2.*\/h2>/gi : /<h3.*\/h3>/gi);

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -597,6 +597,10 @@ ${files["main.ts"]}
                     steps = tutorialmd.split(/^###[^#].*$/gmi);
                     newAuthoring = false;
                 }
+                if (steps[0].indexOf("# Not found") == 0) {
+                    pxt.log(`Tutorial not found: ${tutorialid}`);
+                    throw new Error(`Tutorial not found: ${tutorialid}`);
+                }
                 let stepInfo: editor.TutorialStepInfo[] = [];
                 tutorialmd.replace(newAuthoring ? /^##[^#](.*)$/gmi : /^###[^#](.*)$/gmi, (f, s) => {
                     let info: editor.TutorialStepInfo = {
@@ -639,6 +643,9 @@ ${files["main.ts"]}
                                         toolboxSubset[blk.type] = 1;
                                     }
                                 }
+                            }).catch(() => {
+                                pxt.log(`Failed to decompile tutorial: ${tutorialid}`);
+                                throw new Error(`Failed to decompile tutorial: ${tutorialid}`);
                             })
                         }
                         return Promise.resolve();
@@ -664,6 +671,16 @@ ${files["main.ts"]}
                             toolboxSubset: toolboxSubset
                         }, "*");
                     });
+            })
+            .catch((e: Error) => {
+                pxt.log(`Failed to load tutorial: ${tutorialid}`);
+                pxt.log(e.message);
+                // return the result
+                window.parent.postMessage(<pxsim.TutorialFailedMessage>{
+                    type: "tutorial",
+                    tutorial: tutorialid,
+                    subtype: "error"
+                }, "*");
             })
     }
 

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -129,6 +129,11 @@ namespace pxsim {
         step: number;
     }
 
+    export interface TutorialFailedMessage extends TutorialMessage {
+        subtype: "error";
+        message?: string;
+    }
+
     export namespace Embed {
         export function start() {
             window.addEventListener("message", receiveMessage, false);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1593,7 +1593,6 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
     leaveTutorial() {
         core.showLoading("leavingtutorial", lf("leaving tutorial..."));
         this.exitTutorialAsync()
-            .then(() => Promise.delay(500))
             .done(() => {
                 core.hideLoading("leavingtutorial");
                 this.openHome();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1603,8 +1603,10 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
     exitTutorialAsync() {
         // tutorial project is temporary, no need to delete
         let curr = pkg.mainEditorPkg().header;
+        let files = pkg.mainEditorPkg().getAllFiles();
         curr.temporary = false;
         return workspace.saveAsync(curr, {})
+            .then(() => { workspace.installAsync(curr, files) })
             .finally(() => {
                 this.setState({ tutorialOptions: undefined, tracing: undefined, editorState: undefined });
                 core.resetFocus();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1580,10 +1580,19 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         });
     }
 
-    exitTutorial(keep?: boolean) {
+    completeTutorial() {
+        pxt.tickEvent("tutorial.complete");
+        this.leaveTutorial();
+    }
+
+    exitTutorial() {
         pxt.tickEvent("tutorial.exit");
+        this.leaveTutorial();
+    }
+
+    leaveTutorial() {
         core.showLoading("leavingtutorial", lf("leaving tutorial..."));
-        this.exitTutorialAsync(keep)
+        this.exitTutorialAsync()
             .then(() => Promise.delay(500))
             .done(() => {
                 core.hideLoading("leavingtutorial");
@@ -1591,27 +1600,13 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
             })
     }
 
-    exitTutorialAsync(keep?: boolean) {
+    exitTutorialAsync() {
         // tutorial project is temporary, no need to delete
         let curr = pkg.mainEditorPkg().header;
-        let files = pkg.mainEditorPkg().getAllFiles();
-        if (!keep) {
-            curr.isDeleted = true;
-        } else {
-            curr.temporary = false;
-        }
-        this.setState({ active: false, editorState: undefined });
+        curr.temporary = false;
         return workspace.saveAsync(curr, {})
-            .then(() => { return keep ? workspace.installAsync(curr, files) : Promise.resolve(null); })
-            .then(() => {
-                if (workspace.getHeaders().length > 0) {
-                    return this.loadHeaderAsync(workspace.getHeaders()[0], null);
-                } else {
-                    return this.newProject();
-                }
-            })
             .finally(() => {
-                this.setState({ active: true, tutorialOptions: undefined, tracing: undefined });
+                this.setState({ tutorialOptions: undefined, tracing: undefined, editorState: undefined });
                 core.resetFocus();
             });
     }
@@ -1624,11 +1619,6 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         if (this.editor && this.editor.isReady) {
             this.editor.setHighContrast(highContrastOn);
         }
-    }
-
-    completeTutorial() {
-        pxt.tickEvent("tutorial.complete");
-        this.openHome();
     }
 
     showTutorialHint() {
@@ -1799,7 +1789,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                                     </sui.DropdownMenuItem>}
 
                                 {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={() => this.launchFullEditor()} /> : undefined}
-                                {inTutorial ? <sui.ButtonMenuItem class="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={() => this.exitTutorial(true)} /> : undefined}
+                                {inTutorial ? <sui.ButtonMenuItem class="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={() => this.exitTutorial()} /> : undefined}
 
                                 {!sandbox ? <a href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo organization" onClick={() => pxt.tickEvent("menu.org")}>
                                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1549,7 +1549,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
     startTutorial(tutorialId: string, tutorialTitle?: string) {
         pxt.tickEvent("tutorial.start");
         // Check for Internet access
-        if (!Cloud.isOnline()) {
+        if (!pxt.Cloud.isNavigatorOnline()) {
             core.errorNotification(lf("No Internet access, please connect and try again."));
             this.home.showHome();
         } else {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1549,7 +1549,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
     startTutorial(tutorialId: string, tutorialTitle?: string) {
         pxt.tickEvent("tutorial.start");
         // Check for Internet access
-        if (!pxt.BrowserUtils.isOnline()) {
+        if (!Cloud.isOnline()) {
             core.errorNotification(lf("No Internet access, please connect and try again."));
             this.home.showHome();
         } else {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -80,7 +80,6 @@ export class Editor extends srceditor.Editor {
             editorDiv.appendChild(loading);
 
             this.loadingXmlPromise = compiler.getBlocksAsync()
-                .finally(() => { this.loadingXml = false })
                 .then(bi => {
                     this.blockInfo = bi;
                     let showSearch = this.showSearch;
@@ -112,11 +111,13 @@ export class Editor extends srceditor.Editor {
                     Blockly.svgResize(this.editor);
                     this.isFirstBlocklyLoad = false;
                 }).finally(() => {
+                    this.loadingXml = false
                     editorDiv.removeChild(loading);
+                    core.hideLoading("loadingblocks");
                 });
 
             if (this.isFirstBlocklyLoad) {
-                core.showLoadingAsync(lf("loading..."), this.loadingXmlPromise).done();
+                core.showLoadingAsync("loadingblocks",lf("loading..."), this.loadingXmlPromise).done();
             } else {
                 this.loadingXmlPromise.done();
             }

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -31,14 +31,14 @@ let loadingQueue: string[] = [];
 let loadingQueueMsg: pxt.Map<string> = {};
 
 export function hideLoading(id: string) {
-    pxt.log("hideloading: " + id);
+    pxt.debug("hideloading: " + id);
     if (loadingQueueMsg[id] != undefined) {
         // loading exists, remove from queue
         const index = loadingQueue.indexOf(id);
         if (index > -1) loadingQueue.splice(index, 1);
         delete loadingQueueMsg[id];
     } else {
-        pxt.log("Loading not in queue, disregard: " + id);
+        pxt.debug("Loading not in queue, disregard: " + id);
     }
     if (loadingQueue.length > 0) {
         // Show the next loading message
@@ -57,7 +57,7 @@ export function hideLoading(id: string) {
 }
 
 export function showLoading(id: string, msg: string) {
-    pxt.log("showloading: " + id);
+    pxt.debug("showloading: " + id);
     initializeDimmer();
     $('.ui.dimmer.loading').dimmer('show');
     $('.ui.dimmer.loading').html(`

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -27,18 +27,37 @@ export function isLoading() {
     return !!$('.ui.loading.dimmer .loadingcontent')[0];
 }
 
-export function hideLoading() {
-    $('.ui.dimmer.loading .loadingcontent').remove();
-    $('.ui.dimmer.loading').dimmer('hide');
-    if (!dimmerInitialized) {
-        initializeDimmer();
+let loadingQueue: string[] = [];
+let loadingQueueMsg: pxt.Map<string> = {};
+
+export function hideLoading(id: string) {
+    pxt.log("hideloading: " + id);
+    if (loadingQueueMsg[id] != undefined) {
+        // loading exists, remove from queue
+        const index = loadingQueue.indexOf(id);
+        if (index > -1) loadingQueue.splice(index, 1);
+        delete loadingQueueMsg[id];
+    } else {
+        pxt.log("Loading not in queue, disregard: " + id);
     }
-    setTimeout(function () {
+    if (loadingQueue.length > 0) {
+        // Show the next loading message
+        displayNextLoading();
+    } else {
+        // Hide loading
+        $('.ui.dimmer.loading .loadingcontent').remove();
         $('.ui.dimmer.loading').dimmer('hide');
-    }, 200);
+        if (!dimmerInitialized) {
+            initializeDimmer();
+        }
+        setTimeout(function () {
+            $('.ui.dimmer.loading').dimmer('hide');
+        }, 200);
+    }
 }
 
-export function showLoading(msg: string) {
+export function showLoading(id: string, msg: string) {
+    pxt.log("showloading: " + id);
     initializeDimmer();
     $('.ui.dimmer.loading').dimmer('show');
     $('.ui.dimmer.loading').html(`
@@ -46,6 +65,15 @@ export function showLoading(msg: string) {
     <div class="ui text large loader msg" aria-live="assertive">${lf("Please wait")}</div>
   </div>
 `)
+    loadingQueue.push(id);
+    loadingQueueMsg[id] = msg;
+    displayNextLoading();
+}
+
+function displayNextLoading() {
+    if (!loadingQueue.length) return;
+    const id = loadingQueue[loadingQueue.length - 1]; // get last item
+    const msg = loadingQueueMsg[id];
     $('.ui.dimmer.loading .msg').text(msg);
 }
 
@@ -56,22 +84,22 @@ function initializeDimmer() {
     dimmerInitialized = true;
 }
 
-let asyncLoadingTimeout: number;
+let asyncLoadingTimeout: pxt.Map<number> = {};
 
-export function showLoadingAsync(msg: string, operation: Promise<any>, delay: number = 700) {
-    clearTimeout(asyncLoadingTimeout);
-    asyncLoadingTimeout = setTimeout(function () {
-        showLoading(msg);
+export function showLoadingAsync(id: string, msg: string, operation: Promise<any>, delay: number = 700) {
+    clearTimeout(asyncLoadingTimeout[id]);
+    asyncLoadingTimeout[id] = setTimeout(function () {
+        showLoading(id, msg);
     }, delay);
 
     return operation.finally(() => {
-        cancelAsyncLoading();
+        cancelAsyncLoading(id);
     });
 }
 
-export function cancelAsyncLoading() {
-    clearTimeout(asyncLoadingTimeout);
-    hideLoading();
+export function cancelAsyncLoading(id: string) {
+    clearTimeout(asyncLoadingTimeout[id]);
+    hideLoading(id);
 }
 
 export function navigateInWindow(url: string) {

--- a/webapp/src/electron.ts
+++ b/webapp/src/electron.ts
@@ -58,7 +58,7 @@ export function init() {
                 sendMessage("quit");
             } else {
                 pxt.tickEvent("update.acceptedCritical");
-                core.showLoading(lf("Downloading update..."));
+                core.showLoading("downloadingupdate", lf("Downloading update..."));
                 sendMessage("update", {
                     targetVersion: args.targetVersion,
                     type: args.type
@@ -103,7 +103,7 @@ export function init() {
                     }
 
                     if (!isUrl) {
-                        core.showLoading(lf("Downloading update..."));
+                        core.showLoading("downloadingupdate", lf("Downloading update..."));
                     }
 
                     sendMessage("update", {
@@ -131,7 +131,7 @@ export function init() {
     function onUpdateDownloadError(args: UpdateEventInfo) {
         const isCritical = args && args.type === UpdateEventType.Critical;
 
-        core.hideLoading();
+        core.hideLoading("downloadingupdate");
         displayUpdateError(lf("There was an error downloading the update"), isCritical ? lf("Quit") : lf("Ok"))
             .finally(() => {
                 if (isCritical) {

--- a/webapp/src/logview.tsx
+++ b/webapp/src/logview.tsx
@@ -142,14 +142,14 @@ export class LogView extends React.Component<{}, LogViewState> {
                 }),
                     _.find('#datastreamstart').click(() => {
                         _.modal('hide');
-                        core.showLoading(lf("creating stream in Microsoft Azure..."))
+                        core.showLoading("createazurestream", lf("creating stream in Microsoft Azure..."))
                         pxt.streams.createStreamAsync(pxt.appTarget.id)
                             .then(stream => {
-                                core.hideLoading();
+                                core.hideLoading("createazurestream");
                                 this.setStream(stream);
                             }).catch(e => {
                                 pxt.reportException(e, {});
-                                core.hideLoading();
+                                core.hideLoading("createazurestream");
                                 core.warningNotification(lf("Oops, we could not create the stream. Please try again later."));
                             }).done();
                     })

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -92,7 +92,7 @@ export class Editor extends srceditor.Editor {
             }
 
             const failedAsync = (file: string, programTooLarge = false) => {
-                core.cancelAsyncLoading();
+                core.cancelAsyncLoading("switchtoblocks");
                 this.forceDiagnosticsUpdate();
                 return this.showConversionFailedDialog(file, programTooLarge);
             }
@@ -154,7 +154,7 @@ export class Editor extends srceditor.Editor {
                 });
         });
 
-        core.showLoadingAsync(lf("switching to blocks..."), promise).done();
+        core.showLoadingAsync("switchtoblocks", lf("switching to blocks..."), promise).done();
     }
 
     public showConversionFailedDialog(blockFile: string, programTooLarge: boolean): Promise<void> {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -134,8 +134,12 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
 
         const chgHeader = (hdr: pxt.workspace.Header) => {
             pxt.tickEvent("projects.header");
+            core.showLoading("changeheader", lf("Loading..."));
             this.hide();
             this.props.parent.loadHeaderAsync(hdr)
+                .done(() => {
+                    core.hideLoading("changeheader");
+                })
         }
         const chgGallery = (scr: pxt.CodeCard) => {
             pxt.tickEvent("projects.gallery", { name: scr.name });
@@ -162,7 +166,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                     if (opts) {
                         if (loadBlocks) {
                             const ts = opts.filesOverride["main.ts"]
-                            this.props.parent.createProjectAsync(opts)
+                            return this.props.parent.createProjectAsync(opts)
                                 .then(() => {
                                     return compiler.getBlocksAsync()
                                         .then(blocksInfo => compiler.decompileSnippetAsync(ts, blocksInfo))
@@ -172,7 +176,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                                     core.hideLoading("changingcode");
                                 })
                         } else {
-                            this.props.parent.newProject(opts);
+                            return this.props.parent.newProject(opts);
                         }
                     }
                     core.hideLoading("changingcode");

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -155,7 +155,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
         }
 
         const chgCode = (scr: pxt.CodeCard, loadBlocks?: boolean) => {
-            core.showLoading(lf("Loading..."));
+            core.showLoading("changingcode", lf("Loading..."));
             gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
                 .done(opts => {
                     if (opts) {
@@ -171,6 +171,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                             this.props.parent.newProject(opts);
                         }
                     }
+                    core.hideLoading("changingcode");
                 });
         }
         const importProject = () => {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -169,7 +169,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
                                         .then(resp => this.props.parent.updateFileAsync("main.blocks", resp, true))
                                     })
                                 .done(() => {
-                                    core.hideLoading();
+                                    core.hideLoading("changingcode");
                                 })
                         } else {
                             this.props.parent.newProject(opts);

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -146,13 +146,13 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             pxt.tickEvent("packages.github");
             this.hide();
             let p = pkg.mainEditorPkg();
-            core.showLoading(lf("downloading package..."));
+            core.showLoading("downloadingpackage", lf("downloading package..."));
             pxt.packagesConfigAsync()
                 .then(config => pxt.github.latestVersionAsync(scr.fullName, config))
                 .then(tag => pxt.github.pkgConfigAsync(scr.fullName, tag)
                     .then(cfg => addDepIfNoConflict(cfg, "github:" + scr.fullName + "#" + tag)))
                 .catch(core.handleNetworkError)
-                .finally(() => core.hideLoading());
+                .finally(() => core.hideLoading("downloadingpackage"));
         }
         const addDepIfNoConflict = (config: pxt.PackageConfig, version: string) => {
             return pkg.mainPkg.findConflictsAsync(config, version)


### PR DESCRIPTION
This PR includes changes to bring a loading queue to the core show/hide loading methods. The issue with the current paradigm of just showing the loading spinner at different points and then hiding it at various points is that it's non deterministic and it's possible to be done with one action, but not done with another (namely tutorials). It's common to find yourself still waiting for the tutorial to load but since the new project has finished loading and all the blocks are there, the spinner disappears. 

This introduces an ID associated with each show/hide loading call, and uses a queue to show the messages. If one action is complete, it shows the next until there are no more to show. 

PR also includes a couple of catch clauses and a tutorial error message to send the parent if we fail to decompile the blocks or fail to find the tutorial referenced. 

PR also checks for internet connection before starting to load a tutorial. Since we rely on the iframe loading and requesting the tutorial from the server, we need to check that the iframe is able to connect to the Internet in the first place. 
using navigator.isOnline:
http://caniuse.com/#feat=online-status


Tested on: 
- [x] Edge
- [x] IE
- [x] Chrome Mac
- [x] Firefox Mac and Windows
- [x] Safari