### PR TITLE
Various UI fixes

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -89,6 +89,7 @@ declare namespace pxt {
 
         color?: string; // one of semantic ui colors
         description?: string;
+        extracontent?: string;
         blocksXml?: string;
         typeScript?: string;
         imageUrl?: string;

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "pouchdb": "^5.2.1",
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
-    "semantic-ui-less": "^2.2.10",
+    "semantic-ui-less": "^2.2.11",
     "typings": "^2.1.0",
     "tslint": "^3.9.0",
     "typescript": "1.8.7",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2172,13 +2172,11 @@ namespace pxt.blocks {
             if (a == that.selectedItem_ || a == toolbox.tree_) {
                 return;
             }
-
-            if (a === null) {
-                collapseSubcategories(that.selectedItem_);
-                editor.lastInvertedCategory = that.selectedItem_;
-            }
-
+            let oldSelectedItem = that.selectedItem_;
             oldSetSelectedItem.call(that, a);
+            if (a === null) {
+                collapseSubcategories(oldSelectedItem);
+            }
         };
 
         // TODO: look into porting this code over to pxt-blockly
@@ -2923,7 +2921,7 @@ namespace pxt.blocks {
                 let headingLabel = goog.dom.createDom('label');
                 headingLabel.setAttribute('text', lf("Functions"));
                 headingLabel.setAttribute('web-class', 'blocklyFlyoutHeading');
-                headingLabel.setAttribute('web-icon', '\uf107');
+                headingLabel.setAttribute('web-icon', '\uf109');
                 headingLabel.setAttribute('web-icon-class', 'blocklyFlyoutIconfunctions');
                 headingLabel.setAttribute('web-icon-color', getNamespaceColor('functions'));
                 xmlList.push(headingLabel as HTMLElement);

--- a/pxtblocks/codecardrenderer.ts
+++ b/pxtblocks/codecardrenderer.ts
@@ -122,6 +122,11 @@ namespace pxt.docs.codeCard {
             }
         }
 
+        if (card.extracontent) {
+            let extracontent = div(r, "extra content", "div");
+            extracontent.appendChild(document.createTextNode(card.extracontent));
+        }
+
         return r;
     }
 }

--- a/theme/home.less
+++ b/theme/home.less
@@ -85,7 +85,7 @@
         color: @homeCardColor;
         border: @homeCardBorderSize solid @homeCardBorderColor !important;
         background-color: @homeCardBackgroundColor;
-        .ui.image, .content {
+        .ui.image, .ui.imagewrapper, .content {
             border-radius: @homeCardImageBorderRadius !important;
         }
         .header {

--- a/theme/packagedialog.less
+++ b/theme/packagedialog.less
@@ -1,0 +1,17 @@
+
+
+/* Script search cards */
+.searchdialog {
+    .cards {
+        overflow-y: auto;
+        overflow-x: hidden;
+        margin-top: 0.5rem;
+    }    
+    .ui.card {
+        height: 20rem;
+        .ui.cardimage {
+            height: 11rem;
+        }
+    }
+}
+

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -5,6 +5,7 @@
 
 @import 'common';
 @import 'monaco';
+@import 'packagedialog';
 @import 'tutorial';
 @import 'sidedoc';
 @import 'home';

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -110,7 +110,11 @@
 
 
 /* Project code cards */
-
+.ui.card .ui.imagewrapper {
+    overflow: hidden;
+    border-top-left-radius: @borderRadius;
+    border-top-right-radius: @borderRadius;
+}
 .ui.cardimage {
     background-color: @secondaryColor;
     background-size: cover;

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -35,13 +35,6 @@ body {
     margin-right: 0.25rem;
 }
 
-.searchdialog .cards {
-    max-height: 20rem;
-    overflow-y: auto;
-    overflow-x: hidden;
-    margin-top:0.5rem;
-}
-
 .ui.card > .content > a.header {
     word-break: break-all;
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -205,6 +205,7 @@ export class ProjectView
                 let txt = this.editor.getCurrentSource()
                 if (txt != this.editorFile.content)
                     simulator.makeDirty();
+                if (this.editor.isIncomplete()) return Promise.resolve();
                 return this.editorFile.setContentAsync(txt);
             });
     }
@@ -340,6 +341,7 @@ export class ProjectView
 
     private typecheck = pxtc.Util.debounce(
         () => {
+            if (this.editor.isIncomplete()) return;
             let state = this.editor.snapshotState()
             compiler.typecheckAsync()
                 .done(resp => {
@@ -2189,6 +2191,8 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
     if (!hash) return false;
     let editor = theEditor;
     if (!editor) return false;
+
+    if (isProjectRelatedHash(hash)) editor.home.hide();
 
     switch (hash.cmd) {
         case "doc":

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -237,7 +237,7 @@ export class Editor extends srceditor.Editor {
                 agreeClass: "positive",
                 agreeIcon: "checkmark",
                 body: message,
-                size: "small"
+                size: "tiny"
             }).then(() => {
                 if (opt_callback) {
                     opt_callback();
@@ -261,7 +261,7 @@ export class Editor extends srceditor.Editor {
                 disagreeLbl: lf("No"),
                 disagreeClass: "positive",
                 disagreeIcon: "checkmark",
-                size: "small"
+                size: "tiny"
             }).then(b => {
                 callback(b == 1);
             })
@@ -282,7 +282,7 @@ export class Editor extends srceditor.Editor {
                 defaultValue: defaultValue,
                 agreeLbl: lf("Ok"),
                 disagreeLbl: lf("Cancel"),
-                size: "small"
+                size: "tiny"
             }).then(value => {
                 callback(value);
             })

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -51,14 +51,14 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
                     {card.header}
                 </div> : null }
             {card.label || card.blocksXml || card.typeScript || imageUrl || cardType == "file" ? <div className={"ui image"}>
-                {card.label ? <label className={`ui ${card.labelClass ? card.labelClass : "orange right ribbon" } label`}>{card.label}</label> : undefined }
+                {card.label ? <label className={`ui ${card.labelClass ? card.labelClass : "orange right ribbon"} label`}>{card.label}</label> : undefined }
                 {card.blocksXml ? <blockspreview.BlocksPreview key="promoblocks" xml={card.blocksXml} /> : undefined}
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : undefined}
-                {imageUrl ? <div className="ui cardimage" style={ { backgroundImage: `url("${imageUrl}")`}} /> : undefined}
+                {imageUrl ? <div className="ui imagewrapper"><div className="ui cardimage" style={ { backgroundImage: `url("${imageUrl}")` }} /> </div> : undefined}
                 {card.cardType == "file" ? <div className="ui fileimage" /> : undefined}
             </div> : undefined }
             {card.icon || card.iconContent ?
-                <div className="ui"><div className={`ui button massive fluid ${card.iconColor} ${card.iconContent ? "iconcontent" : ""}`}>
+                <div className="ui imagewrapper"><div className={`ui button massive fluid ${card.iconColor} ${card.iconContent ? "iconcontent" : ""}`}>
                     { card.icon ? <sui.Icon icon={`${'icon ' + card.icon}`} /> : undefined }
                     { card.iconContent || undefined }
                 </div></div> : undefined }
@@ -67,9 +67,10 @@ export class CodeCardView extends React.Component<pxt.CodeCard, CodeCardState> {
                     {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}
                     {card.description ? <div className="description tall">{renderMd(card.description) }</div> : null}
                 </div> : undefined }
-                {card.time ? <div className="meta">
-                    {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
-                </div> : undefined}
+            {card.time ? <div className="meta">
+                {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time) }</span> : null}
+            </div> : undefined}
+            {card.extracontent ? <div className="extra content"> {card.extracontent} </div> : undefined}
         </div>;
 
         if (!card.onClick && url) {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -555,7 +555,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         }]
 
         return (
-            <sui.Modal open={visible} className="exitandsave" header={lf("Exit Project")} size="small"
+            <sui.Modal open={visible} className="exitandsave" header={lf("Exit Project")} size="tiny"
                 onClose={() => this.hide()} dimmer={true}
                 actions={actions}
                 closeIcon={true}

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -232,7 +232,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
         const headerText = lf("Extensions");
         return (
-            <sui.Modal open={this.state.visible} dimmer={true} header={headerText} className="searchdialog" size="large"
+            <sui.Modal open={this.state.visible} dimmer={true} header={headerText} className="searchdialog" longer={true} size="fullscreen"
                 onClose={() => this.setState({ visible: false }) }
                 closeIcon={true}
                 helpUrl="/packages"
@@ -287,10 +287,11 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                         {ghdata.filter(repo => repo.status != pxt.github.GitRepoStatus.Approved).map(scr =>
                             <codecard.CodeCardView
                                 name={scr.name.replace(/^pxt-/, "") }
-                                description={lf("User provided package, not endorsed by Microsoft.")
-                                    + " " + (scr.description || "") }
+                                description={(scr.description || "") }
+                                extracontent={lf("User provided package, not endorsed by Microsoft.")}
                                 key={'ghd' + scr.fullName}
                                 onClick={() => installGh(scr) }
+                                imageUrl={pxt.github.repoIconUrl(scr) }
                                 url={'github:' + scr.fullName}
                                 color="red"
                                 role="option"

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -792,6 +792,7 @@ export interface ModalProps {
     open?: boolean;
     mountNode?: any;
     size?: string;
+    longer?: boolean;
     allowResetFocus?: boolean;
 
     headerClass?: string;
@@ -945,6 +946,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
             dimmer,
             dimmerClassName,
             size,
+            longer,
             allowResetFocus
         } = this.props
 
@@ -952,6 +954,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
         const classes = cx([
             'ui',
             size,
+            longer ? 'longer' : '',
             basic ? 'basic' : '',
             scrolling ? 'scrolling' : '',
             'modal transition visible active',
@@ -971,7 +974,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
                         : undefined}
                 </div> : undefined}
                 {this.props.description ? <label id={this.id + 'description'} className="accessible-hidden">{this.props.description}</label> : undefined}
-                <div id={this.id + 'desc'} className="content">
+                <div id={this.id + 'desc'} className={`${longer ? 'scrolling' : ''} content`}>
                     {children}
                 </div>
                 {this.props.actions && this.props.actions.length > 0 ?

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -135,7 +135,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
             className: 'green'
         }]
 
-        return <sui.Modal open={visible} className="hintdialog" size="small" header={header} closeIcon={true}
+        return <sui.Modal open={visible} className="hintdialog" size="" longer={true} header={header} closeIcon={true}
                 onClose={() => this.setState({ visible: false })} dimmer={true}
                 actions={actions}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>


### PR DESCRIPTION
Fix issue with sub category menu breaking drag. Fixes https://github.com/Microsoft/pxt-adafruit/issues/401
Add extracontent area in codecards, allowing us to add the package disclaimer in that area
Moving scriptsearch css logic into its own file and making the package cards more standardized
Fix issue with saving in the middle of a drag Fixes https://github.com/Microsoft/pxt-adafruit/issues/355
Support the "longer" type of modals introduced in semantic 2.2.11, useful for hints / extension dialog