### PR TITLE
Fix nbsp issue to replace all globally

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -135,7 +135,7 @@ namespace pxt.blocks.layout {
 
     export function serializeNode(sg: Node): string {
         const xmlString = new XMLSerializer().serializeToString(sg)
-            .replace('&nbsp;', '&#160;'); // Replace &nbsp; with &#160; as a workaround for having nbsp missing from SVG xml     
+            .replace(new RegExp('&nbsp;', 'g'), '&#160;'); // Replace &nbsp; with &#160; as a workaround for having nbsp missing from SVG xml     
         return xmlString;
     }
 


### PR DESCRIPTION
Fix nbsp issue to replace all instances of nbsp instead of the first one. 
Nbsp issue affects Safari rendering of SVGs as it yields a parse error in the XML. 
Further details here: http://jsfiddle.net/5zk67h59/4/