### PR TITLE
decode gallery path in service

### DIFF
--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -35,7 +35,7 @@ mountVirtualApi("cloud-search", {
 })
 
 mountVirtualApi("gallery", {
-    getAsync: p => gallery.loadGalleryAsync(stripProtocol(p)).catch((e) => {
+    getAsync: p => gallery.loadGalleryAsync(stripProtocol(decodeURIComponent(p))).catch((e) => {
         return Promise.resolve(e);
     }),
     expirationTime: p => 3600 * 1000


### PR DESCRIPTION
gallery path is encoded on the caller side, so decoding on the service side. Necessary to point to subfolders.