### PR TITLE
Clear project name val when the editor file changes

### DIFF
--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -13,6 +13,8 @@ export class Editor extends srceditor.Editor {
     isSaving: boolean;
     changeMade: boolean = false;
 
+    private nameInput: sui.Input;
+
     prepare() {
         this.isReady = true
     }
@@ -93,7 +95,7 @@ export class Editor extends srceditor.Editor {
                     </div>
                 </h3>
                 <div className="ui segment form text">
-                    <sui.Input id={"fileNameInput"} label={lf("Name") } ariaLabel={lf("Type a name for your project") } value={c.name} onChange={setFileName}/>
+                    <sui.Input ref={e => this.nameInput = e} id={"fileNameInput"} label={lf("Name") } ariaLabel={lf("Type a name for your project") } value={c.name} onChange={setFileName}/>
                     {userConfigs.map(uc =>
                         <sui.Checkbox
                             key={`userconfig-${uc.description}`}
@@ -142,6 +144,7 @@ export class Editor extends srceditor.Editor {
 
     loadFileAsync(file: pkg.File): Promise<void> {
         this.config = JSON.parse(file.content)
+        if (this.nameInput) this.nameInput.clearValue();
         this.setDiagnostics(file, this.snapshotState())
         this.changeMade = false;
         return Promise.resolve();

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -379,6 +379,10 @@ export class Input extends data.Component<{
     ariaLabel?: string;
 }, { value: string }> {
 
+    clearValue() {
+        this.setState({ value: undefined });
+    }
+
     copy() {
         const p = this.props
         const el = ReactDOM.findDOMNode(this);


### PR DESCRIPTION
Clear the project settings name input when returning to the editor or loading a different file.