### PR TITLE
3rd party docs rendering

### DIFF
--- a/common-docs/SUMMARY.md
+++ b/common-docs/SUMMARY.md
@@ -72,4 +72,5 @@
     * [Command Line Interface](/cli)
     * [Visual Studio Code support](/code)
     * [Coding on Raspberry Pi](/raspberry-pi)
+    * [Blocks Embed](/blocks-embed)
 

--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -18,9 +18,42 @@ If you're looking for a better solution, carry on reading.
 
 The MakeCode approach to solve this issue is to render the code snippets on the client using the same block rendering engine as the editor. The idea is to load an IFrame from the MakeCode editor that will render the blocks for you.
 
+## Implementation
+
 The first part is to register a message handler that will communicate with the rendering ``IFrame``.
 The renderer sends a ``renderready`` message when it is loaded and ready to receive messages.
+
+```typescript-ignore
+export interface RenderReadyResponseMessage extends SimulatorMessage {
+    source: "makecode",
+    type: "renderready"
+}
+```
+
 It sends back a ``renderblocks`` response message with the rendered blocks.
+
+```typescript-ignore
+export interface RenderBlocksRequestMessage extends SimulatorMessage {
+    type: "renderblocks",
+    id: string;
+    code: string;
+    options?: {
+        package?: string;
+        snippetMode?: boolean;
+    }
+}
+
+export interface RenderBlocksResponseMessage extends SimulatorMessage {
+    source: "makecode",
+    type: "renderblocks",
+    id: string;
+    svg?: string;
+    width?: number;
+    height?: number;
+}
+```
+
+This snippet registers a message handler.
 
 ```typescript-ignore
 window.addEventListener("message", function (ev) {

--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -53,7 +53,7 @@ export interface RenderBlocksResponseMessage extends SimulatorMessage {
 }
 ```
 
-This snippet registers a message handler.
+This snippet registers a message handler. Feel free to write it using your favorite JS framework.
 
 ```typescript-ignore
 window.addEventListener("message", function (ev) {
@@ -68,7 +68,13 @@ window.addEventListener("message", function (ev) {
             var svg = msg.svg; // this is an string containing SVG
             var id = msg.id; // this is the id you sent
             // replace text with svg
-            document.getElementById(id).innerHTML = svg;
+            var img = document.createElement("img");
+            img.src = msg.uri;
+            img.width = msg.width;
+            img.height = msg.height;
+            var code = document.getElementById(id)
+            code.parentElement.insertBefore(img, code)
+            code.parentElement.removeChild(code);
             break;
     }
 }, false);

--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -1,0 +1,74 @@
+# Blocks embed
+
+MakeCode provides a lightweight blocks rendering engine that renders code snippets into SVG images. 
+
+## The Curse of screenshots
+
+Unlike text based programming languages, block based snippets cannot be easily rendered in a documentation page.
+A quick solution is take screenshots of the snippets but things can quickly become unsustainable:
+
+* screenshots cannot be compiled - so it's hard to maintain then
+* screenshots are not localizable - non-English speaking users won't be able to read the blocks
+* screenshots cannot be reloaded easily into the editor
+* screenshots don't play well with source control system - you cannot diff changes efficiently.
+
+If you're looking for a better solution, carry on reading.
+
+## Rendering blocks on the spot
+
+The MakeCode approach to solve this issue is to render the code snippets on the client using the same block rendering engine as the editor. The idea is to load an IFrame from the MakeCode editor that will render the blocks for you.
+
+The first part is to register a message handler that will communicate with the rendering ``IFrame``.
+The renderer sends a ``renderready`` message when it is loaded and ready to receive messages.
+It sends back a ``renderblocks`` response message with the rendered blocks.
+
+```typescript-ignore
+window.addEventListener("message", function (ev) {
+    var msg = ev.data;
+    if (msg.source != "makecode") return;
+
+    switch (msg.type) {
+        case "renderready":
+            // start rendering snippets!
+            break;
+        case "renderblocks":
+            var svg = msg.svg; // this is an string containing SVG
+            var id = msg.id; // this is the id you sent
+            // replace text with svg
+            document.getElementById(id).innerHTML = svg;
+            break;
+    }
+}, false);
+```
+
+To request to render code, send a ``renderblocks`` message to the rendering IFrame.
+
+```typescript-ignore
+function makeCodeRenderPre(pre) {
+    var f = document.getElementById("makecoderenderer");
+    f.contentWindow.postMessage({
+        type: "renderblocks",
+        id: pre.id,
+        code: pre.innerText
+    }, "@homeurl@");
+}
+```
+
+The last step is to load the rendering iFrame in the HTML DOM and hide it so that it does not interferre with your page.
+
+```typescript-ignore
+function makeCodeInjectRenderer() {
+    var f = document.createElement("iframe");
+    f.id = "makecoderenderer";
+    f.style.position = "absolute";
+    f.style.left = 0;
+    f.style.bottom = 0;
+    f.style.width = "1px";
+    f.style.height = "1px";            
+    f.src = "@homeurl@--docs?render=1"
+    document.body.appendChild(f);
+}
+
+// load the renderer
+makeCodeInjectRenderer();
+```

--- a/common-docs/share.md
+++ b/common-docs/share.md
@@ -8,7 +8,13 @@ Once you've made your project, you can save it the cloud, share it, or embed it 
 
 ## Sharing the URL
 
-You can share the URL for the project with other people, and they will be able to visit that page to see your project, download it, or edit it.
+You can share the URL for the project with other people, and they will be able to visit that page to see your project, download it, or edit it. 
+
+### ~hint
+
+**Developers:** This page supports [OEmbed](https://oembed.com/).
+
+### ~
 
 ## Embedding into a blog or web site
 
@@ -58,12 +64,6 @@ Google Sites doesn't currently [support iframes in custom HTML][google-sites-ifr
 ### Embedding in Markdown documents
 
 [Markdown][] is a popular text format supported by many blog editors. As Markdown supports embedded HTML, you should be able to paste the HTML into the document, although some sites may prevent you from doing this.
-
-### ~hint
-
-**Developers:** This page supports OEmbed as well 
-
-### ~
 
 [wordpress.com]: https://wordpress.com
 [wordpress-vip]: https://vip.wordpress.com/documentation/embedding-rich-media-from-around-the-web-with-protected-embeds/#scripts-iframes-and-objects

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -133,10 +133,10 @@ namespace pxt.blocks.layout {
     }
 
     export function blocklyToSvgAsync(sg: SVGElement, x: number, y: number, width: number, height: number): Promise<{
-        width: number; height: number; xml: string;
+        width: number; height: number; svg: string; xml: string;
     }> {
         if (!sg.childNodes[0])
-            return Promise.resolve<{ width: number; height: number; xml: string; }>(undefined);
+            return Promise.resolve<{ width: number; height: number; svg: string; xml: string; }>(undefined);
 
         sg.removeAttribute("width");
         sg.removeAttribute("height");
@@ -157,7 +157,7 @@ namespace pxt.blocks.layout {
 
             return expandImagesAsync(xsg)
                 .then(() => {
-                    return { width: width, height: height, xml: documentToSvg(xsg) };
+                    return { width: width, height: height, svg: new XMLSerializer().serializeToString(xsg), xml: documentToSvg(xsg) };
                 });
             })
     }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -338,8 +338,8 @@ namespace pxt.BrowserUtils {
     export function loadAjaxAsync(url: string): Promise<string> {
         return new Promise<string>((resolve, reject) => {
             let httprequest = new XMLHttpRequest();
-            httprequest.onreadystatechange = function() {
-                if (httprequest.readyState == XMLHttpRequest.DONE ) {
+            httprequest.onreadystatechange = function () {
+                if (httprequest.readyState == XMLHttpRequest.DONE) {
                     if (httprequest.status == 200) {
                         resolve(httprequest.responseText);
                     }
@@ -351,5 +351,62 @@ namespace pxt.BrowserUtils {
             httprequest.open("GET", url, true);
             httprequest.send();
         })
+    }
+
+    export function initTheme() {
+        function patchCdn(url: string): string {
+            if (!url) return url;
+            return url.replace("@cdnUrl@", pxt.getOnlineCdnUrl());
+        }
+
+        const theme = pxt.appTarget.appTheme;
+        if (theme) {
+            if (theme.accentColor) {
+                let style = document.createElement('style');
+                style.type = 'text/css';
+                style.innerHTML = `.ui.accent { color: ${theme.accentColor}; }
+                .ui.inverted.menu .accent.active.item, .ui.inverted.accent.menu  { background-color: ${theme.accentColor}; }`;
+                document.getElementsByTagName('head')[0].appendChild(style);
+
+                theme.appLogo = patchCdn(theme.appLogo)
+                theme.cardLogo = patchCdn(theme.cardLogo)
+            }
+        }
+        // RTL languages
+        if (Util.isUserLanguageRtl()) {
+            pxt.debug("rtl layout");
+            document.body.classList.add("rtl");
+            document.body.style.direction = "rtl";
+
+            // replace semantic.css with rtlsemantic.css
+            const links = Util.toArray(document.head.getElementsByTagName("link"));
+            const semanticLink = links.filter(l => Util.endsWith(l.getAttribute("href"), "semantic.css"))[0];
+            if (semanticLink) {
+                const semanticHref = semanticLink.getAttribute("data-rtl");
+                if (semanticHref) {
+                    pxt.debug(`swapping to ${semanticHref}`)
+                    semanticLink.setAttribute("href", semanticHref);
+                }
+            }
+            // replace blockly.css with rtlblockly.css
+            const blocklyLink = links.filter(l => Util.endsWith(l.getAttribute("href"), "blockly.css"))[0];
+            if (blocklyLink) {
+                const blocklyHref = blocklyLink.getAttribute("data-rtl");
+                if (blocklyHref) {
+                    pxt.debug(`swapping to ${blocklyHref}`)
+                    blocklyLink.setAttribute("href", blocklyHref);
+                }
+            }
+        }
+
+        if (pxt.appTarget.simulator
+            && pxt.appTarget.simulator.boardDefinition
+            && pxt.appTarget.simulator.boardDefinition.visual) {
+            let boardDef = pxt.appTarget.simulator.boardDefinition.visual as pxsim.BoardImageDefinition;
+            if (boardDef.image) {
+                boardDef.image = patchCdn(boardDef.image)
+                if (boardDef.outlineImage) boardDef.outlineImage = patchCdn(boardDef.outlineImage)
+            }
+        }
     }
 }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -337,25 +337,26 @@ namespace pxt.runner {
     export function startRenderServer() {
         // notify parent that render engine is loaded
         window.addEventListener("message", function (ev) {
-            const msg = ev.data as pxsim.RenderRequestMessage;
-            if (msg.type == "render") {
+            const msg = ev.data as pxsim.RenderBlocksRequestMessage;
+            if (msg.type == "renderblocks") {
                 runner.decompileToBlocksAsync(msg.code, msg.options)
-                    .then(result => pxt.blocks.layout.blocklyToSvgAsync(result.blocksSvg, 0, 0, result.blocksSvg.width.baseVal.value, result.blocksSvg.height.baseVal.value))
+                    .then(result => result.blocksSvg ? pxt.blocks.layout.blocklyToSvgAsync(result.blocksSvg, 0, 0, result.blocksSvg.viewBox.baseVal.width, result.blocksSvg.viewBox.baseVal.height) : undefined)
                     .then(res => {
-                        window.parent.postMessage({
+                        window.parent.postMessage(<pxsim.RenderBlocksResponseMessage>{
                             source: "makecode",
-                            type: "blocks",
+                            type: "renderblocks",
                             id: msg.id,
-                            width: res.width,
-                            height: res.height,
-                            svg: res.xml
+                            width: res ? res.width : undefined,
+                            height: res ? res.height : undefined,
+                            svg: res ? res.svg : undefined,
+                            uri: res ? res.xml : undefined
                         }, "*")
                     })
             }
         }, false);
-        window.parent.postMessage({
+        window.parent.postMessage(<pxsim.RenderReadyResponseMessage>{
             source: "makecode",
-            type: "ready"
+            type: "renderready"
         }, "*");
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -334,6 +334,31 @@ namespace pxt.runner {
         }
     }
 
+    export function startRenderServer() {
+        // notify parent that render engine is loaded
+        window.addEventListener("message", function (ev) {
+            const msg = ev.data as pxsim.RenderRequestMessage;
+            if (msg.type == "render") {
+                runner.decompileToBlocksAsync(msg.code, msg.options)
+                    .then(result => pxt.blocks.layout.blocklyToSvgAsync(result.blocksSvg, 0, 0, result.blocksSvg.width.baseVal.value, result.blocksSvg.height.baseVal.value))
+                    .then(res => {
+                        window.parent.postMessage({
+                            source: "makecode",
+                            type: "blocks",
+                            id: msg.id,
+                            width: res.width,
+                            height: res.height,
+                            svg: res.xml
+                        }, "*")
+                    })
+            }
+        }, false);
+        window.parent.postMessage({
+            source: "makecode",
+            type: "ready"
+        }, "*");
+    }
+
     export function startDocsServer(loading: HTMLElement, content: HTMLElement) {
         function render(doctype: string, src: string) {
             pxt.debug(`rendering ${doctype}`);

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -335,23 +335,39 @@ namespace pxt.runner {
     }
 
     export function startRenderServer() {
+        pxt.tickEvent("renderer.ready");
+
+        const jobQueue: pxsim.RenderBlocksRequestMessage[] = [];
+        let jobPromise: Promise<void> = undefined;
+
+        function consumeQueue() {
+            if (jobPromise) return; // other worker already in action
+            const msg = jobQueue.shift();
+            if (!msg) return; // no more work
+
+            jobPromise = runner.decompileToBlocksAsync(msg.code, msg.options)
+                .then(result => result.blocksSvg ? pxt.blocks.layout.blocklyToSvgAsync(result.blocksSvg, 0, 0, result.blocksSvg.viewBox.baseVal.width, result.blocksSvg.viewBox.baseVal.height) : undefined)
+                .then(res => {
+                    window.parent.postMessage(<pxsim.RenderBlocksResponseMessage>{
+                        source: "makecode",
+                        type: "renderblocks",
+                        id: msg.id,
+                        width: res ? res.width : undefined,
+                        height: res ? res.height : undefined,
+                        svg: res ? res.svg : undefined,
+                        uri: res ? res.xml : undefined
+                    }, "*");
+                    jobPromise = undefined;
+                    consumeQueue();
+                })
+        }
+
         // notify parent that render engine is loaded
         window.addEventListener("message", function (ev) {
             const msg = ev.data as pxsim.RenderBlocksRequestMessage;
             if (msg.type == "renderblocks") {
-                runner.decompileToBlocksAsync(msg.code, msg.options)
-                    .then(result => result.blocksSvg ? pxt.blocks.layout.blocklyToSvgAsync(result.blocksSvg, 0, 0, result.blocksSvg.viewBox.baseVal.width, result.blocksSvg.viewBox.baseVal.height) : undefined)
-                    .then(res => {
-                        window.parent.postMessage(<pxsim.RenderBlocksResponseMessage>{
-                            source: "makecode",
-                            type: "renderblocks",
-                            id: msg.id,
-                            width: res ? res.width : undefined,
-                            height: res ? res.height : undefined,
-                            svg: res ? res.svg : undefined,
-                            uri: res ? res.xml : undefined
-                        }, "*")
-                    })
+                jobQueue.push(msg);
+                consumeQueue();
             }
         }, false);
         window.parent.postMessage(<pxsim.RenderReadyResponseMessage>{

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -120,14 +120,28 @@ namespace pxsim {
         step: number;
     }
 
-    export interface RenderRequestMessage extends SimulatorMessage {
+    export interface RenderReadyResponseMessage extends SimulatorMessage {
+        source: "makecode",
+        type: "renderready"
+    }
+
+    export interface RenderBlocksRequestMessage extends SimulatorMessage {
+        type: "renderblocks",
         id: string;
-        type: "render",
         code: string;
         options?: {
             package?: string;
             snippetMode?: boolean;
         }
+    }
+
+    export interface RenderBlocksResponseMessage extends SimulatorMessage {
+        source: "makecode",
+        type: "renderblocks",
+        id: string;
+        svg?: string;
+        width?: number;
+        height?: number;
     }
 
     export namespace Embed {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -112,12 +112,22 @@ namespace pxsim {
         subtype: "loaded";
         showCategories?: boolean;
         stepInfo: TutorialStepInfo[];
-        toolboxSubset?: {[index: string]: number };
+        toolboxSubset?: { [index: string]: number };
     }
 
     export interface TutorialStepChangeMessage extends TutorialMessage {
         subtype: "stepchange";
         step: number;
+    }
+
+    export interface RenderRequestMessage extends SimulatorMessage {
+        id: string;
+        type: "render",
+        code: string;
+        options?: {
+            package?: string;
+            snippetMode?: boolean;
+        }
     }
 
     export namespace Embed {

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -92,6 +92,7 @@
         var loading = document.getElementById('loading');
         var content = document.getElementById('content');        
         ksRunnerReady(function() {
+            pxt.BrowserUtils.initTheme();
             pxt.docs.requireMarked = function() { return marked; }
             var projectid = /projectid=([^&?]+)/i.exec(window.location.href); 
             var code = /code=([^&?]+)/i.exec(window.location.href);

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -97,6 +97,7 @@
             var code = /code=([^&?]+)/i.exec(window.location.href);
             var md = /md=([^&?]+)/i.exec(window.location.href);
             var markdown = code ? "```blocks\n" + decodeURIComponent(code[1]) + "```" : md ? decodeURIComponent(md[1]) : undefined;
+            var embed = /render=1/i.exec(window.location.href);
             if (markdown) {
                 console.log('rendering code:')
                 console.log(markdown);
@@ -110,6 +111,8 @@
                     $(content).show();
                 });
             }
+            else if (embed)
+                pxt.runner.startRenderServer();
             else
                 pxt.runner.startDocsServer(loading, content);
         });

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -64,13 +64,13 @@
             color: transparent;
         }
     </style>
+    <link rel="stylesheet" data-rtl="/blb/rtlsemantic.css" href="/blb/semantic.css" type="text/css">
+    <link id="blocklycss" rel="stylesheet" data-rtl="/blb/rtlblockly.css" href="/blb/blockly.css" type="text/css">
 </head>
 
 <body id="docs">
     <style type="text/css">
         @import "/blb/highlight.js/styles/vs.css";
-        @import "/blb/semantic.css";
-        @import "/blb/blockly.css";
         @import "/blb/icons.css";
     </style>
     <div id='loading' class="ui active inverted dimmer">

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -45,7 +45,13 @@
                     var svg = msg.svg;
                     var id = msg.id;
                     // replace text with svg
-                    document.getElementById(id).innerHTML = svg;
+                    var img = document.createElement("img");
+                    img.src = msg.uri;
+                    img.width = msg.width;
+                    img.height = msg.height;
+                    var code = document.getElementById(id)
+                    code.parentElement.insertBefore(img, code)
+                    code.parentElement.removeChild(code);
                     break;
             }
         }, false);

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -15,6 +15,10 @@
     <div id="blocks"></div>
 
     <script>
+        var code = `
+basic.showString("hello!")
+basic.showIcon(IconNames.Heart)
+`        
         var ready = false;
         var status = document.getElementById("status");
         status.innerText = 'initializing...'
@@ -24,15 +28,15 @@
             console.log('msg: ' + msg);
             if (msg.source != "makecode") return;
             switch (msg.type) {
-                case "ready": 
+                case "renderready": 
                     ready = true;
                     status.innerText = 'rendering';
                     f.contentWindow.postMessage({
-                        type: "render",
-                        code: `basic.showString("hello!")`
+                        type: "renderblocks",
+                        code: code
                     }, "*") 
                     break;
-                case "blocks":
+                case "renderblocks":
                     document.getElementById('blocks').innerHTML = msg.svg;
                     break;
             }

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -3,8 +3,10 @@
 <body>
     <pre id="mycode">
     basic.showString("hello!")
-    basic.showIcon(IconNames.Heart)                    
     </pre>
+    <pre id="mycode2">
+            basic.showIcon(IconNames.Heart)                    
+            </pre>
     <div id="status"></div>
     <div id="blocks"></div>
 
@@ -16,7 +18,7 @@
             f.style.left = 0;
             f.style.bottom = 0;
             f.style.width = "1px";
-            f.style.height = "1px";            
+            f.style.height = "1px";
             f.src = "/--docs?render=1"
             document.body.appendChild(f);
         }
@@ -29,7 +31,7 @@
                 code: pre.innerText
             }, "*");
         }
-        
+
         window.addEventListener("message", function (ev) {
             var msg = ev.data;
             if (msg.source != "makecode") return;
@@ -37,6 +39,7 @@
             switch (msg.type) {
                 case "renderready":
                     makeCodeRenderPre(document.getElementById("mycode"))
+                    makeCodeRenderPre(document.getElementById("mycode2"))
                     break;
                 case "renderblocks":
                     var svg = msg.svg;

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+    <style>
+    iframe {
+        width: 1px;
+        height: 1px;
+        position: absolute;
+        left: 0;
+        bottom: 1;
+    }
+    </style>
+</head>
+<body>
+    <div id="status"></div>
+    <div id="blocks"></div>
+
+    <script>
+        var ready = false;
+        var status = document.getElementById("status");
+        status.innerText = 'initializing...'
+
+        window.onmessage = function (ev) {
+            var msg = ev.data;
+            console.log('msg: ' + msg);
+            if (msg.source != "makecode") return;
+            switch (msg.type) {
+                case "ready": 
+                    ready = true;
+                    status.innerText = 'rendering';
+                    f.contentWindow.postMessage({
+                        type: "render",
+                        code: `basic.showString("hello!")`
+                    }, "*") 
+                    break;
+                case "blocks":
+                    document.getElementById('blocks').innerHTML = msg.svg;
+                    break;
+            }
+        }
+
+
+        // inject docs iframe
+        var f = document.createElement("iframe")
+        f.src = "/--docs?render=1"
+        document.body.appendChild(f);
+
+    </script>
+</body>
+
+</html>

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -1,53 +1,53 @@
 <html>
-<head>
-    <style>
-    iframe {
-        width: 1px;
-        height: 1px;
-        position: absolute;
-        left: 0;
-        bottom: 1;
-    }
-    </style>
-</head>
+
 <body>
+    <pre id="mycode">
+    basic.showString("hello!")
+    basic.showIcon(IconNames.Heart)                    
+    </pre>
     <div id="status"></div>
     <div id="blocks"></div>
 
     <script>
-        var code = `
-basic.showString("hello!")
-basic.showIcon(IconNames.Heart)
-`        
-        var ready = false;
-        var status = document.getElementById("status");
-        status.innerText = 'initializing...'
-
-        window.onmessage = function (ev) {
-            var msg = ev.data;
-            console.log('msg: ' + msg);
-            if (msg.source != "makecode") return;
-            switch (msg.type) {
-                case "renderready": 
-                    ready = true;
-                    status.innerText = 'rendering';
-                    f.contentWindow.postMessage({
-                        type: "renderblocks",
-                        code: code
-                    }, "*") 
-                    break;
-                case "renderblocks":
-                    document.getElementById('blocks').innerHTML = msg.svg;
-                    break;
-            }
+        function makeCodeInjectRenderer() {
+            var f = document.createElement("iframe");
+            f.id = "makecoderenderer";
+            f.style.position = "absolute";
+            f.style.left = 0;
+            f.style.bottom = 0;
+            f.style.width = "1px";
+            f.style.height = "1px";            
+            f.src = "/--docs?render=1"
+            document.body.appendChild(f);
         }
 
+        function makeCodeRenderPre(pre) {
+            var f = document.getElementById("makecoderenderer");
+            f.contentWindow.postMessage({
+                type: "renderblocks",
+                id: pre.id,
+                code: pre.innerText
+            }, "*");
+        }
+        
+        window.addEventListener("message", function (ev) {
+            var msg = ev.data;
+            if (msg.source != "makecode") return;
 
-        // inject docs iframe
-        var f = document.createElement("iframe")
-        f.src = "/--docs?render=1"
-        document.body.appendChild(f);
+            switch (msg.type) {
+                case "renderready":
+                    makeCodeRenderPre(document.getElementById("mycode"))
+                    break;
+                case "renderblocks":
+                    var svg = msg.svg;
+                    var id = msg.id;
+                    // replace text with svg
+                    document.getElementById(id).innerHTML = svg;
+                    break;
+            }
+        }, false);
 
+        makeCodeInjectRenderer();
     </script>
 </body>
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2020,57 +2020,6 @@ let myexports: any = {
 
 export var ksVersion: string;
 
-function initTheme() {
-    const theme = pxt.appTarget.appTheme;
-    if (theme.accentColor) {
-        let style = document.createElement('style');
-        style.type = 'text/css';
-        style.innerHTML = `.ui.accent { color: ${theme.accentColor}; }
-        .ui.inverted.menu .accent.active.item, .ui.inverted.accent.menu  { background-color: ${theme.accentColor}; }`;
-        document.getElementsByTagName('head')[0].appendChild(style);
-    }
-    // RTL languages
-    if (Util.isUserLanguageRtl()) {
-        pxt.debug("rtl layout");
-        pxsim.U.addClass(document.body, "rtl");
-        document.body.style.direction = "rtl";
-
-        // replace semantic.css with rtlsemantic.css
-        const links = Util.toArray(document.head.getElementsByTagName("link"));
-        const semanticLink = links.filter(l => Util.endsWith(l.getAttribute("href"), "semantic.css"))[0];
-        const semanticHref = semanticLink.getAttribute("data-rtl");
-        if (semanticHref) {
-            pxt.debug(`swapping to ${semanticHref}`)
-            semanticLink.setAttribute("href", semanticHref);
-        }
-        // replace blockly.css with rtlblockly.css
-        const blocklyLink = links.filter(l => Util.endsWith(l.getAttribute("href"), "blockly.css"))[0];
-        const blocklyHref = blocklyLink.getAttribute("data-rtl");
-        if (blocklyHref) {
-            pxt.debug(`swapping to ${blocklyHref}`)
-            blocklyLink.setAttribute("href", blocklyHref);
-        }
-    }
-
-    function patchCdn(url: string): string {
-        if (!url) return url;
-        return url.replace("@cdnUrl@", pxt.getOnlineCdnUrl());
-    }
-
-    theme.appLogo = patchCdn(theme.appLogo)
-    theme.cardLogo = patchCdn(theme.cardLogo)
-
-    if (pxt.appTarget.simulator
-        && pxt.appTarget.simulator.boardDefinition
-        && pxt.appTarget.simulator.boardDefinition.visual) {
-        let boardDef = pxt.appTarget.simulator.boardDefinition.visual as pxsim.BoardImageDefinition;
-        if (boardDef.image) {
-            boardDef.image = patchCdn(boardDef.image)
-            if (boardDef.outlineImage) boardDef.outlineImage = patchCdn(boardDef.outlineImage)
-        }
-    }
-}
-
 function parseHash(): { cmd: string; arg: string } {
     let hashCmd = ""
     let hashArg = ""
@@ -2254,7 +2203,7 @@ $(document).ready(() => {
                 pxt.appTarget.versions.branch,
                 live);
         })
-        .then(() => initTheme())
+        .then(() => pxt.BrowserUtils.initTheme())
         .then(() => cmds.initCommandsAsync())
         .then(() => {
             compiler.init();

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -228,7 +228,9 @@ export class EditorPackage {
     }
 
     getAllFiles() {
-        return Util.mapMap(this.files, (k, f) => f.content)
+        let r = Util.mapMap(this.files, (k, f) => f.content)
+        delete r[pxt.SERIAL_EDITOR_FILE]
+        return r
     }
 
     saveFilesAsync(immediate?: boolean) {


### PR DESCRIPTION
The foundation is starting to include a lot of screenshots in their web site. This change allows them to easily integrate MakeCode rendered blocks into their page.

The change exposes a new endpoint in /--docs where the embedded IFrame acts as a rendering engine for block program. There is no interference with the 3rd party CSS or JS since it just requires loading the IFrame and send/receive a few messages.

* lanch ``http://localhost:3232/rendertest.html`` to test the feature.

This is a first stab at this kind of feature. We should make it ridicuslouly easy for web devs to support rendered blocks in their blogs/web sites. Because this loads a single IFrame for all doc snippets, it is much faster to render than using individual embeds.