### PR TITLE
Show cookie on top

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -153,7 +153,7 @@ html, body {
    bottom: 12rem;
    width: 18rem;
    text-align: left;
-   z-index:1000;
+   z-index:100000;
 }
 
 #cookiemsg > a {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1675,10 +1675,6 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         const useModulator = compile.useModulator;
         const { hideMenuBar, hideEditorToolbar } = targetTheme;
         const isHeadless = simOpts.headless;
-        const isElectron = /[?&]electron=1/.test(window.location.href) || !!(window as any).ipcRenderer;
-        const cookieKey = "cookieconsent"
-        const cookieConsented = targetTheme.hideCookieNotice || isElectron || pxt.winrt.isWinRT() || !!pxt.storage.getLocal(cookieKey)
-            || sandbox;
         const simActive = this.state.embedSimView;
         const blockActive = this.isBlocksActive();
         const javascriptActive = this.isJavaScriptActive();
@@ -1686,22 +1682,27 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         const selectLanguage = targetTheme.selectLanguage;
         const betaUrl = targetTheme.betaUrl;
 
-        const consentCookie = () => {
-            pxt.storage.setLocal(cookieKey, "1");
-            this.forceUpdate();
-        }
-
         const showSideDoc = sideDocs && this.state.sideDocsLoadUrl && !this.state.sideDocsCollapsed;
         const shouldHideEditorFloats = (this.state.hideEditorFloats || this.state.collapseEditorTools) && (!inTutorial || isHeadless);
         const shouldCollapseEditorTools = this.state.collapseEditorTools && (!inTutorial || isHeadless);
 
         // For apps, if the user is not on the live website, display a warning banner
-        const isApp = isElectron || pxt.winrt.isWinRT() || !!(window as any).ipcRenderer;
+        const isApp = electron.isElectron || pxt.winrt.isWinRT();
         const isLocalServe = location.hostname === "localhost";
         const isExperimentalUrlPath = location.pathname !== "/"
             && (targetTheme.appPathNames || []).indexOf(location.pathname) === -1;
         const showExperimentalBanner = !isLocalServe && isApp && !this.state.hideExperimentalBanner && isExperimentalUrlPath;
         const liveUrl = pxt.appTarget.appTheme.homeUrl + location.search + location.hash;
+
+        // cookie concent
+        const cookieKey = "cookieconsent"
+        const cookieConsented = targetTheme.hideCookieNotice || isApp || !!pxt.storage.getLocal(cookieKey)
+            || sandbox;
+
+        const consentCookie = () => {
+            pxt.storage.setLocal(cookieKey, "1");
+            this.forceUpdate();
+        }
 
         // update window title
         document.title = this.state.header ? `${this.state.header.name} - ${pxt.appTarget.name}` : pxt.appTarget.name;
@@ -1786,7 +1787,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                                         {targetTheme.privacyUrl ? <a className="ui item" href={targetTheme.privacyUrl} role="menuitem" title={lf("Privacy & Cookies")} target="_blank" tabIndex={-1}>{lf("Privacy & Cookies")}</a> : undefined}
                                         {targetTheme.termsOfUseUrl ? <a className="ui item" href={targetTheme.termsOfUseUrl} role="menuitem" title={lf("Terms Of Use")} target="_blank" tabIndex={-1}>{lf("Terms Of Use")}</a> : undefined}
                                         <sui.Item role="menuitem" text={lf("About...")} onClick={() => this.about()} tabIndex={-1} />
-                                        {isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...")} onClick={() => electron.checkForUpdate()} tabIndex={-1} /> : undefined}
+                                        {electron.isPxtElectron ? <sui.Item role="menuitem" text={lf("Check for updates...")} onClick={() => electron.checkForUpdate()} tabIndex={-1} /> : undefined}
                                         {targetTheme.feedbackUrl ? <div className="ui divider"></div> : undefined}
                                         {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback")} target="_blank" rel="noopener" tabIndex={-1}>{lf("Give Feedback")}</a> : undefined}
                                     </sui.DropdownMenuItem>}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1675,8 +1675,9 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         const useModulator = compile.useModulator;
         const { hideMenuBar, hideEditorToolbar } = targetTheme;
         const isHeadless = simOpts.headless;
+        const isElectron = /[?&]electron=1/.test(window.location.href) || !!(window as any).ipcRenderer;
         const cookieKey = "cookieconsent"
-        const cookieConsented = targetTheme.hideCookieNotice || electron.isElectron || pxt.winrt.isWinRT() || !!pxt.storage.getLocal(cookieKey)
+        const cookieConsented = targetTheme.hideCookieNotice || isElectron || pxt.winrt.isWinRT() || !!pxt.storage.getLocal(cookieKey)
             || sandbox;
         const simActive = this.state.embedSimView;
         const blockActive = this.isBlocksActive();
@@ -1695,7 +1696,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         const shouldCollapseEditorTools = this.state.collapseEditorTools && (!inTutorial || isHeadless);
 
         // For apps, if the user is not on the live website, display a warning banner
-        const isApp = electron.isElectron || pxt.winrt.isWinRT() || !!(window as any).ipcRenderer;
+        const isApp = isElectron || pxt.winrt.isWinRT() || !!(window as any).ipcRenderer;
         const isLocalServe = location.hostname === "localhost";
         const isExperimentalUrlPath = location.pathname !== "/"
             && (targetTheme.appPathNames || []).indexOf(location.pathname) === -1;
@@ -1785,7 +1786,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                                         {targetTheme.privacyUrl ? <a className="ui item" href={targetTheme.privacyUrl} role="menuitem" title={lf("Privacy & Cookies")} target="_blank" tabIndex={-1}>{lf("Privacy & Cookies")}</a> : undefined}
                                         {targetTheme.termsOfUseUrl ? <a className="ui item" href={targetTheme.termsOfUseUrl} role="menuitem" title={lf("Terms Of Use")} target="_blank" tabIndex={-1}>{lf("Terms Of Use")}</a> : undefined}
                                         <sui.Item role="menuitem" text={lf("About...")} onClick={() => this.about()} tabIndex={-1} />
-                                        {electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...")} onClick={() => electron.checkForUpdate()} tabIndex={-1} /> : undefined}
+                                        {isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...")} onClick={() => electron.checkForUpdate()} tabIndex={-1} /> : undefined}
                                         {targetTheme.feedbackUrl ? <div className="ui divider"></div> : undefined}
                                         {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback")} target="_blank" rel="noopener" tabIndex={-1}>{lf("Give Feedback")}</a> : undefined}
                                     </sui.DropdownMenuItem>}

--- a/webapp/src/electron.ts
+++ b/webapp/src/electron.ts
@@ -28,7 +28,9 @@ interface ElectronMessage {
 
 let electronSocket: WebSocket = null;
 
-export const isElectron = /[?&]electron=1/.test(window.location.href);
+export const isPxtElectron = /[?&]electron=1/.test(window.location.href);
+export const isIpcRenderer = !!(window as any).ipcRenderer;
+export const isElectron = isPxtElectron || isIpcRenderer;
 
 export function init() {
     if (!isElectron || !Cloud.isLocalHost() || !Cloud.localToken) {


### PR DESCRIPTION
Always show cookie on top of everything else. 

Cleanup electron logic so that there's one centralized place for the source of truth. Also only showing cookie message on website, not in an app.
