### PR TITLE
moving refcounting in runtime to recycle between runs

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -6,6 +6,7 @@ namespace pxsim {
         id?: string;
         boardDefinition?: BoardDefinition;
         frameCounter?: number;
+        refCountingDebug?: boolean;
         options?: any;
         parts?: string[];
         partDefinitions?: Map<PartDefinition>

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -240,7 +240,7 @@ namespace pxsim {
             let o = <RefObject>v
             check(o.refcnt > 0)
             if (--o.refcnt == 0) {
-                delete runtime.liveRefObjs[o.id + ""]
+                runtime.unregisterLiveObject(o);
                 o.destroy()
             }
         }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -45,12 +45,14 @@ namespace pxsim {
     }
 
     export class RefObject {
-        id: number = runtime ? runtime.refObjId++ : -1;
+        id: number;
         refcnt: number = 1;
 
         constructor() {
             if (runtime)
-                runtime.liveRefObjs[this.id + ""] = this;
+                this.id = runtime.registerLiveObject(this);
+            else
+                this.id = 0;
         }
 
         destroy() { }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -10,17 +10,9 @@ namespace pxsim {
         }
     }
 
-    let refObjId = 1;
-    let liveRefObjs: any = {};
-    let stringRefCounts: any = {};
-    let refCounting = true;
     let floatingPoint = false;
     let cfgKey: Map<number> = {}
     let cfg: Map<number> = {}
-
-    export function noRefCounting() {
-        refCounting = false;
-    }
 
     export function getConfig(id: number) {
         if (cfg.hasOwnProperty(id + ""))
@@ -53,22 +45,20 @@ namespace pxsim {
     }
 
     export class RefObject {
-        id: number = refObjId++;
+        id: number = runtime ? runtime.refObjId++ : -1;
         refcnt: number = 1;
 
         constructor() {
-            liveRefObjs[this.id + ""] = this
+            if (runtime)
+                runtime.liveRefObjs[this.id + ""] = this;
         }
 
         destroy() { }
 
         print() {
-            //console.log(`RefObject id:${this.id} refs:${this.refcnt}`)
+            if (runtime && runtime.refCountingDebug)
+                console.log(`RefObject id:${this.id} refs:${this.refcnt}`)
         }
-    }
-
-    export function noLeakTracking(r: RefObject) {
-        delete liveRefObjs[r.id + ""]
     }
 
     export class FnWrapper {
@@ -105,7 +95,8 @@ namespace pxsim {
         }
 
         print() {
-            //console.log(`RefInstance id:${this.id} (${this.vtable.name}) len:${this.fields.length}`)
+            if (runtime && runtime.refCountingDebug)
+                console.log(`RefRecord id:${this.id} (${this.vtable.name}) len:${this.fields.length}`)
         }
     }
 
@@ -133,7 +124,8 @@ namespace pxsim {
         }
 
         print() {
-            //console.log(`RefAction id:${this.id} refs:${this.refcnt} len:${this.fields.length}`)
+            if (runtime && runtime.refCountingDebug)
+                console.log(`RefAction id:${this.id} refs:${this.refcnt} len:${this.fields.length}`)
         }
     }
 
@@ -190,7 +182,8 @@ namespace pxsim {
         }
 
         print() {
-            //console.log(`RefRefLocal id:${this.id} refs:${this.refcnt} v:${this.v}`)
+            if (runtime && runtime.refCountingDebug)
+                console.log(`RefRefLocal id:${this.id} refs:${this.refcnt} v:${this.v}`)
         }
     }
 
@@ -223,7 +216,8 @@ namespace pxsim {
         }
 
         print() {
-            //console.log(`RefMap id:${this.id} refs:${this.refcnt} size:${this.data.length}`)
+            if (runtime && runtime.refCountingDebug)
+                console.log(`RefMap id:${this.id} refs:${this.refcnt} size:${this.data.length}`)
         }
     }
 
@@ -239,12 +233,12 @@ namespace pxsim {
     }
 
     export function decr(v: any): void {
-        if (!refCounting) return
+        if (!runtime || !runtime.refCounting) return
         if (v instanceof RefObject) {
             let o = <RefObject>v
             check(o.refcnt > 0)
             if (--o.refcnt == 0) {
-                delete liveRefObjs[o.id + ""]
+                delete runtime.liveRefObjs[o.id + ""]
                 o.destroy()
             }
         }
@@ -255,7 +249,7 @@ namespace pxsim {
     }
 
     export function incr(v: any) {
-        if (!refCounting) return v
+        if (!runtime || !runtime.refCounting) return v
         if (v instanceof RefObject) {
             let o = <RefObject>v
             check(o.refcnt > 0)
@@ -265,16 +259,8 @@ namespace pxsim {
     }
 
     export function dumpLivePointers() {
-        if (!refCounting) return
-        Object.keys(liveRefObjs).forEach(k => {
-            (<RefObject>liveRefObjs[k]).print()
-        })
-        Object.keys(stringRefCounts).forEach(k => {
-            let n = stringRefCounts[k]
-            console.log("Live String:", JSON.stringify(k), "refcnt=", n)
-        })
+        if (runtime) runtime.dumpLivePointers();
     }
-
     export namespace numops {
         export function toString(v: any) {
             if (v === null) return "null"

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -249,6 +249,12 @@ namespace pxsim {
         currFrame: StackFrame;
         entry: LabelFn;
 
+        refCountingDebug = true;
+        refObjId = 1;
+        liveRefObjs: pxsim.Map<RefObject> = {};
+        stringRefCounts: any = {};
+        refCounting = true;
+
         overwriteResume: (retPC: number) => void;
         getResume: () => ResumeFn;
         run: (cb: ResumeFn) => void;
@@ -314,6 +320,21 @@ namespace pxsim {
                 }
                 if (this.stateChanged) this.stateChanged();
             }
+        }
+
+        dumpLivePointers() {
+            if (!this.refCounting || !this.refCountingDebug) return;
+
+            const liveObjectNames = Object.keys(this.liveRefObjs);
+            const stringRefCountNames = Object.keys(this.stringRefCounts);
+            console.log(`Live objects: ${liveObjectNames.length} objects, ${stringRefCountNames.length} strings`)
+            liveObjectNames.forEach(k => {
+                (<RefObject>this.liveRefObjs[k]).print()
+            })
+            stringRefCountNames.forEach(k => {
+                const n = this.stringRefCounts[k]
+                console.log("Live String:", JSON.stringify(k), "refcnt=", n)
+            })
         }
 
         constructor(msg: SimulatorRunMessage) {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -249,7 +249,7 @@ namespace pxsim {
         currFrame: StackFrame;
         entry: LabelFn;
 
-        refCountingDebug = true;
+        refCountingDebug = false;
         refObjId = 1;
         liveRefObjs: pxsim.Map<RefObject> = {};
         stringRefCounts: any = {};

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -249,7 +249,7 @@ namespace pxsim {
         currFrame: StackFrame;
         entry: LabelFn;
 
-        public refCountingDebug = true;
+        public refCountingDebug = false;
         private refObjId = 1;
         private liveRefObjs: pxsim.Map<RefObject> = {};
         private stringRefCounts: any = {};

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -250,10 +250,10 @@ namespace pxsim {
         entry: LabelFn;
 
         public refCountingDebug = false;
+        public refCounting = true;
         private refObjId = 1;
         private liveRefObjs: pxsim.Map<RefObject> = {};
         private stringRefCounts: any = {};
-        private refCounting = true;
 
         overwriteResume: (retPC: number) => void;
         getResume: () => ResumeFn;
@@ -351,6 +351,7 @@ namespace pxsim {
             U.assert(!!initCurrentRuntime);
 
             this.id = msg.id
+            this.refCountingDebug = !!msg.refCountingDebug;
 
             let yieldMaxSteps = 100
 

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -249,17 +249,24 @@ namespace pxsim {
         currFrame: StackFrame;
         entry: LabelFn;
 
-        refCountingDebug = false;
-        refObjId = 1;
-        liveRefObjs: pxsim.Map<RefObject> = {};
-        stringRefCounts: any = {};
-        refCounting = true;
+        public refCountingDebug = true;
+        private refObjId = 1;
+        private liveRefObjs: pxsim.Map<RefObject> = {};
+        private stringRefCounts: any = {};
+        private refCounting = true;
 
         overwriteResume: (retPC: number) => void;
         getResume: () => ResumeFn;
         run: (cb: ResumeFn) => void;
         setupTop: (cb: ResumeFn) => StackFrame;
         handleDebuggerMsg: (msg: DebuggerMessage) => void;
+
+        registerLiveObject(object: RefObject) {
+            const id = this.refObjId++;
+            if (this.refCounting)
+                this.liveRefObjs[id + ""] = object;
+            return id;
+        }
 
         runningTime(): number {
             return U.now() - this.startTime;

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -268,6 +268,11 @@ namespace pxsim {
             return id;
         }
 
+        unregisterLiveObject(object: RefObject) {
+            U.assert(object.refcnt == 0, "ref count is not 0");
+            delete this.liveRefObjs[object.id + ""]
+        }
+
         runningTime(): number {
             return U.now() - this.startTime;
         }
@@ -335,9 +340,7 @@ namespace pxsim {
             const liveObjectNames = Object.keys(this.liveRefObjs);
             const stringRefCountNames = Object.keys(this.stringRefCounts);
             console.log(`Live objects: ${liveObjectNames.length} objects, ${stringRefCountNames.length} strings`)
-            liveObjectNames.forEach(k => {
-                (<RefObject>this.liveRefObjs[k]).print()
-            })
+            liveObjectNames.forEach(k => this.liveRefObjs[k].print());
             stringRefCountNames.forEach(k => {
                 const n = this.stringRefCounts[k]
                 console.log("Live String:", JSON.stringify(k), "refcnt=", n)

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -39,7 +39,8 @@ namespace pxsim {
         mute?: boolean;
         highContrast?: boolean;
         cdnUrl?: string;
-        localizedStrings?: pxsim.Map<string>
+        localizedStrings?: pxsim.Map<string>;
+        refCountingDebug?: boolean;
     }
 
     export interface HwDebugger {
@@ -237,7 +238,8 @@ namespace pxsim {
                 mute: opts.mute,
                 highContrast: opts.highContrast,
                 cdnUrl: opts.cdnUrl,
-                localizedStrings: opts.localizedStrings
+                localizedStrings: opts.localizedStrings,
+                refCountingDebug: opts.refCountingDebug
             }
 
             this.applyAspectRatio();

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -195,7 +195,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResul
         aspectRatio: parts.length ? pxt.appTarget.simulator.partsAspectRatio : pxt.appTarget.simulator.aspectRatio,
         partDefinitions: pkg.computePartDefinitions(parts),
         cdnUrl: pxt.webConfig.commitCdnUrl,
-        localizedStrings: simTranslations
+        localizedStrings: simTranslations,
+        refCountingDebug: pxt.options.debug
     }
     postSimEditorEvent("started");
 


### PR DESCRIPTION
We were leaking refcounted objects in the simulator. Moving ref counting in the runtime state.