### PR TITLE
Tagged Template blocks

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1411,7 +1411,7 @@ ${output}</xml>`;
                                 }
                             }
                         }
-                        else if (e.kind === SK.TaggedTemplateExpression) {
+                        else if (e.kind === SK.TaggedTemplateExpression && param.fieldOptions && param.fieldOptions["taggedTemplate"]) {
                             addField(getField(vName, Util.htmlEscape(e.getText())));
                             return;
                         }
@@ -2064,7 +2064,7 @@ ${output}</xml>`;
                         return Util.lf("Field editor does not support literal arguments");
                     }
                 }
-                else if (e.kind === SK.TaggedTemplateExpression) {
+                else if (e.kind === SK.TaggedTemplateExpression && param.fieldEditor) {
                     let tagName = param.fieldOptions && param.fieldOptions["taggedTemplate"];
 
                     if (!tagName) {

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2591,6 +2591,15 @@ ${lbl}: .short 0xffff
             let attrs = parseComments(decl)
             let res: ir.Expr
 
+            let callInfo: CallInfo = {
+                decl,
+                qName: decl ? getFullName(checker, decl.symbol) : "?",
+                attrs,
+                args: [node.template],
+                isExpression: true
+            };
+            (node as any).callInfo = callInfo;
+
             function handleHexLike(pp: (s: string) => string) {
                 if (node.template.kind != SK.NoSubstitutionTemplateLiteral)
                     throw unhandled(node, lf("substitution not supported in hex literal", attrs.shim), 9265);

--- a/tests/decompile-test/baselines/tagged_templates_as_args.blocks
+++ b/tests/decompile-test/baselines/tagged_templates_as_args.blocks
@@ -1,0 +1,42 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="nofieldeditor_template">
+<value name="img">
+<block type="typescript_expression">
+<field name="EXPRESSION">img&#96;1234&#96;</field>
+</block>
+</value>
+<next>
+<block type="shadow_template">
+<value name="img">
+<shadow type="imageeditor"/>
+<block type="typescript_expression">
+<field name="EXPRESSION">img&#96;1234&#96;</field>
+</block>
+</value>
+<next>
+<block type="nofieldeditor_template">
+<value name="img">
+<block type="imageeditor">
+<field name="img">1234</field>
+</block>
+</value>
+<next>
+<block type="shadow_template">
+<value name="img">
+<shadow type="imageeditor">
+<field name="img">1234</field>
+</shadow>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;templateStrings.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/baselines/tagged_templates_id.blocks
+++ b/tests/decompile-test/baselines/tagged_templates_id.blocks
@@ -1,0 +1,21 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">template_with_id</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="imageeditor">
+<field name="img">1234</field>
+</block>
+</value>
+<next>
+<block type="typescript_statement">
+<mutation numlines="1" error="Unsupported statement in block&#58; TaggedTemplateExpression" line0="withID&#96;1234&#96;&#59;" />
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;templateStrings.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/tagged_templates_as_args.ts
+++ b/tests/decompile-test/cases/tagged_templates_as_args.ts
@@ -1,0 +1,7 @@
+/// <reference path="./testBlocks/templateStrings.ts" />
+
+template.noFieldEditorTemplate(img`1234`);
+template.shadowBlockTemplate(img`1234`);
+
+template.noFieldEditorTemplate(withID`1234`);
+template.shadowBlockTemplate(withID`1234`);

--- a/tests/decompile-test/cases/tagged_templates_id.ts
+++ b/tests/decompile-test/cases/tagged_templates_id.ts
@@ -1,0 +1,6 @@
+/// <reference path="./testBlocks/templateStrings.ts" />
+
+
+let template_with_id = withID`1234`;
+
+withID`1234`;

--- a/tests/decompile-test/cases/testBlocks/templateStrings.ts
+++ b/tests/decompile-test/cases/testBlocks/templateStrings.ts
@@ -1,4 +1,4 @@
-declare interface Image {    
+declare interface Image {
     /**
      * Get a pixel color
      */
@@ -14,6 +14,10 @@ function img(lits: any, ...args: any[]): Image { return null }
 //% groups=["0.","1#","2T","3t","4N","5n","6G","7g","8","9","aAR","bBP","cCp","dDO","eEY","fFW"]
 function badt(lits: any, ...args: any[]): Image { return null }
 
+//% shim=@f4 helper=image::ofBuffer blockIdentity="template.imageEditor"
+//% groups=["0.","1#","2T","3t","4N","5n","6G","7g","8","9","aAR","bBP","cCp","dDO","eEY","fFW"]
+function withID(lits: any, ...args: any[]): Image { return null }
+
 namespace template {
 
     /**
@@ -25,5 +29,16 @@ namespace template {
     //% img.fieldOptions.taggedTemplate="img"
     export function create(img: Image): number {
         return 0
+    }
+
+    /**
+     * Image editor...
+     * @param img the iamge
+     */
+    //% blockId=imageeditor block="%img" shim=TD_ID
+    //% img.fieldEditor="gridpicker"
+    //% img.fieldOptions.taggedTemplate="img"
+    export function imageEditor(img: Image): Image {
+        return img;
     }
 }

--- a/tests/decompile-test/cases/testBlocks/templateStrings.ts
+++ b/tests/decompile-test/cases/testBlocks/templateStrings.ts
@@ -41,4 +41,22 @@ namespace template {
     export function imageEditor(img: Image): Image {
         return img;
     }
+
+    /**
+     * Image editor...
+     * @param img the iamge
+     */
+    //% blockId=nofieldeditor_template block="%img"
+    export function noFieldEditorTemplate(img: Image): void {
+
+    }
+
+    /**
+     * Image editor...
+     * @param img the iamge
+     */
+    //% blockId=shadow_template block="%img=imageeditor"
+    export function shadowBlockTemplate(img: Image): void {
+
+    }
 }

--- a/tests/decompile-test/decompilerunner.ts
+++ b/tests/decompile-test/decompilerunner.ts
@@ -118,23 +118,32 @@ function replaceFileExtension(file: string, extension: string) {
     return file && file.substr(0, file.length - path.extname(file).length) + extension;
 }
 
-function decompileAsyncWorker(f: string, dependency?: string): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-        const input = fs.readFileSync(f, "utf8")
-        const pkg = new pxt.MainPackage(new TestHost("decompile-pkg", input, dependency ? [dependency] : [], true));
+let cachedOpts: pxtc.CompileOptions;
 
-        pkg.getCompileOptionsAsync()
-            .then(opts => {
-                opts.ast = true;
-                opts.testMode = true;
-                opts.ignoreFileResolutionErrors = true;
-                const decompiled = pxtc.decompile(opts, "main.ts", true);
-                if (decompiled.success) {
-                    resolve(decompiled.outfiles["main.blocks"]);
-                }
-                else {
-                    reject("Could not decompile " + f + JSON.stringify(decompiled.diagnostics, null, 4));
-                }
-            });
-    });
+function decompileAsyncWorker(f: string, dependency?: string): Promise<string> {
+    return getOptsAsync(dependency)
+        .then(opts => {
+            const input = fs.readFileSync(f, "utf8")
+            opts.fileSystem["main.ts"] = input;
+            opts.ast = true;
+            opts.testMode = true;
+            opts.ignoreFileResolutionErrors = true;
+            const decompiled = pxtc.decompile(opts, "main.ts", true);
+            if (decompiled.success) {
+                return decompiled.outfiles["main.blocks"];
+            }
+            else {
+                return Promise.reject("Could not decompile " + f + JSON.stringify(decompiled.diagnostics, null, 4));
+            }
+        })
+}
+
+function getOptsAsync(dependency: string) {
+    if (!cachedOpts) {
+        const pkg = new pxt.MainPackage(new TestHost("decompile-pkg", "// TODO", dependency ? [dependency] : [], true));
+
+        return pkg.getCompileOptionsAsync()
+            .then(opts => cachedOpts = opts);
+    }
+    return Promise.resolve(cachedOpts);
 }


### PR DESCRIPTION
Tagged template functions can now have shim blocks just like enums. The syntax is the same, just add `blockIdentity="qualified name"` to the declaration of the function. Note that the block is defined on the shim function and *not* on the tagged template function. See `tests/decompile-test/cases/testBlocks/templateStrings.ts` for an example (the `withID` function).
