### PR TITLE
Fix package extension css interfering with home screen

### DIFF
--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -5,13 +5,14 @@
 
 /* Full screen dialog */
 
-.modals.dimmer .ui.fullscreen.scrolling.modal {
+.modals.dimmer .ui.home.scrolling.modal {
+    width: 100% !important;
     height: 100% !important;
     margin: 0 !important;
     padding: 0 !important;
 }
 
-.ui.fullscreen.dimmer {
+.ui.home.dimmer {
     background-color: white;
     transition: none;
 }

--- a/theme/themes/pxt/modules/modal.variables
+++ b/theme/themes/pxt/modules/modal.variables
@@ -1,8 +1,3 @@
 /*******************************
          Site Overrides
 *******************************/
-
-
-/* Make fullscreen modals appear as fullscreen pages */
-@scrollingMargin: 0rem;
-@fullScreenWidth: 100%;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -209,7 +209,7 @@ export class Projects extends data.Component<ProjectsProps, ProjectsState> {
         const tabIcon = tab == HOME ? "home large" : undefined;
 
         return (
-            <sui.Modal open={visible} className="projectsdialog" size="fullscreen" onClose={() => this.hide(/* closeOnly */ true) } dimmer={true} closeOnDimmerClick>
+            <sui.Modal open={visible} className="projectsdialog" size="home" onClose={() => this.hide(/* closeOnly */ true) } dimmer={true} closeOnDimmerClick>
                 <div id="menubar" role="banner">
                     <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">
                         <div className="left menu">

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -838,7 +838,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
             }
 
             const marginTop = -Math.round(height / 2);
-            const scrolling = this.props.size == 'fullscreen' || height >= window.innerHeight;
+            const scrolling = this.props.size == 'home' || height >= window.innerHeight;
 
             const newState: ModalState = {};
 


### PR DESCRIPTION
The package extension modal is fullscreen and the fullscreen modal was previously reserved for the home screen. 
Making the home screen have it's own size modal called home, and adding CSS just for that. 
Modal for package extension can still use a fullscreen size.