### PR TITLE
Update text blocks with better defaults

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -195,7 +195,7 @@ declare interface String {
      * @param start first character index; can be negative from counting from the end, eg:0
      * @param length number of characters to extract
      */
-    //% shim=String_::substr length.defl=1000000
+    //% shim=String_::substr length.defl=10
     //% help=text/substr
     //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
     substr(start: number, length?: number): string;
@@ -213,11 +213,12 @@ declare interface String {
 
 /**
   * Convert a string to an integer.
-  * @param s A string to convert into a number.
+  * @param s A string to convert into a number. eg: 123
   */
 //% shim=String_::toNumber
 //% help=text/parse-int
 //% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
+//% text.defl="123"
 declare function parseInt(text: string): number;
 
 interface Object { }

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -373,7 +373,7 @@ namespace pxt.blocks {
                 url: 'reference/text/length',
                 category: 'text',
                 block: {
-                    TEXT_LENGTH_TITLE: Util.lf("length of text %1")
+                    TEXT_LENGTH_TITLE: Util.lf("length of %1")
                 }
             },
             'text_join': {

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -238,7 +238,7 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
         <block type="text_length">
             <value name="VALUE">
                 <shadow type="text">
-                    <field name="TEXT">abc</field>
+                    <field name="TEXT">Hello</field>
                 </shadow>
             </value>
         </block>
@@ -246,12 +246,12 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
             <mutation items="2"></mutation>
             <value name="ADD0">
                 <shadow type="text">
-                    <field name="TEXT"></field>
+                    <field name="TEXT">Hello</field>
                 </shadow>
             </value>
             <value name="ADD1">
                 <shadow type="text">
-                    <field name="TEXT"></field>
+                    <field name="TEXT">World</field>
                 </shadow>
             </value>
         </block>

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -238,7 +238,7 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
         <block type="text_length">
             <value name="VALUE">
                 <shadow type="text">
-                    <field name="TEXT">Hello</field>
+                    <field name="TEXT">${lf("Hello")}</field>
                 </shadow>
             </value>
         </block>
@@ -246,12 +246,12 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
             <mutation items="2"></mutation>
             <value name="ADD0">
                 <shadow type="text">
-                    <field name="TEXT">Hello</field>
+                    <field name="TEXT">${lf("Hello")}</field>
                 </shadow>
             </value>
             <value name="ADD1">
                 <shadow type="text">
-                    <field name="TEXT">World</field>
+                    <field name="TEXT">${lf("World")}</field>
                 </shadow>
             </value>
         </block>


### PR DESCRIPTION
- join: "Hello" "World"
- substring had a default length of 1000000 ??
- changed `length of text ""` to `length of ""`
- changed parseInt to have a default number string to make it's function a little more obvious

I would have liked to change the compare block, but I don't think it's possible with our current architecture. @riknoll thoughts?

Before:
<img width="501" alt="screen shot 2017-09-30 at 9 19 50 am" src="https://user-images.githubusercontent.com/16690124/31046096-8c7e99f2-a5c0-11e7-81bd-7a4158baf8b7.png">

After:
<img width="486" alt="screen shot 2017-09-30 at 9 17 45 am" src="https://user-images.githubusercontent.com/16690124/31046097-934c909a-a5c0-11e7-93b7-15b27f198941.png">
