### PR TITLE
Snippets are not docs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4112,7 +4112,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string): Promise
         // look for snippets
         getCodeSnippets(entrypath, md).forEach((snippet, snipIndex) => {
             snippets.push(snippet);
-            const dir = path.join("built/docs/snippets", snippet.type);
+            const dir = path.join("built/snippets", snippet.type);
             const fn = `${dir}/${entrypath.replace(/^\//, '').replace(/\//g, '-').replace(/\.\w+$/, '')}-${snipIndex}.ts`;
             nodeutil.mkdirP(dir);
             fs.writeFileSync(fn, snippet.code);


### PR DESCRIPTION
Snippets are generated in built/docs which gets uploaded to the built repo. Moving to built/snippets