### PR TITLE
Only load AI when cookie consent given

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -110,7 +110,14 @@ namespace pxt {
             }
 
             all(info.Js || [], injectScriptAsync, msccError => {
-                initializeAppInsights(!msccError && typeof mscc !== "undefined" && mscc.hasConsent());
+                if (!msccError && typeof mscc !== "undefined") {
+                    if (mscc.hasConsent()) {
+                        initializeAppInsights(true)
+                    }
+                    else {
+                        mscc.on("consent", () => initializeAppInsights(true));
+                    }
+                }
             });
         });
     }


### PR DESCRIPTION
There are two cases where AI can still be loaded without the cookie:

1. There is an error when trying to contact our backend to get the mscc payload
2. The editor is in sandbox mode

Otherwise, we will only load AI if cookie consent is given. This affects all pages; not just the editor. For docs you will either have to have already given consent (i.e. in the editor) or click a link since those are the only interactive elements on those pages.

