### PR TITLE
v0: Fix hex cache generation

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1649,7 +1649,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
             .then(() => testForBuildTargetAsync(isPrj))
             .then((compileOpts) => {
                 // For the projects, we need to save the base HEX file to the offline HEX cache
-                if (isPrj && pxt.appTarget.compile.hasHex) {
+                if (isPrj && pxt.appTarget.compile && pxt.appTarget.compile.hasHex) {
                     if (!compileOpts) {
                         console.error(`Failed to extract native image for project ${dirname}`);
                         return;
@@ -1658,13 +1658,13 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                     // Place the base HEX image in the hex cache if necessary
                     let sha = compileOpts.extinfo.sha;
                     let hex: string[] = compileOpts.hexinfo.hex;
-                    let hexFile = path.join(hexCachePath, sha + pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex");
+                    let hexFile = path.join(hexCachePath, sha + ".hex");
 
                     if (fs.existsSync(hexFile)) {
-                        pxt.debug(`native image already in offline cache for project ${dirname}`);
+                        pxt.log(`\tnative image already in offline cache for project ${dirname}: ${hexFile}`);
                     } else {
                         fs.writeFileSync(hexFile, hex.join(os.EOL));
-                        pxt.debug(`created native image in offline cache for project ${dirname}: ${hexFile}`);
+                        pxt.log(`\tcreated native image in offline cache for project ${dirname}: ${hexFile}`);
                     }
                 }
             })
@@ -2006,7 +2006,7 @@ class SnippetHost implements pxt.Host {
     }
 
     downloadPackageAsync(pkg: pxt.Package): Promise<void> {
-        //console.log(`downloadPackageAsync(${pkg.id})`)        
+        //console.log(`downloadPackageAsync(${pkg.id})`)
         return Promise.resolve()
     }
 


### PR DESCRIPTION
Was a simple order of operation bug. I ended up just removing uf2 caching, since it will never be needed in v0.