### PR TITLE
Atob or not atob

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -182,7 +182,7 @@ namespace pxt.blocks.layout {
 
     export function documentToSvg(xsg: Node): string {
         const xml = new XMLSerializer().serializeToString(xsg);
-        const data = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(xml)));
+        const data = "data:image/svg+xml;base64," + ts.pxtc.encodeBase64(unescape(encodeURIComponent(xml)));
         return data;
     }
 

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -1,7 +1,4 @@
 namespace ts.pxtc {
-
-    export var decodeBase64 = function (s: string) { return atob(s); }
-
     // supporting multiple sizes (byte, short, int, long)
     export interface BitSizeInfo {
         size: number;

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -617,7 +617,7 @@ _stored_program: .string "`
         let src = serialize(bin, opts)
         src = patchSrcHash(bin, src)
         if (opts.embedBlob)
-            src += addSource(opts.embedMeta, decodeBase64(opts.embedBlob))
+            src += addSource(opts.embedMeta, ts.pxtc.decodeBase64(opts.embedBlob))
         let checksumWords = 8
         let pageSize = hex.flashCodeAlign(opts.target)
         if (opts.target.flashChecksumAddr) {
@@ -667,7 +667,7 @@ __flash_checksums:
                 bin.checksumBlock = chk;
             }
             if (opts.target.useUF2) {
-                const myhex = btoa(hex.patchHex(bin, res.buf, false, true)[0])
+                const myhex = ts.pxtc.encodeBase64(hex.patchHex(bin, res.buf, false, true)[0])
                 bin.writeFile(pxtc.BINARY_UF2, myhex)
             } else {
                 const myhex = hex.patchHex(bin, res.buf, false, false).join("\r\n") + "\r\n"

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -237,11 +237,11 @@ namespace pxt.BrowserUtils {
     }
 
     export function browserDownloadBinText(text: string, name: string, contentType: string = "application/octet-stream", userContextWindow?: Window, onError?: (err: any) => void): string {
-        return browserDownloadBase64(btoa(text), name, contentType, userContextWindow, onError)
+        return browserDownloadBase64(ts.pxtc.encodeBase64(text), name, contentType, userContextWindow, onError)
     }
 
     export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", userContextWindow?: Window, onError?: (err: any) => void): string {
-        return browserDownloadBase64(btoa(Util.toUTF8(text)), name, contentType, userContextWindow, onError)
+        return browserDownloadBase64(ts.pxtc.encodeBase64(Util.toUTF8(text)), name, contentType, userContextWindow, onError)
     }
 
     export function isBrowserDownloadInSameWindow(): boolean {

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -731,7 +731,7 @@ int main() {
 
         let data = JSON.stringify(creq)
         res.sha = U.sha256(data)
-        res.compileData = btoa(U.toUTF8(data))
+        res.compileData = ts.pxtc.encodeBase64(U.toUTF8(data))
         res.shimsDTS = shimsDTS.finish()
         res.enumsDTS = enumsDTS.finish()
 
@@ -1138,7 +1138,7 @@ namespace pxt.hex {
                     buf += "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
                 }
             } else {
-                buf = pxtc.decodeBase64(nxt)
+                buf = ts.pxtc.decodeBase64(nxt)
             }
 
             Util.assert(buf.length > 0)
@@ -1217,7 +1217,7 @@ namespace pxt.hex {
                     let bin = ""
                     for (let k = 0; k < outln.length; k += 2)
                         bin += String.fromCharCode(parseInt(outln.slice(k, k + 2), 16))
-                    outp.push(btoa(bin))
+                    outp.push(ts.pxtc.encodeBase64(bin))
                 }
             }
         }

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -765,7 +765,7 @@ namespace pxt {
                                     eVER: pxt.appTarget.versions ? pxt.appTarget.versions.target : "",
                                     pxtTarget: appTarget.id,
                                 })
-                                opts.embedBlob = btoa(U.uint8ArrayToString(buf))
+                                opts.embedBlob = ts.pxtc.encodeBase64(U.uint8ArrayToString(buf))
                             });
                     } else {
                         return Promise.resolve()

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -511,8 +511,6 @@ namespace ts.pxtc {
 
     }
 
-    export var decodeBase64 = function (s: string) { return atob(s); }
-
     export namespace UF2 {
         export const UF2_MAGIC_START0 = 0x0A324655; // "UF2\n"
         export const UF2_MAGIC_START1 = 0x9E5D5157; // Randomly selected

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -6,6 +6,11 @@ namespace ts.pxtc {
 
 import pxtc = ts.pxtc
 
+namespace ts.pxtc {
+    export var decodeBase64 = function (s: string) { return atob(s); }
+    export var encodeBase64 = function (s: string) { return btoa(s); }
+}
+
 namespace ts.pxtc.Util {
     export function bufferSerial(buffers: pxt.Map<string>, data: string = "", source: string = "?", maxBufLen: number = 255) {
         for (let i = 0; i < data.length; ++i) {
@@ -987,7 +992,7 @@ namespace ts.pxtc.Util {
 
         // encode
         if (/xml|svg/.test(mimetype)) return `data:${mimetype},${encodeURIComponent(data)}`
-        else return `data:${mimetype || "image/png"};base64,${btoa(toUTF8(data))}`;
+        else return `data:${mimetype || "image/png"};base64,${ts.pxtc.encodeBase64(toUTF8(data))}`;
     }
 }
 

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -65,7 +65,7 @@ namespace pxt.runner {
         if (woptions.showEdit && !theme.hideDocsEdit) { // edit button
             const $editBtn = $(`<a class="item" role="button" tabindex="0" aria-label="${lf("edit")}"><i role="presentation" aria-hidden="true" class="edit icon"></i></a>`).click(() => {
                 decompileResult.package.compressToFileAsync(options.showJavaScript ? pxt.JAVASCRIPT_PROJECT_NAME : pxt.BLOCKS_PROJECT_NAME)
-                    .done(buf => window.open(`${getEditUrl(options)}/#project:${window.btoa(Util.uint8ArrayToString(buf))}`, 'pxt'))
+                    .done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'))
             })
             $menu.append($editBtn);
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -833,7 +833,7 @@ export class ProjectView
         pxt.debug("exporting project");
         return this.exportProjectToFileAsync()
             .then((buf) => {
-                return window.btoa(Util.uint8ArrayToString(buf));
+                return ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf));
             });
     }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -24,7 +24,7 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
     const fn = pkg.genFileName(ext);
     const userContext = pxt.BrowserUtils.isBrowserDownloadWithinUserContext();
     if (userContext) {
-        url = pxt.BrowserUtils.toDownloadDataUri(pxt.isOutputText() ? btoa(out) : out, pxt.appTarget.compile.hexMimeType);
+        url = pxt.BrowserUtils.toDownloadDataUri(pxt.isOutputText() ? ts.pxtc.encodeBase64(out) : out, pxt.appTarget.compile.hexMimeType);
     } else if (!pxt.isOutputText()) {
         pxt.debug('saving ' + fn)
         url = pxt.BrowserUtils.browserDownloadBase64(

--- a/webapp/src/worker.ts
+++ b/webapp/src/worker.ts
@@ -10,10 +10,10 @@ importScripts(
 
 let pm: any = postMessage;
 
-// work around safari not providing atob
-if (typeof atob === "undefined") {
+// work around safari not providing bota
+if (typeof btoa === "undefined") {
     // http://www.rise4fun.com/Bek/base64encode
-    pxtc.decodeBase64 = function (_input: string): string {
+    ts.pxtc.encodeBase64 = function (_input: string): string {
         function _base64(_x: number): number { return ((_x <= 0x19) ? (_x + 0x41) : ((_x <= 0x33) ? (_x + 0x47) : ((_x <= 0x3D) ? (_x - 0x4) : ((_x == 0x3E) ? 0x2B : 0x2F)))); };
         let result = new Array();
         let _q = 0x0;
@@ -47,6 +47,112 @@ if (typeof atob === "undefined") {
             result.push(String.fromCharCode(_base64(_r), 0x3D));
         }
         return result.join('');
+    }
+}
+
+// work around safari not providing atob
+if (typeof atob === "undefined") {
+    //http://www.rise4fun.com/Bek/Cbl
+    ts.pxtc.decodeBase64 = function (_input: string): string {
+        function _D(_x: number): number { return ((_x == 0x2F) ? 0x3F : ((_x == 0x2B) ? 0x3E : ((_x <= 0x39) ? (_x + 0x4) : ((_x <= 0x5A) ? (_x - 0x41) : (_x - 0x47))))); };
+
+        function _Bits(m: number, n: number, c: number): number {
+            let mask = 0;
+            for (let i = 0; i <= (m - n); i++) { mask = (mask << 1) + 1; }
+            return (c >> n) & mask;
+        };
+        let result = new Array();
+        let _q0 = true;
+        let _q1 = false;
+        let _q2 = false;
+        let _q3 = false;
+        let _q4 = false;
+        let _q5 = false;
+        let _r = 0x0;
+        let rx = new RegExp("^([A-Za-z0-9+/=])$");
+        for (let _i = 0; _i < _input.length; _i++) {
+            let _x = _input.charCodeAt(_i);
+            if ((!String.fromCharCode(_x).match(rx) || ((_x == 0x3D) && (_q0 || _q1)) || ((_x == 0x3D) && !(_r == 0x0)) || (!(_x == 0x3D) && _q4) || _q5)) {
+                // throw { name: 'InvalidInput' };
+                return undefined;
+            }
+            else if (_q0) {
+                _r = (_D(_x) << 0x2);
+                _q0 = false;
+                _q1 = true;
+                _q2 = false;
+                _q3 = false;
+                _q4 = false;
+                _q5 = false;
+            }
+            else if (_q1) {
+                result.push(String.fromCharCode((_r | _Bits(0x5, 0x4, _D(_x)))));
+                _r = ((_D(_x) & 0xF) << 0x4);
+                _q0 = false;
+                _q1 = false;
+                _q2 = true;
+                _q3 = false;
+                _q4 = false;
+                _q5 = false;
+            }
+            else if (_q2) {
+                if ((_x == 0x3D)) {
+                    _r = 0x0;
+                    _q0 = false;
+                    _q1 = false;
+                    _q2 = false;
+                    _q3 = false;
+                    _q4 = true;
+                    _q5 = false;
+                }
+                else {
+                    result.push(String.fromCharCode((_r | _Bits(0x5, 0x2, _D(_x)))));
+                    _r = ((_D(_x) & 0x3) << 0x6);
+                    _q0 = false;
+                    _q1 = false;
+                    _q2 = false;
+                    _q3 = true;
+                    _q4 = false;
+                    _q5 = false;
+                }
+            }
+            else if (_q3) {
+                if ((_x == 0x3D)) {
+                    _r = 0x0;
+                    _q0 = false;
+                    _q1 = false;
+                    _q2 = false;
+                    _q3 = false;
+                    _q4 = false;
+                    _q5 = true;
+                }
+                else {
+                    result.push(String.fromCharCode((_r | _D(_x))));
+                    _r = 0x0;
+                    _q0 = true;
+                    _q1 = false;
+                    _q2 = false;
+                    _q3 = false;
+                    _q4 = false;
+                    _q5 = false;
+                }
+            }
+            else if (_q4) {
+                _r = 0x0;
+                _q0 = false;
+                _q1 = false;
+                _q2 = false;
+                _q3 = false;
+                _q4 = false;
+                _q5 = true;
+            }
+        }
+        if (!(_q0 || _q5)) {
+            //throw { name: 'InvalidInput' };
+            return undefined;
+        }
+        const r = result.join('');
+        return r;
     }
 }
 


### PR DESCRIPTION
- always use ts.pxtc.encodeBase64 or ts.pxtc.decodeBase64 instead of atob/btoa (not defined in Safari web workers)

This fix should solve the long standing issue around files generated by Safari that cannot be reloaded.