### PR TITLE
Adding missing polyfills in pxtcompiler

### DIFF
--- a/webapp/src/worker.ts
+++ b/webapp/src/worker.ts
@@ -50,6 +50,64 @@ if (typeof atob === "undefined") {
     }
 }
 
+// Polyfill for Uint8Array.slice for IE and Safari
+// https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice
+if (!Uint8Array.prototype.slice) {
+    Object.defineProperty(Uint8Array.prototype, 'slice', {
+        value: Array.prototype.slice,
+        writable: true,
+        enumerable: true
+    });
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
+if (!Uint8Array.prototype.fill) {
+    Object.defineProperty(Uint8Array.prototype, 'fill', {
+        writable: true,
+        enumerable: true,
+        value: function (value: Uint8Array) {
+
+            // Steps 1-2.
+            if (this == null) {
+                throw new TypeError('this is null or not defined');
+            }
+
+            let O = Object(this);
+
+            // Steps 3-5.
+            let len = O.length >>> 0;
+
+            // Steps 6-7.
+            let start = arguments[1];
+            let relativeStart = start >> 0;
+
+            // Step 8.
+            let k = relativeStart < 0 ?
+                Math.max(len + relativeStart, 0) :
+                Math.min(relativeStart, len);
+
+            // Steps 9-10.
+            let end = arguments[2];
+            let relativeEnd = end === undefined ?
+                len : end >> 0;
+
+            // Step 11.
+            let final = relativeEnd < 0 ?
+                Math.max(len + relativeEnd, 0) :
+                Math.min(relativeEnd, len);
+
+            // Step 12.
+            while (k < final) {
+                O[k] = value;
+                k++;
+            }
+
+            // Step 13.
+            return O;
+        }
+    });
+}
+
 onmessage = ev => {
     let res = pxtc.service.performOperation(ev.data.op, ev.data.arg)
     pm({


### PR DESCRIPTION
The compiler is broken in IE11 because we forgot some polyfills. These polyfills are duplicated from `pxtsim/util.ts` because pxtsim and pxtcompiler don't have a common dependency we can put these in.