### PR TITLE
Cleanup output shapes

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1763,8 +1763,7 @@ namespace pxt.blocks {
                         "check": ['Array']
                     }
                 ],
-                "output": 'Number',
-                "outputShape": OutputShape.ROUND
+                "output": 'Number'
             });
         }
 
@@ -2468,7 +2467,6 @@ namespace pxt.blocks {
                     ],
                     "inputsInline": true,
                     "output": "Number",
-                    "outputShape": mathOp2Def.outputShape,
                     "colour": getNamespaceColor('math')
                 });
 
@@ -2501,7 +2499,6 @@ namespace pxt.blocks {
                     ],
                     "inputsInline": true,
                     "output": "Number",
-                    "outputShape": mathOp3Def.outputShape,
                     "colour": getNamespaceColor('math')
                 });
 
@@ -3107,8 +3104,7 @@ namespace pxt.blocks {
                         "check": ['String']
                     }
                 ],
-                "output": 'Number',
-                "outputShape": OutputShape.ROUND
+                "output": 'Number'
             });
         }
         installBuiltinHelpInfo(textLengthId);

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -100,15 +100,8 @@ namespace pxt.blocks {
         tooltip?: string | Map<string>;
         operators?: Map<string[]>;
         block?: Map<string>;
-        outputShape?: number;
         blockTextSearch?: string; // Which block text to use for searching; if undefined, search uses all texts in BlockDefinition.block, joined with space
         tooltipSearch?: string; // Which tooltip to use for searching; if undefined, search uses all tooltips in BlockDefinition.tooltip, joined with space
-    }
-
-    export enum OutputShape {
-        HEXAGON = 1, // Blockly.OUTPUT_SHAPE_HEXAGONAL
-        ROUND = 2, // Blockly.OUTPUT_SHAPE_ROUND
-        SQUARE = 3 // Blockly.OUTPUT_SHAPE_SQUARE
     }
 
     let _blockDefinitions: Map<BlockDefinition>;
@@ -167,8 +160,7 @@ namespace pxt.blocks {
                 operators: {
                     'op': ["min", "max"]
                 },
-                category: 'math',
-                outputShape: OutputShape.ROUND
+                category: 'math'
             },
             'math_op3': {
                 name: Util.lf("absolute number"),
@@ -177,8 +169,7 @@ namespace pxt.blocks {
                 category: 'math',
                 block: {
                     message0: Util.lf("absolute of %1")
-                },
-                outputShape: OutputShape.ROUND
+                }
             },
             'math_number': {
                 name: Util.lf("{id:block}number"),


### PR DESCRIPTION
Since we already dug this up, removing output shapes for builtins as it's not required at this point.

Filing an issue to clean up other features that are not used: https://github.com/Microsoft/pxt/issues/3145