### PR TITLE
Log adding github package name.

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -128,7 +128,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             if (ev.keyCode == 13) upd(ev);
         }
         const installGh = (scr: pxt.github.GitRepo) => {
-            pxt.tickEvent("packages.github");
+            pxt.tickEvent("packages.github", { name: scr.fullName });
             this.hide();
             let p = pkg.mainEditorPkg();
             core.showLoading(lf("downloading package..."));


### PR DESCRIPTION
Logging the github package name that's added to a project to get a good idea of what packages are used. This PR is against v0.