### PR TITLE
performance improvements in Thumb code generator

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -302,6 +302,7 @@ declare namespace ts.pxtc {
         hidSelectors?: HidSelector[];
         emptyEventHandlerComments?: boolean; // true adds a comment for empty event handlers
         vmOpCodes?: pxt.Map<number>;
+        commonalize?: boolean;
     }
 
     interface CompileOptions {

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -324,8 +324,8 @@ ${baseLabel}:
                     this.emitExpr(jmp.expr)
 
                     // TODO: remove ARM-specific code
-                    if (jmp.expr.exprKind == ir.EK.RuntimeCall && 
-                            (jmp.expr.data === "thumb::subs" || U.startsWith(jmp.expr.data, "_cmp_"))) {
+                    if (jmp.expr.exprKind == ir.EK.RuntimeCall &&
+                        (jmp.expr.data === "thumb::subs" || U.startsWith(jmp.expr.data, "_cmp_"))) {
                         // no cmp required
                     } else {
                         this.write(this.t.cmp_zero("r0"))

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -324,7 +324,8 @@ ${baseLabel}:
                     this.emitExpr(jmp.expr)
 
                     // TODO: remove ARM-specific code
-                    if (jmp.expr.exprKind == ir.EK.RuntimeCall && jmp.expr.data === "thumb::subs") {
+                    if (jmp.expr.exprKind == ir.EK.RuntimeCall && 
+                            (jmp.expr.data === "thumb::subs" || U.startsWith(jmp.expr.data, "_cmp_"))) {
                         // no cmp required
                     } else {
                         this.write(this.t.cmp_zero("r0"))

--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -10,11 +10,13 @@ namespace ts.pxtc {
         "numops::ands": "_numops_ands",
         "pxt::toInt": "_numops_toInt",
         "pxt::fromInt": "_numops_fromInt",
+        "pxt::incr": "_pxt_incr",
+        "pxt::decr": "_pxt_decr",
     }
 
     // snippets for ARM Thumb assembly
     export class ThumbSnippets extends AssemblerSnippets {
-        hasCommonalize() { return true }
+        hasCommonalize() { return !!target.commonalize }
         stackAligned() {
             return target.stackAlign && target.stackAlign > 1
         }
@@ -235,6 +237,22 @@ _numops_fromInt:
     bl pxt::fromInt
     ${this.popPC()}
 `
+
+            for (let op of ["incr", "decr"]) {
+                r += `
+_pxt_${op}:
+    @scope _pxt_${op}
+    lsls r3, r0, #30
+    bne .skip
+    cmp r0, #0
+    beq .skip
+    ${this.pushLR()}
+    bl pxt::${op}
+    ${this.popPC()}
+.skip:
+    bx lr
+`
+            }
 
             return r
         }

--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -218,9 +218,16 @@ _numops_${op}:
 
                 r += `
 .boxed:
-    ${this.pushLR()}
+    push {r4, lr}
+    push {r0, r1}
     bl numops::${op}
-    ${this.popPC()}
+    movs r4, r0
+    pop {r0}
+    bl _pxt_decr
+    pop {r0}
+    bl _pxt_decr
+    movs r0, r4
+    pop {r4, pc}
 `
             }
 

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2851,6 +2851,16 @@ ${lbl}: .short 0xffff
                         return "Number_::neq";
                 }
             }
+            
+            if (opts.target.taggedInts && isThumb()) {
+                switch (n) {
+                    case "numops::adds":
+                    case "numops::subs":
+                    case "numops::eors":
+                    case "numops::ands":
+                        return "@nomask@" + n
+                }
+            }
 
             return n
         }

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1500,7 +1500,10 @@ ${lbl}: .short 0xffff
         function isConstLiteral(decl: Declaration) {
             if (isGlobalVar(decl)) {
                 if (decl.parent.flags & NodeFlags.Const) {
-                    return !isSideEffectfulInitializer((decl as VariableDeclaration).initializer)
+                    let init = (decl as VariableDeclaration).initializer
+                    if (!init) return false
+                    if (init.kind == SK.ArrayLiteralExpression) return false
+                    return !isSideEffectfulInitializer(init)
                 }
             }
             return false

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -745,6 +745,10 @@ namespace ts.pxtc.ir {
 
     export function rtcallMask(name: string, mask: number, callingConv: CallingConvention, args: Expr[]) {
         let decrs: ir.Expr[] = []
+        if (U.startsWith(name, "@nomask@")) {
+            name = name.slice(8)
+            mask = 0
+        }
         if (isStackMachine())
             name += "^" + mask
         else

--- a/pxtcompiler/emitter/thumb.ts
+++ b/pxtcompiler/emitter/thumb.ts
@@ -240,6 +240,9 @@ namespace ts.pxtc.thumb {
                             return true
                         case "bl":
                             switch (l.words[1]) {
+                                case "_numops_fromInt":
+                                case "_pxt_incr":
+                                case "_pxt_decr":
                                 case "pxt::incr":
                                 case "pxt::decr":
                                 case "pxt::fromInt":

--- a/pxtcompiler/emitter/thumb.ts
+++ b/pxtcompiler/emitter/thumb.ts
@@ -16,7 +16,7 @@
 
 namespace ts.pxtc.thumb {
 
-export class ThumbProcessor extends pxtc.assembler.AbstractProcessor {
+    export class ThumbProcessor extends pxtc.assembler.AbstractProcessor {
 
         constructor() {
             super();
@@ -222,6 +222,8 @@ export class ThumbProcessor extends pxtc.assembler.AbstractProcessor {
         }
 
         public commonalize(file: assembler.File): void {
+            if (!target.commonalize)
+                return
             // this is a heuristic - we could allow more instructions
             // to be shared, but it seems to result in less sharing
             let canBeShared = (l: assembler.Line) => {


### PR DESCRIPTION
It improves perf by about 2.5x.

This also disables commonalize pass by default - it shrinks code by 25% but causes 25% speed overhead - we're not short of space on any ARM targets using that right now, so let's disable by default.

