### PR TITLE
Expand tiny share view

### DIFF
--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -61,7 +61,7 @@
 */
 
 @tallEditorBreakpoint: 44rem;
-@thinEditorBreakpoint: 24rem;
+@thinEditorBreakpoint: 50rem;
 
 /*--------------
    Form Input

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -118,12 +118,14 @@ export class ProjectView
         this.reload = false; //set to true in case of reset of the project where we are going to reload the page.
         this.settings = JSON.parse(pxt.storage.getLocal("editorSettings") || "{}")
         const shouldShowHomeScreen = this.shouldShowHomeScreen();
+        const isSandbox = pxt.shell.isSandboxMode() || pxt.shell.isReadOnly();
 
         this.state = {
             showFiles: false,
             home: shouldShowHomeScreen,
             active: document.visibilityState == 'visible',
-            collapseEditorTools: pxt.appTarget.simulator.headless || pxt.BrowserUtils.isMobile()
+            collapseEditorTools: pxt.appTarget.simulator.headless || (!isSandbox && pxt.BrowserUtils.isMobile()),
+            embedSimView: isSandbox
         };
         if (!this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 19;
         if (!this.settings.fileHistory) this.settings.fileHistory = [];

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -103,7 +103,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const hasUndo = this.props.parent.editor.hasUndo();
         const hasRedo = this.props.parent.editor.hasRedo();
 
-        const showCollapsed = !tutorial;
+        const showCollapsed = !tutorial && !sandbox;
         const showProjectRename = !tutorial && !readOnly;
         const showUndoRedo = !tutorial && !readOnly;
         const showZoomControls = !tutorial;


### PR DESCRIPTION
Expand tiny share view to a wider height range.
Don't allow collapse in sandbox mode as it conflicts with sim embed view.