### PR TITLE
Uwp hid improvements

### DIFF
--- a/pxtlib/hf2.ts
+++ b/pxtlib/hf2.ts
@@ -26,6 +26,7 @@ namespace pxt.HF2 {
         error(msg: string): any;
         reconnectAsync(): Promise<void>;
         disconnectAsync(): Promise<void>;
+        isSwitchingToBootloader?: () => void;
 
         // these are implemneted by HID-bridge
         talksAsync?(cmds: TalkArgs[]): Promise<Uint8Array[]>;
@@ -381,6 +382,9 @@ namespace pxt.HF2 {
             if (this.bootloaderMode)
                 return Promise.resolve()
             log(`Switching into bootloader mode`)
+            if (this.io.isSwitchingToBootloader) {
+                this.io.isSwitchingToBootloader();
+            }
             return this.talkAsync(HF2_CMD_START_FLASH)
                 .then(() => this.initAsync())
                 .then(() => {

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -5,8 +5,6 @@ type WHID = Windows.Devices.HumanInterfaceDevice.HidDevice;
 
 namespace pxt.winrt {
     class WindowsRuntimeIO implements pxt.HF2.PacketIO {
-        static uf2Selectors: string[];
-
         onData = (v: Uint8Array) => { };
         onEvent = (v: Uint8Array) => { };
         onError = (e: Error) => { };
@@ -22,6 +20,11 @@ namespace pxt.winrt {
         reconnectAsync(): Promise<void> {
             return this.disconnectAsync()
                 .then(() => this.initAsync());
+        }
+
+        isSwitchingToBootloader() {
+            expectingAdd = true;
+            expectingRemove = true;
         }
 
         disconnectAsync(): Promise<void> {
@@ -54,10 +57,7 @@ namespace pxt.winrt {
             Util.assert(!this.dev, "HID interface not properly reseted");
             const wd = Windows.Devices;
             const whid = wd.HumanInterfaceDevice.HidDevice;
-            if (!WindowsRuntimeIO.uf2Selectors) {
-                this.initUf2Selectors();
-            }
-            const getDevicesPromise = WindowsRuntimeIO.uf2Selectors.reduce((soFar, currentSelector) => {
+            const getDevicesPromise = hidSelectors.reduce((soFar, currentSelector) => {
                 // Try all selectors, in order, until some devices are found
                 return soFar.then((devices) => {
                     if (devices && devices.length) {
@@ -105,22 +105,66 @@ namespace pxt.winrt {
                     return Promise.reject(err);
                 });
         }
-
-        private initUf2Selectors() {
-            const whid = Windows.Devices.HumanInterfaceDevice.HidDevice;
-            WindowsRuntimeIO.uf2Selectors = [];
-            if (pxt.appTarget && pxt.appTarget.compile && pxt.appTarget.compile.hidSelectors) {
-                pxt.appTarget.compile.hidSelectors.forEach((s) => {
-                    const sel = whid.getDeviceSelector(parseInt(s.usagePage), parseInt(s.usageId), parseInt(s.vid), parseInt(s.pid));
-                    WindowsRuntimeIO.uf2Selectors.push(sel);
-                });
-            }
-        }
     }
 
     export function mkPacketIOAsync(): Promise<pxt.HF2.PacketIO> {
         const b = new WindowsRuntimeIO()
         return b.initAsync()
             .then(() => b);
+    }
+
+    const hidSelectors: string[] = [];
+    const watchers: Windows.Devices.Enumeration.DeviceWatcher[] = [];
+    let deviceCount: number = 0;
+    let expectingAdd: boolean = false;
+    let expectingRemove: boolean = false;
+
+    export function initWinrtHid(reconnectUf2WrapperCb: () => Promise<void>, disconnectUf2WrapperCb: () => Promise<void>) {
+        const wd = Windows.Devices;
+        const wde = Windows.Devices.Enumeration.DeviceInformation;
+        const whid = wd.HumanInterfaceDevice.HidDevice;
+        if (pxt.appTarget && pxt.appTarget.compile && pxt.appTarget.compile.hidSelectors) {
+            pxt.appTarget.compile.hidSelectors.forEach((s) => {
+                const sel = whid.getDeviceSelector(parseInt(s.usagePage), parseInt(s.usageId), parseInt(s.vid), parseInt(s.pid));
+                hidSelectors.push(sel);
+            });
+        }
+        hidSelectors.forEach((s) => {
+            const watcher = wde.createWatcher(s, null);
+            watcher.addEventListener("added", (e: Windows.Devices.Enumeration.DeviceInformation) => {
+                pxt.debug(`new hid device detected: ${e.id}`);
+                if (expectingAdd) {
+                    expectingAdd = false;
+                } else {
+                    // A new device was plugged in. If it's the first one, then reconnect the UF2 wrapper. Otherwise,
+                    // we're already connected to a plugged device, so don't do anything.
+                    ++deviceCount
+                    if (deviceCount === 1 && reconnectUf2WrapperCb) {
+                        reconnectUf2WrapperCb();
+                    }
+                }
+            });
+            watcher.addEventListener("removed", (e: Windows.Devices.Enumeration.DeviceInformation) => {
+                pxt.debug(`hid device closed: ${e.id}`);
+                if (expectingRemove) {
+                    expectingRemove = false;
+                } else {
+                    // A device was unplugged. If there were more than 1 device, we don't know whether the unplugged
+                    // one is the one we were connected to. In that case, reconnect the UF2 wrapper. If no more devices
+                    // are left, disconnect the existing wrapper while we wait for a new device to be plugged in.
+                    --deviceCount
+                    if (deviceCount > 0 && reconnectUf2WrapperCb) {
+                        reconnectUf2WrapperCb();
+                    } else if (deviceCount === 0 && disconnectUf2WrapperCb) {
+                        disconnectUf2WrapperCb();
+                    }
+                }
+            });
+            watcher.addEventListener("updated", (e: Windows.Devices.Enumeration.DeviceInformation) => {
+                // As per MSDN doc, we MUST subscribe to this event, otherwise the watcher doesn't work
+            });
+            watchers.push(watcher);
+        });
+        watchers.forEach((w) => w.start());
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1776,7 +1776,7 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
             <div id='root' className={rootClasses}>
                 {hideMenuBar ? undefined :
                     <header className="menubar" role="banner">
-                        {inEditor ? <accessibility.EditorAccessibilityMenu parent={this} highContrast={this.state.highContrast}/> : undefined }
+                        {inEditor ? <accessibility.EditorAccessibilityMenu parent={this} highContrast={this.state.highContrast} /> : undefined}
                         <notification.NotificationBanner parent={this} />
                         <container.MainMenu parent={this} />
                     </header>}
@@ -1785,40 +1785,40 @@ ${compileService && compileService.githubCorePackage && compileService.gittag ? 
                 </div> : undefined}
                 <div id="simulator">
                     <aside id="filelist" className="ui items">
-                        <label htmlFor="boardview" id="boardviewLabel" className="accessible-hidden" aria-hidden="true">{lf("Simulator") }</label>
+                        <label htmlFor="boardview" id="boardviewLabel" className="accessible-hidden" aria-hidden="true">{lf("Simulator")}</label>
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-labelledby="boardviewLabel">
                         </div>
                         <simtoolbar.SimulatorToolbar parent={this} />
                         <div className="ui item portrait hide">
-                            {pxt.options.debug && !this.state.running ? <sui.Button key='debugbtn' class='teal' icon="xicon bug" text={"Sim Debug"} onClick={() => this.runSimulator({ debug: true }) } /> : ''}
-                            {pxt.options.debug ? <sui.Button key='hwdebugbtn' class='teal' icon="xicon chip" text={"Dev Debug"} onClick={() => this.hwDebug() } /> : ''}
+                            {pxt.options.debug && !this.state.running ? <sui.Button key='debugbtn' class='teal' icon="xicon bug" text={"Sim Debug"} onClick={() => this.runSimulator({ debug: true })} /> : ''}
+                            {pxt.options.debug ? <sui.Button key='hwdebugbtn' class='teal' icon="xicon chip" text={"Dev Debug"} onClick={() => this.hwDebug()} /> : ''}
                         </div>
                         {useSerialEditor ?
                             <div id="serialPreview" className="ui editorFloat portrait hide">
-                                <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={() => this.openSerial(true) } />
-                                <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={() => this.openSerial(false) } />
+                                <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={() => this.openSerial(true)} />
+                                <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={() => this.openSerial(false)} />
                             </div> : undefined}
                         {sandbox || isBlocks || this.editor == this.serialEditor ? undefined : <filelist.FileList parent={this} />}
                     </aside>
                 </div>
                 <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
-                    {this.allEditors.map(e => e.displayOuter()) }
+                    {this.allEditors.map(e => e.displayOuter())}
                 </div>
                 {inHome ? <div id="homescreen" className="full-abs" role="main">
                     <div className="ui home projectsdialog">
                         <div className="menubar" role="banner">
-                            <accessibility.HomeAccessibilityMenu parent={this} highContrast={this.state.highContrast}/> }
+                            <accessibility.HomeAccessibilityMenu parent={this} highContrast={this.state.highContrast} /> }
                             <projects.ProjectsMenu parent={this} />
                         </div>
                         <projects.Projects parent={this} ref={v => this.home = v} />
                     </div>
-                </div> : undefined }
+                </div> : undefined}
                 {inTutorial ? <tutorial.TutorialHint ref="tutorialhint" parent={this} /> : undefined}
                 {inTutorial ? <tutorial.TutorialContent ref="tutorialcontent" parent={this} /> : undefined}
-                {showEditorToolbar ? <div id="editortools" role="complementary" aria-label={lf("Editor toolbar") }>
+                {showEditorToolbar ? <div id="editortools" role="complementary" aria-label={lf("Editor toolbar")}>
                     <editortoolbar.EditorToolbar ref="editortools" parent={this} />
                 </div> : undefined}
-                {sideDocs ? <container.SideDocs ref="sidedoc" parent={this} sideDocsCollapsed={this.state.sideDocsCollapsed} docsUrl={this.state.sideDocsLoadUrl}/> : undefined}
+                {sideDocs ? <container.SideDocs ref="sidedoc" parent={this} sideDocsCollapsed={this.state.sideDocsCollapsed} docsUrl={this.state.sideDocsLoadUrl} /> : undefined}
                 {sandbox ? undefined : <scriptsearch.ScriptSearch parent={this} ref={v => this.scriptSearch = v} />}
                 {sandbox ? undefined : <extensions.Extensions parent={this} ref={v => this.extensions = v} />}
                 {inHome ? <projects.ImportDialog parent={this} ref={v => this.importDialog = v} /> : undefined}
@@ -1886,7 +1886,15 @@ function initSerial() {
         return;
 
     if (hidbridge.shouldUse()) {
-        // Serial is already taken care of by our WinRT module
+        hidbridge.configureHidSerial((buf, isErr) => {
+            let data = Util.fromUTF8(Util.uint8ArrayToString(buf))
+            //pxt.debug('serial: ' + data)
+            window.postMessage({
+                type: 'serial',
+                id: 'n/a', // TODO
+                data
+            }, "*")
+        });
         return;
     }
 
@@ -1962,7 +1970,7 @@ function showIcons() {
     core.confirmAsync({
         header: "Icons",
         htmlBody:
-        usedIcons.map(s => `<i style='font-size:2em' class="ui icon ${s}"></i>&nbsp;${s}&nbsp; `).join("\n")
+            usedIcons.map(s => `<i style='font-size:2em' class="ui icon ${s}"></i>&nbsp;${s}&nbsp; `).join("\n")
     })
 }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -148,7 +148,7 @@ export function initCommandsAsync(): Promise<void> {
         pxt.commands.deployCoreAsync = webusbDeployCoreAsync;
     } else if (pxt.winrt.isWinRT()) { // windows app
         if (pxt.appTarget.serial && pxt.appTarget.serial.useHF2) {
-            pxt.winrt.initWinrtHid(() => hidbridge.initAsync(true), ), () => hidbridge.disconnectWrapperAsync()));
+            pxt.winrt.initWinrtHid(() => hidbridge.initAsync(true).then(() => {}), () => hidbridge.disconnectWrapperAsync());
             pxt.HF2.mkPacketIOAsync = pxt.winrt.mkPacketIOAsync;
             pxt.commands.deployCoreAsync = hidDeployCoreAsync;
         } else {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -148,9 +148,13 @@ export function initCommandsAsync(): Promise<void> {
         pxt.commands.deployCoreAsync = webusbDeployCoreAsync;
     } else if (pxt.winrt.isWinRT()) { // windows app
         if (pxt.appTarget.serial && pxt.appTarget.serial.useHF2) {
+            pxt.winrt.initWinrtHid(() => hidbridge.initAsync(true), ), () => hidbridge.disconnectWrapperAsync()));
             pxt.HF2.mkPacketIOAsync = pxt.winrt.mkPacketIOAsync;
             pxt.commands.deployCoreAsync = hidDeployCoreAsync;
         } else {
+            // If we're not using HF2, then the target is using their own deploy logic in extension.ts, so don't use
+            // the wrapper callbacks
+            pxt.winrt.initWinrtHid(null, null);
             if (pxt.appTarget.serial && pxt.appTarget.serial.rawHID) {
                 pxt.HF2.mkPacketIOAsync = pxt.winrt.mkPacketIOAsync;
             }

--- a/webapp/src/hidbridge.ts
+++ b/webapp/src/hidbridge.ts
@@ -159,15 +159,26 @@ class BridgeIO implements pxt.HF2.PacketIO {
 }
 
 let uf2Wrapper: pxt.HF2.Wrapper;
-let initPromise: Promise<pxt.HF2.Wrapper>
+let initPromise: Promise<pxt.HF2.Wrapper>;
+let serialHandler: (buf: Uint8Array, isStderr: boolean) => void;
 
 function hf2Async() {
     return pxt.HF2.mkPacketIOAsync()
         .then(h => {
-            uf2Wrapper = new pxt.HF2.Wrapper(h)
+            uf2Wrapper = new pxt.HF2.Wrapper(h);
+            if (serialHandler) {
+                uf2Wrapper.onSerial = serialHandler;
+            }
             return uf2Wrapper.reconnectAsync(true)
                 .then(() => uf2Wrapper)
         })
+}
+
+export function configureHidSerial(serialCb: (buf: Uint8Array, isStderr: boolean) => void): void {
+    serialHandler = serialCb;
+    if (uf2Wrapper) {
+        uf2Wrapper.onSerial = serialHandler;
+    }
 }
 
 export function disconnectWrapperAsync(): Promise<void> {

--- a/webapp/src/hidbridge.ts
+++ b/webapp/src/hidbridge.ts
@@ -158,20 +158,27 @@ class BridgeIO implements pxt.HF2.PacketIO {
     }
 }
 
+let uf2Wrapper: pxt.HF2.Wrapper;
+let initPromise: Promise<pxt.HF2.Wrapper>
+
 function hf2Async() {
     return pxt.HF2.mkPacketIOAsync()
         .then(h => {
-            let w = new pxt.HF2.Wrapper(h)
-            return w.reconnectAsync(true)
-                .then(() => w)
+            uf2Wrapper = new pxt.HF2.Wrapper(h)
+            return uf2Wrapper.reconnectAsync(true)
+                .then(() => uf2Wrapper)
         })
 }
 
-let initPromise: Promise<pxt.HF2.Wrapper>
+export function disconnectWrapperAsync(): Promise<void> {
+    if (uf2Wrapper) {
+        return uf2Wrapper.disconnectAsync();
+    }
+    return Promise.resolve();
+}
+
 export function initAsync(force = false) {
-    let isFirstInit = false;
     if (!initPromise) {
-        isFirstInit = true;
         initPromise = hf2Async()
             .catch(err => {
                 initPromise = null
@@ -182,9 +189,7 @@ export function initAsync(force = false) {
     return initPromise
         .then((w) => {
             wrapper = w;
-            if (force || pxt.winrt.isWinRT() && !isFirstInit) {
-                // For WinRT, disconnecting the device after flashing once puts the wrapper in a bad state.
-                // To workaround this, reconnect every time.
+            if (force) {
                 return wrapper.reconnectAsync();
             }
             return Promise.resolve();


### PR DESCRIPTION
- Uses the WinRT device watcher to reconnect as little as possible to HID devices
- As a result, the serial data polling logic is no longer needed, since we already reconnect when a device is newly plugged in

Not sure if this will fix the Adafruit crash issue, but it certainly makes the whole HID connection much cleaner for UF2