### PR TITLE
Update to pxt-monaco-typescript v.2.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "monaco-editor": "0.10.0",
-    "pxt-monaco-typescript": "2.3.4",
+    "pxt-monaco-typescript": "2.3.5",
     "jake": "^8.0.12",
     "jquery": "^2.2.0",
     "karma": "^1.7.0",


### PR DESCRIPTION
Update to pxt-monaco-typescript v.2.3.5 with the fix to hide all functions and properties that start with an underscore in intellisense