### PR TITLE
Add support for bold field annotation inside the block text

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -632,6 +632,10 @@ declare namespace Blockly {
         position_(): void;
     }
 
+    class FieldLabel extends Field {
+        constructor(text: string, opt_class: string);
+    }
+
     class FieldTextDropdown extends FieldTextInput {
         constructor(text: string, menuGenerator: ({ src: string; alt: string; width: number; height: number; } | string)[][], opt_validator?: Function, opt_restrictor?: any);
     }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -601,13 +601,17 @@ namespace pxt.blocks {
     }
 
     function initField(i: any, ni: number, fn: pxtc.SymbolInfo, ns: pxtc.SymbolInfo, pre: string, right?: boolean, type?: string, nsinfo?: pxtc.SymbolInfo): any {
-        if (pre && pre.indexOf('`') > -1) {
-            // parse and create icon fields for every inline icon
-            let regex = /([^`]+|(`([^`]+)`))/gi;
+        if (pre && (pre.indexOf('`') > -1 || pre.indexOf('*') > -1)) {
+            // parse and create icon or bold fields for every inline icon / bold text
+            let regex = /([^`\*]+|(`([^`]+)`)|(\*([^\*]+)\*))/gi; // `icon` indicates icon, *test* indicates bold text
             let match: RegExpExecArray;
             while (match = regex.exec(pre)) {
                 let img: B.FieldImage;
-                if (match[3] && (img = iconToFieldImage(match[3]))) {
+                if (match[5] && match[4][0] === '*') {
+                    // Bold text, eg: *test*
+                    i.appendField(new pxtblockly.FieldBoldLabel(match[5]));
+                } else if (match[3] && match[2][0] === '`' && (img = iconToFieldImage(match[3]))) {
+                    // Icon field, eg: `test`
                     i.appendField(img);
                 } else {
                     i.appendField(match[1]);

--- a/pxtblocks/fields/field_boldtext.ts
+++ b/pxtblocks/fields/field_boldtext.ts
@@ -1,0 +1,12 @@
+/// <reference path="../../localtypings/pxtblockly.d.ts" />
+
+namespace pxtblockly {
+
+    export class FieldBoldLabel extends Blockly.FieldLabel implements Blockly.FieldCustom {
+        public isFieldCustom_ = true;
+
+        constructor(value: string, options?: Blockly.FieldCustomOptions, opt_validator?: Function) {
+            super(value, 'blocklyBoldText');
+        }
+    }
+}

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -55,6 +55,10 @@ svg.blocklySvg {
 
 span.blocklyTreeLabel, text.blocklyText, input.blocklyHtmlInput, .blocklyDropDownDiv .goog-menuitem {
     font-family: @blocklyFont !important;
+    font-weight: normal;
+}
+text.blocklyText.blocklyBoldText {
+    font-weight: bold;
 }
 
 /* Used by custom field in grey expression blocks */


### PR DESCRIPTION
Adds support for bold fields inside of the text label. 
This is annotated inside the block annotation using markdown annotation (*). 

For example: 
```
//% blockId="testFunction" block="test *function*"
export function testFunction() {

}
```
In the above, function will be bold.