### PR TITLE
Simplify the about dialog

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1672,12 +1672,11 @@ export class ProjectView
         const description = pxt.appTarget.description || pxt.appTarget.title;
         const githubUrl = pxt.appTarget.appTheme.githubUrl;
         core.confirmAsync({
-            header: lf("About {0}", pxt.appTarget.name),
+            header: lf("About"),
             hideCancel: true,
             agreeLbl: lf("Ok"),
             agreeClass: "positive focused",
             htmlBody: `
-${description ? `<p>${Util.htmlEscape(description)}</p>` : ``}
 ${githubUrl ? `<p>${lf("{0} version:", Util.htmlEscape(pxt.appTarget.name))} <a class="focused" href="${Util.htmlEscape(githubUrl)}/releases/tag/v${Util.htmlEscape(pxt.appTarget.versions.target)}" aria-label="${lf("{0} version : {1}", Util.htmlEscape(pxt.appTarget.name), Util.htmlEscape(pxt.appTarget.versions.target))}" target="_blank">${Util.htmlEscape(pxt.appTarget.versions.target)}</a></p>` : ``}
 <p>${lf("{0} version:", "Microsoft MakeCode")} <a href="https://github.com/Microsoft/pxt/releases/tag/v${Util.htmlEscape(pxt.appTarget.versions.pxt)}" aria-label="${lf("{0} version: {1}", "Microsoft MakeCode", Util.htmlEscape(pxt.appTarget.versions.pxt))}" target="_blank">${Util.htmlEscape(pxt.appTarget.versions.pxt)}</a></p>
 ${compileService && compileService.githubCorePackage && compileService.gittag ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.htmlEscape("https://github.com/" + compileService.githubCorePackage + '/releases/tag/' + compileService.gittag)}" aria-label="${lf("{0} version: {1}", "C++ runtime", Util.htmlEscape(compileService.gittag))}" target="_blank">${Util.htmlEscape(compileService.gittag)}</a></p>` : ""}


### PR DESCRIPTION
Here are the screenshot before and after

Before: 
![image](https://user-images.githubusercontent.com/6107272/38762376-34f0c6d2-3f40-11e8-9f3a-a280c0c6efb9.png)

After:
![image](https://user-images.githubusercontent.com/6107272/38762385-47d9da40-3f40-11e8-96a9-bfe02fb2a12a.png)

Basically removes 3 reference to the board to just single one. Took cue from Edge about dialog

![image](https://user-images.githubusercontent.com/6107272/38762399-62cc4a72-3f40-11e8-8a7a-8ce57335380b.png)


