### PR TITLE
don't build docs if no theme

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3725,7 +3725,7 @@ export function buildTargetDocsAsync(docs: boolean, locs: boolean, fileFilter?: 
         createOnly
     }).then((compileOpts) => { });
     // from target location?
-    if (fs.existsSync("pxtarget.json"))
+    if (fs.existsSync("pxtarget.json") && !!readJson("pxtarget.json").appTheme)
         return forEachBundledPkgAsync((pkg, dirname) => {
             pxt.log(`building docs in ${dirname}`);
             return build();


### PR DESCRIPTION
A fix for pxt-common-packages. We should not try to build the docs from there. The idea is that if a target does not have a theme, it does not have a front end - thus it is not complete. So we don't build the docs.