### PR TITLE
Button and card UI fixes

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -360,11 +360,8 @@ div.simframe > iframe {
 }
 
 /* Icon and text */
-.ui.menu > .menu > .ui.item > .icon-and-text.icon {
-    margin: 0em auto;
-}
-.ui.menu > .menu > .ui.item > .icon-and-text.icon ~ span.ui.text {
-    margin-left: 0.6em;
+.ui.item.icon > .icon-and-text.icon ~ .ui.text, .ui.button.icon > .icon-and-text.icon ~ .ui.text {
+    margin-left: 0.4em !important;
 }
 
 /* Beta */

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -69,6 +69,19 @@
     }
     .content {
         height: 3rem;
+        z-index: 1;
+        padding-bottom: 0;
+        width: 100%;
+        .header {
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+    }
+    .ui.image ~ .content {
+        .header {
+            color: white;
+        }
     }
 }
 

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -37,7 +37,7 @@ export function cx(classes: string[]): string {
 }
 
 function genericClassName(cls: string, props: UiProps, ignoreIcon: boolean = false): string {
-    return `${cls} ${ignoreIcon ? '' : props.icon && props.text ? 'icon-and-text' : props.icon ? 'icon' : ""} ${props.class || ""}`;
+    return `${cls} ${ignoreIcon ? '' : props.icon && props.text ? 'icon icon-and-text' : props.icon ? 'icon' : ""} ${props.class || ""}`;
 }
 
 function genericContent(props: UiProps) {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -248,8 +248,8 @@ export class TutorialCard extends data.Component<ISettingsProps, {}> {
                     </div>
                     <sui.Button id="tutorialOkButton" class="large green okbutton showlightbox focused" text={lf("Ok") } onClick={() => this.closeLightbox() } onKeyDown={sui.fireClickOnEnter} />
                 </div>
-                {hasNext ? <sui.Button icon="right chevron" class={`ui right icon button nextbutton right attached green ${!hasNext ? 'disabled' : ''}`} text={lf("Next") } ariaLabel={lf("Go to the next step of the tutorial.")} onClick={() => this.nextTutorialStep() } onKeyDown={sui.fireClickOnEnter} /> : undefined }
-                {hasFinish ? <sui.Button icon="left checkmark" class={`ui icon orange button ${!tutorialReady ? 'disabled' : 'focused'}`} text={lf("Finish") } ariaLabel={lf("Finish the tutorial.")} onClick={() => this.finishTutorial() } onKeyDown={sui.fireClickOnEnter} /> : undefined }
+                {hasNext ? <sui.Button icon="right chevron" rightIcon class={`nextbutton right attached green ${!hasNext ? 'disabled' : ''}`} text={lf("Next") } ariaLabel={lf("Go to the next step of the tutorial.")} onClick={() => this.nextTutorialStep() } onKeyDown={sui.fireClickOnEnter} /> : undefined }
+                {hasFinish ? <sui.Button icon="left checkmark" class={`orange right attached ${!tutorialReady ? 'disabled' : 'focused'}`} text={lf("Finish") } ariaLabel={lf("Finish the tutorial.")} onClick={() => this.finishTutorial() } onKeyDown={sui.fireClickOnEnter} /> : undefined }
             </div>
         </div>;
     }


### PR DESCRIPTION
- Alignment of buttons and text in the top menu. 
- Right align and attach next and finish tutorial button
- Card fixes:
  - add ellipsis to the text if it's too long
  - make the header color white only if there's an image