### PR TITLE
remove vertical bar right of logo

### DIFF
--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -20,7 +20,6 @@
         background-repeat: no-repeat;
         background-size: contain;
         background-image: @fileLogoUrl;
-        border-right: 1px solid @solidBorderColor;
     }
     .content {
         margin-left: 4rem;


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-minecraft/issues/381

![image](https://user-images.githubusercontent.com/4175913/30940927-d3ca94e4-a397-11e7-9bf0-5a2b1675a550.png)

