### PR TITLE
Translate list var name in controls_for_of

### DIFF
--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -26,7 +26,7 @@ export default function() {
             <block type="controls_for_of">
                 <value name="LIST">
                     <shadow type="variables_get">
-                        <field name="VAR">list</field>
+                        <field name="VAR">${lf("{id:var}list")}</field>
                     </shadow>
                 </value>
             </block>


### PR DESCRIPTION
Translate the default list var name in the `controls_for_of` block.

Missing in #3249 and eaa5b7c?