### PR TITLE
open example markdown in sidedocs when opening example

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -174,6 +174,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                                             if (resp.success) {
                                                 this.props.parent.overrideBlocksFile(resp.outfiles["main.blocks"])
                                             }
+                                            this.props.parent.setSideDoc(scr.url, loadBlocks);
                                         })
                                 })
                                 .done(() => {


### PR DESCRIPTION
Automatically load the example markdown in the side docs to allow for authoring a context.