### PR TITLE
Translate the delete variable confirmation dialog

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2286,6 +2286,7 @@ namespace pxt.blocks {
         // Dropdown menu of variables_get
         msg.RENAME_VARIABLE = lf("Rename variable...");
         msg.DELETE_VARIABLE = lf("Delete the \"%1\" variable");
+        msg.DELETE_VARIABLE_CONFIRMATION = lf("Delete %1 uses of the \"%2\" variable?");
 
         // builtin variables_set
         const variablesSetId = "variables_set";


### PR DESCRIPTION
This is to make it possible to translate this dialog.
![image](https://user-images.githubusercontent.com/485416/31853619-7c1d5438-b6c6-11e7-8037-51b468457353.png)

Please do not forget to update the `strings.json` file soon.