### PR TITLE
Only include poweredby images when flag is set.

### DIFF
--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -109,10 +109,15 @@
 @loaderImageUrl: "../docs/static/loader.svg";
 @loaderImage: data-uri(@loaderImageUrl);
 
+@includePoweredByImages: false;
 @poweredBySmallUrl: "../docs/static/logo/Powered-By-Microsoft-logo-small.png";
-@poweredBySmall: data-uri(@poweredBySmallUrl);
+@poweredBySmall: none;
 @poweredByLargeUrl: "../docs/static/logo/Powered-By-Microsoft-logo.png";
-@poweredByLarge: data-uri(@poweredByLargeUrl);
+@poweredByLarge: none;
+.includePoweredByImages() when not (@includePoweredByImages = false) {
+  @poweredBySmall: data-uri(@poweredBySmallUrl);
+  @poweredByLarge: data-uri(@poweredByLargeUrl);
+}
 
 @docsAvatarImageUrl: none;
 @docsAvatarImage: none;


### PR DESCRIPTION
set @includePoweredByImages: true in target site.variables in order to include these files.

Fixes https://github.com/Microsoft/pxt/issues/4016

Couldn't find any way to test in less if a file exists.