### PR TITLE
don't expand full script urls

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -346,6 +346,9 @@ namespace pxt.BrowserUtils {
     }
 
     function resolveCdnUrl(path: string): string {
+        // don't expand full urls
+        if (/^https?:\/\//i.test(path))
+            return path;
         const monacoPaths: Map<string> = (window as any).MonacoPaths || {};
         const url = monacoPaths[path] || (pxt.webConfig.commitCdnUrl + path);
         return url;


### PR DESCRIPTION
This is another cross-version interaction with docs.js. pxt.BrowserUtils.loadScriptAsync does expand url. It should not expanded pre-expanded urls (isomorphic).