### PR TITLE
Add an 'editor features' base page

### DIFF
--- a/common-docs/about/editor-features.md
+++ b/common-docs/about/editor-features.md
@@ -1,0 +1,73 @@
+# MakeCode editor features
+
+The MakeCode editor window has many features to help you create, download, and save your coding projects.
+
+## Creating blocks and code
+
+### Blocks Toolbox
+
+The blocks you use in your project are found in the **Toolbox**. The Toolbox is a sidebar list of block categories for different code functions and operations. To get a block from the toolbox, you select a block category and a block shelf opens showing you the available blocks. You grab a block from the shelf and pull it onto the block workspace. There's also a search control to help you find the blocks your interested in.
+
+#### #blocks-images
+
+### JavaScript editor
+
+The JavaScript editor is a fully functional text editor that's code aware. This means that it can help complete functions and statements for you by providing hints and text completion. A detailed discription of the JavaScript editor features is here:  https://makecode.com/js/editor.
+
+#### #jseditor-images
+
+## Editor controls
+
+### Home
+
+The **Home** button takes you to the [Home Screen](@homeurl@) which shows recent projects and other activities.
+
+#### #home-images
+
+### Share
+
+The **Share** button displays the **Share Project** window which lets you publish your project to the public cloud.
+
+#### #share-images
+
+### Blocks or JavaScript #blocksjs
+
+To switch the your code view from **Blocks** to **JavaScript**, or back again, press one of the view buttons at the top and center of the window.
+
+#### #blocksjs-images
+
+### Help
+
+The **Help** button shows a menu of help options that take you to support or reference pages.
+
+#### #help-images
+
+### More
+
+The **More** button gives a menu of project settings and options.
+
+#### #moresettings-images
+
+### Undo and Redo #undoredo
+
+You can undo and redo recent changes you make either in **Blocks** or **JavaScript** with the **Undo** and **Redo** buttons in the bottom right of the editor window.
+
+#### #undoredo-images
+
+### Zoom In and Zoom Out #zoom
+
+There are two zoom buttons in the lower right part of the editor view. The **(+)** button is to zoom in and the **(-)** button is to zoom out. The zoom buttons change the size of the blocks when you're in the **Blocks** view. When you're working with the code in the **JavaScript** view, the zoom buttons change the size of the text.
+
+#### #zoom-images
+
+### Save Project
+
+You can choose a name for your project and save it. Type in a name for the project and press the **disk icon** to save.
+
+#### #saveproject-images
+
+### Download #download
+
+The **Download** button will copy your program to a drive on your computer. You can copy your program directly to your @boardname@ if it's connected and a drive for it shows up on your computer.
+
+#### #download-images


### PR DESCRIPTION
This is in response to #1247 asking for an editor overview page. This is a base page which is overridden in the target, if desired, to add customized feature images and possibly additional sections.