### PR TITLE
Support saving projects in PNG screenshots

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -298,6 +298,7 @@ declare namespace ts.pxtc {
         useUF2?: boolean;
         useMkcd?: boolean;
         useELF?: boolean;
+        saveAsPNG?: boolean;
         useModulator?: boolean;
         webUSB?: boolean; // use WebUSB when supported        
         hexMimeType?: string;
@@ -339,6 +340,7 @@ declare namespace ts.pxtc {
         trace?: boolean;
         justMyCode?: boolean;
         computeUsedSymbols?: boolean;
+        name?: string;
 
         alwaysDecompileOnStart?: boolean; // decompiler only
 

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -68,6 +68,7 @@ namespace ts.pxtc {
             jssource += "pxsim.noRefCounting();\n"
         if (bin.target.floatingPoint)
             jssource += "pxsim.enableFloatingPoint();\n"
+        jssource += "pxsim.setTitle(" + JSON.stringify(bin.options.name || "") + ");\n"
         let cfg: pxt.Map<number> = {}
         let cfgKey: pxt.Map<number> = {}
         for (let ce of bin.res.configData || []) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -619,7 +619,8 @@ namespace pxt {
                 sourceFiles: [],
                 fileSystem: {},
                 target: target,
-                hexinfo: { hex: [] }
+                hexinfo: { hex: [] },
+                name: this.config.name
             }
 
             const generateFile = (fn: string, cont: string) => {

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -12,6 +12,7 @@ namespace pxsim {
 
     export let floatingPoint = false;
     export let refCounting = true;
+    export let title = "";
     let cfgKey: Map<number> = {}
     let cfg: Map<number> = {}
 
@@ -57,6 +58,10 @@ namespace pxsim {
 
     export function enableFloatingPoint() {
         floatingPoint = true
+    }
+
+    export function setTitle(t: string) {
+        title = t;
     }
 
     export class RefObject {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -107,6 +107,7 @@ export class ProjectView
     importDialog: projects.ImportDialog;
     exitAndSaveDialog: projects.ExitAndSaveDialog;
     prevEditorId: string;
+    screenshotHandler: (img: string) => void;
 
     private lastChangeTime: number;
     private reload: boolean;
@@ -834,11 +835,8 @@ export class ProjectView
         }
     }
 
-    importProjectFile(file: File) {
-        if (!file) return;
-
-        ts.pxtc.Util.fileReadAsBufferAsync(file)
-            .then(buf => pxt.lzmaDecompressAsync(buf))
+    private importProjectCoreAsync(buf: Uint8Array) {
+        return pxt.lzmaDecompressAsync(buf)
             .then(contents => {
                 let data = JSON.parse(contents) as pxt.cpp.HexFile;
                 this.importHex(data);
@@ -846,6 +844,20 @@ export class ProjectView
                 core.warningNotification(lf("Sorry, we could not import this project."))
                 this.openHome();
             });
+    }
+
+    importProjectFile(file: File) {
+        if (!file) return;
+        ts.pxtc.Util.fileReadAsBufferAsync(file)
+            .then(buf => this.importProjectCoreAsync(buf))
+    }
+
+    importPNGFile(file: File) {
+        if (!file) return;
+        ts.pxtc.Util.fileReadAsBufferAsync(file)
+            .then(buf => screenshot.decodeBlobAsync("data:image/png;base64," +
+                btoa(Util.uint8ArrayToString(buf))))
+            .then(buf => this.importProjectCoreAsync(buf))
     }
 
     importFile(file: File) {
@@ -858,6 +870,8 @@ export class ProjectView
             this.importTypescriptFile(file);
         } else if (isProjectFile(file.name)) {
             this.importProjectFile(file);
+        } else if (isPNGFile(file.name)) {
+            this.importPNGFile(file);
         } else {
             const importer = this.resourceImporters.filter(fi => fi.canImport(file))[0];
             if (importer) {
@@ -951,11 +965,25 @@ export class ProjectView
 
     saveProjectToFileAsync(): Promise<void> {
         const mpkg = pkg.mainPkg
-        return this.exportProjectToFileAsync()
-            .then((buf: Uint8Array) => {
-                const fn = pkg.genFileName(".mkcd");
-                pxt.BrowserUtils.browserDownloadUInt8Array(buf, fn, 'application/octet-stream');
+        if (pxt.appTarget.compile.saveAsPNG) {
+            simulator.driver.postMessage({ type: "screenshot" })
+            return new Promise<void>((resolve, reject) => {
+                this.screenshotHandler = (img) => {
+                    this.screenshotHandler = null
+                    resolve(this.exportProjectToFileAsync()
+                        .then(blob => screenshot.encodeBlobAsync(img, blob))
+                        .then(img => {
+                            const fn = pkg.genFileName(".png");
+                            pxt.BrowserUtils.browserDownloadDataUri(img, fn);
+                        }))
+                }
             })
+        } else
+            return this.exportProjectToFileAsync()
+                .then((buf: Uint8Array) => {
+                    const fn = pkg.genFileName(".mkcd");
+                    pxt.BrowserUtils.browserDownloadUInt8Array(buf, fn, 'application/octet-stream');
+                })
     }
 
     addPackage() {
@@ -1376,11 +1404,14 @@ export class ProjectView
     importFileDialog() {
         let input: HTMLInputElement;
         let ext = ".mkcd";
-        if (pxt.appTarget.compile && pxt.appTarget.compile.hasHex) {
+        if (pxt.appTarget.compile.hasHex) {
             ext = ".hex";
         }
-        if (pxt.appTarget.compile && pxt.appTarget.compile.useUF2) {
+        if (pxt.appTarget.compile.useUF2) {
             ext = ".uf2";
+        }
+        if (pxt.appTarget.compile.saveAsPNG) {
+            ext = ".png";
         }
         core.confirmAsync({
             header: lf("Open {0} file", ext),
@@ -1871,6 +1902,10 @@ function isProjectFile(filename: string): boolean {
     return /\.(pxt|mkcd)$/i.test(filename)
 }
 
+function isPNGFile(filename: string): boolean {
+    return /\.png$/i.test(filename)
+}
+
 function initLogin() {
     {
         let qs = core.parseQueryString((location.hash || "#").slice(1).replace(/%23access_token/, "access_token"))
@@ -1949,8 +1984,11 @@ function initScreenshots() {
             pxt.tickEvent("sim.screenshot");
             const scmsg = msg as pxsim.SimulatorScreenshotMessage;
             pxt.debug('received screenshot');
-            screenshot.saveAsync(theEditor.state.header, scmsg.data)
-                .done(() => { pxt.debug('screenshot saved') })
+            if (theEditor.screenshotHandler)
+                theEditor.screenshotHandler(scmsg.data)
+            else
+                screenshot.saveAsync(theEditor.state.header, scmsg.data)
+                    .done(() => { pxt.debug('screenshot saved') })
         };
     }, false);
 }

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -42,3 +42,64 @@ export function saveAsync(header: Header, screenshot: string): Promise<void> {
                 });
         });
 }
+
+export function loadImageAsync(url: string) {
+    return new Promise<HTMLCanvasElement>((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => {
+            const canvas = document.createElement("canvas")
+            canvas.width = img.width
+            canvas.height = img.height
+            const ctx = canvas.getContext("2d")
+            ctx.drawImage(img, 0, 0);
+            resolve(canvas)
+        };
+    })
+}
+
+// randomly selected
+const imageHeaderPref = [75, 15, 39, 177]
+
+export function encodeBlobAsync(dataURL: string, blob: Uint8Array) {
+    return loadImageAsync(dataURL)
+        .then(canvas => {
+            const neededBits = blob.length * 8
+            // we take 6 bytes for the magic - 2 bits per channel, 6 bits per pixel - 8 pixels
+            const magicPixels = 8
+            const usableBytes = (canvas.width * canvas.height - magicPixels) * 3
+            let bpp = 1
+            while (bpp < 4) {
+                if (usableBytes * bpp >= neededBits)
+                    break
+            }
+            let addedLines = 0
+            const addedLimit = canvas.width * canvas.height * 4
+            if (usableBytes * bpp < neededBits) {
+                const missing = neededBits - usableBytes * bpp
+                const bitsPerLine = canvas.width * 3 * 8
+                addedLines = Math.ceil(missing / bitsPerLine)
+                const c2 = document.createElement("canvas")
+                c2.width = canvas.width
+                c2.height = canvas.height + addedLines
+                const ctx = c2.getContext("2d")
+                ctx.drawImage(canvas, 0, 0)
+                canvas = c2
+            }
+
+            function encode(ptr: number, bpp: number, data: ArrayLike<number>) {
+                for (let i = 0; i < data.length; ++i) {
+                    
+                }
+            }
+
+            const imageHeader = imageHeaderPref.concat([(addedLines >> 8) | (bpp << 6), addedLines & 0xff])
+
+            const ctx = canvas.getContext("2d")
+            const imgdat = ctx.getImageData(0, 0, canvas.width, canvas.height)
+            let ptr = 0
+
+            for ()
+
+
+          })
+}


### PR DESCRIPTION
This adds `saveAsPNG` option in pxtarget. When enabled, the save button will ask the simulator for a screenshot and embed the project source code in the screenshot. Also adds loading.

Also, adds `pxsim.title` with the title of the project (it can be printed on the screenshot)