### PR TITLE
Home screen perf improvements

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -170,7 +170,6 @@ declare namespace pxt {
         docMenu?: DocMenuEntry[];
         TOC?: TOCMenuEntry[];
         hideSideDocs?: boolean;
-        showHomeScreen?: boolean; // show the home page on editor load
         homeScreenHero?: string; // home screen hero image
         sideDoc?: string; // deprecated
         hasReferenceDocs?: boolean; // if true: the monaco editor will add an option in the context menu to load the reference docs

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -56,6 +56,8 @@ namespace pxt.editor {
 
         highContrast?: boolean;
         hideExperimentalBanner?: boolean;
+
+        home?: boolean;
     }
 
     export interface EditorState {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -358,4 +358,17 @@ namespace pxt.BrowserUtils {
             httprequest.send();
         })
     }
+
+    /**
+     * Utility method to change the hash. 
+     * Pass keepHistory to retain an entry of the change in the browser history.
+     */
+    export function changeHash(hash: string, keepHistory?: boolean) {
+        if (hash.charAt(0) != '#') hash = '#' + hash;
+        if (keepHistory) {
+            window.location.hash = hash;
+        } else {
+            window.history.replaceState('', '', hash)
+        }
+    }
 }

--- a/theme/home.less
+++ b/theme/home.less
@@ -9,9 +9,16 @@
 @carouselArrowSize: 60px;
 @carouselArrowSizeMobile: 40px;
 
-/* Carousel */
+#homescreen {
+    background: @homeScreenBackground;
+    z-index: @menuBarZIndex+1;
+}
 
 .projectsdialog {
+    position: relative;
+    height: 100%;
+    overflow: auto;
+    z-index: @menuBarZIndex+2;
     .getting-started-segment {
         border: 0;
         margin-top: -2.1rem !important;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -642,7 +642,7 @@ export class ProjectView
         if (!h)
             return Promise.resolve()
 
-        window.location.hash = "#editor";
+        pxt.BrowserUtils.changeHash("#editor", true);
         this.stopSimulator(true);
         pxt.blocks.cleanBlocks();
         this.clearSerial()
@@ -889,7 +889,7 @@ export class ProjectView
         this.stopSimulator();
         this.setState({ home: true });
         // clear the hash
-        window.location.hash = "";
+        pxt.BrowserUtils.changeHash("", true);
     }
 
     exitAndSave() {
@@ -2255,7 +2255,7 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
         case "newproject": // shortcut to create a new blocks proj
             pxt.tickEvent("hash.newproject")
             editor.newProject();
-            window.location.hash = "";
+            pxt.BrowserUtils.changeHash("");
             return true;
         case "newjavascript": // shortcut to create a new JS proj
             pxt.tickEvent("hash.newjavascript");
@@ -2265,36 +2265,41 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
                     "main.blocks": ""
                 }
             });
-            window.location.hash = "";
+            pxt.BrowserUtils.changeHash("");
+            return true;
+        case "gettingstarted":
+            pxt.tickEvent("hash.gettingstarted");
+            editor.newProject();
+            pxt.BrowserUtils.changeHash("");
             return true;
         case "tutorial": // shortcut to a tutorial. eg: #tutorial:tutorials/getting-started
             pxt.tickEvent("hash.tutorial")
             editor.startTutorial(hash.arg);
-            window.location.hash = "";
+            pxt.BrowserUtils.changeHash("");
             return true;
         case "home": // shortcut to home
             pxt.tickEvent("hash.home");
             editor.openHome();
-            window.location.hash = "";
+            pxt.BrowserUtils.changeHash("");
             return true;
         case "sandbox":
         case "pub":
         case "edit": // load a published proj, eg: #pub:27750-32291-62442-22749
             pxt.tickEvent("hash." + hash.cmd);
-            window.location.hash = "";
+            pxt.BrowserUtils.changeHash("");
             loadHeaderBySharedId(hash.arg);
             return true;
         case "sandboxproject":
         case "project":
             pxt.tickEvent("hash." + hash.cmd);
             const fileContents = Util.stringToUint8Array(atob(hash.arg));
-            window.location.hash = "";
+            pxt.BrowserUtils.changeHash("");
             core.showLoading("loadingproject", lf("loading project..."));
             theEditor.importProjectFromFileAsync(fileContents)
                 .done(() => core.hideLoading("loadingheader"));
             return true;
         case "reload": // need to reload last project - handled later in the load process
-            if (loading) window.location.hash = "";
+            if (loading) pxt.BrowserUtils.changeHash("");
             return false;
     }
 
@@ -2395,7 +2400,7 @@ $(document).ready(() => {
     const wsPortMatch = /wsport=(\d+)/i.exec(window.location.href);
     if (wsPortMatch) {
         pxt.options.wsPort = parseInt(wsPortMatch[1]) || 3233;
-        window.location.hash = window.location.hash.replace(wsPortMatch[0], "");
+        pxt.BrowserUtils.changeHash(window.location.hash.replace(wsPortMatch[0], ""));
     } else {
         pxt.options.wsPort = 3233;
     }
@@ -2450,7 +2455,7 @@ $(document).ready(() => {
             const mlang = /(live)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
             if (mlang && window.location.hash.indexOf(mlang[0]) >= 0) {
                 lang.setCookieLang(mlang[2]);
-                window.location.hash = window.location.hash.replace(mlang[0], "");
+                pxt.BrowserUtils.changeHash(window.location.hash.replace(mlang[0], ""));
             }
             const useLang = mlang ? mlang[2] : (lang.getCookieLang() || pxt.appTarget.appTheme.defaultLocale || navigator.userLanguage || navigator.language);
             const live = !pxt.appTarget.appTheme.disableLiveTranslations || (mlang && !!mlang[1]);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -114,13 +114,26 @@ export class ProjectView
         document.title = pxt.appTarget.title || pxt.appTarget.name;
         this.reload = false; //set to true in case of reset of the project where we are going to reload the page.
         this.settings = JSON.parse(pxt.storage.getLocal("editorSettings") || "{}")
+
         this.state = {
             showFiles: false,
+            home: this.shouldShowHomeScreen(),
             active: document.visibilityState == 'visible',
             collapseEditorTools: pxt.appTarget.simulator.headless || pxt.BrowserUtils.isMobile()
         };
         if (!this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 19;
         if (!this.settings.fileHistory) this.settings.fileHistory = [];
+    }
+
+    shouldShowHomeScreen() {
+        const hash = parseHash();
+        const isSandbox = pxt.shell.isSandboxMode() || pxt.shell.isReadOnly();
+        // Only show the start screen if there are no initial projects requested
+        // (e.g. from the URL hash or from WinRT activation arguments)
+        const skipStartScreen = pxt.appTarget.appTheme.allowParentController
+            || !pxt.appTarget.appTheme.showHomeScreen || /skipHomeScreen=1/i.test(window.location.href)
+            || window.location.hash == "#editor";
+        return !isSandbox && !skipStartScreen && !isProjectRelatedHash(hash);
     }
 
     updateVisibility() {
@@ -137,8 +150,8 @@ export class ProjectView
             if (workspace.isSessionOutdated()) {
                 pxt.debug('workspace changed, reloading...')
                 let id = this.state.header ? this.state.header.id : '';
-                workspace.initAsync()
-                    .done(() => id ? this.loadHeaderAsync(workspace.getHeader(id)) : Promise.resolve());
+                // workspace.initAsync()
+                //     .done(() => id ? this.loadHeaderAsync(workspace.getHeader(id)) : Promise.resolve());
             } else if (this.state.resumeOnVisibility && !this.state.running) {
                 this.setState({ resumeOnVisibility: false });
                 this.runSimulator();
@@ -419,11 +432,15 @@ export class ProjectView
         return this.allEditors.filter(e => e.acceptsFile(f))[0]
     }
 
+    private updatingEditorFile = false;
     private updateEditorFile(editorOverride: srceditor.Editor = null) {
         if (!this.state.active)
             return;
         if (this.state.currFile == this.editorFile && !editorOverride)
             return;
+        if (this.updatingEditorFile)
+            return;
+        this.updatingEditorFile = true;
         this.saveSettings();
 
         const hc = this.state.highContrast;
@@ -456,6 +473,7 @@ export class ProjectView
                 if (this.state.showBlocks && this.editor == this.textEditor) this.textEditor.openBlocks();
             }).finally(() => {
                 this.forceUpdate();
+                this.updatingEditorFile = false;
             })
     }
 
@@ -607,7 +625,7 @@ export class ProjectView
                         curr.isDeleted = true
                         workspace.saveAsync(curr, {})
                             .then(() => {
-                                this.home.showHome();
+                                this.openHome();
                             }).finally(() => {
                                 core.hideLoading("tutorial")
                             });
@@ -625,14 +643,11 @@ export class ProjectView
         if (!h)
             return Promise.resolve()
 
+        window.location.hash = "#editor";
         this.stopSimulator(true);
         pxt.blocks.cleanBlocks();
         this.clearSerial()
-        this.setState({
-            showFiles: false,
-            editorState: editorState,
-            tutorialOptions: inTutorial ? this.state.tutorialOptions : undefined
-        })
+        Util.jsonMergeFrom(editorState || {}, this.state.editorState || {});
         return pkg.loadPkgAsync(h.id)
             .then(() => {
                 simulator.makeDirty();
@@ -649,6 +664,10 @@ export class ProjectView
                         file = main.lookupFile("this/" + file.getVirtualFileName()) || file
                 }
                 this.setState({
+                    home: false,
+                    showFiles: false,
+                    editorState: editorState,
+                    tutorialOptions: inTutorial ? this.state.tutorialOptions : undefined,
                     header: h,
                     projectName: h.name,
                     currFile: file,
@@ -710,7 +729,7 @@ export class ProjectView
             return workspace.saveAsync(curr, {})
                 .then(() => {
                     if (workspace.getHeaders().length > 0) {
-                        this.home.showHome();
+                        this.openHome();
                     } else {
                         this.newProject();
                     }
@@ -814,7 +833,7 @@ export class ProjectView
                 this.importHex(data);
             }).catch(e => {
                 core.warningNotification(lf("Sorry, we could not import this project."))
-                pxt.appTarget.appTheme.showHomeScreen ? this.home.showHome() : this.newProject();
+                pxt.appTarget.appTheme.showHomeScreen ? this.openHome() : this.newProject();
             });
     }
 
@@ -860,7 +879,6 @@ export class ProjectView
             files => {
                 if (files) {
                     pxt.tickEvent("dragandrop.open")
-                    this.home.hide();
                     this.importFile(files[0]);
                 }
             }
@@ -869,7 +887,9 @@ export class ProjectView
 
     openHome() {
         pxt.tickEvent("menu.open");
-        this.home.showHome();
+        this.setState({ home: true });
+        // clear the hash
+        window.location.hash = "";
     }
 
     exitAndSave() {
@@ -1359,8 +1379,6 @@ export class ProjectView
             if (res) {
                 pxt.tickEvent("menu.open.file");
                 this.importFile(input.files[0]);
-            } else {
-                this.home.showHome();
             }
         })
     }
@@ -1453,8 +1471,6 @@ export class ProjectView
                 } else {
                     loadHeaderBySharedId(id);
                 }
-            } else {
-                this.home.showHome();
             }
         })
     }
@@ -1618,7 +1634,6 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         // Check for Internet access
         if (!pxt.Cloud.isNavigatorOnline()) {
             core.errorNotification(lf("No Internet access, please connect and try again."));
-            this.home.showHome();
         } else {
             core.showLoading("tutorial", lf("starting tutorial..."));
             this.startTutorialAsync(tutorialId, tutorialTitle);
@@ -1736,6 +1751,8 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
         const sideDocs = !(sandbox || targetTheme.hideSideDocs);
         const tutorialOptions = this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
+        const inHome = this.state.home && !sandbox;
+        const inEditor = this.state.header;
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial;
         const run = true; // !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
         const restart = run && !simOpts.hideRestart;
@@ -1909,6 +1926,9 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                 <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
                     {this.allEditors.map(e => e.displayOuter()) }
                 </div>
+                {inHome ? <div id="homescreen" className="full-abs" role="main">
+                    <projects.Projects parent={this} ref={v => this.home = v} />
+                </div> : undefined }
                 {inTutorial ? <tutorial.TutorialHint ref="tutorialhint" parent={this} /> : undefined}
                 {inTutorial ? <tutorial.TutorialContent ref="tutorialcontent" parent={this} /> : undefined}
                 {showEditorToolbar ? <div id="editortools" role="complementary" aria-label={lf("Editor toolbar") }>
@@ -1916,9 +1936,8 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                 </div> : undefined}
                 {sideDocs ? <container.SideDocs ref="sidedoc" parent={this} /> : undefined}
                 {sandbox ? undefined : <scriptsearch.ScriptSearch parent={this} ref={v => this.scriptSearch = v} />}
-                {sandbox ? undefined : <projects.Projects parent={this} ref={v => this.home = v} />}
                 {sandbox ? undefined : <extensions.Extensions parent={this} ref={v => this.extensions = v} />}
-                {sandbox ? undefined : <projects.ImportDialog parent={this} ref={v => this.importDialog = v} />}
+                {inHome ? <projects.ImportDialog parent={this} ref={v => this.importDialog = v} /> : undefined}
                 {sandbox ? undefined : <projects.ExitAndSaveDialog parent={this} ref={v => this.exitAndSaveDialog = v} />}
                 {sandbox || !sharingEnabled ? undefined : <share.ShareEditor parent={this} ref={v => this.shareEditor = v} />}
                 {selectLanguage ? <lang.LanguagePicker parent={this} ref={v => this.languagePicker = v} /> : undefined}
@@ -2222,7 +2241,7 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
     let editor = theEditor;
     if (!editor) return false;
 
-    if (isProjectRelatedHash(hash)) editor.home.hide();
+    if (isProjectRelatedHash(hash)) editor.setState({ home: false });
 
     switch (hash.cmd) {
         case "doc":
@@ -2233,12 +2252,12 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
             pxt.tickEvent("hash.follow")
             editor.newEmptyProject(undefined, hash.arg);
             return true;
-        case "newproject":
+        case "newproject": // shortcut to create a new blocks proj
             pxt.tickEvent("hash.newproject")
             editor.newProject();
             window.location.hash = "";
             return true;
-        case "newjavascript":
+        case "newjavascript": // shortcut to create a new JS proj
             pxt.tickEvent("hash.newjavascript");
             editor.newProject({
                 prj: pxt.appTarget.blocksprj,
@@ -2248,24 +2267,19 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
             });
             window.location.hash = "";
             return true;
-        case "gettingstarted":
-            pxt.tickEvent("hash.gettingstarted")
-            editor.newProject();
-            window.location.hash = "";
-            return true;
-        case "tutorial":
+        case "tutorial": // shortcut to a tutorial. eg: #tutorial:tutorials/getting-started
             pxt.tickEvent("hash.tutorial")
             editor.startTutorial(hash.arg);
             window.location.hash = "";
             return true;
-        case "home":
+        case "home": // shortcut to home
             pxt.tickEvent("hash.home");
             editor.openHome();
             window.location.hash = "";
             return true;
         case "sandbox":
         case "pub":
-        case "edit":
+        case "edit": // load a published proj, eg: #pub:27750-32291-62442-22749
             pxt.tickEvent("hash." + hash.cmd);
             window.location.hash = "";
             loadHeaderBySharedId(hash.arg);
@@ -2469,7 +2483,6 @@ $(document).ready(() => {
             return workspace.initAsync();
         })
         .then(() => {
-            $("#loading").remove();
             render();
             return workspace.syncAsync();
         })
@@ -2491,14 +2504,11 @@ $(document).ready(() => {
             let hd = workspace.getHeaders()[0];
             if (ent) hd = workspace.getHeader(ent.id);
 
-            // Only show the start screen if there are no initial projects requested
-            // (e.g. from the URL hash or from WinRT activation arguments)
-            const skipStartScreen = pxt.appTarget.appTheme.allowParentController
-                || !pxt.appTarget.appTheme.showHomeScreen || /skipHomeScreen=1/i.test(window.location.href);
-            const shouldShowHomeScreen = !isSandbox && !skipStartScreen && !hasWinRTProject && !isProjectRelatedHash(hash);
-            if (shouldShowHomeScreen) {
-                theEditor.home.showHome();
+            if (theEditor.shouldShowHomeScreen() && !hasWinRTProject) {
                 return Promise.resolve();
+            } else {
+                // Hide the home screen
+                theEditor.setState({ home: false });
             }
             if (hash.cmd && handleHash(hash, true)) {
                 return Promise.resolve();
@@ -2513,7 +2523,9 @@ $(document).ready(() => {
             return Promise.resolve();
         })
         .then(() => workspace.importLegacyScriptsAsync())
-        .done(() => { });
+        .done(() => {
+            $("#loading").remove();
+        });
 
     document.addEventListener("visibilitychange", ev => {
         if (theEditor)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -131,8 +131,7 @@ export class ProjectView
         // Only show the start screen if there are no initial projects requested
         // (e.g. from the URL hash or from WinRT activation arguments)
         const skipStartScreen = pxt.appTarget.appTheme.allowParentController
-            || !pxt.appTarget.appTheme.showHomeScreen || /skipHomeScreen=1/i.test(window.location.href)
-            || window.location.hash == "#editor";
+            || !pxt.appTarget.appTheme.showHomeScreen || window.location.hash == "#editor";
         return !isSandbox && !skipStartScreen && !isProjectRelatedHash(hash);
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -887,6 +887,7 @@ export class ProjectView
 
     openHome() {
         pxt.tickEvent("menu.open");
+        this.stopSimulator();
         this.setState({ home: true });
         // clear the hash
         window.location.hash = "";

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -74,13 +74,8 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             || this.state.searchFor != nextState.searchFor
     }
 
-    private numDaysOld(d1: number) {
-        let diff = Math.abs((Date.now() / 1000) - d1);
-        return Math.floor(diff / (60 * 60 * 24));
-    }
-
     renderCore() {
-        const { visible, tab } = this.state;
+        const { visible } = this.state;
 
         const targetTheme = pxt.appTarget.appTheme;
         const targetConfig = this.getData("target-config:") as pxt.TargetConfig;
@@ -211,7 +206,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                         <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment">
                             <h2 className="ui header">{Util.rlf(galleryName) } </h2>
                             <div className="content">
-                                <ProjectsCarousel key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]} onClick={(scr: any) => chgGallery(scr) } setSelected={(index) => this.setSelected(galleryName, index) } selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined}/>
+                                <ProjectsCarousel key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]} onClick={(scr: any) => chgGallery(scr) } />
                             </div>
                         </div>
                     ) }
@@ -313,10 +308,10 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                                 youTubeId={scr.youTubeId}
                                 label={scr.label}
                                 labelClass={scr.labelClass}
-                                onClick={() => onClick(scr)}
-                            />
+                                onClick={() => onClick(scr) }
+                                />
                         </div>
-                    )}
+                    ) }
                 </carousel.Carousel>
             }
         } else {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -22,12 +22,7 @@ import Cloud = pxt.Cloud;
 interface ProjectsState {
     searchFor?: string;
     visible?: boolean;
-    tab?: string;
-    isInitialStartPage?: boolean;
-    welcomeDescription?: string;
 }
-
-const HOME = "__welcome";
 
 export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     private prevUrlData: Cloud.JsonScript[] = [];
@@ -37,34 +32,11 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     constructor(props: ISettingsProps) {
         super(props)
         this.state = {
-            visible: false,
-            tab: HOME
+            visible: false
         }
-    }
-
-    hide(closeOnly: boolean = false) {
-        if (this.state.isInitialStartPage && closeOnly) {
-            // If this was the initial start page and the dialog was close without a selection being made, load the
-            // previous project if available or create a new one
-            pxt.tickEvent("projects.welcome.hide");
-            this.props.parent.newProject();
-        }
-        this.setState({ visible: false, isInitialStartPage: false });
-    }
-
-    showHome() {
-        pxt.tickEvent("projects.show");
-        this.props.parent.stopSimulator();
-        this.setState({
-            visible: true,
-            tab: HOME,
-            isInitialStartPage: true
-        });
     }
 
     fetchGallery(tab: string, path: string): pxt.CodeCard[] {
-        if (this.state.tab != tab) return [];
-
         let res = this.getData(`gallery:${encodeURIComponent(path)}`) as gallery.Gallery[];
         if (res) {
             if (res instanceof Error) {
@@ -91,8 +63,6 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     }
 
     fetchLocalData(): pxt.workspace.Header[] {
-        if (this.state.tab != HOME) return [];
-
         let headers: pxt.workspace.Header[] = this.getData("header:*")
         if (this.state.searchFor)
             headers = headers.filter(hdr => hdr.name.toLowerCase().indexOf(this.state.searchFor.toLowerCase()) > -1);
@@ -101,9 +71,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
 
     shouldComponentUpdate(nextProps: ISettingsProps, nextState: ProjectsState, nextContext: any): boolean {
         return this.state.visible != nextState.visible
-            || this.state.tab != nextState.tab
             || this.state.searchFor != nextState.searchFor
-            || this.state.welcomeDescription != nextState.welcomeDescription;
     }
 
     private numDaysOld(d1: number) {
@@ -132,7 +100,6 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         const chgHeader = (hdr: pxt.workspace.Header) => {
             pxt.tickEvent("projects.header");
             core.showLoading("changeheader", lf("Loading..."));
-            this.hide();
             this.props.parent.loadHeaderAsync(hdr)
                 .done(() => {
                     core.hideLoading("changeheader");
@@ -140,7 +107,6 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         }
         const chgGallery = (scr: pxt.CodeCard) => {
             pxt.tickEvent("projects.gallery", { name: scr.name });
-            if (!scr.youTubeId || (scr.url && !/^https:\/\//i.test(scr.url))) this.hide();
             switch (scr.cardType) {
                 case "example": chgCode(scr, true); break;
                 case "codeExample": chgCode(scr, false); break;
@@ -190,84 +156,72 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         }
         const importProject = () => {
             pxt.tickEvent("projects.importdialog");
-            this.hide();
             this.props.parent.importProjectDialog();
         }
-        const gettingStarted = () => {
-            pxt.tickEvent("projects.gettingstarted");
-            this.hide();
-            this.props.parent.gettingStarted();
-        }
 
-        const hadFetchError = this.galleryFetchErrors[tab];
-        const isLoading = tab != HOME && !hadFetchError && !gals[tab].length;
         const showHeroBanner = !!targetTheme.homeScreenHero;
         const betaUrl = targetTheme.betaUrl;
 
         const tabClasses = sui.cx([
-            isLoading ? 'loading' : '',
             'ui segment bottom attached tab active tabsegment'
         ]);
 
-        const tabName = tab == HOME ? lf("Home") : Util.rlf(tab);
-        const tabIcon = tab == HOME ? "home large" : undefined;
-
         return (
-            <sui.Modal open={visible} className="projectsdialog" size="home" onClose={() => this.hide(/* closeOnly */ true)} dimmer={true} closeOnDimmerClick>
+            <div className="ui home projectsdialog">
                 <div id="menubar" role="banner">
                     <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">
                         <div className="left menu">
-                            <a href={targetTheme.logoUrl} aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => pxt.tickEvent("projects.brand")}>
+                            <a href={targetTheme.logoUrl} aria-label={lf("{0} Logo", targetTheme.boardName) } role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => pxt.tickEvent("projects.brand") }>
                                 {targetTheme.logo || targetTheme.portraitLogo
-                                    ? <img className={`ui logo ${targetTheme.logo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo)} alt={lf("{0} Logo", targetTheme.boardName)} />
+                                    ? <img className={`ui logo ${targetTheme.logo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo) } alt={lf("{0} Logo", targetTheme.boardName) } />
                                     : <span className="name">{targetTheme.boardName}</span>}
-                                {targetTheme.portraitLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo)} alt={lf("{0} Logo", targetTheme.boardName)} />) : null}
+                                {targetTheme.portraitLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo) } alt={lf("{0} Logo", targetTheme.boardName) } />) : null}
                             </a>
                         </div>
-                        <div className="ui item">{tabIcon ? <sui.Icon icon={`icon ${tabIcon}`} /> : undefined} {tabName}</div>
+                        <div className="ui item"><sui.Icon icon={`icon home large`} /> {lf("Home") }</div>
                         <div className="right menu">
-                            <a href={targetTheme.organizationUrl} target="blank" rel="noopener" className="ui item logo organization" onClick={() => pxt.tickEvent("projects.org")}>
+                            <a href={targetTheme.organizationUrl} target="blank" rel="noopener" className="ui item logo organization" onClick={() => pxt.tickEvent("projects.org") }>
                                 {targetTheme.organizationWideLogo || targetTheme.organizationLogo
-                                    ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo)} alt={lf("{0} Logo", targetTheme.organization)} />
+                                    ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo) } alt={lf("{0} Logo", targetTheme.organization) } />
                                     : <span className="name">{targetTheme.organization}</span>}
-                                {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo)} alt={lf("{0} Logo", targetTheme.organization)} />) : null}
+                                {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo) } alt={lf("{0} Logo", targetTheme.organization) } />) : null}
                             </a>
                         </div>
-                        {betaUrl ? <a href={`${betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta")}</a> : undefined}
+                        {betaUrl ? <a href={`${betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta") }</a> : undefined}
                     </div>
                 </div>
-                {tab == HOME ? <div className={tabClasses}>
+                <div className={tabClasses}>
                     {showHeroBanner ?
                         <div className="ui segment getting-started-segment" style={{ backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` }} /> : undefined}
                     <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment">
                         <div className="ui grid equal width padded">
                             <div className="column">
-                                <h2 className="ui header">{lf("My Projects")} </h2>
+                                <h2 className="ui header">{lf("My Projects") } </h2>
                             </div>
                             <div className="column right aligned">
                                 {pxt.appTarget.compile || (pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.publishing && pxt.appTarget.cloud.importing) ?
-                                    <sui.Link key="import" icon="upload" class="label basic import-dialog-btn" textClass="landscape only" text={lf("Import")} title={lf("Import a project")} onClick={() => importProject()} /> : undefined}
+                                    <sui.Button key="import" icon="upload" class="mini import-dialog-btn" textClass="landscape only" text={lf("Import") } title={lf("Import a project") } onClick={() => importProject() } /> : undefined}
                             </div>
                         </div>
                         <div className="content">
-                            <ProjectsCarousel key={`mystuff_carousel`} parent={this.props.parent} name={'recent'} hide={() => this.hide()} onClick={(scr: any) => chgHeader(scr)} />
+                            <ProjectsCarousel key={`mystuff_carousel`} parent={this.props.parent} name={'recent'} onClick={(scr: any) => chgHeader(scr) } />
                         </div>
                     </div>
                     {Object.keys(galleries).map(galleryName =>
                         <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment">
-                            <h2 className="ui header">{Util.rlf(galleryName)} </h2>
+                            <h2 className="ui header">{Util.rlf(galleryName) } </h2>
                             <div className="content">
-                                <ProjectsCarousel key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]} hide={() => this.hide()} onClick={(scr: any) => chgGallery(scr)} />
+                                <ProjectsCarousel key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]} onClick={(scr: any) => chgGallery(scr) } setSelected={(index) => this.setSelected(galleryName, index) } selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined}/>
                             </div>
                         </div>
-                    )}
+                    ) }
                     {targetTheme.organizationUrl || targetTheme.organizationUrl || targetTheme.privacyUrl ? <div className="ui horizontal small divided link list homefooter">
                         {targetTheme.organizationUrl && targetTheme.organization ? <a className="item focused" target="_blank" rel="noopener" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
-                        {targetTheme.termsOfUseUrl ? <a target="_blank" className="item focused" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use")}</a> : undefined}
-                        {targetTheme.privacyUrl ? <a target="_blank" className="item focused" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy")}</a> : undefined}
+                        {targetTheme.termsOfUseUrl ? <a target="_blank" className="item focused" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use") }</a> : undefined}
+                        {targetTheme.privacyUrl ? <a target="_blank" className="item focused" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy") }</a> : undefined}
                     </div> : undefined}
-                </div> : undefined}
-            </sui.Modal >
+                </div>
+            </div>
         );
     }
 }
@@ -276,12 +230,10 @@ interface ProjectsCarouselProps extends ISettingsProps {
     name: string;
     path?: string;
     cardWidth?: number;
-    hide: Function;
     onClick: Function;
 }
 
 interface ProjectsCarouselState {
-
 }
 
 export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, ProjectsCarouselState> {
@@ -326,7 +278,6 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
 
     newProject() {
         pxt.tickEvent("projects.new");
-        this.props.hide();
         this.props.parent.newProject();
     }
 
@@ -345,8 +296,8 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
             const cards = this.fetchGallery(path);
             if (this.hasFetchErrors) {
                 return <div className="ui carouselouter">
-                    <div className="carouselcontainer" tabIndex={0} onClick={() => this.setState({})}>
-                        <p className="ui grey inverted segment">{lf("Oops, please connect to the Internet and try again.")}</p>
+                    <div className="carouselcontainer" tabIndex={0} onClick={() => this.setState({}) }>
+                        <p className="ui grey inverted segment">{lf("Oops, please connect to the Internet and try again.") }</p>
                     </div>
                 </div>
             } else {
@@ -377,7 +328,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
             if (headers.length == 0) {
                 return <div className="ui carouselouter">
                     <div className="carouselcontainer">
-                        <p>{lf("This is where you will you find your code.")}</p>
+                        <p>{lf("This is where you will you find your code.") }</p>
                     </div>
                 </div>
             } else {
@@ -385,7 +336,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                     {headers.map((scr, index) =>
                         <div key={'local' + scr.id + scr.recentUse}>
                             {scr.id == 'new' ?
-                                <div className="ui card link newprojectcard focused" tabIndex={0} title={lf("Creates a new empty project")} onClick={() => this.newProject()} onKeyDown={sui.fireClickOnEnter} >
+                                <div className="ui card link newprojectcard focused" tabIndex={0} title={lf("Creates a new empty project") } onClick={() => this.newProject() } onKeyDown={sui.fireClickOnEnter} >
                                     <div className="content">
                                         <sui.Icon icon="huge add circle" />
                                         <span className="header">{scr.name}</span>
@@ -393,16 +344,16 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                                 </div>
                                 :
                                 <codecard.CodeCardView
-                                    ref={(view) => { if (index === 1) this.latestProject = view }}
+                                    ref={(view) => { if (index === 1) this.latestProject = view } }
                                     cardType="file"
                                     className="file"
                                     name={scr.name}
                                     time={scr.recentUse}
                                     url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}
-                                    onClick={() => onClick(scr)}
-                                />}
+                                    onClick={() => onClick(scr) }
+                                    />}
                         </div>
-                    )}
+                    ) }
                 </carousel.Carousel>
             }
         }
@@ -427,7 +378,6 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
 
     close() {
         this.setState({ visible: false });
-        this.props.parent.openHome();
     }
 
     show() {
@@ -449,36 +399,36 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
         }
 
         return (
-            <sui.Modal open={this.state.visible} className="importdialog" header={lf("Import")} size="small"
-                onClose={() => this.close()} dimmer={true}
+            <sui.Modal open={this.state.visible} className="importdialog" header={lf("Import") } size="small"
+                onClose={() => this.close() } dimmer={true}
                 closeIcon={true}
                 closeOnDimmerClick closeOnDocumentClick
-            >
+                >
                 <div className="ui cards">
                     {pxt.appTarget.compile ?
                         <codecard.CodeCardView
-                            ariaLabel={lf("Open files from your computer")}
+                            ariaLabel={lf("Open files from your computer") }
                             className="focused"
                             role="button"
                             key={'import'}
                             icon="upload"
                             iconColor="secondary"
-                            name={lf("Import File...")}
-                            description={lf("Open files from your computer")}
-                            onClick={() => importHex()}
-                        /> : undefined}
+                            name={lf("Import File...") }
+                            description={lf("Open files from your computer") }
+                            onClick={() => importHex() }
+                            /> : undefined}
                     {pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.publishing && pxt.appTarget.cloud.importing ?
                         <codecard.CodeCardView
-                            ariaLabel={lf("Open a shared project URL")}
+                            ariaLabel={lf("Open a shared project URL") }
                             className="focused"
                             role="button"
                             key={'importurl'}
                             icon="cloud download"
                             iconColor="secondary"
-                            name={lf("Import URL...")}
-                            description={lf("Open a shared project URL")}
-                            onClick={() => importUrl()}
-                        /> : undefined}
+                            name={lf("Import URL...") }
+                            description={lf("Open a shared project URL") }
+                            onClick={() => importUrl() }
+                            /> : undefined}
                 </div>
             </sui.Modal>
         )
@@ -549,20 +499,20 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
             icon: 'check',
             className: 'positive'
         }, {
-            label: lf("Cancel"),
-            icon: 'cancel',
-            onClick: cancel
-        }]
+                label: lf("Cancel"),
+                icon: 'cancel',
+                onClick: cancel
+            }]
 
         return (
-            <sui.Modal open={visible} className="exitandsave" header={lf("Exit Project")} size="tiny"
-                onClose={() => this.hide()} dimmer={true}
+            <sui.Modal open={visible} className="exitandsave" header={lf("Exit Project") } size="tiny"
+                onClose={() => this.hide() } dimmer={true}
                 actions={actions}
                 closeIcon={true}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
-            >
+                >
                 <div className="ui form">
-                    <sui.Input id={"projectNameInput"} class="focused" label={lf("Project Name")} ariaLabel={lf("Type a name for your project")} value={projectName} onChange={onChange} />
+                    <sui.Input id={"projectNameInput"} class="focused" label={lf("Project Name") } ariaLabel={lf("Type a name for your project") } value={projectName} onChange={onChange} />
                 </div>
             </sui.Modal>
         )


### PR DESCRIPTION
Improve home screen performance by making it not a modal. Shying away from having to handle the home screen state all over the place. The App is now in charge of the home screen state.
The result is fantastic, the home screen loads right away with no weird transition in between.

Two modes. A user is either in home, or in the editor. 
The only way to switch to editor mode is to load a header (loadHeaderAsync). (so for card actions that open urls, or when errors occur, the editor is not loaded). This avoids having to constantly show home when an error occurs anywhere.
When a header is loaded, the url hash changes to #editor (so if a user reloads, they go back to their previous project). 
If you go back to home, the hash is cleared. 

The import dialogs are now part of home, and so they show up as modals on top of the home screen. Rather than on top of the editor (previously)

Other entry points: (Tested)
#pub, loads the project, clears the hash, and then the editor hash is shown since a project is loaded
#tutorial, same as above
#newproject, and #newjavascript, create a new project

Haven't tested: #doc, and #follow. 
I've added comments on other hash shortcut but I'm not familiar with these two.

The simulator, and the various editors are still prepared in the background, ready for a project to be loaded. 
I stop the simulator when returning back to home
Reduces the two setStates in loadHeaderAsync to one, perf reasons
Fixed an issue with the editor loading a file twice, if render is called consecutively (added a lock to only load one file at a time) Fixes https://github.com/Microsoft/pxt/issues/3378
Fixes https://github.com/Microsoft/pxt-chibitronics/issues/112
Cleaned up more leftover code from the previous projects dialog.

Targets that use the css rule .ui.modal.home or .ui.modal.projectsdialog will need to update their CSS to use .ui.home.projectsdialog

@guillaumejenkins @mmoskal @pelikhan please review, this is a big change to how we load things. 

Still needs to be tested: 
- [ ] UWP / Electron app
- [ ] Reload logic
- [ ] #doc and #follow
- [x] session outdated (app::updateVisibility)