### PR TITLE
Fix z-index of flyout scrollbars so it's above the flyout.

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -14,10 +14,9 @@
     z-index: 105;
 }
 
-/* Set Z index of the Blockly scrollbars to be beneath the BlocklyWidgetDiv */
-.blocklyScrollbarHorizontal, .blocklyScrollbarVertical {
-    z-index: 8 !important;
-}
+/* Blockly z-index: */
+/* blocklyFlyout: 20 */
+/* blocklyFlyoutScrollbar: 30 */
 
 .blocklyTooltipDiv {
     border:none !important;

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -134,18 +134,18 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     <div className="ui equal width grid">
                         <div className="left aligned column">
                             <div className="ui icon small buttons">
-                                <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={() => this.toggleCollapse('mobile') } />
+                                <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "") } title={collapseTooltip} onClick={() => this.toggleCollapse('mobile') } />
                                 {headless && run ? <sui.Button class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('mobile') } /> : undefined }
                                 {headless && restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('mobile') } /> : undefined }
                                 {headless && trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('mobile') } /> : undefined }
-                                {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} ariaLabel={lf("Download your code")} onClick={() => this.compile('mobile') } /> : undefined }
+                                {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} ariaLabel={lf("Download your code") } onClick={() => this.compile('mobile') } /> : undefined }
                             </div>
                         </div>
                         <div className="right aligned column">
                             {!readOnly ?
                                 <div className="ui icon small buttons">
-                                    <sui.Button icon='save' class={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onClick={() => this.saveFile('mobile') } />
-                                    {showUndoRedo ? <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('mobile') } /> : undefined }
+                                    <sui.Button icon='save' class={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project") } onClick={() => this.saveFile('mobile') } />
+                                    {showUndoRedo ? <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "") } title={lf("Undo") } onClick={() => this.undo('mobile') } /> : undefined }
                                 </div> : undefined }
                         </div>
                         <div className="right aligned column">
@@ -165,26 +165,28 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                             {showCollapsed ?
                                 <div className="row" style={{ paddingTop: "1rem" }}>
                                     <div className="ui vertical icon small buttons">
-                                        <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} ariaLabel={lf("{0}, {1}", collapseTooltip, collapsed ? lf("Collapsed") : "Expanded")} onClick={() => this.toggleCollapse('mobile') } />
+                                        <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} ariaLabel={lf("{0}, {1}", collapseTooltip, collapsed ? lf("Collapsed") : "Expanded") } onClick={() => this.toggleCollapse('mobile') } />
                                     </div>
                                 </div> : undefined }
                         </div>
                         <div className="three wide column">
                         </div>
-                        <div className="ui grid column">
-                            {readOnly || !showUndoRedo ? undefined :
-                                <div className="row">
+                        <div className="column">
+                            <div className="ui grid">
+                                {readOnly || !showUndoRedo ? undefined :
+                                    <div className="row">
+                                        <div className="column">
+                                            <div className="ui icon large buttons">
+                                                <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "") } title={lf("Undo") } onClick={() => this.undo('mobile') } />
+                                            </div>
+                                        </div>
+                                    </div>}
+                                <div className="row" style={readOnly || !showUndoRedo ? undefined : { paddingTop: 0 }}>
                                     <div className="column">
                                         <div className="ui icon large buttons">
-                                            <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('mobile') } />
+                                            {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('mobile') } /> : undefined }
+                                            {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
                                         </div>
-                                    </div>
-                                </div>}
-                            <div className="row" style={readOnly || !showUndoRedo ? undefined : { paddingTop: 0 }}>
-                                <div className="column">
-                                    <div className="ui icon large buttons">
-                                        {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('mobile') } /> : undefined }
-                                        {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
                                     </div>
                                 </div>
                             </div>
@@ -197,7 +199,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         {headless ?
                             <div className="left aligned six wide column">
                                 <div className="ui icon buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
+                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "") } title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
                                     {run ? <sui.Button role="menuitem" class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('tablet') } /> : undefined }
                                     {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('tablet') } /> : undefined }
                                     {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('tablet') } /> : undefined }
@@ -206,19 +208,19 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                             </div> :
                             <div className="left aligned six wide column">
                                 <div className="ui icon buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
+                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "") } title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
                                     {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} text={downloadText} title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
                                 </div>
                             </div> }
                         <div className="column four wide">
                             {readOnly ? undefined :
-                                <sui.Button icon='save' class={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onClick={() => this.saveFile('tablet') } /> }
+                                <sui.Button icon='save' class={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project") } onClick={() => this.saveFile('tablet') } /> }
                         </div>
                         <div className="column six wide right aligned">
                             {showUndoRedo ?
                                 <div className="ui icon small buttons">
-                                    <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('tablet') } />
-                                    <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Red"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={() => this.redo('tablet') } />
+                                    <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "") } title={lf("Undo") } onClick={() => this.undo('tablet') } />
+                                    <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Red"), !hasRedo ? lf("Disabled") : "") } title={lf("Redo") } onClick={() => this.redo('tablet') } />
                                 </div> : undefined }
                             {showZoomControls ?
                                 <div className="ui icon small buttons">
@@ -236,7 +238,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                             {showCollapsed ?
                                 <div className="row" style={{ paddingTop: "1rem" }}>
                                     <div className="ui vertical icon small buttons">
-                                        <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} ariaLabel={lf("{0}, {1}", collapseTooltip, collapsed ? lf("Collapsed") : "Expanded")} onClick={() => this.toggleCollapse('tablet') } />
+                                        <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} ariaLabel={lf("{0}, {1}", collapseTooltip, collapsed ? lf("Collapsed") : "Expanded") } onClick={() => this.toggleCollapse('tablet') } />
                                     </div>
                                 </div> : undefined }
                         </div>
@@ -253,7 +255,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     <div className="row" style={compileBtn ? { paddingTop: 0 } : {}}>
                                         <div className="column">
                                             <div className="ui item large right labeled fluid input projectname-input projectname-tablet" title={lf("Pick a name for your project") }>
-                                                <label htmlFor="fileNameInput1" id="fileNameInputLabel1" className="accessible-hidden">{lf("Type a name for your project")}</label>
+                                                <label htmlFor="fileNameInput1" id="fileNameInputLabel1" className="accessible-hidden">{lf("Type a name for your project") }</label>
                                                 <input id="fileNameInput1"
                                                     type="text"
                                                     aria-labelledby="fileNameInputLabel1"
@@ -261,7 +263,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                                     value={projectName || ''}
                                                     onChange={(e) => this.saveProjectName((e.target as any).value, 'tablet') }>
                                                 </input>
-                                                <sui.Button icon='save' class={`large right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onClick={() => this.saveFile('tablet') } />
+                                                <sui.Button icon='save' class={`large right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project") } onClick={() => this.saveFile('tablet') } />
                                             </div>
                                         </div>
                                     </div> : undefined }
@@ -274,8 +276,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                         <div className="column">
                                             {showUndoRedo ?
                                                 <div className="ui icon large buttons">
-                                                    <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo")} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} onClick={() => this.undo() } />
-                                                    <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn} ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo")} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} onClick={() => this.redo() } />
+                                                    <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo") } ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "") } onClick={() => this.undo() } />
+                                                    <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn} ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo") } ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "") } onClick={() => this.redo() } />
                                                 </div> : undefined }
                                             {showZoomControls ?
                                                 <div className="ui icon large buttons">
@@ -315,7 +317,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     {showProjectRename ?
                         <div className="column left aligned">
                             <div className={`ui right labeled input projectname-input projectname-computer`} title={lf("Pick a name for your project") }>
-                                <label htmlFor="fileNameInput2" id="fileNameInputLabel2" className="accessible-hidden">{lf("Type a name for your project")}</label>
+                                <label htmlFor="fileNameInput2" id="fileNameInputLabel2" className="accessible-hidden">{lf("Type a name for your project") }</label>
                                 <input id="fileNameInput2"
                                     type="text"
                                     aria-labelledby="fileNameInputLabel2"
@@ -323,14 +325,14 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     value={projectName || ''}
                                     onChange={(e) => this.saveProjectName((e.target as any).value, 'computer') }>
                                 </input>
-                                <sui.Button icon='save' class={`small right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onClick={() => this.saveFile('computer') } />
+                                <sui.Button icon='save' class={`small right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project") } onClick={() => this.saveFile('computer') } />
                             </div>
                         </div> : undefined }
                     <div className="column right aligned">
                         {showUndoRedo ?
                             <div className="ui icon small buttons">
-                                <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('computer') } />
-                                <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={() => this.redo('computer') } />
+                                <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "") } title={lf("Undo") } onClick={() => this.undo('computer') } />
+                                <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "") } title={lf("Redo") } onClick={() => this.redo('computer') } />
                             </div> : undefined }
                         {showZoomControls ?
                             <div className="ui icon small buttons">


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt/issues/3086

@guillaumejenkins please test, I remove the previous CSS that was setting it explicitly to 8 as Blockly has: 
- blocklyFlyout at 20
- blocklyFlyoutScrollbar at 30

and your comment was that it should be below the widgetDiv, however the widgetDiv is set to 100 above it. Please test this @guillaumejenkins 


Also: While testing I found this issue with the scrollbars in the mobile view where the editortoolbar's grid is shown above the scrollbar and restricts the user from getting to the scrollbar: 
<img width="404" alt="screen shot 2017-09-29 at 12 01 57 pm" src="https://user-images.githubusercontent.com/16690124/31024775-24ea2d9a-a50e-11e7-83a3-4e8b56abdae7.png">

Fixing in this PR as well.