### PR TITLE
Offline translation files

### DIFF
--- a/docfiles/editorcards.html
+++ b/docfiles/editorcards.html
@@ -145,23 +145,3 @@ aria-label="Code the Sparkfun SAMD21 board">
     <span class="ui button large">Code</span>
   </div>
 </a>
-<!--
-        <div class="ui card raised link" onclick="window.open('https://mini.pxt.io');">
-          <div class="targetlogo">
-            <img class="ui centered targetlogo image" src="/static/targets/calliope/Calliopeminieditor.svg" alt="Calliope logo"/>
-          </div>
-
-          <div class="image">
-            <div class="ui red right ribbon label"> Beta </div>
-            <img class="ui large bordered rounded image" src="/static/targets/calliope/calliope.simplified.svg" alt="Calliope Mini board"/>
-          </div>
-
-          <div class="ui inverted segment labelsegment">
-            <h3>Mini</h3>
-          </div>
-
-          <div class="ui inverted segment actionsegment">
-            <a class="ui button large" target="_blank" href="https://mini.pxt.io" aria=label="Code the Calliope Mini">Code</a>
-          </div>
-        </div>
-        -->

--- a/docfiles/labscards.html
+++ b/docfiles/labscards.html
@@ -62,23 +62,3 @@ aria-label="App editor">
   <span class="ui button large">Code</span>
 </div>
 </a>
-<!--
-        <div class="ui card raised link" onclick="window.open('https://mini.pxt.io');">
-          <div class="targetlogo">
-            <img class="ui centered targetlogo image" src="/static/targets/calliope/Calliopeminieditor.svg" alt="Calliope logo"/>
-          </div>
-
-          <div class="image">
-            <div class="ui red right ribbon label"> Beta </div>
-            <img class="ui large bordered rounded image" src="/static/targets/calliope/calliope.simplified.svg" alt="Calliope Mini board"/>
-          </div>
-
-          <div class="ui inverted segment labelsegment">
-            <h3>Mini</h3>
-          </div>
-
-          <div class="ui inverted segment actionsegment">
-            <a class="ui button large" target="_blank" href="https://mini.pxt.io" aria=label="Code the Calliope Mini">Code</a>
-          </div>
-        </div>
-        -->

--- a/docs/courses/cornellMPS2017.md
+++ b/docs/courses/cornellMPS2017.md
@@ -15,7 +15,7 @@ Example domains include:
 * Business workflow: encode business rules as a program; 
 * Formula designer: generate web apps to compute simple equations.
 
-The web site https://ar.pxt.io/ shows a MakeCode environment a graduate student created over the summer of 2017 to 
+The web site http://www.playfulcomputation.group/arcadia.html shows a MakeCode environment a graduate student created over the summer of 2017 to 
 allow programming of music-making applications based on augmented reality.  
 
 ## Activities necessary to achieve the project goal

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -1,7 +1,7 @@
 namespace pxt.Cloud {
     import Util = pxtc.Util;
 
-    export var apiRoot = "https://www.pxt.io/api/";
+    export var apiRoot = "https://makecode.com/api/";
     export var accessToken = "";
     export var localToken = "";
     let _isOnline = true;

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -360,15 +360,15 @@ namespace ts.pxtc.Util {
     // function on the leading edge, instead of the trailing.
     export function throttle(func: (...args: any[]) => any, wait: number, immediate?: boolean): any {
         let timeout: any;
-        return function() {
+        return function () {
             let context = this;
             let args = arguments;
-            let later = function() {
+            let later = function () {
                 timeout = null;
                 if (!immediate) func.apply(context, args);
             };
             let callNow = immediate && !timeout;
-            if (!timeout) timeout = setTimeout( later, wait );
+            if (!timeout) timeout = setTimeout(later, wait);
             if (callNow) func.apply(context, args);
         };
     }
@@ -830,7 +830,7 @@ namespace ts.pxtc.Util {
                             .filter(k => !!tr[k])
                             .forEach(k => translations[k] = tr[k])
                     }, e => {
-                        console.log(`failed to load localizations for file ${file}`);
+                        pxt.reportException(e, { "path": file.path, "branch": file.branch });
                         hadError = true;
                     });
             })
@@ -841,17 +841,18 @@ namespace ts.pxtc.Util {
                     }
                     return Promise.resolve(translations);
                 });
+        } else {
+            return Util.httpGetJsonAsync(baseUrl + "locales/" + code + "/strings.json")
+                .then(tr => {
+                    if (tr) {
+                        translations = tr;
+                        _translationsCache[translationsCacheId] = translations;
+                    }
+                }, e => {
+                    console.error('failed to load localizations')
+                })
+                .then(() => translations);
         }
-        return Util.httpGetJsonAsync(baseUrl + "locales/" + code + "/strings.json")
-            .then(tr => {
-                if (tr) {
-                    translations = tr;
-                    _translationsCache[translationsCacheId] = translations;
-                }
-            }, e => {
-                console.error('failed to load localizations')
-            })
-            .then(() => translations);
     }
 
     export function htmlEscape(_input: string) {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -775,10 +775,10 @@ namespace ts.pxtc.Util {
         // hitting the cloud
         function downloadFromCloudAsync() {
             // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
-            let url = `${pxt.Cloud.apiRoot}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
+            let url = `https://makecode.com/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
             if (branch) url += '&branch=' + encodeURIComponent(branch);
             const headers: pxt.Map<string> = {};
-            if (etag) headers["If-None-Matched"] = etag;
+            if (etag) headers["If-None-Match"] = etag;
             return requestAsync({ url, headers }).then(resp => {
                 // if 304, translation not changed, skipe
                 if (_translationDb && resp.statusCode == 304)
@@ -786,11 +786,11 @@ namespace ts.pxtc.Util {
                 else if (_translationDb && resp.statusCode == 200) {
                     // store etag and translations
                     etag = resp.headers["ETag"] || "";
-                    pxt.debug(`saving translations for ${lang}, ${filename}, ${branch || ""}, ${etag}`)
-                    _translationDb.setAsync(lang, filename, branch, etag, resp.json)
-                        .done();
+                    return _translationDb.setAsync(lang, filename, branch, etag, resp.json)
+                        .then(() => resp.json);
                 }
-                return resp.json
+
+                return resp.json;
             })
         }
 
@@ -880,7 +880,7 @@ namespace ts.pxtc.Util {
 
             const pAll = Promise.mapSeries(stringFiles, (file) => downloadLiveTranslationsAsync(code, file.path, file.branch)
                 .then(mergeTranslations, e => {
-                    pxt.reportException(e, { "path": file.path, "branch": file.branch });
+                    console.log(e.message);
                     hadError = true;
                 })
             );

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -782,7 +782,7 @@ namespace ts.pxtc.Util {
             else if (_translationCache && resp.statusCode == 200) {
                 // store etag and translations
                 pxt.debug(`saving translations for ${lang}/${filename}/${branch || ""}/${etag || ""}`)
-                _translationCache.setAsync(lang, filename, branch, resp.headers["ETag"], resp.json)
+                _translationCache.setAsync(lang, filename, branch, resp.headers["ETag"] || "", resp.json)
                     .done();
             }
             return resp.json

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -758,7 +758,7 @@ namespace ts.pxtc.Util {
 
     export function downloadLiveTranslationsAsync(lang: string, filename: string, branch?: string): Promise<pxt.Map<string>> {
         // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
-        let url = `https://www.pxt.io/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
+        let url = `${pxt.Cloud.apiRoot}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
         if (branch) url += '&branch=' + encodeURIComponent(branch);
         return Util.httpGetJsonAsync(url);
     }

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -720,6 +720,7 @@ namespace ts.pxtc.Util {
     }
 
     export interface ITranslationDbEntry {
+        id?: string;
         etag: string;
         strings: pxt.Map<string>;
         cached?: boolean; // cached in memory, no download needed

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -791,6 +791,9 @@ namespace ts.pxtc.Util {
                 }
 
                 return resp.json;
+            }, e => {
+                console.log(`failed to load translations from ${url}`)
+                return undefined;
             })
         }
 

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -731,8 +731,8 @@ namespace ts.pxtc.Util {
     }
 
     export interface ITranslationCache {
-        loadAsync(lang: string, filename: string, branch: string): Promise<ITranslationCacheEntry>;
-        saveAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void>;
+        getAsync(lang: string, filename: string, branch: string): Promise<ITranslationCacheEntry>;
+        setAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void>;
     }
 
     // wired up in the app to store translations in pouchdb

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -488,7 +488,7 @@ namespace ts.pxtc.Util {
     export function requestAsync(options: HttpRequestOptions): Promise<HttpResponse> {
         return httpRequestCoreAsync(options)
             .then(resp => {
-                if (resp.statusCode != 200 && !options.allowHttpErrors) {
+                if ((resp.statusCode != 200 && resp.statusCode != 304) && !options.allowHttpErrors) {
                     let msg = Util.lf("Bad HTTP status code: {0} at {1}; message: {2}",
                         resp.statusCode, options.url, (resp.text || "").slice(0, 500))
                     let err: any = new Error(msg)
@@ -774,14 +774,14 @@ namespace ts.pxtc.Util {
         let url = `${pxt.Cloud.apiRoot}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
         if (branch) url += '&branch=' + encodeURIComponent(branch);
         const headers: pxt.Map<string> = {};
-        if (etag) headers["If-Not-Matched"] = etag;
+        if (etag) headers["If-None-Matched"] = etag;
         return requestAsync({ url, headers }).then(resp => {
             // if 304, translation not changed, skipe
             if (_translationCache && resp.statusCode == 304)
                 return undefined;
-            else if (_translationCache && resp.statusCode == 200 && resp.headers["ETag"]) {
+            else if (_translationCache && resp.statusCode == 200) {
                 // store etag and translations
-                pxt.debug(`saving translations for ${lang}/${filename}/${branch}/${etag}`)
+                pxt.debug(`saving translations for ${lang}/${filename}/${branch || ""}/${etag || ""}`)
                 _translationCache.setAsync(lang, filename, branch, resp.headers["ETag"], resp.json)
                     .done();
             }
@@ -1149,7 +1149,7 @@ namespace ts.pxtc.BrowserImpl {
         })
     }
 
-    let sha256_k = new Uint32Array([
+    const sha256_k = new Uint32Array([
         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
         0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
         0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -728,6 +728,7 @@ namespace ts.pxtc.Util {
     export interface ITranslationCacheEntry {
         etag: string;
         strings: pxt.Map<string>;
+        _rev?: string;
     }
 
     export interface ITranslationCache {
@@ -770,6 +771,7 @@ namespace ts.pxtc.Util {
     }
 
     export function downloadLiveTranslationsAsync(lang: string, filename: string, branch?: string, etag?: string): Promise<pxt.Map<string>> {
+        let _rev: string = undefined;
         function downloadFromCloudAsync() {
             // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
             let url = `${pxt.Cloud.apiRoot}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
@@ -784,7 +786,7 @@ namespace ts.pxtc.Util {
                     // store etag and translations
                     etag = resp.headers["ETag"] || "";
                     pxt.debug(`saving translations for ${lang}, ${filename}, ${branch || ""}, ${etag}`)
-                    _translationCache.setAsync(lang, filename, branch, etag, resp.json)
+                    _translationCache.setAsync(lang, filename, branch, etag, _rev, resp.json)
                         .done();
                 }
                 return resp.json
@@ -797,6 +799,7 @@ namespace ts.pxtc.Util {
                 // if cached, return immediately
                 if (entry) {
                     etag = entry.etag;
+                    _rev = entry._rev;
                     // background update
                     downloadFromCloudAsync().done();
                     return entry.strings;

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -119,13 +119,13 @@ class TranslationDb implements ts.pxtc.Util.ITranslationDb {
     }
     setAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void> {
         const id = this.key(lang, filename, branch);
-        const entry = {
+        const entry: ts.pxtc.Util.ITranslationDbEntry = {
             id,
             etag,
             strings
         };
         pxt.debug(`translation cache: save ${id}-${etag}`)
-        return this.table.forceSetAsync(entry).then(() => { 
+        return this.table.forceSetAsync(entry).then(() => {
             entry.cached = true;
             this.memCache[id] = entry;
         });

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -115,7 +115,7 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
             strings
         };
         pxt.debug(`translation cache: save ${id}-${etag}`)
-        return this.table.setAsync(entry).then(() => { });
+        return this.table.forceSetAsync(entry).then(() => { });
     }
 
 }

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -125,9 +125,12 @@ class TranslationDb implements ts.pxtc.Util.ITranslationDb {
             strings
         };
         pxt.debug(`translation cache: save ${id}-${etag}`)
-        return this.table.forceSetAsync(entry).then(() => {
-            entry.cached = true;
-            this.memCache[id] = entry;
+        const mem = pxt.Util.clone(entry);
+        mem.cached = true;
+        delete (<any>mem)._rev;
+        this.memCache[id] = mem;
+        return this.table.forceSetAsync(entry).then(() => {}, e => {
+            pxt.log(`translate cache: conflict for ${id}`);
         });
     }
 

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -93,7 +93,7 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
         return `${lang}|${filename}|${branch || ""}`;
     }
 
-    loadAsync(lang: string, filename: string, branch?: string): Promise<ts.pxtc.Util.ITranslationCacheEntry> {
+    getAsync(lang: string, filename: string, branch?: string): Promise<ts.pxtc.Util.ITranslationCacheEntry> {
         const id = this.key(lang, filename, branch);
         pxt.debug(`translation cache: load ${id}`)
         return this.table.getAsync(id).then(
@@ -107,7 +107,7 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
             } // not found
         );
     }
-    saveAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void> {
+    setAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void> {
         const id = this.key(lang, filename, branch);
         const entry = {
             id,

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -90,7 +90,7 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
     }
 
     private key(lang: string, filename: string, branch: string) {
-        return `${lang}|${filename}|${branch || ""}`;
+        return `${lang}-${filename}-${branch || ""}`;
     }
 
     getAsync(lang: string, filename: string, branch?: string): Promise<ts.pxtc.Util.ITranslationCacheEntry> {
@@ -107,12 +107,13 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
             } // not found
         );
     }
-    setAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void> {
+    setAsync(lang: string, filename: string, branch: string, etag: string, rev: string, strings: pxt.Map<string>): Promise<void> {
         const id = this.key(lang, filename, branch);
         const entry = {
             id,
             etag,
-            strings
+            strings,
+            _rev: rev
         };
         pxt.debug(`translation cache: save ${id}-${etag}`)
         return this.table.forceSetAsync(entry).then(() => { });

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -103,7 +103,7 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
             },
             e => {
                 pxt.debug(`translation cache miss ${id}`);
-                return { etag: undefined, strings: undefined };
+                return undefined;
             } // not found
         );
     }

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -83,8 +83,9 @@ export class Table {
     }
 }
 
-export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
+class TranslationDb implements ts.pxtc.Util.ITranslationDb {
     table: Table;
+
     constructor() {
         this.table = new Table("translations");
     }
@@ -93,13 +94,13 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
         return `${lang}-${filename}-${branch || ""}`;
     }
 
-    getAsync(lang: string, filename: string, branch?: string): Promise<ts.pxtc.Util.ITranslationCacheEntry> {
+    getAsync(lang: string, filename: string, branch?: string): Promise<ts.pxtc.Util.ITranslationDbEntry> {
         const id = this.key(lang, filename, branch);
         pxt.debug(`translation cache: load ${id}`)
         return this.table.getAsync(id).then(
             v => {
                 pxt.debug(`translation cache hit ${id}`);
-                return { etag: v.etag, strings: v.strings };
+                return v;
             },
             e => {
                 pxt.debug(`translation cache miss ${id}`);
@@ -121,4 +122,4 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
 
 }
 
-ts.pxtc.Util._translationCache = new TranslationCache();
+ts.pxtc.Util._translationDb = new TranslationDb();

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -120,4 +120,4 @@ export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
 
 }
 
-ts.pxtc.Util.translationCache = new TranslationCache();
+ts.pxtc.Util._translationCache = new TranslationCache();

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -82,3 +82,31 @@ export class Table {
         return getDbAsync().then(db => db.put(obj)).then((resp: any) => resp.rev)
     }
 }
+
+export class TranslationCache implements ts.pxtc.Util.ITranslationCache {
+    table: Table;
+    constructor() {
+        this.table = new Table("translations");
+    }
+
+    private key(lang: string, filename: string, branch: string) {
+        return `${lang}|${filename}|${branch}`;
+    }
+
+    loadAsync(lang: string, filename: string, branch?: string): Promise<ts.pxtc.Util.ITranslationCacheEntry> {
+        const id = this.key(lang, filename, branch);
+        return this.table.getAsync(id).then(v => { return { etag: v.etag, strings: v.strings }; });
+    }
+    saveAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void> {
+        const id = this.key(lang, filename, branch);
+        const entry = {
+            id,
+            etag,
+            strings
+        };
+        return this.table.setAsync(entry).then(() => {});
+    }
+
+}
+
+ts.pxtc.Util.translationCache = new TranslationCache();


### PR DESCRIPTION
This change provides offline storage for localization files.

- [x] cleanup "pxt.io" -> "makecode.com"
- [x] store download translations in pouchdb (along with ETag)
- [x] use If-None-Match when requesting translations, lazy background update
- [x] handling offline misses gracefully
- [x] in-memory caching to avoid multiple refresh during the same browser session
