### PR TITLE
FieldNote dropdown colour for lone blocks

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -64,6 +64,13 @@ declare namespace goog {
         function clamp(n: number, min: number, max: number): void;
     }
 
+    namespace color { 
+        class Rgb { }
+        function rgbArrayToHex(rgb: goog.color.Rgb): string;
+        function darken(rgb: goog.color.Rgb, factor: number): goog.color.Rgb;
+        function hexToRgb(hexColor: string): goog.color.Rgb;
+    }
+
     namespace ui {
         class Control extends Component {
             getChildCount(): number;

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -61,14 +61,20 @@ namespace pxtblockly {
 
     let regex: RegExp = /^Note\.(.+)$/;
 
+    export interface FieldNoteOptions extends Blockly.FieldCustomOptions {
+        editorColor?: string;
+    }
+
     //  Class for a note input field.
     export class FieldNote extends Blockly.FieldNumber implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
         //  value of the field
         private note_: string;
 
-        //  colour of the block
+        //  colour of the dropdown
         private colour_: string;
+        //  colour of the dropdown border
+        private colourBorder_: string;
 
         /**
          * default number of piano keys
@@ -98,12 +104,16 @@ namespace pxtblockly {
         private noteName_: Array<string> = [];
 
 
-        constructor(text: string, options: Blockly.FieldCustomOptions, validator?: Function) {
+        constructor(text: string, params: FieldNoteOptions, validator?: Function) {
             super(text);
 
             FieldNote.superClass_.constructor.call(this, text, validator);
             this.note_ = text;
-            this.colour_ = pxtblockly.parseColour(options.colour);
+
+            if (params.editorColor) {
+                this.colour_ = pxtblockly.parseColour(params.editorColor);
+                this.colourBorder_ = goog.color.rgbArrayToHex(goog.color.darken(goog.color.hexToRgb(this.colour_), 0.2));
+            }
         }
 
         /**
@@ -396,6 +406,13 @@ namespace pxtblockly {
          * Create a piano under the note field.
          */
         showEditor_(opt_quietInput?: boolean): void {
+            if (!this.colour_) {
+                this.colour_ = ((this.sourceBlock_ as any).isShadow()) ?
+                    this.sourceBlock_.parentBlock_.getColour() : this.sourceBlock_.getColour();
+                this.colourBorder_ = ((this.sourceBlock_ as any).isShadow()) ?
+                    this.sourceBlock_.parentBlock_.getColourTertiary() : this.sourceBlock_.getColourTertiary();
+            }
+
             // If there is an existing drop-down someone else owns, hide it immediately and clear it.
             Blockly.DropDownDiv.hideWithoutAnimation();
             Blockly.DropDownDiv.clearContent();
@@ -776,10 +793,7 @@ namespace pxtblockly {
             pianoDiv.style.height = (pianoHeight + 1) + "px";
             //contentDiv.style.width = (pianoWidth + 1) + "px";
 
-            let primaryColour = ((this.sourceBlock_ as any).isShadow()) ?
-                this.sourceBlock_.parentBlock_.getColour() : this.sourceBlock_.getColour();
-
-            (Blockly.DropDownDiv as any).setColour(primaryColour, (this.sourceBlock_ as any).getColourTertiary());
+            (Blockly.DropDownDiv as any).setColour(this.colour_, this.colourBorder_);
 
             // Calculate positioning based on the field position.
             let scale = (this.sourceBlock_.workspace as any).scale;

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -62,7 +62,7 @@ namespace pxtblockly {
     let regex: RegExp = /^Note\.(.+)$/;
 
     export interface FieldNoteOptions extends Blockly.FieldCustomOptions {
-        editorColor?: string;
+        editorColour?: string;
     }
 
     //  Class for a note input field.
@@ -110,8 +110,8 @@ namespace pxtblockly {
             FieldNote.superClass_.constructor.call(this, text, validator);
             this.note_ = text;
 
-            if (params.editorColor) {
-                this.colour_ = pxtblockly.parseColour(params.editorColor);
+            if (params.editorColour) {
+                this.colour_ = pxtblockly.parseColour(params.editorColour);
                 this.colourBorder_ = goog.color.rgbArrayToHex(goog.color.darken(goog.color.hexToRgb(this.colour_), 0.2));
             }
         }


### PR DESCRIPTION
Fix field note background, since we can't trust the block color when it's a lone block.

Explanation of fix:
The dropdown for the note picker was relying on either the parent block's color or the shadow block's color for determining what color to use as the background of the dropdown. 

This is problematic for blocks like the note block which use block colors of white. When the block is alone like so: 
<img width="102" alt="screen shot 2017-10-05 at 10 33 27 am" src="https://user-images.githubusercontent.com/16690124/31241574-1e82b418-a9b9-11e7-8f3b-e745e8f506ba.png">
It's blockColor is white and it has no parent block to indicate what color to use for the dropdown, so instead of making the dropdown white. I've added an option for the fieldNote to use a custom color that's authored by the developer (editorColour).
