### PR TITLE
Make serialTextColor dark by default

### DIFF
--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -164,7 +164,7 @@
    Serial editor
 --------------------*/
 @serialBackgroundColor: lighten(@simulatorBackground, 2);
-@serialTextColor: @invertedTextColor;
+@serialTextColor: @darkTextColor;
 @serialGraphBackground: @lightGrey;
 @serialGraphColor: black;
 @editorCloseColor: black;


### PR DESCRIPTION
Goes with https://github.com/Microsoft/pxt-adafruit/pull/414