### PR TITLE
When available, automatically-flash device with latest changes

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -323,6 +323,7 @@ declare namespace ts.pxtc {
         emptyEventHandlerComments?: boolean; // true adds a comment for empty event handlers
         vmOpCodes?: pxt.Map<number>;
         commonalize?: boolean;
+        backgroundDeploy?: boolean;
     }
 
     interface CompileOptions {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -42,6 +42,7 @@ namespace pxt.editor {
         running?: boolean;
         resumeOnVisibility?: boolean;
         compiling?: boolean;
+        canBackgroundDeploy?: boolean;
         isSaving?: boolean;
         publishing?: boolean;
         hideEditorFloats?: boolean;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -42,7 +42,7 @@ namespace pxt.editor {
         running?: boolean;
         resumeOnVisibility?: boolean;
         compiling?: boolean;
-        canBackgroundDeploy?: boolean;
+        backgroundDeploy?: boolean;
         isSaving?: boolean;
         publishing?: boolean;
         hideEditorFloats?: boolean;

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -1,6 +1,7 @@
 namespace pxt.commands {
     // overriden by targets
     export let deployCoreAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
+    export let backgroundDeployCoreAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void> = undefined;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -347,7 +347,7 @@ export class ProjectView
         if (Util.now() - this.lastChangeTime < 1000) return;
         if (!this.state.active)
             return;
-        if (!!pxt.commands.backgroundDeployCoreAsync)
+        if (!!pxt.commands.backgroundDeployCoreAsync && this.state.running) // require at least one
             this.compile(false, true);
         else
             this.runSimulator({ background: true });

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -347,11 +347,8 @@ export class ProjectView
         if (Util.now() - this.lastChangeTime < 1000) return;
         if (!this.state.active)
             return;
-        const backgroundDeploy = this.state.canBackgroundDeploy // at least 1 "compile button"
-            && pxt.appTarget.compile && !!pxt.appTarget.compile.backgroundDeploy // target supports
-            && !!pxt.commands.backgroundDeployCoreAsync; // support in this shell
 
-        if (backgroundDeploy)
+        if (this.state.backgroundDeploy)
             this.compile(false, true);
         else
             this.runSimulator({ background: true });
@@ -1199,8 +1196,11 @@ export class ProjectView
                 if (simRestart) this.runSimulator();
             })
             .done(() => {
-                if (!background)
-                    this.setState({ canBackgroundDeploy: true });
+                if (!background && !this.state.backgroundDeploy // at least 1 "compile button"
+                    && !!pxt.commands.backgroundDeployCoreAsync // support in this shell    
+                    && ((pxt.appTarget.compile && !!pxt.appTarget.compile.backgroundDeploy) || /backgroundDeploy=1/i.test(window.location.href))
+                )
+                    this.setState({ backgroundDeploy: true });
             });
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -347,7 +347,11 @@ export class ProjectView
         if (Util.now() - this.lastChangeTime < 1000) return;
         if (!this.state.active)
             return;
-        if (!!pxt.commands.backgroundDeployCoreAsync && this.state.running) // require at least one
+        const backgroundDeploy = this.state.canBackgroundDeploy // at least 1 "compile button"
+            && pxt.appTarget.compile && !!pxt.appTarget.compile.backgroundDeploy // target supports
+            && !!pxt.commands.backgroundDeployCoreAsync; // support in this shell
+
+        if (backgroundDeploy)
             this.compile(false, true);
         else
             this.runSimulator({ background: true });
@@ -1194,7 +1198,10 @@ export class ProjectView
                 this.setState({ compiling: false, isSaving: false });
                 if (simRestart) this.runSimulator();
             })
-            .done();
+            .done(() => {
+                if (!background)
+                    this.setState({ canBackgroundDeploy: true });
+            });
     }
 
     overrideTypescriptFile(text: string) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1145,7 +1145,7 @@ export class ProjectView
             pxt.tickEvent("compile.double");
             return;
         }
-        const simRestart = this.state.running;
+        const simRestart = this.state.running || background;
         this.setState({ compiling: true });
         this.clearSerial();
         this.editor.beforeCompile();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1168,8 +1168,8 @@ export class ProjectView
                 if (saveOnly) {
                     return pxt.commands.saveOnlyAsync(resp);
                 }
-                const deployAsync = (background ? pxt.commands.backgroundDeployCoreAsync : pxt.commands.deployCoreAsync)
-                    || pxt.commands.deployCoreAsync;
+                Util.assert(!background || !!pxt.commands.backgroundDeployCoreAsync);
+                const deployAsync = background ? pxt.commands.backgroundDeployCoreAsync : pxt.commands.deployCoreAsync;
                 return deployAsync(resp)
                     .catch(e => {
                         if (!background) {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -320,8 +320,10 @@ export function initCommandsAsync(): Promise<void> {
         };
     } else if (hidbridge.shouldUse() && !pxt.appTarget.serial.noDeploy && !forceHexDownload) {
         pxt.commands.deployCoreAsync = hidDeployCoreAsync;
+        pxt.commands.deployCoreAsync = hidDeployCoreAsync;
     } else if (Cloud.isLocalHost() && Cloud.localToken && !forceHexDownload) { // local node.js
         pxt.commands.deployCoreAsync = localhostDeployCoreAsync;
+        pxt.commands.backgroundDeployCoreAsync = localhostDeployCoreAsync;
     } else { // in browser
         pxt.commands.deployCoreAsync = browserDownloadDeployCoreAsync;
     }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -253,7 +253,7 @@ function webUsbDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
 function webUsbBackgroundDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     pxt.tickEvent(`webusb.deploy.background`);
     return hidDeployCoreAsync(resp)
-        .catch(e => { 
+        .catch(e => {
             pxt.reportException(e)
         }); // fail silently
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -320,7 +320,7 @@ export function initCommandsAsync(): Promise<void> {
         };
     } else if (hidbridge.shouldUse() && !pxt.appTarget.serial.noDeploy && !forceHexDownload) {
         pxt.commands.deployCoreAsync = hidDeployCoreAsync;
-        pxt.commands.deployCoreAsync = hidDeployCoreAsync;
+        pxt.commands.backgroundDeployCoreAsync = hidDeployCoreAsync;
     } else if (Cloud.isLocalHost() && Cloud.localToken && !forceHexDownload) { // local node.js
         pxt.commands.deployCoreAsync = localhostDeployCoreAsync;
         pxt.commands.backgroundDeployCoreAsync = localhostDeployCoreAsync;

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -105,7 +105,6 @@ function hidDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     // error message handled in browser download
     if (!resp.success)
         return browserDownloadDeployCoreAsync(resp);
-    core.infoNotification(lf("Downloading..."));
     let f = resp.outfiles[pxtc.BINARY_UF2]
     let blocks = pxtc.UF2.parseFile(Util.stringToUint8Array(atob(f)))
     return hidbridge.initAsync()
@@ -246,6 +245,12 @@ function webUsbDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
         .catch(e => askWebUSBPairAsync(resp));
 }
 
+function webUsbBackgroundDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
+    pxt.tickEvent(`webusb.deploy.background`);
+    return hidDeployCoreAsync(resp)
+        .catch(e => { }); // fail silently
+}
+
 function localhostDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     pxt.debug('local deployment...');
     core.infoNotification(lf("Uploading .hex file..."));
@@ -280,6 +285,7 @@ export function initCommandsAsync(): Promise<void> {
 
     if (pxt.usb.isEnabled && pxt.appTarget.compile.useUF2) {
         pxt.commands.deployCoreAsync = webUsbDeployCoreAsync;
+        pxt.commands.backgroundDeployCoreAsync = webUsbBackgroundDeployCoreAsync;
     } else if (pxt.winrt.isWinRT()) { // windows app
         if (pxt.appTarget.serial && pxt.appTarget.serial.useHF2) {
             pxt.winrt.initWinrtHid(() => hidbridge.initAsync(true).then(() => { }), () => hidbridge.disconnectWrapperAsync());

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -298,6 +298,7 @@ export function initCommandsAsync(): Promise<void> {
             pxt.winrt.initWinrtHid(() => hidbridge.initAsync(true).then(() => { }), () => hidbridge.disconnectWrapperAsync());
             pxt.HF2.mkPacketIOAsync = pxt.winrt.mkPacketIOAsync;
             pxt.commands.deployCoreAsync = hidDeployCoreAsync;
+            pxt.commands.backgroundDeployCoreAsync = hidDeployCoreAsync;
         } else {
             // If we're not using HF2, then the target is using their own deploy logic in extension.ts, so don't use
             // the wrapper callbacks


### PR DESCRIPTION
This change enables automicatic flashing for webusb (hidden under a flag in pxtarget). It also acts as a nice stress test. Guarded by href ``backgroundDeploy=1`` or pxtarget flag
TODO
- [ ] decide what kind user interaction is needed to turn on/off this feature. Right now it is tied to running the simulator: if the simulator restarts in the background, then it flashes as well.
- [x] support in WinRT
- [x] support node.js hid
- [x] support for hid bridge
- [ ] since the device unmounts and remounts, Windows plays an annoying sound