### PR TITLE
Support populating dropdown values from namespace properties

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -40,6 +40,10 @@ namespace ts.pxtc {
         type: string;
     }
 
+    export interface ConstantDesc extends PropertyDesc {
+        attrs: CommentAttrs;
+    }
+
     export interface PropertyOption {
         value: any;
     }
@@ -69,6 +73,7 @@ namespace ts.pxtc {
         qName?: string;
         pkg?: string;
         snippet?: string;
+        constants?: ConstantDesc[]; // defined on namespaces only
     }
 
     export interface ApisInfo {
@@ -173,6 +178,8 @@ namespace ts.pxtc {
         paramFieldEditor?: pxt.Map<string>; //.fieldEditor
         paramShadowOptions?: pxt.Map<pxt.Map<string>>; //.shadowOptions.
         paramFieldEditorOptions?: pxt.Map<pxt.Map<string>>; //.fieldOptions.
+
+        blockValuesNs?: string; // qualified name of the namespace that provides the dropdown values of this block
     }
 
     export interface LocationInfo {


### PR DESCRIPTION
Support properties on namespaces to be used as dropdown values in blocks (instead of Enums)

Reason for this change: 
Enums are limiting and cannot be extended by the target or other packages. An example of this is the showAnimation method in adafruit that accepts an enum as the animation ID. If we wanted to create packages that potentially add new animations, we couldn't extend the Enum to add more attributes as it's defined in one place, and TS doesn't support merging of enums.

This way we can define namespace properties like so: 
```
namespace LightAnimation {
      export const Rainbow = 0;
      export const Sparkle = 1;
      export const ColorCycle = 2;
}
```

and a target or package can add to that list by exporting more properties under that namespace. All the properties will get merged, and the block that used to only include the 5 or so animations that are built in, now can be expanded by the target or the package ecosystem to include more animations built by others. 

Each of these properties can be annotated just like enums with block names and blockImages, etc. 

@riknoll I'm a little unsure how to write tests for this, since the values defined on the namespace are only relevant when populating the dropdown field. 