### PR TITLE
Port search improvements and fix search crash

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -536,7 +536,7 @@ namespace ts.pxtc.service {
     let lastFuse: Fuse<SearchInfo>;
     let builtinItems: SearchInfo[];
     let blockDefinitions: pxt.Map<pxt.blocks.BlockDefinition>;
-    let tbSubset: pxt.Map<boolean>;
+    let tbSubset: pxt.Map<boolean | string>;
 
     function fileDiags(fn: string) {
         if (!/\.ts$/.test(fn))
@@ -728,11 +728,11 @@ namespace ts.pxtc.service {
 
                 if (search.subset) {
                     tbSubset = search.subset;
-                    builtinSearchSet = builtinItems.filter(s => tbSubset[s.id]);
+                    builtinSearchSet = builtinItems.filter(s => !!tbSubset[s.id]);
                 }
 
                 if (tbSubset) {
-                    subset = blockInfo.blocks.filter(s => tbSubset[s.attributes.blockId]);
+                    subset = blockInfo.blocks.filter(s => !!tbSubset[s.attributes.blockId]);
                 }
                 else {
                     subset = blockInfo.blocks;
@@ -740,14 +740,17 @@ namespace ts.pxtc.service {
                 }
 
                 let searchSet: SearchInfo[] = subset.map(s => {
-                    return {
+                    const mappedSi: SearchInfo = {
                         id: s.attributes.blockId,
                         qName: s.qName,
                         name: s.name,
-                        nameSpace: s.namespace,
+                        namespace: s.namespace,
                         block: s.attributes.block,
-                        jsDoc: s.attributes.jsDoc
+                        jsdoc: s.attributes.jsDoc,
+                        localizedCategory: tbSubset && typeof tbSubset[s.attributes.blockId] === "string"
+                            ? tbSubset[s.attributes.blockId] as string : undefined
                     };
+                    return mappedSi;
                 });
 
 
@@ -769,10 +772,11 @@ namespace ts.pxtc.service {
                     findAllMatches: false,
                     caseSensitive: false,
                     keys: [
-                        { name: 'name', weight: 0.3125 },
-                        { name: 'namespace', weight: 0.1875 },
+                        { name: 'name', weight: 0.3 },
+                        { name: 'namespace', weight: 0.1 },
+                        { name: 'localizedCategory', weight: 0.1 },
                         { name: 'block', weight: 0.4375 },
-                        { name: 'jsDoc', weight: 0.0625 }
+                        { name: 'jsdoc', weight: 0.0625 }
                     ],
                     sortFn: function (a: any, b: any): number {
                         const wa = a.qName ? 1 - weights[a.item.qName] / mw : 1;

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -278,7 +278,7 @@ namespace pxt.blocks {
                 name: Util.lf("{id:block}number"),
                 url: '/blocks/math/random',
                 category: 'math',
-                tooltip: (pxt.appTarget.compile && pxt.appTarget.compile.floatingPoint) ?
+                tooltip: (pxt.appTarget && pxt.appTarget.compile && pxt.appTarget.compile.floatingPoint) ?
                     Util.lf("a decimal number") : Util.lf("an integer number")
             },
             'math_integer': {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1107,7 +1107,7 @@ namespace ts.pxtc.service {
     }
 
     export interface SearchOptions {
-        subset?: pxt.Map<boolean>;
+        subset?: pxt.Map<boolean | string>;
         term: string;
         localizedApis?: ApisInfo;
         localizedStrings?: pxt.Map<string>;
@@ -1126,6 +1126,7 @@ namespace ts.pxtc.service {
         namespace?: string;
         jsdoc?: string;
         field?: [string, string];
+        localizedCategory?: string;
     }
 }
 


### PR DESCRIPTION
- Port search improvements from stable2.4:
  - Filtered (disabled and hidden) blocks are excluded from search
  - Localized category names are now searched
- Fix search crash caused by `pxt.appTarget` being undefined inside workers