### PR TITLE
Allow for optional shadowing of object instance of property get/set.

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -403,11 +403,12 @@ namespace ts.pxtc {
 
                     // allowable %blockCombineShadow strings:-
                     //   '{name shadow},' or '{value shadow}' or ',{value shadow}' or '{name shadow},{value shadow}'
-                    const match = s.attributes.blockCombineShadow.match(/^([^,.]*),?([^,.]*)$/);
+                    const attribute = s.attributes.blockCombineShadow;
+                    const match = attribute.match(/^([^,.]*),?([^,.]*)$/);
                     if (match && match.length == 3) {
                         paramNameShadow = match[1].trim();
                         paramValueShadow = match[2].trim();
-                        if (paramValueShadow.length == 0 && !paramNameShadow.endsWith("=")) {
+                        if (paramValueShadow.length == 0 && !Util.endsWith(attribute, ",")) {
                             paramValueShadow = paramNameShadow;
                             paramNameShadow = "";
                         }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -397,7 +397,7 @@ namespace ts.pxtc {
             if (!ex) {
                 const tp = `@${rtp}@`
 
-                let paramNameShadow, paramValueShadow;
+                let paramNameShadow: string, paramValueShadow: string;
 
                 if (s.attributes.blockCombineShadow) {
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -396,8 +396,26 @@ namespace ts.pxtc {
             let ex = U.lookup(m, mkey)
             if (!ex) {
                 const tp = `@${rtp}@`
-                const paramName = s.namespace.toLowerCase()
-                const paramValue = `value=${s.attributes.blockCombineShadow || ""}`;
+
+                let paramNameShadow, paramValueShadow;
+
+                if (s.attributes.blockCombineShadow) {
+
+                    // allowable %blockCombineShadow strings:-
+                    //   '{name shadow},' or '{value shadow}' or ',{value shadow}' or '{name shadow},{value shadow}'
+                    const match = s.attributes.blockCombineShadow.match(/^([^,.]*),?([^,.]*)$/);
+                    if (match && match.length == 3) {
+                        paramNameShadow = match[1].trim();
+                        paramValueShadow = match[2].trim();
+                        if (paramValueShadow.length == 0 && !paramNameShadow.endsWith("=")) {
+                            paramValueShadow = paramNameShadow;
+                            paramNameShadow = "";
+                        }
+                    }
+                }
+
+                const paramName = `${s.namespace.toLowerCase()}=${paramNameShadow || ""}`
+                const paramValue = `value=${paramValueShadow || ""}`;
 
                 ex = m[mkey] = {
                     attributes: {


### PR DESCRIPTION
Allowable `%blockCombineShadow` strings:-

'{name shadow},' or '{value shadow}' or ',{value shadow}' or '{name shadow},{value shadow}' 

e.g.
```
    /**
     * Active camera.
     */
    //% blockCombine
    //% blockCombineShadow=world_scene,camera_perspective
    //% shim=.camera property
    camera: Camera;
```

Fixes https://github.com/Microsoft/pxt/issues/4195.