### PR TITLE
Fixing equality operators in common docs

### DIFF
--- a/common-docs/blocks/logic.md
+++ b/common-docs/blocks/logic.md
@@ -5,7 +5,7 @@ if(true) {}
 true;
 true && false;
 !true;
-1 != 0;
+1 != 1;
 ```
 ## See also #seealso
 

--- a/common-docs/blocks/logic/boolean.md
+++ b/common-docs/blocks/logic/boolean.md
@@ -19,8 +19,8 @@ let not = !true;
 The next six blocks represent comparison operators that yield a Boolean value. Most comparisons you will do involve [numbers](/types/number):
 
 ```block
-let equality = 42 == 0;
-let inequality = 42 != 0;
+let equality = 42 == 42;
+let inequality = 42 != 42;
 let lowerThan = 42 < 0;
 let greaterThan = 42 > 0;
 let lowerOrEqualThan =42 <= 0;


### PR DESCRIPTION
In the new TS version you can't compare two different numbers directly because they are considered different literal types (i.e. instead of "number" and "number" the types would be "0" and "42"). This doesn't have much of a practical effect because those expressions will always evaluate the same way anyways. 