### PR TITLE
Suggest a friendly name replacement macro

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -198,6 +198,7 @@ declare namespace pxt {
         hasReferenceDocs?: boolean; // if true: the monaco editor will add an option in the context menu to load the reference docs
         feedbackUrl?: string; // is set: a feedback link will show in the settings menu
         boardName?: string;
+        boardCommonName?: string; // common nickname to use for the board or product
         driveDisplayName?: string; // name of the drive as it shows in the explorer
         privacyUrl?: string;
         termsOfUseUrl?: string;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -197,8 +197,8 @@ declare namespace pxt {
         sideDoc?: string; // deprecated
         hasReferenceDocs?: boolean; // if true: the monaco editor will add an option in the context menu to load the reference docs
         feedbackUrl?: string; // is set: a feedback link will show in the settings menu
-        boardName?: string;
-        boardCommonName?: string; // common nickname to use for the board or product
+        boardName?: string; // official branded name for the board or product
+        boardNickname?: string; // common nickname to use for the board or product
         driveDisplayName?: string; // name of the drive as it shows in the explorer
         privacyUrl?: string;
         termsOfUseUrl?: string;

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -261,7 +261,7 @@ namespace pxt.docs {
         if (theme.boardName)
             params["boardname"] = html2Quote(theme.boardName);
         if (theme.boardNickname)
-            params["nickname"] = html2Quote(theme.boardNickname);
+            params["boardnickname"] = html2Quote(theme.boardNickname);
         if (theme.driveDisplayName)
             params["drivename"] = html2Quote(theme.driveDisplayName);
         if (theme.homeUrl)

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -260,8 +260,8 @@ namespace pxt.docs {
 
         if (theme.boardName)
             params["boardname"] = html2Quote(theme.boardName);
-        if (theme.boardCommonName)
-            params["nickname"] = html2Quote(theme.boardCommonName);
+        if (theme.boardNickname)
+            params["nickname"] = html2Quote(theme.boardNickname);
         if (theme.driveDisplayName)
             params["drivename"] = html2Quote(theme.driveDisplayName);
         if (theme.homeUrl)

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -260,6 +260,8 @@ namespace pxt.docs {
 
         if (theme.boardName)
             params["boardname"] = html2Quote(theme.boardName);
+        if (theme.boardCommonName)
+            params["nickname"] = html2Quote(theme.boardCommonName);
         if (theme.driveDisplayName)
             params["drivename"] = html2Quote(theme.driveDisplayName);
         if (theme.homeUrl)


### PR DESCRIPTION
In order to have a "friendly" name for a board or product when `@boardname@` is used for strict branding, I suggest something like `@nickname@`. This is declared in appTheme as `boardCommonName`.