### PR TITLE
Don't use blockly ids when serializing xml.

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -949,7 +949,7 @@ declare namespace Blockly {
         function domToPrettyText(dom: Element): string;
         function domToWorkspace(dom: Element, workspace: Workspace): string[];
         function textToDom(text: string): Element;
-        function workspaceToDom(workspace: Workspace): Element;
+        function workspaceToDom(workspace: Workspace, noid?: boolean): Element;
     }
 
     interface Options {

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -3,7 +3,7 @@
 
 namespace pxt.blocks {
     export function saveWorkspaceXml(ws: Blockly.Workspace): string {
-        let xml = Blockly.Xml.workspaceToDom(ws);
+        let xml = Blockly.Xml.workspaceToDom(ws, true);
         let text = Blockly.Xml.domToPrettyText(xml);
         return text;
     }

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -14,8 +14,8 @@ namespace pxt.blocks.layout {
     }
 
     function injectDisabledBlocks(oldWs: B.Workspace, newWs: B.Workspace): string {
-        const oldDom = Blockly.Xml.workspaceToDom(oldWs);
-        const newDom = Blockly.Xml.workspaceToDom(newWs);
+        const oldDom = Blockly.Xml.workspaceToDom(oldWs, true);
+        const newDom = Blockly.Xml.workspaceToDom(newWs, true);
         Util.toArray(oldDom.childNodes)
             .filter(n => n.nodeType == Node.ELEMENT_NODE && n.localName == "block" && (<Element>n).getAttribute("disabled") == "true")
             .forEach(n => newDom.appendChild(newDom.ownerDocument.importNode(n, true)));


### PR DESCRIPTION
Don't use blockly ids when serializing xml.