### PR TITLE
Allow for missing width/height in pxt buildsprites

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4009,7 +4009,7 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
             U.userError(`only 8 bit per channel png images supported`)
         if (sheet.width > 255 || sheet.height > 255)
             U.userError(`PNG image too big`)
-        
+
         if (!info.width) info.width = sheet.width
         if (!info.height) info.height = sheet.height
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4009,6 +4009,9 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
             U.userError(`only 8 bit per channel png images supported`)
         if (sheet.width > 255 || sheet.height > 255)
             U.userError(`PNG image too big`)
+        
+        if (!info.width) info.width = sheet.width
+        if (!info.height) info.height = sheet.height
 
         let nx = (sheet.width / info.width) | 0
         let ny = (sheet.height / info.height) | 0


### PR DESCRIPTION
This allows for easy handling of non-sheet images - just don't specify width/height anywhere