### PR TITLE
Adding a decompiler flag for fixed instance parameters

### DIFF
--- a/tests/decompile-test/baselines/tagged_template_fixed_instance.blocks
+++ b/tests/decompile-test/baselines/tagged_template_fixed_instance.blocks
@@ -1,0 +1,14 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="shadow_fixed_template">
+<value name="img">
+<shadow type="fixshim">
+<field name="f">1234</field>
+</shadow>
+</value>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;templateStrings.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/tagged_template_fixed_instance.ts
+++ b/tests/decompile-test/cases/tagged_template_fixed_instance.ts
@@ -1,0 +1,2 @@
+/// <reference path="./testBlocks/templateStrings.ts" />
+template.fixedInstanceArg(fix`1234`);

--- a/tests/decompile-test/cases/testBlocks/templateStrings.ts
+++ b/tests/decompile-test/cases/testBlocks/templateStrings.ts
@@ -6,6 +6,11 @@ declare interface Image {
     get(x: number, y: number): number;
 }
 
+//% fixedInstances
+declare interface Fixed {
+    whatever(): void;
+}
+
 //% shim=@f4 helper=image::ofBuffer
 //% groups=["0.","1#","2T","3t","4N","5n","6G","7g","8","9","aAR","bBP","cCp","dDO","eEY","fFW"]
 function img(lits: any, ...args: any[]): Image { return null }
@@ -17,6 +22,10 @@ function badt(lits: any, ...args: any[]): Image { return null }
 //% shim=@f4 helper=image::ofBuffer blockIdentity="template.imageEditor"
 //% groups=["0.","1#","2T","3t","4N","5n","6G","7g","8","9","aAR","bBP","cCp","dDO","eEY","fFW"]
 function withID(lits: any, ...args: any[]): Image { return null }
+
+//% shim=@f4 helper=image::ofBuffer blockIdentity="template.fixShim"
+//% groups=["0.","1#","2T","3t","4N","5n","6G","7g","8","9","aAR","bBP","cCp","dDO","eEY","fFW"]
+function fix(lits: any, ...args: any[]): Fixed { return null }
 
 namespace template {
 
@@ -57,6 +66,23 @@ namespace template {
      */
     //% blockId=shadow_template block="%img=imageeditor"
     export function shadowBlockTemplate(img: Image): void {
+
+    }
+
+    /**
+     * Image editor...
+     * @param img the iamge
+     */
+    //% blockId=fixshim block="%img" shim=TD_ID
+    //% img.fieldEditor="gridpicker"
+    //% img.fieldOptions.taggedTemplate="fix"
+    //% img.fieldOptions.decompileIndirectFixedInstances="true"
+    export function fixShim(f: Fixed): Fixed {
+        return f;
+    }
+
+    //% blockId=shadow_fixed_template block="%img=fixshim"
+    export function fixedInstanceArg(fix: Fixed): void {
 
     }
 }

--- a/tests/decompile-test/decompilerunner.ts
+++ b/tests/decompile-test/decompilerunner.ts
@@ -85,15 +85,18 @@ function decompileTestAsync(filename: string) {
             baselineExists = false
         }
 
-        if (!baselineExists) {
-            return reject("Baseline does not exist for " + basename);
-        }
-
         return decompileAsyncWorker(filename, testBlocksDir)
             .then(decompiled => {
+                const outFile = path.join(replaceFileExtension(filename, ".local.blocks"));
+
+                if (!baselineExists) {
+                    fs.writeFileSync(outFile, decompiled)
+                    fail(`no baseline found for ${basename}, output written to ${outFile}`);
+                    return;
+                }
+
                 const baseline = fs.readFileSync(baselineFile, "utf8")
                 if (!compareBaselines(decompiled, baseline)) {
-                    const outFile = path.join(replaceFileExtension(filename, ".local.blocks"))
                     fs.writeFileSync(outFile, decompiled)
                     fail(`${basename} did not match baseline, output written to ${outFile}`);
                 }


### PR DESCRIPTION
Fixes a bug where the `Image` type could not be passed as a parameter to an API unless the thing being passed is declared as a fixed instance. This lets shim APIs declare that they can take indirect references to fixed instances as parameters.