### PR TITLE
Trim whitespace before decompiling and compiling expression blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -514,7 +514,7 @@ namespace pxt.blocks {
     }
 
     function extractTsExpression(e: Environment, b: B.Block, comments: string[]): JsNode {
-        return mkText(b.getFieldValue("EXPRESSION"));
+        return mkText(b.getFieldValue("EXPRESSION").trim());
     }
 
     function compileNumber(e: Environment, b: B.Block, comments: string[]): JsNode {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -636,7 +636,7 @@ ${output}</xml>`;
         }
 
         function getTypeScriptExpressionBlock(n: ts.Node) {
-            const text = applyRenamesInRange(n.getFullText(), n.getFullStart(), n.getEnd());
+            const text = applyRenamesInRange(n.getFullText(), n.getFullStart(), n.getEnd()).trim();
             trackVariableUsagesInText(n);
             return getFieldBlock(pxtc.TS_OUTPUT_TYPE, "EXPRESSION", text);
         }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-adafruit/issues/384

The underlying issue is probably a blockly bug. A bunch of spaces were being added for seemingly no reason.