### PR TITLE
execute forceUpdates async instead synchronously

### DIFF
--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -141,7 +141,7 @@ function notify(ce: CacheEntry) {
     }
 
     if (ce.components.length > 0)
-        Util.nextTick(() => ce.components.forEach(c => c.forceUpdate()))
+        ce.components.forEach(c => Util.nextTick(() =>  c.forceUpdate()))
 }
 
 function getVirtualApi(path: string) {


### PR DESCRIPTION
This 1/2 line fix solves the issue of the gallery not loading when no scripts where installed. The root of the issue is that only the first component subscribe to a path was "force updated". That worked when you had scripts but failed when you didn't.

It's not clear why we are not seeing this in other targets.

test build:
https://makecode.adafruit.com/app/6c6371385ae0c2ae88523f20a37544f123b83f33-41283cc61a
