### PR TITLE
Flyout buttons in High contrast

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -326,6 +326,9 @@
         fill: black !important;
         border-right: 1px solid white !important;
     }
+    .blocklyFlyoutButtonBackground {
+        fill: black !important;
+    }
 
     .monacoFlyout {
         background: black !important;


### PR DESCRIPTION
Invert flyout button backgrounds in high contrast

![screen shot 2018-04-09 at 4 29 56 pm](https://user-images.githubusercontent.com/16690124/38528170-440e01aa-3c13-11e8-8419-6eb8ed7ecc4d.png)

