### PR TITLE
Don't overuse pxt loader

### DIFF
--- a/theme/themes/pxt/elements/loader.overrides
+++ b/theme/themes/pxt/elements/loader.overrides
@@ -3,28 +3,27 @@
 *******************************/
 
 
-.ui.loader:before {
+.ui.loader.main:before, 
+.ui.loader.avatar:before {
    border: none;
    border-radius: 0px;
    box-shadow: none;
 }
 
-.ui.loader:after {
-   border: none;
-   box-shadow: none;
-   border-radius: 0px;
-   margin: 40px auto;
-   background: transparent @loaderImage no-repeat center center;
-   background-size: 100%;
-  -webkit-animation: @loaderAnimation @loaderSpeed infinite linear;
-  animation: @loaderAnimation @loaderSpeed infinite linear;
+.ui.loader.main:after {
+  border: none;
+  box-shadow: none;
+  border-radius: 0px;
+  background: transparent @loaderImage no-repeat center center;
+  background-size: 100%;
+ -webkit-animation: @loaderAnimation @loaderSpeed infinite linear;
+ animation: @loaderAnimation @loaderSpeed infinite linear;
 }
 
 .ui.loader.avatar:after {
    border: none;
    box-shadow: none;
    border-radius: 0px;
-   margin: 40px auto;
    background: transparent @avatarImage no-repeat center center;
    background-size: 100%;
   -webkit-animation: @loaderAnimation @loaderSpeed infinite linear;

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -74,7 +74,7 @@
         @import "/blb/highlight.js/styles/vs.css";
     </style>
     <div id='loading' class="ui active inverted dimmer">
-        <div class="ui large loader"></div>
+        <div class="ui loader"></div>
     </div>
     <div id="content" class="ui container">
         <i class="spinner loading icon"></i>

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -13,7 +13,7 @@
 
 <body class="main">
     <div id='loading' class="ui active dimmer">
-        <div class="ui large loader"></div>
+        <div class="ui large main loader"></div>
     </div>
 
     <div id='custom-content'>

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -63,7 +63,7 @@ export function showLoading(id: string, msg: string) {
     $('.ui.dimmer.loading').dimmer('show');
     $('.ui.dimmer.loading').html(`
   <div class="content loadingcontent">
-    <div class="ui text large loader msg" aria-live="assertive">${lf("Please wait")}</div>
+    <div class="ui text large loader main msg" aria-live="assertive">${lf("Please wait")}</div>
   </div>
 `)
     loadingQueue.push(id);


### PR DESCRIPTION
We don't want to show the big pxt loader for all loader, only the main editor one. 

Everything else can use the spinning wheel, or maybe customize later. 
