### PR TITLE
Allow arbitrary 'yotta' settings

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -637,10 +637,11 @@ namespace pxt.cpp {
             res.generatedFiles["/package.json"] = JSON.stringify(packageJson, null, 4) + "\n"
         } else if (isCodal) {
             let cs = pxt.appTarget.compileService
+            let cfg = U.clone(cs.codalDefinitions) || {}
             let codalJson = {
                 "target": cs.codalTarget + ".json",
-                "definitions": U.clone(cs.codalDefinitions) || {},
-                "config": U.clone(cs.codalDefinitions) || {},
+                "definitions": cfg,
+                "config": cfg,
                 "application": "pxtapp",
                 "output_folder": "build",
                 // include these, because we use hash of this file to see if anything changed
@@ -648,12 +649,12 @@ namespace pxt.cpp {
                 "pxt_gittag": cs.gittag,
             }
             U.iterMap(U.jsonFlatten(configJson), (k, v) => {
-                k = k.toUpperCase()
+                k = k
+                    .replace(/^codal\./, "device.")
+                    .toUpperCase()
                     .replace(/[\.\-]/g, "_")
-                    .replace("CODAL_", "DEVICE_")
                     .replace("MICROBIT_DAL_BLUETOOTH_", "MICROBIT_BLE_")
-                codalJson.definitions[k] = v
-                codalJson.config[k] = v
+                cfg[k] = v
             })
             res.generatedFiles["/codal.json"] = JSON.stringify(codalJson, null, 4) + "\n"
         } else if (isPlatformio) {


### PR DESCRIPTION
One can now do:
```
yotta: { config: { "CODAL_FOO_BAR": 12 } }
```
