### PR TITLE
Change jsDoc desc for parseInt to lower 'a'

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -246,7 +246,7 @@ declare interface String {
 }
 
 /**
-  * Convert A string to an integer.
+  * Convert a string to an integer.
   * @param s A string to convert into a number.
   */
 //% shim=String_::toNumber


### PR DESCRIPTION
The 'A' was confusing the translators when reviewing the jsdoc string.