### PR TITLE
Split out math topics

### DIFF
--- a/common-docs/reference/math.md
+++ b/common-docs/reference/math.md
@@ -37,6 +37,7 @@ let divide = 8/4;
 ```
 
 ### Remainder (%)
+
 This is a extra operator for division. You can find out how much is left over if one number doesn't
 divide into the other number evenly.
 
@@ -58,7 +59,7 @@ let item = Math.abs(-5);
 
 ## Minimum and maximum of two values
 
-You can get the smaller or the bigger of two numbers with the min() and max() functions.
+You can get the smaller or the bigger of two numbers with the [min](/reference/math/min) and [max](/reference/math/max) functions.
 
 * The minimum of 2 and 9: **Math.min(2, 9)** equals 2.
 * The maximum of 3 and 9: **Math.max(3, 9)** equals 9.
@@ -77,66 +78,7 @@ Make up any number from a minimum value to a some maximum value. If you want a r
 let myRandom = Math.randomRange(0, 5);
 ```
 
-## Trigonometry
-Functions for finding numbers of angles, sides of triangles, and positions on a circle. These
-functions are also used to make information for wave signals.
+## See also #seealso
 
-### What's your angle? Degrees or radians
-
-A compass shows where North is and the direction to it is 0 degrees (which is also 360 degrees). If you walk directly to the East, then your direction will be 90 degrees on the compass. This is
-also the measurement of the angle between the path of your direction and the path to North. If point
-yourself to North and spin around to the right (clockwise) in one spot, you will see the compass change from 0 degrees, go up to 359 degrees, and back to 0 degrees. So, a full rotation is 360 degrees, or full
-circle.
-
-Another way to measure angles is to use numbers that are special to the size of circles. A circle has two important numbers related to it. They are called the _radius_ and _pi_. The radius is the distance from the center of the circle to its outside edge. A long time ago, people learned that no matter how big
-a circle is, if you divide the length of its outside edge by the length of its radius, you always get the same number back. They decided to call this number **_pi_**. It's **2** times **_pi_** actually, because they used the whole length across the circle which is two lengths of the radius.
-
-Now, we don't have to worry about the radius anymore, we can just use some part of **2_pi_** to tell where any spot on the edge of a circle is. Any part or all of **2_pi_** is called _radians_. We can use radians to measure an angle of direction too, just like with the compass. Except now, we spin **2_pi_** radians around the circle instead of 360 degrees.
-
-### ~hint
-**What number is _pi_?**
-
-As it turns out, **_pi_** is an _irrational_ number. That means it has a fractional part that uses more digits than we can display. So, it's best to use a constant in code for the value of **_pi_**. In case you're curious, the first 32 digits of **_pi_** are: **3.1415926535897932384626433832795**.
-
- Luckily, you can use the built-in constant **Math.PI**.
-### ~
-
-In code, you use _radians_ for angle measures. All of the math functions for trigonometry use radians.
-
-### ~hint
-**Changing degrees to radians**
-
-What's 60 degrees in radians? Well, one radian is _(2 \* Math.PI / 360)_ radians. Or, to make it
-simple, _(Math.PI / 180)_ radians. So, 60 degrees is _(60 \* Math.PI / 180)_ radians.
-### ~
-
-### Sine
-
-Get the length of the vertical (up or down) side of a right triangle at some angle. But, the
-_sine_ value is the length of the vertical side divided by the length of the longest side,
-its _hypotenuse_.
-
-What's the sine of 60 degrees? **Math.sin(60 \* Math.PI / 180)** equals 0.5. The vertical side of a right triangle
-is one half the length of the longest side when the opposite angle is 60 degrees.
-
-```typescript-ignore
-let ySide = Math.sin(60 * Math.PI / 180)
-```
-
-### Cosine
-
-Get the length of the horizontal (left or right) side of a right triangle at some angle. But, the
-_cosine_ value is the length of the horizontal side divided by the length of the longest side,
-its _hypotenuse_.
-
-What's the cosine of 45 degrees? **Math.cos(45 \* Math.PI / 180)** equals 0.707. The length of the horizontal side
-of a right triangle is about 70 percent of the length of the longest side when the angle between them
-is 45 degrees.
-
-```typescript-ignore
-let xSide = Math.cos(45 * Math.PI / 180)
-```
-
-## See also
-
+[abs](/reference/math/abs), [min](/reference/math/min), [max](/reference/math/max),
 [randomRange](/reference/math/random-range)

--- a/common-docs/reference/math/abs.md
+++ b/common-docs/reference/math/abs.md
@@ -1,0 +1,33 @@
+# abs
+
+The absolute value of a number.
+
+```sig
+Math.abs(-5);
+```
+
+When you want to know how much a number is without its _sign_ (+/-). The absolute value of -5 is 5 and the
+the absolute value 5 is also 5. The absolute value is sometimes called the _magnitude_.
+
+## Parameters
+
+* **x**: The [number](/types/number) to return the absolute value for. This can be a negative number (`-1`), positive number (`6`), or `0`.
+
+## Returns
+
+* a [number](/types/number) that is the absolute value of number in ``x``.
+
+## Example #example
+
+Find the absolute value of `-34`. Do some checks to make sure the absolute value is really `34`. Set the value to `0` if the checks fail.
+
+```blocks
+let pos = Math.abs(-34);
+if (pos > 0) {
+    if (pos != 34) {
+        pos = 0;
+    }
+} else {
+    pos = 0;
+}
+```

--- a/common-docs/reference/math/max.md
+++ b/common-docs/reference/math/max.md
@@ -1,0 +1,30 @@
+# max
+
+The maximum of two values.
+
+```sig
+Math.max(8, 2);
+```
+
+You find the larger of two numbers with the **max** function.
+
+## Parameters
+
+**a**: The first number to check to see if it is more than the second number.
+**b**: The second number to check to see if it is more than a first number.
+
+## Returns
+
+* the larger of the two numbers in ``a`` or ``b``.
+
+## Example
+
+Find out which value is more: `7` or `16`.
+
+```blocks
+let minival = Math.max(7, 16);
+```
+
+## See also
+
+[min](/reference/math/min)

--- a/common-docs/reference/math/min.md
+++ b/common-docs/reference/math/min.md
@@ -1,0 +1,30 @@
+# min
+
+The minimum of two values.
+
+```sig
+Math.min(8, 2);
+```
+
+You find the smaller of two numbers with the **min** function.
+
+## Parameters
+
+**a**: The first number to check to see if it is less than the second number.
+**b**: The second number to check to see if it is less than a first number.
+
+## Returns
+
+* the smaller of the two numbers ``a`` or ``b``.
+
+## Example
+
+Find out which value is less: `2` or `9`.
+
+```blocks
+let minival = Math.min(2, 9);
+```
+
+## See also
+
+[max](/reference/math/max)

--- a/common-docs/reference/math/random-range.md
+++ b/common-docs/reference/math/random-range.md
@@ -1,15 +1,30 @@
-# Random Range
+# random Range
 
-Returns a pseudo-random number in the range ``[min, max];`` that is, from ``0`` (inclusive) up to including ``1`` (inclusive), which you can then scale to your desired range. 
+Return a pseudo-random value within a range of numbers.
 
 ```sig
 Math.randomRange(0, 10)
 ```
 
+Returns a pseudo-random number in the range ``[min, max];`` that is, from ``0`` (inclusive) up to including ``1`` (inclusive), which you can then scale to your desired range. 
+
+## Parameters
+
+* **min**: the smallest possible pseudo-random number to return.
+* **max**: the largest possible pseudo-random number to return.
+
 ## Returns
 
 * a pseudo-random [number](types/number) between ``max`` (inclusive) and ``max`` (inclusive).
 
+## Example
+
+Generate a random number between `0` and `100`.
+
+```blocks
+let centoRandom = Math.randomRange(0, 100);
+```
+
 ## See Also
 
-[``||random||``](/reference/math/random)
+[random](/reference/math/random)

--- a/common-docs/reference/math/trigonometry.md
+++ b/common-docs/reference/math/trigonometry.md
@@ -1,0 +1,64 @@
+# Trigonometry
+
+Functions for finding numbers of angles, sides of triangles, and positions on a circle. These
+functions are also used to make information for wave signals.
+
+## What's your angle? Degrees or radians
+
+A compass shows where North is and the direction to it is 0 degrees (which is also 360 degrees). If you walk directly to the East, then your direction will be 90 degrees on the compass. This is
+also the measurement of the angle between the path of your direction and the path to North. If point
+yourself to North and spin around to the right (clockwise) in one spot, you will see the compass change from 0 degrees, go up to 359 degrees, and back to 0 degrees. So, a full rotation is 360 degrees, or full
+circle.
+
+Another way to measure angles is to use numbers that are special to the size of circles. A circle has two important numbers related to it. They are called the _radius_ and _pi_. The radius is the distance from the center of the circle to its outside edge. A long time ago, people learned that no matter how big
+a circle is, if you divide the length of its outside edge by the length of its radius, you always get the same number back. They decided to call this number **_pi_**. It's **2** times **_pi_** actually, because they used the whole length across the circle which is two lengths of the radius.
+
+Now, we don't have to worry about the radius anymore, we can just use some part of **2_pi_** to tell where any spot on the edge of a circle is. Any part or all of **2_pi_** is called _radians_. We can use radians to measure an angle of direction too, just like with the compass. Except now, we spin **2_pi_** radians around the circle instead of 360 degrees.
+
+### ~hint
+
+**What number is _pi_?**
+
+As it turns out, **_pi_** is an _irrational_ number. That means it has a fractional part that uses more digits than we can display. So, it's best to use a constant in code for the value of **_pi_**. In case you're curious, the first 32 digits of **_pi_** are: **3.1415926535897932384626433832795**.
+
+Luckily, you can use the built-in constant **Math.PI**.
+
+### ~
+
+In code, you use _radians_ for angle measures. All of the math functions for trigonometry use radians.
+
+### ~hint
+
+**Changing degrees to radians**
+
+What's 60 degrees in radians? Well, one radian is _(2 \* Math.PI / 360)_ radians. Or, to make it
+simple, _(Math.PI / 180)_ radians. So, 60 degrees is _(60 \* Math.PI / 180)_ radians.
+
+### ~
+
+## Sine
+
+Get the length of the vertical (up or down) side of a right triangle at some angle. But, the
+_sine_ value is the length of the vertical side divided by the length of the longest side,
+its _hypotenuse_.
+
+What's the sine of 60 degrees? **Math.sin(60 \* Math.PI / 180)** equals 0.5. The vertical side of a right triangle
+is one half the length of the longest side when the opposite angle is 60 degrees.
+
+```typescript-ignore
+let ySide = Math.sin(60 * Math.PI / 180)
+```
+
+## Cosine
+
+Get the length of the horizontal (left or right) side of a right triangle at some angle. But, the
+_cosine_ value is the length of the horizontal side divided by the length of the longest side,
+its _hypotenuse_.
+
+What's the cosine of 45 degrees? **Math.cos(45 \* Math.PI / 180)** equals 0.707. The length of the horizontal side
+of a right triangle is about 70 percent of the length of the longest side when the angle between them
+is 45 degrees.
+
+```typescript-ignore
+let xSide = Math.cos(45 * Math.PI / 180)
+```


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-chibitronics/issues/158.

-[x] Move trigonometry out into a side-doc to preserve the content.
-[x] Add _abs_, _min_, _max_ topics for the **Math** reference.

Not adding any _math_ cards as block decompile/generation for Math functions is especially tangled up in _core.d.ts_, _pxt-helpers.ts_, _blocks.ts_, _blocklyloader.ts_, and so on.
