### PR TITLE
Include localized category in search and respect filters

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -294,7 +294,7 @@ namespace pxt.blocks {
             }
 
             if (showCategories === CategoryMode.Basic && isAdvanced &&
-                shouldUseBlockInSearch(fn.attributes.blockId, catName.toLowerCase(), filters)) {
+                shouldUseBlockInSearch(fn.attributes.blockId, catName, filters)) {
                 usedBlocks[fn.attributes.blockId] = ns; // ns is localized already
                 updateUsedBlocks = true;
             }
@@ -1243,7 +1243,7 @@ namespace pxt.blocks {
                 const bId = b.getAttribute("type");
                 const bCategoryId = b.parentElement && b.parentElement.nodeName === "category" ? b.parentElement.getAttribute("nameid") : undefined;
                 const bTranslatedCat = bCategoryId ? b.parentElement.getAttribute("name") : undefined;
-                if (shouldUseBlockInSearch(bId, bCategoryId.toLowerCase(), filters)) {
+                if (shouldUseBlockInSearch(bId, bCategoryId, filters)) {
                     usedBlocks[bId] = bTranslatedCat || true;
                     updateUsedBlocks = true;
                 }
@@ -1438,7 +1438,7 @@ namespace pxt.blocks {
                         const b = blockElements.item(i);
                         const bId = b.getAttribute("type");
                         const translatedCatName = Util.rlf(`{id:category}${name}`, []);
-                        if (shouldUseBlockInSearch(bId, name.toLowerCase(), filters)) {
+                        if (shouldUseBlockInSearch(bId, name, filters)) {
                             usedBlocks[bId] = translatedCatName;
                         }
                     }
@@ -3253,6 +3253,9 @@ namespace pxt.blocks {
     function shouldUseBlockInSearch(blockId: string, namespaceId: string, filters: BlockFilters): boolean {
         if (!filters) {
             return true;
+        }
+        if (namespaceId) {
+            namespaceId = namespaceId.toLowerCase();
         }
         const isNamespaceFiltered = filters.namespaces &&
             filters.namespaces[namespaceId] === FilterState.Disabled || filters.namespaces[namespaceId] === FilterState.Hidden;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -52,7 +52,7 @@ namespace pxt.blocks {
     // Matches arrays and tuple types
     const arrayTypeRegex = /^(?:Array<.+>)|(?:.+\[\])|(?:\[.+\])$/;
 
-    let usedBlocks: Map<boolean> = {};
+    let usedBlocks: Map<boolean | string> = {}; // Maps a block ID to its translated category name, or to true if not in category mode
     let updateUsedBlocks = false;
 
     // list of built-in blocks, should be touched.
@@ -217,7 +217,7 @@ namespace pxt.blocks {
         return result;
     }
 
-    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: HTMLElement, showCategories = CategoryMode.Basic, pnames: pxt.blocks.BlockParameters) {
+    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: HTMLElement, showCategories = CategoryMode.Basic, pnames: pxt.blocks.BlockParameters, filters?: BlockFilters) {
         // identity function are just a trick to get an enum drop down in the block
         // while allowing the parameter to be a number
         if (fn.attributes.blockHidden)
@@ -293,9 +293,10 @@ namespace pxt.blocks {
                 }
             }
 
-            if (showCategories === CategoryMode.Basic && isAdvanced) {
-                const type = block.getAttribute("type");
-                usedBlocks[type] = true;
+            if (showCategories === CategoryMode.Basic && isAdvanced &&
+                shouldUseBlockInSearch(fn.attributes.blockId, catName.toLowerCase(), filters)) {
+                usedBlocks[fn.attributes.blockId] = ns; // ns is localized already
+                updateUsedBlocks = true;
             }
 
             if (fn.attributes.optionalVariableArgs && fn.attributes.toolboxVariableArgs) {
@@ -1238,10 +1239,15 @@ namespace pxt.blocks {
             const blocks = tb.getElementsByTagName("block");
 
             for (let i = 0; i < blocks.length; i++) {
-                usedBlocks[blocks.item(i).getAttribute("type")] = true;
+                const b = blocks.item(i);
+                const bId = b.getAttribute("type");
+                const bCategoryId = b.parentElement && b.parentElement.nodeName === "category" ? b.parentElement.getAttribute("nameid") : undefined;
+                const bTranslatedCat = bCategoryId ? b.parentElement.getAttribute("name") : undefined;
+                if (shouldUseBlockInSearch(bId, bCategoryId.toLowerCase(), filters)) {
+                    usedBlocks[bId] = bTranslatedCat || true;
+                    updateUsedBlocks = true;
+                }
             }
-
-            updateUsedBlocks = true;
         }
 
         // Filter the blocks
@@ -1254,11 +1260,16 @@ namespace pxt.blocks {
                     let blockState = filters.blocks && filters.blocks[type] != undefined ? filters.blocks[type] : (defaultState != undefined ? defaultState : filters.defaultState);
                     switch (blockState) {
                         case FilterState.Hidden:
-                            blk.parentNode.removeChild(blk); --bi; break;
+                            delete usedBlocks[type];
+                            blk.parentNode.removeChild(blk); --bi;
+                            break;
                         case FilterState.Disabled:
-                            blk.setAttribute("disabled", "true"); break;
+                            delete usedBlocks[type];
+                            blk.setAttribute("disabled", "true");
+                            break;
                         case FilterState.Visible:
-                            hasChild = true; break;
+                            hasChild = true;
+                            break;
                     }
                 }
                 return hasChild;
@@ -1408,7 +1419,6 @@ namespace pxt.blocks {
 
         return tb;
 
-
         function initBuiltinCategoryXml(name: string, remove: boolean) {
             if (remove) {
                 removeCategory(tb, name);
@@ -1426,7 +1436,11 @@ namespace pxt.blocks {
                     const blockElements = cat.getElementsByTagName("block");
                     for (let i = 0; i < blockElements.length; i++) {
                         const b = blockElements.item(i);
-                        usedBlocks[b.getAttribute("type")] = true;
+                        const bId = b.getAttribute("type");
+                        const translatedCatName = Util.rlf(`{id:category}${name}`, []);
+                        if (shouldUseBlockInSearch(bId, name.toLowerCase(), filters)) {
+                            usedBlocks[bId] = translatedCatName;
+                        }
                     }
 
                     if (showCategories === CategoryMode.Basic) {
@@ -3234,5 +3248,16 @@ namespace pxt.blocks {
             if (jresObject && jresObject.icon)
                 jresIconCache[jresId] = jresObject.icon;
         })
+    }
+
+    function shouldUseBlockInSearch(blockId: string, namespaceId: string, filters: BlockFilters): boolean {
+        if (!filters) {
+            return true;
+        }
+        const isNamespaceFiltered = filters.namespaces &&
+            filters.namespaces[namespaceId] === FilterState.Disabled || filters.namespaces[namespaceId] === FilterState.Hidden;
+        const isBlockFiltered = filters.blocks &&
+            filters.blocks[blockId] === FilterState.Disabled || filters.blocks[blockId] === FilterState.Hidden;
+        return !isNamespaceFiltered && !isBlockFiltered;
     }
 }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -741,8 +741,8 @@ namespace ts.pxtc.service {
                         namespace: s.namespace,
                         block: s.attributes.block,
                         jsdoc: s.attributes.jsDoc,
-                        localizedCategory: search.subset && typeof search.subset[s.attributes.blockId] === "string"
-                            ? search.subset[s.attributes.blockId] as string : undefined
+                        localizedCategory: tbSubset && typeof tbSubset[s.attributes.blockId] === "string"
+                            ? tbSubset[s.attributes.blockId] as string : undefined
                     };
                     return mappedSi;
                 });

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -865,7 +865,7 @@ namespace ts.pxtc.service {
     }
 
     export interface SearchOptions {
-        subset?: pxt.Map<boolean>;
+        subset?: pxt.Map<boolean | string>;
         term: string;
         localizedApis?: ApisInfo;
         localizedStrings?: pxt.Map<string>;
@@ -884,6 +884,7 @@ namespace ts.pxtc.service {
         namespace?: string;
         jsdoc?: string;
         field?: [string, string];
+        localizedCategory?: string;
     }
 }
 


### PR DESCRIPTION
- Search now respects `disabled` and `hidden` filters, both at the category and the block level
- Search now includes localized category name (since it's different from the namespace)