### PR TITLE
Fix monaco editor function coloring for top level blocks

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -220,7 +220,8 @@ export class Editor extends srceditor.Editor {
             const colors: pxt.Map<string> = {};
             this.getNamespaces().forEach((ns) => {
                 const metaData = this.getNamespaceAttrs(ns);
-                const blocks = snippets.isBuiltin(ns) ? snippets.getBuiltinCategory(ns).blocks : this.nsMap[ns];
+                const blocks = snippets.isBuiltin(ns) ?
+                    snippets.getBuiltinCategory(ns).blocks.concat(this.nsMap[ns] || []) : this.nsMap[ns];
 
                 if (metaData.color && blocks) {
                     let hexcolor = fixColor(metaData.color);


### PR DESCRIPTION
Include both built in blocks and blocks in a namespace when populating the theme for all blocks.

