### PR TITLE
Fix monaco toolbox resizing text

### DIFF
--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -179,7 +179,7 @@
    Editor
 --------------------*/
 
-@blocklyToolboxColor: rgba(0, 0, 0, 0.05);
+@blocklyToolboxColor: white;
 @trashIconColor: @primaryColor;
 
 /*-------------------

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -951,7 +951,7 @@ export class Editor extends srceditor.Editor {
 
             // Draw the shape of the block
             monacoBlock.style.fontSize = `${monacoEditor.parent.settings.editorFontSize}px`;
-            monacoBlock.style.lineHeight = `${monacoEditor.parent.settings.editorFontSize}px`;
+            monacoBlock.style.lineHeight = `${monacoEditor.parent.settings.editorFontSize + 1}px`;
             monacoBlock.style.backgroundColor = monacoBlockDisabled ?
                 `${Blockly.PXTUtils.fadeColour(color || '#ddd', 0.8, false)}` :
                 `${color}`;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -634,6 +634,7 @@ export class Editor extends srceditor.Editor {
             monacoHeadingText.className = `monacoFlyoutHeadingText`;
             monacoHeadingText.style.display = 'inline-block';
             monacoHeadingText.style.fontSize = `${fontSize + 5}px`;
+            monacoHeadingText.style.lineHeight = `${fontSize + 5}px`;
             monacoHeadingText.textContent = category ? category : `${Util.capitalize(ns)}`;
 
             monacoHeadingLabel.appendChild(monacoHeadingIcon);
@@ -672,6 +673,7 @@ export class Editor extends srceditor.Editor {
                 groupLabelText.className = 'monacoFlyoutLabelText';
                 groupLabelText.style.display = 'inline-block';
                 groupLabelText.style.fontSize = `${fontSize}px`;
+                groupLabelText.style.lineHeight = `${fontSize + 5}px`;
                 groupLabelText.textContent = pxt.Util.rlf(`{id:group}${group}`);
                 groupLabel.appendChild(groupLabelText);
                 monacoFlyout.appendChild(groupLabel);
@@ -949,6 +951,7 @@ export class Editor extends srceditor.Editor {
 
             // Draw the shape of the block
             monacoBlock.style.fontSize = `${monacoEditor.parent.settings.editorFontSize}px`;
+            monacoBlock.style.lineHeight = `${monacoEditor.parent.settings.editorFontSize}px`;
             monacoBlock.style.backgroundColor = monacoBlockDisabled ?
                 `${Blockly.PXTUtils.fadeColour(color || '#ddd', 0.8, false)}` :
                 `${color}`;
@@ -1226,6 +1229,7 @@ export class Editor extends srceditor.Editor {
 
     private highlightDecorations: string[] = [];
     highlightStatement(brk: pxtc.LocationInfo) {
+        if (!brk) this.clearHighlightedStatements();
         if (!brk || !this.currFile || this.currFile.name != brk.fileName || !this.editor) return;
         let position = this.editor.getModel().getPositionAt(brk.start);
         let end = this.editor.getModel().getPositionAt(brk.start + brk.length);
@@ -1239,7 +1243,7 @@ export class Editor extends srceditor.Editor {
     }
 
     clearHighlightedStatements() {
-        if (this.highlightDecorations)
+        if (this.editor && this.highlightDecorations)
             this.editor.deltaDecorations(this.highlightDecorations, []);
     }
 


### PR DESCRIPTION
Fix monaco toolbox resizing text (line height). 

When zoomed in all the way in the monaco toolbox. 
Before: 
<img width="519" alt="screen shot 2018-04-05 at 11 58 54 pm" src="https://user-images.githubusercontent.com/16690124/38407190-5c136076-392d-11e8-8901-e2414f9ca2b7.png">

After: 
<img width="598" alt="screen shot 2018-04-05 at 11 52 58 pm" src="https://user-images.githubusercontent.com/16690124/38407195-60d386ae-392d-11e8-893f-5df12a90a847.png">

Also: 
- Clear highlight when passed null. 
- Use a better default toolbox color for blockly.