### PR TITLE
Fix dropdown menu / sidedoc zindex conflict

### DIFF
--- a/theme/themes/pxt/globals/zindex.variables
+++ b/theme/themes/pxt/globals/zindex.variables
@@ -15,7 +15,7 @@
 @menuBarZIndex: 101; /* From semantic */
 
 /* Editor */
-@aboveEditorZIndex: 100;
+@aboveEditorZIndex: 90;
 
 /* Blockly */
 @blocklyToolboxZIndex: 40;


### PR DESCRIPTION
Lower editor zindex so the menu dropdown / menu is above the sidedoc