### PR TITLE
Fixing first time build of sim-only targets

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2892,6 +2892,9 @@ function simulatorCoverage(pkgCompileRes: pxtc.CompileResult, pkgOpts: pxtc.Comp
         sources.push("built/common-sim.d.ts")
     }
 
+    if (!fs.existsSync(sources[0]))
+        return // simulator not yet built; will try next time
+
     let opts: pxtc.CompileOptions = {
         fileSystem: {},
         sourceFiles: sources,


### PR DESCRIPTION
This fixes this build error:

```
*** Build failed: target build failed: ENOENT: no such file or directory, open '/Users/michal/src/pxt-32/built/sim.d.ts'
```

The missing implementation checking doesn't seem very effective anyways, so I guess it's fine to do with a delay of one build.