### PR TITLE
Use touch events on touch devices for sim events

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -101,6 +101,10 @@ namespace pxt.BrowserUtils {
                 || navigator.maxTouchPoints > 0);       // works on IE10/11 and Surface);
     }
 
+    export function hasPointerEvents(): boolean {
+        return typeof window != "undefined" && !!(window as any).PointerEvent;
+    }
+
     export function hasSaveAs(): boolean {
         return isEdge() || isIE() || isFirefox();
     }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -219,18 +219,34 @@ namespace pxsim {
         leave: string
     }
 
-    export const pointerEvents = typeof window != "undefined" && !!(window as any).PointerEvent ? {
-        up: "pointerup",
-        down: "pointerdown",
-        move: "pointermove",
-        leave: "pointerleave"
-    } : {
+    export function isTouchEnabled(): boolean {
+        return typeof window !== "undefined" &&
+                ('ontouchstart' in window                              // works on most browsers
+                || (navigator && navigator.maxTouchPoints > 0));       // works on IE10/11 and Surface);
+    }
+
+    export function hasPointerEvents(): boolean {
+        return typeof window != "undefined" && !!(window as any).PointerEvent;
+    }
+
+    export const pointerEvents = hasPointerEvents() ? {
+            up: "pointerup",
+            down: "pointerdown",
+            move: "pointermove",
+            leave: "pointerleave"
+        } : isTouchEnabled() ?
+        {
+            up: "mouseup",
+            down: "touchstart",
+            move: "touchmove",
+            leave: "touchend"
+        } :
+        {
             up: "mouseup",
             down: "mousedown",
             move: "mousemove",
             leave: "mouseleave"
         };
-
 }
 
 namespace pxsim.visuals {


### PR DESCRIPTION
For sim events, we've been using pointer events on pointer event enabled devices and mouse events on all the rest. 
There is another class of events, touch events, that we should use on touch devices since mouse events are still triggered on touch devices, but much later in the process. 

ie: on a desktop a 2 second long hold goes as follows: mouse down, 2 seconds, then mouse up
on a touch devices, the same action would do: touch start, 2 seconds, touch end, mouse down, mouse up. 

Here's the full order on touch devices: 
```
touchstart
touchmove
touchend
mouseover
mousemove
mousedown
mouseup
click
```

Fixes #2405 and probably a bunch of other issues on touch devices

Fix needs to be integrated to master.

Test matrix: 
- [x] IOS 10
- [x] Chrome Mac
- [x] Edge
- [ ] Touch device using Pointer events, eg: Surface

Tested with this code snippet: 
```
basic.forever(() => {
    if (input.buttonIsPressed(Button.A)) {
        basic.showIcon(IconNames.Heart)
    } else {
        basic.clearScreen()
    }
})
```