### PR TITLE
Tags should be versions

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -368,6 +368,8 @@ namespace pxt.github {
                     .then(refsRes => {
                         let tags = Object.keys(refsRes.refs)
                         tags.reverse()
+                        // only look for vxx.xx.xx tags
+                        tags = tags.filter(t => /^v\d+(\.\d+(\.\d+)?)?$/i.test(t));
                         if (tags[0])
                             return Promise.resolve(tags[0])
                         else


### PR DESCRIPTION
When adding a package, only consider v**.**.** tags (fix for blocklytalkBLE who had some other tags)