### PR TITLE
simpler type signature of rgb2hsl

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -428,8 +428,7 @@ namespace pxsim.visuals {
     }
 
     //expects rgb from 0,255, gives h in [0,360], s in [0, 100], l in [0, 100]
-    export function rgbToHsl(rgb: [number, number, number]): [number, number, number] {
-        let [r, g, b] = rgb;
+    export function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
         let [r$, g$, b$] = [r / 255, g / 255, b / 255];
         let cMin = Math.min(r$, g$, b$);
         let cMax = Math.max(r$, g$, b$);


### PR DESCRIPTION
A small (breaking) change to simplify neopixel sim.
@microsoftsam this will break chibi.