### PR TITLE
Fixes the leaky key in the telemetry URL

### DIFF
--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -24,12 +24,15 @@
                     telemetryItem.properties["WindowsApp"] = 1;
             });
         });
+
         appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
 
-        var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
+        //Scrub the key (if any) from the URL.
         function scrubUrl(url) {
+            var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
             return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
         }
+
     }
     pxt.initAnalyticsAsync();
 </script>

--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -18,7 +18,6 @@
                 var telemetryItem = envelope.data.baseData;
                 telemetryItem.properties = telemetryItem.properties || {};
                 telemetryItem.properties["target"] = pxtConfig.targetId;
-                telemetryItem.properties["version"] = pxtConfig.targetVersion;
                 telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
                 telemetryItem.properties["cookie"] = includeCookie;
                 if (typeof Windows !== "undefined")

--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -24,7 +24,6 @@
                     telemetryItem.properties["WindowsApp"] = 1;
             });
         });
-
         appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
 
         //Scrub the key (if any) from the URL.
@@ -32,7 +31,6 @@
             var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
             return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
         }
-
     }
     pxt.initAnalyticsAsync();
 </script>

--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -20,6 +20,7 @@
                 telemetryItem.properties["target"] = pxtConfig.targetId;
                 telemetryItem.properties["version"] = pxtConfig.targetVersion;
                 telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
+                telemetryItem.properties["cookie"] = includeCookie;
                 if (typeof Windows !== "undefined")
                     telemetryItem.properties["WindowsApp"] = 1;
             });

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -26,8 +26,9 @@
         });
         appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
 
-        var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
+        //Scrub the key (if any) from the URL.
         function scrubUrl(url) {
+            var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
             return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
         }
     }

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -18,8 +18,8 @@
                 var telemetryItem = envelope.data.baseData;
                 telemetryItem.properties = telemetryItem.properties || {};
                 telemetryItem.properties["target"] = pxtConfig.targetId;
-                telemetryItem.properties["version"] = pxtConfig.targetVersion;
                 telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
+                telemetryItem.properties["cookie"] = includeCookie;
                 if (typeof Windows !== "undefined")
                     telemetryItem.properties["WindowsApp"] = 1;
             });


### PR DESCRIPTION
Var scriptIdRegex is not hoisted up and when the call to scrubURL function is invoked it sees scriptIdRegex being undefined and doesn't scrub the URL. 

It is ok to declare it as a local variable as all the browsers cache the regex parse tree. 

I will port to v0. 