### PR TITLE
Support a better high contrast mode for Blockly blocks

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -380,4 +380,21 @@
             border-color: darken(#fff, 10.0) !important;
         }
     }
+
+    /* Blockly blocks */
+    .blocklyPath {
+        stroke-width: 4px !important;
+        fill: black;
+    }
+    .blocklyBlockBackground {
+        stroke-width: 2px;
+        fill: black;
+    }
+    .blocklyText {
+        fill: white;
+    }
+    .blocklyFlyoutBackground {
+        stroke-width: 1px;
+        stroke: white;
+    }
 }


### PR DESCRIPTION
Support a better high contrast mode for Blockly blocks: 

![screen shot 2018-01-10 at 5 05 04 pm](https://user-images.githubusercontent.com/16690124/34803512-90eb0b52-f628-11e7-9e6d-7c9382dd7f50.png)

This gives us a better contrast ratio between the black background and the white text, avoiding any issues users might run in contrasting between the white text and the color of a block. 
We should still aim to have colors that contrast well with white, but if users are struggling or if the color is still not 100% within the color contrast ratio limits, this gives users another end point to view the blocks that they are struggling to distinguish or read the text. 