### PR TITLE
Fixing missing checkmark icons (in modal)

### DIFF
--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -353,7 +353,7 @@ export function confirmAsync(options: ConfirmOptions): Promise<number> {
         options.buttons.push({
             label: options.agreeLbl || lf("Go ahead!"),
             class: options.agreeClass,
-            icon: options.agreeIcon,
+            icon: options.agreeIcon || "checkmark",
             onclick: () => {
                 result = 1
             }
@@ -398,7 +398,7 @@ export function promptAsync(options: PromptOptions): Promise<string> {
         options.buttons.push({
             label: options.agreeLbl || lf("Go ahead!"),
             class: options.agreeClass,
-            icon: options.agreeIcon,
+            icon: options.agreeIcon || "checkmark",
             onclick: () => {
                 let dialogInput = document.getElementById('promptDialogInput') as HTMLInputElement;
                 result = dialogInput.value;


### PR DESCRIPTION
Previous PR: https://github.com/Microsoft/pxt/pull/4066 enabled optional icons for modal actions. Had to add a default for prompt and confirm dialog. 

