### PR TITLE
Fix import button positioning

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -96,6 +96,10 @@
             padding-right: @carouselArrowSize !important;
         }
     }
+    .import-dialog-btn {
+        position: relative;
+        z-index: 1; /* Move up so it's above the carousel container that has an offset margin */
+    }
     /* Footer, Privary, Terms of Use */
     .homefooter {
         left: 0;


### PR DESCRIPTION
Fix import button position so that it's above the carousel container and can be clicked


Fixes https://github.com/Microsoft/pxt-adafruit/issues/501