### PR TITLE
update readPin regex

### DIFF
--- a/pxtsim/allocator.ts
+++ b/pxtsim/allocator.ts
@@ -159,7 +159,7 @@ namespace pxsim {
     }
     export function readPin(arg: string): MicrobitPin {
         U.assert(!!arg, "Invalid pin: " + arg);
-        const pin = /^(\w+)\.((P|A|D)\d+)$/.exec(arg);
+        const pin = /^(\w+)\..*((P|A|D)\d+)$/.exec(arg);
         return pin ? <MicrobitPin>pin[2] : undefined;
     }
     function mkReverseMap(map: { [key: string]: string }) {


### PR DESCRIPTION
Update the readPin regex to support pins of the format: input.pinA0 and input.ButtonD0