### PR TITLE
No default variable (Flyout)

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2868,17 +2868,6 @@ namespace pxt.blocks {
         Blockly.Variables.flyoutCategoryBlocks = function (workspace) {
             let variableModelList = workspace.getVariablesOfType('');
             variableModelList.sort(Blockly.VariableModel.compareByName);
-            // In addition to the user's variables, we also want to display the default
-            // variable name at the top.  We also don't want this duplicated if the
-            // user has created a variable of the same name.
-            for (let i = 0, tempVar: any; tempVar = variableModelList[i]; i++) {
-                if (tempVar.name == varname) {
-                    variableModelList.splice(i, 1);
-                    break;
-                }
-            }
-            const defaultVar = new Blockly.VariableModel(workspace, varname);
-            variableModelList.unshift(defaultVar);
 
             let xmlList: HTMLElement[] = [];
             if (variableModelList.length > 0) {


### PR DESCRIPTION
Remove the default variable in the Variables flyout. Always start with a simple "Make a variable" button. 
Users don't see the variable blocks until they create a variable..

<img width="223" alt="screen shot 2018-04-10 at 1 05 09 pm" src="https://user-images.githubusercontent.com/16690124/38587612-f7a253e2-3cd6-11e8-9612-f4a7537679ad.png">

Resolves https://github.com/Microsoft/pxt/issues/1539