### PR TITLE
escape new project name

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -130,7 +130,8 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
 
         const chgCode = (scr: pxt.CodeCard, loadBlocks: boolean, prj?: pxt.ProjectTemplate) => {
             core.showLoading("changingcode", lf("loading..."));
-            gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
+            const name = scr.name.toLowerCase().replace(/\W/, '');
+            gallery.loadExampleAsync(name, scr.url)
                 .done(opts => {
                     if (opts) {
                         if (prj) opts.prj = prj;


### PR DESCRIPTION
Remove funny characters when creating project from template.