### PR TITLE
Remove extra spaces from Blockly labels

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -804,7 +804,7 @@ namespace pxt.blocks {
                     if (part.kind !== "param") {
                         const f = newLabel(part);
                         if (f) {
-                            fields.push({ field: newLabel(part) });
+                            fields.push({ field: f });
                         }
                     }
                     else {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -617,7 +617,7 @@ namespace pxt.blocks {
             return iconToFieldImage(part.uri);
         }
 
-        const txt = part.text.trim();
+        const txt = removeOuterSpace(part.text)
         if (!txt) {
             return undefined;
         }
@@ -3373,5 +3373,22 @@ namespace pxt.blocks {
 
     function getConstantDropdownValues(apis: pxtc.ApisInfo, qName: string) {
         return pxt.Util.values(apis.byQName).filter(sym => sym.attributes.blockIdentity === qName);
+    }
+
+    // Trims off a single space from beginning and end (if present)
+    function removeOuterSpace(str: string) {
+        if (str === " ") {
+            return "";
+        }
+        else if (str.length > 1) {
+            const startSpace = str.charAt(0) == " ";
+            const endSpace = str.charAt(str.length - 1) == " ";
+
+            if (startSpace || endSpace) {
+                return str.substring(startSpace ? 1 : 0, endSpace ? str.length - 1 : str.length);
+            }
+        }
+
+        return str;
     }
 }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -616,17 +616,23 @@ namespace pxt.blocks {
         if (part.kind === "image") {
             return iconToFieldImage(part.uri);
         }
-        else if (part.cssClass) {
-            return new Blockly.FieldLabel(part.text, part.cssClass);
+
+        const txt = part.text.trim();
+        if (!txt) {
+            return undefined;
+        }
+
+        if (part.cssClass) {
+            return new Blockly.FieldLabel(txt, part.cssClass);
         }
         else if (part.style.length) {
-            return new pxtblockly.FieldStyledLabel(part.text, {
+            return new pxtblockly.FieldStyledLabel(txt, {
                 bold: part.style.indexOf("bold") !== -1,
                 italics: part.style.indexOf("italics") !== -1
             })
         }
         else {
-            return new Blockly.FieldLabel(part.text, undefined);
+            return new Blockly.FieldLabel(txt, undefined);
         }
     }
 
@@ -796,7 +802,10 @@ namespace pxt.blocks {
 
                 inputParts.forEach(part => {
                     if (part.kind !== "param") {
-                        fields.push({ field: newLabel(part) });
+                        const f = newLabel(part);
+                        if (f) {
+                            fields.push({ field: newLabel(part) });
+                        }
                     }
                     else {
                         // find argument


### PR DESCRIPTION
The "edges" of blockly labels come with an implicit space, so we can remove whitespace from either side of the labels that we add to blocks