### PR TITLE
"pxt testghpkgs"

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4890,7 +4890,7 @@ function testGithubPackagesAsync(c?: commandParser.ParsedCommand): Promise<void>
     function pxtAsync(dir: string, ...args: string[]) {
         return nodeutil.spawnAsync({
             cmd: "node",
-            args: [path.join(process.cwd(), "node_modules/pxt-core/built/cli.js")].concat(args),
+            args: [path.join(process.cwd(), "node_modules/pxt-core/pxt-cli/cli.js")].concat(args),
             cwd: dir
         })
     }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4906,7 +4906,7 @@ function testGithubPackagesAsync(c?: commandParser.ParsedCommand): Promise<void>
         pxt.log(`  ${pkgpgh}`)
         // clone or sync package
         const pkgdir = path.join(pkgsroot, pkgpgh);
-        return gitAsync(".", "clone", "-b", repos[pkgpgh].tag, `https://github.com/${pkgpgh}`, pkgdir)
+        return gitAsync(".", "clone", "-q", "-b", repos[pkgpgh].tag, `https://github.com/${pkgpgh}`, pkgdir)
             .then(() => pxtAsync(pkgdir, "install"))
             .then(() => pxtAsync(pkgdir, "build"))
             .catch(e => {


### PR DESCRIPTION
Automates the process of search, clone, building approved packages

```
$ pxt testghpkgs
Using target adafruit with build engine codal
  target: v1.1.7 C:\gh\pxt-adafruit
  pxt-core: v3.10.4 C:\gh\pxt
testing github packages
microsoft/pxt-gestures#v0.0.2
microsoft/pxt-neoanim#v0.4.1
found 2 packages
  microsoft/pxt-neoanim
[run] git clone -q -b v0.4.1 https://github.com/microsoft/pxt-neoanim built\ghpkgs\microsoft\pxt-neoanim
Note: checking out '2b045dd3bd1c042802b5c6b2f88677a2b4b73dc9'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

[run] cd built\ghpkgs\microsoft\pxt-neoanim; node C:\gh\pxt-adafruit\node_modules\pxt-core\pxt-cli\cli.js install
Using target adafruit with build engine codal
  target: v1.1.7 C:\gh\pxt-adafruit
  pxt-core: v3.10.4 C:\gh\pxt
skipping download of local pkg: file:.
[run] cd built\ghpkgs\microsoft\pxt-neoanim; node C:\gh\pxt-adafruit\node_modules\pxt-core\pxt-cli\cli.js build
Using target adafruit with build engine codal
  target: v1.1.7 C:\gh\pxt-adafruit
  pxt-core: v3.10.4 C:\gh\pxt
Package built; written to binary.uf2; size: 277848
  microsoft/pxt-gestures
[run] git clone -q -b v0.0.2 https://github.com/microsoft/pxt-gestures built\ghpkgs\microsoft\pxt-gestures
Note: checking out '7326b0a3c460d4c0b25346a4f4c4d9ff3a2f72e1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

[run] cd built\ghpkgs\microsoft\pxt-gestures; node C:\gh\pxt-adafruit\node_modules\pxt-core\pxt-cli\cli.js install
Using target adafruit with build engine codal
  target: v1.1.7 C:\gh\pxt-adafruit
  pxt-core: v3.10.4 C:\gh\pxt
skipping download of local pkg: file:.
[run] cd built\ghpkgs\microsoft\pxt-gestures; node C:\gh\pxt-adafruit\node_modules\pxt-core\pxt-cli\cli.js build
Using target adafruit with build engine codal
  target: v1.1.7 C:\gh\pxt-adafruit
  pxt-core: v3.10.4 C:\gh\pxt
Package built; written to binary.uf2; size: 249176
------------------------
0 packages with errors
```