### PR TITLE
[v0] Fix regression in Field Note 

### DIFF
--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -439,9 +439,11 @@ namespace pxtblockly {
 
             //  create piano div
             let div = Blockly.WidgetDiv.DIV;
-            let pianoDiv = goog.dom.createDom("div", {});
+            let pianoDiv = goog.dom.createDom("div", {}) as HTMLElement;
             pianoDiv.className = "blocklyPianoDiv";
             div.appendChild(pianoDiv);
+            pianoDiv.style.position = 'absolute';
+            pianoDiv.style.top = '20px';
             let scrollOffset = goog.style.getViewportPageOffset(document);
             //let pianoHeight = keyHeight + div.scrollHeight + 5;
             let xy = this.getAbsoluteXY_();
@@ -695,7 +697,7 @@ namespace pxtblockly {
              * @private 
              */
             function getShowNoteStyle(topPosition: number, leftPosition: number, isMobile: boolean) {
-                topPosition += keyHeight;
+                topPosition += keyHeight - (isMobile ? 0 : 2);
                 if (isMobile)
                     topPosition += prevNextHeight;
                 let div = goog.dom.createDom("div",

--- a/theme/fieldeditors.less
+++ b/theme/fieldeditors.less
@@ -33,6 +33,8 @@ display: inline-block;
 line-height: normal;
 position: absolute;
 text-align: center;
+border-bottom-left-radius: 2px;
+border-bottom-right-radius: 2px;
 }
 
 .blocklyWidgetDiv .blocklyNotePrevNext {


### PR DESCRIPTION
Fix field note regression hiding the text field underneath it. 
Fixed by pushing the pianoDiv down 20 pixels to give room for the textbox.

![image](https://user-images.githubusercontent.com/16690124/36281320-21fd842c-1252-11e8-9817-23f7b044dcbe.png)

Fixes https://github.com/Microsoft/pxt-microbit/issues/620

Doesn't affect master. 
Tested on Chrome 64, Edge 16, IE 11, Firefox and Safari.