### PR TITLE
Scroll home screen to selected element

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -13,7 +13,7 @@
 .blocklyWidgetDiv {
     z-index: @blocklyWidgetDivZIndex;
 }
-.blocklyDropdownDiv {
+.blocklyDropDownDiv {
     z-index: @blocklyDropdownDivZIndex;
 }
 

--- a/theme/home.less
+++ b/theme/home.less
@@ -107,6 +107,7 @@
         position: absolute;
         .item {
             font-size: 0.8rem !important;
+            color: @homeFooterColor !important;
         }
     }
     .ui.card {

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -99,7 +99,8 @@
      PXT Variables
 *******************************/
 
-@avatarUrl: data-uri("../docs/static/avatar.svg");
+@avatarUrlPath: "../docs/static/avatar.svg";
+@avatarUrl: data-uri(@avatarUrlPath);
 @fileLogoUrl: data-uri("../docs/static/filelogo.svg");
 
 @poweredBySmall: data-uri("../docs/static/logo/Powered-By-Microsoft-logo-small.png");

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -214,6 +214,7 @@
 @homeCardColor: @textColor;
 @homeCardMetaColor: @homeCardColor;
 @homeCardHeaderColor: @homeCardColor;
+@homeFooterColor: @homeCardColor;
 
 @homeCardImageBorderRadius: 0;
 @homeCardBackgroundColor: white;

--- a/theme/themes/pxt/globals/zindex.variables
+++ b/theme/themes/pxt/globals/zindex.variables
@@ -34,7 +34,7 @@
 
 /* Grid picker */
 @gridPickerZIndex: @blocklyWidgetDivZIndex+1; /* Needs to be above the @blocklyWidgetDivZIndex */
-@gridPickerTooltipZIndex: (@dimmerZIndex)-1; /* Just below dimmer */
+@gridPickerTooltipZIndex: (@dimmerZIndex)-5; /* Just below dimmer */
 
 /* Monaco */
 @monacoFlyoutZIndex: @blocklyFlyoutZIndex; /* Same as blockly Flyout */
@@ -53,7 +53,7 @@
 @tutorialLightboxCardZIndex: @dimmerZIndex+1;
 
 /* Home screen */
-@homeScreenZIndex: @menuBarZIndex+1; /* Above the menu bar */
+@homeScreenZIndex: (@dimmerZIndex)-1; /* Just below the dimmer */
 
 /* Side doc */
 @sidedocZIndex: @aboveEditorZIndex+5; /* Above the editor and its components */

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -239,6 +239,18 @@ code.lang-filterblocks {
         Media Adjustments
 *******************************/
 
+
+/* > Small Monitor */
+@media only screen and (min-width: @computerBreakpoint) {
+    /* Hide the editor toolbor in tutorial mode */
+    .tutorial #editortools  {
+        background: transparent;
+    }
+    .tutorial #maineditor > div.full-abs {
+        bottom: 0;
+    }
+}
+
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -88,6 +88,30 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         }
     }
 
+    componentDidUpdate(prevProps: ISettingsProps, prevState: ProjectsState) {
+        if (this.state.selectedCategory !== prevState.selectedCategory) {
+            this.ensureSelectedItemVisible();
+        }
+    }
+
+    ensureSelectedItemVisible() {
+        let activeCarousel = this.refs['activeCarousel'];
+        if (activeCarousel) {
+            let domNode = (activeCarousel as ProjectsCarousel).getCarouselDOM();
+            this.scrollElementIntoViewIfNeeded(domNode);
+        }
+    }
+
+    scrollElementIntoViewIfNeeded(domNode: Element) {
+        let containerDomNode = ReactDOM.findDOMNode(this.refs['homeContainer']);
+        // Determine if `domNode` fully fits inside `containerDomNode`.
+        // If not, set the container's scrollTop appropriately.
+        const domTop = (domNode as HTMLElement).getBoundingClientRect().top;
+        const delta = domTop;
+        const offset = 30;
+        containerDomNode.parentElement.scrollTop = containerDomNode.parentElement.scrollTop + delta - offset;
+    }
+
     renderCore() {
         const { visible, selectedCategory, selectedIndex } = this.state;
 
@@ -181,7 +205,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             'ui segment bottom attached tab active tabsegment'
         ]);
 
-        return <div className={tabClasses}>
+        return <div ref="homeContainer" className={tabClasses}>
             {showHeroBanner ?
                 <div className="ui segment getting-started-segment" style={{ backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` }} /> : undefined}
             <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment">
@@ -202,7 +226,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment">
                     <h2 className="ui header heading">{Util.rlf(galleryName) } </h2>
                     <div className="content">
-                        <ProjectsCarousel key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]} onClick={(scr: any) => chgGallery(scr) } setSelected={(index: number) => this.setSelected(galleryName, index) } selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined}/>
+                        <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`} key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]} onClick={(scr: any) => chgGallery(scr) } setSelected={(index: number) => this.setSelected(galleryName, index) } selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined}/>
                     </div>
                 </div>
             ) }
@@ -319,6 +343,16 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
         this.props.setSelected(undefined);
     }
 
+    getCarouselDOM() {
+        let carouselDom = ReactDOM.findDOMNode(this.refs["carousel"]);
+        return carouselDom;
+    }
+
+    getDetailDOM() {
+        let detailDom = ReactDOM.findDOMNode(this.refs["detailView"]);
+        return detailDom;
+    }
+
     renderCore() {
         const { name, path, selectedIndex } = this.props;
         const theme = pxt.appTarget.appTheme;
@@ -346,7 +380,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                 </div>
             } else {
                 return <div>
-                    <carousel.Carousel bleedPercent={20} selectedIndex={selectedIndex}>
+                    <carousel.Carousel ref="carousel" bleedPercent={20} selectedIndex={selectedIndex}>
                         {cards.map((scr, index) =>
                             <div key={path + scr.name}>
                                 <codecard.CodeCardView
@@ -363,7 +397,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                             </div>
                         ) }
                     </carousel.Carousel>
-                    <div className={`detailview ${cards.filter((scr, index) => index == selectedIndex).length > 0 ? 'visible' : ''}`}>
+                    <div ref="detailView" className={`detailview ${cards.filter((scr, index) => index == selectedIndex).length > 0 ? 'visible' : ''}`}>
                         {cards.filter((scr, index) => index == selectedIndex).length > 0 ? <div tabIndex={0} className="close"><sui.Icon icon="remove circle" onClick={() => this.closeDetail() } /> </div> : undefined }
                         {cards.filter((scr, index) => index == selectedIndex).map(scr =>
                             <ProjectsDetail parent={this.props.parent}


### PR DESCRIPTION
Scroll home screen to element. Placing the selected element in the top left.

![scrollhomescreen](https://user-images.githubusercontent.com/16690124/32353212-b3d2cc36-bfe1-11e7-9160-dac5bd083f6c.gif)

Couple other minor UI home screen fixes.

Fixes https://github.com/Microsoft/pxt-adafruit/issues/445
