### PR TITLE
Correct the localization for Taiwan

### DIFF
--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -48,7 +48,7 @@ const allLanguages: pxt.Map<Language> = {
     "uk": { englishName: "Ukrainian", localizedName: "Українська" },
     "vi": { englishName: "Vietnamese", localizedName: "Tiếng việt" },
     "zh-CN": { englishName: "Chinese (Simplified, China)", localizedName: "简体中文 (中国)" },
-    "zh-TW": { englishName: "Chinese (Traditional, Taiwan)", localizedName: "中文 (台湾)" },
+    "zh-TW": { englishName: "Chinese (Traditional, Taiwan)", localizedName: "正體中文 (臺灣)" },
 };
 const pxtLangCookieId = "PXT_LANG";
 const langCookieExpirationDays = 30;


### PR DESCRIPTION
The English word「Taiwan」in Chinese (Traditional, Taiwan) should be 臺灣 instead of 台湾 since 台湾 is the word in Chinese (Simplified, China).And when talking about localization we will use 正體中文 instead of just 中文.