### PR TITLE
Fix 'create.md' for arrays.

### DIFF
--- a/common-docs/reference/arrays/create.md
+++ b/common-docs/reference/arrays/create.md
@@ -1,13 +1,34 @@
 # create
 
-Create a new array that can be used to store values.
+Create a new array to store one or more values.
 
-```block
+## Create an array
+
+### Empty array
+
+You can create arrays with no items. If you do that, you'll need tell what [type](/types) the array will be. This is an empty array:
+
+```typescript
 let empty: string[] = []
 ```
+
+```blocks
+let empty: string[] = []
+```
+
+### One item array
+
+You can create and _initialize_ an array with an item. Arrays created with at least one item automatically have the [type](/types) of the item. This is called a _type inference_.
+
+
 ```block
 let oneItem = ["item"]
 ```
+
+### Multiple item array
+
+Create arrays with more than one item if you want.
+
 ```block
 let twoItems = [1, 2]
 ```


### PR DESCRIPTION
- [x] Empty arrays don't render in _block_, use _blocks_.
- [x] Add some text to describe initialization.

Will do a pick to ``v0`` also.