### PR TITLE
Fix undefined pxsim.noRefCounting.

### DIFF
--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -14,6 +14,10 @@ namespace pxsim {
     let cfgKey: Map<number> = {}
     let cfg: Map<number> = {}
 
+    export function noRefCounting() {
+        if (runtime) runtime.refCounting = false;
+    }
+
     export function getConfig(id: number) {
         if (cfg.hasOwnProperty(id + ""))
             return cfg[id + ""]


### PR DESCRIPTION
Fix undefined pxsim.noRefCounting by adding it back using the new runtime.refCounting to indicate when the refCounting is off.

Issue: https://github.com/Microsoft/pxt/pull/3401#issuecomment-345413821

Verified this fix resolves the error introduced in the SIM.