### PR TITLE
more appcompat around docs.js

### DIFF
--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -198,8 +198,11 @@ function setupBlocklyAsync() {
                     pxt.blocks.registerFieldEditor(fi.selector, fi.editor, fi.validator);
                 })
         })
-    // backward compatibility
-    } else if (pxt.appTarget.appTheme && pxt.appTarget.appTheme.extendEditor) {
+    }
+
+    // backward compatibility: load editor
+    if (pxt.semver.strcmp("v3.9", pxt.appTarget.versions.target) < 0 &&
+        pxt.appTarget.appTheme && pxt.appTarget.appTheme.extendEditor) {
         let opts = {};
         promise = promise.then(function () {
             return pxt.BrowserUtils.loadScriptAsync(pxt.webConfig.commitCdnUrl + "editor.js")

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -201,7 +201,8 @@ function setupBlocklyAsync() {
     }
 
     // backward compatibility: load editor
-    if (pxt.semver.strcmp("v3.9", pxt.appTarget.versions.target) < 0 &&
+    if (pxt.appTarget.versions &&
+        pxt.semver.strcmp("v3.9", pxt.appTarget.versions.target) < 0 &&
         pxt.appTarget.appTheme && pxt.appTarget.appTheme.extendEditor) {
         let opts = {};
         promise = promise.then(function () {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -350,8 +350,15 @@ namespace pxt.BrowserUtils {
         if (/^https?:\/\//i.test(path))
             return path;
         const monacoPaths: Map<string> = (window as any).MonacoPaths || {};
-        const url = monacoPaths[path] || (pxt.webConfig.commitCdnUrl + path);
-        return url;
+        const blobPath = monacoPaths[path];
+        // find compute blob url
+        if (blobPath)
+            return blobPath;
+        // might have been exanded already
+        if (path.startsWith(pxt.webConfig.commitCdnUrl))
+            return path;
+        // append CDN
+        return pxt.webConfig.commitCdnUrl + path;
     }
 
     export function loadStyleAsync(path: string, rtl?: boolean): Promise<void> {


### PR DESCRIPTION
- [ ] check the target version and include editor.js for pxt versions < 3.9.
- [ ] don't patch CDN urls that already patched