### PR TITLE
Support localized and custom text inside Field toggle

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -563,6 +563,8 @@ declare namespace Blockly {
         static getCachedWidth(textElement: Element): number;
         addArgType(argType: string): void;
         updateTextNode_(): void;
+        getSize(): goog.math.Size;
+        getSvgRoot(): Element;
     }
 
     class FieldVariable extends Field {
@@ -730,6 +732,7 @@ declare namespace Blockly {
         bumpNeighbours_(): void;
         select(): void;
         getRelativeToSurfaceXY(): goog.math.Coordinate;
+        getOutputShape(): number;
     }
 
     class Comment extends Icon {

--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -733,6 +733,7 @@ declare namespace Blockly {
         select(): void;
         getRelativeToSurfaceXY(): goog.math.Coordinate;
         getOutputShape(): number;
+        getSvgRoot(): Element;
     }
 
     class Comment extends Icon {

--- a/localtypings/pxtblockly.d.ts
+++ b/localtypings/pxtblockly.d.ts
@@ -4,6 +4,8 @@ declare namespace Blockly {
 
     interface FieldCustomOptions {
         colour?: string | number;
+        label?: string;
+        type?: string;
     }
 
     interface FieldCustomDropdownOptions extends FieldCustomOptions {

--- a/pxtblocks/blocklycustomeditor.ts
+++ b/pxtblocks/blocklycustomeditor.ts
@@ -32,6 +32,8 @@ namespace pxt.blocks {
         registerFieldEditor('imagedropdown', pxtblockly.FieldImageDropdown);
         registerFieldEditor('colorwheel', pxtblockly.FieldColorWheel);
         registerFieldEditor('toggle', pxtblockly.FieldToggle);
+        registerFieldEditor('toggleonoff', pxtblockly.FieldToggleOnOff);
+        registerFieldEditor('toggleyesno', pxtblockly.FieldToggleYesNo);
         registerFieldEditor('colornumber', pxtblockly.FieldColorNumber);
     }
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -660,6 +660,7 @@ namespace pxt.blocks {
                 let isFixed = typeInfo && !!typeInfo.attributes.fixedInstances
                 let customField = (fn.attributes.paramFieldEditor && fn.attributes.paramFieldEditor[p]);
                 let fieldLabel = pr.name.charAt(0).toUpperCase() + pr.name.slice(1);
+                let fieldType = pr.type;
 
                 if (isEnum || isFixed) {
                     const syms = Util.values(info.apis.byQName)
@@ -706,7 +707,8 @@ namespace pxt.blocks {
                         const options = {
                             data: dd,
                             colour: color,
-                            label: fieldLabel
+                            label: fieldLabel,
+                            type: fieldType
                         } as Blockly.FieldCustomDropdownOptions;
                         Util.jsonMergeFrom(options, fn.attributes.paramFieldEditorOptions && fn.attributes.paramFieldEditorOptions[pr.name] || {});
                         i.appendField(createFieldEditor(customField, defl, options), attrNames[n].name);
@@ -719,7 +721,8 @@ namespace pxt.blocks {
                     const defl = fn.attributes.paramDefl[pr.name] || "";
                     const options = {
                         colour: color,
-                        label: fieldLabel
+                        label: fieldLabel,
+                        type: fieldType
                     } as Blockly.FieldCustomOptions;
                     Util.jsonMergeFrom(options, fn.attributes.paramFieldEditorOptions && fn.attributes.paramFieldEditorOptions[pr.name] || {});
                     i.appendField(createFieldEditor(customField, defl, options), attrNames[n].name);

--- a/pxtblocks/fields/field_toggle_onoff.ts
+++ b/pxtblocks/fields/field_toggle_onoff.ts
@@ -1,0 +1,20 @@
+/// <reference path="../../localtypings/blockly.d.ts" />
+
+namespace pxtblockly {
+
+    export class FieldToggleOnOff extends FieldToggle implements Blockly.FieldCustom {
+        public isFieldCustom_ = true;
+
+        constructor(state: string, params: Blockly.FieldCustomOptions, opt_validator?: Function) {
+            super(state, params, opt_validator);
+        }
+
+        getTrueText() {
+            return lf("ON");
+        }
+
+        getFalseText() {
+            return lf("OFF");
+        }
+    }
+}

--- a/pxtblocks/fields/field_toggle_yesno.ts
+++ b/pxtblocks/fields/field_toggle_yesno.ts
@@ -1,0 +1,20 @@
+/// <reference path="../../localtypings/blockly.d.ts" />
+
+namespace pxtblockly {
+
+    export class FieldToggleYesNo extends FieldToggle implements Blockly.FieldCustom {
+        public isFieldCustom_ = true;
+
+        constructor(state: string, params: Blockly.FieldCustomOptions, opt_validator?: Function) {
+            super(state, params, opt_validator);
+        }
+
+        getTrueText() {
+            return lf("Yes");
+        }
+
+        getFalseText() {
+            return lf("No");
+        }
+    }
+}


### PR DESCRIPTION
Localising the text inside of the field editor, supporting custom text length (dependent on language). 
Adding two new field editors: 
- FieldToggleYesNo
- FieldToggleOnOff

The default toggle is now True / False. 

Creating new fields with custom text is a simple as extending FieldToggle and replacing the getTrueText and getFalseText methods. 

Sample:
<img width="516" alt="screen shot 2017-10-12 at 10 17 37 pm" src="https://user-images.githubusercontent.com/16690124/31531615-f2dd8dda-af9c-11e7-8b4e-96994c7d0f9e.png">

Tested on: 
- Chrome Mac
- Edge 15
- IE 11