### PR TITLE
Workaround to fix parseerror in SVG xml when rendering blocks [Safari]

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -143,9 +143,11 @@ namespace pxt.blocks.layout {
         sg.removeAttribute("height");
         sg.removeAttribute("transform");
 
+        let xmlString = new XMLSerializer().serializeToString(sg);
+        xmlString = xmlString.replace('&nbsp;', '&#160;'); // Replace &nbsp; with &#160; as a workaround for having nbsp missing from SVG xml 
         const xsg = new DOMParser().parseFromString(
             `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="${XLINK_NAMESPACE}" width="${width}" height="${height}" viewBox="${x} ${y} ${width} ${height}">
-            ${new XMLSerializer().serializeToString(sg)}
+            ${xmlString}
             </svg>`, "image/svg+xml");
         const cssLink = xsg.createElementNS("http://www.w3.org/1999/xhtml", "style");
         const customCssHref = (document.getElementById("blocklycss") as HTMLLinkElement).href;


### PR DESCRIPTION
When rendering blockly SVG to an image, we first parse the XML generated by blockly. The on-start block and any blocks that contain a space in their name will have &nbsp; in the text content. This is valid HTML but in the XML SVG standard. 

A workaround for this as outlined in this chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=340794
is to do a string replace for &nbsp; and convert it to &#160; 

In all our rendered images we always had a parseerror section in the XML including in Chrome, but Chrome / Firefox just recovered better and ignored the parseerror section, whereas Safari didn't.
```
<parsererror style="display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black"><h3>This page contains the following errors:</h3><div style="font-family:monospace;font-size:12px">error on line 3 at column 4189: Entity 'nbsp' not defined
</div><h3>Below is a rendering of the page up to the first error.</h3></parsererror
```

As a product of this: 
- the editor controller renderblocks renders correctly in Safari
- sharing embed SVG works in Safari (when there is an on start block)

Tested on: 
- Chrome Mac, 
- Safari

Note: needs cherry picking to master