### PR TITLE
Fix switch ref-counting in native integer targets

### DIFF
--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -296,6 +296,10 @@ namespace pxsim {
         export function toFloat(v: number) { return v }
 
         export function ignore(v: any) { return v; }
+
+        export function ptreqDecr(a: any, b: any) {
+            return Number_.eqDecr(a, b)
+        }
     }
 
     export namespace pxtcore {

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -231,6 +231,14 @@ namespace pxsim {
         export function le(x: number, y: number) { return x <= y; }
         export function neq(x: number, y: number) { return !eq(x, y); }
         export function eq(x: number, y: number) { return pxtrt.nullFix(x) == pxtrt.nullFix(y); }
+        export function eqDecr(x: number, y: number) {
+            if (pxtrt.nullFix(x) == pxtrt.nullFix(y)) {
+                decr(y);
+                return true;
+            } else {
+                return false
+            }
+        }
         export function gt(x: number, y: number) { return x > y; }
         export function ge(x: number, y: number) { return x >= y; }
         export function div(x: number, y: number) { return Math.floor(x / y) | 0; }
@@ -301,6 +309,15 @@ namespace pxsim {
 
         export function compare(s1: string, s2: string) {
             if (s1 == s2) return 0;
+            if (s1 < s2) return -1;
+            return 1;
+        }
+
+        export function compareDecr(s1: string, s2: string) {
+            if (s1 == s2) {
+                decr(s2)
+                return 0;
+            }
             if (s1 < s2) return -1;
             return 1;
         }


### PR DESCRIPTION
This is a forward port of #3623 - it doesn't affect SAMD21, and should not affect pure JS targets. It should affect AVR and LTC.