### PR TITLE
V0 fixes

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1458,6 +1458,7 @@ function buildSemanticUIAsync(parsed?: commandParser.ParsedCommand) {
             "FirefoxAndroid >= 55"
         ]
         const cssnano = require('cssnano')({
+            zindex: false,
             autoprefixer: { browsers: browserList, add: true }
         });
         const rtlcss = require('rtlcss');

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -707,7 +707,7 @@ namespace pxt.blocks {
     ///////////////////////////////////////////////////////////////////////////////
 
     function extractNumber(b: B.Block): number {
-        let v = b.getFieldValue(b.type === "math_number_minmax" ? "SLIDER" : "NUM");
+        let v = b.getFieldValue("NUM");
         const parsed = parseFloat(v);
         checkNumber(parsed, b);
         return parsed;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1835,7 +1835,7 @@ namespace pxt.blocks {
 
     function collapseSubcategories(cat: Blockly.Toolbox.TreeNode, child?: Blockly.Toolbox.TreeNode) {
         while (cat) {
-            if (cat.isUserCollapsible_ && cat != child && (!child || !isChild(child, cat))) {
+            if (cat.isUserCollapsible_ && cat.getTree() && cat != child && (!child || !isChild(child, cat))) {
                 cat.setExpanded(false);
                 cat.updateRow();
             }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -138,7 +138,7 @@ namespace pxt.editor {
 
         openTutorials(): void;
         setTutorialStep(step: number): void;
-        exitTutorial(keep?: boolean): void;
+        exitTutorial(): void;
         completeTutorial(): void;
         showTutorialHint(): void;
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -134,6 +134,7 @@ namespace pxt.editor {
         setSideDoc(path: string, blocksEditor?: boolean): void;
         setSideMarkdown(md: string): void;
         removeFile(fn: IFile, skipConfirm?: boolean): void;
+        updateFileAsync(name: string, content: string, open?: boolean): Promise<void>;
 
         openTutorials(): void;
         setTutorialStep(step: number): void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -483,6 +483,17 @@ export class ProjectView
         })
     }
 
+    updateFileAsync(name: string, content: string, open?: boolean): Promise<void> {
+        const p = pkg.mainEditorPkg();
+        p.setFile(name, content);
+        return p.updateConfigAsync(cfg => cfg.files.indexOf(name) < 0 ? cfg.files.push(name) : 0)
+            .then(() => {
+                if (open) this.setFile(p.lookupFile("this/" + name));
+                return p.savePkgAsync();
+            })
+            .then(() => this.reloadHeaderAsync())
+    }
+
     setSideMarkdown(md: string) {
         let sd = this.refs["sidedoc"] as container.SideDocs;
         if (!sd) return;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1502,26 +1502,20 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
             });
     }
 
-    exitTutorial(keep?: boolean) {
+    exitTutorial() {
         pxt.tickEvent("tutorial.exit");
         core.showLoading(lf("leaving tutorial..."));
-        this.exitTutorialAsync(keep)
+        this.exitTutorialAsync()
             .then(() => Promise.delay(500))
             .done(() => core.hideLoading());
     }
 
-    exitTutorialAsync(keep?: boolean) {
-        // tutorial project is temporary, no need to delete
+    exitTutorialAsync() {
         let curr = pkg.mainEditorPkg().header;
         let files = pkg.mainEditorPkg().getAllFiles();
-        if (!keep) {
-            curr.isDeleted = true;
-        } else {
-            curr.temporary = false;
-        }
+
         this.setState({ active: false, filters: undefined });
-        return workspace.saveAsync(curr, {})
-            .then(() => { return keep ? workspace.installAsync(curr, files) : Promise.resolve(null); })
+        return workspace.saveAsync(curr, files)
             .then(() => {
                 if (workspace.getHeaders().length > 0) {
                     return this.loadHeaderAsync(workspace.getHeaders()[0], null);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1687,7 +1687,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                     </sui.DropdownMenuItem> }
 
                                 {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit") } onClick={() => this.launchFullEditor() } /> : undefined}
-                                {inTutorial ? <sui.ButtonMenuItem class="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial") } textClass="landscape only" onClick={() => this.exitTutorial(true) } /> : undefined}
+                                {inTutorial ? <sui.ButtonMenuItem class="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial") } textClass="landscape only" onClick={() => this.exitTutorial() } /> : undefined}
                                 {!sandbox ? <a id="organization" href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo" onClick={() => pxt.tickEvent("menu.org") }>
                                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo
                                         ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo) } alt={lf("{0} Logo", targetTheme.organization)} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -139,13 +139,20 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 .done(opts => {
                     if (opts) {
                         if (loadBlocks) {
-                            const ts = opts.filesOverride["main.ts"]
-                            compiler.getBlocksAsync()
-                                .then(blocksInfo => compiler.decompileSnippetAsync(ts, blocksInfo))
-                                .then(resp => {
-                                    opts.filesOverride["main.blocks"] = resp
-                                    this.props.parent.newProject(opts);
-                                })
+                            return this.props.parent.createProjectAsync(opts)
+                            .then(() => {
+                                return compiler.getBlocksAsync()
+                                    .then(blocksInfo => compiler.decompileAsync("main.ts", blocksInfo))
+                                    .then(resp => {
+                                        if (resp.success) {
+                                            return this.props.parent.updateFileAsync("main.blocks", resp.outfiles["main.blocks"], true)
+                                        }
+                                        return Promise.resolve();
+                                    })
+                            })
+                            .done(() => {
+                                core.hideLoading();
+                            })
                         } else {
                             this.props.parent.newProject(opts);
                         }

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -135,9 +135,13 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             pxt.packagesConfigAsync()
                 .then(config => pxt.github.latestVersionAsync(scr.fullName, config))
                 .then(tag => pxt.github.pkgConfigAsync(scr.fullName, tag)
-                    .then(cfg => addDepIfNoConflict(cfg, "github:" + scr.fullName + "#" + tag)))
-                .catch(core.handleNetworkError)
-                .finally(() => core.hideLoading());
+                .then(cfg => {
+                    // Done downloading, hide the loading
+                    core.hideLoading();
+                    return cfg;
+                })
+                .then(cfg => addDepIfNoConflict(cfg, "github:" + scr.fullName + "#" + tag)))
+                .catch(core.handleNetworkError);
         }
         const addDepIfNoConflict = (config: pxt.PackageConfig, version: string) => {
             return pkg.mainPkg.findConflictsAsync(config, version)
@@ -164,7 +168,6 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                             lf("Packages {0} and {1} are incompatible with {2}. Remove them and add {2}?", conflicts.slice(0, -1).map((c) => c.pkg0.id).join(", "), conflicts.slice(-1)[0].pkg0.id, config.name);
 
                         addDependencyPromise = addDependencyPromise
-                            .then(() => core.hideLoading())
                             .then(() => core.confirmAsync({
                                 header: lf("Some packages will be removed"),
                                 agreeLbl: lf("Remove package(s) and add {0}", config.name),

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -164,6 +164,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                             lf("Packages {0} and {1} are incompatible with {2}. Remove them and add {2}?", conflicts.slice(0, -1).map((c) => c.pkg0.id).join(", "), conflicts.slice(-1)[0].pkg0.id, config.name);
 
                         addDependencyPromise = addDependencyPromise
+                            .then(() => core.hideLoading())
                             .then(() => core.confirmAsync({
                                 header: lf("Some packages will be removed"),
                                 agreeLbl: lf("Remove package(s) and add {0}", config.name),


### PR DESCRIPTION
1. Fix loading dialog interfering with the package conflict dialog. When the dialog appears it needs to make sure it hide the loading spinner. 
Fixes https://github.com/Microsoft/pxt/issues/3110
2. Fix blockly compiler merge issue, where the SLIDER's field name is NUM in v0 but SLIDER in master blockly. https://github.com/Microsoft/pxt/commit/a20834fde50f7a95277267198bca1343428d46e6
3. Integrating cssnano fix from master for the Edge / IE gridpicker z-index issue: Fixes https://github.com/Microsoft/pxt/issues/3130
4. Moving over decompilation issue in gallery. Fixes https://github.com/Microsoft/pxt/pull/3078
5. Fix multiple tutorial projects as a result of exit tutorial. 
6. Integrate this fix https://github.com/Microsoft/pxt/pull/2353 that fixes the getShowLines issue in https://github.com/Microsoft/pxt/issues/3109 and https://github.com/Microsoft/pxt/issues/2723 and https://github.com/Microsoft/pxt/issues/2876 
