### PR TITLE
Fixing our rimraf usage

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -25,7 +25,7 @@ import * as gdb from './gdb';
 import * as clidbg from './clidbg';
 import * as pyconv from './pyconv';
 
-const rimraf: (f: string, opts: any, cb: () => void) => void = require('rimraf');
+const rimraf: (f: string, opts: any, cb: (err: any, res: any) => void) => void = require('rimraf');
 
 let forceCloudBuild = process.env["KS_FORCE_CLOUD"] === "yes"
 let forceLocalBuild = process.env["PXT_FORCE_LOCAL"] === "yes"
@@ -3800,7 +3800,7 @@ export function staticpkgAsync(parsed: commandParser.ParsedCommand) {
 
     pxt.log(`packaging editor to ${builtPackaged}`)
 
-    let p = rimrafAsync(builtPackaged, {}, null)
+    let p = rimrafAsync(builtPackaged, {})
         .then(() => bump ? bumpAsync() : Promise.resolve())
         .then(() => internalBuildTargetAsync({ packaged: true }));
     if (ghpages) return p.then(() => ghpPushAsync(builtPackaged, minify));
@@ -3825,9 +3825,9 @@ function internalStaticPkgAsync(builtPackaged: string, label: string, minify: bo
 
 export function cleanAsync(parsed: commandParser.ParsedCommand) {
     pxt.log('cleaning built folders')
-    return rimrafAsync("built", {}, null)
-        .then(() => rimrafAsync("libs/**/built", {}, null))
-        .then(() => rimrafAsync("projects/**/built", {}, null))
+    return rimrafAsync("built", {})
+        .then(() => rimrafAsync("libs/**/built", {}))
+        .then(() => rimrafAsync("projects/**/built", {}))
         .then(() => { });
 }
 


### PR DESCRIPTION
I broke this with the TS 2.6.1 change. The issue was that our typing for rimraf was too vague and ended up confusing the TS compiler into thinking the callback was an argument and not a node.js-style callback. That messes up the `promisify` typing and it cascaded from there.