### PR TITLE
Preserve sandbox hash in embedded pages

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2220,8 +2220,8 @@ $(() => {
     const appCacheUpdated = () => {
         try {
             // On embedded pages, preserve the loaded project
-            if (pxt.BrowserUtils.isIFrame() && hash.cmd === "pub") {
-                location.hash = `#pub:${hash.arg}`;
+            if (pxt.BrowserUtils.isIFrame() && (hash.cmd === "pub" || hash.cmd === "sandbox")) {
+                location.hash = `#${hash.cmd}:${hash.arg}`;
             }
             // if in editor, reload project
             else if (theEditor


### PR DESCRIPTION
We use `#sandbox`  in the share page instead of `#pub`. I can't test this locally.