### PR TITLE
Fix acc menu for semantic version running in v0

### DIFF
--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -13,7 +13,7 @@
 
 <body id='root' class='root'>
 
-<div class="ui accessibleMenu borderless fixed menu" role="menubar">
+<div id="accessibleMenu" class="ui accessibleMenu borderless fixed menu" role="menubar">
     @accMenu@
 </div>
 

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -185,12 +185,14 @@ svg {
     padding-bottom: 3em;
 }
 
-.accessibleMenu .ui.item.link {
+#accessibleMenu .ui.item.link {
+    position: absolute;
     height: 4em;
     line-height: 4em;
     font-size: 1em;
     text-align: center;
-    color: white;
+    color: #387894;
+    background: hsla(0,0%,100%,.9)!important;
 }
 
 /* Styling the table of contents much like the Semantic UI documentation site: http://semantic-ui.com/introduction/getting-started.html */

--- a/docs/index.html
+++ b/docs/index.html
@@ -286,7 +286,7 @@
 		}
 		/* Accessible menu */
 
-		.accessibleMenu {
+		#accessibleMenu {
 			width: 100%;
 			position: absolute;
 			top: -20em;
@@ -296,19 +296,19 @@
 			left: 0;
 		}
 
-		.accessibleMenu .ui.item.link {
+		#accessibleMenu .ui.item.link {
 			position: absolute;
 			left: 0;
 			right: 0;
 			padding: 12px 10px;
-			background: rgba(255, 255, 255, .9);
 			font-weight: 700;
 			text-align: center;
-			color: #0072c6;
+			color: #387894;
+			background: hsla(0,0%,100%,.9)!important;
 		}
 
-		.accessibleMenu .ui.item.link:focus,
-		.accessibleMenu .ui.item.link:hover {
+		#accessibleMenu .ui.item.link:focus,
+		#accessibleMenu .ui.item.link:hover {
 			box-shadow: 3px 3px 5px #aaa;
 			top: 20em;
 			text-decoration: none;
@@ -427,7 +427,7 @@
 				Microsoft MakeCode
 			</h1>
 
-			<div class="accessibleMenu" role="menubar">
+			<div id="accessibleMenu" class="accessibleMenu" role="menubar">
 				<a id="skiptocontent" class="ui item link" role="menuitem" href="#document-main" tabindex="1">Skip to Content</a>
 			</div>
 

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -320,7 +320,6 @@ namespace pxt.docs {
         if (theme.accentColor) style += `
 .ui.accent { color: ${theme.accentColor}; }
 .ui.inverted.accent { background: ${theme.accentColor}; }
-.accessibleMenu a { background: ${theme.accentColor}; }
 `
         params["targetstyle"] = style;
 

--- a/theme/accessibility.less
+++ b/theme/accessibility.less
@@ -41,7 +41,7 @@
     clip: rect(0 0 0 0);
 }
 
-.ui.menu.accessibleMenu {
+.ui.menu.accessibleMenu, #accessibleMenu {
     z-index: 1001 !important;
     top: -20em !important;
     padding: 0;
@@ -67,7 +67,7 @@
 
 /* <= Tablet (Mobile + Tablet) */
 @media only screen and (max-width: @largestTabletScreen) {
-    .menubar .ui.menu.accessibleMenu {
+    .menubar .ui.menu.accessibleMenu, #accessibleMenu {
         height: @mobileMenuHeight !important;
         min-height: @mobileMenuHeight !important;
     }


### PR DESCRIPTION
PR https://github.com/Microsoft/pxt/pull/3389 switched the accmenu to have a class instead of an ID. 
Since v0 and master share the same semantic ui. I'm bringing back the id just for the docs, but still adding the class to allow us to fix this in the future.