### PR TITLE
adding array.foreach

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -86,7 +86,7 @@ interface Array<T> {
 
     /**
       * Call a defined callback function on each element of an array.
-      * @param callbackfn A function that accepts up to two arguments. The map method calls the callbackfn function one time for each element in the array.
+      * @param callbackfn A function that accepts up to two arguments. The forEach method calls the callbackfn function one time for each element in the array.
       */
     //% helper=arrayForEach weight=40
     forEach(callbackfn: (value: T, index: number) => void): void;

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -83,6 +83,14 @@ interface Array<T> {
     //% helper=arrayMap weight=40
     map<U>(callbackfn: (value: T, index: number) => U): U[];
 
+
+    /**
+      * Call a defined callback function on each element of an array.
+      * @param callbackfn A function that accepts up to two arguments. The map method calls the callbackfn function one time for each element in the array.
+      */
+    //% helper=arrayForEach weight=40
+    forEach(callbackfn: (value: T, index: number) => void): void;
+    
     /**
       * Return the elements of an array that meet the condition specified in a callback function.
       * @param callbackfn A function that accepts up to two arguments. The filter method calls the callbackfn function one time for each element in the array.

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -75,6 +75,13 @@ namespace helpers {
         return res
     }
 
+    export function arrayForEach<T>(arr: T[], callbackfn: (value: T, index: number) => void): void {
+        let len = arr.length // caching this seems to match V8
+        for (let i = 0; i < len; ++i) {
+            callbackfn(arr[i], i);
+        }
+    }
+
     export function arrayFilter<T>(arr: T[], callbackfn: (value: T, index: number) => boolean): T[] {
         let res: T[] = []
         let len = arr.length

--- a/tests/compile-test/lang-test0/241arrayforeach.ts
+++ b/tests/compile-test/lang-test0/241arrayforeach.ts
@@ -6,7 +6,7 @@ function testArrayForEach() {
     for (let s of strs) {
         r += s
     }
-    assert(r == "AX1X2X3", "map")
+    assert(r == "AX1X2X3", "forEach")
 }
 
 testArrayForEach()

--- a/tests/compile-test/lang-test0/241arrayforeach.ts
+++ b/tests/compile-test/lang-test0/241arrayforeach.ts
@@ -1,0 +1,12 @@
+function testArrayForEach() {
+    msg("testArrayFoEach");
+    let strs: string[] = [];
+    [1, 2, 3].forEach(x => strs.push("X" + x))
+    let r = "A"
+    for (let s of strs) {
+        r += s
+    }
+    assert(r == "AX1X2X3", "map")
+}
+
+testArrayForEach()

--- a/tests/compile-test/lang-test0/pxt.json
+++ b/tests/compile-test/lang-test0/pxt.json
@@ -24,6 +24,7 @@
         "22lambdas.ts",
         "23generics.ts",
         "24arraymap.ts",
+        "241arrayforeach.ts",
         "25lamdacapture.ts",
         "26staticclasses.ts",
         "27accessors.ts",


### PR DESCRIPTION
Note that both Array.Map and Array.forEach should leave a sparse array sparse, but they don't in our case.