### PR TITLE
Allow targets to override download instructions

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -246,6 +246,7 @@ namespace pxt.editor {
         resourceImporters?: IResourceImporter[];
         beforeCompile?: () => void;
         deployCoreAsync?: (resp: pxtc.CompileResult) => Promise<void>;
+        showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync?: (options: any) => Promise<number>) => Promise<void>;
         fieldEditors?: IFieldCustomOptions[];
         toolboxOptions?: IToolboxOptions;
     }

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -3,4 +3,5 @@ namespace pxt.commands {
     export let deployCoreAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
+    export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync?: (options: any) => Promise<number>) => Promise<void> = undefined;
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -150,7 +150,10 @@ export class ProjectView
         } else {
             if (workspace.isSessionOutdated()) {
                 pxt.debug('workspace changed, reloading...')
-                this.openHome();
+                workspace.initAsync()
+                    .done(() => {
+                        this.openHome();
+                    });
             } else if (this.state.resumeOnVisibility && !this.state.running) {
                 this.setState({ resumeOnVisibility: false });
                 this.runSimulator();
@@ -2173,6 +2176,10 @@ function initExtensionsAsync(): Promise<void> {
             if (res.deployCoreAsync) {
                 pxt.debug(`\tadded custom deploy core async`);
                 pxt.commands.deployCoreAsync = res.deployCoreAsync;
+            }
+            if (res.showUploadInstructionsAsync) {
+                pxt.debug(`\tadded custom upload instructions async`);
+                pxt.commands.showUploadInstructionsAsync = res.showUploadInstructionsAsync;
             }
             if (res.beforeCompile) {
                 theEditor.beforeCompile = res.beforeCompile;

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -54,10 +54,10 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
     }
 
     if (resp.saveOnly || pxt.BrowserUtils.isBrowserDownloadInSameWindow()) return Promise.resolve();
-    else return showUploadInstructionsAsync(fn, url);
+    else return pxt.commands.showUploadInstructionsAsync(fn, url, core.confirmAsync);
 }
 
-function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
+function showUploadInstructionsAsync(fn: string, url: string, confirmAsync?: (options: any) => Promise<number>): Promise<void> {
     const boardName = pxt.appTarget.appTheme.boardName || "???";
     const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
 
@@ -75,7 +75,7 @@ function showUploadInstructionsAsync(fn: string, url: string): Promise<void> {
             pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex",
             boardDriveName, boardName);
     if (useUF2) body = lf("Press the `reset` button once on the {0}.", boardName) + " " + body;
-    return core.confirmAsync({
+    return confirmAsync({
         header: lf("Download completed..."),
         body,
         hideCancel: true,
@@ -137,6 +137,7 @@ function localhostDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
 export function initCommandsAsync(): Promise<void> {
     pxt.commands.browserDownloadAsync = browserDownloadAsync;
     pxt.commands.saveOnlyAsync = browserDownloadDeployCoreAsync;
+    pxt.commands.showUploadInstructionsAsync = showUploadInstructionsAsync;
     const forceHexDownload = /forceHexDownload/i.test(window.location.href);
 
     if (/webusb=1/i.test(window.location.href) && pxt.appTarget.compile.useUF2) {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -425,10 +425,10 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
 export interface ProjectsDetailProps extends ISettingsProps {
     name: string;
     description?: string;
-    url?: string;
     imageUrl?: string;
     largeImageUrl?: string;
     youTubeId?: string;
+    url?: string;
     onClick: () => void;
     cardType: string;
 }
@@ -440,14 +440,15 @@ export interface ProjectsDetailState {
 export class ProjectsDetail extends data.Component<ProjectsDetailProps, ProjectsDetailState> {
 
     renderCore() {
-        const { name, description, imageUrl, largeImageUrl, youTubeId, onClick, cardType } = this.props;
+        const { name, description, imageUrl, largeImageUrl, youTubeId, url, onClick, cardType } = this.props;
 
         const image = largeImageUrl || imageUrl || (youTubeId ? `https://img.youtube.com/vi/${youTubeId}/maxresdefault.jpg` : undefined);
 
-        let clickLabel = lf("Instructions");
+        let clickLabel = lf("Show Instructions");
         if (cardType == "tutorial") clickLabel = lf("Begin Tutorial");
         else if (cardType == "codeExample" || cardType == "example") clickLabel = lf("Try Example Code");
         else if (youTubeId) clickLabel = lf("Watch Video");
+        else if (url) clickLabel = lf("Launch Website");
 
         const actions = [{
             label: clickLabel,


### PR DESCRIPTION
Targets can use the extension story to override download instructions. 