### PR TITLE
Port new cookie consent to V0

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -9,7 +9,7 @@ var cmdIn = ju.cmdIn;
 var strpSrcMap = ju.strpSrcMap;
 
 function tscIn(task, dir, builtDir) {
-    let command = 'node ../node_modules/typescript/bin/tsc'
+    let command = 'node ' + path.relative(dir, './node_modules/typescript/bin/tsc')
     if (process.env.sourceMaps === 'true') {
         command += ' --sourceMap --mapRoot file:///' + path.resolve(builtDir)
     }
@@ -26,7 +26,7 @@ function loadText(filename) {
     return fs.readFileSync(filename, "utf8");
 }
 
-task('default', ['updatestrings', 'built/pxt.js', 'built/pxt.d.ts', 'built/pxtrunner.js', 'built/backendutils.js', 'wapp', 'monaco-editor'], { parallelLimit: 10 })
+task('default', ['updatestrings', 'built/pxt.js', 'built/pxt.d.ts', 'built/pxtrunner.js', 'built/backendutils.js', 'wapp', 'monaco-editor', 'built/web/pxtweb.js'], { parallelLimit: 10 })
 
 task('test', ['default', 'testfmt', 'testerr', 'testlang', 'testdecompiler', 'karma'])
 
@@ -102,6 +102,7 @@ compileDir("pxtsim", ["built/pxtlib.js", "built/pxtblocks.js"])
 compileDir("pxteditor", ["built/pxtlib.js", "built/pxtblocks.js"])
 compileDir("cli", ["built/pxtlib.js", "built/pxtsim.js"])
 compileDir("backendutils", ['pxtlib/util.ts', 'pxtlib/docsrender.ts'])
+file("built/web/pxtweb.js", expand(["docfiles/pxtweb"]), { async: true }, function () { tscIn(this, "docfiles/pxtweb", "built") })
 
 task("karma", ["blocklycompilertest"], function() {
     var command;
@@ -146,6 +147,7 @@ task("lint", [], { async: true }, function () {
         "pxtsim",
         "pxtwinrt",
         "webapp/src",
+        "docfiles/pxtweb",
         "monacots"]
         .map(function (d) { return "node node_modules/tslint/bin/tslint ./" + d + "/*.ts" })
         , { printStdout: true }, function () {

--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -1,1 +1,37 @@
-<!-- @include tracking.html -->
+<script type="text/javascript" src="/blb/pxtweb.js"></script>
+<script type="text/javascript">
+    window.loadAppInsights = function (includeCookie) {
+        var appInsights=window.appInsights||function(config){
+            function i(config){t[config]=function(){var i=arguments;t.queue.push(function(){t[config].apply(t,i)})}}var t={config:config},u=document,e=window,o="script",s="AuthenticatedUserContext",h="start",c="stop",l="Track",a=l+"Event",v=l+"Page",y=u.createElement(o),r,f;y.src=config.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{t.cookie=u.cookie}catch(p){}for(t.queue=[],t.version="1.0",r=["Event","Exception","Metric","PageView","Trace","Dependency"];r.length;)i("track"+r.pop());return i("set"+s),i("clear"+s),i(h+a),i(c+a),i(h+v),i(c+v),i("flush"),config.disableExceptionTracking||(r="onerror",i("_"+r),f=e[r],e[r]=function(config,i,u,e,o){var s=f&&f(config,i,u,e,o);return s!==!0&&t["_"+r](config,i,u,e,o),s}),t
+        }({
+            instrumentationKey:"9801ed01-c40f-46ec-aa40-2a1742a9e71c",
+            disableAjaxTracking: true,
+            overridePageViewDuration: false,
+            disableExceptionTracking: true,
+            isCookieUseDisabled: !includeCookie,
+            isStorageUseDisabled: true
+        });
+        window.appInsights=appInsights;
+        appInsights.queue.push(function () {
+            appInsights.context.addTelemetryInitializer(function (envelope) {
+                if (typeof pxtConfig === "undefined") return;
+                var telemetryItem = envelope.data.baseData;
+                telemetryItem.properties = telemetryItem.properties || {};
+                telemetryItem.properties["target"] = pxtConfig.targetId;
+                telemetryItem.properties["version"] = pxtConfig.targetVersion;
+                telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
+                if (typeof window !== "undefined" && window.location && /[?&]electron=1/i.test(window.location.href))
+                    telemetryItem.properties["electron"] = 1;
+                if (typeof Windows !== "undefined")
+                    telemetryItem.properties["WindowsApp"] = 1;
+            });
+        });
+        appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
+
+        var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
+        function scrubUrl(url) {
+            return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
+        }
+    }
+    pxt.initAnalyticsAsync();
+</script>

--- a/docfiles/pxtweb/README.md
+++ b/docfiles/pxtweb/README.md
@@ -1,0 +1,5 @@
+# pxtweb
+
+The intention of these files is to be the common code for all the
+"full pages" we serve (e.g. the editor, the docs, and makecode.com).
+Code in this directory should not have any dependencies.

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -1,0 +1,267 @@
+/// <reference path="../../localtypings/mscc.d.ts" />
+
+namespace pxt {
+    type Map<T> = {[index: string]: T};
+
+    interface CookieBannerInfo {
+        /* Does the banner need to be shown? */
+        IsConsentRequired: boolean;
+
+        /* Name of the cookie, usually MSCC */
+        CookieName: string;
+
+        /* HTML for the banner to be embedded into the page */
+        Markup: string;
+
+        /* Scripts to be loaded in the page for the banner */
+        Js: string[];
+
+        /* CSS files to be loaded in the page for the banner*/
+        Css: string[];
+
+        /* The minimum date for which consent is considered valid (any consent given before this date does not count) */
+        MinimumConsentDate: string;
+
+        /* Error message from the server, if present */
+        Error?: string;
+    }
+
+    interface HttpResponse {
+        status: number;
+        body: string;
+    }
+
+    interface Callback<T> {
+        (err?: any, res?: T): void;
+    }
+
+    const eventBufferSizeLimit = 20;
+    const queues: TelemetryQueue<any, any, any>[] = [];
+
+    let analyticsLoaded = false;
+
+    class TelemetryQueue<A, B, C> {
+        private q: [A, B, C][] = [];
+        constructor (private log: (a?: A, b?: B, c?: C) => void) {
+            queues.push(this);
+        }
+
+        public track(a: A, b: B, c: C) {
+            if (analyticsLoaded) {
+                this.log(a, b, c);
+            }
+            else {
+                this.q.push([a, b, c]);
+                if (this.q.length > eventBufferSizeLimit) this.q.shift();
+            }
+        }
+
+        public flush() {
+            while (this.q.length) {
+                const [a, b, c] = this.q.shift();
+                this.log(a, b, c);
+            }
+        }
+    }
+
+    let eventLogger: TelemetryQueue<string, Map<string>, Map<number>>;
+    let exceptionLogger: TelemetryQueue<any, string, Map<string>>;
+
+    export function initAnalyticsAsync() {
+        getCookieBannerAsync(document.domain, detectLocale(), (bannerErr, info) => {
+            if (bannerErr || info.Error) {
+                // Start app insights, just don't drop any cookies
+                initializeAppInsights(false);
+                return;
+            }
+
+            // Clear the cookies if the consent is too old, mscc won't do it automatically
+            if (isConsentExpired(info.CookieName, info.MinimumConsentDate)) {
+                const definitelyThePast = new Date(0).toUTCString();
+                document.cookie = `ai_user=; expires=${definitelyThePast}`;
+                document.cookie = `ai_session=; expires=${definitelyThePast}`;
+                document.cookie = `${info.CookieName}=0; expires=${definitelyThePast}`;
+            }
+
+            let bannerDiv = document.getElementById("cookiebanner");
+            if (!bannerDiv) {
+                bannerDiv = document.createElement("div");
+                document.body.insertBefore(bannerDiv, document.body.firstChild);
+            }
+
+            // The markup is trusted because it's from our backend, so it shouldn't need to be scrubbed
+            bannerDiv.innerHTML = info.Markup;
+
+            if (info.Css && info.Css.length) {
+                info.Css.forEach(injectStylesheet)
+            }
+
+            all(info.Js || [], injectScriptAsync, msccError => {
+                initializeAppInsights(!msccError && typeof mscc !== "undefined" && mscc.hasConsent());
+            });
+        });
+    }
+
+    export function aiTrackEvent(id: string, data?: any, measures?: any) {
+        if (!eventLogger) {
+            eventLogger = new TelemetryQueue((a, b, c) => (window as any).appInsights.trackEvent(a, b, c));
+        }
+        eventLogger.track(id, data, measures);
+    }
+
+    export function aiTrackException(err: any, kind?: string, props?: any) {
+        if (!exceptionLogger) {
+            exceptionLogger = new TelemetryQueue((a, b, c) => (window as any).appInsights.trackException(a, b, c));
+        }
+        exceptionLogger.track(err, kind, props);
+    }
+
+    function detectLocale() {
+        // Intentionally ignoring the default locale in the target settings and the language cookie
+        // Warning: app.tsx overwrites the hash after reading the language so this needs
+        // to be called before that happens
+        const mlang = /(live)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
+        return mlang ? mlang[2] : ((navigator as any).userLanguage || navigator.language);
+    }
+
+    function getCookieBannerAsync(domain: string, locale: string, cb: Callback<CookieBannerInfo>) {
+        httpGetAsync(`https://makecode.com/api/mscc/${domain}/${locale}`, function(err, resp) {
+            if (err) {
+                cb(err);
+                return;
+            }
+
+            if (resp.status === 200) {
+                try {
+                    const info = JSON.parse(resp.body);
+                    cb(undefined, info as CookieBannerInfo);
+                    return;
+                }
+                catch (e) {
+                    cb(new Error("Bad response from server: " + resp.body))
+                    return;
+                }
+            }
+            cb(new Error("didn't get 200 response: " + resp.status + " " + resp.body));
+        });
+    }
+
+    function isConsentExpired(cookieName: string, minimumConsentDate: string) {
+        const minDate = Date.parse(minimumConsentDate);
+
+        if (!isNaN(minDate)) {
+            if (document && document.cookie) {
+                const cookies = document.cookie.split(";");
+                for (let cookie of cookies) {
+                    cookie = cookie.trim();
+                    if (cookie.indexOf("=") == cookieName.length && cookie.substr(0, cookieName.length) == cookieName) {
+                        const value = parseInt(cookie.substr(cookieName.length + 1));
+                        if (!isNaN(value)) {
+                            // The cookie value is the consent date in seconds since the epoch
+                            return value < Math.floor(minDate / 1e3);
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    function initializeAppInsights(includeCookie = false) {
+        // loadAppInsights is defined in docfiles/tracking.html
+        const loadAI = (window as any).loadAppInsights;
+        if (loadAI) {
+            loadAI(includeCookie);
+            analyticsLoaded = true;
+            queues.forEach(a => a.flush());
+        }
+    }
+
+    function httpGetAsync(url: string, cb: Callback<HttpResponse>) {
+        try {
+            let client: XMLHttpRequest;
+            let resolved = false
+            client = new XMLHttpRequest();
+            client.onreadystatechange = () => {
+                if (resolved) return // Safari/iOS likes to call this thing more than once
+
+                if (client.readyState == 4) {
+                    resolved = true
+                    let res: HttpResponse = {
+                        status: client.status,
+                        body: client.responseText
+                    }
+                    cb(undefined, res);
+                }
+            }
+
+            client.open("GET", url);
+            client.send();
+        }
+        catch (e) {
+            cb(e);
+        }
+    }
+
+    function injectStylesheet(href: string) {
+        if (document.head) {
+            const link = document.createElement("link");
+            link.setAttribute("rel", "stylesheet");
+            link.setAttribute("href", href);
+            link.setAttribute("type", "text/css");
+            document.head.appendChild(link);
+        }
+    }
+
+    function injectScriptAsync(src: string, cb: Callback<void>) {
+        let resolved = false;
+        if (document.body) {
+            const script = document.createElement("script");
+            script.setAttribute("type", "text/javascript");
+            script.onload = function (ev) {
+                if (!resolved) {
+                    cb();
+                    resolved = true;
+                }
+            };
+            script.onerror = function (err) {
+                if (!resolved) {
+                    cb(err);
+                    resolved = true;
+                }
+            }
+            document.body.appendChild(script);
+            script.setAttribute("src", src);
+        }
+        else {
+            throw new Error("Bad call to injectScriptAsync")
+        }
+    }
+
+    // No promises, so here we are
+    function all<T, U>(values: T[], func: (value: T, innerCb: Callback<U>) => void, cb: Callback<U[]>) {
+        let index = 0;
+        let res: U[] = [];
+
+        let doNext = () => {
+            if (index >= values.length) {
+                cb(undefined, res);
+            }
+            else {
+                func(values[index++], (err, val) => {
+                    if (err) {
+                        cb(err);
+                    }
+                    else {
+                        res.push(val);
+                        doNext();
+                    }
+                });
+            }
+        };
+
+        doNext();
+    }
+}

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -71,8 +71,9 @@ namespace pxt {
         getCookieBannerAsync(document.domain, detectLocale(), (bannerErr, info) => {
             if (bannerErr || info.Error) {
                 // Start app insights, just don't drop any cookies
-                initializeAppInsights(false);
-                return;
+                // initializeAppInsights(false);
+                // return;
+                info = { "IsConsentRequired": true, "CookieName": "MSCC", "Markup": "<div id='msccBanner' dir='ltr' data-site-name='uhf-makecode' data-mscc-version='0.4.0' data-nver='aspnet-2.0.7' data-sver='0.1.2' class='cc-banner' role='alert'><div class='cc-container'><svg class='cc-icon cc-v-center' x='0px' y='0px' viewBox='0 0 44 44' height='30px' fill='none' stroke='currentColor'><circle cx='22' cy='22' r='20' stroke-width='2'></circle><line x1='22' x2='22' y1='18' y2='33' stroke-width='3'></line><line x1='22' x2='22' y1='12' y2='15' stroke-width='3'></line></svg> <span class='cc-v-center cc-text'>This site uses cookies for analytics, personalized content and ads. By continuing to browse this site, you agree to this use.</span> <a href='https://go.microsoft.com/fwlink/?linkid=845480' aria-label='Learn more about Microsoft&#39;s Cookie Policy' id='msccLearnMore' class='cc-link cc-v-center cc-float-right' data-mscc-ic='false'>Learn more</a></div></div>", "Css": ["https://uhf.microsoft.com/mscc/statics/mscc-0.4.0.min.css"], "Js": ["https://uhf.microsoft.com/mscc/statics/mscc-0.4.0.min.js"], "MinimumConsentDate": "2019-04-01T00:00:00", "Error": null, "lastUpdate": 1517615910 } as any;
             }
 
             // Clear the cookies if the consent is too old, mscc won't do it automatically

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -104,14 +104,14 @@ namespace pxt {
 
     export function aiTrackEvent(id: string, data?: any, measures?: any) {
         if (!eventLogger) {
-            eventLogger = new TelemetryQueue((a, b, c) => (window as any).appInsights.trackEvent(a, b, c));
+            eventLogger = new TelemetryQueue<string, Map<string>, Map<number>>((a, b, c) => (window as any).appInsights.trackEvent(a, b, c));
         }
         eventLogger.track(id, data, measures);
     }
 
     export function aiTrackException(err: any, kind?: string, props?: any) {
         if (!exceptionLogger) {
-            exceptionLogger = new TelemetryQueue((a, b, c) => (window as any).appInsights.trackException(a, b, c));
+            exceptionLogger = new TelemetryQueue<any, string, Map<string>>((a, b, c) => (window as any).appInsights.trackException(a, b, c));
         }
         exceptionLogger.track(err, kind, props);
     }

--- a/docfiles/pxtweb/tsconfig.json
+++ b/docfiles/pxtweb/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "declaration": true,
+        "out": "../../built/web/pxtweb.js",
+        "newLine": "LF",
+        "sourceMap": false,
+        "lib": ["dom", "dom.iterable", "scripthost", "es6"],
+        "types": []
+    }
+}

--- a/docfiles/pxtweb/tsconfig.json
+++ b/docfiles/pxtweb/tsconfig.json
@@ -6,8 +6,6 @@
         "declaration": true,
         "out": "../../built/web/pxtweb.js",
         "newLine": "LF",
-        "sourceMap": false,
-        "lib": ["dom", "dom.iterable", "scripthost", "es6"],
-        "types": []
+        "sourceMap": false
     }
 }

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -1,33 +1,37 @@
+<script type="text/javascript" src="/doccdn/pxtweb.js"></script>
 <script type="text/javascript">
-    var appInsights=window.appInsights||function(config){
-        function i(config){t[config]=function(){var i=arguments;t.queue.push(function(){t[config].apply(t,i)})}}var t={config:config},u=document,e=window,o="script",s="AuthenticatedUserContext",h="start",c="stop",l="Track",a=l+"Event",v=l+"Page",y=u.createElement(o),r,f;y.src=config.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{t.cookie=u.cookie}catch(p){}for(t.queue=[],t.version="1.0",r=["Event","Exception","Metric","PageView","Trace","Dependency"];r.length;)i("track"+r.pop());return i("set"+s),i("clear"+s),i(h+a),i(c+a),i(h+v),i(c+v),i("flush"),config.disableExceptionTracking||(r="onerror",i("_"+r),f=e[r],e[r]=function(config,i,u,e,o){var s=f&&f(config,i,u,e,o);return s!==!0&&t["_"+r](config,i,u,e,o),s}),t
-    }({
-        instrumentationKey:"9801ed01-c40f-46ec-aa40-2a1742a9e71c",
-        disableAjaxTracking: true,
-        overridePageViewDuration: false,
-        disableExceptionTracking: true,
-        isCookieUseDisabled: true,
-        isStorageUseDisabled: true
-    });
-    window.appInsights=appInsights;
-    appInsights.queue.push(function () {
-        appInsights.context.addTelemetryInitializer(function (envelope) {
-            if (typeof pxtConfig === "undefined") return;
-            var telemetryItem = envelope.data.baseData;
-            telemetryItem.properties = telemetryItem.properties || {};
-            telemetryItem.properties["target"] = pxtConfig.targetId;
-            telemetryItem.properties["version"] = pxtConfig.targetVersion;
-            telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
-            if (typeof window !== "undefined" && window.location && /[?&]electron=1/i.test(window.location.href))
-                telemetryItem.properties["electron"] = 1;
-            if (typeof Windows !== "undefined")
-                telemetryItem.properties["WindowsApp"] = 1;
+    window.loadAppInsights = function (includeCookie) {
+        var appInsights=window.appInsights||function(config){
+            function i(config){t[config]=function(){var i=arguments;t.queue.push(function(){t[config].apply(t,i)})}}var t={config:config},u=document,e=window,o="script",s="AuthenticatedUserContext",h="start",c="stop",l="Track",a=l+"Event",v=l+"Page",y=u.createElement(o),r,f;y.src=config.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{t.cookie=u.cookie}catch(p){}for(t.queue=[],t.version="1.0",r=["Event","Exception","Metric","PageView","Trace","Dependency"];r.length;)i("track"+r.pop());return i("set"+s),i("clear"+s),i(h+a),i(c+a),i(h+v),i(c+v),i("flush"),config.disableExceptionTracking||(r="onerror",i("_"+r),f=e[r],e[r]=function(config,i,u,e,o){var s=f&&f(config,i,u,e,o);return s!==!0&&t["_"+r](config,i,u,e,o),s}),t
+        }({
+            instrumentationKey:"9801ed01-c40f-46ec-aa40-2a1742a9e71c",
+            disableAjaxTracking: true,
+            overridePageViewDuration: false,
+            disableExceptionTracking: true,
+            isCookieUseDisabled: !includeCookie,
+            isStorageUseDisabled: true
         });
-    });
-    appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
+        window.appInsights=appInsights;
+        appInsights.queue.push(function () {
+            appInsights.context.addTelemetryInitializer(function (envelope) {
+                if (typeof pxtConfig === "undefined") return;
+                var telemetryItem = envelope.data.baseData;
+                telemetryItem.properties = telemetryItem.properties || {};
+                telemetryItem.properties["target"] = pxtConfig.targetId;
+                telemetryItem.properties["version"] = pxtConfig.targetVersion;
+                telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
+                if (typeof window !== "undefined" && window.location && /[?&]electron=1/i.test(window.location.href))
+                    telemetryItem.properties["electron"] = 1;
+                if (typeof Windows !== "undefined")
+                    telemetryItem.properties["WindowsApp"] = 1;
+            });
+        });
+        appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
 
-    var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
-    function scrubUrl(url) {
-        return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
+        var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
+        function scrubUrl(url) {
+            return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
+        }
     }
+    pxt.initAnalyticsAsync();
 </script>

--- a/localtypings/mscc.d.ts
+++ b/localtypings/mscc.d.ts
@@ -1,0 +1,44 @@
+declare namespace mscc {
+    /**
+    * The current mscc cookie name
+    */
+    const cookieName: string;
+
+    /**
+    * The current mscc version
+    */
+    const version: string;
+
+    /**
+    * If true, consent will automatically be given by the user via
+    * interacting with the site. When enabled, MSCC will listen for click
+    * events on the current page, setting consent if the user clicks.
+    *
+    * @default: true
+    */
+    let interactiveConsentEnabled: boolean;
+
+    /**
+    * The valid event types that can be subscribed to
+    */
+    type EventTypes = 'consent';
+
+    /**
+    * The subscriber method as part of mscc's pubsub model.
+    *
+    * @param name - the name of the event to be subscribed to
+    * @param fn - the function to call after the event is published
+    */
+    function on(name: EventTypes, fn: Function): void;
+
+    /**
+    * Set hasConsent to true, and set the consent cookie. If the mscc cookie banner is
+    * present on the page, the banner will be closed. Is idempotent.
+    */
+    function setConsent(): void;
+
+    /**
+    * Returns true if the user has given consent, otherwise false.
+    */
+    function hasConsent(): boolean;
+}

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -1,23 +1,34 @@
+/// <reference path="../localtypings/mscc" />
+
+namespace pxt {
+    // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
+    export declare function aiTrackEvent(id: string, data?: any, measures?: any): void;
+    export declare function aiTrackException(err: any, kind: string, props: any): void;
+}
+
 namespace pxt.analytics {
     export function enable() {
-        let ai = (window as any).appInsights;
-        if (!ai) return;
+        if (!pxt.aiTrackException || !pxt.aiTrackEvent) return;
 
-        pxt.debug('enabling app insights')
+        pxt.debug('setting up app insights')
 
         const te = pxt.tickEvent;
-        pxt.tickEvent = function (id: string, data?: Map<string | number>): void {
-            if (te) te(id, data);
-            if (!data) ai.trackEvent(id);
+        pxt.tickEvent = function (id: string, data?: Map<string | number>, opts?: TelemetryEventOptions): void {
+            if (te) te(id, data, opts);
+
+            if (opts && opts.interactiveConsent && typeof mscc !== "undefined" && !mscc.hasConsent()) {
+                mscc.setConsent();
+            }
+            if (!data) pxt.aiTrackEvent(id);
             else {
                 const props: Map<string> = {};
                 const measures: Map<number> = {};
                 for (const k in data)
                     if (typeof data[k] == "string") props[k] = <string>data[k];
                     else measures[k] = <number>data[k];
-                ai.trackEvent(id, props, measures);
+                    pxt.aiTrackEvent(id, props, measures);
             }
-        }
+        };
 
         const rexp = pxt.reportException;
         pxt.reportException = function (err: any, data: pxt.Map<string>): void {
@@ -27,8 +38,9 @@ namespace pxt.analytics {
                 version: pxt.appTarget.versions.target
             }
             if (data) Util.jsonMergeFrom(props, data);
-            ai.trackException(err, 'exception', props)
-        }
+            pxt.aiTrackException(err, 'exception', props)
+        };
+
         const re = pxt.reportError;
         pxt.reportError = function (cat: string, msg: string, data?: pxt.Map<string>): void {
             if (re) re(cat, msg, data);
@@ -43,8 +55,8 @@ namespace pxt.analytics {
                     message: msg
                 }
                 if (data) Util.jsonMergeFrom(props, data);
-                ai.trackException(err, 'error', props)
+                pxt.aiTrackException(err, 'error', props);
             }
-        }
+        };
     }
 }

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -59,4 +59,23 @@ namespace pxt.analytics {
             }
         };
     }
+
+    export function setConsent() {
+        if (typeof mscc !== "undefined" && !mscc.hasConsent()) {
+            mscc.setConsent();
+        }
+    }
+
+    /**
+     * Helper method for generating a function that can be used to wrap onClick handlers
+     * that should trigger interactive consent
+     */
+    export function consentWrapper<T>(that: T) {
+        return (cb: () => void) => {
+            return () => {
+                cb.bind(that)();
+                setConsent();
+            };
+        };
+    }
 }

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -77,10 +77,14 @@ namespace pxt {
         }
     }
 
+    export interface TelemetryEventOptions {
+        interactiveConsent: boolean;
+    }
+
     /**
      * Track an event.
      */
-    export var tickEvent: (id: string, data?: Map<string | number>) => void = function (id) { }
+    export var tickEvent: (id: string, data?: Map<string | number>, opts?: TelemetryEventOptions) => void = function (id) { }
 
     let activityEvents: Map<number> = {};
     const tickActivityDebounced = Util.debounce(() => {

--- a/theme/common.less
+++ b/theme/common.less
@@ -24,7 +24,7 @@ html, body {
 
 #msccBanner {
     /* Don't change! This legal text should always be above everything else */
-    z-index: @aboveEverythingZIndex;
+    z-index: 100000;
 }
 
 #editorcontent {

--- a/theme/common.less
+++ b/theme/common.less
@@ -32,6 +32,10 @@ html, body {
     position: relative;
 }
 
+#mainmenu {
+    position: relative !important;
+}
+
 #filelist,
 #maineditor,
 #sidedocs {

--- a/theme/common.less
+++ b/theme/common.less
@@ -14,6 +14,24 @@ html, body {
 }
 
 /* Main Layout */
+#allcontent {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+}
+
+#msccBanner {
+    /* Don't change! This legal text should always be above everything else */
+    z-index: @aboveEverythingZIndex;
+}
+
+#editorcontent {
+    flex: 1 1 auto;
+    position: relative;
+}
+
 #filelist,
 #maineditor,
 #sidedocs {

--- a/theme/common.less
+++ b/theme/common.less
@@ -174,25 +174,6 @@ html, body {
     font-weight: 100 !important;
 }
 
-/* Cookie Message */
-#cookiemsg {
-   position: absolute;
-   right: 2rem;
-   bottom: 12rem;
-   width: 18rem;
-   text-align: left;
-   z-index:1000;
-}
-
-#cookiemsg > a {
-   color:white;
-   text-decoration: underline;
-}
-
-.collapsedEditorTools #cookiemsg {
-   bottom: 6rem;
-}
-
 /* Simulator */
 div.simframe {
     border:none;
@@ -782,9 +763,6 @@ Avatar
     .collapsedEditorTools #maineditor {
         left: 0;
     }
-    #cookiemsg {
-        bottom: 7.5rem;
-    }
 
     /* Full screen */
     .fullscreensim #filelist {
@@ -1022,9 +1000,6 @@ Avatar
         .sandbox #msg {
         bottom: 1.5rem !important;
     }
-    .sandbox #cookiemsg {
-        bottom: 3rem;
-    }
     .sandbox #editortools {
         display: none;
     }
@@ -1102,14 +1077,5 @@ Avatar
     }
     .simView div.simframe:only-child > iframe {
         max-width: 100%;
-    }
-    .sandbox #cookiemsg {
-        left: 0;
-        right: 0;
-        margin-left: 0.2rem;
-        margin-right: 0.2rem;
-        width: inherit;
-        bottom: 1.5rem;
-        padding: 0.3rem;
     }
 }

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -45,7 +45,7 @@
     }
 
     /* Menu bar */
-    #menubar .menu > .item:focus > i, 
+    #menubar .menu > .item:focus > i,
     #menubar .menu > .item:focus > span {
         color: @selected !important;
     }
@@ -97,7 +97,7 @@
         }
     }
 
-    .ui.button.download-button:hover > span, 
+    .ui.button.download-button:hover > span,
     .ui.button.download-button:hover > i {
         color: white !important;
     }
@@ -105,7 +105,7 @@
     /* Inputs */
     .ui.input input {
         background: black !important;
-        color: white !important; 
+        color: white !important;
         border: 1px solid white !important;
     }
     input::placeholder {
@@ -159,14 +159,14 @@
             }
         }
     }
-    
+
     .ui.menu .ui.dropdown .menu > .divider {
         background: black !important;
         border-top: 1px solid white !important;
     }
 
     /* Editor switch toggle */
-    #menubar .ui.menu .item.editor-menuitem { 
+    #menubar .ui.menu .item.editor-menuitem {
         border: 1px solid white !important;
     }
 
@@ -222,7 +222,7 @@
         .header, .description, .meta {
             color: white !important;
         }
-        
+
         &:focus {
             .header, .description, .meta {
                 color: @selected !important;
@@ -236,12 +236,6 @@
         }
     }
 
-    #cookiemsg {
-        background: black !important;
-        border-radius: 0em;
-        border: 1px solid white !important;
-    }
-
     /* Tutorial */
     .ui.message {
         background-color: black !important;
@@ -250,7 +244,7 @@
         .tutorialmessage {
             outline: 1px solid white !important;
             border: none !important;
-        
+
             &:focus {
                 color: @selected !important;
             }
@@ -274,7 +268,7 @@
 
     .blocklyToolboxDiv, .monacoToolboxDiv {
         background: black !important;
-        border-left: 1px solid white !important; 
+        border-left: 1px solid white !important;
         border-right: 1px solid white !important;
     }
 
@@ -316,7 +310,7 @@
 
     #maineditor, .ui.segment.form {
         background: black !important;
-            
+
         label {
             color: white !important;
         }

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -21,7 +21,12 @@
         <div class="ui large loader"></div>
     </div>
 
-    <div id='content' class="ui dimmable full-abs">
+    <div id="allcontent">
+        <div id="cookiebanner"></div>
+        <div id="editorcontent">
+            <div id='content' class="ui dimmable full-abs">
+            </div>
+        </div>
     </div>
 
     <div id='msg' aria-live="polite">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1675,9 +1675,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         const audio = run && !inTutorial && targetTheme.hasAudio;
         const { hideMenuBar, hideEditorToolbar } = targetTheme;
         const isHeadless = simOpts.headless;
-        const cookieKey = "cookieconsent"
-        const cookieConsented = targetTheme.hideCookieNotice || electron.isElectron || pxt.winrt.isWinRT() || !!pxt.storage.getLocal(cookieKey)
-            || sandbox;
         const simActive = this.state.embedSimView;
         const blockActive = this.isBlocksActive();
         const javascriptActive = this.isJavaScriptActive();
@@ -1685,11 +1682,6 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         const selectLanguage = targetTheme.selectLanguage;
         const showEditorToolbar = !hideEditorToolbar && this.editor.hasEditorToolbar();
         const useSerialEditor = pxt.appTarget.serial && !!pxt.appTarget.serial.useEditor;
-
-        const consentCookie = () => {
-            pxt.storage.setLocal(cookieKey, "1");
-            this.forceUpdate();
-        }
 
         const showSideDoc = sideDocs && this.state.sideDocsLoadUrl && !this.state.sideDocsCollapsed;
 
@@ -1719,14 +1711,16 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
         }
         const rootClasses = sui.cx(rootClassList);
 
+        const uiHandler = pxt.analytics.consentWrapper(this);
+
         return (
             <div id='root' className={rootClasses}>
                 {hideMenuBar ? undefined :
                     <header id="menubar" role="banner" className={"ui menu"}>
                         <div id="accessibleMenu" role="menubar">
-                            <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon js" text={lf("Skip to JavaScript editor")} onClick={() => this.openJavaScript()} />
-                            {selectLanguage ? <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={() => this.selectLang()} /> : undefined}
-                            {targetTheme.highContrast ? <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" text={this.state.highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={() => this.toggleHighContrast()} /> : undefined}
+                            <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon js" text={lf("Skip to JavaScript editor")} onClick={uiHandler(this.openJavaScript)} />
+                            {selectLanguage ? <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={uiHandler(this.selectLang)} /> : undefined}
+                            {targetTheme.highContrast ? <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" text={this.state.highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={uiHandler(this.toggleHighContrast)} /> : undefined}
                         </div>
                         <notificationbanner.NotificationBanner parent={this} />
                         <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar" aria-label={lf("Main menu")}>
@@ -1737,48 +1731,48 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                                         : <span className="name">{targetTheme.name}</span>}
                                     {targetTheme.portraitLogo ? (<span className="ui portrait only"><img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo)} alt={`${targetTheme.boardName} Logo`} /></span>) : null}
                                 </a>
-                                {!inTutorial ? <sui.Item class="icon openproject" role="menuitem" textClass="landscape only" icon="folder open large" ariaLabel={lf("Create or open recent project")} text={lf("Projects")} onClick={() => this.openProject()} /> : null}
-                                {!inTutorial && this.state.header && sharingEnabled ? <sui.Item class="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project")} text={lf("Share")} icon="share alternate large" onClick={() => this.embed()} /> : null}
+                                {!inTutorial ? <sui.Item class="icon openproject" role="menuitem" textClass="landscape only" icon="folder open large" ariaLabel={lf("Create or open recent project")} text={lf("Projects")} onClick={uiHandler(this.openProject)} /> : null}
+                                {!inTutorial && this.state.header && sharingEnabled ? <sui.Item class="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project")} text={lf("Share")} icon="share alternate large" onClick={uiHandler(this.embed)} /> : null}
                                 {inTutorial ? <sui.Item class="tutorialname" tabIndex={-1} textClass="landscape only" text={tutorialOptions.tutorialName} /> : null}
                             </div> : <div className="left menu">
                                     <span id="logo" className="ui item logo">
-                                        <img className="ui mini image" src={Util.toDataUri(rightLogo)} tabIndex={0} onClick={() => this.launchFullEditor()} onKeyDown={sui.fireClickOnEnter} alt={`${targetTheme.boardName} Logo`} />
+                                        <img className="ui mini image" src={Util.toDataUri(rightLogo)} tabIndex={0} onClick={uiHandler(this.launchFullEditor)} onKeyDown={sui.fireClickOnEnter} alt={`${targetTheme.boardName} Logo`} />
                                     </span>
                                 </div>}
                             {!inTutorial && !targetTheme.blocksOnly ? <div className="ui item link editor-menuitem">
                                 {sandbox ? <sui.Item class="sim-menuitem thin portrait only" role="menuitem" textClass="landscape only" text={lf("Simulator")} icon={simActive && this.state.running ? "stop" : "play"} active={simActive} onClick={() => this.openSimView()} title={!simActive ? lf("Show Simulator") : runTooltip} /> : undefined}
-                                <sui.Item class="blocks-menuitem" role="menuitem" textClass="landscape only" text={lf("Blocks")} icon="xicon blocks" active={blockActive} onClick={() => this.openBlocks()} title={lf("Convert code to Blocks")} />
-                                <sui.Item class="javascript-menuitem" role="menuitem" textClass="landscape only" text={lf("JavaScript")} icon="xicon js" active={javascriptActive} onClick={() => this.openJavaScript(false)} title={lf("Convert code to JavaScript")} />
+                                <sui.Item class="blocks-menuitem" role="menuitem" textClass="landscape only" text={lf("Blocks")} icon="xicon blocks" active={blockActive} onClick={uiHandler(this.openBlocks)} title={lf("Convert code to Blocks")} />
+                                <sui.Item class="javascript-menuitem" role="menuitem" textClass="landscape only" text={lf("JavaScript")} icon="xicon js" active={javascriptActive} onClick={uiHandler(() => this.openJavaScript(false))} title={lf("Convert code to JavaScript")} />
                             </div> : undefined}
                             {inTutorial ? <tutorial.TutorialMenuItem parent={this} /> : undefined}
                             <div className="right menu">
                                 {docMenu ? <container.DocsMenuItem parent={this} /> : undefined}
                                 {sandbox || inTutorial ? undefined :
                                     <sui.DropdownMenuItem icon='setting large' title={lf("More...")} class="more-dropdown-menuitem">
-                                        {this.state.header ? <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json"))} tabIndex={-1} /> : undefined}
-                                        {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...")} onClick={() => this.addPackage()} tabIndex={-1} /> : undefined}
-                                        {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={() => this.removeProject()} tabIndex={-1} /> : undefined}
-                                        {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={() => this.showReportAbuse()} tabIndex={-1} /> : undefined}
+                                        {this.state.header ? <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={uiHandler(() => this.setFile(pkg.mainEditorPkg().lookupFile("this/pxt.json")))} tabIndex={-1} /> : undefined}
+                                        {this.state.header && packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Add Package...")} onClick={uiHandler(this.addPackage)} tabIndex={-1} /> : undefined}
+                                        {this.state.header ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={uiHandler(this.removeProject)} tabIndex={-1} /> : undefined}
+                                        {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={uiHandler(this.showReportAbuse)} tabIndex={-1} /> : undefined}
                                         <div className="ui divider"></div>
                                         {selectLanguage ? <sui.Item icon="xicon globe" role="menuitem" text={lf("Language")} onClick={() => this.selectLang()} tabIndex={-1} /> : undefined}
-                                        {targetTheme.highContrast ? <sui.Item role="menuitem" text={this.state.highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={() => this.toggleHighContrast()} tabIndex={-1} /> : undefined}
+                                        {targetTheme.highContrast ? <sui.Item role="menuitem" text={this.state.highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={uiHandler(this.toggleHighContrast)} tabIndex={-1} /> : undefined}
                                         {
                                             // we always need a way to clear local storage, regardless if signed in or not
                                         }
-                                        <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={() => this.reset()} tabIndex={-1} />
+                                        <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={uiHandler(this.reset)} tabIndex={-1} />
                                         <div className="ui divider"></div>
                                         {targetTheme.privacyUrl ? <a className="ui item" href={targetTheme.privacyUrl} role="menuitem" title={lf("Privacy & Cookies")} target="_blank" tabIndex={-1}>{lf("Privacy & Cookies")}</a> : undefined}
                                         {targetTheme.termsOfUseUrl ? <a className="ui item" href={targetTheme.termsOfUseUrl} role="menuitem" title={lf("Terms Of Use")} target="_blank" tabIndex={-1}>{lf("Terms Of Use")}</a> : undefined}
-                                        <sui.Item role="menuitem" text={lf("About...")} onClick={() => this.about()} tabIndex={-1} />
+                                        <sui.Item role="menuitem" text={lf("About...")} onClick={uiHandler(this.about)} tabIndex={-1} />
                                         {electron.isElectron ? <sui.Item role="menuitem" text={lf("Check for updates...")} onClick={() => electron.checkForUpdate()} tabIndex={-1} /> : undefined}
                                         {targetTheme.feedbackUrl ? <div className="ui divider"></div> : undefined}
                                         {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback")} target="_blank" rel="noopener" tabIndex={-1} >{lf("Give Feedback")}</a> : undefined}
 
                                     </sui.DropdownMenuItem>}
 
-                                {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={() => this.launchFullEditor()} /> : undefined}
-                                {inTutorial ? <sui.ButtonMenuItem class="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={() => this.exitTutorial()} /> : undefined}
-                                {!sandbox ? <a id="organization" href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo" onClick={() => pxt.tickEvent("menu.org")}>
+                                {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={uiHandler(this.launchFullEditor)} /> : undefined}
+                                {inTutorial ? <sui.ButtonMenuItem class="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={uiHandler(this.exitTutorial)} /> : undefined}
+                                {!sandbox ? <a id="organization" href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo" onClick={uiHandler(() => pxt.tickEvent("menu.org"))}>
                                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo
                                         ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo)} alt={lf("{0} Logo", targetTheme.organization)} />
                                         : <span className="name">{targetTheme.organization}</span>}
@@ -1789,7 +1783,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                     </header>}
                 {gettingStarted ?
                     <div id="getting-started-btn">
-                        <sui.Button class="portrait hide bottom attached small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started")} onClick={() => this.gettingStarted()} />
+                        <sui.Button class="portrait hide bottom attached small getting-started-btn" title={gettingStartedTooltip} text={lf("Getting Started")} onClick={uiHandler(this.gettingStarted)} />
                     </div>
                     : undefined}
                 <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
@@ -1802,24 +1796,24 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                         </div>
                         {!isHeadless ? <aside className="ui item grid centered portrait hide simtoolbar" role="complementary" aria-label={lf("Simulator toolbar")}>
                             <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>
-                                {make ? <sui.Button icon='configure' class="fluid sixty secondary" text={lf("Make")} title={makeTooltip} onClick={() => this.openInstructions()} /> : undefined}
-                                {run ? <sui.Button key='runbtn' class={`play-button ${this.state.running ? "stop" : "play"}`} icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator()} /> : undefined}
-                                {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator()} /> : undefined}
-                                {trace ? <sui.Button key='debug' class={`trace-button ${this.state.tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace()} /> : undefined}
+                                {make ? <sui.Button icon='configure' class="fluid sixty secondary" text={lf("Make")} title={makeTooltip} onClick={uiHandler(this.openInstructions)} /> : undefined}
+                                {run ? <sui.Button key='runbtn' class={`play-button ${this.state.running ? "stop" : "play"}`} icon={this.state.running ? "stop" : "play"} title={runTooltip} onClick={uiHandler(this.startStopSimulator)} /> : undefined}
+                                {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={uiHandler(this.restartSimulator)} /> : undefined}
+                                {trace ? <sui.Button key='debug' class={`trace-button ${this.state.tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={uiHandler(this.toggleTrace)} /> : undefined}
                             </div>
                             <div className={`ui icon buttons ${this.state.fullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>
-                                {audio ? <sui.Button key='mutebtn' class={`mute-button ${this.state.mute ? 'red' : ''}`} icon={`${this.state.mute ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={() => this.toggleMute()} /> : undefined}
-                                {fullscreen ? <sui.Button key='fullscreenbtn' class={`fullscreen-button`} icon={`${this.state.fullscreen ? 'compress' : 'maximize'}`} title={fullscreenTooltip} onClick={() => this.toggleSimulatorFullscreen()} /> : undefined}
+                                {audio ? <sui.Button key='mutebtn' class={`mute-button ${this.state.mute ? 'red' : ''}`} icon={`${this.state.mute ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={uiHandler(this.toggleMute)} /> : undefined}
+                                {fullscreen ? <sui.Button key='fullscreenbtn' class={`fullscreen-button`} icon={`${this.state.fullscreen ? 'compress' : 'maximize'}`} title={fullscreenTooltip} onClick={uiHandler(this.toggleSimulatorFullscreen)} /> : undefined}
                             </div>
                         </aside> : undefined}
                         <div className="ui item portrait hide">
-                            {pxt.options.debug && !this.state.running ? <sui.Button key='debugbtn' class='teal' icon="xicon bug" text={"Sim Debug"} onClick={() => this.runSimulator({ debug: true })} /> : ''}
-                            {pxt.options.debug ? <sui.Button key='hwdebugbtn' class='teal' icon="xicon chip" text={"Dev Debug"} onClick={() => this.hwDebug()} /> : ''}
+                            {pxt.options.debug && !this.state.running ? <sui.Button key='debugbtn' class='teal' icon="xicon bug" text={"Sim Debug"} onClick={uiHandler(() => this.runSimulator({ debug: true }))} /> : ''}
+                            {pxt.options.debug ? <sui.Button key='hwdebugbtn' class='teal' icon="xicon chip" text={"Dev Debug"} onClick={uiHandler(this.hwDebug)} /> : ''}
                         </div>
                         {useSerialEditor ?
                             <div id="serialPreview" className="ui editorFloat portrait hide">
-                                <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={() => this.openSerial(true)} />
-                                <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={() => this.openSerial(false)} />
+                                <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={uiHandler(() => this.openSerial(true))} />
+                                <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={uiHandler(() => this.openSerial(false))} />
                             </div> : undefined}
                         {sandbox || isBlocks || this.editor == this.serialEditor ? undefined : <filelist.FileList parent={this} />}
                     </aside>
@@ -1843,15 +1837,8 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
                     {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" rel="noopener" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
                     <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use")}</a>
                     <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy")}</a>
-                    <span className="item"><a className="ui thin portrait only" title={compileTooltip} onClick={() => this.compile()}><i className="icon download" />{lf("Download")}</a></span>
+                    <span className="item"><a className="ui thin portrait only" title={compileTooltip} onClick={uiHandler(this.compile)}><i className="icon download" />{lf("Download")}</a></span>
                 </div> : undefined}
-                {cookieConsented ? undefined : <div id='cookiemsg' className="ui teal inverted black segment" role="alert">
-                    <button aria-label={lf("Close")} tabIndex={0} className="ui right floated icon button clear inverted" onClick={consentCookie}>
-                        <i className="remove icon"></i>
-                    </button>
-                    {lf("By using this site you agree to the use of cookies for analytics.")}
-                    <a target="_blank" className="ui link" href={pxt.appTarget.appTheme.privacyUrl} rel="noopener">{lf("Learn more")}</a>
-                </div>}
             </div>
         );
     }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -115,6 +115,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const trace = run && simOpts.enableTrace;
         const tracing = this.props.parent.state.tracing;
         const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo");
+        const uiHandler = pxt.analytics.consentWrapper(this);
 
         let downloadButtonClasses = "";
         let saveButtonClasses = "";
@@ -131,38 +132,38 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     <div className="ui equal width grid">
                         <div className="left aligned column">
                             <div className="ui icon small buttons">
-                                <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={() => this.toggleCollapse('mobile') } />
-                                {headless && run ? <sui.Button class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('mobile') } /> : undefined }
-                                {headless && restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('mobile') } /> : undefined }
-                                {headless && trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('mobile') } /> : undefined }
-                                {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
+                                <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={uiHandler(() => this.toggleCollapse('mobile') )} />
+                                {headless && run ? <sui.Button class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={uiHandler(() => this.startStopSimulator('mobile') )} /> : undefined }
+                                {headless && restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={uiHandler(() => this.restartSimulator('mobile') )} /> : undefined }
+                                {headless && trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={uiHandler(() => this.toggleTrace('mobile') )} /> : undefined }
+                                {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" title={compileTooltip} onClick={uiHandler(() => this.compile('mobile') )} /> : undefined }
                             </div>
                         </div>
                         <div className="right aligned column">
                             {!readOnly ?
                                 <div className="ui icon small buttons">
-                                    <sui.Button icon='save' class={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project")} onClick={() => this.saveFile('mobile') } />
-                                    {showUndoRedo ? <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('mobile') } /> : undefined }
+                                    <sui.Button icon='save' class={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project")} onClick={uiHandler(() => this.saveFile('mobile') )} />
+                                    {showUndoRedo ? <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={uiHandler(() => this.undo('mobile') )} /> : undefined }
                                 </div> : undefined }
                         </div>
                         <div className="right aligned column">
                             {showZoomControls ?
                                 <div className="ui icon small buttons">
-                                    <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={() => this.zoomIn('mobile') } />
-                                    <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={() => this.zoomOut('mobile') } />
+                                    <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={uiHandler(() => this.zoomIn('mobile') )} />
+                                    <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={uiHandler(() => this.zoomOut('mobile') )} />
                                 </div> : undefined }
                         </div>
                     </div> :
                     <div className="ui equal width grid">
                         <div className="left aligned two wide column">
                             <div className="ui vertical icon small buttons">
-                                {run ? <sui.Button class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('mobile') } /> : undefined }
-                                {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('mobile') } /> : undefined }
+                                {run ? <sui.Button class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={uiHandler(() => this.startStopSimulator('mobile') )} /> : undefined }
+                                {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={uiHandler(() => this.restartSimulator('mobile') )} /> : undefined }
                             </div>
                             {showCollapsed ?
                             <div className="row" style={{ paddingTop: "1rem" }}>
                                 <div className="ui vertical icon small buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('mobile') } />
+                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={uiHandler(() => this.toggleCollapse('mobile') )} />
                                 </div>
                             </div> : undefined }
                         </div>
@@ -173,15 +174,15 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 <div className="row">
                                     <div className="column">
                                         <div className="ui icon large buttons">
-                                            <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('mobile') } />
+                                            <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={uiHandler(() => this.undo('mobile') )} />
                                         </div>
                                     </div>
                                 </div>}
                             <div className="row" style={readOnly || !showUndoRedo ? undefined : { paddingTop: 0 }}>
                                 <div className="column">
                                     <div className="ui icon large buttons">
-                                        {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('mobile') } /> : undefined }
-                                        {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" title={compileTooltip} onClick={() => this.compile('mobile') } /> : undefined }
+                                        {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={uiHandler(() => this.toggleTrace('mobile') )} /> : undefined }
+                                        {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" title={compileTooltip} onClick={uiHandler(() => this.compile('mobile') )} /> : undefined }
                                     </div>
                                 </div>
                             </div>
@@ -194,46 +195,46 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         {headless ?
                             <div className="left aligned six wide column">
                                 <div className="ui icon buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
-                                    {run ? <sui.Button role="menuitem" class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('tablet') } /> : undefined }
-                                    {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('tablet') } /> : undefined }
-                                    {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('tablet') } /> : undefined }
-                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
+                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={uiHandler(() => this.toggleCollapse('tablet') )} />
+                                    {run ? <sui.Button role="menuitem" class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={uiHandler(() => this.startStopSimulator('tablet') )} /> : undefined }
+                                    {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={uiHandler(() => this.restartSimulator('tablet') )} /> : undefined }
+                                    {trace ? <sui.Button key='tracebtn' class={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={uiHandler(() => this.toggleTrace('tablet') )} /> : undefined }
+                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" title={compileTooltip} onClick={uiHandler(() => this.compile('tablet') )} /> : undefined }
                                 </div>
                             </div> :
                             <div className="left aligned six wide column">
                                 <div className="ui icon buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
-                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" text={ lf("Download") } title={compileTooltip} onClick={() => this.compile('tablet') } /> : undefined }
+                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onClick={uiHandler(() => this.toggleCollapse('tablet') )} />
+                                    {compileBtn ? <sui.Button class={`primary download-button download-button-full ${downloadButtonClasses}`} icon="download" text={ lf("Download") } title={compileTooltip} onClick={uiHandler(() => this.compile('tablet') )} /> : undefined }
                                 </div>
                             </div> }
                         <div className="column four wide">
                             {readOnly ? undefined :
-                                <sui.Button icon='save' class={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project")} onClick={() => this.saveFile('tablet') } /> }
+                                <sui.Button icon='save' class={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project")} onClick={uiHandler(() => this.saveFile('tablet') )} /> }
                         </div>
                         <div className="column six wide right aligned">
                             {showUndoRedo ?
                                 <div className="ui icon small buttons">
-                                    <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('tablet') } />
-                                    <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Red"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={() => this.redo('tablet') } />
+                                    <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={uiHandler(() => this.undo('tablet') )} />
+                                    <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Red"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={uiHandler(() => this.redo('tablet') )} />
                                 </div> : undefined }
                             {showZoomControls ?
                                 <div className="ui icon small buttons">
-                                    <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={() => this.zoomIn('tablet') } />
-                                    <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={() => this.zoomOut('tablet') } />
+                                    <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={uiHandler(() => this.zoomIn('tablet') )} />
+                                    <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={uiHandler(() => this.zoomOut('tablet') )} />
                                 </div> : undefined }
                         </div>
                     </div>
                     : <div className="ui grid">
                         <div className="left aligned two wide column">
                             <div className="ui vertical icon small buttons">
-                                {run ? <sui.Button role="menuitem" class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('tablet') } /> : undefined }
-                                {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('tablet') } /> : undefined }
+                                {run ? <sui.Button role="menuitem" class={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={uiHandler(() => this.startStopSimulator('tablet') )} /> : undefined }
+                                {restart ? <sui.Button key='restartbtn' class={`restart-button`} icon="refresh" title={restartTooltip} onClick={uiHandler(() => this.restartSimulator('tablet') )} /> : undefined }
                             </div>
                             {showCollapsed ?
                             <div className="row" style={{ paddingTop: "1rem" }}>
                                 <div className="ui vertical icon small buttons">
-                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('tablet') } />
+                                    <sui.Button icon={`${collapsed ? 'toggle up' : 'toggle down'}`} class={`collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={uiHandler(() => this.toggleCollapse('tablet') )} />
                                 </div>
                             </div> : undefined }
                         </div>
@@ -243,7 +244,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                             <div className="ui grid right aligned">
                                  {compileBtn ? <div className="row">
                                     <div className="column">
-                                       <sui.Button role="menuitem" class={`primary large fluid download-button download-button-full ${downloadButtonClasses}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={() => this.compile('tablet') } />
+                                       <sui.Button role="menuitem" class={`primary large fluid download-button download-button-full ${downloadButtonClasses}`} icon="download" text={lf("Download") } title={compileTooltip} onClick={uiHandler(() => this.compile('tablet') )} />
                                     </div>
                                 </div> : undefined }
                                 {showProjectRename ?
@@ -258,7 +259,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                                     value={projectName || ''}
                                                     onChange={(e) => this.saveProjectName((e.target as any).value, 'tablet') }>
                                                 </input>
-                                                <sui.Button icon='save' class={`large right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} ariaLabel={lf("Save the project")} title={lf("Save") } onClick={() => this.saveFile('tablet') } />
+                                                <sui.Button icon='save' class={`large right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} ariaLabel={lf("Save the project")} title={lf("Save") } onClick={uiHandler(() => this.saveFile('tablet') )} />
                                             </div>
                                         </div>
                                     </div> : undefined }
@@ -271,20 +272,20 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     <div className="column">
                                     {showUndoRedo ?
                                         <div className="ui icon large buttons">
-                                            <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo() } />
-                                            <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={() => this.redo() } />
+                                            <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={uiHandler(() => this.undo() )} />
+                                            <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={uiHandler(() => this.redo() )} />
                                         </div> : undefined }
                                     {showZoomControls ?
                                         <div className="ui icon large buttons">
-                                            <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={() => this.zoomIn() } />
-                                            <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={() => this.zoomOut() } />
+                                            <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={uiHandler(() => this.zoomIn() )} />
+                                            <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={uiHandler(() => this.zoomOut() )} />
                                         </div> : undefined }
                                     </div>
                                 </div> : undefined }
                                 {trace ?
                                     <div className="row" style={showUndoRedo || showZoomControls ? { paddingTop: 0 } : {}}>
                                         <div className="column">
-                                            <sui.Button key='tracebtn' class={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('tablet') } />
+                                            <sui.Button key='tracebtn' class={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={uiHandler(() => this.toggleTrace('tablet') )} />
                                         </div>
                                     </div> : undefined }
                             </div>
@@ -296,16 +297,16 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     <div id="downloadArea" className="ui column items">{headless ?
                             <div className="ui item">
                                 <div className="ui icon large buttons">
-                                    {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} class={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } /> : undefined }
-                                    {run ? <sui.Button role="menuitem" class={`large play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('computer') } /> : undefined }
-                                    {restart ? <sui.Button key='restartbtn' class={`large restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('computer') } /> : undefined }
-                                    {trace ? <sui.Button key='tracebtn' class={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={() => this.toggleTrace('computer') } /> : undefined }
-                                    {compileBtn ? <sui.Button icon='icon download' class={`primary large download-button ${downloadButtonClasses}`} title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
+                                    {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} class={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={uiHandler(() => this.toggleCollapse('computer') )} /> : undefined }
+                                    {run ? <sui.Button role="menuitem" class={`large play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={uiHandler(() => this.startStopSimulator('computer') )} /> : undefined }
+                                    {restart ? <sui.Button key='restartbtn' class={`large restart-button`} icon="refresh" title={restartTooltip} onClick={uiHandler(() => this.restartSimulator('computer') )} /> : undefined }
+                                    {trace ? <sui.Button key='tracebtn' class={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={uiHandler(() => this.toggleTrace('computer') )} /> : undefined }
+                                    {compileBtn ? <sui.Button icon='icon download' class={`primary large download-button ${downloadButtonClasses}`} title={compileTooltip} onClick={uiHandler(() => this.compile('computer') )} /> : undefined }
                                 </div>
                             </div> :
                             <div className="ui item">
-                                {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} class={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer') } /> : undefined }
-                                {compileBtn ? <sui.Button icon='icon download' class={`primary huge fluid download-button ${downloadButtonClasses}`} text={lf("Download") } title={compileTooltip} onClick={() => this.compile('computer') } /> : undefined }
+                                {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} class={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={uiHandler(() => this.toggleCollapse('computer') )} /> : undefined }
+                                {compileBtn ? <sui.Button icon='icon download' class={`primary huge fluid download-button ${downloadButtonClasses}`} text={lf("Download") } title={compileTooltip} onClick={uiHandler(() => this.compile('computer') )} /> : undefined }
                             </div>
                         }
                     </div>
@@ -320,19 +321,19 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     value={projectName || ''}
                                     onChange={(e) => this.saveProjectName((e.target as any).value, 'computer') }>
                                 </input>
-                                <sui.Button icon='save' class={`small right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project")} onClick={() => this.saveFile('computer') } />
+                                <sui.Button icon='save' class={`small right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save") } ariaLabel={lf("Save the project")} onClick={uiHandler(() => this.saveFile('computer') )} />
                             </div>
                         </div> : undefined }
                     <div className="column right aligned">
                         {showUndoRedo ?
                             <div className="ui icon small buttons">
-                                <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={() => this.undo('computer') } />
-                                <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={() => this.redo('computer') } />
+                                <sui.Button icon='xicon undo' class={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo") } onClick={uiHandler(() => this.undo('computer') )} />
+                                <sui.Button icon='xicon redo' class={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} title={lf("Redo") } onClick={uiHandler(() => this.redo('computer') )} />
                             </div> : undefined }
                         {showZoomControls ?
                             <div className="ui icon small buttons">
-                                <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={() => this.zoomIn('computer') } />
-                                <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={() => this.zoomOut('computer') } />
+                                <sui.Button icon='plus circle' class="editortools-btn zoomin-editortools-btn" title={lf("Zoom In") } onClick={uiHandler(() => this.zoomIn('computer') )} />
+                                <sui.Button icon='minus circle' class="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out") } onClick={uiHandler(() => this.zoomOut('computer') )} />
                             </div> : undefined }
                     </div>
                 </div>

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -167,9 +167,9 @@ export class Editor extends srceditor.Editor {
         }).then(b => {
             // discard
             if (!b) {
-                pxt.tickEvent("typescript.keepText");
+                pxt.tickEvent("typescript.keepText", undefined, { interactiveConsent: true });
             } else {
-                pxt.tickEvent("typescript.discardText");
+                pxt.tickEvent("typescript.discardText", undefined, { interactiveConsent: true });
                 this.parent.saveBlocksToTypeScriptAsync().then((src) => {
                     this.overrideFile(src);
                     this.parent.setFile(bf);
@@ -685,7 +685,7 @@ export class Editor extends srceditor.Editor {
         let color = pxt.blocks.convertColour(metaColor);
 
         treeitem.onclick = (ev: MouseEvent) => {
-            pxt.tickEvent("monaco.toolbox.click");
+            pxt.tickEvent("monaco.toolbox.click", undefined, { interactiveConsent: true });
 
             let monacoFlyout = document.getElementById('monacoFlyoutWidget');
             monacoEditor.resetFlyout(false);
@@ -792,7 +792,7 @@ export class Editor extends srceditor.Editor {
                     if (!monacoBlockDisabled) {
                         monacoBlock.draggable = true;
                         monacoBlock.onclick = (ev2: MouseEvent) => {
-                            pxt.tickEvent("monaco.toolbox.itemclick");
+                            pxt.tickEvent("monaco.toolbox.itemclick", undefined, { interactiveConsent: true });
 
                             monacoEditor.resetFlyout(true);
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -120,7 +120,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             this.props.parent.loadHeaderAsync(hdr)
         }
         const chgGallery = (scr: pxt.CodeCard) => {
-            pxt.tickEvent("projects.gallery", { name: scr.name });
+            pxt.tickEvent("projects.gallery", { name: scr.name }, { interactiveConsent: true });
             this.hide();
             switch (scr.cardType) {
                 case "example": chgCode(scr, true); break;
@@ -174,22 +174,22 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 .done(() => core.hideLoading())
         }
         const importHex = () => {
-            pxt.tickEvent("projects.import");
+            pxt.tickEvent("projects.import", undefined, { interactiveConsent: true });
             this.hide();
             this.props.parent.importFileDialog();
         }
         const importUrl = () => {
-            pxt.tickEvent("projects.importurl");
+            pxt.tickEvent("projects.importurl", undefined, { interactiveConsent: true });
             this.hide();
             this.props.parent.importUrlDialog();
         }
         const importLegacy = () => {
-            pxt.tickEvent("projects.importlegacy");
+            pxt.tickEvent("projects.importlegacy", undefined, { interactiveConsent: true });
             this.hide();
             window.location.href = legacyUrl;
         }
         const newProject = () => {
-            pxt.tickEvent("projects.new");
+            pxt.tickEvent("projects.new", undefined, { interactiveConsent: true });
             this.hide();
             this.props.parent.newProject();
         }

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -283,7 +283,7 @@ export class Editor extends srceditor.Editor {
     }
 
     goBack() {
-        pxt.tickEvent("serial.backButton")
+        pxt.tickEvent("serial.backButton", undefined, { interactiveConsent: true })
         this.parent.openPreviousEditor()
     }
 

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -140,7 +140,7 @@ pxt extract ${url}`;
 
         }
         const publish = () => {
-            pxt.tickEvent("menu.embed.publish");
+            pxt.tickEvent("menu.embed.publish", undefined, { interactiveConsent: true });
             this.props.parent.anonymousPublishAsync().done(() => {
                 this.setState({ pubCurrent: true });
             });

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -21,7 +21,7 @@ export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
     openTutorialStep(step: number) {
         let options = this.props.parent.state.tutorialOptions;
         options.tutorialStep = step;
-        pxt.tickEvent(`tutorial.step`, { tutorial: options.tutorial, step: step });
+        pxt.tickEvent(`tutorial.step`, { tutorial: options.tutorial, step: step }, { interactiveConsent: true });
         this.props.parent.setTutorialStep(step);
     }
 
@@ -164,7 +164,7 @@ export class TutorialCard extends data.Component<ISettingsProps, {}> {
 
         options.tutorialStep = nextStep;
 
-        pxt.tickEvent(`tutorial.next`, { tutorial: options.tutorial, step: nextStep });
+        pxt.tickEvent(`tutorial.next`, { tutorial: options.tutorial, step: nextStep }, { interactiveConsent: true });
         this.props.parent.setTutorialStep(nextStep);
     }
 
@@ -271,12 +271,12 @@ export class TutorialComplete extends data.Component<ISettingsProps, TutorialCom
     }
 
     moreTutorials() {
-        pxt.tickEvent(`tutorial.completed.more`);
+        pxt.tickEvent(`tutorial.completed.more`, undefined, { interactiveConsent: true });
         this.props.parent.openTutorials();
     }
 
     exitTutorial() {
-        pxt.tickEvent(`tutorial.completed.exit`);
+        pxt.tickEvent(`tutorial.completed.exit`, undefined, { interactiveConsent: true });
         this.hide();
         this.props.parent.exitTutorial();
     }


### PR DESCRIPTION
Bringing over the changes in master to V0. I did this entire merge by hand, so please take a look to make sure I didn't make any obvious mistakes. I still need to do testing.

I had to do a lot more granular instrumentation in this PR than I did in the previous one. In master, every target enters through the home screen which was pretty well covered by our telemetry (every UI element had a call to `pxt.tickEvent()` that I could instrument). App.tsx is much more complicated than the home screen because most of the methods that are called in `onClick` handlers are also called elsewhere. The cookie can only be set in response to user action so I had to edit every click handler to set the consent separately from the telemetry.

Another note is that I couldn't think of an easy way to instrument Blockly, so interacting with Blockly will not remove the banner. It's not a big deal because just about everything else will get rid of the banner including clicking "new project" and "download". If anyone has any suggestions for how to instrument Blockly let me know. I thought about using their [events](https://developers.google.com/blockly/guides/configure/web/events) but I wasn't confident enough that I could always determine whether those were fired as the result of user action or not.