### PR TITLE
Allow for not checking in shims.d.ts and _locales

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -169,7 +169,7 @@ namespace pxt {
     }
 
     export interface Host {
-        readFile(pkg: Package, filename: string): string;
+        readFile(pkg: Package, filename: string, skipAdditionalFiles?: boolean): string;
         writeFile(pkg: Package, filename: string, contents: string, force?: boolean): void;
         downloadPackageAsync(pkg: Package): Promise<void>;
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo>;

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -623,9 +623,9 @@ namespace pxt {
                 if (this.config.files.indexOf(fn) < 0)
                     U.userError(lf("please add '{0}' to \"files\" in {1}", fn, pxt.CONFIG_NAME))
                 cont = "// Auto-generated. Do not edit.\n" + cont + "\n// Auto-generated. Do not edit. Really.\n"
-                if (this.host().readFile(this, fn) !== cont) {
+                if (this.host().readFile(this, fn, true) !== cont) {
                     pxt.debug(`updating ${fn} (size=${cont.length})...`)
-                    this.host().writeFile(this, fn, cont)
+                    this.host().writeFile(this, fn, cont, true)
                 }
             }
 


### PR DESCRIPTION
This PR:
* builds packages before simulator
* writes shims.d.ts etc even if the common-packages version is the same (for consistency)
* right now, if we change the shims.d.ts generation, it will likely break github packages; after this change it should work (force in writeFile)
* adds `pxt cleangen` to delete generated files