### PR TITLE
Only import PNG files if the target has saveAsPNG turned on

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1911,7 +1911,7 @@ function isProjectFile(filename: string): boolean {
 }
 
 function isPNGFile(filename: string): boolean {
-    return /\.png$/i.test(filename)
+    return pxt.appTarget && pxt.appTarget.compile && pxt.appTarget.compile.saveAsPNG && /\.png$/i.test(filename);
 }
 
 function initLogin() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1911,7 +1911,7 @@ function isProjectFile(filename: string): boolean {
 }
 
 function isPNGFile(filename: string): boolean {
-    return pxt.appTarget && pxt.appTarget.compile && pxt.appTarget.compile.saveAsPNG && /\.png$/i.test(filename);
+    return pxt.appTarget.compile && pxt.appTarget.compile.saveAsPNG && /\.png$/i.test(filename);
 }
 
 function initLogin() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1911,7 +1911,7 @@ function isProjectFile(filename: string): boolean {
 }
 
 function isPNGFile(filename: string): boolean {
-    return pxt.appTarget.compile && pxt.appTarget.compile.saveAsPNG && /\.png$/i.test(filename);
+    return pxt.appTarget.compile.saveAsPNG && /\.png$/i.test(filename);
 }
 
 function initLogin() {


### PR DESCRIPTION
I was copying and pasting a block in the blocks editor and it caused the entire app to freeze. I guess I had a PNG on my clipboard (not sure why copying a block didn't overwrite that) because it was hanging in the decode function. I don't know why it hung, but we shouldn't try to load PNG's in non-PNG supporting editors anyhow.