### PR TITLE
Add support for math functions and constants

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -659,6 +659,17 @@ namespace pxt.blocks {
 
     }
 
+    function compileMathJsOp(e: Environment, b: B.Block, comments: string[]): JsNode {
+        const op = b.getFieldValue("OP");
+        const args = [compileExpression(e, getInputTargetBlock(b, "ARG0"), comments)];
+
+        if ((b as any).getInput("ARG1")) {
+            args.push(compileExpression(e, getInputTargetBlock(b, "ARG1"), comments));
+        }
+
+        return H.mathCall(op, args);
+    }
+
     function compileProcedure(e: Environment, b: B.Block, comments: string[]): JsNode[] {
         const name = escapeVarName(b.getFieldValue("NAME"), e, true);
         const stmts = getInputTargetBlock(b, "STACK");
@@ -755,6 +766,8 @@ namespace pxt.blocks {
                 expr = compileListGet(e, b, comments); break;
             case "lists_index_set":
                 expr = compileListSet(e, b, comments); break;
+            case "math_js_op":
+                expr = compileMathJsOp(e, b, comments); break;
             case pxtc.TS_OUTPUT_TYPE:
                 expr = extractTsExpression(e, b, comments); break;
             default:

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1755,7 +1755,7 @@ namespace pxt.blocks {
         };
     }
 
-    function installHelpResources(id: string, name: string, tooltip: any, url: string, colour: string, colourSecondary?: string, colourTertiary?: string) {
+    export function installHelpResources(id: string, name: string, tooltip: any, url: string, colour: string, colourSecondary?: string, colourTertiary?: string) {
         let block = Blockly.Blocks[id];
         let old = block.init;
         if (!old) return;
@@ -2611,6 +2611,8 @@ namespace pxt.blocks {
         const mathModuloDef = pxt.blocks.getBlockDefinition(mathModuloId);
         msg.MATH_MODULO_TITLE = mathModuloDef.block["MATH_MODULO_TITLE"];
         installBuiltinHelpInfo(mathModuloId);
+
+        initMathOpBlock();
     }
 
     export function getNamespaceColor(ns: string): string {

--- a/pxtblocks/mathOperations.ts
+++ b/pxtblocks/mathOperations.ts
@@ -1,0 +1,89 @@
+namespace pxt.blocks {
+    // This array determines the order of the dropdown
+    const allOperations = pxt.blocks.MATH_FUNCTIONS.unary.concat(pxt.blocks.MATH_FUNCTIONS.binary);
+
+    export function initMathOpBlock() {
+        const mathOpId = "math_js_op";
+        const mathOpDef = pxt.blocks.getBlockDefinition(mathOpId);
+        Blockly.Blocks[mathOpId] = {
+            init: function () {
+                const b = this as Blockly.Block;
+                b.setPreviousStatement(false);
+                b.setNextStatement(false);
+                b.setOutput(true, "Number");
+                b.setOutputShape(Blockly.OUTPUT_SHAPE_ROUND);
+                b.setInputsInline(true);
+
+                const ddi = b.appendDummyInput("op_dropdown")
+                ddi.appendField(
+                    new Blockly.FieldDropdown(allOperations.map(op => [mathOpDef.block[op], op]),
+                        (op: string) => onOperatorSelect(b, op)),
+                    "OP");
+
+                addArgInput(b, false);
+
+                // Because the number of inputs changes, we need a mutation. Technically the op tells us
+                // how many inputs we should have but we can't read its value at init time
+                appendMutation(b, {
+                    mutationToDom: mutation => {
+                        mutation.setAttribute("op-type", ((b as any).getInput("ARG1", true) ? "binary" : "unary").toString());
+                        return mutation;
+                    },
+                    domToMutation: saved => {
+                        if (saved.hasAttribute("op-type")) {
+                            if (saved.getAttribute("op-type") == "binary") {
+                                addArgInput(b, true);
+                            }
+                        }
+                    }
+                });
+            }
+        };
+
+        installHelpResources(
+            mathOpId,
+            mathOpDef.name,
+            function (block: Blockly.Block) {
+                return (mathOpDef.tooltip as Map<string>)[block.getFieldValue("OP")];
+            },
+            mathOpDef.url,
+            getNamespaceColor(mathOpDef.category)
+        );
+
+        function onOperatorSelect(b: Blockly.Block, op: string) {
+            if (isUnaryOp(op)) {
+                b.removeInput("ARG1", true);
+            }
+            else if (!((b as any).getInput("ARG1"))) {
+                addArgInput(b, true);
+            }
+        }
+
+        function addArgInput(b: Blockly.Block, second: boolean) {
+            const i = b.appendValueInput("ARG" + (second ? 1 : 0));
+            i.setCheck("Number");
+            if (second) {
+                (i.connection as any).setShadowDom(numberShadowDom());
+                (i.connection as any).respawnShadow_();
+            }
+        }
+    }
+
+    function isUnaryOp(op: string) {
+        return pxt.blocks.MATH_FUNCTIONS.unary.indexOf(op) !== -1;
+    }
+
+    let cachedDom: Element;
+    function numberShadowDom() {
+        // <shadow type="math_number"><field name="NUM">0</field></shadow>
+        if (!cachedDom) {
+            cachedDom = document.createElement("shadow")
+            cachedDom.setAttribute("type", "math_number");
+            const field = document.createElement("field");
+            field.setAttribute("name", "NUM");
+            field.textContent = "0";
+            cachedDom.appendChild(field);
+        }
+        return cachedDom;
+    }
+}

--- a/pxtblocks/mathOperations.ts
+++ b/pxtblocks/mathOperations.ts
@@ -1,5 +1,4 @@
 namespace pxt.blocks {
-    // This array determines the order of the dropdown
     const allOperations = pxt.blocks.MATH_FUNCTIONS.unary.concat(pxt.blocks.MATH_FUNCTIONS.binary);
 
     export function initMathOpBlock() {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1159,6 +1159,16 @@ ${output}</xml>`;
                 r.fields = [getField("OP", "POWER")];
                 return r;
             }
+            else if (pxt.Util.startsWith(info.qName, "Math.")) {
+                const op = info.qName.substring(5);
+                if (isSupportedMathFunction(op)) {
+                    const r = mkExpr("math_js_op");
+                    r.inputs = info.args.map((arg, index) => mkValue("ARG" + index, getOutputBlock(arg), "math_number"))
+                    r.fields = [getField("OP", op)];
+                    r.mutation = { "op-type": info.args.length == 2 ? "binary" : "unary" };
+                    return r;
+                }
+            }
 
             if (info.attrs.blockId === pxtc.PAUSE_UNTIL_TYPE) {
                 const r = mkStmt(pxtc.PAUSE_UNTIL_TYPE);
@@ -1774,6 +1784,12 @@ ${output}</xml>`;
             else if (info.qName == "Math.pow") {
                 return undefined;
             }
+            else if (pxt.Util.startsWith(info.qName, "Math.")) {
+                const op = info.qName.substring(5);
+                if (isSupportedMathFunction(op)) {
+                    return undefined;
+                }
+            }
 
             if (info.attrs.blockId === pxtc.PAUSE_UNTIL_TYPE) {
                 const predicate = n.arguments[0];
@@ -2318,5 +2334,9 @@ ${output}</xml>`;
             default:
                 return false;
         }
+    }
+
+    function isSupportedMathFunction(op: string) {
+        return pxt.blocks.MATH_FUNCTIONS.unary.indexOf(op) !== -1 || pxt.blocks.MATH_FUNCTIONS.binary.indexOf(op) !== -1;
     }
 }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -118,7 +118,15 @@ namespace ts.pxtc {
             if (stripParams) {
                 t = t.getCallSignatures()[0].getReturnType()
             }
-            return typechecker.typeToString(t, undefined, TypeFormatFlags.UseFullyQualifiedType)
+            const readableName = typechecker.typeToString(t, undefined, TypeFormatFlags.UseFullyQualifiedType)
+
+            // TypeScript 2.0.0+ will assign constant variables numeric literal types which breaks the
+            // type checking we do in the blocks
+            if (!isNaN(Number(readableName))) {
+                return "number";
+            }
+
+            return readableName;
         }
 
         let kind = getSymbolKind(stmt)

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -2,6 +2,15 @@
 
 namespace pxt.blocks {
     const THIS_NAME = "this";
+
+    // The JS Math functions supported in the blocks. The order of this array
+    // determines the order of the dropdown in the math_js_op block
+    export const MATH_FUNCTIONS = {
+        unary: ["sqrt", "sin", "cos", "tan", "log", "ceil", "floor",
+        "trunc", "round", "exp", "asin", "acos", "atan"],
+        binary: ["atan2", "imul", "idiv"]
+    };
+
     export interface BlockParameter {
         // Declared parameter name as it appears in the code. This is the name used
         // when customizing the field in the comment attributes
@@ -319,6 +328,51 @@ namespace pxt.blocks {
                 category: 'math',
                 block: {
                     MATH_MODULO_TITLE: Util.lf("remainder of %1 ÷ %2")
+                }
+            },
+            'math_js_op': {
+                name: Util.lf("math function"),
+                tooltip: {
+                    "log": Util.lf("Returns the natural logarithm of the argument"),
+                    "exp": Util.lf("Returns Euler's constant (e) raised to the power of the argument"),
+                    "sin": Util.lf("Returns the sine of the argument"),
+                    "cos": Util.lf("Returns the cosine of the argument"),
+                    "tan": Util.lf("Returns the tangent of the argument"),
+                    "asin": Util.lf("Returns the arcsine of the argument"),
+                    "acos": Util.lf("Returns the arccosine of the argument"),
+                    "atan": Util.lf("Returns the arctangent of the argument"),
+                    "sqrt": Util.lf("Returns the square root of the argument"),
+                    "ceil": Util.lf("Returns the lowest integer value greater than or equal to the argument"),
+                    "floor": Util.lf("Returns the highest integer value lesser than or equal to the argument"),
+                    "trunc": Util.lf("Returns the value of the argument with the decimal component removed"),
+                    "round": Util.lf("Returns the value of the argument 'rounded' to the nearest integer"),
+                    "atan2": Util.lf("Returns the arctangent of the quotient of the two arguments"),
+                    "imul": Util.lf("Returns the integer result of product of the two arguments"),
+                    "idiv": Util.lf("Returns the integer result of the quotient of the two arguments"),
+                },
+                url: '/blocks/math',
+                operators: {
+                    'OP': ["sqrt", "sin", "cos", "tan", "log", "ceil", "floor",
+                    "trunc", "round", "exp", "asin", "acos", "atan", "atan2", "imul", "idiv"]
+                },
+                category: 'math',
+                block: {
+                    "log": Util.lf("{id:op}ln"),
+                    "exp": Util.lf("{id:op}e^x"),
+                    "sin": Util.lf("{id:op}sin"),
+                    "cos": Util.lf("{id:op}cos"),
+                    "tan": Util.lf("{id:op}tan"),
+                    "asin": Util.lf("{id:op}asin"),
+                    "acos": Util.lf("{id:op}acos"),
+                    "atan": Util.lf("{id:op}atan"),
+                    "sqrt": Util.lf("{id:op}square root"),
+                    "ceil": Util.lf("{id:op}ceiling"),
+                    "floor": Util.lf("{id:op}floor"),
+                    "trunc": Util.lf("{id:op}truncate"),
+                    "round": Util.lf("{id:op}round"),
+                    "atan2": Util.lf("{id:op}atan2"),
+                    "imul": Util.lf("{id:op}imul"),
+                    "idiv": Util.lf("{id:op}idiv"),
                 }
             },
             'variables_change': {

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -6,9 +6,8 @@ namespace pxt.blocks {
     // The JS Math functions supported in the blocks. The order of this array
     // determines the order of the dropdown in the math_js_op block
     export const MATH_FUNCTIONS = {
-        unary: ["sqrt", "sin", "cos", "tan", "log", "ceil", "floor",
-        "trunc", "round", "exp", "asin", "acos", "atan"],
-        binary: ["atan2", "imul", "idiv"]
+        unary: ["sqrt", "sin", "cos", "tan", "ceil", "floor"],
+        binary: ["atan2"]
     };
 
     export interface BlockParameter {
@@ -333,46 +332,27 @@ namespace pxt.blocks {
             'math_js_op': {
                 name: Util.lf("math function"),
                 tooltip: {
-                    "log": Util.lf("Returns the natural logarithm of the argument"),
-                    "exp": Util.lf("Returns Euler's constant (e) raised to the power of the argument"),
                     "sin": Util.lf("Returns the sine of the argument"),
                     "cos": Util.lf("Returns the cosine of the argument"),
                     "tan": Util.lf("Returns the tangent of the argument"),
-                    "asin": Util.lf("Returns the arcsine of the argument"),
-                    "acos": Util.lf("Returns the arccosine of the argument"),
-                    "atan": Util.lf("Returns the arctangent of the argument"),
                     "sqrt": Util.lf("Returns the square root of the argument"),
                     "ceil": Util.lf("Returns the lowest integer value greater than or equal to the argument"),
                     "floor": Util.lf("Returns the highest integer value lesser than or equal to the argument"),
-                    "trunc": Util.lf("Returns the value of the argument with the decimal component removed"),
-                    "round": Util.lf("Returns the value of the argument 'rounded' to the nearest integer"),
                     "atan2": Util.lf("Returns the arctangent of the quotient of the two arguments"),
-                    "imul": Util.lf("Returns the integer result of product of the two arguments"),
-                    "idiv": Util.lf("Returns the integer result of the quotient of the two arguments"),
                 },
                 url: '/blocks/math',
                 operators: {
-                    'OP': ["sqrt", "sin", "cos", "tan", "log", "ceil", "floor",
-                    "trunc", "round", "exp", "asin", "acos", "atan", "atan2", "imul", "idiv"]
+                    'OP': ["sqrt", "sin", "cos", "tan", "ceil", "floor", "atan2"]
                 },
                 category: 'math',
                 block: {
-                    "log": Util.lf("{id:op}ln"),
-                    "exp": Util.lf("{id:op}e^x"),
                     "sin": Util.lf("{id:op}sin"),
                     "cos": Util.lf("{id:op}cos"),
                     "tan": Util.lf("{id:op}tan"),
-                    "asin": Util.lf("{id:op}asin"),
-                    "acos": Util.lf("{id:op}acos"),
-                    "atan": Util.lf("{id:op}atan"),
                     "sqrt": Util.lf("{id:op}square root"),
                     "ceil": Util.lf("{id:op}ceiling"),
                     "floor": Util.lf("{id:op}floor"),
-                    "trunc": Util.lf("{id:op}truncate"),
-                    "round": Util.lf("{id:op}round"),
                     "atan2": Util.lf("{id:op}atan2"),
-                    "imul": Util.lf("{id:op}imul"),
-                    "idiv": Util.lf("{id:op}idiv"),
                 }
             },
             'variables_change': {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -122,6 +122,7 @@ namespace ts.pxtc {
         blockImage?: boolean; // for enum variable, specifies that it should use an image from a predefined location
         fixedInstances?: boolean;
         fixedInstance?: boolean;
+        constantShim?: boolean;
         indexedInstanceNS?: string;
         indexedInstanceShim?: string;
         defaultInstance?: string;
@@ -443,7 +444,7 @@ namespace ts.pxtc {
     }
 
     const numberAttributes = ["weight", "imageLiteral"]
-    const booleanAttributes = ["advanced", "handlerStatement", "afterOnStart", "optionalVariableArgs", "blockHidden"]
+    const booleanAttributes = ["advanced", "handlerStatement", "afterOnStart", "optionalVariableArgs", "blockHidden", "constantShim"]
 
     export function parseCommentString(cmt: string): CommentAttrs {
         let res: CommentAttrs = {

--- a/tests/decompile-test/baselines/constant_shim.blocks
+++ b/tests/decompile-test/baselines/constant_shim.blocks
@@ -1,0 +1,49 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">cs_1</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="constant_dropdown">
+<field name="constant">constant.PI</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">cs_2</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="constant_dropdown">
+<field name="constant">constant.LN2</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">cs_3</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="constant_dropdown">
+<field name="constant">constant.PI</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">cs_4</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="constant_dropdown">
+<field name="constant">constant.LN2</field>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;constantShim.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/baselines/math_ops.blocks
+++ b/tests/decompile-test/baselines/math_ops.blocks
@@ -1,0 +1,128 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">math_op_1</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="unary" />
+<field name="OP">sin</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">math_op_2</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="unary" />
+<field name="OP">cos</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">math_op_3</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="unary" />
+<field name="OP">tan</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">2</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">math_op_4</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="unary" />
+<field name="OP">sqrt</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">3</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">math_op_5</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="unary" />
+<field name="OP">ceil</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">4</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">math_op_6</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="unary" />
+<field name="OP">floor</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">math_op_7</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="binary" />
+<field name="OP">atan2</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">6</field>
+</shadow>
+</value>
+<value name="ARG1">
+<shadow type="math_number">
+<field name="NUM">7</field>
+</shadow>
+</value>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/constant_shim.ts
+++ b/tests/decompile-test/cases/constant_shim.ts
@@ -1,0 +1,6 @@
+/// <reference path="./testBlocks/constantShim.ts" />
+
+let cs_1 = constant.PI;
+let cs_2 = constant.LN2;
+let cs_3 = constant._constant(constant.PI);
+let cs_4 = constant._constant(constant.LN2);

--- a/tests/decompile-test/cases/math_ops.ts
+++ b/tests/decompile-test/cases/math_ops.ts
@@ -1,0 +1,7 @@
+let math_op_1 = Math.sin(0);
+let math_op_2 = Math.cos(1);
+let math_op_3 = Math.tan(2);
+let math_op_4 = Math.sqrt(3);
+let math_op_5 = Math.ceil(4);
+let math_op_6 = Math.floor(5);
+let math_op_7 = Math.atan2(6, 7);

--- a/tests/decompile-test/cases/testBlocks/constantShim.ts
+++ b/tests/decompile-test/cases/testBlocks/constantShim.ts
@@ -1,0 +1,20 @@
+/**
+ * Test constants like Math.PI
+ */
+//% color=#5C2D91 weight=31
+//% advanced=true
+namespace constant {
+    //% blockIdentity=constant._constant
+    export const PI = 3.14;
+    //% blockIdentity=constant._constant
+    export const LN2 = 0;
+
+    /**
+     * Constants defined on the namespace
+     */
+    //% blockId=constant_dropdown block="%constant" constantShim
+    //% shim=TD_ID weight=20 blockGap=8
+    export function _constant(constant: number): number {
+        return constant;
+    }
+}

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -6,6 +6,7 @@
         "mb.ts",
         "expandableBlocks.ts",
         "fixedInstance.ts",
+        "constantShim.ts",
         "cp.ts"
     ],
     "public": true,

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -183,7 +183,7 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
             </value>
         </block>
         <block type="math_js_op">
-            <field name="OP">log</field>
+            <field name="OP">sqrt</field>
             <value name="ARG0">
                 <shadow type="math_number">
                     <field name="NUM">0</field>

--- a/webapp/src/toolbox.ts
+++ b/webapp/src/toolbox.ts
@@ -1,5 +1,5 @@
 const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display: none">
-    <category name="Loops" nameid="loops" colour="#107c10" category="50" web-icon="\uf01e" iconclass="blocklyTreeIconloops" expandedclass="blocklyTreeIconloops">    
+    <category name="Loops" nameid="loops" colour="#107c10" category="50" web-icon="\uf01e" iconclass="blocklyTreeIconloops" expandedclass="blocklyTreeIconloops">
         <block type="controls_repeat_ext">
             <value name="TIMES">
                 <shadow type="math_whole_number">
@@ -27,7 +27,7 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
             </value>
         </block>
     </category>
-    <category name="Logic" nameid="logic" colour="#006970" category="49" web-icon="\uf074" iconclass="blocklyTreeIconlogic" expandedclass="blocklyTreeIconlogic">    
+    <category name="Logic" nameid="logic" colour="#006970" category="49" web-icon="\uf074" iconclass="blocklyTreeIconlogic" expandedclass="blocklyTreeIconlogic">
         <label text="Conditionals" web-class="blocklyFlyoutGroup" web-line="1.5"/>
         <block type="controls_if" gap="8">
             <value name="IF0">
@@ -83,7 +83,7 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
     </category>
     <category name="Variables" nameid="variables" colour="#A80000" custom="VARIABLE" category="48" iconclass="blocklyTreeIconvariables" expandedclass="blocklyTreeIconvariables">
     </category>
-    <category name="Math" nameid="math" colour="#712672" category="47" web-icon="\uf1ec" iconclass="blocklyTreeIconmath" expandedclass="blocklyTreeIconmath">    
+    <category name="Math" nameid="math" colour="#712672" category="47" web-icon="\uf1ec" iconclass="blocklyTreeIconmath" expandedclass="blocklyTreeIconmath">
         <block type="math_arithmetic" gap="8">
             <value name="A">
                 <shadow type="math_number">
@@ -177,6 +177,14 @@ const defaultToolboxString = `<xml id="blocklyToolboxDefinition" style="display:
         </block>
         <block type="math_op3">
             <value name="x">
+                <shadow type="math_number">
+                    <field name="NUM">0</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_js_op">
+            <field name="OP">log</field>
+            <value name="ARG0">
                 <shadow type="math_number">
                     <field name="NUM">0</field>
                 </shadow>


### PR DESCRIPTION
This PR adds a math function block. My criteria for which functions were included was mostly about which ones I have ever used in my life, and the list I came up with was:

1. `Math.sin(0)`
2. `Math.cos(1)`
3. `Math.tan(2)`
4.  `Math.sqrt(3)`
5.  `Math.ceil(4)`
6. `Math.floor(5)`
7. `Math.atan2(6, 7)`

And here are the ones that were cut:

1. `Math.asin(0)`
2. `Math.acos(1)`
3. `Math.atan(2)`
4. `Math.log(3)`
5. `Math.exp(4)`
6. `Math.trunc(5)`
6. `Math.round(6)`
7. `Math.imul(7, 8)`
7. `Math.idiv(9, 10)`


In addition to functions, I have also added support for constants on namespaces. It works exactly like enum blocks work; you add a dummy shim function (with the comment attribute `constantsShim`) and then annotate the constants you want in the dropdown with `blockIdentity="qName"`. I don't do any type checking.

@ganicke I filled in some placeholders for the tooltip text so take a look!