### PR TITLE
Handle array return types in blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -165,6 +165,10 @@ namespace pxt.blocks {
         const check = b.outputConnection.check_ && b.outputConnection.check_.length ? b.outputConnection.check_[0] : "T";
 
         if (check === "Array") {
+            if (b.outputConnection.check_.length > 1) {
+                // HACK: The real type is stored as the second check
+                return ground(b.outputConnection.check_[1])
+            }
             // The only block that hits this case should be lists_create_with, so we
             // can safely infer the type from the first input that has a return type
             let tp: Point;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -791,7 +791,7 @@ namespace pxt.blocks {
             inputs.forEach(inputParts => {
                 const fields: NamedField[] = [];
                 let inputName: string;
-                let inputCheck: string;
+                let inputCheck: string | string[];
                 let hasParameter = false;
 
                 inputParts.forEach(part => {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -768,7 +768,7 @@ namespace pxt.blocks {
             //TODO
             default:
                 if (isArrayType(fn.retType)) {
-                    block.setOutput(true, "Array");
+                    block.setOutput(true, ["Array", fn.retType]);
                 }
                 else {
                     block.setOutput(true, fn.retType !== "T" ? fn.retType : undefined);
@@ -904,7 +904,7 @@ namespace pxt.blocks {
                             } else if (pr.type == "string") {
                                 inputCheck = "String"
                             } else {
-                                inputCheck = pr.type == "T" ? undefined : (isArrayType(pr.type) ? "Array" : pr.type);
+                                inputCheck = pr.type == "T" ? undefined : (isArrayType(pr.type) ? ["Array", pr.type] : pr.type);
                             }
                         }
                     }

--- a/tests/blocklycompiler-test/baselines/array_return_type.ts
+++ b/tests/blocklycompiler-test/baselines/array_return_type.ts
@@ -1,0 +1,2 @@
+let item: exp.Fixed[] = []
+item = exp.arrayReturnType(0)

--- a/tests/blocklycompiler-test/cases/array_return_type.blocks
+++ b/tests/blocklycompiler-test/cases/array_return_type.blocks
@@ -1,0 +1,24 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+    <variables>
+      <variable type="" id="5exh#{O$pE*e=qdBeH[c">item</variable>
+    </variables>
+    <block type="pxt-on-start" id="CMkEav+xM`.0r7v7Ja%3" x="0" y="0">
+      <statement name="HANDLER">
+        <block type="variables_set" id="wZpGsZ17[(GVI)1p5jXN">
+          <field name="VAR" id="5exh#{O$pE*e=qdBeH[c" variabletype="">item</field>
+          <value name="VALUE">
+            <shadow type="math_number" id="KJXDa5ETCvB./411lUTc">
+              <field name="NUM">0</field>
+            </shadow>
+            <block type="test_arrayReturnType" id=".P*r/KF.R5YAEa=mf_6j">
+              <value name="n">
+                <shadow type="math_number" id="W0SM^}tN.paW)]FC~8)W">
+                  <field name="NUM">0</field>
+                </shadow>
+              </value>
+            </block>
+          </value>
+        </block>
+      </statement>
+    </block>
+  </xml>

--- a/tests/blocklycompiler-test/test-library/expandableBlocks.ts
+++ b/tests/blocklycompiler-test/test-library/expandableBlocks.ts
@@ -30,4 +30,10 @@ namespace exp {
     //% weight=99 inlineInputMode="inline"
     //% blockId=basicOpt block="string %str number %ang || boolean %opt enum %enu"
     export function basicOpt(str: string, ang: number, opt?: boolean, enu?: Direction) { }
+
+    //% blockId="test_arrayReturnType" block="array return type %n"
+   export function arrayReturnType(n : number): Fixed[] {
+        let res: Fixed[] = []
+        return res
+    }
 }

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -279,6 +279,10 @@ describe("blockly compiler", function() {
         it("should handle empty array blocks", (done: () => void) => {
             blockTestAsync("lists_empty_arrays").then(done, done);
         });
+
+        it("should handle functions with list return types", (done: () => void) => {
+            blockTestAsync("array_return_type").then(done, done);
+        });
     });
 
     describe("compiling logic", () => {


### PR DESCRIPTION
Type inference doesn't work at all right now because it always calculates the return type as `number[]`