### PR TITLE
support for emitting ~, ** op in JS

### DIFF
--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -5,7 +5,6 @@ namespace ts.pxtc {
         "numops::div": "/",
         "numops::mod": "%",
         "numops::muls": "*",
-        "numops::exps": "**",
         "numops::ands": "&",
         "numops::orrs": "|",
         "numops::eors": "^",

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -5,6 +5,7 @@ namespace ts.pxtc {
         "numops::div": "/",
         "numops::mod": "%",
         "numops::muls": "*",
+        "numops::exps": "**",
         "numops::ands": "&",
         "numops::orrs": "|",
         "numops::eors": "^",

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -8,6 +8,7 @@ namespace ts.pxtc {
         "numops::ands": "&",
         "numops::orrs": "|",
         "numops::eors": "^",
+        "numops::bnot": "~", // unary
         "numops::lsls": "<<",
         "numops::asrs": ">>",
         "numops::lsrs": ">>>",
@@ -320,8 +321,8 @@ switch (step) {
                 text = `${args[0]}${name}(${args.slice(1).join(", ")})`
             else if (U.startsWith(name, "new "))
                 text = `new ${shimToJs(name.slice(4))}(${args.join(", ")})`
-            else if (args.length == 2 && bin.target.floatingPoint && U.lookup(jsOpMap, name))
-                text = `(${args[0]} ${U.lookup(jsOpMap, name)} ${args[1]})`
+            else if (bin.target.floatingPoint && U.lookup(jsOpMap, name))
+                text = args.length == 2 ? `(${args[0]} ${U.lookup(jsOpMap, name)} ${args[1]})` : `(${U.lookup(jsOpMap, name)} ${args[0]})`;
             else
                 text = `${shimToJs(name)}(${args.join(", ")})`
 

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3275,6 +3275,7 @@ ${lbl}: .short 0xffff
                 case SK.SlashToken: return "numops::div";
                 case SK.PercentToken: return "numops::mod";
                 case SK.AsteriskToken: return "numops::muls";
+                case SK.AsteriskAsteriskToken: return "numops::exps";
                 case SK.AmpersandToken: return "numops::ands";
                 case SK.BarToken: return "numops::orrs";
                 case SK.CaretToken: return "numops::eors";

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2800,7 +2800,7 @@ ${lbl}: .short 0xffff
                         let v = valueToInt(inner)
                         if (v != null)
                             return emitLit(~v)
-                        return ir.rtcallMask("numops::bnot", 1, ir.CallingConvention.Plain, [inner]);
+                        return ir.rtcallMask(mapIntOpName("numops::bnot"), 1, ir.CallingConvention.Plain, [inner]);
                     }
                     default:
                         break

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -63,7 +63,7 @@ namespace ts.pxtc {
     }
 
     type TemplateLiteralFragment = TemplateHead | TemplateMiddle | TemplateTail;
-    export type EmittableAsCall = FunctionLikeDeclaration | SignatureDeclaration | ObjectLiteralElementLike| PropertySignature | ModuleDeclaration;
+    export type EmittableAsCall = FunctionLikeDeclaration | SignatureDeclaration | ObjectLiteralElementLike | PropertySignature | ModuleDeclaration;
 
     let lastNodeId = 0
     let currNodeWave = 1
@@ -341,7 +341,7 @@ namespace ts.pxtc {
         }
     }
 
-   export function isObjectType(t: Type): t is ObjectType {
+    export function isObjectType(t: Type): t is ObjectType {
         return "objectFlags" in t;
     }
 
@@ -545,7 +545,7 @@ namespace ts.pxtc {
 
     function isBuiltinType(t: Type) {
         let ok = TypeFlags.String | TypeFlags.StringLiteral |
-            TypeFlags.Number | TypeFlags.NumberLiteral  |
+            TypeFlags.Number | TypeFlags.NumberLiteral |
             TypeFlags.Boolean | TypeFlags.BooleanLiteral |
             TypeFlags.Enum | TypeFlags.EnumLiteral
         return t.flags & ok
@@ -2786,14 +2786,22 @@ ${lbl}: .short 0xffff
                         return emitIncrement(node.operand, "numops::adds", false)
                     case SK.MinusMinusToken:
                         return emitIncrement(node.operand, "numops::subs", false)
-                    case SK.MinusToken:
+                    case SK.MinusToken: {
                         let inner = emitExpr(node.operand)
                         let v = valueToInt(inner)
                         if (v != null)
                             return emitLit(-v)
                         return emitIntOp("numops::subs", emitLit(0), inner)
+                    }
                     case SK.PlusToken:
                         return emitExpr(node.operand) // no-op
+                    case SK.TildeToken: {
+                        let inner = emitExpr(node.operand)
+                        let v = valueToInt(inner)
+                        if (v != null)
+                            return emitLit(~v)
+                        return ir.rtcallMask("numops::bnot", 1, ir.CallingConvention.Plain, [inner]);
+                    }
                     default:
                         break
                 }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -289,6 +289,9 @@ namespace pxsim {
         export function toBool(v: any) {
             return !!v
         }
+        export function exps(x: number, y: number) {
+            return Math.pow(x, y)
+        }
     }
 
     export namespace langsupp {

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -243,6 +243,8 @@ namespace pxsim {
         export function ge(x: number, y: number) { return x >= y; }
         export function div(x: number, y: number) { return Math.floor(x / y) | 0; }
         export function mod(x: number, y: number) { return x % y; }
+        export function bnot(x: number) { return ~x; }
+        export function exps(x: number, y: number) { return Math_.pow(x, y) | 0; }
         export function toString(x: number) { return initString(x + ""); }
     }
 

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -257,6 +257,8 @@ namespace pxsim {
         export function lsls(x: number, y: number) { return x << y; }
         export function lsrs(x: number, y: number) { return x >>> y; }
         export function asrs(x: number, y: number) { return x >> y; }
+        export function exps(base: number, exponent: number) { return base ** exponent; }
+        export function bnot(x: number) { return ~x; }
 
         export function ignore(v: any) { return v; }
     }
@@ -275,6 +277,8 @@ namespace pxsim {
         export function lsls(x: number, y: number) { return toInt(x << y); }
         export function lsrs(x: number, y: number) { return (x & 0xffff) >>> y; }
         export function asrs(x: number, y: number) { return toInt(x >> y); }
+        export function exps(base: number, exponent: number) { return base ** exponent; }
+        export function bnot(x: number) { return ~x; }
 
         export function ignore(v: any) { return v; }
     }

--- a/tests/compile-test/lang-test0/02numbers.ts
+++ b/tests/compile-test/lang-test0/02numbers.ts
@@ -44,6 +44,9 @@ function testNums(): void {
     assert((3 & 6) == 2, "&")
     assert((3 | 6) == 7, "|")
     assert((3 ^ 6) == 5, "^")
+    assert(~1 == -2, "~")
+    let k1 = 1;
+    assert(~k1 == -2, "~")
     assert((-10 >> 2) == -3, ">>")
     assert((-10 >>> 20) == 4095, ">>>")
     assert((-10 << 2) == -40, "<<")
@@ -61,6 +64,9 @@ function testNums(): void {
     msg("nums#4")
 
     assert(105 % 100 == 5, "perc")
+
+    assert((2 ** 3) == 8, "**")
+    assert((z ** 3) = z * z * z, "**")    
 
     // test number->bool conversion, #1057
     // x==20 here

--- a/tests/compile-test/lang-test0/02numbers.ts
+++ b/tests/compile-test/lang-test0/02numbers.ts
@@ -66,7 +66,7 @@ function testNums(): void {
     assert(105 % 100 == 5, "perc")
 
     assert((2 ** 3) == 8, "**")
-    assert((z ** 3) = z * z * z, "**")    
+    assert((z ** 3) == z * z * z, "**")
 
     // test number->bool conversion, #1057
     // x==20 here

--- a/tests/compile-test/lang-test0/02numbers.ts
+++ b/tests/compile-test/lang-test0/02numbers.ts
@@ -44,9 +44,9 @@ function testNums(): void {
     assert((3 & 6) == 2, "&")
     assert((3 | 6) == 7, "|")
     assert((3 ^ 6) == 5, "^")
-    assert(~1 == -2, "~")
+    assert((~1) == -2, "~")
     let k1 = 1;
-    assert(~k1 == -2, "~")
+    assert((~k1) == -2, "~")
     assert((-10 >> 2) == -3, ">>")
     assert((-10 >>> 20) == 4095, ">>>")
     assert((-10 << 2) == -40, "<<")
@@ -66,7 +66,8 @@ function testNums(): void {
     assert(105 % 100 == 5, "perc")
 
     assert((2 ** 3) == 8, "**")
-    assert((z ** 3) == z * z * z, "**")
+    let ke = 3;
+    assert((ke ** 3) == ke * ke * ke, "**")
 
     // test number->bool conversion, #1057
     // x==20 here


### PR DESCRIPTION
Adding support for ~, ** operator in JS.
- [x] tests
- [ ] thumb support
- [ ] AVR support? (@tballmsft )