### PR TITLE
Use github.com proxy in our cloud to avoid throttling

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -117,6 +117,7 @@ declare namespace pxt {
         importing?: boolean; // import url dialog
         embedding?: boolean;
         githubPackages?: boolean; // allow searching github for packages
+        noGithubProxy?: boolean;
     }
 
     interface AppSimulator {

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -154,6 +154,7 @@ function htmlmsg(kind: string, msg: string) {
 
 export function errorNotification(msg: string) {
     pxt.tickEvent("notification.error", { message: msg })
+    debugger // trigger a breakpoint when a debugger is connected, like in U.oops()
     htmlmsg("err", msg)
 }
 

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -29,7 +29,10 @@ mountVirtualApi("cloud", {
 })
 
 mountVirtualApi("cloud-search", {
-    getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(e => core.handleNetworkError(e, [404])),
+    getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(e => {
+        core.handleNetworkError(e, [404])
+        return { statusCode: 404, headers: {}, json: {} }
+    }),
     expirationTime: p => 60 * 1000,
     isOffline: () => !Cloud.isOnline(),
 })


### PR DESCRIPTION
Also:
* add a flag to disable proxy (for external deployments if desired)
* fix a bug that would send requests for `/api/foo` several time per second when searching for `"foo"`

Seems to work on Adafruit for me. Requires more testing.