### PR TITLE
Localizable CSV output separator

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -40,6 +40,16 @@ html, body {
     right: 0;
 }
 
+.no-select {
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none;   /* Chrome/Safari/Opera */
+    -khtml-user-select: none;    /* Konqueror */
+    -moz-user-select: none;      /* Firefox */
+    -ms-user-select: none;       /* Internet Explorer/Edge */
+    user-select: none;           /* Non-prefixed version, currently
+                                    not supported by any browser */
+}
+
 /* Main Editor layout */
 #maineditor {
     left: @simulatorWidth;

--- a/theme/serial.less
+++ b/theme/serial.less
@@ -162,3 +162,13 @@
     .ui.button.editorBack:focus {
     color: @editorCloseColorHover;
 }
+
+div.smoothie-chart-tooltip {
+    background: #444;
+    padding: 1em;
+    margin-top: 20px;
+    font-family: consolas;
+    color: white;
+    font-size: 0.8rem;
+    pointer-events: none;
+}

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -98,7 +98,7 @@ export class Editor extends srceditor.Editor {
         const source = smsg.id || "?"
 
         if (!this.sourceMap[source]) {
-        let sourceIdx = Object.keys(this.sourceMap).length + 1
+            let sourceIdx = Object.keys(this.sourceMap).length + 1
             this.sourceMap[source] = lf("source") + sourceIdx.toString()
         }
         let niceSource = this.sourceMap[source]
@@ -304,8 +304,8 @@ export class StartPauseButton extends data.Component<StartPauseButtonProps, Star
     }
 
     renderCore() {
-        const {toggle} = this.props;
-        const {active} = this.state;
+        const { toggle } = this.props;
+        const { active } = this.state;
 
         return <sui.Button title={active ? lf("Pause recording") : lf("Start recording")} class={`ui left floated icon button ${active ? "green" : "red circular"} toggleRecord`} onClick={toggle}>
             <sui.Icon icon={active ? "pause icon" : "circle icon"} />
@@ -332,13 +332,16 @@ class Chart {
         const chartConfig: IChartOptions = {
             interpolation: 'bezier',
             labels: {
-                disabled: true
+                disabled: false,
+                fillStyle: 'black',
+                fontSize: 14
             },
             responsive: true,
             millisPerPixel: 20,
             grid: {
                 verticalSections: 0,
                 borderVisible: false,
+                millisPerLine: 5000,
                 fillStyle: serialTheme && serialTheme.gridFillStyle || 'transparent',
                 strokeStyle: serialTheme && serialTheme.gridStrokeStyle || '#fff'
             },
@@ -357,7 +360,10 @@ class Chart {
     }
 
     tooltip(timestamp: number, data: { series: TimeSeries, index: number, value: number }[]): string {
-        return data.map(n => `<span>${(n.series as any).timeSeries.__name}: ${n.value}</span>`).join('<br/>');
+        return data.map(n => {
+            const name = (n.series as any).timeSeries.__name;
+            return `<span>${name ? name + ': ' : ''}${n.value}</span>`;
+        }).join('<br/>');
     }
 
     getLine(name: string): TimeSeries {
@@ -376,7 +382,7 @@ class Chart {
 
     makeLabel() {
         this.label = document.createElement("div")
-        this.label.className = "ui orange bottom left attached label seriallabel"
+        this.label.className = "ui orange bottom left attached no-select label seriallabel"
         this.label.innerText = this.variable || "...";
         return this.label;
     }

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -235,7 +235,7 @@ export class Editor extends srceditor.Editor {
     }
 
     downloadCSV() {
-        const sep = lf("{id:csvseparator},");
+        const sep = lf("{id:csvseparator}\t");
         const lines: { name: string; line: TimeSeries; }[] = [];
         this.charts.forEach(chart => Object.keys(chart.lines).forEach(k => lines.push({ name: `${k} (${chart.source})`, line: chart.lines[k] })));
         let csv = lines.map(line => `time (s)${sep} ${line.name}`).join(sep + ' ') + '\r\n';

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -235,15 +235,16 @@ export class Editor extends srceditor.Editor {
     }
 
     downloadCSV() {
+        const sep = lf("{id:csvseparator},");
         const lines: { name: string; line: TimeSeries; }[] = [];
         this.charts.forEach(chart => Object.keys(chart.lines).forEach(k => lines.push({ name: `${k} (${chart.source})`, line: chart.lines[k] })));
-        let csv = lines.map(line => `time (s), ${line.name}`).join(', ') + '\r\n';
+        let csv = lines.map(line => `time (s)${sep} ${line.name}`).join(sep + ' ') + '\r\n';
 
         const datas = lines.map(line => line.line.data);
         const nl = datas.map(data => data.length).reduce((l, c) => Math.max(l, c));
         const nc = this.charts.length;
         for (let i = 0; i < nl; ++i) {
-            csv += datas.map(data => i < data.length ? `${(data[i][0] - data[0][0]) / 1000}, ${data[i][1]}` : ' , ').join(', ');
+            csv += datas.map(data => i < data.length ? `${(data[i][0] - data[0][0]) / 1000}, ${data[i][1]}` : ` ${sep} `).join(sep + ' ');
             csv += '\r\n';
         }
 

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -248,7 +248,7 @@ export class Editor extends srceditor.Editor {
             csv += '\r\n';
         }
 
-        pxt.commands.browserDownloadAsync(csv, "data.csv", "text/csv")
+        pxt.commands.browserDownloadAsync(csv, lf("{id:csvfilename}data") + ".csv", "text/csv")
         core.infoNotification(lf("Exporting data...."));
     }
 


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt/issues/3619.

- separator is localizable string
- using tab instead of , (tested in Excel)

(+ integrating style fixes for serial from master)
