### PR TITLE
Support for targetconfig in packaged editors

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1814,7 +1814,6 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                 pxtCrowdinBranch: pxtCrowdinBranch(),
                 targetCrowdinBranch: targetCrowdinBranch()
             }
-            cfg.packaged = !!options.packaged;
             saveThemeJson(cfg)
 
             const webmanifest = buildWebManifest(cfg)

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1266,7 +1266,7 @@ export interface BuildTargetOptions {
 
 export function buildTargetAsync(options: BuildTargetOptions = {}): Promise<void> {
     if (pxt.appTarget.id == "core")
-        return buildTargetCoreAsync()
+        return buildTargetCoreAsync(options)
 
     let initPromise: Promise<void>;
 
@@ -3733,7 +3733,7 @@ export function staticpkgAsync(parsed: commandParser.ParsedCommand) {
 
     let p = rimrafAsync(builtPackaged, {})
         .then(() => bump ? bumpAsync() : Promise.resolve())
-        .then(() => buildTargetAsync());
+        .then(() => buildTargetAsync({ packaged: true}));
     if (ghpages) return p.then(() => ghpPushAsync(builtPackaged, minify));
     else return p.then(() => internalStaticPkgAsync(builtPackaged, route, minify));
 }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1260,7 +1260,11 @@ function maxMTimeAsync(dirs: string[]) {
         .then(() => max)
 }
 
-export function buildTargetAsync(): Promise<void> {
+export interface BuildTargetOptions {
+    packaged?: boolean;
+}
+
+export function buildTargetAsync(options: BuildTargetOptions = {}): Promise<void> {
     if (pxt.appTarget.id == "core")
         return buildTargetCoreAsync()
 
@@ -1283,7 +1287,7 @@ export function buildTargetAsync(): Promise<void> {
     return initPromise
         .then(() => { copyCommonSim(); return simshimAsync() })
         .then(() => buildFolderAsync('sim', true, pxt.appTarget.id === 'common' ? 'common-sim' : 'sim'))
-        .then(buildTargetCoreAsync)
+        .then(() => buildTargetCoreAsync(options))
         .then(() => buildFolderAsync('cmds', true))
         .then(() => buildSemanticUIAsync())
         .then(() => {
@@ -1732,7 +1736,7 @@ function updateTOC(cfg: pxt.TargetBundle) {
     }
 }
 
-function buildTargetCoreAsync() {
+function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
     let cfg = readLocalPxTarget()
     updateDefaultProjects(cfg);
     updateTOC(cfg);
@@ -1811,6 +1815,7 @@ function buildTargetCoreAsync() {
                 targetCrowdinBranch: targetCrowdinBranch()
             }
             cfg.config = fs.existsSync("targetconfig.json") ? readJson("targetconfig.json") : {};
+            cfg.packaged = !!options.packaged;
             saveThemeJson(cfg)
 
             const webmanifest = buildWebManifest(cfg)
@@ -3095,7 +3100,7 @@ function testDirAsync(parsed: commandParser.ParsedCommand) {
                 .then(testAsync)
                 .then(() => {
                     if (pxt.appTarget.compile.hasHex)
-                        fs.writeFileSync(hexPath, fs.readFileSync(`built/binary.${pxt.appTarget.compile.useUF2 ? "uf2" : "hex" }`))
+                        fs.writeFileSync(hexPath, fs.readFileSync(`built/binary.${pxt.appTarget.compile.useUF2 ? "uf2" : "hex"}`))
                 })
         } else {
             let start = Date.now()

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1781,20 +1781,20 @@ function buildTargetCoreAsync() {
                     // For the projects, we need to save the base HEX file to the offline HEX cache
                     if (isPrj && pxt.appTarget.compile.hasHex) {
                         if (!compileOpts) {
-                            console.error(`Failed to extract HEX image for project ${dirname}`);
+                            console.error(`Failed to extract native image for project ${dirname}`);
                             return;
                         }
 
                         // Place the base HEX image in the hex cache if necessary
                         let sha = compileOpts.extinfo.sha;
                         let hex: string[] = compileOpts.hexinfo.hex;
-                        let hexFile = path.join(hexCachePath, sha + ".hex");
+                        let hexFile = path.join(hexCachePath, sha + pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex");
 
                         if (fs.existsSync(hexFile)) {
-                            pxt.debug(`.hex image already in offline cache for project ${dirname}`);
+                            pxt.debug(`native image already in offline cache for project ${dirname}`);
                         } else {
                             fs.writeFileSync(hexFile, hex.join(os.EOL));
-                            pxt.debug(`created .hex image in offline cache for project ${dirname}: ${hexFile}`);
+                            pxt.debug(`created native image in offline cache for project ${dirname}: ${hexFile}`);
                         }
                     }
                 })
@@ -3095,7 +3095,7 @@ function testDirAsync(parsed: commandParser.ParsedCommand) {
                 .then(testAsync)
                 .then(() => {
                     if (pxt.appTarget.compile.hasHex)
-                        fs.writeFileSync(hexPath, fs.readFileSync("built/binary.hex"))
+                        fs.writeFileSync(hexPath, fs.readFileSync(`built/binary.${pxt.appTarget.compile.useUF2 ? "uf2" : "hex" }`))
                 })
         } else {
             let start = Date.now()

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1810,7 +1810,7 @@ function buildTargetCoreAsync() {
                 pxtCrowdinBranch: pxtCrowdinBranch(),
                 targetCrowdinBranch: targetCrowdinBranch()
             }
-
+            cfg.config = fs.existsSync("targetconfig.json") ? readJson("targetconfig.json") : {};
             saveThemeJson(cfg)
 
             const webmanifest = buildWebManifest(cfg)

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1814,7 +1814,6 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                 pxtCrowdinBranch: pxtCrowdinBranch(),
                 targetCrowdinBranch: targetCrowdinBranch()
             }
-            cfg.config = fs.existsSync("targetconfig.json") ? readJson("targetconfig.json") : {};
             cfg.packaged = !!options.packaged;
             saveThemeJson(cfg)
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -40,6 +40,7 @@ declare namespace pxt {
         appTheme: AppTheme;
         compileService?: TargetCompileService;
         analytics?: AppAnalytics;
+        config?: TargetConfig; // targetconfig when compiled (used for packaged targets)
     }
 
     interface ProjectTemplate {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -28,7 +28,6 @@ declare namespace pxt {
         nickname?: string; // friendly id used when generating files, folders, etc... id is used instead if missing
         name: string;
         description?: string;
-        packaged?: boolean; // no support for cloud backend
         corepkg: string;
         title?: string;
         cloud?: AppCloud;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -41,7 +41,6 @@ declare namespace pxt {
         appTheme: AppTheme;
         compileService?: TargetCompileService;
         analytics?: AppAnalytics;
-        config?: TargetConfig; // targetconfig when compiled (used for packaged targets)
     }
 
     interface ProjectTemplate {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -28,6 +28,7 @@ declare namespace pxt {
         nickname?: string; // friendly id used when generating files, folders, etc... id is used instead if missing
         name: string;
         description?: string;
+        packaged?: boolean; // no support for cloud backend
         corepkg: string;
         title?: string;
         cloud?: AppCloud;

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -58,6 +58,9 @@ namespace pxt.Cloud {
     }
 
     export function downloadTargetConfigAsync(): Promise<pxt.TargetConfig> {
+        if (pxt.appTarget.packaged) // packaged, no backend
+            return Promise.resolve(pxt.appTarget.config || {});
+
         if (!Cloud.isOnline()) // offline
             return Promise.resolve(undefined);
 

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -26,7 +26,7 @@ namespace pxt.Cloud {
     }
 
     export function privateRequestAsync(options: Util.HttpRequestOptions) {
-        options.url = apiRoot + options.url
+        options.url = pxt.appTarget.packaged ? pxt.webConfig.relprefix + options.url : apiRoot + options.url;
         options.allowGzipPost = true
         if (!Cloud.isOnline()) {
             return offlineError(options.url);
@@ -58,13 +58,10 @@ namespace pxt.Cloud {
     }
 
     export function downloadTargetConfigAsync(): Promise<pxt.TargetConfig> {
-        if (pxt.appTarget.packaged) // packaged, no backend
-            return Promise.resolve(pxt.appTarget.config || {});
-
         if (!Cloud.isOnline()) // offline
             return Promise.resolve(undefined);
 
-        const url = `config/${pxt.appTarget.id}/targetconfig`;
+        const url = pxt.appTarget.packaged ? `targetconfig.json` : `config/${pxt.appTarget.id}/targetconfig`;
         if (Cloud.isLocalHost())
             return Util.requestAsync({
                 url: "/api/" + url,
@@ -83,9 +80,11 @@ namespace pxt.Cloud {
     }
 
     export function downloadMarkdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
-        docid = docid.replace(/^\//, "");
-        let url = `md/${pxt.appTarget.id}/${docid}?targetVersion=${encodeURIComponent(pxt.webConfig.targetVersion)}`;
-        if (locale != "en") {
+        const packaged = pxt.appTarget.packaged;
+        let url = packaged
+            ? `docs/${docid}.md`
+            : `md/${pxt.appTarget.id}/${docid.replace(/^\//, "")}?targetVersion=${encodeURIComponent(pxt.webConfig.targetVersion)}`;
+        if (!packaged && locale != "en") {
             url += `&lang=${encodeURIComponent(Util.userLanguage())}`
             if (live) url += "&live=1"
         }

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -26,7 +26,7 @@ namespace pxt.Cloud {
     }
 
     export function privateRequestAsync(options: Util.HttpRequestOptions) {
-        options.url = pxt.appTarget.packaged ? pxt.webConfig.relprefix + options.url : apiRoot + options.url;
+        options.url = pxt.webConfig.isStatic ? pxt.webConfig.relprefix + options.url : apiRoot + options.url;
         options.allowGzipPost = true
         if (!Cloud.isOnline()) {
             return offlineError(options.url);
@@ -61,7 +61,7 @@ namespace pxt.Cloud {
         if (!Cloud.isOnline()) // offline
             return Promise.resolve(undefined);
 
-        const url = pxt.appTarget.packaged ? `targetconfig.json` : `config/${pxt.appTarget.id}/targetconfig`;
+        const url = pxt.webConfig.isStatic ? `targetconfig.json` : `config/${pxt.appTarget.id}/targetconfig`;
         if (Cloud.isLocalHost())
             return Util.requestAsync({
                 url: "/api/" + url,
@@ -80,7 +80,7 @@ namespace pxt.Cloud {
     }
 
     export function downloadMarkdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
-        const packaged = pxt.appTarget.packaged;
+        const packaged = !!pxt.webConfig.isStatic;
         let url = packaged
             ? `docs/${docid}.md`
             : `md/${pxt.appTarget.id}/${docid.replace(/^\//, "")}?targetVersion=${encodeURIComponent(pxt.webConfig.targetVersion)}`;


### PR DESCRIPTION
When an editor is packaged, load targetconfig from local path