### PR TITLE
Support for `//% blockCombine`

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -400,7 +400,7 @@ class Foo {
     //% blockCombine
     y: number;
     // exposed with custom name
-    //% blockCombine="foo bar"
+    //% blockCombine block="foo bar"
     foo_bar: number;
     
     // not exposed

--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -8,7 +8,7 @@ simulator files.
 
 ## Category
 
-Each top-level javascript namespace is used to populate a category in the Block Editor toolbox. The name will automatically be capitalized in the toolbox.
+Each top-level TypeScript namespace is used to populate a category in the Block Editor toolbox. The name will automatically be capitalized in the toolbox.
 
 ```typescript-ignore
 namespace basic {
@@ -54,7 +54,9 @@ you can specify the `blockId` and `block` parameters.
 export function showNumber(v: number, interval: number = 150): void
 { }
 ```
-* `blockId` is a constant, unique id for the block. This id is serialized in block code so changing it will break your users.
+* `blockId` is a constant, unique id for the block. This id is serialized in block code so changing 
+  it will break your users. If not specified, it is derived from namespace and function names, 
+  so renaming your functions or namespaces will break both your TypeScript and Blocks users.
 * `block` contains the syntax to build the block structure (more below).
 
 Other optional attributes can also be used:
@@ -274,7 +276,7 @@ class Message {
 }
 ```
 
-* when annotating an instance method, you need to specify the ``%this`` parameter in the block syntax definition.
+* when annotating an instance method, you need to specify the ``%this`` parameter in the block syntax definition. It can be called something else, eg ``%msg``.
 
 You will need to expose a factory method to create your objects as needed. For the example above, we add a function that creates the message:
 
@@ -316,10 +318,10 @@ It is possible to expose these instances in a manner similar to an enum:
 
 ```typescript-ignore
 //% fixedInstances
+//% blockNamespace=pins
 class DigitalPin {
     ...
     //% blockId=device_set_digital_pin block="digital write|pin %name|to %value"
-    //% blockNamespace=pins
     digitalWrite(value: number): void { ... }
 }
 
@@ -363,6 +365,11 @@ even in different libraries or namespaces.
 
 This feature is often used with `indexedInstance*` attributes.
 
+The `blockNamespace` attribute specifies which drawer in the toolbox will
+be used for this block. It can be specified on methods or on classes (to apply
+to all methods in the class). Often, you will want to also set `color=...`,
+also either on class or method.
+
 It is also possible to define the instances to be used in blocks in TypeScript,
 for example:
 
@@ -378,6 +385,39 @@ when it is used, even though it is initialized with something that can possibly
 have side effects. This happens automatically when there is no initializer,
 or the initializer is a simple constant, but for function calls and constructors
 you have to include `whenUsed`.
+
+### Properties
+
+Fields and get/set accessors of classes defined in TypeScript can be exposed in blocks.
+Typically, you want a single block for all getters for a given type, a single block
+for setters, and possibly a single block for updates (compiling to the ``+=`` operator).
+This can be done automatically with `//% blockCombine` annotation, for example:
+
+```typescript
+class Foo {
+    //% blockCombine
+    x: number;
+    //% blockCombine
+    y: number;
+    // exposed with custom name
+    //% blockCombine="foo bar"
+    foo_bar: number;
+    
+    // not exposed
+    _bar: number;
+    _qux: number;
+
+    // exposed as read-only (only in the getter block)
+    //% blockCombine
+    get bar() { return this._bar }
+
+    // exposed in both getter and setter
+    //% blockCombine
+    get qux() { return this._qux }
+    //% blockCombine
+    set qux(v: number) { if (v != 42) this._qux = v }
+}
+```
 
 ## Ordering
 

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -473,7 +473,7 @@ namespace pxt.blocks {
 
     function getConcreteType(point: Point, found: Point[] = []) {
         const t = find(point)
-        if (found.indexOf(t)  === -1) {
+        if (found.indexOf(t) === -1) {
             found.push(t);
             if (!t.type || t.type === "Array") {
                 if (t.parentType) {
@@ -654,7 +654,7 @@ namespace pxt.blocks {
         const listExpr = compileExpression(e, listBlock, comments);
         const index = compileExpression(e, getInputTargetBlock(b, "INDEX"), comments);
         const value = compileExpression(e, getInputTargetBlock(b, "VALUE"), comments);
-        const res =  mkGroup([listExpr, mkText("["), index, mkText("] = "), value]);
+        const res = mkGroup([listExpr, mkText("["), index, mkText("] = "), value]);
 
         return listBlock.type === "lists_create_with" ? prefixWithSemicolon(res) : res;
 
@@ -1106,6 +1106,16 @@ namespace pxt.blocks {
             return args[0];
         else if (func.property) {
             return H.mkPropertyAccess(func.f, args[0]);
+        } else if (func.f == "@get@") {
+            return H.mkPropertyAccess(args[1].op.replace(/.*\./, ""), args[0]);
+        } else if (func.f == "@set@") {
+            return H.mkAssign(
+                H.mkPropertyAccess(args[1].op.replace(/.*\./, "").replace(/@set/, ""), args[0]),
+                args[2]);
+        } else if (func.f == "@change@") {
+            return mkStmt(H.mkSimpleCall("+=", [
+                H.mkPropertyAccess(args[1].op.replace(/.*\./, "").replace(/@set/, ""), args[0]),
+                args[2]]))
         } else if (func.isExtensionMethod) {
             if (func.attrs.defaultInstance) {
                 let instance: JsNode;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -825,11 +825,12 @@ namespace pxt.blocks {
                         let isEnum = typeInfo && typeInfo.kind == pxtc.SymbolKind.Enum
                         let isFixed = typeInfo && !!typeInfo.attributes.fixedInstances && !pr.shadowBlockId;
                         let isConstantShim = !!fn.attributes.constantShim;
+                        let isCombined = pr.type == "@combined@"
                         let customField = pr.fieldEditor;
                         let fieldLabel = defName.charAt(0).toUpperCase() + defName.slice(1);
                         let fieldType = pr.type;
 
-                        if (isEnum || isFixed || isConstantShim) {
+                        if (isEnum || isFixed || isConstantShim || isCombined) {
                             let syms: pxtc.SymbolInfo[];
 
                             if (isEnum) {
@@ -837,6 +838,9 @@ namespace pxt.blocks {
                             }
                             else if (isFixed) {
                                 syms = getFixedInstanceDropdownValues(info.apis, typeInfo.qName);
+                            }
+                            else if (isCombined) {
+                                syms = fn.combinedProperties.map(p => U.lookup(info.apis.byQName, p))
                             }
                             else {
                                 syms = getConstantDropdownValues(info.apis, fn.qName);
@@ -846,7 +850,11 @@ namespace pxt.blocks {
                                 console.error(`no instances of ${typeInfo.qName} found`)
                             }
                             const dd = syms.map(v => {
-                                const k = v.attributes.block || v.attributes.blockId || v.name;
+                                let k = v.attributes.block || v.attributes.blockId || v.name;
+                                let comb = v.attributes.blockCombine
+                                if (comb) {
+                                    k = comb != "true" ? comb : k.replace(/@set/, "")
+                                }
                                 return [
                                     v.attributes.iconURL || v.attributes.blockImage ? {
                                         src: v.attributes.iconURL || Util.pathJoin(pxt.webConfig.commitCdnUrl, `blocks/${v.namespace.toLowerCase()}/${v.name.toLowerCase()}.png`),

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -860,9 +860,8 @@ namespace pxt.blocks {
                             const dd = syms.map(v => {
                                 let k = v.attributes.block || v.attributes.blockId || v.name;
                                 let comb = v.attributes.blockCombine
-                                if (comb) {
-                                    k = comb != "true" ? comb : k.replace(/@set/, "")
-                                }
+                                if (!!comb)
+                                    k = k.replace(/@set/, "")
                                 return [
                                     v.attributes.iconURL || v.attributes.blockImage ? {
                                         src: v.attributes.iconURL || Util.pathJoin(pxt.webConfig.commitCdnUrl, `blocks/${v.namespace.toLowerCase()}/${v.name.toLowerCase()}.png`),

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -167,38 +167,38 @@ namespace ts.pxtc.decompiler {
 
 
     class LSHost implements ts.LanguageServiceHost {
-            constructor(private p: ts.Program) {}
+        constructor(private p: ts.Program) { }
 
-            getCompilationSettings(): ts.CompilerOptions {
-                const opts = this.p.getCompilerOptions();
-                opts.noLib = true;
-                return opts;
-            }
+        getCompilationSettings(): ts.CompilerOptions {
+            const opts = this.p.getCompilerOptions();
+            opts.noLib = true;
+            return opts;
+        }
 
-            getNewLine(): string { return "\n" }
+        getNewLine(): string { return "\n" }
 
-            getScriptFileNames(): string[] {
-                return this.p.getSourceFiles().map(f => f.fileName);
-            }
+        getScriptFileNames(): string[] {
+            return this.p.getSourceFiles().map(f => f.fileName);
+        }
 
-            getScriptVersion(fileName: string): string {
-                return "0";
-            }
+        getScriptVersion(fileName: string): string {
+            return "0";
+        }
 
-            getScriptSnapshot(fileName: string): ts.IScriptSnapshot {
-                const f = this.p.getSourceFile(fileName);
-                return {
-                    getLength: () => f.getFullText().length,
-                    getText: () => f.getFullText(),
-                    getChangeRange: () => undefined
-                };
-            }
+        getScriptSnapshot(fileName: string): ts.IScriptSnapshot {
+            const f = this.p.getSourceFile(fileName);
+            return {
+                getLength: () => f.getFullText().length,
+                getText: () => f.getFullText(),
+                getChangeRange: () => undefined
+            };
+        }
 
-            getCurrentDirectory(): string { return "."; }
+        getCurrentDirectory(): string { return "."; }
 
-            getDefaultLibFileName(options: ts.CompilerOptions): string { return ""; }
+        getDefaultLibFileName(options: ts.CompilerOptions): string { return ""; }
 
-            useCaseSensitiveFileNames(): boolean { return true; }
+        useCaseSensitiveFileNames(): boolean { return true; }
     }
 
     /**
@@ -369,7 +369,7 @@ ${output}</xml>`;
         }
 
         function countBlock() {
-            emittedBlocks ++;
+            emittedBlocks++;
             if (emittedBlocks > MAX_BLOCKS) {
                 let e = new Error(Util.lf("Could not decompile because the script is too large"));
                 (<any>e).programTooLarge = true;
@@ -768,6 +768,9 @@ ${output}</xml>`;
                 return undefined;
             }
 
+            if (callInfo.attrs.blockCombine)
+                return getPropertyGetBlock(n)
+
             if (callInfo.attrs.blockId === "lists_length" || callInfo.attrs.blockId === "text_length") {
                 const r = mkExpr(U.htmlEscape(callInfo.attrs.blockId));
                 r.inputs = [getValue("VALUE", n.expression)];
@@ -777,7 +780,7 @@ ${output}</xml>`;
 
             let value = U.htmlEscape(callInfo.attrs.blockId || callInfo.qName);
 
-            const [parent, ] = getParent(n);
+            const [parent,] = getParent(n);
             const parentCallInfo: pxtc.CallInfo = parent && (parent as any).callInfo;
             if (asField || !(blockId || callInfo.attrs.blockIdentity) || parentCallInfo && parentCallInfo.qName === callInfo.attrs.blockIdentity) {
                 return {
@@ -990,11 +993,17 @@ ${output}</xml>`;
                     if (n.left.kind === SK.Identifier) {
                         return getVariableSetOrChangeBlock(n.left as ts.Identifier, n.right);
                     }
+                    else if (n.left.kind == SK.PropertyAccessExpression) {
+                        return getPropertySetBlock(n.left as ts.PropertyAccessExpression, n.right, "@set@");
+                    }
                     else {
                         return getArraySetBlock(n.left as ts.ElementAccessExpression, n.right);
                     }
                 case SK.PlusEqualsToken:
-                    return getVariableSetOrChangeBlock(n.left as ts.Identifier, n.right, true);
+                    if (n.left.kind == SK.PropertyAccessExpression)
+                        return getPropertySetBlock(n.left as ts.PropertyAccessExpression, n.right, "@change@");
+                    else
+                        return getVariableSetOrChangeBlock(n.left as ts.Identifier, n.right, true);
                 case SK.MinusEqualsToken:
                     const r = mkStmt("variables_change");
                     countBlock();
@@ -1055,7 +1064,7 @@ ${output}</xml>`;
             }
             else {
                 r = mkStmt("controls_simple_for");
-                r.fields =  [getField("VAR", renamed)];
+                r.fields = [getField("VAR", renamed)];
                 r.inputs = [];
                 r.handlers = [];
 
@@ -1094,7 +1103,7 @@ ${output}</xml>`;
             const r = mkStmt("controls_for_of");
             r.inputs = [getValue("LIST", n.expression)];
             r.fields = [getField("VAR", renamed)];
-            r.handlers =  [{ name: "DO", statement: getStatementBlock(n.statement) }];
+            r.handlers = [{ name: "DO", statement: getStatementBlock(n.statement) }];
 
             return r
         }
@@ -1116,6 +1125,34 @@ ${output}</xml>`;
                 getValue("INDEX", left.argumentExpression, numberType),
                 getValue("VALUE", right)
             ];
+            return r;
+        }
+
+
+        function getPropertySetBlock(left: ts.PropertyAccessExpression, right: ts.Expression, tp: string) {
+            return getPropertyBlock(left, right, tp) as StatementNode
+        }
+
+        function getPropertyGetBlock(left: ts.PropertyAccessExpression) {
+            return getPropertyBlock(left, null, "@get@") as ExpressionNode
+        }
+
+        function getPropertyBlock(left: ts.PropertyAccessExpression, right: ts.Expression, tp: string): StatementNode | ExpressionNode {
+            const info: pxtc.CallInfo = (left as any).callInfo
+            const sym = env.blocks.apis.byQName[info ? info.qName : ""]
+            if (!sym || !sym.attributes.blockCombine) {
+                error(left);
+                return undefined;
+            }
+            const setter = env.blocks.blocks.find(b => b.namespace == sym.namespace && b.name == tp)
+            const r = right ? mkStmt(setter.attributes.blockId) : mkExpr(setter.attributes.blockId)
+            const pp = setter.attributes._def.parameters;
+            r.inputs = [
+                getValue(pp[0].name, left.expression),
+                getValue(pp[1].name, left.expression),
+            ];
+            if (right)
+                r.inputs.push(getValue(pp[2].name, right));
             return r;
         }
 
@@ -1193,7 +1230,7 @@ ${output}</xml>`;
                     const name = getVariableName(node.expression as ts.Identifier);
                     if (env.declaredFunctions[name]) {
                         const r = mkStmt("procedures_callnoreturn");
-                        r.mutation = {"name": name};
+                        r.mutation = { "name": name };
                         return r;
                     }
                     else {
@@ -1352,7 +1389,7 @@ ${output}</xml>`;
                                 if (field && decompileLiterals(field)) {
                                     const fieldBlock = getFieldBlock(param.shadowBlockId, field.definitionName, fieldText, true);
                                     if (param.shadowOptions) {
-                                        fieldBlock.mutation = {"customfield": Util.htmlEscape(JSON.stringify(param.shadowOptions))};
+                                        fieldBlock.mutation = { "customfield": Util.htmlEscape(JSON.stringify(param.shadowOptions)) };
                                     }
                                     v = mkValue(vName, fieldBlock, param.shadowBlockId);
                                     defaultV = false;
@@ -1714,16 +1751,18 @@ ${output}</xml>`;
         }
 
         function checkBinaryExpression(n: ts.BinaryExpression, env: DecompilerEnv) {
-            if (n.left.kind !== SK.Identifier && n.left.kind !== SK.ElementAccessExpression) {
-                return Util.lf("Only variable names may be assigned to")
-            }
-
             if (n.left.kind === SK.ElementAccessExpression) {
                 if (n.operatorToken.kind !== SK.EqualsToken) {
                     return Util.lf("Element access expressions may only be assigned to using the equals operator");
                 }
             }
-            else {
+            else if (n.left.kind === SK.PropertyAccessExpression) {
+                if (n.operatorToken.kind !== SK.EqualsToken &&
+                    n.operatorToken.kind !== SK.PlusEqualsToken) {
+                    return Util.lf("Property access expressions may only be assigned to using the = and += operators");
+                }
+            }
+            else if (n.left.kind === SK.Identifier) {
                 switch (n.operatorToken.kind) {
                     case SK.EqualsToken:
                         return checkExpression(n.right, env);
@@ -1733,6 +1772,9 @@ ${output}</xml>`;
                     default:
                         return Util.lf("Unsupported operator token in statement {0}", SK[n.operatorToken.kind]);
                 }
+            }
+            else {
+                return Util.lf("This expression cannot be assigned to")
             }
             return undefined;
         }
@@ -1875,8 +1917,8 @@ ${output}</xml>`;
 
                 // Callbacks and default instance parameters do not appear in the block
                 // definition string so they won't show up in the above count
-                if (hasCallback) --diff;
-                if (info.attrs.defaultInstance) --diff;
+                if (hasCallback) diff--;
+                if (info.attrs.defaultInstance) diff--;
 
                 if (diff > 0) {
                     return Util.lf("Function call has more arguments than are supported by its block");
@@ -1890,7 +1932,7 @@ ${output}</xml>`;
                     if (fail || instance && i === 0) {
                         return;
                     }
-                    if (instance) --i;
+                    if (instance) i--;
                     fail = checkArgument(arg);
                 });
 
@@ -2203,7 +2245,7 @@ ${output}</xml>`;
                 return op2 === SK.MinusToken || op2 === SK.PlusToken || op2 === SK.ExclamationToken ?
                     undefined : Util.lf("Unsupported prefix unary operator{0}", op2);
             case SK.PropertyAccessExpression:
-                return checkPropertyAccessExpression(n as ts.PropertyAccessExpression);
+                return checkPropertyAccessExpression(n as ts.PropertyAccessExpression, env);
             case SK.CallExpression:
                 return checkStatement(n, env, true);
         }
@@ -2214,11 +2256,14 @@ ${output}</xml>`;
             return validStringRegex.test(literal) ? undefined : Util.lf("Only whitespace character allowed in string literals is space");
         }
 
-        function checkPropertyAccessExpression(n: ts.PropertyAccessExpression) {
+        function checkPropertyAccessExpression(n: ts.PropertyAccessExpression, env: DecompilerEnv) {
             const callInfo: pxtc.CallInfo = (n as any).callInfo;
             if (callInfo) {
                 if (callInfo.attrs.blockIdentity || callInfo.attrs.blockId === "lists_length" || callInfo.attrs.blockId === "text_length") {
                     return undefined;
+                }
+                else if (callInfo.attrs.blockCombine) {
+                    return checkExpression(n.expression, env)
                 }
                 else if (callInfo.decl.kind === SK.EnumMember) {
                     const [parent, child] = getParent(n);

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -447,15 +447,6 @@ namespace ts.pxtc {
             return cached
         let res = parseCommentString(getComments(node))
         res._name = getName(node)
-        if (node0.kind == SK.FunctionDeclaration && res.block === "true" && !res.blockId) {
-            const fn = node0 as ts.FunctionDeclaration;
-            if ((fn.symbol as any).parent) {
-                res.blockId = `${(fn.symbol as any).parent.name}_${getDeclName(fn)}`;
-                res.block = `${U.uncapitalize(node.symbol.name)}${fn.parameters.length ? '|' + fn.parameters
-                    .filter(p => !p.questionToken)
-                    .map(p => `${U.uncapitalize((p.name as ts.Identifier).text)} %${(p.name as Identifier).text}`).join('|') : ''}`;
-            }
-        }
         node.pxtCommentAttrs = res
         return res
     }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -54,6 +54,8 @@ namespace ts.pxtc {
                 return SymbolKind.Method;
             case SK.PropertyDeclaration:
             case SK.PropertySignature:
+            case SK.GetAccessor:
+            case SK.SetAccessor:
                 return SymbolKind.Property;
             case SK.FunctionDeclaration:
                 return SymbolKind.Function;
@@ -164,7 +166,7 @@ namespace ts.pxtc {
                     }
             }
 
-            return {
+            let r: SymbolInfo = {
                 kind,
                 namespace: m ? m[1] : "",
                 name: m ? m[2] : qName,
@@ -228,6 +230,11 @@ namespace ts.pxtc {
                 }),
                 snippet: service.getSnippet(decl, attributes)
             }
+
+            if (stmt.kind == SK.GetAccessor)
+                r.isReadOnly = true
+
+            return r
         }
         return null;
     }
@@ -337,6 +344,8 @@ namespace ts.pxtc {
                     return;
                 }
                 let qName = getFullName(typechecker, stmt.symbol)
+                if (stmt.kind == SK.SetAccessor)
+                    qName += "@set" // otherwise we get a clash with the getter
                 let si = createSymbolInfo(typechecker, qName, stmt)
                 if (si) {
                     let existing = U.lookup(res.byQName, qName)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -122,7 +122,7 @@ namespace ts.pxtc {
         blockAllowMultiple?: boolean; // override single block behavior for events
         blockHidden?: boolean; // not available directly in toolbox
         blockImage?: boolean; // for enum variable, specifies that it should use an image from a predefined location
-        blockCombine?: string;
+        blockCombine?: boolean;
         fixedInstances?: boolean;
         fixedInstance?: boolean;
         constantShim?: boolean;
@@ -436,7 +436,14 @@ namespace ts.pxtc {
         }
 
         for (let s of pxtc.Util.values(info.byQName)) {
-            if (!!s.attributes.block
+            if (s.attributes.blockCombine) {
+                if (!s.isReadOnly) {
+                    addCombined("set", s)
+                    addCombined("change", s)
+                }
+                if (!/@set/.test(s.name))
+                    addCombined("get", s)
+            } else if (!!s.attributes.block
                 && !s.attributes.fixedInstance
                 && s.kind != pxtc.SymbolKind.EnumMember) {
                 if (!s.attributes.blockId)
@@ -453,13 +460,6 @@ namespace ts.pxtc {
                     updateBlockDef(s.attributes)
                 }
                 blocks.push(s)
-            } else if (s.attributes.blockCombine) {
-                if (!s.isReadOnly) {
-                    addCombined("set", s)
-                    addCombined("change", s)
-                }
-                if (!/@set/.test(s.name))
-                    addCombined("get", s)
             }
         }
 
@@ -544,7 +544,14 @@ namespace ts.pxtc {
     }
 
     const numberAttributes = ["weight", "imageLiteral"]
-    const booleanAttributes = ["advanced", "handlerStatement", "afterOnStart", "optionalVariableArgs", "blockHidden", "constantShim"]
+    const booleanAttributes = [
+        "advanced",
+        "handlerStatement",
+        "afterOnStart",
+        "optionalVariableArgs",
+        "blockHidden",
+        "constantShim"
+    ];
 
     export function parseCommentString(cmt: string): CommentAttrs {
         let res: CommentAttrs = {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -550,7 +550,8 @@ namespace ts.pxtc {
         "afterOnStart",
         "optionalVariableArgs",
         "blockHidden",
-        "constantShim"
+        "constantShim",
+        "blockCombine"
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -423,7 +423,7 @@ namespace ts.pxtc {
                     tp == "set" ?
                         `set %${paramName} %property to %value` :
                         `change %${paramName} %property by %value`
-                ex.attributes.blockId = ex.namespace + "_" + ex.name
+                ex.attributes.blockId = ex.namespace + "_blockCombine_" + tp
                 ex.qName = ex.namespace + "." + ex.name
                 updateBlockDef(ex.attributes)
                 blocks.push(ex)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -433,7 +433,20 @@ namespace ts.pxtc {
         }
 
         for (let s of pxtc.Util.values(info.byQName)) {
-            if (!!s.attributes.block && !!s.attributes.blockId && s.kind != pxtc.SymbolKind.EnumMember) {
+            if (!!s.attributes.block && s.kind != pxtc.SymbolKind.EnumMember) {
+                if (!s.attributes.blockId)
+                    s.attributes.blockId = s.qName.replace(/\./g, "_")
+                if (s.attributes.block == "true") {
+                    let b = U.uncapitalize(s.name)
+                    if (s.kind == SymbolKind.Method || s.kind == SymbolKind.Property) {
+                        b += " %" + s.namespace.toLowerCase()
+                    }
+                    for (let p of s.parameters || []) {
+                        b += " %" + p.name
+                    }
+                    s.attributes.block = b
+                    updateBlockDef(s.attributes)
+                }
                 blocks.push(s)
             } else if (s.attributes.blockCombine) {
                 if (!s.isReadOnly) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -389,6 +389,7 @@ namespace ts.pxtc {
                 tp == "set" ? combinedSet : combinedChange
             let ex = U.lookup(m, s.namespace)
             if (!ex) {
+                let paramName = s.namespace.toLowerCase()
                 ex = m[s.namespace] = {
                     attributes: {
                         callingConvention: ir.CallingConvention.Plain,
@@ -418,10 +419,10 @@ namespace ts.pxtc {
                     retType: isGet ? "number" : "void",
                     combinedProperties: [],
                 }
-                ex.attributes.block = isGet ? "%object %property" :
+                ex.attributes.block = isGet ? `%${paramName} %property` :
                     tp == "set" ?
-                        "set %object %property to %value" :
-                        "change %object %property by %value"
+                        `set %${paramName} %property to %value` :
+                        `change %${paramName} %property by %value`
                 ex.attributes.blockId = ex.namespace + "_" + ex.name
                 ex.qName = ex.namespace + "." + ex.name
                 updateBlockDef(ex.attributes)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -837,12 +837,12 @@ namespace ts.pxtc {
 
         function eatToken(pred: (c: string) => boolean, skipCurrent = false) {
             let current = "";
-            if (skipCurrent)++strIndex
+            if (skipCurrent) strIndex++
             while (strIndex < def.length && pred(def[strIndex])) {
                 current += def[strIndex];
                 ++strIndex;
             }
-            if (current)--strIndex;
+            if (current) strIndex--;
             return current;
         }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -71,6 +71,8 @@ namespace ts.pxtc {
         pkg?: string;
         snippet?: string;
         blockFields?: ParsedBlockDef;
+        isReadOnly?: boolean;
+        combinedProperties?: string[];
     }
 
     export interface ApisInfo {
@@ -120,6 +122,7 @@ namespace ts.pxtc {
         blockAllowMultiple?: boolean; // override single block behavior for events
         blockHidden?: boolean; // not available directly in toolbox
         blockImage?: boolean; // for enum variable, specifies that it should use an image from a predefined location
+        blockCombine?: string;
         fixedInstances?: boolean;
         fixedInstance?: boolean;
         constantShim?: boolean;
@@ -307,19 +310,19 @@ namespace ts.pxtc {
 
     /* @internal */
     const enum TokenKind {
-        SingleAsterisk      = 1,
-        DoubleAsterisk      = 1 << 1,
-        SingleUnderscore    = 1 << 2,
-        DoubleUnderscore    = 1 << 3,
-        Escape              = 1 << 4,
-        Pipe                = 1 << 5,
-        Parameter           = 1 << 6,
-        Word                = 1 << 7,
-        Image               = 1 << 8,
-        TaggedText               = 1 << 9,
+        SingleAsterisk = 1,
+        DoubleAsterisk = 1 << 1,
+        SingleUnderscore = 1 << 2,
+        DoubleUnderscore = 1 << 3,
+        Escape = 1 << 4,
+        Pipe = 1 << 5,
+        Parameter = 1 << 6,
+        Word = 1 << 7,
+        Image = 1 << 8,
+        TaggedText = 1 << 9,
 
-        TripleUnderscore    = SingleUnderscore | DoubleUnderscore,
-        TripleAsterisk      = SingleAsterisk | DoubleAsterisk,
+        TripleUnderscore = SingleUnderscore | DoubleUnderscore,
+        TripleAsterisk = SingleAsterisk | DoubleAsterisk,
         StyleMarks = TripleAsterisk | TripleUnderscore,
         Bold = DoubleUnderscore | DoubleAsterisk,
         Italics = SingleUnderscore | SingleAsterisk
@@ -375,8 +378,85 @@ namespace ts.pxtc {
     }
 
     export function getBlocksInfo(info: ApisInfo): BlocksInfo {
-        const blocks = pxtc.Util.values(info.byQName)
-            .filter(s => !!s.attributes.block && !!s.attributes.blockId && (s.kind != pxtc.SymbolKind.EnumMember));
+        const blocks: SymbolInfo[] = []
+        const combinedSet: pxt.Map<SymbolInfo> = {}
+        const combinedGet: pxt.Map<SymbolInfo> = {}
+        const combinedChange: pxt.Map<SymbolInfo> = {}
+
+        function addCombined(tp: string, s: SymbolInfo) {
+            const isGet = tp == "get"
+            const m = isGet ? combinedGet :
+                tp == "set" ? combinedSet : combinedChange
+            let ex = U.lookup(m, s.namespace)
+            if (!ex) {
+                ex = m[s.namespace] = {
+                    attributes: {
+                        callingConvention: ir.CallingConvention.Plain,
+                        paramDefl: {},
+                    },
+                    name: "@" + tp + "@",
+                    namespace: s.namespace,
+                    pkg: s.pkg,
+                    kind: SymbolKind.Property,
+                    parameters: [
+                        {
+                            name: "property",
+                            description: isGet ?
+                                U.lf("the name of the property to read") :
+                                U.lf("the name of the property to change"),
+                            isEnum: true,
+                            type: "@combined@"
+                        },
+                        {
+                            name: "value",
+                            description: tp == "set" ?
+                                U.lf("the new value of the property") :
+                                U.lf("the amount by which to change the property"),
+                            type: "number"
+                        }
+                    ].slice(0, isGet ? 1 : 2),
+                    retType: isGet ? "number" : "void",
+                    combinedProperties: [],
+                }
+                ex.attributes.block = isGet ? "%object %property" :
+                    tp == "set" ?
+                        "set %object %property to %value" :
+                        "change %object %property by %value"
+                ex.attributes.blockId = ex.namespace + "_" + ex.name
+                ex.qName = ex.namespace + "." + ex.name
+                updateBlockDef(ex.attributes)
+                blocks.push(ex)
+            }
+
+            ex.combinedProperties.push(s.qName)
+        }
+
+        for (let s of pxtc.Util.values(info.byQName)) {
+            if (!!s.attributes.block && !!s.attributes.blockId && s.kind != pxtc.SymbolKind.EnumMember) {
+                blocks.push(s)
+            } else if (s.attributes.blockCombine) {
+                if (!s.isReadOnly) {
+                    addCombined("set", s)
+                    addCombined("change", s)
+                }
+                if (!/@set/.test(s.name))
+                    addCombined("get", s)
+            }
+        }
+
+        // derive common block properties from namespace
+        for (let b of blocks) {
+            let parent = U.lookup(info.byQName, b.namespace)
+            if (!parent) continue
+            let pattr = parent.attributes as any
+            let battr = b.attributes as any
+
+            for (let n of ["blockNamespace", "color", "blockGap"]) {
+                if (battr[n] === undefined && pattr[n])
+                    battr[n] = pattr[n]
+            }
+        }
+
         return {
             apis: info,
             blocks,
@@ -738,12 +818,12 @@ namespace ts.pxtc {
 
         function eatToken(pred: (c: string) => boolean, skipCurrent = false) {
             let current = "";
-            if (skipCurrent) ++strIndex
+            if (skipCurrent)++strIndex
             while (strIndex < def.length && pred(def[strIndex])) {
                 current += def[strIndex];
                 ++strIndex;
             }
-            if (current) --strIndex;
+            if (current)--strIndex;
             return current;
         }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -394,6 +394,9 @@ namespace ts.pxtc {
                     attributes: {
                         callingConvention: ir.CallingConvention.Plain,
                         paramDefl: {},
+                        jsDoc: isGet
+                            ? U.lf("Read value of a property on an object")
+                            : U.lf("Update value of property on an object")
                     },
                     name: "@" + tp + "@",
                     namespace: s.namespace,

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -436,7 +436,9 @@ namespace ts.pxtc {
         }
 
         for (let s of pxtc.Util.values(info.byQName)) {
-            if (!!s.attributes.block && s.kind != pxtc.SymbolKind.EnumMember) {
+            if (!!s.attributes.block
+                && !s.attributes.fixedInstance
+                && s.kind != pxtc.SymbolKind.EnumMember) {
                 if (!s.attributes.blockId)
                     s.attributes.blockId = s.qName.replace(/\./g, "_")
                 if (s.attributes.block == "true") {


### PR DESCRIPTION
This adds support for a new `//% blockCombine` attribute that can be specified on properties to generate enum-like setter and getter. See changes in docs for docs. This includes compiler and decompiler support.

It also fixes support for `//% block` without arguments and inference of `blockId` - IMHO we should remove `blockId` from the non-shipped APIs for simplicity.