### PR TITLE
store crowdin branch information in versions object

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1835,13 +1835,15 @@ function pxtVersion(): string {
 }
 
 function pxtCrowdinBranch(): string {
-    return pxt.appTarget.id == "core" ?
-        readJson("pxtarget.json").appTheme.crowdinBranch :
-        readJson("node_modules/pxt-core/pxtarget.json").appTheme.crowdinBranch;
+    const theme = pxt.appTarget.id == "core" ?
+        readJson("pxtarget.json").appTheme :
+        readJson("node_modules/pxt-core/pxtarget.json").appTheme;
+    return theme ? theme.crowdinBranch : undefined;
 }
 
 function targetCrowdinBranch(): string {
-    return readJson("pxtarget.json").appTheme.crowdinBranch;
+    const theme = readJson("pxtarget.json").appTheme;
+    return theme ? theme.crowdinBranch : undefined;
 }
 
 function buildAndWatchAsync(f: () => Promise<string[]>): Promise<void> {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1804,7 +1804,8 @@ function buildTargetCoreAsync() {
                 commits: info.commitUrl,
                 target: readJson("package.json")["version"],
                 pxt: pxtVersion(),
-                pxtCrowdinBranch: pxtCrowdinBranch()
+                pxtCrowdinBranch: pxtCrowdinBranch(),
+                targetCrowdinBranch: targetCrowdinBranch()
             }
 
             saveThemeJson(cfg)
@@ -1837,6 +1838,10 @@ function pxtCrowdinBranch(): string {
     return pxt.appTarget.id == "core" ?
         readJson("pxtarget.json").appTheme.crowdinBranch :
         readJson("node_modules/pxt-core/pxtarget.json").appTheme.crowdinBranch;
+}
+
+function targetCrowdinBranch(): string {
+    return readJson("pxtarget.json").appTheme.crowdinBranch;
 }
 
 function buildAndWatchAsync(f: () => Promise<string[]>): Promise<void> {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -197,7 +197,7 @@ declare namespace pxt {
         simAnimationExit?: string; // Simulator exit animation
         hasAudio?: boolean; // target uses the Audio manager. if true: a mute button is added to the simulator toolbar.
         crowdinProject?: string;
-        crowdinBranch?: string; // optional branch specification for pxt
+        crowdinBranch?: string; // optional branch specification for localization files
         monacoToolbox?: boolean; // if true: show the monaco toolbox when in the monaco editor
         blockHats?: boolean; // if true, event blocks have hats
         allowParentController?: boolean; // allow parent iframe to control editor

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -7,6 +7,7 @@ declare namespace pxt {
         target: string;
         pxt: string;
         pxtCrowdinBranch?: string;
+        targetCrowdinBranch?: string;
         tag?: string;
         branch?: string;
         commits?: string; // URL

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -152,7 +152,7 @@ namespace pxt.runner {
             true,
             cfg.commitCdnUrl, lang,
             versions ? versions.pxtCrowdinBranch : "",
-            versions ? versions.branch : "",
+            versions ? versions.targetCrowdinBranch : "",
             live)
             .then(() => {
                 mainPkg = new pxt.MainPackage(new Host());
@@ -297,7 +297,7 @@ namespace pxt.runner {
                 pxt.webConfig.commitCdnUrl,
                 editorLocale.replace(localeLiveRx, ''),
                 pxt.appTarget.versions.pxtCrowdinBranch,
-                pxt.appTarget.versions.branch,
+                pxt.appTarget.versions.targetCrowdinBranch,
                 localeLiveRx.test(editorLocale)
             );
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2276,7 +2276,7 @@ $(document).ready(() => {
                 config.commitCdnUrl,
                 useLang,
                 pxt.appTarget.versions.pxtCrowdinBranch,
-                pxt.appTarget.versions.branch,
+                pxt.appTarget.versions.targetCrowdinBranch,
                 live)
                 // Download sim translations and save them in the sim
                 .then(() => Util.downloadSimulatorLocalizationAsync(
@@ -2284,7 +2284,7 @@ $(document).ready(() => {
                     config.commitCdnUrl,
                     useLang,
                     pxt.appTarget.versions.pxtCrowdinBranch,
-                    pxt.appTarget.versions.branch,
+                    pxt.appTarget.versions.targetCrowdinBranch,
                     live
                 )).then((simStrings) => {
                     if (simStrings)


### PR DESCRIPTION
We are using the pxt branch information which does necessarily match crowdin. Pulling the correct branch info from the crowdinbranch field.
This impacts the Minecraft/Seeed editor, where target-strings.json is not being loaded.