### PR TITLE
Fix HID/serial re-connecting

### DIFF
--- a/pxtlib/hf2.ts
+++ b/pxtlib/hf2.ts
@@ -406,6 +406,13 @@ namespace pxt.HF2 {
             return this.talkAsync(HF2_CMD_READ_WORDS, args)
         }
 
+        pingAsync() {
+            if (this.rawMode)
+                return Promise.resolve()
+            return this.talkAsync(HF2_CMD_BININFO)
+                .then(buf => { })
+        }
+
         flashAsync(blocks: pxtc.UF2.Block[]) {
             let start = Date.now()
             let fstart = 0

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1979,17 +1979,17 @@ function initLogin() {
     }
 }
 
-let hidConnectionPoller: number;
+let serialConnectionPoller: number;
 let hidPingInterval: number;
 
-function startHidConnectionPoller() {
-    if (hidConnectionPoller == null)
-        hidConnectionPoller = window.setInterval(initSerial, 5000);
+function startSerialConnectionPoller() {
+    if (serialConnectionPoller == null)
+        serialConnectionPoller = window.setInterval(initSerial, 5000);
 }
 
-function stopHidConnectionPoller() {
-    clearInterval(hidConnectionPoller);
-    hidConnectionPoller = null;
+function stopSerialConnectionPoller() {
+    clearInterval(serialConnectionPoller);
+    serialConnectionPoller = null;
 }
 
 function initSerial() {
@@ -2001,15 +2001,15 @@ function initSerial() {
             .then(dev => {
                 // disable poller when connected; otherwise the forceful reconnecting interferes with
                 // flashing; it may also lead to data loss on serial stream
-                stopHidConnectionPoller()
+                stopSerialConnectionPoller()
                 if (hidPingInterval == null)
                     hidPingInterval = window.setInterval(() => {
-                        if (hidConnectionPoller == null)
+                        if (serialConnectionPoller == null)
                             dev.pingAsync()
                                 .then(() => {
                                 }, e => {
                                     pxt.debug("re-starting connection poller")
-                                    startHidConnectionPoller()
+                                    startSerialConnectionPoller()
                                 })
                     }, 4900)
                 dev.onSerial = (buf, isErr) => {
@@ -2024,7 +2024,7 @@ function initSerial() {
             })
             .catch(e => {
                 pxt.log(`hidbridge failed to load, ${e}`);
-                startHidConnectionPoller();
+                startSerialConnectionPoller();
             })
         return
     }
@@ -2034,15 +2034,15 @@ function initSerial() {
     let serialBuffers: pxt.Map<string> = {};
     ws.onopen = (ev) => {
         pxt.debug('serial: socket opened');
-        stopHidConnectionPoller()
+        stopSerialConnectionPoller()
     }
     ws.onclose = (ev) => {
         pxt.debug('serial: socket closed')
-        startHidConnectionPoller()
+        startSerialConnectionPoller()
     }
     ws.onerror = (ev) => {
         pxt.debug('serial: error')
-        startHidConnectionPoller()
+        startSerialConnectionPoller()
     }
     ws.onmessage = (ev) => {
         try {
@@ -2465,7 +2465,7 @@ $(document).ready(() => {
                 theEditor.setState({ editorState: state });
             }
             initSerial();
-            startHidConnectionPoller();
+            startSerialConnectionPoller();
             initScreenshots();
             initHashchange();
             electron.init();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1980,21 +1980,18 @@ function initLogin() {
 }
 
 let hidConnectionPoller: number;
-let hidPollerDelay: number;
 
 function startHidConnectionPoller() {
-    hidConnectionPoller = window.setInterval(initSerial, 5000);
+    if (hidConnectionPoller == null)
+        hidConnectionPoller = window.setInterval(initSerial, 5000);
 }
 
-function setHidPollerDelay() {
-    clearTimeout(hidPollerDelay);
+function stopHidConnectionPoller() {
     clearInterval(hidConnectionPoller);
-    hidPollerDelay = window.setTimeout(startHidConnectionPoller, 5000);
+    hidConnectionPoller = null;
 }
 
 function initSerial() {
-    startHidConnectionPoller();
-
     if (!pxt.appTarget.serial || !pxt.winrt.isWinRT() && (!Cloud.isLocalHost() || !Cloud.localToken))
         return;
 
@@ -2003,18 +2000,21 @@ function initSerial() {
             .then(dev => {
                 // disable poller when connected; otherwise the forceful reconnecting interferes with
                 // flashing; it may also lead to data loss on serial stream
-                clearInterval(hidConnectionPoller);
+                stopHidConnectionPoller()
+                // TODO add dev.onError
                 dev.onSerial = (buf, isErr) => {
-                    // setHidPollerDelay();
+                    let data = Util.fromUTF8(Util.uint8ArrayToString(buf))
+                    //pxt.debug('serial: ' + data)
                     window.postMessage({
                         type: 'serial',
                         id: 'n/a', // TODO
-                        data: Util.fromUTF8(Util.uint8ArrayToString(buf))
+                        data
                     }, "*")
                 }
             })
             .catch(e => {
                 pxt.log(`hidbridge failed to load, ${e}`);
+                startHidConnectionPoller();
             })
         return
     }
@@ -2024,14 +2024,21 @@ function initSerial() {
     let serialBuffers: pxt.Map<string> = {};
     ws.onopen = (ev) => {
         pxt.debug('serial: socket opened');
+        stopHidConnectionPoller()
     }
     ws.onclose = (ev) => {
         pxt.debug('serial: socket closed')
+        startHidConnectionPoller()
+    }
+    ws.onerror = (ev) => {
+        pxt.debug('serial: error')
+        startHidConnectionPoller()
     }
     ws.onmessage = (ev) => {
         try {
             let msg = JSON.parse(ev.data) as pxsim.SimulatorSerialMessage;
             if (msg && msg.type == "serial") {
+                //pxt.debug('serial: ' + msg.data)
                 pxt.Util.bufferSerial(serialBuffers, msg.data, msg.id);
             }
         }
@@ -2448,6 +2455,7 @@ $(document).ready(() => {
                 theEditor.setState({ editorState: state });
             }
             initSerial();
+            startHidConnectionPoller();
             initScreenshots();
             initHashchange();
             electron.init();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1980,6 +1980,7 @@ function initLogin() {
 }
 
 let hidConnectionPoller: number;
+let hidPingInterval: number;
 
 function startHidConnectionPoller() {
     if (hidConnectionPoller == null)
@@ -2001,7 +2002,16 @@ function initSerial() {
                 // disable poller when connected; otherwise the forceful reconnecting interferes with
                 // flashing; it may also lead to data loss on serial stream
                 stopHidConnectionPoller()
-                // TODO add dev.onError
+                if (hidPingInterval == null)
+                    hidPingInterval = window.setInterval(() => {
+                        if (hidConnectionPoller == null)
+                            dev.pingAsync()
+                                .then(() => {
+                                }, e => {
+                                    pxt.debug("re-starting connection poller")
+                                    startHidConnectionPoller()
+                                })
+                    }, 4900)
                 dev.onSerial = (buf, isErr) => {
                     let data = Util.fromUTF8(Util.uint8ArrayToString(buf))
                     //pxt.debug('serial: ' + data)


### PR DESCRIPTION
Fixes #3325

It also adds a loop that pings the device every few seconds, and only when the device fails to respond (most likely disconnected), it tries to re-connect.

