### PR TITLE
Fixing some cherry pick errors in cookie banner

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -71,9 +71,8 @@ namespace pxt {
         getCookieBannerAsync(document.domain, detectLocale(), (bannerErr, info) => {
             if (bannerErr || info.Error) {
                 // Start app insights, just don't drop any cookies
-                // initializeAppInsights(false);
-                // return;
-                info = { "IsConsentRequired": true, "CookieName": "MSCC", "Markup": "<div id='msccBanner' dir='ltr' data-site-name='uhf-makecode' data-mscc-version='0.4.0' data-nver='aspnet-2.0.7' data-sver='0.1.2' class='cc-banner' role='alert'><div class='cc-container'><svg class='cc-icon cc-v-center' x='0px' y='0px' viewBox='0 0 44 44' height='30px' fill='none' stroke='currentColor'><circle cx='22' cy='22' r='20' stroke-width='2'></circle><line x1='22' x2='22' y1='18' y2='33' stroke-width='3'></line><line x1='22' x2='22' y1='12' y2='15' stroke-width='3'></line></svg> <span class='cc-v-center cc-text'>This site uses cookies for analytics, personalized content and ads. By continuing to browse this site, you agree to this use.</span> <a href='https://go.microsoft.com/fwlink/?linkid=845480' aria-label='Learn more about Microsoft&#39;s Cookie Policy' id='msccLearnMore' class='cc-link cc-v-center cc-float-right' data-mscc-ic='false'>Learn more</a></div></div>", "Css": ["https://uhf.microsoft.com/mscc/statics/mscc-0.4.0.min.css"], "Js": ["https://uhf.microsoft.com/mscc/statics/mscc-0.4.0.min.js"], "MinimumConsentDate": "2019-04-01T00:00:00", "Error": null, "lastUpdate": 1517615910 } as any;
+                initializeAppInsights(false);
+                return;
             }
 
             // Clear the cookies if the consent is too old, mscc won't do it automatically

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1687,7 +1687,7 @@ namespace pxt.blocks {
                 const collapseOption: any = { enabled: hasExpandedBlocks };
                 collapseOption.text = lf("Collapse Block");
                 collapseOption.callback = function () {
-                    pxt.tickEvent("blocks.context.collapse")
+                    pxt.tickEvent("blocks.context.collapse", undefined, { interactiveConsent: true })
                     toggleOption(true);
                 };
                 menuOptions.push(collapseOption);
@@ -1696,7 +1696,7 @@ namespace pxt.blocks {
                 const expandOption: any = { enabled: hasCollapsedBlocks };
                 expandOption.text = lf("Expand Block");
                 expandOption.callback = function () {
-                    pxt.tickEvent("blocks.context.expand")
+                    pxt.tickEvent("blocks.context.expand", undefined, { interactiveConsent: true })
                     toggleOption(false);
                 };
                 menuOptions.push(expandOption);
@@ -1738,7 +1738,7 @@ namespace pxt.blocks {
                     lf("Delete {0} Blocks", deleteList.length),
                 enabled: deleteList.length > 0,
                 callback: function () {
-                    pxt.tickEvent("blocks.context.delete");
+                    pxt.tickEvent("blocks.context.delete", undefined, { interactiveConsent: true });
                     if (deleteList.length < 2 ||
                         window.confirm(lf("Delete all {0} blocks?", deleteList.length))) {
                         deleteNext();
@@ -1751,7 +1751,7 @@ namespace pxt.blocks {
                 text: lf("Format Code"),
                 enabled: true,
                 callback: () => {
-                    pxt.tickEvent("blocks.context.format");
+                    pxt.tickEvent("blocks.context.format", undefined, { interactiveConsent: true });
                     pxt.blocks.layout.flow(this);
                 }
             }
@@ -1762,7 +1762,7 @@ namespace pxt.blocks {
                     text: lf("Download Screenshot"),
                     enabled: topBlocks.length > 0,
                     callback: () => {
-                        pxt.tickEvent("blocks.context.screenshot");
+                        pxt.tickEvent("blocks.context.screenshot", undefined, { interactiveConsent: true });
                         pxt.blocks.layout.screenshotAsync(this)
                             .done((uri) => {
                                 if (pxt.BrowserUtils.isSafari())


### PR DESCRIPTION
Accidentally merged in some test code when porting these changes to V0.

Luckily, this never got released. It probably wouldn't have even been an issue because the test data has a purposefully fake "minimum consent date" so that the cookies always get cleared anyways. The MSCC cookie is still set but it only contains a timestamp and will be cleared on reload.