### PR TITLE
Correct monaco snippets for fixed instances

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -788,7 +788,7 @@ export class Editor extends srceditor.Editor {
             let snippetPrefix = fn.noNamespace ? "" : ns;
             let isInstance = false;
             let addNamespace = false;
-            let namespaceToUse = ""
+            let namespaceToUse = "";
 
             const element = fn as pxtc.SymbolInfo;
             if (element.attributes.block) {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -801,14 +801,15 @@ export class Editor extends srceditor.Editor {
                         let instances = Util.values(this.blockInfo.apis.byQName)
                         let getExtendsTypesFor = function(name: string) {
                             return instances
-                                    .filter(v => v.extendsTypes && v.extendsTypes.indexOf(name) !== -1)
+                                    .filter(v => v.extendsTypes)
+                                    .filter(v => v.extendsTypes.reduce((x, y) => x || y.indexOf(name) != -1, false))
                                     .reduce((x, y) => x.concat(y.extendsTypes), [])
                         }
                         namespaceToUse = element.attributes.blockNamespace || nsInfo.namespace || "";
                         instances = instances.filter(value =>
                             value.kind === pxtc.SymbolKind.Variable &&
                             value.attributes.fixedInstance &&
-                            getExtendsTypesFor(nsInfo.namespace + "." + nsInfo.name).indexOf(value.retType) !== -1)
+                            getExtendsTypesFor(nsInfo.name).indexOf(value.retType) !== -1)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
                         if (instances.length) {
                             snippetPrefix = `${instances[0].name}`

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -797,10 +797,16 @@ export class Editor extends srceditor.Editor {
                 else if (element.namespace) { // some blocks don't have a namespace such as parseInt
                     const nsInfo = this.blockInfo.apis.byQName[element.namespace];
                     if (nsInfo.attributes.fixedInstances) {
-                        const instances = Util.values(this.blockInfo.apis.byQName).filter(value =>
+                        let instances = Util.values(this.blockInfo.apis.byQName)
+                        let getExtendsTypesFor = function(name: string) {
+                            return instances
+                                    .filter(v => v.extendsTypes && v.extendsTypes.indexOf(name) !== -1)
+                                    .reduce((x, y) => x.concat(y.extendsTypes), [])
+                        }
+                        instances = instances.filter(value =>
                             value.kind === pxtc.SymbolKind.Variable &&
                             value.attributes.fixedInstance &&
-                            value.retType.endsWith(nsInfo.name))
+                            getExtendsTypesFor(nsInfo.namespace + "." + nsInfo.name).indexOf(value.retType) !== -1)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
                         if (instances.length) {
                             snippetPrefix = `${instances[0].name}`

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -806,21 +806,20 @@ export class Editor extends srceditor.Editor {
                                     .reduce((x, y) => x.concat(y.extendsTypes), [])
                         }
                         namespaceToUse = element.attributes.blockNamespace || nsInfo.namespace || "";
-                        let strictInstances = instances.filter(value =>
+                        let fixedInstances = instances.filter(value =>
                             value.kind === pxtc.SymbolKind.Variable &&
-                            value.attributes.fixedInstance &&
+                            value.attributes.fixedInstance
+                        );
+                        let exactInstances = fixedInstances.filter(value =>
                             value.retType == nsInfo.name)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
-                        let relatedInstances = instances.filter(value =>
-                            value.kind === pxtc.SymbolKind.Variable &&
-                            value.attributes.fixedInstance &&
+                        let extendedInstances = fixedInstances.filter(value =>
                             getExtendsTypesFor(nsInfo.name).indexOf(value.retType) !== -1)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
-                        if (strictInstances.length) {
-                            snippetPrefix = `${strictInstances[0].name}`
-                        }
-                        else if (relatedInstances.length) {
-                            snippetPrefix = `${relatedInstances[0].name}`
+                        if (exactInstances.length) {
+                            snippetPrefix = `${exactInstances[0].name}`
+                        } else if (extendedInstances.length) {
+                            snippetPrefix = `${extendedInstances[0].name}`
                         }
                         isInstance = true;
                         addNamespace = true;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -788,6 +788,7 @@ export class Editor extends srceditor.Editor {
             let snippetPrefix = fn.noNamespace ? "" : ns;
             let isInstance = false;
             let addNamespace = false;
+            let namespaceToUse = ""
 
             const element = fn as pxtc.SymbolInfo;
             if (element.attributes.block) {
@@ -803,6 +804,7 @@ export class Editor extends srceditor.Editor {
                                     .filter(v => v.extendsTypes && v.extendsTypes.indexOf(name) !== -1)
                                     .reduce((x, y) => x.concat(y.extendsTypes), [])
                         }
+                        namespaceToUse = element.attributes.blockNamespace || nsInfo.namespace || "";
                         instances = instances.filter(value =>
                             value.kind === pxtc.SymbolKind.Variable &&
                             value.attributes.fixedInstance &&
@@ -848,7 +850,7 @@ export class Editor extends srceditor.Editor {
                     let currPos = monacoEditor.editor.getPosition();
                     let cursor = model.getOffsetAt(currPos)
                     let insertText = snippetPrefix ? `${snippetPrefix}.${snippet}` : snippet;
-                    insertText = addNamespace ? `${/([^\.]+)/.exec(element.namespace)[0]}.${insertText}` : insertText;
+                    insertText = addNamespace ? `${firstWord(namespaceToUse)}.${insertText}` : insertText;
                     insertText = (currPos.column > 1) ? '\n' + insertText :
                         model.getWordUntilPosition(currPos) != undefined && model.getWordUntilPosition(currPos).word != '' ?
                             insertText + '\n' : insertText;
@@ -885,7 +887,7 @@ export class Editor extends srceditor.Editor {
                     });
 
                     let insertText = snippetPrefix ? `${snippetPrefix}.${snippet}` : snippet;
-                    insertText = addNamespace ? `${/([^\.]+)/.exec(element.namespace)[0]}.${insertText}` : insertText;
+                    insertText = addNamespace ? `${firstWord(namespaceToUse)}.${insertText}` : insertText;
                     e.dataTransfer.setData('text', insertText); // IE11 only supports text
                 }
                 monacoBlock.ondragend = (e: DragEvent) => {
@@ -1668,4 +1670,8 @@ export class TreeItem extends data.Component<TreeItemProps, {}> {
             {this.props.children}
         </div>
     }
+}
+
+function firstWord(s: string) {
+    return /[^\.]+/.exec(s)[0]
 }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -806,13 +806,21 @@ export class Editor extends srceditor.Editor {
                                     .reduce((x, y) => x.concat(y.extendsTypes), [])
                         }
                         namespaceToUse = element.attributes.blockNamespace || nsInfo.namespace || "";
-                        instances = instances.filter(value =>
+                        let strictInstances = instances.filter(value =>
+                            value.kind === pxtc.SymbolKind.Variable &&
+                            value.attributes.fixedInstance &&
+                            value.retType == nsInfo.name)
+                            .sort((v1, v2) => v1.name.localeCompare(v2.name));
+                        let relatedInstances = instances.filter(value =>
                             value.kind === pxtc.SymbolKind.Variable &&
                             value.attributes.fixedInstance &&
                             getExtendsTypesFor(nsInfo.name).indexOf(value.retType) !== -1)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
-                        if (instances.length) {
-                            snippetPrefix = `${instances[0].name}`
+                        if (strictInstances.length) {
+                            snippetPrefix = `${strictInstances[0].name}`
+                        }
+                        else if (relatedInstances.length) {
+                            snippetPrefix = `${relatedInstances[0].name}`
                         }
                         isInstance = true;
                         addNamespace = true;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -793,25 +793,27 @@ export class Editor extends srceditor.Editor {
                 if (element.attributes.defaultInstance) {
                     snippetPrefix = element.attributes.defaultInstance;
                 }
+                /**
                 else if (element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Property) {
                     const params = pxt.blocks.parameterNames(element);
                     snippetPrefix = params.attrNames["this"].name;
                     isInstance = true;
                 }
+                **/
                 else if (element.namespace) { // some blocks don't have a namespace such as parseInt
                     const nsInfo = this.blockInfo.apis.byQName[element.namespace];
-                    if (nsInfo.kind === pxtc.SymbolKind.Class) {
-                        return undefined;
-                    }
-                    else if (nsInfo.attributes.fixedInstances) {
+                    if (nsInfo.attributes.fixedInstances) {
                         const instances = Util.values(this.blockInfo.apis.byQName).filter(value =>
                             value.kind === pxtc.SymbolKind.Variable &&
                             value.attributes.fixedInstance &&
-                            value.retType === nsInfo.name)
+                            value.retType.endsWith(nsInfo.name))
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
                         if (instances.length) {
                             snippetPrefix = `${instances[0].namespace}.${instances[0].name}`
                         }
+                    }
+                    else if (nsInfo.kind === pxtc.SymbolKind.Class) {
+                        return undefined;
                     }
                 }
             }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -805,14 +805,21 @@ export class Editor extends srceditor.Editor {
                                     .filter(v => v.extendsTypes.reduce((x, y) => x || y.indexOf(name) != -1, false))
                                     .reduce((x, y) => x.concat(y.extendsTypes), [])
                         }
+                        // if blockNamespace exists, e.g., "pins", use it for snippet
+                        // else use nsInfo.namespace, e.g., "motors"
                         namespaceToUse = element.attributes.blockNamespace || nsInfo.namespace || "";
+                        // all fixed instances for this namespace
                         let fixedInstances = instances.filter(value =>
                             value.kind === pxtc.SymbolKind.Variable &&
                             value.attributes.fixedInstance
                         );
+                        // first try to get fixed instances whose retType matches nsInfo.name
+                        // e.g., DigitalPin
                         let exactInstances = fixedInstances.filter(value =>
                             value.retType == nsInfo.name)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
+                        // second choice: use fixed instances whose retType extends type of nsInfo.name
+                        // e.g., nsInfo.name == AnalogPin and instance retType == PwmPin
                         let extendedInstances = fixedInstances.filter(value =>
                             getExtendsTypesFor(nsInfo.name).indexOf(value.retType) !== -1)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));


### PR DESCRIPTION

![screen shot 2018-01-05 at 11 11 08 am](https://user-images.githubusercontent.com/16658549/34624006-6ba71076-f208-11e7-97e4-18bce6603590.png)

![screen shot 2018-01-05 at 11 10 56 am](https://user-images.githubusercontent.com/16658549/34624003-6803fa06-f208-11e7-9951-dc55f8897814.png)

Reworks creation of monaco snippets for fixed instances in toolbox and javascript editor.
- Toolbox snippets now look like `fixedInstanceName.method()`, e.g., `A0.analogRead()`.
- Javascript editor snippets now look like `namespace.fixedInstanceName.method()`, e.g., `pins.A0.analogRead()`.
- New logic to map fixed instances w/specialized classes to the correct namespace by creating a lookup array of all classes and subclasses within the namespace.

  