### PR TITLE
Allow block parameters to be implicitly converted to strings

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -16,7 +16,7 @@ namespace basic {
 }
 ```
 
-You can also provide a JsDoc comment, color and weight for the namespace, as well as a friendly name (in Unicode). 
+You can also provide a JsDoc comment, color and weight for the namespace, as well as a friendly name (in Unicode).
 We strongly recommend carefully picking colors as it dramatically impacts
 that appearance and readability of your blocks. All blocks within the same namespace have the same color so that users can find the category easily from
 samples.
@@ -219,6 +219,26 @@ export function readUntil(del: string) : string {
 }
 ```
 
+### Tip: implicit conversion for string parameters
+
+If you have an API that takes a string as an argument it is possible to bypass the usual
+type checking done in the blocks editor and allow any typed block to be placed in the input. PXT
+will automatically convert whatever block is connected to the argument's input into a string
+in the generated TypeScript. To enable that behavior, set `shadowOptions.toString` on the
+parameter like so:
+
+```
+    //% blockId=console_log block="console|log %msg"
+    //% text.shadowOptions.toString=true
+    export function log(text: string): void {
+        serial.writeString(text + "\r\n");
+    }
+```
+
+Note that the parameter is referred to using its declared name (`text`) and not the
+name in the block definition string (`msg`).
+
+
 ## Docs and default values
 
 The JSDoc comment is automatically used as the help for the block.
@@ -351,7 +371,7 @@ namespace pins {
     //% fixedInstance whenUsed
     export const A7 = new AnalogPin(7);
 }
-``` 
+```
 
 The `whenUsed` annotation causes the variable to be only included in compilation
 when it is used, even though it is initialized with something that can possibly

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1079,6 +1079,11 @@ namespace pxt.blocks {
                 // FIXME: No need to do this if the previous statement was a code block
                 return prefixWithSemicolon(compileExpression(e, target, comments));
             }
+
+            if (p.shadowOptions && p.shadowOptions.toString && returnType(e, target) !== pString) {
+                return H.mkSimpleCall("+", [H.mkStringLiteral(""), compileExpression(e, target, comments)]);
+            }
+
             return compileExpression(e, target, comments)
         }
     }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -791,7 +791,7 @@ namespace pxt.blocks {
             inputs.forEach(inputParts => {
                 const fields: NamedField[] = [];
                 let inputName: string;
-                let inputCheck: string;
+                let inputCheck: string | string[];
                 let hasParameter = false;
 
                 inputParts.forEach(part => {
@@ -902,7 +902,12 @@ namespace pxt.blocks {
                             } else if (pr.type == "boolean") {
                                 inputCheck = "Boolean"
                             } else if (pr.type == "string") {
-                                inputCheck = "String"
+                                if (pr.shadowOptions && pr.shadowOptions["toString"]) {
+                                    inputCheck = undefined;
+                                }
+                                else {
+                                    inputCheck = "String"
+                                }
                             } else {
                                 inputCheck = pr.type == "T" ? undefined : (isArrayType(pr.type) ? "Array" : pr.type);
                             }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -902,7 +902,7 @@ namespace pxt.blocks {
                             } else if (pr.type == "boolean") {
                                 inputCheck = "Boolean"
                             } else if (pr.type == "string") {
-                                if (pr.shadowOptions && pr.shadowOptions["toString"]) {
+                                if (pr.shadowOptions && pr.shadowOptions.toString) {
                                     inputCheck = undefined;
                                 }
                                 else {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1320,6 +1320,16 @@ ${output}</xml>`;
                             addInput(getValue(aName, e, param.shadowBlockId))
                         }
                         break;
+                    case SK.BinaryExpression:
+                        if (param && param.shadowOptions && param.shadowOptions.toString) {
+                            const be = e as BinaryExpression;
+                            if (be.operatorToken.kind === SK.PlusToken && isEmptyStringNode(be.left)) {
+                                addInput(getValue(U.htmlEscape(param.definitionName), be.right, param.shadowBlockId || "text"));
+                                break;
+                            }
+                        }
+                        addInput(getValue(U.htmlEscape(param.definitionName), e, param.shadowBlockId))
+                        break;
                     default:
                         let v: ValueNode;
                         const vName = U.htmlEscape(param.definitionName);
@@ -2060,6 +2070,13 @@ ${output}</xml>`;
 
             return undefined;
         }
+    }
+
+    function isEmptyStringNode(node: Node) {
+        if (node.kind === SK.StringLiteral || node.kind === SK.NoSubstitutionTemplateLiteral) {
+            return (node as LiteralLikeNode).text === "";
+        }
+        return false;
     }
 
     function isAutoDeclaration(decl: VariableDeclaration) {

--- a/tests/blocklycompiler-test/baselines/to_string_arg.ts
+++ b/tests/blocklycompiler-test/baselines/to_string_arg.ts
@@ -1,0 +1,5 @@
+let item = 0
+console.log("")
+console.log("" + 5)
+console.log("" + item)
+console.log("" + (0 == 0))

--- a/tests/blocklycompiler-test/cases/to_string_arg.blocks
+++ b/tests/blocklycompiler-test/cases/to_string_arg.blocks
@@ -1,0 +1,62 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+    <variables>
+      <variable type="" id="[KphBG)G|B*8X9h2!(A#">item</variable>
+    </variables>
+    <block type="pxt-on-start" id="N,i05v`Ex0a9C(9{:TBi" x="157" y="112">
+      <statement name="HANDLER">
+        <block type="console_log" id="+7e9tdnh-@;Ng;vy]6J=">
+          <value name="text">
+            <shadow type="text" id="@9N/!VrU*o5tARX0H7)Y">
+              <field name="TEXT"></field>
+            </shadow>
+          </value>
+          <next>
+            <block type="console_log" id="LfFCK)PKKdzx+:f^7@|C">
+              <value name="text">
+                <shadow type="text" id=":,i3v^W2ZT#n=gN?9Iq?">
+                  <field name="TEXT"></field>
+                </shadow>
+                <block type="math_number" id="9RfSwSE`}@mz/[)X.e#Z">
+                  <field name="NUM">5</field>
+                </block>
+              </value>
+              <next>
+                <block type="console_log" id="D/rKuFMQ-IJ#cIf2Sm)B">
+                  <value name="text">
+                    <shadow type="text" id=":,i3v^W2ZT#n=gN?9Iq?">
+                      <field name="TEXT"></field>
+                    </shadow>
+                    <block type="variables_get" id="X6+6uJFBrho%vLYlD79}">
+                      <field name="VAR" id="[KphBG)G|B*8X9h2!(A#" variabletype="">item</field>
+                    </block>
+                  </value>
+                  <next>
+                    <block type="console_log" id="is_@A;U,{@tiTx*_^UkN">
+                      <value name="text">
+                        <shadow type="text" id=":,i3v^W2ZT#n=gN?9Iq?">
+                          <field name="TEXT"></field>
+                        </shadow>
+                        <block type="logic_compare" id=";XU-ui)[5R$}FoAf,cNx">
+                          <field name="OP">EQ</field>
+                          <value name="A">
+                            <shadow type="math_number" id="?,[_MJtf^=y-LZm~EWdb">
+                              <field name="NUM">0</field>
+                            </shadow>
+                          </value>
+                          <value name="B">
+                            <shadow type="math_number" id=",+?+7fLX#P]=EBPGc2aM">
+                              <field name="NUM">0</field>
+                            </shadow>
+                          </value>
+                        </block>
+                      </value>
+                    </block>
+                  </next>
+                </block>
+              </next>
+            </block>
+          </next>
+        </block>
+      </statement>
+    </block>
+  </xml>

--- a/tests/blocklycompiler-test/test-library/pxt.json
+++ b/tests/blocklycompiler-test/test-library/pxt.json
@@ -2,7 +2,8 @@
     "name": "test-compile",
     "description": "Project that defines a variety of blocks to be used in blockly compiler test cases",
     "files": [
-        "expandableBlocks.ts"
+        "expandableBlocks.ts",
+        "toStringArgs.ts"
     ],
     "public": true,
     "dependencies": {},

--- a/tests/blocklycompiler-test/test-library/toStringArgs.ts
+++ b/tests/blocklycompiler-test/test-library/toStringArgs.ts
@@ -1,0 +1,16 @@
+/**
+ * Reading and writing data to the console output.
+ */
+//% weight=12 color=#002050 icon="\uf120"
+//% advanced=true
+namespace console {
+    /**
+     * Write a line of text to the console output.
+     * @param value to send
+     */
+    //% weight=90
+    //% help=console/log blockGap=8 text.shadowOptions.toString=true
+    //% blockId=console_log block="console|log %text"
+    export function log(text: string): void {
+    }
+}

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -126,7 +126,7 @@ class BlocklyCompilerTestHost implements pxt.Host {
         } else if (pxt.appTarget && pxt.appTarget.bundledpkgs[module.id] && filename === pxt.CONFIG_NAME) {
             return pxt.appTarget.bundledpkgs[module.id][pxt.CONFIG_NAME];
         }
-        
+
         if (module.id == "testlib") {
             const split = filename.split(/[/\\]/);
             filename = "test-library/" + split[split.length - 1];
@@ -348,6 +348,10 @@ describe("blockly compiler", function() {
     describe("compiling special blocks", () => {
         it("should compile the predicate in pause until", done => {
             blockTestAsync("pause_until").then(done, done);
+        });
+
+        it("should implicitly convert arguments marged as toString to a string", done => {
+            blockTestAsync("to_string_arg").then(done, done);
         });
     });
 

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -350,7 +350,7 @@ describe("blockly compiler", function() {
             blockTestAsync("pause_until").then(done, done);
         });
 
-        it("should implicitly convert arguments marged as toString to a string", done => {
+        it("should implicitly convert arguments marked as toString to a string", done => {
             blockTestAsync("to_string_arg").then(done, done);
         });
     });

--- a/tests/decompile-test/baselines/to_string_inputs.blocks
+++ b/tests/decompile-test/baselines/to_string_inputs.blocks
@@ -1,0 +1,44 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="test_toStringArg">
+<value name="msg">
+<shadow type="text">
+<field name="TEXT">whatever</field>
+</shadow>
+</value>
+<next>
+<block type="test_toStringArg">
+<value name="msg">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="math_number">
+<field name="NUM">5</field>
+</block>
+</value>
+<next>
+<block type="test_toStringArg">
+<value name="msg">
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">whatever</field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="math_number">
+<field name="NUM">5</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -196,6 +196,13 @@ namespace testNamespace {
 
     //% blockId=test_customFieldEditorNoLiterals block="%value=test_customShadowFieldNoLiterals %value2=test_customShadowFieldNoLiterals2"
     export function customFieldEditorNoLiterals(value: number, value2: string): void {  }
+
+
+    //% blockId=test_toStringArg block="to string %msg"
+    //% msg.shadowOptions.toString=true
+    export function toStringArg(msg: string) {
+
+    }
 }
 
 //% color=#A80000 weight=30

--- a/tests/decompile-test/cases/to_string_inputs.ts
+++ b/tests/decompile-test/cases/to_string_inputs.ts
@@ -1,0 +1,5 @@
+/// <reference path="./testBlocks/basic.ts" />
+
+testNamespace.toStringArg("whatever");
+testNamespace.toStringArg("" + 5);
+testNamespace.toStringArg("whatever" + 5);


### PR DESCRIPTION
Finally you can drag any block into `console.log()` and `serial.write()`!