### PR TITLE
Fix overlapping navigation buttons in docs

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -275,8 +275,8 @@ svg {
     bottom: 0;
     margin: 0;
     padding: 10px;
-    max-width: 150px;
-    min-width: 90px;
+    max-width: 5rem;
+    min-width: 5rem;
     display: flex;
     justify-content: center;
     align-content: center;
@@ -288,6 +288,9 @@ svg {
     -moz-transition: all 350ms ease;
     -o-transition: all 350ms ease;
     transition: all 350ms ease;
+}
+.navigation.icon {
+    width: 100%;
 }
 
 .navigation.navigation-next {


### PR DESCRIPTION
Fix issue with navigation buttons overlapping the body text making it hard to select the text.
This has to be in v0 as it's a docs fix and we need to publish the doc CSS from v0.

The fix was to make sure the nav buttons had a limited width smaller than the padding of the main body text.
 
After: 
<img width="557" alt="screen shot 2017-10-01 at 10 52 52 pm" src="https://user-images.githubusercontent.com/16690124/31062782-4e2a06f0-a6fb-11e7-9ae9-6bc8cbc00cbf.png">

Fixes https://github.com/Microsoft/pxt/issues/3104
