### PR TITLE
allow loading scripts from other targets

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -31,6 +31,7 @@ declare namespace pxt {
         id: string; // has to match ^[a-z]+$; used in URLs and domain names
         platformid?: string; // eg "codal"; used when search for gh packages ("for PXT/codal"); defaults to id
         nickname?: string; // friendly id used when generating files, folders, etc... id is used instead if missing
+        aliases?: string[]; // allows to import scripts from other editor with different ids 
         name: string;
         description?: string;
         corepkg: string;

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -863,6 +863,13 @@ int main() {
         source: string;
     }
 
+    export function matchTargetId(data: pxt.cpp.HexFile, id: string): boolean {
+        return data.meta.cloudId == "ks/" + id
+            || data.meta.cloudId == pxt.CLOUD_ID + id
+            // trying to load white-label file into main target
+            || (Util.startsWith(data.meta.cloudId, pxt.CLOUD_ID + id))
+    }
+
     export function unpackSourceFromHexFileAsync(file: File): Promise<HexFile> { // string[] (guid)
         if (!file) return undefined;
 
@@ -989,10 +996,10 @@ namespace pxt.hex {
                                                 resolve(U.httpGetTextAsync(hexurl + ".hex"))
                                             }
                                         },
-                                        e => {
-                                            setTimeout(tryGet, 1000)
-                                            return null
-                                        })
+                                            e => {
+                                                setTimeout(tryGet, 1000)
+                                                return null
+                                            })
                                 }
                                 tryGet();
                             })))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -713,8 +713,8 @@ export class ProjectView
 
     hexFileImporters: pxt.editor.IHexFileImporter[] = [{
         id: "default",
-        canImport: data => data.meta.cloudId == "ks/" + pxt.appTarget.id || data.meta.cloudId == pxt.CLOUD_ID + pxt.appTarget.id // match on targetid
-            || (Util.startsWith(data.meta.cloudId, pxt.CLOUD_ID + pxt.appTarget.id)) // trying to load white-label file into main target
+        canImport: data => pxt.cpp.matchTargetId(data, pxt.appTarget.id)
+            || (pxt.appTarget.aliases && pxt.appTarget.aliases.some(alias => pxt.cpp.matchTargetId(data, alias)))  
         ,
         importAsync: (project, data) => {
             let h: pxt.workspace.InstallHeader = {


### PR DESCRIPTION
Allows to specify additional target ids to load hex files from older targets. Typically this is useful when switching between compatible targets with older ids.