### PR TITLE
add ``blockSetVariable`` to auto-wrap factory into set variable

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -443,6 +443,12 @@ this macro allows to define groups of blocks. The default ``blockGap`` value is 
 ...
 ```
 
+## Variable assignment
+
+If a block instantiates a custom object, like a sprite, it's most likely that the user
+will want to store in a variable. Add ``blockSetVariable`` to modify the toolbox entry
+to include the variable.
+
 ## Testing your Blocks
 
 We recommend to build your block APIs iteratively and try it out in the editor to get the "feel of it".

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -239,7 +239,7 @@ namespace pxt.blocks {
         return result;
     }
 
-    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: HTMLElement, showCategories = CategoryMode.Basic, comp: pxt.blocks.BlockCompileInfo, filters?: BlockFilters) {
+    function injectToolbox(tb: Element, info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, block: Element, showCategories = CategoryMode.Basic, comp: pxt.blocks.BlockCompileInfo, filters?: BlockFilters) {
         // identity function are just a trick to get an enum drop down in the block
         // while allowing the parameter to be a number
         if (fn.attributes.blockHidden)
@@ -362,6 +362,22 @@ namespace pxt.blocks {
                 });
             }
             else {
+                // if requested, wrap block into a "set variable block"
+                if (fn.attributes.blockSetVariable) {
+
+                    const setblock = Blockly.Xml.textToDom(`
+<block type="variables_set" gap="${fn.attributes.blockGap || 8}">
+<field name="VAR" variabletype="">${fn.retType.toLowerCase()}</field>
+</block>`);
+                    {
+                        let value = goog.dom.createDom('value');
+                        value.setAttribute('name', 'VALUE');
+                        value.appendChild(block.cloneNode(true));
+                        setblock.appendChild(value);
+                    }
+                    block = setblock;
+                }
+
                 if (showCategories !== CategoryMode.None && !(showCategories === CategoryMode.Basic && isAdvanced)) {
                     insertBlock(block, category, fn.attributes.weight, fn.attributes.group);
                     injectToolboxIconCss();

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -363,7 +363,7 @@ namespace pxt.blocks {
             }
             else {
                 // if requested, wrap block into a "set variable block"
-                if (fn.attributes.blockSetVariable) {
+                if (fn.attributes.blockSetVariable && fn.retType) {
 
                     const setblock = Blockly.Xml.textToDom(`
 <block type="variables_set" gap="${fn.attributes.blockGap || 8}">

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -366,11 +366,11 @@ namespace pxt.blocks {
                 if (fn.attributes.blockSetVariable && fn.retType) {
 
                     const setblock = Blockly.Xml.textToDom(`
-<block type="variables_set" gap="${fn.attributes.blockGap || 8}">
-<field name="VAR" variabletype="">${fn.retType.toLowerCase()}</field>
+<block type="variables_set" gap="${Util.htmlEscape((fn.attributes.blockGap || 8) + "")}">
+<field name="VAR" variabletype="">${Util.htmlEscape(fn.retType.toLowerCase())}</field>
 </block>`);
                     {
-                        let value = goog.dom.createDom('value');
+                        let value = document.createElement('value');
                         value.setAttribute('name', 'VALUE');
                         value.appendChild(block.cloneNode(true));
                         setblock.appendChild(value);

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -556,7 +556,7 @@ namespace ts.pxtc {
         "blockHidden",
         "constantShim",
         "blockCombine",
-        "blockVariable"
+        "blockSetVariable"
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -123,6 +123,7 @@ namespace ts.pxtc {
         blockHidden?: boolean; // not available directly in toolbox
         blockImage?: boolean; // for enum variable, specifies that it should use an image from a predefined location
         blockCombine?: boolean;
+        blockSetVariable?: boolean; // show block with variable assigment in toolbox
         fixedInstances?: boolean;
         fixedInstance?: boolean;
         constantShim?: boolean;
@@ -554,7 +555,8 @@ namespace ts.pxtc {
         "optionalVariableArgs",
         "blockHidden",
         "constantShim",
-        "blockCombine"
+        "blockCombine",
+        "blockVariable"
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {


### PR DESCRIPTION
When function instantiates an object, we most likely want to store it in a variable. the ``blockSetVariable`` does that automatically.

![image](https://user-images.githubusercontent.com/4175913/37797504-3af25b24-2dd7-11e8-9f93-09877bde33d6.png)

TODO: support a formatting in "block" to specify the name of the return variable so that it can be localized.