### PR TITLE
Fix crash when applying '|' on float on Thumb

### DIFF
--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -18,6 +18,7 @@ namespace ts.pxtc {
         "numops::adds": "_numops_adds",
         "numops::subs": "_numops_subs",
         "numops::orrs": "_numops_orrs",
+        "numops::eors": "_numops_eors",
         "numops::ands": "_numops_ands",
         "pxt::toInt": "_numops_toInt",
         "pxt::fromInt": "_numops_fromInt",

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3059,6 +3059,7 @@ ${lbl}: .short 0xffff
                     case "numops::subs":
                     case "numops::eors":
                     case "numops::ands":
+                    case "numops::orrs":
                         return "@nomask@" + n
                 }
             }


### PR DESCRIPTION
(and possibly a memory leak for '^')

The lists of operators were not the same - both had 4 operations, but one `|` the other `^`