### PR TITLE
Removing references to typings and tsd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 before_script:
   - "npm install"
-  - "typings install"
 sudo: false
 notifications:
   email:
@@ -15,7 +14,6 @@ notifications:
 cache:
   directories:
     - node_modules
-    - typings
 addons:
   apt:
     sources:

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -194,8 +194,7 @@ task('bump', function () {
 task('update', function () {
     jake.exec([
         "git pull",
-        "npm install",
-        "tsd reinstall"
+        "npm install"
     ], { printStdout: true });
 })
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,12 @@ npm link ../pxt
 First, install [Node](https://nodejs.org/en/): minimum version 5.7. Then install the following:
 ```
 npm install -g jake
-npm install -g typings
 ```
 
 To build the PXT command line tools:
 
 ```
 npm install
-typings install
 jake
 ```
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "semantic-ui-less": "^2.2.11",
-    "typings": "^2.1.0",
     "tslint": "^3.9.0",
     "typescript": "2.6.1",
     "webfonts-generator": "^0.4.0",


### PR DESCRIPTION
With the move to TypeScript 2.6.1, we now use @types