### PR TITLE
load gallery list from targetconfig

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4059,12 +4059,17 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string): Promise
     // push entries from pxtarget
     const theme = pxt.appTarget.appTheme;
     if (theme) {
-        if (theme.galleries)
-            Object.keys(theme.galleries).forEach(gallery => todo.push(theme.galleries[gallery]));
         if (theme.sideDoc)
             todo.push(theme.sideDoc);
         if (theme.usbDocs)
             todo.push(theme.usbDocs);
+    }
+
+    // push galleries for targetconfig
+    if (fs.existsSync("targetconfig.json")) {
+        const targeConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
+        if (targeConfig.galleries)
+            Object.keys(targeConfig.galleries).forEach(gallery => todo.push(targeConfig.galleries[gallery]));
     }
 
     while (todo.length) {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -7,6 +7,7 @@ declare namespace pxt {
     interface TargetConfig {
         packages?: PackagesConfig;
         languages?: string[];
+        galleries?: pxt.Map<string>;
     }
 
     interface PackagesConfig {
@@ -186,7 +187,6 @@ declare namespace pxt {
         simAnimationEnter?: string; // Simulator enter animation
         simAnimationExit?: string; // Simulator exit animation
         hasAudio?: boolean; // target uses the Audio manager. if true: a mute button is added to the simulator toolbar.
-        galleries?: pxt.Map<string>; // list of galleries to display in projects dialog
         crowdinProject?: string;
         crowdinBranch?: string; // optional branch specification for pxt
         monacoToolbox?: boolean; // if true: show the monaco toolbox when in the monaco editor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "2.1.11",
+  "version": "2.2.0",
   "description": "Microsoft MakeCode, also known as Programming Experience Toolkit (PXT), provides Blocks / JavaScript tools and editors",
   "keywords": [
     "TypeScript",

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -115,7 +115,8 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         const {visible, tab} = this.state;
 
         const targetTheme = pxt.appTarget.appTheme;
-        const galleries = targetTheme.galleries || {};
+        const targetConfig = this.getData("target-config:") as pxt.TargetConfig;
+        const galleries = (targetConfig ? targetConfig.galleries : undefined) || {};
 
         // lf("Make")
         // lf("Code")


### PR DESCRIPTION
Galleries are specific in the targetconfig which allows to modify them without shipping the entire editor.