### PR TITLE
Move target logos into app cache

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -987,7 +987,8 @@ function uploadCoreAsync(opts: UploadOptions) {
             "@defaultLocaleStrings@": "",
             "@cachedHexFiles@": "",
             "@targetEditorJs@": targetEditorJs ? `${opts.localDir}editor.js` : "",
-            "@targetImages@": targetImages.length ? targetImages.map(i => `${opts.localDir}${i}`).join('\n') : ''
+            "@targetImages@": targetImages.length ? targetImages.map(k =>
+                `${opts.localDir}${path.join('./docs', logos[k])}`).join('\n') : ''
         }
     }
 
@@ -1521,11 +1522,20 @@ function buildWebManifest(cfg: pxt.TargetBundle) {
     return webmanifest;
 }
 
-function saveThemeJson(cfg: pxt.TargetBundle) {
+function saveThemeJson(cfg: pxt.TargetBundle, packaged?: boolean) {
     cfg.appTheme.id = cfg.id
     cfg.appTheme.title = cfg.title
     cfg.appTheme.name = cfg.name
     cfg.appTheme.description = cfg.description
+
+    if (packaged) {
+        let logos = (cfg.appTheme as any as Map<string>);
+        Object.keys(logos)
+            .filter(k => /(logo|hero)$/i.test(k) && /^\.\//.test(logos[k]))
+            .forEach(k => {
+                logos[k] = path.join('./docs', logos[k]);
+            })
+    }
 
     if (!cfg.appTheme.htmlDocIncludes)
         cfg.appTheme.htmlDocIncludes = {}
@@ -1863,7 +1873,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                 pxtCrowdinBranch: pxtCrowdinBranch(),
                 targetCrowdinBranch: targetCrowdinBranch()
             }
-            saveThemeJson(cfg)
+            saveThemeJson(cfg, options.packaged)
 
             const webmanifest = buildWebManifest(cfg)
             const targetjson = JSON.stringify(cfg, null, 2)

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -388,11 +388,11 @@ namespace pxt.BrowserUtils {
                 style.innerHTML = `.ui.accent { color: ${theme.accentColor}; }
                 .ui.inverted.menu .accent.active.item, .ui.inverted.accent.menu  { background-color: ${theme.accentColor}; }`;
                 document.getElementsByTagName('head')[0].appendChild(style);
-
             }
-            theme.appLogo = patchCdn(theme.appLogo)
-            theme.cardLogo = patchCdn(theme.cardLogo)
-            theme.homeScreenHero = patchCdn(theme.homeScreenHero)
+
+            let targetImages = Object.keys(theme as any as Map<string>)
+                .filter(k => /(logo|hero)$/i.test(k) && /^\.\//.test((theme as any)[k]))
+                .forEach(k => (theme as any)[k] = patchCdn((theme as any)[k]));
         }
         // RTL languages
         if (Util.isUserLanguageRtl()) {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -391,7 +391,7 @@ namespace pxt.BrowserUtils {
             }
 
             let targetImages = Object.keys(theme as any as Map<string>)
-                .filter(k => /(logo|hero)$/i.test(k) && /^\.\//.test((theme as any)[k]))
+                .filter(k => /(logo|hero)$/i.test(k) && /^@cdnUrl@/.test((theme as any)[k]))
                 .forEach(k => (theme as any)[k] = patchCdn((theme as any)[k]));
         }
         // RTL languages

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -267,7 +267,7 @@ namespace pxt.docs {
             params["homeurl"] = html2Quote(theme.homeUrl);
         params["targetid"] = theme.id || "???";
         params["targetname"] = theme.name || "Microsoft MakeCode";
-        params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui mini image" src="${U.toDataUri(theme.docsLogo)}" />` : ""
+        params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui mini image" src="${theme.docsLogo}" />` : ""
         let ghURLs = d.ghEditURLs || []
         if (ghURLs.length) {
             let ghText = `<p style="margin-top:1em">\n`

--- a/webapp/public/release.manifest
+++ b/webapp/public/release.manifest
@@ -59,6 +59,9 @@ https://az416426.vo.msecnd.net/scripts/a/ai.0.js
 
 @timestamp@
 
+# target
+@targetImages@
+
 /blb/target.js
   
 NETWORK:

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -235,9 +235,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
             {!sandbox ? <div className="left menu">
                 <a aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" tabIndex={0} onClick={() => this.brandIconClick()} onKeyDown={sui.fireClickOnEnter}>
                     {logo || portraitLogo
-                        ? <img className={`ui logo ${logo ? " portrait hide" : ''}`} src={Util.toDataUri(logo || portraitLogo)} alt={lf("{0} Logo", targetTheme.boardName)} />
+                        ? <img className={`ui logo ${logo ? " portrait hide" : ''}`} src={logo || portraitLogo} alt={lf("{0} Logo", targetTheme.boardName)} />
                         : <span className="name">{targetTheme.boardName}</span>}
-                    {portraitLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(portraitLogo)} alt={lf("{0} Logo", targetTheme.boardName)} />) : null}
+                    {portraitLogo ? (<img className='ui mini image portrait only' src={portraitLogo} alt={lf("{0} Logo", targetTheme.boardName)} />) : null}
                 </a>
                 {targetTheme.betaUrl ? <a href={`${targetTheme.betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta")}</a> : undefined}
                 {!inTutorial ? <sui.Item class="icon openproject" role="menuitem" textClass="landscape only" icon="home large" ariaLabel={lf("Home screen")} text={lf("Home")} onClick={() => this.goHome()} /> : null}
@@ -266,9 +266,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
 
                 {!sandbox ? <a href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo organization" onClick={() => this.orgIconClick()}>
                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo
-                        ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo)} alt={lf("{0} Logo", targetTheme.organization)} />
+                        ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={targetTheme.organizationWideLogo || targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />
                         : <span className="name">{targetTheme.organization}</span>}
-                    {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo)} alt={lf("{0} Logo", targetTheme.organization)} />) : null}
+                    {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />) : null}
                 </a> : undefined}
             </div>
         </div>;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -231,18 +231,18 @@ export class ProjectsMenu extends data.Component<ISettingsProps, {}> {
             <div className="left menu">
                 <a href={targetTheme.logoUrl} aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" onClick={() => this.brandIconClick()}>
                     {targetTheme.logo || targetTheme.portraitLogo
-                        ? <img className={`ui logo ${targetTheme.logo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.logo || targetTheme.portraitLogo)} alt={lf("{0} Logo", targetTheme.boardName)} />
+                        ? <img className={`ui logo ${targetTheme.logo ? " portrait hide" : ''}`} src={targetTheme.logo || targetTheme.portraitLogo} alt={lf("{0} Logo", targetTheme.boardName)} />
                         : <span className="name">{targetTheme.boardName}</span>}
-                    {targetTheme.portraitLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.portraitLogo)} alt={lf("{0} Logo", targetTheme.boardName)} />) : null}
+                    {targetTheme.portraitLogo ? (<img className='ui mini image portrait only' src={targetTheme.portraitLogo} alt={lf("{0} Logo", targetTheme.boardName)} />) : null}
                 </a>
             </div>
             <div className="ui item"><sui.Icon icon={`icon home large`} /> {lf("Home")}</div>
             <div className="right menu">
                 <a href={targetTheme.organizationUrl} target="blank" rel="noopener" className="ui item logo organization" onClick={() => this.orgIconClick()}>
                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo
-                        ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={Util.toDataUri(targetTheme.organizationWideLogo || targetTheme.organizationLogo)} alt={lf("{0} Logo", targetTheme.organization)} />
+                        ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={targetTheme.organizationWideLogo || targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />
                         : <span className="name">{targetTheme.organization}</span>}
-                    {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={Util.toDataUri(targetTheme.organizationLogo)} alt={lf("{0} Logo", targetTheme.organization)} />) : null}
+                    {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />) : null}
                 </a>
             </div>
             {targetTheme.betaUrl ? <a href={`${targetTheme.betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta")}</a> : undefined}


### PR DESCRIPTION
Move target images out of target.json and over into the release manifest to reduce the size of target.json and allow us to make use of browser app cache for those images between releases. 

Works locally, need to test on the cloud.