### PR TITLE
Support for JSON resources in PXT projects

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2973,9 +2973,9 @@ function compilesOK(opts: pxtc.CompileOptions, fn: string, content: string) {
 
 function getApiInfoAsync() {
     return prepBuildOptionsAsync(BuildOption.GenDocs)
-        .then(pxtc.compile)
-        .then(res => {
-            return pxtc.getApiInfo(res.ast, true)
+        .then(opts => {
+            let res = pxtc.compile(opts);
+            return pxtc.getApiInfo(opts, res.ast, true)
         })
 }
 
@@ -3303,7 +3303,7 @@ function testSnippetsAsync(snippets: CodeSnippet[], re?: string): Promise<void> 
                 if (/^block/.test(snippet.type)) {
                     //Similar to pxtc.decompile but allows us to get blocksInfo for round trip
                     const file = resp.ast.getSourceFile('main.ts');
-                    const apis = pxtc.getApiInfo(resp.ast);
+                    const apis = pxtc.getApiInfo(opts, resp.ast);
                     const blocksInfo = pxtc.getBlocksInfo(apis);
                     const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, { snippetMode: false })
                     const success = !!bresp.outfiles['main.blocks']
@@ -3436,7 +3436,7 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
 
             switch (buildOpts.mode) {
                 case BuildOption.GenDocs:
-                    const apiInfo = pxtc.getApiInfo(res.ast)
+                    const apiInfo = pxtc.getApiInfo(compileOptions, res.ast)
                     // keeps apis from this module only
                     for (const infok in apiInfo.byQName) {
                         const info = apiInfo.byQName[infok];

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
     * [Static File Drops](/cli/staticpkg)
     * [Simulator](/targets/simulator)
     * [Theming Editor](/targets/theming)
+    * [Embedding resources](/jres)
 * [Creating Packages](/packages)
     * [Getting started](/packages/getting-started)
     * [pxt.json](/packages/pxtJson)

--- a/docs/async.md
+++ b/docs/async.md
@@ -83,7 +83,7 @@ export function downloadData(url:string) { return "" }
 In the simulator you return a promise:
 
 ```typescript-ignore
-export function downloadDataAsync(url:string) {
+export function downloadData(url:string) {
     return new Promise<string>((resolve, reject) =>
         $.get(url, (data, status) => {
             resolve(data)

--- a/docs/jres.md
+++ b/docs/jres.md
@@ -1,0 +1,37 @@
+# Embedding resources in projects
+
+Let's say you want to add some sound resources.
+
+In `mysounds.ts` you put definitions of constants for all sounds. You pass an empty
+hex literal to the constructor - it will be replaced with the data from `sounds.jres`
+file, based on the `jres=...` annotation. The `jres=...` also implies `whenUsed`, ie., the
+sound object will only be created if it is actually referenced from somewhere.
+
+```typescript-ignore
+namespace sfx {
+    //% fixedInstance jres=sounds.bark
+    export const bark = new Sound(hex ``) 
+    //% fixedInstance jres=sounds.purr
+    export const purr = new Sound(hex ``) 
+}
+```
+
+The `sounds.jres` file contains the data. The file has a special `*` key, specifies
+default metadata for other keys. The rest of keys specify resources.
+
+```json
+{
+    "*": {
+        "namespace": "sounds",
+        "dataEncoding": "base64",
+        "mimeType": "audio/wav"
+    },
+    "bark": {
+        "data": "CiAgICAiYnVpbHQvcHh0cGFydHMu...IsCiAgICAic",
+        "icon": "data:image/png,base64:dHMiLAogICAgI...93ZWIvd"
+    },
+    "purr": {
+        // ...
+    }
+}
+```

--- a/docs/jres.md
+++ b/docs/jres.md
@@ -36,6 +36,10 @@ default metadata for other keys. The rest of keys specify resources.
 }
 ```
 
+Currently, only `base64` is supported as data encoding. If you skip `dataEncoding` in the `.jres` file,
+it will now and in future default to `base64`.
+
+
 ## Short forms
 
 In case, there's only the `"data"` field present, the file can be shortened:

--- a/docs/jres.md
+++ b/docs/jres.md
@@ -16,7 +16,7 @@ namespace sfx {
 }
 ```
 
-The `sounds.jres` file contains the data. The file has a special `*` key, specifies
+The `sounds.jres` file contains the data. The file has a special `*` key, which specifies
 default metadata for other keys. The rest of keys specify resources.
 
 ```json
@@ -33,5 +33,31 @@ default metadata for other keys. The rest of keys specify resources.
     "purr": {
         // ...
     }
+}
+```
+
+## Short forms
+
+In case, there's only the `"data"` field present, the file can be shortened:
+
+```json
+{
+    "*": {
+        "namespace": "images",
+        "dataEncoding": "base64",
+        "mimeType": "image/png"
+    },
+    "eyes": "CiAgICAiYnVpbHQvcHh0cGFydHMu...IsCiAgICAic",
+    "smile": "dHMiLAogICAgI...93ZWIvd"
+}
+```
+
+In case where the `jres` name matches the namespace and name of the constant,
+it can be omitted, as in:
+
+```typescript-ignore
+namespace images {
+    //% fixedInstance jres
+    export const eyes = new Image(hex ``) 
 }
 ```

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -305,6 +305,7 @@ declare namespace ts.pxtc {
         target: CompileTarget;
         testMode?: boolean;
         sourceFiles?: string[];
+        jres?: Map<pxt.JRes>;
         hexinfo: HexInfo;
         extinfo?: ExtensionInfo;
         noEmit?: boolean;

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -119,7 +119,7 @@ declare namespace pxt {
     interface JRes {
         id: string; // something like "sounds.bark"
         data: string;
-        dataEncoding?: string; // "base64" (default) or "hex"
+        dataEncoding?: string; // must be "base64" or missing (meaning the same)
         icon?: string; // URL (usually data-URI) for the icon
         namespace?: string; // used to construct id
         mimeType: string;

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -115,4 +115,13 @@ declare namespace pxt {
         target?: string;
         className?: string;
     }
+
+    interface JRes {
+        id: string; // something like "sounds.bark"
+        data: string;
+        dataEncoding?: string; // "base64" (default) or "hex"
+        icon?: string; // URL (usually data-URI) for the icon
+        namespace?: string; // used to construct id
+        mimeType: string;
+    }
 }

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -203,7 +203,7 @@ namespace ts.pxtc {
         if (!resp.success) return resp;
 
         let file = resp.ast.getSourceFile(fileName);
-        const apis = getApiInfo(resp.ast);
+        const apis = getApiInfo(opts, resp.ast);
         const blocksInfo = pxtc.getBlocksInfo(apis);
         const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, { snippetMode: false, alwaysEmitOnStart: opts.alwaysDecompileOnStart }, pxtc.decompiler.buildRenameMap(resp.ast, file))
         return bresp;

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3738,10 +3738,14 @@ ${lbl}: .short 0xffff
                 emitBrk(node)
                 if (isGlobalVar(node)) {
                     let attrs = parseComments(node)
-                    if (attrs.jres) {
-                        let jr = U.lookup(opts.jres || {}, attrs.jres)
+                    let jrname = attrs.jres
+                    if (jrname) {
+                        if (jrname == "true") {
+                            jrname = getFullName(checker, node.symbol)
+                        }
+                        let jr = U.lookup(opts.jres || {}, jrname)
                         if (!jr)
-                            userError(9270, lf("resource '{0}' not found in any .jres file", attrs.jres))
+                            userError(9270, lf("resource '{0}' not found in any .jres file", jrname))
                         else {
                             currJres = jr
                         }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -388,6 +388,9 @@ namespace ts.pxtc {
                 if (jr && !si.attributes.iconURL) {
                     si.attributes.iconURL = jr.icon
                 }
+                if (jr && !si.attributes.jresURL) {
+                    si.attributes.jresURL = "data:" + jr.mimeType + ";base64," + jr.data
+                }
             }
         }
 

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -184,12 +184,12 @@ namespace ts.pxtc {
                             });
                         }
                         else {
-                           parameters = callbackParameters.map((sym, i) => {
-                               return {
-                                   name: sym.getName(),
-                                   type: typechecker.typeToString(typechecker.getTypeOfSymbolAtLocation(sym, p))
-                               };
-                           });
+                            parameters = callbackParameters.map((sym, i) => {
+                                return {
+                                    name: sym.getName(),
+                                    type: typechecker.typeToString(typechecker.getTypeOfSymbolAtLocation(sym, p))
+                                };
+                            });
                         }
                     }
                     let options: Map<PropertyOption> = {};
@@ -308,7 +308,7 @@ namespace ts.pxtc {
         }
     }
 
-    export function getApiInfo(program: Program, legacyOnly = false): ApisInfo {
+    export function getApiInfo(opts: CompileOptions, program: Program, legacyOnly = false): ApisInfo {
         let res: ApisInfo = {
             byQName: {}
         }
@@ -380,6 +380,15 @@ namespace ts.pxtc {
             si.qName = qName;
             si.attributes._source = null
             if (si.extendsTypes && si.extendsTypes.length) toclose.push(si)
+            
+            let jrname = si.attributes.jres
+            if (jrname) {
+                if (jrname == "true") jrname = qName
+                let jr = U.lookup(opts.jres || {}, jrname)
+                if (jr && !si.attributes.iconURL) {
+                    si.attributes.iconURL = jr.icon
+                }
+            }
         }
 
         // transitive closure of inheritance
@@ -595,7 +604,7 @@ namespace ts.pxtc.service {
         },
         compileTd: v => {
             let res = compile(v.options);
-            return getApiInfo(res.ast, true);
+            return getApiInfo(host.opts, res.ast, true);
         },
 
         assemble: v => {
@@ -633,7 +642,7 @@ namespace ts.pxtc.service {
         apiInfo: () => {
             lastBlocksInfo = undefined;
             lastFuse = undefined;
-            return lastApiInfo = getApiInfo(service.getProgram());
+            return lastApiInfo = getApiInfo(host.opts, service.getProgram());
         },
         blocksInfo: blocksInfoOp,
         apiSearch: v => {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -111,6 +111,10 @@ namespace pxt {
                     for (let k of Object.keys(js)) {
                         if (k == "*") continue
                         let v = js[k]
+                        if (typeof v == "string") {
+                            // short form
+                            v = { data: v } as any
+                        }
                         let ns = v.namespace || base.namespace || ""
                         if (ns) ns += "."
                         let id = v.id || ns + k

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -103,6 +103,37 @@ namespace pxt {
             this.host().writeFile(this, pxt.CONFIG_NAME, cfg)
         }
 
+        parseJRes(allres: Map<JRes> = {}) {
+            for (const f of this.getFiles()) {
+                if (U.endsWith(f, ".jres")) {
+                    let js: Map<JRes> = JSON.parse(this.readFile(f))
+                    let base = js["*"]
+                    for (let k of Object.keys(js)) {
+                        if (k == "*") continue
+                        let v = js[k]
+                        let ns = v.namespace || base.namespace || ""
+                        if (ns) ns += "."
+                        let id = v.id || ns + k
+                        let icon = v.icon
+                        let mimeType = v.mimeType || base.mimeType
+                        let dataEncoding = v.dataEncoding || base.dataEncoding || "base64"
+                        if (!icon && dataEncoding == "base64" && (mimeType == "image/png" || mimeType == "image/jpeg")) {
+                            icon = "data:" + mimeType + ";base64," + v.data
+                        }
+                        allres[id] = {
+                            id,
+                            data: v.data,
+                            dataEncoding: v.dataEncoding || base.dataEncoding || "base64",
+                            icon,
+                            namespace: ns,
+                            mimeType
+                        }
+                    }
+                }
+            }
+            return allres
+        }
+
         private resolveVersionAsync() {
             let v = this._verspec
 
@@ -488,6 +519,7 @@ namespace pxt {
 
     export class MainPackage extends Package {
         public deps: Map<Package> = {};
+        private _jres: Map<JRes>;
 
         constructor(public _host: Host) {
             super("this", "file:.", null, null)
@@ -534,6 +566,16 @@ namespace pxt {
             let res = U.clone(appTarget.compile)
             U.assert(!!res)
             return res
+        }
+
+        getJRes() {
+            if (!this._jres) {
+                this._jres = {}
+                for (const pkg of this.sortedDeps()) {
+                    pkg.parseJRes(this._jres)
+                }
+            }
+            return this._jres
         }
 
         getCompileOptionsAsync(target: CompileTarget = this.getTargetOptions()) {
@@ -625,6 +667,7 @@ namespace pxt {
                             }
                         }
                     }
+                    opts.jres = this.getJRes()
                     return opts;
                 })
         }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -128,6 +128,7 @@ namespace ts.pxtc {
         colorSecondary?: string;
         colorTertiary?: string;
         icon?: string;
+        iconURL?: string;
         imageLiteral?: number;
         weight?: number;
         parts?: string;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -128,6 +128,7 @@ namespace ts.pxtc {
         colorSecondary?: string;
         colorTertiary?: string;
         icon?: string;
+        jresURL?: string;
         iconURL?: string;
         imageLiteral?: number;
         weight?: number;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -139,6 +139,7 @@ namespace ts.pxtc {
         subcategory?: string;
         group?: string;
         whenUsed?: boolean;
+        jres?: string;
         // On namepspace
         subcategories?: string[];
         groups?: string[];
@@ -480,6 +481,8 @@ namespace ts.pxtc {
             res.callingConvention = ir.CallingConvention.Async
         if (res.promise)
             res.callingConvention = ir.CallingConvention.Promise
+        if (res.jres)
+            res.whenUsed = true
         if (res.subcategories) {
             try {
                 res.subcategories = JSON.parse(res.subcategories as any);

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -705,7 +705,7 @@ ${files["main.ts"]}
                     return Promise.resolve<DecompileResult>({ package: mainPkg, compileJS: resp });
 
                 // decompile to blocks
-                let apis = pxtc.getApiInfo(resp.ast);
+                let apis = pxtc.getApiInfo(opts, resp.ast);
                 return ts.pxtc.localizeApisAsync(apis, mainPkg)
                     .then(() => {
                         let blocksInfo = pxtc.getBlocksInfo(apis);


### PR DESCRIPTION
This allows adding resources (sounds, images, etc) to PXT projects. They are stored in `.jres` files and glued using a `.ts` file. See docs below for explanation.

The resources are then exposed in `CommentAttrs` when asking compile service for list of APIs, so they can be used for grid pickers. There's `iconURL` and `jresURL`. Normally both would be data-URIs. For image resources they might be the same.