### PR TITLE
Fixing handler args blocks

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -136,9 +136,10 @@ namespace pxt.blocks {
                         range
                     });
 
-                    if (p.handlerParameters) {
-                        p.handlerParameters.forEach(arg => res.handlerArgs.push(arg))
-                    }
+                }
+
+                if (p.handlerParameters) {
+                    p.handlerParameters.forEach(arg => res.handlerArgs.push(arg))
                 }
             });
         }


### PR DESCRIPTION
I broke the Minecraft onChat block with the parser updates.