### PR TITLE
Remove extra fullstop from Math.random eg parameter

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -294,7 +294,7 @@ declare namespace Math {
 
     /**
      * Return a pseudorandom number between 0 and `limit`.
-     * @param limit the upper bound of the number generated, eg: 4.
+     * @param limit the upper bound of the number generated, eg: 4
      */
     //% blockId="device_random" block="pick random 0 to %limit" blockGap=8
     //% help=math/random


### PR DESCRIPTION
Remove extra fullstop causing autocomplete to add an extra full stop when completing the random function.

```
Math.random(4.)
```
is what gets inserted

Only affects v0. Fixes #3292