### PR TITLE
Fix delete and reset buttons

### DIFF
--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -266,7 +266,7 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
     let btnno = 0
     for (let b of buttons) {
         html += `
-      <${b.url ? "a" : "button"} class="ui right labeled icon button ${b.class || "approve positive"} focused" data-btnid="${btnno++}" ${b.url ? `href="${b.url}"` : ""} ${b.fileName ? `download="${Util.htmlEscape(b.fileName)}"` : ''} target="_blank">
+      <${b.url ? "a" : "button"} class="ui right labeled icon button approve ${b.class || "positive"} focused" data-btnid="${btnno++}" ${b.url ? `href="${b.url}"` : ""} ${b.fileName ? `download="${Util.htmlEscape(b.fileName)}"` : ''} target="_blank">
         ${Util.htmlEscape(b.label)}
         ${b.icon ? `<i class="${b.icon || "checkmark"} icon"></i>` : '' }
       </${b.url ? "a" : "button"}>`


### PR DESCRIPTION
https://github.com/Microsoft/pxt/commit/79579505b3f8ec17c2a7624e5179649dd488ee47#diff-d8cf7897d76809964c79553d02e3e75c broke the delete and reset buttons. 

Mostly we do something real silly and attach to "approve buttons" in the modal, which I didn't realise at the time as it didn't make sense to add the approve class to all buttons, but anyway here's the fix. 