### PR TITLE
Handle app cache updates in the simulator

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -71,7 +71,7 @@ namespace pxsim {
     }
     export interface SimulatorCommandMessage extends SimulatorMessage {
         type: "simulator",
-        command: "modal" | "restart"
+        command: "modal" | "restart" | "reload"
         header?: string;
         body?: string;
         copyable?: string;
@@ -179,6 +179,7 @@ namespace pxsim {
         export function start() {
             window.addEventListener("message", receiveMessage, false);
             let frameid = window.location.hash.slice(1)
+            initAppcache();
             Runtime.postMessage(<SimulatorReadyMessage>{ type: 'ready', frameid: frameid });
         }
 
@@ -199,7 +200,7 @@ namespace pxsim {
                     if (handleCustomMessage) handleCustomMessage((<SimulatorCustomMessage>data));
                     break;
                 case 'pxteditor':
-                    break; //handled elsewhere                
+                    break; //handled elsewhere
                 case 'debugger':
                     if (runtime) {
                         runtime.handleDebuggerMsg(data as DebuggerMessage);
@@ -287,6 +288,19 @@ namespace pxsim {
         if (typeof window !== 'undefined' && window.parent && window.parent !== window) {
             window.parent.postMessage(message, "*");
         }
+    }
+
+    function initAppcache() {
+        if (typeof window !== 'undefined') {
+            if (window.applicationCache.status === window.applicationCache.UPDATEREADY) {
+                reload();
+            }
+            window.applicationCache.addEventListener("updateready", () => reload());
+        }
+    }
+
+    export function reload() {
+        Runtime.postMessage({ type: "simulator", command: "reload" } as SimulatorCommandMessage)
     }
 }
 

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -109,6 +109,10 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
                 case "restart":
                     cfg.restartSimulator();
                     break;
+                case "reload":
+                    stop(true);
+                    cfg.restartSimulator();
+                    break;
                 case "modal":
                     stop();
                     if (!pxt.shell.isSandboxMode() && (!msg.displayOnceId || !displayedModals[msg.displayOnceId])) {


### PR DESCRIPTION
Hopefully this should fix the bug where the editor updates its appcache, reloads the page, and the simulator does not appear. I can't test the end-to-end scenario but I did verify that my reload message works as expected.