### PR TITLE
display version in home screen

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -206,6 +206,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 {targetTheme.selectLanguage ? <sui.Link class="item focused" text={lf("Language")} onClick={() => selectLang()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 {targetTheme.termsOfUseUrl ? <a target="_blank" className="item focused" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use")}</a> : undefined}
                 {targetTheme.privacyUrl ? <a target="_blank" className="item focused" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy")}</a> : undefined}
+                {pxt.appTarget.versions ? <span className="item focused">v{pxt.appTarget.versions.target}</span> : undefined}
             </div> : undefined}
         </div>;
     }


### PR DESCRIPTION
Display version in bottom of home screen. Too annoying to check the about dialog for that one.
![image](https://user-images.githubusercontent.com/4175913/38902322-f213b9ec-4254-11e8-9223-b68f2d929f2a.png)
