### PR TITLE
Home screen changes as discussed at the UI meeting

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -161,7 +161,7 @@ declare namespace pxt {
         hideSideDocs?: boolean;
         showHomeScreen?: boolean; // show the home page on editor load
         homeScreenHero?: string; // home screen hero image
-        sideDoc?: string; // if set: show the getting started button on the home screen, clicking on getting started button links to that page
+        sideDoc?: string; // deprecated
         hasReferenceDocs?: boolean; // if true: the monaco editor will add an option in the context menu to load the reference docs
         feedbackUrl?: string; // is set: a feedback link will show in the settings menu
         boardName?: string;

--- a/theme/common.less
+++ b/theme/common.less
@@ -109,7 +109,7 @@ html, body {
 
 #downloadArea {
     margin-top: 0 !important;
-    padding-top: 0.7rem;
+    padding-top: 0.55rem;
     background-color: @simulatorBackground;
 }
 
@@ -361,8 +361,9 @@ div.simframe > iframe {
 }
 
 /* Icon and text */
-.ui.item.icon > .icon-and-text.icon ~ .ui.text, .ui.button.icon > .icon-and-text.icon ~ .ui.text {
-    margin-left: 0.4em !important;
+.ui.item.icon > .icon-and-text.icon ~ .ui.text,
+.ui.button.icon > .icon-and-text.icon ~ .ui.text {
+    margin-left: 0.5em !important;
 }
 
 /* Beta */

--- a/theme/home.less
+++ b/theme/home.less
@@ -20,9 +20,7 @@
         border-radius: 0;
         background-repeat: no-repeat;
         background-size: cover;
-        .ui.grid {
-            height: 300px;
-        }
+        height: 300px;
         .column {
             padding: 0 !important;
         }
@@ -65,9 +63,6 @@
         .column.right.aligned {
             padding-right: @carouselArrowSize !important;
         }
-    }
-    .gallerysegment.mystuff-segment .carouselarrow .icon {
-        top: 30%;
     }
     /* Footer, Privary, Terms of Use */
     .homefooter {
@@ -160,9 +155,7 @@
     /* Carousel */
     .projectsdialog {
         .getting-started-segment {
-            .ui.grid {
-                height: 250px;
-            }
+            height: 250px;
             .getting-started {
                 padding: @carouselArrowSizeMobile;
                 margin-top: 40px;

--- a/theme/home.less
+++ b/theme/home.less
@@ -15,7 +15,6 @@
     .getting-started-segment {
         border: 0;
         margin-top: -2.1rem !important;
-        margin-bottom: 0;
         padding: 0;
         border-radius: 0;
         background-repeat: no-repeat;

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -33,6 +33,11 @@
     background: @invertedBackground;
 }
 
+
+#root #menubar .menu > .ui.item:hover .icon {
+    transform: scale(1.2);
+}
+
 @media only screen and (max-width: @largestTabletScreen) {
     #menubar .ui.menu {
         height: @mobileMenuHeight !important;

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -25,13 +25,13 @@
         margin-left: 4rem;
         min-width: 5rem;
         padding-left: 1.5rem;
-        height: 4rem;
+        height: 8rem;
         .header {
             word-wrap: break-word;
         }
     }
     .meta {
-        height: 3rem;
+        height: 4rem;
         padding: 1rem;
         text-align: right;
     }
@@ -41,7 +41,7 @@
 /* New project card */
 
 .ui.card.link.newprojectcard {
-    background: fade(@primaryColor, 50%) !important;
+    background: fade(@primaryColor, 90%) !important;
     border: 2px solid @solidBorderColor;
     text-align: center;
     color: @white;

--- a/theme/themes/pxt/views/card.variables
+++ b/theme/themes/pxt/views/card.variables
@@ -5,7 +5,7 @@
 @solidBorderColor: #e9eef2;
 @hoverBorderColor: white;
 
-@borderWidth: 3px;
+@borderWidth: 5px;
 
 @border: @borderWidth solid @solidBorderColor;
 @linkHoverBorder: @borderWidth solid @hoverBorderColor;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -874,6 +874,11 @@ export class ProjectView
         }
     }
 
+    brandIconClick() {
+        pxt.tickEvent("menu.brand");
+        this.exitAndSave();
+    }
+
     exportProjectToFileAsync(): Promise<Uint8Array> {
         const mpkg = pkg.mainPkg;
         return mpkg.compressToFileAsync(this.getPreferredEditor())
@@ -1702,7 +1707,6 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         const tutorialOptions = this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial;
-        const gettingStarted = !sandbox && targetTheme && !!targetTheme.sideDoc;
         const run = true; // !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
         const restart = run && !simOpts.hideRestart;
         const trace = run && simOpts.enableTrace;
@@ -1781,7 +1785,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
 
                         <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar" aria-label={lf("Main menu")}>
                             {!sandbox ? <div className="left menu">
-                                <a href={targetTheme.logoUrl} aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => pxt.tickEvent("menu.brand")}>
+                                <a aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => this.brandIconClick()} onKeyDown={sui.fireClickOnEnter}>
                                     {targetTheme.logo || targetTheme.portraitLogo
                                         ? <img className={`ui logo ${targetTheme.logo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo)} alt={lf("{0} Logo", targetTheme.boardName)} />
                                         : <span className="name">{targetTheme.boardName}</span>}
@@ -1883,7 +1887,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                 </div> : undefined}
                 {sideDocs ? <container.SideDocs ref="sidedoc" parent={this} /> : undefined}
                 {sandbox ? undefined : <scriptsearch.ScriptSearch parent={this} ref={v => this.scriptSearch = v} />}
-                {sandbox ? undefined : <projects.Projects parent={this} ref={v => this.home = v} hasGettingStarted={gettingStarted} />}
+                {sandbox ? undefined : <projects.Projects parent={this} ref={v => this.home = v} />}
                 {sandbox ? undefined : <extensions.Extensions parent={this} ref={v => this.extensions = v} />}
                 {sandbox ? undefined : <projects.ImportDialog parent={this} ref={v => this.importDialog = v} />}
                 {sandbox ? undefined : <projects.ExitAndSaveDialog parent={this} ref={v => this.exitAndSaveDialog = v} />}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -288,6 +288,30 @@ export class Button extends UiElement<ButtonProps> {
     }
 }
 
+export interface LinkProps extends ButtonProps {
+    href?: string;
+}
+
+export class Link extends UiElement<LinkProps> {
+    renderCore() {
+        return (
+            <a className={genericClassName("ui label", this.props) + " " + (this.props.disabled ? "disabled" : "") }
+                id={this.props.id}
+                href={this.props.href}
+                role={this.props.role}
+                title={this.props.title}
+                tabIndex={this.props.tabIndex || 0}
+                aria-label={this.props.ariaLabel}
+                aria-expanded={this.props.ariaExpanded}
+                onClick={this.props.onClick}
+                onKeyDown={this.props.onKeyDown}>
+                {genericContent(this.props) }
+                {this.props.children}
+            </a>
+        );
+    }
+}
+
 export class Popup extends data.Component<UiProps, {}> {
     componentDidMount() {
         this.child(".popup-button").popup({


### PR DESCRIPTION
- Deprecating sideDoc option
- Removing first time here and get started button
- Bringing back the New button in the My projects carousel 
- Clicking on the brand icon inside the editor takes you back to home

<img width="1100" alt="screen shot 2017-10-05 at 9 40 14 am" src="https://user-images.githubusercontent.com/16690124/31233191-090018a0-a9ba-11e7-9dd6-a70d5841c4d5.png">
