### PR TITLE
Update blog page with entries for 01-22-2018

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -1,5 +1,19 @@
 # Microsoft MakeCode Blog
 
+## [Hello 2018](/blog/bett/01-22-2018)
+
+January 22nd, 2018 by [jaqster](https://github.com/jaqster)
+
+Wow, hard to believe it’s 2018 already. We’re announcing some very cool stuff to kick off the new year...
+**[Read more](/blog/bett/01-22-2018)**
+
+## [MakeCode support for Wonder Workshop Cue](/blog/wonder-workshop/01-22-2018)
+
+January 22nd, 2018 by [jaqster](https://github.com/jaqster)
+
+Today, we are excited to announce MakeCode support for Cue!
+**[Read more](/blog/wonder-workshop/01-22-2018)**
+
 ## [Micro:bit v0.13.52](/blog/microbit/v0.13.52)
 
 December 8th, 2017


### PR DESCRIPTION
Add the two new entries of posts queued for 01-22-2018. Will merge in after #3730 and #3731.

* BETT announcement: #3731 
* Wonder Workshop announcement: #3730 

Regarding the **Hello 2018** post. Should this be a general New Year's announcement or **Hello BETT 2018** as @pelikhan suggests?

Merge on 01-21-2018 @ 23:59.
