### PR TITLE
do not generate loc strings for deprecated blocs

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -247,6 +247,8 @@ namespace ts.pxtc {
             if (!options.locs || !si.qName) {
                 return;
             }
+            if (si.attributes.deprecated || /^__/.test(si.name))
+                return; // skip deprecated or function starting with __
             pxt.debug(`loc: ${si.qName}`)
             // must match blockly loader
             if (si.kind != SymbolKind.EnumMember) {


### PR DESCRIPTION
Don't generate loc strings for deprecated blocks and typescript functions start with __. This is required for app compat work in Adafruit.