### PR TITLE
Add 'objects & instances' topic to packages

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -30,7 +30,7 @@ namespace basic {
 ```
 
 * `icon` icon Unicode character from the icon font to display. The [Semantic UI](https://semantic-ui.com/elements/icon.html) icon set has been ported from Font Awesome (v4.5.6 at the time of writing), and a full list can be found at http://fontawesome.io/icons/
-* `color` should be included in a comment line starting with `\\%`. The color takes a **hue** value or a HTML color.
+* `color` should be included in a comment line starting with `//%`. The color takes a **hue** value or a HTML color.
 
 To have a category appear under the "Advanced" section of the Block Editor toolbox, add the annotation `advanced=true`.
 
@@ -154,9 +154,7 @@ look the same as the previous example but the compiled code will also include th
 addSomeEventHandler([ArgNames.argumentA, ArgNames.argumentB], ({argumentA, argumentB}) => {
 
 })
-
 ```
-
 
 The other attributes related to object destructuring mutators include:
 
@@ -248,7 +246,6 @@ class Message {
 
 * when annotating an instance method, you need to specify the ``%this`` parameter in the block syntax definition.
 
-
 You will need to expose a factory method to create your objects as needed. For the example above, we add a function that creates the message:
 
 ```typescript-ignore
@@ -281,7 +278,6 @@ In cases when the default constructor has side effects (eg., configuring a pin),
 or if the default value is most often overridden,
 the `autoCreate` syntax should not be used.
 
-
 ### Fixed Instance Set
 
 It is sometimes the case that there is only a fixed number of instances
@@ -306,7 +302,7 @@ namespace pins {
 ```
 
 This will result in a block `digital write pin [D0] to [0]`, where the
-first hold is a dropdown with `D0` and `D1`, and the second hole is a regular
+first hole is a dropdown with `D0` and `D1`, and the second hole is a regular
 integer value. The variables `D0` and `D1` can have additional annotations
 (eg., `block="D#0"`). Currently, only variables are supported with `fixedInstance`
 (`let` or `const`).

--- a/docs/packages/getting-started/objects-instances.md
+++ b/docs/packages/getting-started/objects-instances.md
@@ -91,7 +91,7 @@ namespace tropic {
 }
 ```
 
-MakeCode is limited to using [Static typescript](https://makecode.com/language) so we can't cast a `fruit` to a `banana` or a `coconut` in order to get at the **peel** or **crack** methods.
+MakeCode is limited to using [Static TypeScript](https://makecode.com/language) so we can't cast a `fruit` to a `banana` or a `coconut` in order to get at the **peel** or **crack** methods.
 
 ## Step 2: Make a banana object
 

--- a/docs/packages/getting-started/objects-instances.md
+++ b/docs/packages/getting-started/objects-instances.md
@@ -1,0 +1,304 @@
+# Objects and instances
+
+To create objects to associate certain operations more logically, you can have classes in your namespace. In the `tropic` package, the **pick** function simply returns a **boolean** to indicate that the action was successful or not. The **pick** function would make more sense if it actually returned a `fruit` object like a `banana` if successful.
+
+## Step 1: Make a fruit object
+
+Let's add a class to represent a `fruit` object. Also, let's change **pick** to now return a new `fruit` object. To do this, we'll make individual classes for each fruit in our tropical paradise.
+
+Now, it would be nice if the **pick** function was general enough to pick a fruit of any type and return it to you. Something like:
+
+```typescript
+/**
+ * Types of tropical fruit
+ */
+enum TropicalFruit {
+    Banana = 0,
+    Pinapple = 1,
+    Coconut = 2
+}
+
+/**
+ * Pick fruit, let it ripen or eat.
+ */
+namespace tropic {
+    abstract class fruit {
+        _type: TropicalFruit;
+
+        constructor(TropicalFruit: type) {
+            this._type = type;
+        }
+        whatAmI(): TropicalFruit {
+            return this._type;
+        }
+    }
+
+    export class banana extends fruit {
+        constructor() {
+            super(TropicalFruit.Banana);
+        }
+    }
+    export class pineapple extends fruit {
+        constructor() {
+            super(TropicalFruit.Pineapple);
+        }
+    }
+    export class Coconut extends fruit {
+        constructor() {
+            super(TropicalFruit.Coconut);
+        }
+    }
+
+    /**
+     * Pick a fruit to ripen or eat.
+     */
+    export function pick(TropicalFruit: type): fruit {
+            switch (type) {
+                case TropicalFruit.Pineapple:
+                    return new pineapple();
+                case TropicalFruit.Coconut:
+                    return new coconut();
+                case TropicalFruit.Banana:
+                default:
+                    return new banana();
+            }
+        }
+    }
+}
+```
+
+The **pick** function returns a general `fruit` object and not the specific fruit subclass. Not every fruit opens up the same way so, for `banana`, we would want to call the **peel** method. If we picked a `coconut`, we'd call its **crack** method.
+
+```typescript
+namespace tropic {
+    ...
+    export class banana extends fruit {
+        constructor() {
+            super(TropicalFruit.Banana);
+        }
+        peel(): boolean {
+            return true;
+        }
+    }
+    export class coconut extends fruit {
+        constructor() {
+            super(TropicalFruit.Coconut);
+        }
+        crack(): boolean {
+            return true;
+        }
+    }
+}
+```
+
+MakeCode is limited to using [Static TypeScript](https://makecode.com/language) so we can't cast a `fruit` to a `banana` or a `coconut` in order to get at the **peel** or **crack** methods.
+
+## Step 2: Make a banana object
+
+Well, for now, we can live with just bananas. If we want other fruit, we can code classes for them explicitly. So, we'll make the fruit picker give just bananas.
+
+```typescript
+namespace tropic {
+    ...
+    /**
+     * Pick a fruit to ripen or eat. Just bananas right now.
+     */
+    export function pickBanana(): banana {
+        return new banana();
+    }
+}
+```
+
+With bananas, they can ripen, get peeled, be eaten, or be left to rot. Let's add methods for these actions in the `banana` class.
+
+```typescript
+/**
+ * Appearance and condition of the banana.
+ */
+enum Peel {
+    Green = 0,
+    Yellow = 1,
+    Spotted = 2,
+    Blackened = 3,
+    Peeled = 4
+}
+
+/**
+ * Pick fruit, let it ripen.
+ */
+namespace tropic {
+    /**
+     * The tropical fruit called banana.
+     */
+    export class banana {
+        _condition: Peel;
+
+        constructor() {
+            this._condition = Peel.Green;
+        }
+        /**
+         * Make the banana get riper.
+         * @param tooMuch make the banana ripen too much, eg: false
+         */
+        public ripen(tooMuch: boolean = false): void {
+            if (tooMuch) {
+                this._condition = Peel.Blackened;            
+            } else if (this._condition <= Peel.Spotted) {
+                this._condition = this._condition + 1;
+            }
+        }
+        /**
+         * Peel the skin off of the banana
+         */
+        public peel(): void {
+            this._condition = Peel.Peeled;
+        }
+        /**
+         * See if the banana is ripe yet.
+         */
+        public ripe(): boolean {
+            return (this._condition > Peel.Green);
+        }
+        /**
+         * See how ripe the banana is now.
+         */
+        public howRipe(): Peel {
+            return this._condition;
+        }
+        /**
+         * Let the banana go rotten.
+         */
+        public rot(): void {
+            this._condition = Peel.Blackened;
+        }
+    }
+}
+```
+
+## Step 3: Defining blocks for banana methods
+
+In the blocks model, class methods aren't available, or don't show up, in the Toolbox until there's an actual object instance related to it. The [block definitions](/defining-blocks#objects-and-instance-methods) for the methods must "tag" them to an instance. Let's take the **peel** method as an example. We've inserted the ``%fruit`` parameter at the beginning of the `block` attribute. This is not a parameter for the method, but an association of the block to an instance variable initially called `fruit`. This will cause the **peel** block to be valid in the workspace as a method of `fruit` even if the value of `fruit` is stil `null` or `undefined`. You can think of it as a placeholder or a default instance name, but without it, the **peel** method has no context.
+
+```typescript
+/*
+ * Peel the skin off of the banana.
+ */
+//% blockId=banana_peel block="%fruit|peel"
+public peel(): void {
+    this._condition = Peel.Peeled;
+}
+```
+
+Now, lets's add the new `banana` class to the `tropic` namespace created in the simple package tutorial. Take the code from [banana.ts](./sources#banana-ts) in the supplied sources and save it in the tropic package under _/libs/tropic_. Go to the `pxt.json` file and add "banana.ts" to the `files` list.
+
+```typescript
+"files": [
+    "tropic.ts",
+    "banana.ts"
+],
+```
+
+Restart your target to build the package with the `banana` class added. In the Toolbox you will now see the `banana` methods in the **Tropic** category tagged with the `fruit` instance. Go to the JavaScript editor and paste in this code to test your class:
+
+```typescript
+let fruit = tropic.pickBanana()
+if (!(fruit.ripe())) {
+    fruit.ripen()
+}
+fruit.peel()
+tropic.compost(fruit)
+```
+
+## Step 4: Auto-create instance
+
+Delete the test code from the editor workspace. Switch back to the **Blocks** view and drag the **ripen** method block from **Tropic** into an **on start** block. Now, go to the **JavaScript** view and you will see:
+
+```typescript
+let fruit: tropic.banana = null
+fruit.ripen()
+```
+
+Since you have the `%fruit` parameter in the `block` attribute, the `fruit` instance variable is declared to make the block code valid. There is no valid instance of `banana` though and you can't run this code until you set `fruit` to `tropic.pickBanana()`.
+
+To have MakeCode automatically create an instance of `fruit` when you first pull out a method from `banana`, use the `//% autoCreate` attribute. It is set in the heading of the class.
+
+```typescript
+/**
+ * The tropical fruit called banana.
+ */
+//% autoCreate=tropic.pickBanana
+export class banana {
+    ...
+}
+```
+
+So now, when a **ripen** block is placed onto the workspace, an instance is created by calling the `tropic.pickBanana()` function as an object factory for `fruit`.
+
+Add the `autoCreate` attribute as shown and restart the target. Delete any blocks in the workspace and pull out **ripen** as you did before. After swithing to JavaScript, you'll see that `fruit` is now set to an instance of `banana` rather than being just a variable declaration with a `null` value.
+
+```typescript
+let fruit = tropic.pickBanana()
+fruit.ripen()
+```
+
+## Step 5: Default instances
+
+Maybe you want to have an instance of your class already created when your package is installed. To do this you make a constant and assign it to a new object instance. Here we've added the `fruit` constant as an instance of `banana`.
+
+```typescript
+namespace tropic {
+    /**
+     * The tropical fruit called banana.
+     */
+    export class banana {
+        ...
+    }
+
+    /**
+     * Pick a fruit to ripen. Just bananas right now.
+     */
+    //% blockId=tropic_pick block="pick a banana"
+    export function pickBanana(): banana {
+        return new banana();
+    }
+
+    export const fruit: banana = tropic.pickBanana();
+}
+```
+Now, for each method in `banana` you add the `//% defaultInstance` attribute. For the **peel** method (and the others) the default instance attribute is set to `tropic.fruit`. Remove the `%fruit` parameter from the `block` attribute.
+
+```typescript
+/**
+ * Peel the skin off of the banana
+ */
+//% blockId=banana_peel block="peel"
+//% defaultInstance=tropic.fruit
+public peel(): void {
+    this._condition = Peel.Peeled;
+}
+```
+
+Repeat this for the other methods too. Restart your target to build these changes into the `tropic` package. Go to the Toolbox and drag the **peel** block from **Tropic**. You'll see that it has no instance parameter with it and it's usable directly. Delete that block, go into the JavaScript editor and paste in this code:
+
+```typescript
+if (!(tropic.fruit.ripe())) {
+    tropic.fruit.ripen();
+}
+tropic.fruit.peel();
+tropic.compost(fruit);
+``` 
+
+Since there's already a default instance, the use of **pickBanana** isn't needed unless you want to create another `banana`. Add these two lines to at the bottom of the test code:
+
+```typescript
+let otherFruit = tropic.pickBanana();
+otherFruit.peel();
+```
+
+Switch back to blocks. Notice that the last **peel** method has the `otherFruit` instance parameter added to its block.
+
+## See also
+
+[Objects and instance methods](/defining-blocks#objects-and-instance-methods) section in [Defining blocks](/defining-blocks)
+
+[Sources](./sources) for the package tutorial

--- a/docs/packages/getting-started/objects-instances.md
+++ b/docs/packages/getting-started/objects-instances.md
@@ -91,7 +91,7 @@ namespace tropic {
 }
 ```
 
-MakeCode is limited to using [Static TypeScript](https://makecode.com/language) so we can't cast a `fruit` to a `banana` or a `coconut` in order to get at the **peel** or **crack** methods.
+MakeCode is limited to using [Static TypeScript](/language) so we can't cast a `fruit` to a `banana` or a `coconut` in order to get at the **peel** or **crack** methods.
 
 ## Step 2: Make a banana object
 

--- a/docs/packages/getting-started/objects-instances.md
+++ b/docs/packages/getting-started/objects-instances.md
@@ -8,7 +8,7 @@ Let's add a class to represent a `fruit` object. Also, let's change **pick** to 
 
 Now, it would be nice if the **pick** function was general enough to pick a fruit of any type and return it to you. Something like:
 
-```typescript
+```typescript-ignore
 /**
  * Types of tropical fruit
  */
@@ -69,7 +69,7 @@ namespace tropic {
 
 The **pick** function returns a general `fruit` object and not the specific fruit subclass. Not every fruit opens up the same way so, for `banana`, we would want to call the **peel** method. If we picked a `coconut`, we'd call its **crack** method.
 
-```typescript
+```typescript-ignore
 namespace tropic {
     ...
     export class banana extends fruit {
@@ -91,13 +91,13 @@ namespace tropic {
 }
 ```
 
-MakeCode is limited to using [Static TypeScript](https://makecode.com/language) so we can't cast a `fruit` to a `banana` or a `coconut` in order to get at the **peel** or **crack** methods.
+MakeCode is limited to using [Static typescript](https://makecode.com/language) so we can't cast a `fruit` to a `banana` or a `coconut` in order to get at the **peel** or **crack** methods.
 
 ## Step 2: Make a banana object
 
 Well, for now, we can live with just bananas. If we want other fruit, we can code classes for them explicitly. So, we'll make the fruit picker give just bananas.
 
-```typescript
+```typescript-ignore
 namespace tropic {
     ...
     /**
@@ -111,7 +111,7 @@ namespace tropic {
 
 With bananas, they can ripen, get peeled, be eaten, or be left to rot. Let's add methods for these actions in the `banana` class.
 
-```typescript
+```typescript-ignore
 /**
  * Appearance and condition of the banana.
  */
@@ -179,7 +179,7 @@ namespace tropic {
 
 In the blocks model, class methods aren't available, or don't show up, in the Toolbox until there's an actual object instance related to it. The [block definitions](/defining-blocks#objects-and-instance-methods) for the methods must "tag" them to an instance. Let's take the **peel** method as an example. We've inserted the ``%fruit`` parameter at the beginning of the `block` attribute. This is not a parameter for the method, but an association of the block to an instance variable initially called `fruit`. This will cause the **peel** block to be valid in the workspace as a method of `fruit` even if the value of `fruit` is stil `null` or `undefined`. You can think of it as a placeholder or a default instance name, but without it, the **peel** method has no context.
 
-```typescript
+```typescript-ignore
 /*
  * Peel the skin off of the banana.
  */
@@ -191,7 +191,7 @@ public peel(): void {
 
 Now, lets's add the new `banana` class to the `tropic` namespace created in the simple package tutorial. Take the code from [banana.ts](./sources#banana-ts) in the supplied sources and save it in the tropic package under _/libs/tropic_. Go to the `pxt.json` file and add "banana.ts" to the `files` list.
 
-```typescript
+```typescript-ignore
 "files": [
     "tropic.ts",
     "banana.ts"
@@ -200,7 +200,7 @@ Now, lets's add the new `banana` class to the `tropic` namespace created in the 
 
 Restart your target to build the package with the `banana` class added. In the Toolbox you will now see the `banana` methods in the **Tropic** category tagged with the `fruit` instance. Go to the JavaScript editor and paste in this code to test your class:
 
-```typescript
+```typescript-ignore
 let fruit = tropic.pickBanana()
 if (!(fruit.ripe())) {
     fruit.ripen()
@@ -213,7 +213,7 @@ tropic.compost(fruit)
 
 Delete the test code from the editor workspace. Switch back to the **Blocks** view and drag the **ripen** method block from **Tropic** into an **on start** block. Now, go to the **JavaScript** view and you will see:
 
-```typescript
+```typescript-ignore
 let fruit: tropic.banana = null
 fruit.ripen()
 ```
@@ -222,7 +222,7 @@ Since you have the `%fruit` parameter in the `block` attribute, the `fruit` inst
 
 To have MakeCode automatically create an instance of `fruit` when you first pull out a method from `banana`, use the `//% autoCreate` attribute. It is set in the heading of the class.
 
-```typescript
+```typescript-ignore
 /**
  * The tropical fruit called banana.
  */
@@ -236,7 +236,7 @@ So now, when a **ripen** block is placed onto the workspace, an instance is crea
 
 Add the `autoCreate` attribute as shown and restart the target. Delete any blocks in the workspace and pull out **ripen** as you did before. After swithing to JavaScript, you'll see that `fruit` is now set to an instance of `banana` rather than being just a variable declaration with a `null` value.
 
-```typescript
+```typescript-ignore
 let fruit = tropic.pickBanana()
 fruit.ripen()
 ```
@@ -245,7 +245,7 @@ fruit.ripen()
 
 Maybe you want to have an instance of your class already created when your package is installed. To do this you make a constant and assign it to a new object instance. Here we've added the `fruit` constant as an instance of `banana`.
 
-```typescript
+```typescript-ignore
 namespace tropic {
     /**
      * The tropical fruit called banana.
@@ -267,7 +267,7 @@ namespace tropic {
 ```
 Now, for each method in `banana` you add the `//% defaultInstance` attribute. For the **peel** method (and the others) the default instance attribute is set to `tropic.fruit`. Remove the `%fruit` parameter from the `block` attribute.
 
-```typescript
+```typescript-ignore
 /**
  * Peel the skin off of the banana
  */
@@ -280,7 +280,7 @@ public peel(): void {
 
 Repeat this for the other methods too. Restart your target to build these changes into the `tropic` package. Go to the Toolbox and drag the **peel** block from **Tropic**. You'll see that it has no instance parameter with it and it's usable directly. Delete that block, go into the JavaScript editor and paste in this code:
 
-```typescript
+```typescript-ignore
 if (!(tropic.fruit.ripe())) {
     tropic.fruit.ripen();
 }
@@ -290,7 +290,7 @@ tropic.compost(fruit);
 
 Since there's already a default instance, the use of **pickBanana** isn't needed unless you want to create another `banana`. Add these two lines to at the bottom of the test code:
 
-```typescript
+```typescript-ignore
 let otherFruit = tropic.pickBanana();
 otherFruit.peel();
 ```

--- a/docs/packages/getting-started/ref-docs.md
+++ b/docs/packages/getting-started/ref-docs.md
@@ -1,14 +1,14 @@
 # Reference documents
 
-the documentation for the methods in a package namespace are included with the package. They are markdown files written in the format described by [writing docs](https://makecode.com/writing-docs).
+the documentation for the functions in a package namespace are included with the package. They are markdown files written in the format described by [writing docs](https://makecode.com/writing-docs).
 
 ## Step 0: Document tree discussion
 
-Documentation for namespace methods almost always goes under the _/reference_ document path. Other standard document paths are _/blocks_ and _/types_ but these are for the documents related to built-in blocks. If a package has other related documents that aren't for namespace methods, such as hardware associated with the API in the package, these are place under another path, like _/device_, in the package.
+Documentation for namespace functions almost always goes under the _/reference_ document path. Other standard document paths are _/blocks_ and _/types_ but these are for the documents related to built-in blocks. If a package has other related documents that aren't for namespace functions, such as hardware associated with the API in the package, these are place under another path, like _/device_, in the package.
 
 ### Document file layout
 
-Earlier you saw that the `tropic.ts` and `pxt.json` files were placed under the _/tropic_ folder. To add documents, make a folder called _/docs_ under that one. You put the documents for the namespace methods under a _/reference/<namespace>_ folder. The file layout, including the documents for the two methods in the **tropic** namespace, looks like this:
+Earlier you saw that the `tropic.ts` and `pxt.json` files were placed under the _/tropic_ folder. To add documents, make a folder called _/docs_ under that one. You put the documents for the namespace functions under a _/reference/<namespace>_ folder. The file layout, including the documents for the two functions in the **tropic** namespace, looks like this:
 
 ```
 /libs
@@ -19,11 +19,11 @@ Earlier you saw that the `tropic.ts` and `pxt.json` files were placed under the 
                     peel.md
                     pick.md
                 tropic.md
-    tropic.ts
-    pxt.json
+        tropic.ts
+        pxt.json
 ```
 
-Again, the individual reference document files are placed under _/tropic_ which is under _/reference_. This maps the `tropic` namespace documents under the global reference document tree for the target. The referring URI for the **peel** method when served locally is:
+Again, the individual reference document files are placed under _/tropic_ which is under _/reference_. This maps the `tropic` namespace documents under the global reference document tree for the target. The referring URI for the **peel** function when served locally is:
 
 ```
 localhost:3232/reference/tropic/peel
@@ -60,12 +60,12 @@ Under the _/tropic_ folder create a folder path called: _/docs/reference/tropic_
 
 There's no required format for writing the reference documents. However, current convention is for reference documents to contain these elements, when applicable:
 
-1. Use the method name as the title in a first level heading: `# peel`.
-2. A short paragraph overview of what the method does.
-3. The signature of the method.
+1. Use the function name as the title in a first level heading: `# peel`.
+2. A short paragraph overview of what the function does.
+3. The signature of the function.
 4. A list of parameters (if any) with their types and descriptions.
 5. The return value (if any) description and it's type information.
-6. A example use of the method.
+6. A example use of the function.
 7. Any **See also** links to related reference or external information.
 8. A package tag associating the document with it's package.
 
@@ -110,11 +110,11 @@ tropic
 ```
 ````
 
-Copy the markdown for the **pick** method reference and save it as _pick.md_ under _/docs/reference/tropic_ in the package folder.
+Copy the markdown for the **pick** function reference and save it as _pick.md_ under _/docs/reference/tropic_ in the package folder.
 
 ## Step 3: Write the reference document: `peel.md`
 
-Do the same thing as in **Step 2** and copy the markdown here but save it as _peel.md_ for the other method in `tropic`:
+Do the same thing as in **Step 2** and copy the markdown here but save it as _peel.md_ for the other function in `tropic`:
 
 ````markdown
 # peel
@@ -155,7 +155,7 @@ tropic
 
 ## Step 4: Set the help attributes
 
-Now, go back and open `tropic.ts` again in an editor. We need to add the `help` attribute to each method in order to associate the new documents as help content for the blocks.
+Now, go back and open `tropic.ts` again in an editor. We need to add the `help` attribute to each function in order to associate the new documents as help content for the blocks.
 
 For **pick**, add:
 
@@ -199,7 +199,7 @@ namespace tropic {
 ## Step 5: Make a card page
 
 A nice feature of the MakeCode document system is generation of cards for code statements and
-functions based on signature. The cards show a block from the compiled code of the method in the namespace. Also, the description from the JsDoc is extracted and displayed in the card.
+functions based on signature. The cards show a block from the compiled code of the function in the namespace. Also, the description from the JsDoc is extracted and displayed in the card.
 
 Card pages form the top levels of the reference document tree (usually the second level after the reference page: _reference.md_).
 
@@ -207,14 +207,14 @@ Card pages form the top levels of the reference document tree (usually the secon
 The card page isn't automatically added to the top level reference page, _reference.md_,  when a package is added. If a package is included with a target statically, the card page is added manually in a [namespaces](/writing-docs/macros#namespaces) section.
 ### ~
 
-Cards are declared in a [**cards**](/writing-docs/macros#cards) section in the card markdown page. You have the option of exposing some or all of the available methods from you namespace in the card page. The document for the card page is placed in the _/reference_ folder and has the same name as the namespace folder but with the markdown (md) extension.
+Cards are declared in a [**cards**](/writing-docs/macros#cards) section in the card markdown page. You have the option of exposing some or all of the available functions from your namespace in the card page. The document for the card page is placed in the _/reference_ folder and has the same name as the namespace folder but with the markdown (md) extension.
 
 Here's the card page for the `tropic` namespace package called `tropic.md`:
 
 ````markdown
 # Tropic
 
-The methods to pick, peel, and eat tropical fruit.
+The functions to pick, peel, and eat tropical fruit.
 
 ## Reference
 
@@ -237,6 +237,8 @@ Everything's in place now to make the documents work with the blocks and the in 
 Open a new browser page and navigate to ``localhost:3232/reference/tropic``. You should see the card page for **Tropic** appear. Click on one of the cards to see a reference page.
 
 Go back over to the editor and in the blocks view, right-click one of the blocks from the **Tropic** package. Select **help** in the menu and see the reference show up in the doc slider.
+
+**NEXT:** add a [class and use object instances](./objects-instances) to your package namespace.
 
 ## See also
 

--- a/docs/packages/getting-started/simple-package.md
+++ b/docs/packages/getting-started/simple-package.md
@@ -4,16 +4,16 @@ As a variation of pxt-banana package example from [getting started](/packages/ge
 
 In order to build and test the package, you'll need a running target to add the package to. You can add this example to a target you're already working with or you can use the [pxt-sample](https://github.com/Microsoft/pxt-sample) target.  
 
-## Step 1: Define a namespace and methods
+## Step 1: Define a namespace and functions
 
-Our package has just one block category called `tropic`. The methods we want to expose for this category are contained inside a namespace with that same name. The block category will appear in the Toolbox with this name.
+Our package has just one block category called `tropic`. The functions we want to expose for this category are contained inside a namespace with that same name. The block category will appear in the Toolbox with this name.
 
 ```typescript
 namespace tropic {
 }
 ```
 
-Let's expand the `tropic` namespace and add some methods. If you're running a target and have the editor open, copy the this code into a new project in the editor. Verify that it has no errors and that you can convert it to blocks.
+Let's expand the `tropic` namespace and add some functions. If you're running a target and have the editor open, copy the this code into a new project in the editor. Verify that it has no errors and that you can convert it to blocks.
 
 ```typescript
 /**
@@ -44,7 +44,7 @@ namespace tropic {
 }
 ```
 
-We'll quickly use the methods from `tropic` with a little bit of test code to simulate how they will work if they were added from a package. You can add this bit of code at the bottom of project in the editor to test:
+We'll quickly use the functions from `tropic` with a little bit of test code to simulate how they will work if they were added from a package. You can add this bit of code at the bottom of project in the editor to test:
 
 ```typescript-ignore
 let peeled = false;
@@ -81,7 +81,7 @@ This is what the basic entries in the `pxt.json` do:
 * **description**: The description of the package shown in the package gallery.
 * **icon**: An icon shown along with the description in the package gallery.
 * **files**: The list of sources for the code and blocks of the package.
-* **dependencies**: The other packages that the code in this package will rely on. Often there is a _core_ package that has basic utility methods, helpers, and or data types that other packages will need.
+* **dependencies**: The other packages that the code in this package will rely on. Often there is a _core_ package that has basic utility functions, helpers, and or data types that other packages will need.
 
 ### Icon file
 
@@ -106,7 +106,7 @@ The attributes we've defined for our namespace mean:
 * **icon**: a Unicode identifier for an icon from the [Font Awesome](http://fontawesome.io/icons) icon set.
 * **color**: the RGB color for the catergory item and blocks rendered from the namespace.
 
-For the methods, we add the `blockId` and `block` attributes. This will make the block compiler create actual blocks for the methods. The methods will now show up as blocks under the `tropic` category in the toolbox too.
+For the functions, we add the `blockId` and `block` attributes. This will make the block compiler create actual blocks for the functions. The functions will now show up as blocks under the `tropic` category in the toolbox too.
 
 The text set for `block` is displayed in the blocks shown in the Toolbox and in the blocks editor view.
 
@@ -132,7 +132,7 @@ namespace tropic {
     }
 }
 ```
-You'll notice that the `block` attribute includes a parameter tag called ``%fruit``. This matches to the example methods which have one parameter called `fruit`. This will cause the block in the editor to have a parameter placeholder when compiled.
+You'll notice that the `block` attribute includes a parameter tag called ``%fruit``. This matches to the example functions which have one parameter called `fruit`. This will cause the block in the editor to have a parameter placeholder when compiled.
 
 Let's also add some block descriptions for the `TropicalFruit` enum so that the values will appear in a list as the parameter for **pick** and **peel**.
 
@@ -186,7 +186,7 @@ building cmds...
 
 After the target editor launches from the local server, go to the bottom of the Toolbox in the editor and click on **ADD PACKAGE** (it could be called **EXTENSIONS** or something similar depending on the target). You should see the **tropic** package card with its icon as a gallery selection. Click on it and it will install your package.
 
-The **tropic** category appears in the toolbox list with the color and icon we set as attributes for the namespace. If you click on the category, you will see the **pick** and **peel** methods with a selectable parameter for the ``TropicalFruit`` type.
+The **tropic** category appears in the toolbox list with the color and icon we set as attributes for the namespace. If you click on the category, you will see the **pick** and **peel** functions with a selectable parameter for the ``TropicalFruit`` type.
 
 Switch to JavaScript and paste in again the small section of test code:
 
@@ -199,7 +199,7 @@ if (tropic.pick(TropicalFruit.Banana)) {
 
 Now, switch back to blocks to see **pick** and **peel** appear as blocks. Having added block attributes to the enum values for ``TropicalFruit``, you can go to the parameters for each block and select a different type of fruit.
 
-**NEXT:** add some reference [documentation](./ref-docs) for the package methods.
+**NEXT:** add some reference [documentation](./ref-docs) for the package functions.
 
 ## See also
 

--- a/docs/packages/getting-started/sources.md
+++ b/docs/packages/getting-started/sources.md
@@ -56,6 +56,102 @@ namespace tropic {
     }
 }
 ```
+## banana.ts
+
+```typescript-ignore
+/**
+ * Appearance and condition of the banana.
+ */
+enum Peel {
+    //% block=green
+    Green = 0,
+    //% block=yellow
+    Yellow = 1,
+    //% block=spotted
+    Spotted = 2,
+    //% block=blackened
+    Blackened = 3,
+    //% block=peeled
+    Peeled = 4
+}
+
+namespace tropic {
+    /**
+     * The tropical fruit called banana.
+     */
+    export class banana {
+        _condition: Peel;
+
+        constructor() {
+            this._condition = Peel.Green;
+        }
+        /**
+         * Make the banana get riper.
+         * @param tooMuch make the banana ripen too much, eg: false
+         */
+        //% weight=66 
+        //% blockId=banana_ripen block="%fruit|ripen"
+        public ripen(tooMuch: boolean = false): void {
+            if (tooMuch) {
+                this._condition = Peel.Blackened;            
+            } else if (this._condition <= Peel.Spotted) {
+                this._condition = this._condition + 1;
+            }
+        }
+        /**
+         * Peel the skin off of the banana
+         */
+        //% weight=65
+        //% blockId=banana_peel block="%fruit|peel"
+        public peel(): void {
+            this._condition = Peel.Peeled;
+        }
+        /**
+         * See if the banana is ripe yet.
+         */
+        //% weight=64
+        //% blockId=banana_ripe block="%fruit|ripe"
+        public ripe(): boolean {
+            return (this._condition > Peel.Green);
+        }
+        /**
+         * See how ripe the banana is now.
+         */
+        //% weight=63
+        //% blockId=banana_how_ripe block="%fruit|how ripe"
+        public howRipe(): Peel {
+            return this._condition;
+        }
+        /**
+         * Let the banana go rotten.
+         */
+        //% weight=62
+        //% blockId=banana_rot block="%fruit|let rot"
+        public rot(): void {
+            this._condition = Peel.Blackened;
+        }
+    }
+
+    /**
+     * Pick a fruit to ripen. Just bananas right now.
+     */
+    //% weight=81
+    //% blockId=tropic_pick block="pick a banana"
+    export function pickBanana(): banana {
+        return new banana();
+    }
+
+    /**
+     * Compost a fruit by letting it rot.
+     * @param matter plant matter to compost
+     */
+    //% weight=80
+    //% blockId=tropic_compost block="compost %matter"
+    export function compost(matter: banana): void {
+        matter.rot();
+    }
+}
+```
 
 ## tropic.md
 


### PR DESCRIPTION
- [x] Add a tutorial topic for 'Objects and instances'.
- [x] Change the term for 'method' to 'function' when not referring to a class method. 