### PR TITLE
Light mode optimizations.

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -8,6 +8,8 @@ namespace pxt.runner {
     export interface SimulateOptions {
         id?: string;
         code?: string;
+        highContrast?: boolean;
+        light?: boolean;
     }
 
     class EditorPackage {
@@ -267,7 +269,9 @@ namespace pxt.runner {
                         parts: parts,
                         fnArgs: fnArgs,
                         cdnUrl: pxt.webConfig.commitCdnUrl,
-                        localizedStrings: Util.getLocalizedStrings()
+                        localizedStrings: Util.getLocalizedStrings(),
+                        highContrast: simOptions.highContrast,
+                        light: simOptions.light
                     };
                     if (pxt.appTarget.simulator)
                         runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -14,6 +14,7 @@ namespace pxsim {
         code: string;
         mute?: boolean;
         highContrast?: boolean;
+        light?: boolean;
         cdnUrl?: string;
         localizedStrings?: Map<string>;
         version?: string;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -38,6 +38,7 @@ namespace pxsim {
         partDefinitions?: pxsim.Map<PartDefinition>;
         mute?: boolean;
         highContrast?: boolean;
+        light?: boolean;
         cdnUrl?: string;
         localizedStrings?: pxsim.Map<string>;
         refCountingDebug?: boolean;
@@ -120,7 +121,7 @@ namespace pxsim {
             }
         }
 
-        private createFrame(): HTMLDivElement {
+        private createFrame(light?: boolean): HTMLDivElement {
             const wrapper = document.createElement("div") as HTMLDivElement;
             wrapper.className = 'simframe';
 
@@ -130,6 +131,7 @@ namespace pxsim {
             frame.setAttribute('sandbox', 'allow-same-origin allow-scripts');
             frame.sandbox.value = "allow-scripts allow-same-origin"
             let simUrl = this.options.simUrl || ((window as any).pxtConfig || {}).simUrl || "/sim/simulator.html"
+            if (light) simUrl+= '?light=1';
             if (this.runOptions.aspectRatio)
                 wrapper.style.paddingBottom = (100 / this.runOptions.aspectRatio) + "%";
             frame.src = simUrl + '#' + frame.id;
@@ -238,6 +240,7 @@ namespace pxsim {
                 partDefinitions: opts.partDefinitions,
                 mute: opts.mute,
                 highContrast: opts.highContrast,
+                light: opts.light,
                 cdnUrl: opts.cdnUrl,
                 localizedStrings: opts.localizedStrings,
                 refCountingDebug: opts.refCountingDebug,
@@ -251,7 +254,7 @@ namespace pxsim {
             let frame = this.container.getElementsByTagName("iframe").item(0) as HTMLIFrameElement;
             // lazy allocate iframe
             if (!frame) {
-                let wrapper = this.createFrame();
+                let wrapper = this.createFrame(opts.light);
                 this.container.appendChild(wrapper);
                 frame = wrapper.firstElementChild as HTMLIFrameElement;
             } else this.startFrame(frame);

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -131,7 +131,7 @@ namespace pxsim {
             frame.setAttribute('sandbox', 'allow-same-origin allow-scripts');
             frame.sandbox.value = "allow-scripts allow-same-origin"
             let simUrl = this.options.simUrl || ((window as any).pxtConfig || {}).simUrl || "/sim/simulator.html"
-            if (light) simUrl+= '?light=1';
+            frame.className = 'no-select'
             if (this.runOptions.aspectRatio)
                 wrapper.style.paddingBottom = (100 / this.runOptions.aspectRatio) + "%";
             frame.src = simUrl + '#' + frame.id;

--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -2,7 +2,8 @@ namespace pxsim.visuals {
     export interface BoardViewOptions {
         visual: string | BoardImageDefinition,
         wireframe?: boolean,
-        highContrast?: boolean
+        highContrast?: boolean,
+        light?: boolean
     }
 
     export interface BoardHostOpts {
@@ -16,7 +17,8 @@ namespace pxsim.visuals {
         maxWidth?: string,
         maxHeight?: string,
         wireframe?: boolean,
-        highContrast?: boolean
+        highContrast?: boolean,
+        light?: boolean
     }
 
     export var mkBoardView = (opts: BoardViewOptions): BoardView => {

--- a/theme/light.less
+++ b/theme/light.less
@@ -1,0 +1,36 @@
+/* Import all components */
+@import 'themes/default/globals/site.variables';
+@import 'themes/pxt/globals/site.variables';
+
+/* Reference import */
+@import (reference) "semantic.less";
+
+
+/*******************************
+    Light Mode
+*******************************/
+
+.light * {
+    /*CSS transitions*/
+  -webkit-transition: none!important;
+  -moz-transition: none!important;
+  -ms-transition: none!important;
+  transition: none!important;
+}
+
+.light .ui.dimmer {
+    animation-duration: 0s !important;
+}
+
+.light .ui.loader:after {
+    animation: none !important;
+}
+
+/* Remove blockly filter on drag */
+.light svg.blocklyBlockDragSurface > g {
+    filter: none !important;
+}
+
+.light .blocklyMainBackground {
+    fill: @blocklySvgColor !important;
+}

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -12,6 +12,7 @@
 @import 'serial';
 @import 'docs';
 
+@import 'light';
 @import 'accessibility';
 @import 'highcontrast';
 

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -221,32 +221,3 @@ div.blocklyWidgetDiv {
     display: inline-block;
     float: right;
 }
-
-/*******************************
-    Light Mode
-*******************************/
-
-.light * {
-    /*CSS transitions*/
-  -webkit-transition: none!important;
-  -moz-transition: none!important;
-  -ms-transition: none!important;
-  transition: none!important;
-}
-
-.light .ui.dimmer {
-    animation-duration: 0s !important;
-}
-
-.light .ui.loader:after {
-    animation: none !important;
-}
-
-/* Remove blockly filter on drag */
-.light svg.blocklyBlockDragSurface > g {
-    filter: none !important;
-}
-
-.light .blocklyMainBackground {
-    fill: transparent !important;
-}

--- a/webapp/public/custom.css
+++ b/webapp/public/custom.css
@@ -221,3 +221,32 @@ div.blocklyWidgetDiv {
     display: inline-block;
     float: right;
 }
+
+/*******************************
+    Light Mode
+*******************************/
+
+.light * {
+    /*CSS transitions*/
+  -webkit-transition: none!important;
+  -moz-transition: none!important;
+  -ms-transition: none!important;
+  transition: none!important;
+}
+
+.light .ui.dimmer {
+    animation-duration: 0s !important;
+}
+
+.light .ui.loader:after {
+    animation: none !important;
+}
+
+/* Remove blockly filter on drag */
+.light svg.blocklyBlockDragSurface > g {
+    filter: none !important;
+}
+
+.light .blocklyMainBackground {
+    fill: transparent !important;
+}

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -94,6 +94,8 @@
         var footer = !/nofooter(?:[:=])1/i.exec(window.location.href);
         var debugSim = !!/debugSim(?:[:=])1/i.exec(window.location.href);
         var sims = document.getElementById('simulators');
+        var highContrast = !!/hc(?:[:=])1/i.exec(window.location.href);
+        var light = !!/light(?:[:=])1/i.exec(window.location.href);
 
         if (!id && !code && !debugSim) {
             console.error("missing id or code");
@@ -126,7 +128,12 @@
                 })
             }
             else if (!debugSim) {
-                var options = { id: id ? id[1] : undefined, code: code ? decodeURIComponent(code[1]) : undefined };
+                var options = { 
+                    id: id ? id[1] : undefined,
+                    code: code ? decodeURIComponent(code[1]) : undefined,
+                    highContrast: highContrast,
+                    light: light
+                };
                 console.log('simulating script')
                 pxt.runner.simulateAsync(sims, options).done(function() {
                     console.log('simulator started...')

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1393,7 +1393,7 @@ export class ProjectView
                 this.clearSerial();
                 this.editor.setDiagnostics(this.editorFile, state)
                 if (resp.outfiles[pxtc.BINARY_JS]) {
-                    simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute, this.state.highContrast)
+                    simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute, this.state.highContrast, pxt.options.light)
                     this.setState({ running: true, showParts: simulator.driver.runOptions.parts.length > 0 })
                 } else if (!opts.background) {
                     core.warningNotification(lf("Oops, we could not run this project. Please check your code for errors."))
@@ -2244,6 +2244,9 @@ $(() => {
     const config = pxt.webConfig
     pxt.options.debug = /dbg=1/i.test(window.location.href);
     pxt.options.light = /light=1/i.test(window.location.href) || pxt.BrowserUtils.isARM() || pxt.BrowserUtils.isIE();
+    if (pxt.options.light) {
+        $('body.main').addClass('light');
+    }
     const wsPortMatch = /wsport=(\d+)/i.exec(window.location.href);
     if (wsPortMatch) {
         pxt.options.wsPort = parseInt(wsPortMatch[1]) || 3233;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -275,7 +275,7 @@ export class ProjectsMenu extends data.Component<ISettingsProps, {}> {
         const targetTheme = pxt.appTarget.appTheme;
         const sharingEnabled = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing;
 
-        return <div className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">
+        return <div id="homemenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar">
             <div className="left menu">
                 <a href={targetTheme.logoUrl} aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => this.brandIconClick()}>
                     {targetTheme.logo || targetTheme.portraitLogo

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -41,6 +41,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
     $debugger = $('#debugger')
     let options: pxsim.SimulatorDriverOptions = {
         revealElement: (el) => {
+            if (pxt.options.light) return;
             ($(el) as any).transition({
                 animation: pxt.appTarget.appTheme.simAnimationEnter || 'fly right in',
                 duration: '0.5s',
@@ -49,9 +50,14 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         removeElement: (el, completeHandler) => {
             if (pxt.appTarget.simulator.headless) {
                 $(el).addClass('simHeadless');
-                completeHandler();
+                if (completeHandler) completeHandler();
             }
             else {
+                if (pxt.options.light) {
+                    if (completeHandler) completeHandler();
+                    $(el).remove();
+                    return;
+                }
                 ($(el) as any).transition({
                     animation: pxt.appTarget.appTheme.simAnimationExit || 'fly right out',
                     duration: '0.5s',
@@ -185,7 +191,7 @@ export function isDirty(): boolean { // in need of a restart?
     return dirty;
 }
 
-export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResult, mute?: boolean, highContrast?: boolean) {
+export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResult, mute?: boolean, highContrast?: boolean, light?: boolean) {
     makeClean();
     const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
@@ -200,6 +206,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResul
         debug,
         fnArgs,
         highContrast,
+        light,
         aspectRatio: parts.length ? pxt.appTarget.simulator.partsAspectRatio : pxt.appTarget.simulator.aspectRatio,
         partDefinitions: pkg.computePartDefinitions(parts),
         cdnUrl: pxt.webConfig.commitCdnUrl,


### PR DESCRIPTION
- Disable transitions
- Pass light mode to simulator on initialization and through runoptions
- Disable loading and dimmer animations
- Remove blockly workspace and drag filters
- Remove simulator reveal and remove transitions

Still yet to come, dynamically enabling light mode when compile is slow.