### PR TITLE
Dismiss banner on toolbox click and in native apps

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -1,4 +1,7 @@
 /// <reference path="../../localtypings/mscc.d.ts" />
+/// <reference path="../../pxtwinrt/winrtrefs.d.ts"/>
+
+declare var process: any;
 
 namespace pxt {
     type Map<T> = {[index: string]: T};
@@ -68,6 +71,11 @@ namespace pxt {
     let exceptionLogger: TelemetryQueue<any, string, Map<string>>;
 
     export function initAnalyticsAsync() {
+        if (isNativeApp()) {
+            initializeAppInsights(true);
+            return;
+        }
+
         getCookieBannerAsync(document.domain, detectLocale(), (bannerErr, info) => {
             if (bannerErr || info.Error) {
                 // Start app insights, just don't drop any cookies
@@ -238,6 +246,14 @@ namespace pxt {
         else {
             throw new Error("Bad call to injectScriptAsync")
         }
+    }
+
+    /**
+     * Checks for winrt and electron
+     */
+    function isNativeApp(): boolean {
+        return typeof Windows !== "undefined" ||
+            (typeof process !== "undefined" && process.versions && process.versions["electron"]);
     }
 
     // No promises, so here we are

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -409,6 +409,11 @@ export class Editor extends srceditor.Editor {
                 if (ev.element == 'category') {
                     let toolboxVisible = !!ev.newValue;
                     if (toolboxVisible) {
+                        // WARNING! Because we use the category open/close event to dismiss
+                        // the cookie banner, be careful when manipulating the toolbox to make
+                        // sure that this event only fires as the result of user action. Use
+                        // Blockly.Events.disable() and Blockly.Events.enable() to prevent
+                        // UI events from firing.
                         pxt.analytics.setConsent();
                     }
                     this.parent.setState({ hideEditorFloats: toolboxVisible });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -408,6 +408,9 @@ export class Editor extends srceditor.Editor {
             if (ev.type == 'ui') {
                 if (ev.element == 'category') {
                     let toolboxVisible = !!ev.newValue;
+                    if (toolboxVisible) {
+                        pxt.analytics.setConsent();
+                    }
                     this.parent.setState({ hideEditorFloats: toolboxVisible });
                     if (ev.newValue == lf("{id:category}Add Package")) {
                         (this.editor as any).toolbox_.clearSelection();


### PR DESCRIPTION
This fix comes with a caveat: we need to be vigilant to make sure that we don't accidentally automate something in the future that causes Blockly to fire this event. Right now this works great
