### PR TITLE
Fix makecode.com header scrolling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
 		}
 
 		#makecode-targets {
-			padding-top: 15rem;
+			padding-top: 3rem;
 			padding-bottom: 3rem;
 		}
 
@@ -142,7 +142,8 @@
 		#makecode-resources-container .image {
 			background: white;
 			padding: 2rem;
-			height: 120px;
+			max-height: 120px;
+			min-height: 120px;
 		}
 
 		.targets .welcomeheader {
@@ -256,6 +257,10 @@
 				font-size: 24px;
 				padding-top: 12px;
 			}
+
+			#makecode-targets {
+				padding-top: 15rem;
+			}
 		}
 
 		#makecode-mobile-menu {
@@ -268,6 +273,9 @@
 			}
 			#makecode-mobile-menu {
 				display: block;
+			}
+			#makecode-targets {
+				padding-top: 7rem;
 			}
 		}
 		/* Header menu */
@@ -750,7 +758,7 @@
 
 								<div class="ui container cards stackable four centered link doubling">
 									<a class="ui card" href="https://makecode.com/docs" target="_blank" onclick="tickEvent('makecode.resources.devdocs', {'target': 'makecode'})" aria-label="Developer documentation">
-										<div class="image">
+										<div class="ui medium image centered">
 											<i class="ms-Icon ms-Icon--Documentation ms-fontColor-themePrimary" aria-hidden="true" style="font-size:72px;padding:20px;"></i>
 										</div>
 										<div class="content">
@@ -776,7 +784,7 @@
 
 									<a class="ui card" href="https://github.com/Microsoft/pxt" target="_blank" onclick="tickEvent('makecode.resources.github', {'target': 'makecode'})"
 									 aria-label="PXT Github repository">
-										<div class="image">
+										<div class="ui medium image centered">
 											<img src="/static/images/GitHub_Logo.png" alt="Github logo">
 										</div>
 										<div class="content">
@@ -789,7 +797,7 @@
 
 									<a class="ui card" href="https://crowdin.com/project/kindscript" target="_blank" onclick="tickEvent('makecode.resources.translate', {'target': 'makecode'})"
 									 aria-label="Help translate Makecode on Crowdin">
-										<div class="image">
+										<div class="ui medium image centered">
 											<img src="/static/images/crowdin-logo.png" alt="Crowdin logo">
 										</div>
 										<div class="content">

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
 		}
 
 		#makecode-targets {
-			padding-top: 3rem;
+			padding-top: 15rem;
 			padding-bottom: 3rem;
 		}
 
@@ -185,7 +185,10 @@
 		/* Fixed header */
 
 		#makecode-header {
-			position: relative;
+			position: fixed;
+			top: 0;
+			left: 0;
+			right: 0;
 			padding: 0 40px 0 40px;
 			z-index: 100;
 			color: white;
@@ -238,7 +241,6 @@
 			#makecode-hardware-container {
 				padding: 6rem;
 			}
-
 			#makecode-header h1 {
 				font-size: 62px;
 				padding-top: 34px;
@@ -246,13 +248,11 @@
 				-webkit-transition: font-size 167ms cubic-bezier(.1, .9, .2, 1);
 				transition: font-size 167ms cubic-bezier(.1, .9, .2, 1);
 			}
-			#makecode-header.fix-top {
-				position: fixed;
-				top: 0;
-				left: 0;
-				right: 0;
+			.fix-top #makecode-header {
+				-webkit-box-shadow: 0 10px 30px -10px rgba(0,0,0,0.2);
+				box-shadow: 0 10px 30px -10px rgba(0,0,0,0.2);
 			}
-			#makecode-header.fix-top h1 {
+			.fix-top #makecode-header h1 {
 				font-size: 24px;
 				padding-top: 12px;
 			}
@@ -310,9 +310,9 @@
 		$(document).ready(function () {
 			$(window).bind('scroll', function () {
 				if ($(window).scrollTop() > 50) {
-					$('#makecode-header').addClass('fix-top');
+					$('#root').addClass('fix-top');
 				} else {
-					$('#makecode-header').removeClass('fix-top');
+					$('#root').removeClass('fix-top');
 				}
 			});
 			$('a.launch.icon').click(function () {

--- a/docs/labs.html
+++ b/docs/labs.html
@@ -177,10 +177,17 @@
 		/* Fixed header */
 
 		#makecode-header {
-			position: relative;
+			position: fixed;
+			top: 0;
+			left: 0;
+			right: 0;
 			padding: 0 40px 0 40px;
 			z-index: 100;
 			color: #00ff00;
+		}
+
+		#about {
+			padding-top: 12rem;
 		}
 
 		#makecode-header .menuButton {
@@ -237,13 +244,11 @@
 				-webkit-transition: font-size 167ms cubic-bezier(.1, .9, .2, 1);
 				transition: font-size 167ms cubic-bezier(.1, .9, .2, 1);
 			}
-			#makecode-header.fix-top {
-				position: fixed;
-				top: 0;
-				left: 0;
-				right: 0;
+			.fix-top #makecode-header {
+				-webkit-box-shadow: 0 10px 30px -10px rgba(0,0,0,0.2);
+				box-shadow: 0 10px 30px -10px rgba(0,0,0,0.2);
 			}
-			#makecode-header.fix-top h1 {
+			.fix-top #makecode-header h1 {
 				font-size: 24px;
 				padding-top: 12px;
 			}
@@ -301,9 +306,9 @@
 		$(document).ready(function () {
 			$(window).bind('scroll', function () {
 				if ($(window).scrollTop() > 50) {
-					$('#makecode-header').addClass('fix-top');
+					$('#root').addClass('fix-top');
 				} else {
-					$('#makecode-header').removeClass('fix-top');
+					$('#root').removeClass('fix-top');
 				}
 			});
 			$('a.launch.icon').click(function () {

--- a/docs/labs.html
+++ b/docs/labs.html
@@ -134,7 +134,8 @@
 		#makecode-resources-container .image {
 			background: white;
 			padding: 2rem;
-			height: 120px;
+			max-height: 120px;
+			min-height: 120px;
 		}
 
 		.targets .welcomeheader {
@@ -184,10 +185,6 @@
 			padding: 0 40px 0 40px;
 			z-index: 100;
 			color: #00ff00;
-		}
-
-		#about {
-			padding-top: 12rem;
 		}
 
 		#makecode-header .menuButton {
@@ -252,6 +249,9 @@
 				font-size: 24px;
 				padding-top: 12px;
 			}
+			#about {
+				padding-top: 12rem;
+			}
 		}
 
 		#makecode-mobile-menu {
@@ -264,6 +264,9 @@
 			}
 			#makecode-mobile-menu {
 				display: block;
+			}
+			#about {
+				padding-top: 4rem;
 			}
 		}
 		/* Header menu */
@@ -465,7 +468,7 @@
 								<div class="ui container cards stackable four centered link doubling">
 									<a class="ui card" href="https://makecode.com/target-creation" target="_blank" onclick="tickEvent('makecodelabs.resources.devdocs', {'target': 'makecode'})"
 									 aria-label="Developer documentation">
-										<div class="image">
+										<div class="ui medium image centered">
 											<i class="ms-Icon ms-Icon--Documentation ms-fontColor-themePrimary" aria-hidden="true" style="font-size:72px;padding:20px;"></i>
 										</div>
 										<div class="content">
@@ -478,7 +481,7 @@
 
 									<a class="ui card" href="https://github.com/Microsoft/pxt" target="_blank" onclick="tickEvent('makecodelabs.resources.github', {'target': 'makecode'})"
 									 aria-label="PXT Github repository">
-										<div class="image">
+										<div class="ui medium image centered">
 											<img src="/static/images/GitHub_Logo.png" alt="Github logo">
 										</div>
 										<div class="content">
@@ -491,7 +494,7 @@
 
 									<a class="ui card" href="https://gitter.im/makecode-community/Lobby" target="_blank" onclick="tickEvent('makecodelabs.resources.gitter', {'target': 'makecode'})"
 									 aria-label="Join community on Gitter">
-										<div class="image">
+										<div class="ui medium image centered">
 											<img src="/static/images/gitter-logo.png" alt="Gitter logo">
 										</div>
 										<div class="content">


### PR DESCRIPTION
If you notice as you scroll the header on makecode.com jumps around. This makes it so that the header is always fixed positioned and the top padding of the underneath element is what changes in the different views / whether we have scrolled past a certain point or not.

Before:
![before](https://user-images.githubusercontent.com/16690124/31282448-95f5c5f4-aa80-11e7-8365-7381a401da4b.gif)

After:
![after](https://user-images.githubusercontent.com/16690124/31282453-991aa682-aa80-11e7-8194-6ba6208f361b.gif)

Also fixes a small issue with the positioning of the images in the resource cards in mobile view: 
This is what they looked like currently: 
<img width="526" alt="screen shot 2017-10-06 at 10 25 26 am" src="https://user-images.githubusercontent.com/16690124/31282491-b869cbe4-aa80-11e7-92fe-ff48404f2e8e.png">

Tested on: 
- [x] Chrome Mac
- [x] Edge


