### PR TITLE
Fix home screen scrollbar color

### DIFF
--- a/pxtblocks/fields/field_imagedropdown.ts
+++ b/pxtblocks/fields/field_imagedropdown.ts
@@ -114,7 +114,6 @@ namespace pxtblockly {
                 button.appendChild(buttonImg);
                 contentDiv.appendChild(button);
             }
-            contentDiv.style.width = this.width_ + 'px';
 
             Blockly.DropDownDiv.setColour(this.backgroundColour_, this.borderColour_);
 

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -791,7 +791,6 @@ namespace pxtblockly {
 
             pianoDiv.style.width = pianoWidth + "px";
             pianoDiv.style.height = (pianoHeight + 1) + "px";
-            //contentDiv.style.width = (pianoWidth + 1) + "px";
 
             (Blockly.DropDownDiv as any).setColour(this.colour_, this.colourBorder_);
 

--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -13,6 +13,5 @@
 }
 
 .ui.home.dimmer {
-    background-color: white;
     transition: none;
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -176,7 +176,9 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                                     core.hideLoading("changingcode");
                                 })
                         } else {
-                            return this.props.parent.newProject(opts);
+                            return this.props.parent.createProjectAsync(opts)
+                                .then(() => Promise.delay(500))
+                                .done(() => core.hideLoading("changingcode"));
                         }
                     }
                     core.hideLoading("changingcode");


### PR DESCRIPTION
Fix home screen scrollbar background.

The scrollbar was white, now it's black and targets can change it to whatever color they want:
<img width="198" alt="screen shot 2017-10-06 at 10 15 47 am" src="https://user-images.githubusercontent.com/16690124/31289912-6b70fef8-aa7f-11e7-9616-7b4759edaf2c.png">

- Minor cleanup fixes for image dropdown, and note field picker.
- Fix chgCode when changing into a code example (hide loading)