### PR TITLE
[Integrate] Use touch events on touch devices for sim events.

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -107,6 +107,10 @@ namespace pxt.BrowserUtils {
                 || navigator.maxTouchPoints > 0);       // works on IE10/11 and Surface);
     }
 
+    export function hasPointerEvents(): boolean {
+        return typeof window != "undefined" && !!(window as any).PointerEvent;
+    }
+
     export function hasSaveAs(): boolean {
         return isEdge() || isIE() || isFirefox();
     }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -225,18 +225,34 @@ namespace pxsim {
         leave: string
     }
 
-    export const pointerEvents = typeof window != "undefined" && !!(window as any).PointerEvent ? {
-        up: "pointerup",
-        down: "pointerdown",
-        move: "pointermove",
-        leave: "pointerleave"
-    } : {
+    export function isTouchEnabled(): boolean {
+        return typeof window !== "undefined" &&
+                ('ontouchstart' in window                              // works on most browsers
+                || (navigator && navigator.maxTouchPoints > 0));       // works on IE10/11 and Surface);
+    }
+
+    export function hasPointerEvents(): boolean {
+        return typeof window != "undefined" && !!(window as any).PointerEvent;
+    }
+
+    export const pointerEvents = hasPointerEvents() ? {
+            up: "pointerup",
+            down: "pointerdown",
+            move: "pointermove",
+            leave: "pointerleave"
+        } : isTouchEnabled() ?
+        {
+            up: "mouseup",
+            down: "touchstart",
+            move: "touchmove",
+            leave: "touchend"
+        } :
+        {
             up: "mouseup",
             down: "mousedown",
             move: "mousemove",
             leave: "mouseleave"
         };
-
 }
 
 namespace pxsim.visuals {


### PR DESCRIPTION
Use touch events on touch devices for sim events. Instead of mouse events.

Integrating https://github.com/Microsoft/pxt/pull/3305 to master