### PR TITLE
Fix double newline emit for property change/set statements.

### DIFF
--- a/cli/pyconv.ts
+++ b/cli/pyconv.ts
@@ -1848,7 +1848,7 @@ function stmt(e: py.Stmt): B.JsNode {
         currErrs = ""
     }
     if (cmts.length) {
-        r = B.mkGroup(cmts.map(c => B.H.mkComment(c)).concat(r))
+        r = B.mkGroup(cmts.map(c => B.mkStmt(B.H.mkComment(c))).concat(r))
     }
     return r
 }

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1108,13 +1108,9 @@ namespace pxt.blocks {
         } else if (func.f == "@get@") {
             return H.mkPropertyAccess(args[1].op.replace(/.*\./, ""), args[0]);
         } else if (func.f == "@set@") {
-            return H.mkAssign(
-                H.mkPropertyAccess(args[1].op.replace(/.*\./, "").replace(/@set/, ""), args[0]),
-                args[2]);
+            return H.mkAssign(H.mkPropertyAccess(args[1].op.replace(/.*\./, "").replace(/@set/, ""), args[0]), args[2]);
         } else if (func.f == "@change@") {
-            return mkStmt(H.mkSimpleCall("+=", [
-                H.mkPropertyAccess(args[1].op.replace(/.*\./, "").replace(/@set/, ""), args[0]),
-                args[2]]))
+            return H.mkSimpleCall("+=", [H.mkPropertyAccess(args[1].op.replace(/.*\./, "").replace(/@set/, ""), args[0]), args[2]])
         } else if (func.isExtensionMethod) {
             if (func.attrs.defaultInstance) {
                 let instance: JsNode;

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -180,7 +180,7 @@ namespace pxt.blocks {
         }
 
         export function mkComment(text: string) {
-            return mkStmt(mkText("// " + text))
+            return mkText("// " + text)
         }
 
         export function mkMultiComment(text: string) {
@@ -206,7 +206,7 @@ namespace pxt.blocks {
         }
 
         export function mkAssign(x: JsNode, e: JsNode): JsNode {
-            return mkStmt(mkSimpleCall("=", [x, e]))
+            return mkSimpleCall("=", [x, e])
         }
 
         export function mkParenthesizedExpression(expression: JsNode): JsNode {


### PR DESCRIPTION
See issue https://github.com/Microsoft/pxt/issues/4179.

The JsNode output for property value change statements will always have a double newline trailer as JsNode `mkStmt()` is called twice, once within the change/set node constructions, and once upon return from the Blockly compiler `compileStdCall()`.

The only time this is not the case is when `compileStdCall() `is called as part of an expression and in that context property change/set statements aren't valid anyway.

Also moved out `mkStmt()` from `mkComment().` to make the JSNode helpers consistent. It is up to the clients to make statements as appropriate given their emit context.

The only caller of mkComment() that I could find was pyconv.ts so I fixed that up. Unsure how to test.

