### PR TITLE
Updating some variable fields to use the new Blockly APIs

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1196,7 +1196,8 @@ namespace pxt.blocks {
             let handlerArgs: string[] = []; // = stdfun.handlerArgs.map(arg => escapeVarName(b.getFieldValue("HANDLER_" + arg.name), e));
             for (let i = 0; i < stdfun.comp.handlerArgs.length; i++) {
                 const arg = stdfun.comp.handlerArgs[i];
-                const varName = b.getFieldValue("HANDLER_" + arg.name);
+                const varField = b.getField("HANDLER_" + arg.name);
+                const varName = varField && varField.getText();
                 if (varName !== null) {
                     handlerArgs.push(escapeVarName(varName, e));
                 }
@@ -1469,7 +1470,8 @@ namespace pxt.blocks {
                 let foundIt = false;
                 stdFunc.comp.handlerArgs.forEach(arg => {
                     if (foundIt) return;
-                    let varName = b.getFieldValue("HANDLER_" + arg.name);
+                    const varField = b.getField("HANDLER_" + arg.name);
+                    let varName = varField && varField.getText();
                     if (varName != null && escapeVarName(varName, e) === name) {
                         foundIt = true;
                     }
@@ -1517,7 +1519,8 @@ namespace pxt.blocks {
             let stdFunc = e.stdCallTable[b.type];
             if (stdFunc && stdFunc.comp.handlerArgs.length) {
                 stdFunc.comp.handlerArgs.forEach(arg => {
-                    let varName = b.getFieldValue("HANDLER_" + arg.name)
+                    const varField = b.getField("HANDLER_" + arg.name)
+                    let varName = varField && varField.getText();
                     if (varName != null) {
                         trackLocalDeclaration(escapeVarName(varName, e), arg.type);
                     }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1999,7 +1999,7 @@ namespace pxt.blocks {
                     controlsSimpleForId,
                     controlsSimpleForDef.name,
                     function () {
-                        return U.rlf(<string>controlsSimpleForDef.tooltip, thisBlock.getFieldValue('VAR'));
+                        return U.rlf(<string>controlsSimpleForDef.tooltip, thisBlock.getField('VAR').getText());
                     },
                     controlsSimpleForDef.url,
                     String(pxt.toolbox.getNamespaceColor('loops'))
@@ -2011,7 +2011,7 @@ namespace pxt.blocks {
              * @this Blockly.Block
              */
             getVars: function (): any[] {
-                return [this.getFieldValue('VAR')];
+                return [this.getField('VAR').getText()];
             },
             /**
              * Notification that a variable is renaming.
@@ -2021,8 +2021,10 @@ namespace pxt.blocks {
              * @this Blockly.Block
              */
             renameVar: function (oldName: string, newName: string) {
-                if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
-                    this.setFieldValue(newName, 'VAR');
+                const varField = this.getField('VAR');
+                if (Blockly.Names.equals(oldName, varField.getText())) {
+
+                    varField.setText(newName);
                 }
             },
             /**
@@ -2033,7 +2035,7 @@ namespace pxt.blocks {
             customContextMenu: function (options: any[]) {
                 if (!this.isCollapsed()) {
                     let option: any = { enabled: true };
-                    let name = this.getFieldValue('VAR');
+                    let name = this.getField('VAR').getText();
                     option.text = lf("Create 'get {0}'", name);
                     let xmlField = goog.dom.createDom('field', null, name);
                     xmlField.setAttribute('name', 'VAR');
@@ -2550,7 +2552,7 @@ namespace pxt.blocks {
                     controlsForOfId,
                     controlsForOfDef.name,
                     function () {
-                        return U.rlf(<string>controlsForOfDef.tooltip, thisBlock.getFieldValue('VAR'));
+                        return U.rlf(<string>controlsForOfDef.tooltip, thisBlock.getField('VAR').getText());
                     },
                     controlsForOfDef.url,
                     String(pxt.toolbox.getNamespaceColor('loops'))
@@ -3506,6 +3508,32 @@ namespace pxt.blocks {
         }
 
         return str;
+    }
+
+    /**
+     * Blockly variable fields can't be set directly; you either have to use the
+     * variable ID or set the value of the model and not the field
+     */
+    export function setVarFieldValue(block: Blockly.Block, fieldName: string, newName: string) {
+        const varField = block.getField(fieldName);
+
+        // Check for an existing model with this name; otherwise we'll create
+        // a second variable with the same name and it will show up twice in the UI
+        const vars = block.workspace.getAllVariables();
+        let foundIt = false;
+        if (vars && vars.length) {
+            for (let v = 0; v < vars.length; v++) {
+                const model = vars[v];
+                if (model.name === newName) {
+                    varField.setValue(model.getId());
+                    foundIt = true;
+                }
+            }
+        }
+        if (!foundIt) {
+            (varField as any).initModel();
+            (varField as any).getVariable().name = newName;
+        }
     }
 
     function shouldUseBlockInSearch(blockId: string, namespaceId: string, filters: BlockFilters): boolean {

--- a/pxtblocks/blocklymutators.ts
+++ b/pxtblocks/blocklymutators.ts
@@ -273,7 +273,8 @@ namespace pxt.blocks {
             }
 
             const declarationString =  this.parameters.map(param => {
-                const declaredName = this.block.getFieldValue(param);
+                const varField = this.block.getField(param);
+                const declaredName = varField && varField.getText();
                 const escapedParam = escapeVarName(param, e);
                 if (declaredName !== param) {
                     this.parameterRenames[param] = declaredName;
@@ -296,21 +297,21 @@ namespace pxt.blocks {
             const result: pxt.Map<string> = {};
 
             this.parameters.forEach(param => {
-                result[this.block.getFieldValue(param)] = this.parameterTypes[param];
+                result[this.getVarFieldValue(param)] = this.parameterTypes[param];
             });
 
             return result;
         }
 
         public isDeclaredByMutation(varName: string): boolean {
-            return this.parameters.some(param => this.block.getFieldValue(param) === varName)
+            return this.parameters.some(param => this.getVarFieldValue(param) === varName)
         }
 
         public mutationToDom(): Element {
             // Save the parameters that are currently visible to the DOM along with their names
             const mutation = document.createElement("mutation");
             const attr = this.parameters.map(param => {
-                const varName = this.block.getFieldValue(param);
+                const varName = this.getVarFieldValue(param);
                 if (varName !== param) {
                     this.parameterRenames[param] = Util.htmlEscape(varName);
                 }
@@ -376,7 +377,19 @@ namespace pxt.blocks {
                 this.updateVisibleProperties();
 
                 // Override any names that the user has changed
-                properties.filter(p => !!p.newName).forEach(p => this.block.setFieldValue(p.newName, p.property));
+                properties.filter(p => !!p.newName).forEach(p => this.setVarFieldValue(p.property, p.newName));
+            }
+        }
+
+        protected getVarFieldValue(fieldName: string): string {
+            const varField = this.block.getField(fieldName);
+            return varField && varField.getText();
+        }
+
+        protected setVarFieldValue(fieldName: string, newValue: string) {
+            const varField = this.block.getField(fieldName);
+            if (this.block.getField(fieldName)) {
+                setVarFieldValue(this.block, fieldName, newValue);
             }
         }
 
@@ -428,7 +441,7 @@ namespace pxt.blocks {
 
             this.currentlyVisible.forEach(param => {
                 if (this.parameters.indexOf(param) === -1) {
-                    const name = this.block.getFieldValue(param);
+                    const name = this.getVarFieldValue(param);
 
                     // Persist renames
                     if (name !== param) {

--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -69,7 +69,8 @@ namespace pxt.blocks {
                 el.setAttribute("numArgs", currentlyVisible.toString());
 
                 for (let j = 0; j < currentlyVisible; j++) {
-                    let varName = b.getFieldValue("HANDLER_" + handlerArgs[j].name);
+                    const varField = b.getField("HANDLER_" + handlerArgs[j].name);
+                    let varName = varField && varField.getText();
                     el.setAttribute("arg" + j, varName);
                 }
 
@@ -82,8 +83,11 @@ namespace pxt.blocks {
                 updateShape();
 
                 for (let j = 0; j < currentlyVisible; j++) {
-                    let varName = saved.getAttribute("arg" + j);
-                    b.setFieldValue(varName, "HANDLER_" + handlerArgs[j].name);
+                    const varName = saved.getAttribute("arg" + j);
+                    const fieldName = "HANDLER_" + handlerArgs[j].name;
+                    if (b.getField(fieldName)) {
+                        setVarFieldValue(b, fieldName, varName);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Blockly had a breaking change to their API that was introduced in the comments update. There were a few places where we were still using the old API so this corrects that.

This fixes the Minecraft chat blocks and the event handlers in arcade. Also fixes the tooltip and context menu options of the for-loop block.