### PR TITLE
Release all devices on reset, lang change and /beta

### DIFF
--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -68,6 +68,7 @@ namespace pxt.winrt {
                 });
             }, Promise.resolve<Windows.Devices.Enumeration.DeviceInformationCollection>(null));
 
+            let deviceId: string;
             return getDevicesPromise
                 .then((devices) => {
                     if (!devices || !devices[0]) {
@@ -77,12 +78,15 @@ namespace pxt.winrt {
                     pxt.debug(`hid enumerate ${devices.length} devices`);
                     const device = devices[0];
                     pxt.debug(`hid connect to ${device.name} (${device.id})`);
+                    deviceId = device.id;
                     return whid.fromIdAsync(device.id, Windows.Storage.FileAccessMode.readWrite);
                 })
                 .then((r: WHID) => {
                     this.dev = r;
                     if (!this.dev) {
                         pxt.debug("can't connect to hid device");
+                        let status = Windows.Devices.Enumeration.DeviceAccessInformation.createFromId(deviceId).currentStatus;
+                        pxt.reportError("winrt_device", `could not connect to HID device; device status: ${status}`);
                         return Promise.reject(new Error("can't connect to hid device"));
                     }
                     pxt.debug(`hid device version ${this.dev.version}`);

--- a/pxtwinrt/winrt.ts
+++ b/pxtwinrt/winrt.ts
@@ -98,14 +98,16 @@ namespace pxt.winrt {
                 return Promise.resolve();
             })
             .catch((e) => {
-                pxt.reportError("winrt_device", `error disconnecting packetIO: ${e.message}`);
+                e.message = `error disconnecting packetIO: ${e.message}`;
+                pxt.reportException(e);
             })
             .then(() => {
                 pxt.log("suspending serial");
                 return suspendSerialAsync();
             })
             .catch((e) => {
-                pxt.reportError("winrt_device", `error suspending serial: ${e.message}`);
+                e.message = `error suspending serial: ${e.message}`;
+                pxt.reportException(e);
             });
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -966,13 +966,11 @@ export class ProjectView
                 .then(() => {
                     return pxt.winrt.releaseAllDevicesAsync();
                 })
-                .catch((e) => {
-                    pxt.log(`Error disconnecting devices: ${e.message}`);
-                })
                 .then(() => {
                     return this.resetWorkspace();
                 });
-        });
+        })
+        .done();
     }
 
     promptRenameProjectAsync(): Promise<boolean> {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -962,7 +962,13 @@ export class ProjectView
             disagreeLbl: lf("Cancel")
         }).then(r => {
             if (!r) return Promise.resolve();
-            return hidbridge.disconnectWrapperAsync()
+            return Promise.resolve()
+                .then(() => {
+                    return pxt.winrt.releaseAllDevicesAsync();
+                })
+                .catch((e) => {
+                    pxt.log(`Error disconnecting devices: ${e.message}`);
+                })
                 .then(() => {
                     return this.resetWorkspace();
                 });

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -101,7 +101,11 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
 
         if (langId !== initialLang) {
             pxt.tickEvent(`menu.lang.changelang.${langId}`);
-            window.location.reload();
+            pxt.winrt.releaseAllDevicesAsync()
+                .then(() => {
+                    window.location.reload();
+                })
+                .done();
         } else {
             pxt.tickEvent(`menu.lang.samelang.${langId}`);
             this.hide();

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -133,7 +133,11 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                     homeUrl += "/";
                 }
                 urlPath = urlPath.replace(/^\//, "");
-                window.location.href = homeUrl + urlPath;
+                pxt.winrt.releaseAllDevicesAsync()
+                    .then(() => {
+                        window.location.href = homeUrl + urlPath;
+                    })
+                    .done();
             }
             else {
                 this.setState({ searchFor: str })


### PR DESCRIPTION
Ok so here's what was happening:
- `reader.loadAsync(32)` in our serial logic blocks the device until 32 bytes have been read
- Until 32 bytes have been read, we cannot close the device
- If we navigate (/beta, change lang, reset workspace) while there is an active `loadAsync()` call, even if the navigation occurs, the device remains stuck in that `loadAsync()` call; disconnecting the device doesn't work and reconnecting is impossible until it is unplugged
- `loadAsync()` can be cancelled, but the cancellation is not enough to put the device into a good state, we need to wait until the `loadAsync()` call fully returns (the `cancel()` will make it reject the promise)

So, the overview of this fix:
- If we're about to change lang, go to /beta or reset workspace, we stop all ongoing `loadAsync()` operations
- To do that, we call `cancel()`, then wait for the `loadAsync()` to **fully** return
- We achieve that by waiting on deferred promises that are only resolved in the `.done` of `loadAsync`
- Once all deferred have been resolved, it means we can now safely `close()` all serial devices
- After all devices are closed we can safely navigate away

Also, I fixed our `suspending` handler so that it correctly waits on our async operations