### PR TITLE
Removing share -> screenshot option

### DIFF
--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -12,7 +12,6 @@ type IProjectView = pxt.editor.IProjectView;
 
 export enum ShareMode {
     Code,
-    Screenshot,
     Url,
     Editor,
     Simulator,
@@ -23,8 +22,6 @@ export enum ShareMode {
 export interface ShareEditorState {
     advancedMenu?: boolean;
     mode?: ShareMode;
-    screenshotId?: string;
-    screenshotUri?: string;
     currentPubId?: string;
     pubCurrent?: boolean;
     visible?: boolean;
@@ -55,7 +52,6 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
             || this.state.advancedMenu != nextState.advancedMenu
             || this.state.mode != nextState.mode
             || this.state.pubCurrent != nextState.pubCurrent
-            || this.state.screenshotId != nextState.screenshotId
             || this.state.currentPubId != nextState.currentPubId
             || this.state.sharingError != nextState.sharingError;
     }
@@ -113,37 +109,6 @@ pxt extract ${url}`;
                     case ShareMode.Url:
                         embed = editUrl;
                         break;
-                    default:
-                        if (isBlocks && pxt.blocks.layout.screenshotEnabled()) {
-                            // Render screenshot
-                            if (this.state.screenshotId == currentPubId) {
-                                if (this.state.screenshotUri)
-                                    embed = `<a href="${editUrl}"><img src="${this.state.screenshotUri}" /></a>`
-                                else embed = lf("Ooops, no screenshot available.");
-                            } else {
-                                pxt.debug("rendering share-editor screenshot png");
-                                embed = lf("rendering...");
-                                pxt.blocks.layout.toPngAsync((this.props.parent.editor as blocks.Editor).editor)
-                                    .done(uri => this.setState({ screenshotId: currentPubId, screenshotUri: uri }));
-                            }
-                        } else {
-                            // Render javascript code
-                            pxt.debug("rendering share-editor javascript markdown");
-                            embed = lf("rendering...")
-                            let main = pkg.getEditorPkg(pkg.mainPkg)
-                            let file = main.getMainFile()
-                            if (pkg.File.blocksFileNameRx.test(file.getName()) && file.getVirtualFileName())
-                                file = main.lookupFile("this/" + file.getVirtualFileName()) || file
-                            if (pkg.File.tsFileNameRx.test(file.getName())) {
-                                let fileContents = file.content;
-                                let mdContent = pxt.docs.renderMarkdown({
-                                    template: `@body@`,
-                                    markdown: `\`\`\`javascript\n${fileContents}\n\`\`\``
-                                });
-                                embed = `<a style="text-decoration: none;" href="${editUrl}">${mdContent}</a>`;
-                            }
-                        }
-                        break;
                 }
             }
 
@@ -164,7 +129,6 @@ pxt extract ${url}`;
 
         const formats = [
             { mode: ShareMode.Code, label: lf("Code") },
-            { mode: ShareMode.Screenshot, label: lf("Screenshot") },
             { mode: ShareMode.Editor, label: lf("Editor") },
             { mode: ShareMode.Simulator, label: lf("Simulator") },
             { mode: ShareMode.Cli, label: lf("Command line") }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -14,8 +14,7 @@ export enum ShareMode {
     Code,
     Url,
     Editor,
-    Simulator,
-    Cli
+    Simulator
 }
 
 // This Component overrides shouldComponentUpdate, be sure to update that if the state is updated
@@ -91,11 +90,6 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
                     case ShareMode.Code:
                         embed = pxt.docs.codeEmbedUrl(rootUrl, header.pubId);
                         break;
-                    case ShareMode.Cli:
-                        embed = `pxt target ${pxt.appTarget.id}
-pxt extract ${url}`;
-                        help = lf("Run this command from a shell.");
-                        break;
                     case ShareMode.Editor:
                         embed = pxt.docs.embedUrl(rootUrl, "pub", header.pubId);
                         break;
@@ -131,7 +125,6 @@ pxt extract ${url}`;
             { mode: ShareMode.Code, label: lf("Code") },
             { mode: ShareMode.Editor, label: lf("Editor") },
             { mode: ShareMode.Simulator, label: lf("Simulator") },
-            { mode: ShareMode.Cli, label: lf("Command line") }
         ];
 
         const action = !ready ? lf("Publish project") : undefined;


### PR DESCRIPTION
In favor of lightweight codembed option.

- screenshot can be slow
- screenshot does not work on IE
- screenshot generates huge URLs