### PR TITLE
Make one more microbit-specific setting configurable: flashUsableEnd

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -306,9 +306,10 @@ declare namespace ts.pxtc {
         shortPointers?: boolean; // set to true for 16 bit pointers
         flashCodeAlign?: number; // defaults to 1k
         flashEnd?: number;
+        flashUsableEnd?: number;
+        flashChecksumAddr?: number;
         upgrades?: UpgradePolicy[];
         openocdScript?: string;
-        flashChecksumAddr?: number;
         onStartText?: boolean;
         stackAlign?: number; // 1 word (default), or 2
         hidSelectors?: HidSelector[];

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -231,7 +231,7 @@ namespace ts.pxtc {
                 m = /^:..(....)00/.exec(hex[i])
                 if (m) {
                     let newAddr = parseInt(upperAddr + m[1], 16)
-                    if (newAddr >= 0x3C000)
+                    if (opts.flashUsableEnd && newAddr >= opts.flashUsableEnd)
                         hitEnd()
                     lastIdx = i
                     lastAddr = newAddr


### PR DESCRIPTION
Microbit has a bootloader after `0x3c000` - we used to have this hardcoded. This doesn't need to go in `v0`, but if it ever does, I also added the setting to microbit `pxtarget.json` https://github.com/Microsoft/pxt-microbit/commit/1fc80ba6bd25b80afba8b1c04b7f5cad92f5fad3