### PR TITLE
Remove 'at' directives from header text

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -436,11 +436,11 @@ namespace pxt.docs {
                 return '<li>' + text + '</li>\n';
             }
             renderer.heading = function (text: string, level: number, raw: string) {
-                let m = /(.*)#([\w\-]+)\s*$/.exec(text)
+                let m = /(.*)[#@]([\w\-]+)\s*$/.exec(text)
                 let id = ""
                 if (m) {
                     text = m[1]
-                    id = m[2]
+                    id = (m[1] + m[2]).toLowerCase().replace(/[^\w]+/g, '-')
                 } else {
                     id = raw.toLowerCase().replace(/[^\w]+/g, '-')
                 }

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -440,7 +440,7 @@ namespace pxt.docs {
                 let id = ""
                 if (m) {
                     text = m[1]
-                    id = (m[1] + m[2]).toLowerCase().replace(/[^\w]+/g, '-')
+                    id = m[2]
                 } else {
                     id = raw.toLowerCase().replace(/[^\w]+/g, '-')
                 }


### PR DESCRIPTION
- [x] Filter `@` directives just like routing tags `#` so they won't render.
- [x] Prefix heading text in `id=` tags for a complete ID. Will remove this is if it breaks something needed post render.

Fixes https://github.com/Microsoft/pxt-minecraft/issues/486