### PR TITLE
Adding new parameter field for destructuring mutator

### DIFF
--- a/pxtblocks/blocklymutators.ts
+++ b/pxtblocks/blocklymutators.ts
@@ -412,6 +412,11 @@ namespace pxt.blocks {
             });
         }
 
+        protected propertyNames() {
+            const i = this.getParameterIndex();
+            return this.info.parameters[i].properties.map(property => property.name);
+        }
+
         protected getVisibleBlockTypes(): string[] {
             return this.currentlyVisible.map(p => this.propertyId(p));
         }
@@ -421,6 +426,7 @@ namespace pxt.blocks {
                 return;
             }
             const dummyInput = this.block.inputList.filter(i => i.name === MutatorHelper.mutatedVariableInputName)[0];
+            const allParameters = this.propertyNames();
 
             if (this.prefix && this.currentlyVisible.length === 0) {
                 dummyInput.appendField(this.prefix, DestructuringMutator.prefixLabel);
@@ -442,7 +448,7 @@ namespace pxt.blocks {
             this.parameters.forEach(param => {
                 if (this.currentlyVisible.indexOf(param) === -1) {
                     const fieldValue = this.parameterRenames[param] || param;
-                    dummyInput.appendField(new Blockly.FieldVariable(fieldValue), param);
+                    dummyInput.appendField(new pxtblockly.FieldParameter(fieldValue, param, allParameters), param);
                 }
             });
 

--- a/pxtblocks/fields/field_parameter.ts
+++ b/pxtblocks/fields/field_parameter.ts
@@ -1,0 +1,132 @@
+/// <reference path="../../localtypings/pxtblockly.d.ts" />
+
+declare namespace Blockly {
+    interface Workspace {
+        createVariable(name: string): VariableModel;
+        getVariable(name: string): VariableModel;
+        renameVariable(oldName: string, newName: string): void;
+    }
+}
+
+declare namespace Blockly.Msg {
+    const RENAME_VARIABLE_TITLE: string;
+    const VARIABLE_ALREADY_EXISTS_FOR_ANOTHER_TYPE: string;
+}
+
+declare namespace Blockly.Events {
+    const VAR_DELETE: string;
+    const VAR_RENAME: string;
+
+    interface VarDelete extends Blockly.BlocklyEvent {
+        varName: string;
+        varType: string;
+    }
+
+    interface VarRename extends Blockly.BlocklyEvent {
+        oldName: string;
+        newName: string;
+    }
+}
+
+declare namespace Blockly.Variables {
+    function renameVariable(workspace: Workspace, variable: VariableModel, cb?: (newValue: string) => void): void;
+    function promptName(promptText: string, defaultText: string, callback: (newVar: string) => void): void;
+}
+
+namespace pxtblockly {
+    export class FieldParameter extends Blockly.FieldTextInput {
+        currentName: string;
+        defaultName: string;
+        restrictedNames: string[];
+
+        constructor(initialName: string, defaultName: string, restrictedNames: string[]) {
+            super(initialName, null);
+            this.currentName = initialName;
+            this.defaultName = defaultName;
+            this.restrictedNames = [];
+            restrictedNames.forEach(name => {
+                if (name === this.defaultName) return;
+                this.restrictedNames.push(name.toLowerCase());
+            });
+        }
+
+        init(b?: Blockly.Block) {
+            if (this.fieldGroup_) {
+                return;
+            }
+            super.init(b);
+            this.getOrCreateVariable();
+
+            this.sourceBlock_.workspace.addChangeListener(e => {
+                if (!e) return;
+                if (e.type === Blockly.Events.VAR_DELETE) {
+                    const deleteEvent = e as Blockly.Events.VarDelete;
+                    if (deleteEvent.varName === this.currentName) {
+                        this.currentName = this.defaultName;
+                        this.setValue(this.defaultName);
+                        this.getOrCreateVariable();
+                    }
+                }
+                else if (e.type === Blockly.Events.VAR_RENAME) {
+                    const renameEvent = e as Blockly.Events.VarRename;
+                    if (renameEvent.oldName === this.currentName && renameEvent.newName !== this.currentName) {
+                        this.setValue(renameEvent.newName);
+                        this.currentName = renameEvent.newName;
+                    }
+                }
+            });
+        }
+
+        showEditor_() {
+            (this as any).workspace_ = this.sourceBlock_.workspace;
+            this.renameDialog(this.getOrCreateVariable());
+        }
+
+        renameDialog(variable: Blockly.VariableModel) {
+            const workspace = this.sourceBlock_.workspace;
+
+            let openRenameDialog = (inputValue: string) => {
+                Blockly.Variables.promptName(
+                    Blockly.Msg.RENAME_VARIABLE_TITLE.replace('%1', variable.name), inputValue,
+                    newName => {
+                        if (newName) {
+                            var newVariable = workspace.getVariable(newName);
+                            if (this.isRestrictedName(newName)) {
+                                Blockly.alert(lf("The name '{0}' is reserved. To select that parameter use the gear wheel on the block or enter a different name", newName), () => {
+                                    openRenameDialog(newName);
+                                });
+                            }
+                            else if (newVariable) {
+                                Blockly.alert(lf("A variable with the name '{0}' already exists", newName), () => {
+                                    openRenameDialog(newName);
+                                });
+                            }
+                            else {
+                                workspace.renameVariable(variable.name, newName);
+                            }
+                        }
+                    });
+            };
+            openRenameDialog('');
+        }
+
+        private getOrCreateVariable() {
+            if (!this.sourceBlock_) {
+                return undefined;
+            }
+            const ws = this.sourceBlock_.workspace;
+            const v = ws.getVariable(this.currentName);
+            if (v) {
+                return v;
+            }
+            else {
+                return ws.createVariable(this.currentName);
+            }
+        }
+
+        private isRestrictedName(name: string) {
+            name = name.toLowerCase().replace(/\s/g, '');
+            return this.restrictedNames.indexOf(name) != -1;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the confusing dropdown in the radio blocks. This PR is for V0 only.

![new_parameter_field_take_two](https://user-images.githubusercontent.com/13754588/36336443-ab6e81b2-133c-11e8-9bc5-aafae4a6d465.gif)

Changes include:
1. No more dropdown, you now just get a rename dialog when you click on the parameter
2. Parameters cannot be renamed to an existing variable name
3. Parameters cannot be renamed to other parameters on the block (e.g. `receivedNumber` cannot be renamed to `receivedString`). That check ignores whitespace and capitalization (`receivedstring` and `received string` will both be rejected).
4. Attempting to delete the variable from another block will revert the parameter field to its default value. Previously it deleted the entire block and all of its children

This change is backwards compatible and hopefully subtle enough to not break screenshots. BTW, the above GIF doesn't have quotes around the variable name in the error dialog but I actually fixed that and was too lazy to re-record it.

