### PR TITLE
Serial view improvement

### DIFF
--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -252,13 +252,14 @@ export class Editor extends srceditor.Editor {
         const sep = lf("{id:csvseparator}\t");
         const lines: { name: string; line: number[][]; }[] = [];
         this.charts.forEach(chart => Object.keys(chart.datas).forEach(k => lines.push({ name: `${k} (${chart.source})`, line: chart.datas[k] })));
-        let csv = lines.map(line => `time (s)${sep} ${line.name}`).join(sep + ' ') + '\r\n';
+        let csv = `sep=${sep}\r\n` +
+            lines.map(line => `time (s)${sep}${line.name}`).join(sep) + '\r\n';
 
         const datas = lines.map(line => line.line);
         const nl = datas.map(data => data.length).reduce((l, c) => Math.max(l, c));
         const nc = this.charts.length;
         for (let i = 0; i < nl; ++i) {
-            csv += datas.map(data => i < data.length ? `${(data[i][0] - data[0][0]) / 1000}, ${data[i][1]}` : ` ${sep} `).join(sep + ' ');
+            csv += datas.map(data => i < data.length ? `${(data[i][0] - data[0][0]) / 1000}${sep}${data[i][1]}` : sep).join(sep);
             csv += '\r\n';
         }
 

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -12,7 +12,7 @@ import Cloud = pxt.Cloud
 import Util = pxt.Util
 
 const lf = Util.lf
-const maxEntriesPerChart: number = 2500;
+const maxEntriesPerChart: number = 4000;
 
 export class Editor extends srceditor.Editor {
     savedMessageQueue: pxsim.SimulatorSerialMessage[] = []
@@ -437,7 +437,7 @@ class Chart {
         data.push([timestamp, value]);
         // remove a third of the card
         if (data.length > maxEntriesPerChart)
-            data.splice(0, data.length / 3);
+            data.splice(0, data.length / 4);
     }
 
     start() {


### PR DESCRIPTION
- [x] don't drop stale graphs. this might interfere with experiment when data comes really slowly. Stale graphs can be dropped by hitting pause/start
- [x] store more data points. Smoothie drops the data as soon as it leaves the screen, storing a copy of the data on the side
- [x] specify the separator in the CSV file (`sep=...`) to avoid locale import issues