### PR TITLE
swapping x/y in image format

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -430,22 +430,28 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
         return outp
     }
 
-    if (mainPkg && mainPkg.getFiles().indexOf(constName) >= 0 &&
-        (force || !fs.existsSync(constName))) {
+    if (mainPkg && (force ||
+        (mainPkg.getFiles().indexOf(constName) >= 0 && !fs.existsSync(constName)))) {
         pxt.log(`rebuilding ${constName}...`)
         let files: string[] = []
+        let foundConfig = false
 
-        if (mainPkg.config.dalDTS) {
-            for (let dn of mainPkg.config.dalDTS.includeDirs) {
-                dn = buildEngine.buildPath + "/" + dn
-                if (U.endsWith(dn, ".h")) files.push(dn)
-                else {
-                    let here = nodeutil.allFiles(dn, 20).filter(fn => U.endsWith(fn, ".h"))
-                    U.pushRange(files, here)
+        for (let d of mainPkg.sortedDeps()) {
+            if (d.config.dalDTS) {
+                for (let dn of d.config.dalDTS.includeDirs) {
+                    dn = buildEngine.buildPath + "/" + dn
+                    if (U.endsWith(dn, ".h")) files.push(dn)
+                    else {
+                        let here = nodeutil.allFiles(dn, 20).filter(fn => U.endsWith(fn, ".h"))
+                        U.pushRange(files, here)
+                    }
                 }
+                excludeSyms = d.config.dalDTS.excludePrefix || excludeSyms
+                foundConfig = true
             }
-            excludeSyms = mainPkg.config.dalDTS.excludePrefix || excludeSyms
-        } else {
+        }
+
+        if (!foundConfig) {
             let incPath = buildEngine.buildPath + "/yotta_modules/microbit-dal/inc/"
             if (!fs.existsSync(incPath))
                 incPath = buildEngine.buildPath + "/yotta_modules/codal/inc/";

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3579,6 +3579,12 @@ function gdbAsync(c: commandParser.ParsedCommand) {
         .then(() => gdb.startAsync(c.arguments))
 }
 
+function buildDalDTSAsync() {
+    ensurePkgDir()
+    return mainPkg.loadAsync()
+        .then(() => build.buildDalConst(build.thisBuild, mainPkg, true))
+}
+
 function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult> {
     let compileOptions: pxtc.CompileOptions;
     let compileResult: pxtc.CompileResult;
@@ -5076,6 +5082,12 @@ function initCommands() {
         anyArgs: true,
         advanced: true
     }, gdbAsync);
+
+    p.defineCommand({
+        name: "builddaldts",
+        help: "build dal.d.ts in current directory (might need to move)",
+        advanced: true
+    }, buildDalDTSAsync);
 
     p.defineCommand({
         name: "pokerepo",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4053,61 +4053,9 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
                     key = basename
                 }
 
-                let data = ""
-
-                if (bpp == 4) {
-                    let byteW = (img.width + 1) >> 1
-                    let outBuf = new Buffer(3 + byteW * img.height)
-                    outBuf.fill(0)
-                    outBuf[0] = 0xf4
-                    outBuf[1] = img.width
-                    outBuf[2] = img.height
-                    let outP = 3
-                    let lineP = 0
-                    for (let inP = 0; inP < img.data.length; inP += 4) {
-                        if (lineP >= img.width) {
-                            if (lineP & 1)
-                                outP++
-                            lineP = 0
-                        }
-                        let idx = closestColor(img.data, inP)
-                        if (lineP & 1) {
-                            outBuf[outP++] |= idx
-                        } else {
-                            outBuf[outP] |= (idx << 4)
-                        }
-                        lineP++
-                    }
-                    data = outBuf.toString(star.dataEncoding)
-                } else if (bpp == 1) {
-                    let byteW = (img.width + 7) >> 3
-                    let outBuf = new Buffer(3 + byteW * img.height)
-                    outBuf.fill(0)
-                    outBuf[0] = 0xf1
-                    outBuf[1] = img.width
-                    outBuf[2] = img.height
-                    let outP = 3
-                    let mask = 0x80
-                    let lineP = 0
-                    for (let inP = 0; inP < img.data.length; inP += 4) {
-                        if (lineP >= img.width) {
-                            if (mask != 0x80)
-                                outP++
-                            mask = 0x80
-                            lineP = 0
-                        }
-                        let idx = closestColor(img.data, inP)
-                        if (idx)
-                            outBuf[outP] |= mask
-                        mask >>= 1
-                        if (mask == 0) {
-                            mask = 0x80
-                            outP++
-                        }
-                        lineP++
-                    }
-                    data = outBuf.toString(star.dataEncoding)
-                }
+                let hex = pxtc.f4EncodeImg(img.width, img.height, bpp, (x, y) =>
+                    closestColor(img.data, 4 * (x + y * img.width)))
+                let data = new Buffer(hex, "hex").toString(star.dataEncoding)
 
                 let storeIcon = false
 

--- a/docs/simshim.md
+++ b/docs/simshim.md
@@ -231,7 +231,8 @@ namespace userconfig {
 
 Both of these refer to constants from the `DAL` namespace. There is typically one
 `dal.d.ts` file per target which defines the `DAL` namespace, and it is generated 
-automatically from the C++ sources.
+automatically from the C++ sources. Once all the C++ files are in place, and you
+want to force re-generation of `dal.d.ts` use `pxt builddaldts` command.
 
 For every constant `FOO` in `config` (or `userconfig`), there has to be a corresponding
 `DAL.CFG_FOO` which defines an index under which the configuration setting is stored.

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -123,16 +123,16 @@ namespace pxt.blocks {
             let outP = bmpHeaderSize
 
             if (magic == 0xe1) {
-                let mask = 0x80
+                let mask = 0x01
                 let v = data.charCodeAt(inP++)
                 for (let x = 0; x < w; ++x) {
                     outP = bmpHeaderSize + x
                     for (let y = 0; y < h; ++y) {
                         bmp[outP] = (v & mask) ? 1 : 0
                         outP += outByteW
-                        mask >>= 1
-                        if (mask == 0) {
-                            mask = 0x80
+                        mask <<= 1
+                        if (mask == 0x100) {
+                            mask = 0x01
                             v = data.charCodeAt(inP++)
                         }
                     }
@@ -142,10 +142,10 @@ namespace pxt.blocks {
                     outP = bmpHeaderSize + x
                     for (let y = 0; y < h; y += 2) {
                         let v = data.charCodeAt(inP++)
-                        bmp[outP] = (v >> 4) & 0xf
+                        bmp[outP] = v & 0xf
                         outP += outByteW
                         if (y != h - 1) {
-                            bmp[outP] = v & 0xf
+                            bmp[outP] = (v >> 4) & 0xf
                             outP += outByteW
                         }
                     }

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -104,7 +104,7 @@ ${lbl}: .string ${asmStringLiteral(s)}
         hex_literal(lbl: string, data: string) {
             return `
 .balign 4
-${lbl}: .short 0xffff, ${target.taggedInts ? pxt.REF_TAG_BUFFER + "," : ""} ${data.length >> 1}
+${lbl}: .short 0xffff, ${target.taggedInts ? pxt.REF_TAG_BUFFER + "," : ""} ${data.length >> 1}${target.taggedInts ? ", 0x0000" : ""}
         .hex ${data}${data.length % 4 == 0 ? "" : "00"}
 `
         }

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2514,50 +2514,15 @@ ${lbl}: .short 0xffff
                     }
                 }
 
-                // even-out
-                for (let l of matrix)
-                    while (l.length < maxLen)
-                        l.push(0)
-
-                let r = ""
-
+                let bpp = 8
                 if (attrs.groups.length <= 2) {
-                    r = "f1" + hex2(maxLen) + hex2(matrix.length)
-                    for (let l of matrix) {
-                        let mask = 0x80
-                        let v = 0
-                        for (let n of l) {
-                            if (mask == 0) {
-                                r += hex2(v)
-                                mask = 0x80
-                                v = 0
-                            }
-                            if (n) v |= mask
-                            mask >>= 1
-                        }
-                        r += hex2(v)
-                    }
+                    bpp = 1
                 } else if (attrs.groups.length <= 16) {
-                    r = "f4" + hex2(maxLen) + hex2(matrix.length)
-                    for (let l of matrix) {
-                        for (let n of l)
-                            r += n.toString(16)
-                        if (r.length & 1)
-                            r += "0"
-                    }
-                } else {
-                    r = "f8" + hex2(maxLen) + hex2(matrix.length)
-                    for (let l of matrix)
-                        for (let n of l)
-                            r += hex2(n)
+                    bpp = 4
                 }
-
-                return r
-
-                function hex2(n: number) {
-                    return ("0" + n.toString(16)).slice(-2)
-                }
+                return f4EncodeImg(maxLen, matrix.length, bpp, (x, y) => matrix[y][x] || 0)
             }
+
             function parseHexLiteral(s: string) {
                 let thisJres = currJres
                 if (s[0] == '_' && s[1] == '_' && opts.jres[s]) {

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -829,17 +829,17 @@ __flash_checksums:
         let r = hex2(0xe0 | bpp) + hex2(w) + hex2(h) + "00"
         let ptr = 4
         let curr = 0
-        let shift = 8 - bpp
+        let shift = 0
 
         let pushBits = (n: number) => {
             curr |= n << shift
-            if (shift == 0) {
+            if (shift == 8 - bpp) {
                 r += hex2(curr)
                 ptr++
                 curr = 0
-                shift = 8 - bpp
+                shift = 0
             } else {
-                shift -= bpp
+                shift += bpp
             }
         }
 
@@ -847,7 +847,7 @@ __flash_checksums:
             for (let j = 0; j < h; ++j)
                 pushBits(getPix(i, j))
             if (bpp == 1) {
-                while (shift != 7)
+                while (shift != 0)
                     pushBits(0)
             } else {
                 while (ptr & 3)

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -824,4 +824,42 @@ __flash_checksums:
     }
 
     export let validateShim = hex.validateShim;
+
+    export function f4EncodeImg(w: number, h: number, bpp: number, getPix: (x: number, y: number) => number) {
+        let r = hex2(0xe0 | bpp) + hex2(w) + hex2(h) + "00"
+        let ptr = 4
+        let curr = 0
+        let shift = 8 - bpp
+
+        let pushBits = (n: number) => {
+            curr |= n << shift
+            if (shift == 0) {
+                r += hex2(curr)
+                ptr++
+                curr = 0
+                shift = 8 - bpp
+            } else {
+                shift -= bpp
+            }
+        }
+
+        for (let i = 0; i < w; ++i) {
+            for (let j = 0; j < h; ++j)
+                pushBits(getPix(i, j))
+            if (bpp == 1) {
+                while (shift != 7)
+                    pushBits(0)
+            } else {
+                while (ptr & 3)
+                    pushBits(0)
+            }
+        }
+
+        return r
+
+        function hex2(n: number) {
+            return ("0" + n.toString(16)).slice(-2)
+        }
+
+    }
 }


### PR DESCRIPTION
* the `shim=@f4` annotation for images now uses column-major, little endian order, used by most screens, improving performance
* image encoding refactored and simplified
* the data in `BoxedBuffer` is now word-aligned for better performance
* add `pxt builddatdts` to force rebuild of dal.d.ts

This needs to be synchronized with a PR in common packages: https://github.com/Microsoft/pxt-common-packages/pull/288