### PR TITLE
For TS only on "codeExample" cards

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -73,6 +73,7 @@ namespace pxt.editor {
         temporary?: boolean;
         inTutorial?: boolean;
         dependencies?: pxt.Map<string>;
+        tsOnly?: boolean;
     }
 
     export interface ProjectFilters {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -997,6 +997,10 @@ export class ProjectView
             Util.jsonCopyFrom(files, options.filesOverride)
         if (options.dependencies)
             Util.jsonMergeFrom(cfg.dependencies, options.dependencies)
+        if (options.tsOnly) {
+            cfg.files = cfg.files.filter(f => f != "main.blocks")
+            delete files["main.blocks"]
+        }
         files["pxt.json"] = JSON.stringify(cfg, null, 4) + "\n";
         return workspace.installAsync({
             name: cfg.name,
@@ -1078,7 +1082,7 @@ export class ProjectView
                     return this.resetWorkspace();
                 });
         })
-        .done();
+            .done();
     }
 
     pair() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -174,7 +174,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             }
         }
 
-        const chgCode = (scr: pxt.CodeCard, loadBlocks?: boolean, prj?: pxt.ProjectTemplate) => {
+        const chgCode = (scr: pxt.CodeCard, loadBlocks: boolean, prj?: pxt.ProjectTemplate) => {
             core.showLoading("changingcode", lf("loading..."));
             gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
                 .done(opts => {
@@ -196,6 +196,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                                     core.hideLoading("changingcode");
                                 })
                         } else {
+                            opts.tsOnly = true
                             return this.props.parent.createProjectAsync(opts)
                                 .then(() => Promise.delay(500))
                                 .done(() => core.hideLoading("changingcode"));


### PR DESCRIPTION
This removes main.blocks from project when type is `codeExample` and `example`. For 32 this is what we want, because blocks are just missing and conversion changes semantics. I think this is the usual scenario.