### PR TITLE
Fix debugger move computation

### DIFF
--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -20,7 +20,7 @@ The MakeCode approach to solve this issue is to render the **JavaScript** code s
 
 Here are sample of integration for various documentation/blogging engines.
 
-* [GitBook plugin](https://www.npmjs.com/package/gitbook-plugin-pxt)
+* [GitBook plugin](https://microsoft.github.io/pxt-gitbook-sample/)
 * [MkDocs plugin](https://microsoft.github.io/pxt-mkdocs-sample/)
 
 ## Manual Implementation [try this fiddle](https://jsfiddle.net/ndyz1d57/1/)

--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -20,7 +20,7 @@ The MakeCode approach to solve this issue is to render the **JavaScript** code s
 
 Here are sample of integration for various documentation/blogging engines.
 
-* [GitBook plugin](https://microsoft.github.io/pxt-gitbook-sample/)
+* [GitBook plugin](https://plugins.gitbook.com/plugin/pxt)
 * [MkDocs plugin](https://microsoft.github.io/pxt-mkdocs-sample/)
 
 ## Manual Implementation [try this fiddle](https://jsfiddle.net/ndyz1d57/1/)

--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -12,13 +12,18 @@ A quick solution is take screenshots of the snippets but things can quickly beco
 * screenshots cannot be reloaded easily into the editor
 * screenshots don't play well with source control system - you cannot diff changes efficiently.
 
-If you're looking for a better solution, carry on reading.
-
 ## Rendering blocks on the spot
 
-The MakeCode approach to solve this issue is to render the code snippets on the client using the same block rendering engine as the editor. The idea is to load an IFrame from the MakeCode editor that will render the blocks for you.
+The MakeCode approach to solve this issue is to render the **JavaScript** code snippets on the client using the same block rendering engine as the editor. Under the hood, an IFrame from the MakeCode editor will render the blocks for you.
 
-## Implementation [try this fiddle](https://jsfiddle.net/ndyz1d57/1/)
+## Plugins
+
+Here are sample of integration for various documentation/blogging engines.
+
+* [GitBook plugin](https://www.npmjs.com/package/gitbook-plugin-pxt)
+* [MkDocs plugin](https://microsoft.github.io/pxt-mkdocs-sample/)
+
+## Manual Implementation [try this fiddle](https://jsfiddle.net/ndyz1d57/1/)
 
 The first part is to register a message handler that will communicate with the rendering ``IFrame``.
 The renderer sends a ``renderready`` message when it is loaded and ready to receive messages.

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -92,8 +92,30 @@ namespace pxsim {
         private setState(state: SimulatorState) {
             if (this.state != state) {
                 this.state = state;
+                this.freeze(this.state == SimulatorState.Paused); // don't allow interaction when pause
                 if (this.options.onStateChanged)
                     this.options.onStateChanged(this.state);
+            }
+        }
+
+        private freeze(value: boolean) {
+            const cls = "pause-overlay";
+            if (!value) {
+                this.container.querySelectorAll(`div.simframe div.${cls}`)
+                    .forEach(overlay => overlay.parentElement.removeChild(overlay));
+            } else {
+                this.container.querySelectorAll("div.simframe")
+                    .forEach(frame => {
+                        if (frame.querySelector(`div.${cls}`))
+                            return;
+                        const div = document.createElement("div");
+                        div.className = cls;
+                        div.onclick = (ev) => {
+                            ev.preventDefault();
+                            return false;
+                        };
+                        frame.appendChild(div);
+                    })
             }
         }
 
@@ -296,7 +318,7 @@ namespace pxsim {
                             this.options.revealElement(frame);
                     }
                     break;
-                case 'simulator':  this.handleSimulatorCommand(msg as pxsim.SimulatorCommandMessage); break; //handled elsewhere
+                case 'simulator': this.handleSimulatorCommand(msg as pxsim.SimulatorCommandMessage); break; //handled elsewhere
                 case 'serial': break; //handled elsewhere
                 case 'pxteditor':
                 case 'custom':
@@ -350,7 +372,7 @@ namespace pxsim {
                     return;
             }
 
-            this.postMessage({type: 'debugger', subtype: msg } as pxsim.DebuggerMessage)
+            this.postMessage({ type: 'debugger', subtype: msg } as pxsim.DebuggerMessage)
         }
 
         public setBreakpoints(breakPoints: number[]) {

--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -74,6 +74,17 @@
 .ui.segment.debugvariables.frozen {
     background: #eee;
 }
+/* sim overlay */
+div.simframe div.pause-overlay {
+    background:black;
+    opacity: 0.01;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    z-index: 100;    
+}
 
 /* Old debugger view */
 #root .debuggerview h4 {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -663,11 +663,13 @@ export class Editor extends srceditor.Editor {
                 // don't center if block is still on the screen
                 const marginx = 4;
                 const marginy = 4;
-                if (p.x * s < marginx
-                    || (p.x + c.width) * s > m.viewWidth - marginx
-                    || p.y * s < marginy
-                    || (p.y + c.height) * s > m.viewHeight - marginy)
+                if (p.x * s < m.viewLeft + marginx
+                    || (p.x + c.width) * s > m.viewLeft + m.viewWidth - marginx
+                    || p.y * s < m.viewTop + marginy
+                    || (p.y + c.height) * s > m.viewTop + m.viewHeight - marginy) {
+                    // move the block towards the center
                     this.editor.centerOnBlock(bid);
+                }
                 return true;
             }
         } else {

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -96,6 +96,8 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                     variables[k].value : undefined
             }
         })
+        if (frozen)
+            Object.keys(variables).forEach(k => delete variables[k].prevValue);
         this.setState({ variables: variables, frozen });
         this.nextVariables = {};
     }

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -263,7 +263,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
                 <div className={`ui compact borderless menu icon mini`}>
                     <div className={`ui item link dbg-btn dbg-handle`} key={'toolbarhandle'}
                         onMouseDown={this.toolbarHandleDown.bind(this)}>
-                        <sui.Icon key='iconkey' icon={`icon ellipsis vertical`} />
+                        <sui.Icon key='iconkey' icon={`xicon bug`} />
                     </div>
                     <sui.Item key='dbgpauseresume' class={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "step forward green"}`} title={dbgPauseResumeTooltip} onClick={() => this.dbgPauseResume()} />
                     {!advancedDebugging ? <sui.Item key='dbgstep' class={`dbg-btn dbg-step`} icon={`arrow right ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={() => this.dbgStepInto()} /> : undefined}


### PR DESCRIPTION
- [x] move block correctly
- [x] add overlay on top of simulator when paused. When the debugger is paused, it is very tempting to interact with the simulator... But the buttons are not quite paused which generate events and ... assert.