### PR TITLE
Integer math operators [v0]

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -49,7 +49,7 @@ interface Array<T> {
     //% helper=arrayUnshift weight=69 advanced=true
     //% blockId="array_unshift" block="%list| insert %value| at beginning" blockNamespace="arrays"
     //unshift(...values:T[]): number; //rest is not supported in our compiler yet.
-    unshift(value:T): number;
+    unshift(value: T): number;
 
     /**
       * Return a section of an array.
@@ -130,7 +130,7 @@ interface Array<T> {
      * Remove the first occurence of an object. Return true if removed.
      */
     //% shim=Array_::removeElement weight=48
-    removeElement(element:T) : boolean;
+    removeElement(element: T): boolean;
 
     /** 
      * Remove the element at a certain index.
@@ -241,7 +241,6 @@ declare interface String {
     // block="%this=text| is empty"
     isEmpty(): boolean;
 
-
     [index: number]: string;
 }
 
@@ -254,10 +253,10 @@ declare interface String {
 //% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
 declare function parseInt(text: string): number;
 
-interface Object {}
-interface Function {}
-interface IArguments {}
-interface RegExp {}
+interface Object { }
+interface Function { }
+interface IArguments { }
+interface RegExp { }
 
 type uint8 = number;
 type uint16 = number;
@@ -311,7 +310,6 @@ declare namespace Array {
  * More complex operations with numbers.
  */
 declare namespace Math {
-
     /**
      * Return the value of a base expression taken to a specified power.
      * @param x The base value of the expression.
@@ -336,4 +334,47 @@ declare namespace Math {
     //% shim=Math_::sqrt
     function sqrt(x: number): number;
 
+    /**
+     * Returns the smallest number greater than or equal to its numeric argument. 
+     * @param x A numeric expression.
+     */
+    //% shim=Math_::ceil
+    function ceil(x: number): number;
+
+    /**
+      * Returns the greatest number less than or equal to its numeric argument. 
+      * @param x A numeric expression.
+      */
+    //% shim=Math_::floor
+    function floor(x: number): number;
+
+    /**
+      * Returns the number with the decimal part truncated.
+      * @param x A numeric expression.
+      */
+    //% shim=Math_::trunc
+    function trunc(x: number): number;
+    
+    /** 
+      * Returns a supplied numeric expression rounded to the nearest number.
+      * @param x The value to be rounded to the nearest number.
+      */
+    //% shim=Math_::round
+    function round(x: number): number;
+
+    /**
+     * Returns the value of integer signed 32 bit multiplication of two numbers.
+     * @param x The first number
+     * @param y The second number
+     */
+    //% shim=Math_::imul
+    function imul(x: number, y: number): number;
+
+    /**
+     * Returns the value of integer signed 32 bit division of two numbers.
+     * @param x The first number
+     * @param y The second number
+     */
+    //% shim=Math_::idiv
+    function idiv(x: number, y: number): number;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "0.18.6",
+  "version": "0.19.0",
   "description": "Microsoft MakeCode, a toolkit for Blocks / JavaScript tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -210,7 +210,7 @@ namespace pxsim {
         const bh = (b >>> 16) & 0xffff;
         const bl = b & 0xffff;
         // the shift by 0 fixes the sign on the high part
-        // the final |0 converts the unsigned value into a signed value 
+        // the final |0 converts the unsigned value into a signed value
         return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0) | 0);
     }
 

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -184,8 +184,8 @@ namespace pxsim {
         export function round(n: number) { return Math.round(n) }
         export function ceil(n: number) { return Math.ceil(n) }
         export function floor(n: number) { return Math.floor(n) }
-        export function sqrt(n: number) { return Math.sqrt(n) }
-        export function pow(x: number, y: number) { return Math.pow(x, y) }
+        export function sqrt(n: number) { return Math.sqrt(n) >>> 0 }
+        export function pow(x: number, y: number) { return Math.pow(x, y) >>> 0 }
         export function trunc(x: number) {
             return x > 0 ? Math.floor(x) : Math.ceil(x);
         }

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -173,12 +173,23 @@ namespace pxsim {
     }
 
     export namespace Math_ {
-        export function sqrt(n: number) {
-            return Math.sqrt(n) >>> 0;
+        export function imul(x: number, y: number) {
+            return intMult(x, y)
         }
-        export function pow(x: number, y: number) {
-            return Math.pow(x, y) >>> 0;
+
+        export function idiv(x: number, y: number) {
+            return (x / y) >> 0
         }
+
+        export function round(n: number) { return Math.round(n) }
+        export function ceil(n: number) { return Math.ceil(n) }
+        export function floor(n: number) { return Math.floor(n) }
+        export function sqrt(n: number) { return Math.sqrt(n) }
+        export function pow(x: number, y: number) { return Math.pow(x, y) }
+        export function trunc(x: number) {
+            return x > 0 ? Math.floor(x) : Math.ceil(x);
+        }
+
         export function random(max: number): number {
             if (max < 1) return 0;
             let r = 0;


### PR DESCRIPTION
Introduce various int math operators (idiv, imul, floor, ceil, etc...) for the micro:bit/v0. This will allow package writer to update their code so that it does not break when we switch to floating point arithmetic.
Requires shims in pxt-microbit https://github.com/Microsoft/pxt/pull/4208