### PR TITLE
Fix offline cache for uf2 targets

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1811,7 +1811,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                 .then(() => testForBuildTargetAsync(isPrj))
                 .then((compileOpts) => {
                     // For the projects, we need to save the base HEX file to the offline HEX cache
-                    if (isPrj && pxt.appTarget.compile.hasHex) {
+                    if (isPrj && pxt.appTarget.compile && pxt.appTarget.compile.hasHex) {
                         if (!compileOpts) {
                             console.error(`Failed to extract native image for project ${dirname}`);
                             return;
@@ -1820,13 +1820,13 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         // Place the base HEX image in the hex cache if necessary
                         let sha = compileOpts.extinfo.sha;
                         let hex: string[] = compileOpts.hexinfo.hex;
-                        let hexFile = path.join(hexCachePath, sha + (pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex"));
+                        let hexFile = path.join(hexCachePath, sha + ".hex");
 
                         if (fs.existsSync(hexFile)) {
-                            pxt.debug(`native image already in offline cache for project ${dirname}`);
+                            pxt.log(`native image already in offline cache for project ${dirname}: ${hexFile}`);
                         } else {
                             fs.writeFileSync(hexFile, hex.join(os.EOL));
-                            pxt.debug(`created native image in offline cache for project ${dirname}: ${hexFile}`);
+                            pxt.log(`created native image in offline cache for project ${dirname}: ${hexFile}`);
                         }
                     }
                 })


### PR DESCRIPTION
UF2 base images are still hexfiles, so we should be saving them with .hex extension in the offline cache. This fixes 2 issues:

- We were filtering offline cache on `\.hex$`, so .uf2 files were not put in the manifest
- We were going to put the .uf2 files in the manifest after filtering, which would never have been hit because the editor queries the base file as .hex

With this, 1st time uf2 offline compilation should now work