### PR TITLE
Fix for #3988

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -445,7 +445,10 @@ namespace ts.pxtc {
                     addCombined("get", s)
             } else if (!!s.attributes.block
                 && !s.attributes.fixedInstance
-                && s.kind != pxtc.SymbolKind.EnumMember) {
+                && s.kind != pxtc.SymbolKind.EnumMember
+                && s.kind != pxtc.SymbolKind.Module
+                && s.kind != pxtc.SymbolKind.Interface
+                && s.kind != pxtc.SymbolKind.Class) {
                 if (!s.attributes.blockId)
                     s.attributes.blockId = s.qName.replace(/\./g, "_")
                 if (s.attributes.block == "true") {


### PR DESCRIPTION
With the new auto block logic, we try to generate blocks for namespaces, classes, interfaces.