### PR TITLE
Add support for different MCUs in a single target

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -119,7 +119,7 @@ function patchYottaHexInfo(extInfo: pxtc.ExtensionInfo) {
 }
 
 function patchCodalHexInfo(extInfo: pxtc.ExtensionInfo) {
-    let bin = extInfo.binaryName || pxt.appTarget.compileService.codalBinary
+    let bin = pxt.appTarget.compileService.codalBinary
     let hexPath = thisBuild.buildPath + "/build/" + bin + ".hex"
     return {
         hex: fs.readFileSync(hexPath, "utf8").split(/\r?\n/)

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -119,7 +119,8 @@ function patchYottaHexInfo(extInfo: pxtc.ExtensionInfo) {
 }
 
 function patchCodalHexInfo(extInfo: pxtc.ExtensionInfo) {
-    let hexPath = thisBuild.buildPath + "/build/" + pxt.appTarget.compileService.codalBinary + ".hex"
+    let bin = extInfo.binaryName || pxt.appTarget.compileService.codalBinary
+    let hexPath = thisBuild.buildPath + "/build/" + bin + ".hex"
     return {
         hex: fs.readFileSync(hexPath, "utf8").split(/\r?\n/)
     }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3557,6 +3557,12 @@ interface BuildCoreOptions {
     createOnly?: boolean;
 }
 
+function gdbAsync(c: commandParser.ParsedCommand) {
+    ensurePkgDir()
+    return mainPkg.loadAsync()
+        .then(() => gdb.startAsync(c.arguments))
+}
+
 function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult> {
     let compileOptions: pxtc.CompileOptions;
     let compileResult: pxtc.CompileResult;
@@ -4843,7 +4849,7 @@ function initCommands() {
         argString: "[GDB_ARGUMNETS...]",
         anyArgs: true,
         advanced: true
-    }, gdb.startAsync);
+    }, gdbAsync);
 
     p.defineCommand({
         name: "pokerepo",

--- a/cli/gdb.ts
+++ b/cli/gdb.ts
@@ -75,7 +75,7 @@ function getOpenOcdPath() {
     return { args, gdbBin }
 }
 
-export function startAsync(c: commandParser.ParsedCommand) {
+export function startAsync(gdbArgs: string[]) {
     let cs = pxt.appTarget.compileService
 
     let f =
@@ -107,7 +107,7 @@ echo Use 'rst' command to re-run program from start (set your breakpoints first!
         detached: true,
     })
 
-    let gdbargs = ["--command=built/openocd.gdb", f].concat(c.arguments)
+    let gdbargs = ["--command=built/openocd.gdb", f].concat(gdbArgs)
 
     pxt.log("starting gdb with: " + toolPaths.gdbBin + " " + gdbargs.join(" "))
 

--- a/cli/gdb.ts
+++ b/cli/gdb.ts
@@ -97,6 +97,10 @@ define rst
   monitor reset halt
   continue
 end
+define irq
+  echo "Current IRQ: "
+  p (*(int*)0xE000ED04 & 0x1f) - 16
+end
 echo Use 'rst' command to re-run program from start (set your breakpoints first!).\\n
 `)
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -376,6 +376,7 @@ declare namespace ts.pxtc {
         shimsDTS: string;
         enumsDTS: string;
         onlyPublic: boolean;
+        binaryName?: string;
     }
 
     interface HexInfo {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -164,6 +164,8 @@ declare namespace pxt {
         gittag: string;
         serviceId: string;
         buildEngine?: string;  // default is yotta, set to platformio
+
+        variants?: Map<TargetCompileService>;
     }
 
     interface AppTheme {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -325,6 +325,7 @@ declare namespace ts.pxtc {
         emptyEventHandlerComments?: boolean; // true adds a comment for empty event handlers
         vmOpCodes?: pxt.Map<number>;
         commonalize?: boolean;
+        variants?: pxt.Map<CompileTarget>;
     }
 
     interface CompileOptions {
@@ -376,7 +377,6 @@ declare namespace ts.pxtc {
         shimsDTS: string;
         enumsDTS: string;
         onlyPublic: boolean;
-        binaryName?: string;
     }
 
     interface HexInfo {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -44,6 +44,7 @@ declare namespace pxt {
         compileService?: TargetCompileService;
         analytics?: AppAnalytics;
         ignoreDocsErrors?: boolean;
+        variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
     }
 
     interface ProjectTemplate {
@@ -164,8 +165,6 @@ declare namespace pxt {
         gittag: string;
         serviceId: string;
         buildEngine?: string;  // default is yotta, set to platformio
-
-        variants?: Map<TargetCompileService>;
     }
 
     interface AppTheme {
@@ -325,7 +324,6 @@ declare namespace ts.pxtc {
         emptyEventHandlerComments?: boolean; // true adds a comment for empty event handlers
         vmOpCodes?: pxt.Map<number>;
         commonalize?: boolean;
-        variants?: pxt.Map<CompileTarget>;
     }
 
     interface CompileOptions {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -35,6 +35,7 @@ declare namespace pxt {
         public?: boolean;
         binaryonly?: boolean;
         platformio?: PlatformIOConfig;
+        compileServiceVariant?: string;
         yotta?: YottaConfig;
         npmDependencies?: Map<string>;
         card?: CodeCard;

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -155,6 +155,7 @@ namespace pxt.cpp {
                 gittag: "none",
                 serviceId: "nocompile"
             }
+        compileService = U.clone(compileService)
 
         let compile = appTarget.compile
         if (!compile)
@@ -791,6 +792,16 @@ namespace pxt.cpp {
                 U.jsonCopyFrom(res.platformio.dependencies, j0.dependencies)
             }
 
+            let variant = pkg.config.compileServiceVariant
+            if (variant) {
+                let v = compileService.variants[variant]
+                if (v) {
+                    U.jsonMergeFrom(compileService, v)
+                } else {
+                    U.userError(lf("Compile service variant '{0}' missing in pxtarget.json", variant))
+                }
+            }
+
             if (res.npmDependencies && pkg.config.npmDependencies)
                 U.jsonCopyFrom(res.npmDependencies, pkg.config.npmDependencies)
 
@@ -1228,7 +1239,7 @@ namespace pxt.hex {
     let cdnUrlPromise: Promise<string>;
 
     export let showLoading: (msg: string) => void = (msg) => { };
-    export let hideLoading: () => void = () => {};
+    export let hideLoading: () => void = () => { };
 
     function downloadHexInfoAsync(extInfo: pxtc.ExtensionInfo) {
         let cachePromise = Promise.resolve();
@@ -1286,10 +1297,10 @@ namespace pxt.hex {
                                                 resolve(U.httpGetTextAsync(hexurl + ".hex"))
                                             }
                                         },
-                                        e => {
-                                            setTimeout(tryGet, 1000)
-                                            return null
-                                        })
+                                            e => {
+                                                setTimeout(tryGet, 1000)
+                                                return null
+                                            })
                                 }
                                 tryGet();
                             })))

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -792,16 +792,6 @@ namespace pxt.cpp {
                 U.jsonCopyFrom(res.platformio.dependencies, j0.dependencies)
             }
 
-            let variant = pkg.config.compileServiceVariant
-            if (variant) {
-                let v = compileService.variants[variant]
-                if (v) {
-                    U.jsonMergeFrom(compileService, v)
-                } else {
-                    U.userError(lf("Compile service variant '{0}' missing in pxtarget.json", variant))
-                }
-            }
-
             if (res.npmDependencies && pkg.config.npmDependencies)
                 U.jsonCopyFrom(res.npmDependencies, pkg.config.npmDependencies)
 
@@ -1038,7 +1028,6 @@ int main() {
         res.compileData = ts.pxtc.encodeBase64(U.toUTF8(data))
         res.shimsDTS = shimsDTS.finish()
         res.enumsDTS = enumsDTS.finish()
-        res.binaryName = compileService.codalBinary
 
         prevSnapshot = pkgSnapshot
         prevExtInfo = res

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1038,6 +1038,7 @@ int main() {
         res.compileData = ts.pxtc.encodeBase64(U.toUTF8(data))
         res.shimsDTS = shimsDTS.finish()
         res.enumsDTS = enumsDTS.finish()
+        res.binaryName = compileService.codalBinary
 
         prevSnapshot = pkgSnapshot
         prevExtInfo = res

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -10,6 +10,8 @@ namespace pxt {
     const lf = U.lf;
 
     export let appTarget: TargetBundle;
+    let savedAppTarget: TargetBundle;
+    export let appTargetVariant: string;
 
     export function setAppTarget(trg: TargetBundle) {
         appTarget = trg || <TargetBundle>{};
@@ -44,6 +46,25 @@ namespace pxt {
         if (cs) {
             if (cs.yottaTarget && !cs.yottaBinary)
                 cs.yottaBinary = "pxt-microbit-app-combined.hex"
+        }
+
+        savedAppTarget = U.clone(appTarget)
+    }
+
+    export function setAppTargetVariant(variant: string) {
+        appTargetVariant = variant
+        appTarget = U.clone(savedAppTarget)
+        if (variant) {
+            if (appTarget.compile.variants) {
+                let v = appTarget.compile.variants[variant]
+                if (v)
+                    U.jsonMergeFrom(appTarget.compile, v)
+            }
+            if (appTarget.compileService && appTarget.compileService.variants) {
+                let v = appTarget.compileService.variants[variant]
+                if (v)
+                    U.jsonMergeFrom(appTarget.compileService, v)
+            }
         }
     }
 

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -55,16 +55,14 @@ namespace pxt {
         appTargetVariant = variant
         appTarget = U.clone(savedAppTarget)
         if (variant) {
-            if (appTarget.compile.variants) {
-                let v = appTarget.compile.variants[variant]
-                if (v)
-                    U.jsonMergeFrom(appTarget.compile, v)
+            if (appTarget.variants) {
+                let v = appTarget.variants[variant]
+                if (v) {
+                    U.jsonMergeFrom(appTarget, v)
+                    return
+                }
             }
-            if (appTarget.compileService && appTarget.compileService.variants) {
-                let v = appTarget.compileService.variants[variant]
-                if (v)
-                    U.jsonMergeFrom(appTarget.compileService, v)
-            }
+            U.userError(lf("Variant '{0}' not defined in pxtarget.json", variant))
         }
     }
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -451,6 +451,8 @@ namespace pxt {
                     } else {
                         mod = new Package(id, ver, this.parent, this)
                         this.parent.deps[id] = mod
+                        // we can have "core---nrf52" to be used instead of "core" in other packages
+                        this.parent.deps[id.replace(/---.*/, "")] = mod
                         return mod.loadAsync(isInstall)
                     }
                 })

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -462,6 +462,19 @@ namespace pxt {
                 .then(() => loadDepsRecursive(this.config.dependencies))
                 .then(() => {
                     if (this.level === 0) {
+                        let variant = ""
+                        for (let d of Util.values(this.parent.deps)) {
+                            if (!d.config) continue
+                            let v = d.config.compileServiceVariant
+                            if (!v) continue
+                            if (variant && v != variant) {
+                                U.userError(lf("Conflicting compile service variants '{0}' and '{1}'", v, variant))
+                            }
+                            variant = v
+                        }
+                        if (variant) pxt.log(`Setting compile service variant: ${variant}`)
+                        pxt.setAppTargetVariant(variant)
+
                         // Check for missing packages. We need to add them 1 by 1 in case they conflict with eachother.
                         const mainTs = this.readFile("main.ts");
                         if (!mainTs) return Promise.resolve(null);

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -415,6 +415,7 @@ namespace pxt {
                     initPromise = initPromise.then(() => this.patchCorePackage());
                 initPromise = initPromise.then(() => {
                     if (this.config.files.indexOf("board.json") < 0) return
+                    pxt.setAppTargetVariant(this.config.compileServiceVariant)
                     const def = appTarget.simulator.boardDefinition = JSON.parse(this.readFile("board.json")) as pxsim.BoardDefinition;
                     def.id = this.config.name;
                     appTarget.appTheme.boardName = def.boardName || lf("board");
@@ -462,19 +463,6 @@ namespace pxt {
                 .then(() => loadDepsRecursive(this.config.dependencies))
                 .then(() => {
                     if (this.level === 0) {
-                        let variant = ""
-                        for (let d of Util.values(this.parent.deps)) {
-                            if (!d.config) continue
-                            let v = d.config.compileServiceVariant
-                            if (!v) continue
-                            if (variant && v != variant) {
-                                U.userError(lf("Conflicting compile service variants '{0}' and '{1}'", v, variant))
-                            }
-                            variant = v
-                        }
-                        if (variant) pxt.log(`Setting compile service variant: ${variant}`)
-                        pxt.setAppTargetVariant(variant)
-
                         // Check for missing packages. We need to add them 1 by 1 in case they conflict with eachother.
                         const mainTs = this.readFile("main.ts");
                         if (!mainTs) return Promise.resolve(null);


### PR DESCRIPTION
This adds `variants` map in `pxtarget.json` which can be used to override anything in the target definition. It's used to define a target variant for a different MCU - which redefines compile service, usage of UF2 vs HEX, GDB command, etc. The particular variant is then selected from `pxt.json`. It allows for variant-specific packages, eg `core---nrf52832` which masquerades as `core`. These still share code from common-packages, but can have different platform overrides. 

Not much code, but much flexibility.

This is initially for BLE Nano support in maker.