### PR TITLE
Several changes and bug-fix to allow for combined property blocks that differ in return type.

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1161,7 +1161,8 @@ ${output}</xml>`;
                 error(left);
                 return undefined;
             }
-            const setter = env.blocks.blocks.find(b => b.namespace == sym.namespace && b.name == tp)
+            const qName = `${sym.namespace}.${sym.retType}.${tp}`;
+            const setter = env.blocks.blocks.find(b => b.qName == qName)
             const r = right ? mkStmt(setter.attributes.blockId) : mkExpr(setter.attributes.blockId)
             const pp = setter.attributes._def.parameters;
             r.inputs = [getValue(pp[0].name, left.expression)];

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -235,7 +235,7 @@ namespace ts.pxtc {
                 snippet: service.getSnippet(decl, attributes)
             }
 
-            if ((stmt.kind === SK.GetAccessor && !getDeclarationOfKind(decl.symbol, SK.SetAccessor)) ||
+            if (stmt.kind === SK.GetAccessor ||
                 (stmt.kind === SK.PropertyDeclaration && isReadonly(stmt as Declaration))) {
                 r.isReadOnly = true
             }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -388,6 +388,7 @@ namespace ts.pxtc {
         function addCombined(rtp: string, s: SymbolInfo) {
             const isGet = rtp == "get"
             const isSet = rtp == "set"
+            const isNumberType = s.retType == "number"
             const m = isGet ? combinedGet : (isSet ? combinedSet : combinedChange)
             const mkey = `${s.namespace}.${s.retType}`
 
@@ -399,7 +400,7 @@ namespace ts.pxtc {
 
                 ex = m[mkey] = {
                     attributes: {
-                        blockId: `${mkey}_blockCombine_${rtp}`,
+                        blockId: `${isNumberType ? s.namespace : mkey}_blockCombine_${rtp}`,
                         callingConvention: ir.CallingConvention.Plain,
                         group: s.attributes.group, // first %blockCombine defines
                         paramDefl: {},

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -123,6 +123,7 @@ namespace ts.pxtc {
         blockHidden?: boolean; // not available directly in toolbox
         blockImage?: boolean; // for enum variable, specifies that it should use an image from a predefined location
         blockCombine?: boolean;
+        blockCombineShadow?: string;
         blockSetVariable?: string; // show block with variable assigment in toolbox. Set equal to a name to control the var name
         fixedInstances?: boolean;
         fixedInstance?: boolean;
@@ -384,23 +385,31 @@ namespace ts.pxtc {
         const combinedGet: pxt.Map<SymbolInfo> = {}
         const combinedChange: pxt.Map<SymbolInfo> = {}
 
-        function addCombined(tp: string, s: SymbolInfo) {
-            const isGet = tp == "get"
-            const m = isGet ? combinedGet :
-                tp == "set" ? combinedSet : combinedChange
-            let ex = U.lookup(m, s.namespace)
+        function addCombined(rtp: string, s: SymbolInfo) {
+            const isGet = rtp == "get"
+            const isSet = rtp == "set"
+            const m = isGet ? combinedGet : (isSet ? combinedSet : combinedChange)
+            const mkey = `${s.namespace}.${s.retType}`
+
+            let ex = U.lookup(m, mkey)
             if (!ex) {
-                let paramName = s.namespace.toLowerCase()
-                ex = m[s.namespace] = {
+                const tp = `@${rtp}@`
+                const paramName = s.namespace.toLowerCase()
+                const paramValue = `value=${s.attributes.blockCombineShadow || ""}`;
+
+                ex = m[mkey] = {
                     attributes: {
+                        blockId: `${mkey}_blockCombine_${rtp}`,
                         callingConvention: ir.CallingConvention.Plain,
+                        group: s.attributes.group, // first %blockCombine defines
                         paramDefl: {},
                         jsDoc: isGet
                             ? U.lf("Read value of a property on an object")
                             : U.lf("Update value of property on an object")
                     },
-                    name: "@" + tp + "@",
+                    name: tp,
                     namespace: s.namespace,
+                    qName: `${mkey}.${tp}`,
                     pkg: s.pkg,
                     kind: SymbolKind.Property,
                     parameters: [
@@ -414,22 +423,19 @@ namespace ts.pxtc {
                         },
                         {
                             name: "value",
-                            description: tp == "set" ?
+                            description: isSet ?
                                 U.lf("the new value of the property") :
                                 U.lf("the amount by which to change the property"),
-                            type: "number"
+                            type: s.retType,
                         }
                     ].slice(0, isGet ? 1 : 2),
-                    retType: isGet ? "number" : "void",
-                    combinedProperties: [],
+                    retType: isGet ? s.retType : "void",
+                    combinedProperties: []
                 }
-                ex.attributes.block = isGet ? `%${paramName} %property` :
-                    tp == "set" ?
-                        `set %${paramName} %property to %value` :
-                        `change %${paramName} %property by %value`
-                ex.attributes.blockId = ex.namespace + "_blockCombine_" + tp
-                ex.attributes.group = s.attributes.group; // first group wins
-                ex.qName = ex.namespace + "." + ex.name
+                ex.attributes.block =
+                    isGet ? `%${paramName} %property` :
+                    isSet ? `set %${paramName} %property to %${paramValue}` :
+                            `change %${paramName} %property by %${paramValue}`
                 updateBlockDef(ex.attributes)
                 blocks.push(ex)
             }
@@ -439,12 +445,16 @@ namespace ts.pxtc {
 
         for (let s of pxtc.Util.values(info.byQName)) {
             if (s.attributes.blockCombine) {
-                if (!s.isReadOnly) {
-                    addCombined("set", s)
-                    addCombined("change", s)
-                }
-                if (!/@set/.test(s.name))
+                if (!/@set/.test(s.name)) {
                     addCombined("get", s)
+                }
+
+                if (!s.isReadOnly) {
+                    if (s.retType == 'number') {
+                        addCombined("change", s)
+                    }
+                    addCombined("set", s)
+                }
             } else if (!!s.attributes.block
                 && !s.attributes.fixedInstance
                 && s.kind != pxtc.SymbolKind.EnumMember

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -758,6 +758,11 @@ export class Editor extends srceditor.Editor {
             monacoBlockDisabled = fnState == pxt.editor.FilterState.Disabled;
             if (fnState == pxt.editor.FilterState.Hidden) return undefined;
 
+            const snippet = fn.snippet;
+            if (!snippet) {
+                return undefined;
+            }
+
             let monacoBlockArea = document.createElement('div');
             monacoBlockArea.className = `monacoBlock ${monacoBlockDisabled ? 'monacoDisabledBlock' : ''}`;
             monacoFlyout.appendChild(monacoBlockArea);
@@ -766,7 +771,6 @@ export class Editor extends srceditor.Editor {
             monacoBlock.tabIndex = 0;
             monacoBlockArea.appendChild(monacoBlock);
 
-            const snippet = fn.snippet;
             const comment = fn.attributes.jsDoc;
 
             let snippetPrefix = fn.noNamespace ? "" : ns;


### PR DESCRIPTION
**pxtcompiler/emitter/decompiler.ts**
- Lookup for setter using qualified name that now includes property type (retType).

**pxtcompiler/emitter/service.ts**
- Fix check for readonly symbolinfo and include property declarations.

**pxtlib/service.ts**
- Support value of retType and not 'number'.
- To do this needed to expand the qualified name for the block to be
```typescript
const mkey = `${s.namespace}.${s.retType}` `
```
- Also added in a %blockCombineShadow attribute that will allow the set accessors to default to a shadow type, e.g. a color picker.

For example,

```typescript
//% blockNamespace=design
declare class Material {
    //% blockCombine
    //% blockCombineShadow=color_picker
    //% group="Material"
    //% shim=.color property
    public color: Color;

    //% blockCombine
    //% blockCombineShadow=color_picker
    //% group="Material"
    //% shim=.emissive property
    public readonly emissive: Color;

    //% blockCombine
    //% group="Material"
    //% shim=.roughness property
    public roughness: number;

    //% blockCombine
    //% group="Material"
    //% shim=.metalness property
    public metalness: number;
}
```

**webapp/src/monaco.tsx**
- Fixed pre-existing bug that meant block combined properties would not be populated correctly in the Monaco toolbox as they _currently_ have no snippets generated. Snippets are only generated for function like symbols.