### PR TITLE
Web USB download dialogs

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -12,6 +12,8 @@ declare namespace pxt {
         // localized galleries
         localizedGalleries?: pxt.Map<pxt.Map<string>>;
         windowsStoreLink?: string;
+        // link to the latest firmware urls (boardid -> url)
+        firmwareUrls?: pxt.Map<string>;
     }
 
     interface PackagesConfig {
@@ -298,7 +300,7 @@ declare namespace ts.pxtc {
         useMkcd?: boolean;
         useELF?: boolean;
         useModulator?: boolean;
-        webUSB?: boolean; // use WebUSB when supported
+        webUSB?: boolean; // use WebUSB when supported        
         hexMimeType?: string;
         driveName?: string;
         jsRefCounting?: boolean;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -298,7 +298,7 @@ declare namespace ts.pxtc {
         useMkcd?: boolean;
         useELF?: boolean;
         useModulator?: boolean;
-        webUsb?: boolean; // use WebUSB when supported
+        webUSB?: boolean; // use WebUSB when supported
         hexMimeType?: string;
         driveName?: string;
         jsRefCounting?: boolean;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -298,6 +298,7 @@ declare namespace ts.pxtc {
         useMkcd?: boolean;
         useELF?: boolean;
         useModulator?: boolean;
+        webUsb?: boolean; // use WebUSB when supported
         hexMimeType?: string;
         driveName?: string;
         jsRefCounting?: boolean;

--- a/localtypings/pxtparts.d.ts
+++ b/localtypings/pxtparts.d.ts
@@ -24,6 +24,8 @@ declare namespace pxsim {
         leds?: LEDDefinition[]
     }
     interface BoardDefinition {
+        id?: string, // optional board id   
+        usbDeviceName?: string, // device name as advertise through USB     
         visual: BoardImageDefinition | string,
         gpioPinBlocks?: string[][], // not used
         gpioPinMap: { [pin: string]: string },

--- a/localtypings/pxtparts.d.ts
+++ b/localtypings/pxtparts.d.ts
@@ -24,7 +24,9 @@ declare namespace pxsim {
         leds?: LEDDefinition[]
     }
     interface BoardDefinition {
-        id?: string, // optional board id   
+        id?: string, // optional board id (set to the package id, multiboard only)
+        boardName?: string, // friendly board name (multiboard only)
+        driveDisplayName?: string, // drive name (multiboard only)
         usbDeviceName?: string, // device name as advertise through USB     
         visual: BoardImageDefinition | string,
         gpioPinBlocks?: string[][], // not used

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -416,6 +416,7 @@ namespace pxt {
                 initPromise = initPromise.then(() => {
                     if (this.config.files.indexOf("board.json") < 0) return
                     appTarget.simulator.boardDefinition = JSON.parse(this.readFile("board.json"))
+                    appTarget.simulator.boardDefinition.id = this.config.name;
                     let expandPkg = (v: string) => {
                         let m = /^pkg:\/\/(.*)/.exec(v)
                         if (m) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -415,8 +415,10 @@ namespace pxt {
                     initPromise = initPromise.then(() => this.patchCorePackage());
                 initPromise = initPromise.then(() => {
                     if (this.config.files.indexOf("board.json") < 0) return
-                    appTarget.simulator.boardDefinition = JSON.parse(this.readFile("board.json"))
-                    appTarget.simulator.boardDefinition.id = this.config.name;
+                    const def = appTarget.simulator.boardDefinition = JSON.parse(this.readFile("board.json")) as pxsim.BoardDefinition;
+                    def.id = this.config.name;
+                    appTarget.appTheme.boardName = def.boardName || lf("board");
+                    appTarget.appTheme.driveDisplayName = def.driveDisplayName || lf("DRIVE");
                     let expandPkg = (v: string) => {
                         let m = /^pkg:\/\/(.*)/.exec(v)
                         if (m) {

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -322,7 +322,8 @@ namespace pxt.usb {
     }
 
     export function isAvailable() {
-        // TODO check what Chrome on Win7 and Win8 does
-        return !!(navigator as any).usb
+        // TODO: support other Windows SKU than Windows 10
+        return !!(navigator as any).usb &&
+            (!pxt.BrowserUtils.isWindows() || pxt.BrowserUtils.isWindows10());
     }
 }

--- a/theme/common.less
+++ b/theme/common.less
@@ -556,7 +556,7 @@ Font size
 
 *************************/
 
-ui.small {
+p.ui.font.small {
     font-size:0.8em;
 }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -550,6 +550,17 @@ Field editors
     display: none !important;
 }
 
+/*******************
+
+Font size
+
+*************************/
+
+ui.small {
+    font-size:0.8em;
+}
+
+
 @media only screen and (min-width: @largeMonitorBreakpoint) and (min-height:30em) {
     .ui.widedesktop.only {
         display:inherit !important;

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -165,7 +165,7 @@ function showFirmwareUpdateInstructionsAsync(resp: pxtc.CompileResult): Promise<
                 <div class="content">
                     <div class="description">
                         <span class="ui blue circular label">3</span>
-                        ${lf("Move the .uf2 file to {0}", boardName)}
+                        ${lf("Move the .uf2 file to your board")}
                         <br/>
                         ${lf("Locate the downloaded .uf2 file and drag it to the {0} drive", driveName)}
                     </div>

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -202,7 +202,7 @@ function showWebUSBPairingInstructionsAsync(resp: pxtc.CompileResult): Promise<v
                 <div class="content">
                     <div class="description">
                         <span class="ui blue circular label">2</span>
-                        <strong>${lf("Select {0} in the pairing dialog", webUsbName)}</strong>
+                        ${lf("Select \"{0}\" in the pairing dialog", webUsbName)}
                     </div>
                 </div>
             </div>
@@ -212,18 +212,16 @@ function showWebUSBPairingInstructionsAsync(resp: pxtc.CompileResult): Promise<v
                 <div class="content">
                     <div class="description">
                         <span class="ui blue circular label">3</span>
-                        ${lf("Press Connect")}
+                        ${lf("Press \"Connect\"")}
                     </div>
                 </div>
             </div>
         </div>
     </div>`;
-    const pairBtn = lf("Pair Device");
 
     return core.confirmAsync({
         header: lf("Pair your {0}", boardName),
         htmlBody,
-        agreeLbl: pairBtn
     }).then(r => {
         pxt.usb.pairAsync()
             .then(() => hidDeployCoreAsync(resp))

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -174,7 +174,7 @@ function showFirmwareUpdateInstructionsAsync(resp: pxtc.CompileResult): Promise<
         </div>
     </div>`;
             return core.confirmAsync({
-                header: lf("Upgrade your {0} firmware", boardName),
+                header: lf("Upgrade firmware"),
                 htmlBody,
             })
                 .then(r => r ? showWebUSBPairingInstructionsAsync(resp) : browserDownloadDeployCoreAsync(resp));

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -182,6 +182,7 @@ function showFirmwareUpdateInstructionsAsync(resp: pxtc.CompileResult): Promise<
             return core.confirmAsync({
                 header: lf("Upgrade firmware"),
                 htmlBody,
+                agreeLbl: lf("Upgraded!")
             })
                 .then(r => r ? showWebUSBPairingInstructionsAsync(resp) : browserDownloadDeployCoreAsync(resp));
         });
@@ -228,6 +229,7 @@ function showWebUSBPairingInstructionsAsync(resp: pxtc.CompileResult): Promise<v
 
     return core.confirmAsync({
         header: lf("Pair your {0}", boardName),
+        agreeLbl: lf("Let's pair it!"),
         htmlBody,
     }).then(r => {
         pxt.usb.pairAsync()

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -135,7 +135,7 @@ export function initCommandsAsync(): Promise<void> {
     pxt.commands.showUploadInstructionsAsync = showUploadInstructionsAsync;
     const forceHexDownload = /forceHexDownload/i.test(window.location.href);
 
-    if (pxt.usb.isAvailable() && /webusb=1/i.test(window.location.href)) {
+    if (pxt.usb.isAvailable() && (pxt.appTarget.compile.webUsb || /webusb=1/i.test(window.location.href))) {
         pxt.usb.setEnabled(true)
         pxt.HF2.mkPacketIOAsync = pxt.usb.mkPacketIOAsync
     }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -119,12 +119,13 @@ function showWebUSBPairingInstructionsAsync(resp: pxtc.CompileResult): Promise<v
 
     return core.confirmAsync({
         header: lf("No device detected..."),
-        body: `
-<p>Do you want to pair your ${boardName} to the editor to allow instant download of your code?
-A dialog will open and ask you to select your device.</p>
+        htmlBody: `
+<p>${lf("Do you want to pair your {0} to the editor to allow instant download of your code?", boardName)}
+${lf("A dialog will open and ask you to select your device.")}</p>
         `,
         hasCloseIcon: true,
         hideAgree: true,
+        hideCancel: true,
         buttons: [{
             label: lf("Pair Device"),
             icon: "usb",

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -121,7 +121,7 @@ function askWebUSBPairAsync(resp: pxtc.CompileResult): Promise<void> {
         htmlBody: `
 <p><strong>${lf("Do you want to pair your {0} to the editor?", boardName)}</strong>
 ${lf("You will have access to instant download and data logging.")}</p>
-<p class="small">The pairing experience is a one-time process and available for the Chrome browser version 61 and up.</p>
+<p class="ui small">The pairing experience is a one-time process and available for the Chrome browser version 61 and up.</p>
         `,
     }).then(r => r ? showFirmwareUpdateInstructionsAsync(resp) : browserDownloadDeployCoreAsync(resp));
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -107,7 +107,7 @@ function hidDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     if (!resp.success)
         return browserDownloadDeployCoreAsync(resp);
 
-    core.infoNotification(lf("Flashing device..."));
+    core.infoNotification(lf("Downloading..."));
     let f = resp.outfiles[pxtc.BINARY_UF2]
     let blocks = pxtc.UF2.parseFile(Util.stringToUint8Array(atob(f)))
     return hidbridge.initAsync()
@@ -121,7 +121,7 @@ function askWebUSBPairAsync(resp: pxtc.CompileResult): Promise<void> {
         htmlBody: `
 <p><strong>${lf("Do you want to pair your {0} to the editor?", boardName)}</strong>
 ${lf("You will have access to instant download and data logging.")}</p>
-<p class="ui small">The pairing experience is a one-time process and available for the Chrome browser version 61 and up.</p>
+<p class="ui font small">The pairing experience is a one-time process and available for the Chrome browser version 61 and up.</p>
         `,
     }).then(r => r ? showFirmwareUpdateInstructionsAsync(resp) : browserDownloadDeployCoreAsync(resp));
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -127,7 +127,7 @@ function askWebUSBPairAsync(resp: pxtc.CompileResult): Promise<void> {
         htmlBody: `
 <p><strong>${lf("Do you want to pair your {0} to the editor?", boardName)}</strong>
 ${lf("You will get instant downloads and data logging.")}</p>
-<p class="ui font small">The pairing experience is a one-time process and available for Chrome version 61 and up.</p>
+<p class="ui font small">The pairing experience is a one-time process.</p>
         `,
     }).then(r => r ? showFirmwareUpdateInstructionsAsync(resp) : browserDownloadDeployCoreAsync(resp));
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -120,8 +120,8 @@ function askWebUSBPairAsync(resp: pxtc.CompileResult): Promise<void> {
         header: lf("No device detected..."),
         htmlBody: `
 <p><strong>${lf("Do you want to pair your {0} to the editor?", boardName)}</strong>
-${lf("You will have access to instant download and data logging.")}</p>
-<p class="ui font small">The pairing experience is a one-time process and available for the Chrome browser version 61 and up.</p>
+${lf("You will get instant downloads and data logging.")}</p>
+<p class="ui font small">The pairing experience is a one-time process and available for Chrome version 61 and up.</p>
         `,
     }).then(r => r ? showFirmwareUpdateInstructionsAsync(resp) : browserDownloadDeployCoreAsync(resp));
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -101,12 +101,10 @@ function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (opt
 }
 
 function hidDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
-    pxt.debug('HID deployment...');
-
-    // error message handle in browser download
+    pxt.tickEvent(`hid.deploy`)
+    // error message handled in browser download
     if (!resp.success)
         return browserDownloadDeployCoreAsync(resp);
-
     core.infoNotification(lf("Downloading..."));
     let f = resp.outfiles[pxtc.BINARY_UF2]
     let blocks = pxtc.UF2.parseFile(Util.stringToUint8Array(atob(f)))
@@ -242,6 +240,7 @@ function showWebUSBPairingInstructionsAsync(resp: pxtc.CompileResult): Promise<v
 }
 
 function webUsbDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
+    pxt.tickEvent(`webusb.deploy`)
     return hidDeployCoreAsync(resp)
         .catch(e => askWebUSBPairAsync(resp));
 }


### PR DESCRIPTION
- [x] added "webUSB" flag in "compile" section to enable it by default
- [x] restricted to Windows 10+ on Windows

- when download fails, a first dialog is shown
![image](https://user-images.githubusercontent.com/4175913/36003242-f3c608b0-0ce1-11e8-8af0-0069d3e02f2d.png)
- the upgrade firmware dialog is displayed. The URL is board specific and specified in targetconfig.
![image](https://user-images.githubusercontent.com/4175913/36003255-020f9ca6-0ce2-11e8-9c98-3252abf155bf.png)
- the pairing dialog is shown
![image](https://user-images.githubusercontent.com/4175913/36003280-223404f4-0ce2-11e8-862b-343d0cb2ecd2.png)

