### PR TITLE
support for touch+mouse scenarios

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -239,7 +239,7 @@ namespace pxsim {
 
     export interface IPointerEvents {
         up: string,
-        down: string,
+        down: string[],
         move: string,
         enter: string,
         leave: string
@@ -255,23 +255,23 @@ namespace pxsim {
         return typeof window != "undefined" && !!(window as any).PointerEvent;
     }
 
-    export const pointerEvents = hasPointerEvents() ? {
+    export const pointerEvents: IPointerEvents = hasPointerEvents() ? {
         up: "pointerup",
-        down: "pointerdown",
+        down: ["pointerdown"],
         move: "pointermove",
         enter: "pointerenter",
         leave: "pointerleave"
     } : isTouchEnabled() ?
             {
                 up: "mouseup",
-                down: "touchstart",
+                down: ["mousedown", "touchstart"],
                 move: "touchmove",
                 enter: "touchenter",
                 leave: "touchend"
             } :
             {
                 up: "mouseup",
-                down: "mousedown",
+                down: ["mousedown"],
                 move: "mousemove",
                 enter: "mouseenter",
                 leave: "mouseleave"

--- a/pxtsim/svg.ts
+++ b/pxtsim/svg.ts
@@ -92,10 +92,10 @@ namespace pxsim.svg {
 
     export function onClick(el: Element, click: (ev: MouseEvent) => void) {
         let captured = false;
-        el.addEventListener(pxsim.pointerEvents.down, (ev: MouseEvent) => {
+        pxsim.pointerEvents.down.forEach(evid => el.addEventListener(evid, (ev: MouseEvent) => {
             captured = true;
             return true;
-        }, false);
+        }, false));
         el.addEventListener(pxsim.pointerEvents.up, (ev: MouseEvent) => {
             if (captured) {
                 captured = false;
@@ -113,11 +113,11 @@ namespace pxsim.svg {
         stop?: (ev: MouseEvent) => void,
         keydown?: (ev: KeyboardEvent) => void) {
         let captured = false;
-        el.addEventListener(pxsim.pointerEvents.down, (ev: MouseEvent) => {
+        pxsim.pointerEvents.down.forEach(evid => el.addEventListener(evid, (ev: MouseEvent) => {
             captured = true;
             if (start) start(ev)
             return true;
-        }, false);
+        }, false));
         el.addEventListener(pxsim.pointerEvents.move, (ev: MouseEvent) => {
             if (captured) {
                 if (move) move(ev);

--- a/pxtsim/visuals/buttonpair.ts
+++ b/pxtsim/visuals/buttonpair.ts
@@ -169,9 +169,9 @@ namespace pxsim.visuals {
             let btnStates = [this.state.aBtn, this.state.bBtn];
             let btnSvgs = [this.aBtn, this.bBtn];
             btnSvgs.forEach((btn, index) => {
-                btn.addEventListener(pointerEvents.down, ev => {
+                pxsim.pointerEvents.down.forEach(evid => btn.addEventListener(evid, ev => {
                     btnStates[index].pressed = true;
-                })
+                }))
                 btn.addEventListener(pointerEvents.leave, ev => {
                     btnStates[index].pressed = false;
                 })
@@ -184,9 +184,9 @@ namespace pxsim.visuals {
             let updateBtns = (s: boolean) => {
                 btnStates.forEach(b => b.pressed = s)
             };
-            this.abBtn.addEventListener(pointerEvents.down, ev => {
+            pxsim.pointerEvents.down.forEach(evid => this.abBtn.addEventListener(evid, ev => {
                 updateBtns(true);
-            })
+            }));
             this.abBtn.addEventListener(pointerEvents.leave, ev => {
                 updateBtns(false);
             })


### PR DESCRIPTION
Handle touch or mouse input. Test this change on a computer with touch support. Both mouse and touch should work.
- [x] chrome Windows
- [x] Edge Windows
- [x] Firefox Windows
- [x] IE11 Windows