### PR TITLE
Fixing search whilst still maintaining outputShape

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1764,7 +1764,7 @@ namespace pxt.blocks {
                     }
                 ],
                 "output": 'Number',
-                "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+                "outputShape": OutputShape.ROUND
             });
         }
 
@@ -3108,7 +3108,7 @@ namespace pxt.blocks {
                     }
                 ],
                 "output": 'Number',
-                "outputShape": Blockly.OUTPUT_SHAPE_ROUND
+                "outputShape": OutputShape.ROUND
             });
         }
         installBuiltinHelpInfo(textLengthId);

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -161,7 +161,8 @@ namespace pxt.blocks {
                 operators: {
                     'op': ["min", "max"]
                 },
-                category: 'math'
+                category: 'math',
+                outputShape: Blockly.OUTPUT_SHAPE_ROUND
             },
             'math_op3': {
                 name: Util.lf("absolute number"),
@@ -170,7 +171,8 @@ namespace pxt.blocks {
                 category: 'math',
                 block: {
                     message0: Util.lf("absolute of %1")
-                }
+                },
+                outputShape: Blockly.OUTPUT_SHAPE_ROUND
             },
             'math_number': {
                 name: Util.lf("{id:block}number"),

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -105,6 +105,12 @@ namespace pxt.blocks {
         tooltipSearch?: string; // Which tooltip to use for searching; if undefined, search uses all tooltips in BlockDefinition.tooltip, joined with space
     }
 
+    export enum OutputShape {
+        HEXAGON = 1, // Blockly.OUTPUT_SHAPE_HEXAGONAL
+        ROUND = 2, // Blockly.OUTPUT_SHAPE_ROUND
+        SQUARE = 3 // Blockly.OUTPUT_SHAPE_SQUARE
+    }
+
     let _blockDefinitions: Map<BlockDefinition>;
     export function blockDefinitions(): Map<BlockDefinition> {
         if (!_blockDefinitions) cacheBlockDefinitions();
@@ -162,7 +168,7 @@ namespace pxt.blocks {
                     'op': ["min", "max"]
                 },
                 category: 'math',
-                outputShape: Blockly.OUTPUT_SHAPE_ROUND
+                outputShape: OutputShape.ROUND
             },
             'math_op3': {
                 name: Util.lf("absolute number"),
@@ -172,7 +178,7 @@ namespace pxt.blocks {
                 block: {
                     message0: Util.lf("absolute of %1")
                 },
-                outputShape: Blockly.OUTPUT_SHAPE_ROUND
+                outputShape: OutputShape.ROUND
             },
             'math_number': {
                 name: Util.lf("{id:block}number"),


### PR DESCRIPTION
Revert https://github.com/Microsoft/pxt/pull/3141

Blockly is not defined in the web worker which is where search happens. Using out own enum to define Output Shapes (with the exception of initBlock, where Blockly is defined). 

The enum matches Blockly's values for shapes.