### PR TITLE
Fixing some decompiler edge cases around enums

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1265,7 +1265,7 @@ ${output}</xml>`;
                     shadowBlockInfo = blocksInfo.blocksById[param.shadowBlockId];
                 }
 
-                if (paramInfo && paramInfo.isEnum && e.kind === SK.CallExpression) {
+                if (e.kind === SK.CallExpression) {
                     // Many enums have shim wrappers that need to be unwrapped if used
                     // in a parameter that is of an enum type. By default, enum parameters
                     // are dropdown fields (not value inputs) so we want to decompile the
@@ -1313,7 +1313,7 @@ ${output}</xml>`;
                         if (shadowBlockInfo && shadowBlockInfo.attributes.shim === "TD_ID") {
                             addInput(mkValue(aName, getPropertyAccessExpression(e as PropertyAccessExpression, false, param.shadowBlockId), param.shadowBlockId));
                         }
-                        else if (paramInfo && paramInfo.isEnum || callInfo && callInfo.attrs.fixedInstance) {
+                        else if (paramInfo && paramInfo.isEnum || callInfo && (callInfo.attrs.fixedInstance || callInfo.attrs.blockIdentity === info.qName)) {
                             addField(getField(aName, (getPropertyAccessExpression(e as PropertyAccessExpression, true) as TextNode).value))
                         }
                         else {

--- a/tests/decompile-test/baselines/enum_shadow_blocks.blocks
+++ b/tests/decompile-test/baselines/enum_shadow_blocks.blocks
@@ -1,0 +1,13 @@
+/// <reference path="./testBlocks/enums.ts" />
+
+let enum_var1 = MyEnum.Value2;
+let enum_var2 = enumTest.enumShim(MyEnum.Value2);
+
+enumTest.enumEvent(MyEnum.Value2, function() {
+
+});
+enumTest.enumEvent(enumTest.enumShim(MyEnum.Value2), function() {
+
+});
+enumTest.enumArg(MyEnum.Value2);
+enumTest.enumShadowArg(MyEnum.Value2);

--- a/tests/decompile-test/baselines/enum_shadow_blocks.blocks
+++ b/tests/decompile-test/baselines/enum_shadow_blocks.blocks
@@ -1,13 +1,51 @@
-/// <reference path="./testBlocks/enums.ts" />
-
-let enum_var1 = MyEnum.Value2;
-let enum_var2 = enumTest.enumShim(MyEnum.Value2);
-
-enumTest.enumEvent(MyEnum.Value2, function() {
-
-});
-enumTest.enumEvent(enumTest.enumShim(MyEnum.Value2), function() {
-
-});
-enumTest.enumArg(MyEnum.Value2);
-enumTest.enumShadowArg(MyEnum.Value2);
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="enum_event">
+<field name="enum">MyEnum.Value2</field>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="enum_event">
+<field name="enum">MyEnum.Value2</field>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">enum_var1</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="enum_shim">
+<field name="enum">MyEnum.Value2</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">enum_var2</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="enum_shim">
+<field name="enum">MyEnum.Value2</field>
+</block>
+</value>
+<next>
+<block type="enum_arg">
+<field name="enum">MyEnum.Value2</field>
+<next>
+<block type="enum_shadow_arg">
+<value name="enum">
+<shadow type="enum_shim">
+<field name="enum">MyEnum.Value2</field>
+</shadow>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;enums.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/enum_shadow_blocks.ts
+++ b/tests/decompile-test/cases/enum_shadow_blocks.ts
@@ -1,0 +1,13 @@
+/// <reference path="./testBlocks/enums.ts" />
+
+let enum_var1 = MyEnum.Value2;
+let enum_var2 = enumTest.enumShim(MyEnum.Value2);
+
+enumTest.enumEvent(MyEnum.Value2, function() {
+
+});
+enumTest.enumEvent(enumTest.enumShim(MyEnum.Value2), function() {
+
+});
+enumTest.enumArg(MyEnum.Value2);
+enumTest.enumShadowArg(MyEnum.Value2);

--- a/tests/decompile-test/cases/testBlocks/enums.ts
+++ b/tests/decompile-test/cases/testBlocks/enums.ts
@@ -1,0 +1,47 @@
+const enum MyEnum {
+    //% blockIdentity="enumTest.enumShim"
+    Value1,
+    //% blockIdentity="enumTest.enumShim"
+    Value2
+}
+
+namespace enumTest {
+
+    /**
+     * Enum shim (for shadow blocks)
+     */
+    //% shim=TD_ID
+    //% blockId=enum_shim
+    //% block="enum %enum"
+    export function enumShim(value: MyEnum): number {
+        return value;
+    }
+
+
+    /**
+     * Enum event with no shadow block
+     */
+    //% blockId=enum_event
+    //% block="event %enum"
+    export function enumEvent(value: MyEnum, handler: () => void) {
+
+    }
+
+    /**
+     * Enum API with no shadow block
+     */
+    //% blockId=enum_arg
+    //% block="arg %enum"
+    export function enumArg(value: MyEnum) {
+
+    }
+
+    /**
+     * Enum API with a shadow block
+     */
+    //% blockId=enum_shadow_arg
+    //% block="shadow %enum=enum_shim"
+    export function enumShadowArg(value: number) {
+
+    }
+}

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -3,6 +3,7 @@
     "description": "Project that defines a variety of blocks to be used in decopmiler test cases",
     "files": [
         "basic.ts",
+        "enums.ts",
         "mb.ts",
         "expandableBlocks.ts",
         "fixedInstance.ts",

--- a/tests/decompile-test/decompilerunner.ts
+++ b/tests/decompile-test/decompilerunner.ts
@@ -126,6 +126,7 @@ function decompileAsyncWorker(f: string, dependency?: string): Promise<string> {
         pkg.getCompileOptionsAsync()
             .then(opts => {
                 opts.ast = true;
+                opts.testMode = true;
                 opts.ignoreFileResolutionErrors = true;
                 const decompiled = pxtc.decompile(opts, "main.ts", true);
                 if (decompiled.success) {


### PR DESCRIPTION
This fixes a ton of really specific bugs around enums and decompilation where enums were being decompiled into values (i.e. shadow blocks) when they should have been fields (i.e. dropdowns).