### PR TITLE
Improved workspace comment compilation/decompilation

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -687,7 +687,7 @@ namespace pxt.blocks {
 
     function compileWorkspaceComment(c: Blockly.WorkspaceComment): JsNode {
         const content = c.getContent();
-        return Helpers.mkMultiComment(content);
+        return Helpers.mkMultiComment(content.trim());
     }
 
     function defaultValueForType(t: Point): JsNode {

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -325,27 +325,23 @@ namespace pxt.blocks.layout {
         for (let i = 0; i < groups.length; i++) {
             const group = groups[i];
             if (group.children) {
-                let x = 0;
+                const valueDimensions = group.value.getHeightWidth();
+                group.x = 0;
+                group.y = 0;
+
+                let x = valueDimensions.width + innerGroupMargin;
                 let y = 0;
 
-                // Lay comments out above the parent node
+                // Lay comments out to the right of the parent node
                 for (let j = 0; j < group.children.length; j++) {
                     const child = group.children[j];
                     child.x = x;
-                    child.y = 0;
-                    x += child.width + innerGroupMargin;
-                    y = Math.max(child.height + innerGroupMargin, y);
+                    child.y = y;
+                    y += child.height + innerGroupMargin;
+                    group.width = Math.max(group.width, x + child.width);
                 }
 
-                // These are the coordinates of the parent (below the comments)
-                group.x = 0;
-                group.y = y;
-
-                const valueDimensions = group.value.getHeightWidth();
-
-                // These dimensions are for the entire group
-                group.width = Math.max(x - innerGroupMargin, valueDimensions.width);
-                group.height = y + innerGroupMargin + valueDimensions.height;
+                group.height = Math.max(y - innerGroupMargin, valueDimensions.height);
             }
 
             surfaceArea += (group.height + innerGroupMargin) * (group.width + innerGroupMargin);

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -25,6 +25,12 @@ namespace ts.pxtc.decompiler {
     const lowerCaseAlphabetStartCode = 97;
     const lowerCaseAlphabetEndCode = 122;
 
+    // Bounds for decompilation of workspace comments
+    const minCommentWidth = 160;
+    const minCommentHeight = 120;
+    const maxCommentWidth = 480;
+    const maxCommentHeight = 360;
+
     const validStringRegex = /^[^\f\n\r\t\v\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*$/;
 
     interface DecompilerEnv {
@@ -576,7 +582,15 @@ ${output}</xml>`;
         }
 
         function emitWorkspaceComment(comment: WorkspaceComment) {
-            write(`<comment h="120" w="160" data="${U.htmlEscape(comment.refId)}">`)
+            let maxLineLength = 0;
+            const lines = comment.text.split("\n");
+            lines.forEach(line => maxLineLength = Math.max(maxLineLength, line.length));
+
+            // These are just approximations but they are the best we can do outside the DOM
+            const width = Math.max(Math.min(maxLineLength * 10, maxCommentWidth), minCommentWidth);
+            const height = Math.max(Math.min(lines.length * 40, maxCommentHeight), minCommentHeight);
+
+            write(`<comment h="${height}" w="${width}" data="${U.htmlEscape(comment.refId)}">`)
             write(U.htmlEscape(comment.text))
             write(`</comment>`);
         }

--- a/tests/decompile-test/baselines/comments.blocks
+++ b/tests/decompile-test/baselines/comments.blocks
@@ -1,127 +1,152 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
-<block type="pxt-on-start">
-<statement name="HANDLER">
-<block type="variables_set">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">2</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">3</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">4</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">5</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">6</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">7</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">8</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">9</field>
-</shadow>
-</value>
-<next>
-<block type="variables_change">
-<field name="VAR">x</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">10</field>
-</shadow>
-</value>
-</block>
-</next>
-<comment pinned="false">Paragraphs from&#10;single-line comments</comment>
-</block>
-</next>
-<comment pinned="false">Whitespace between comments and statement</comment>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-<comment pinned="false">Multiple Single-line Comments</comment>
-</block>
-</next>
-<comment pinned="false">Single-line comment</comment>
-</block>
-</statement>
-</block>
-<comment h="120" w="160">More</comment>
-<comment h="120" w="160">than one</comment>
-<comment h="120" w="160">Comment</comment>
-<comment h="120" w="160">Mixing it up</comment>
-<comment h="120" w="160">Single multi-line</comment>
-<comment h="120" w="160">Text at the top&#10;&#10;and the bottom</comment>
-<comment h="120" w="160">Multi-line with double asterisks</comment>
-<comment h="120" w="160">Multi-line with asterisks</comment>
-<comment h="120" w="160">Multi line with no asterisks on body</comment>
-</xml>
+    <block type="pxt-on-start">
+    <statement name="HANDLER">
+    <block type="variables_set">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">1</field>
+    </shadow>
+    </value>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">1</field>
+    </shadow>
+    </value>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">2</field>
+    </shadow>
+    </value>
+    <data>8</data>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">3</field>
+    </shadow>
+    </value>
+    <data>7</data>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">4</field>
+    </shadow>
+    </value>
+    <data>6</data>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">5</field>
+    </shadow>
+    </value>
+    <data>5</data>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">6</field>
+    </shadow>
+    </value>
+    <data>4</data>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">7</field>
+    </shadow>
+    </value>
+    <data>3</data>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">8</field>
+    </shadow>
+    </value>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">9</field>
+    </shadow>
+    </value>
+    <next>
+    <block type="variables_change">
+    <field name="VAR">x</field>
+    <value name="VALUE">
+    <shadow type="math_number">
+    <field name="NUM">10</field>
+    </shadow>
+    </value>
+    <data>0&#59;1&#59;2</data>
+    </block>
+    </next>
+    <comment pinned="false">Paragraphs from&#10;single-line comments</comment>
+    </block>
+    </next>
+    <comment pinned="false">Whitespace between comments and statement</comment>
+    </block>
+    </next>
+    </block>
+    </next>
+    </block>
+    </next>
+    </block>
+    </next>
+    </block>
+    </next>
+    </block>
+    </next>
+    </block>
+    </next>
+    <comment pinned="false">Multiple Single-line Comments</comment>
+    </block>
+    </next>
+    <comment pinned="false">Single-line comment</comment>
+    </block>
+    </statement>
+    </block>
+    <comment h="120" w="160" data="0">
+    More
+    </comment>
+    <comment h="120" w="160" data="1">
+    than one
+    </comment>
+    <comment h="120" w="160" data="2">
+    Comment
+    </comment>
+    <comment h="120" w="160" data="3">
+    Mixing it up
+    </comment>
+    <comment h="120" w="170" data="4">
+    Single multi-line
+    </comment>
+    <comment h="120" w="160" data="5">
+    Text at the top&#10;&#10;and the bottom
+    </comment>
+    <comment h="120" w="320" data="6">
+    Multi-line with double asterisks
+    </comment>
+    <comment h="120" w="250" data="7">
+    Multi-line with asterisks
+    </comment>
+    <comment h="120" w="360" data="8">
+    Multi line with no asterisks on body
+    </comment>
+    </xml>

--- a/tests/decompile-test/baselines/workspace_comments_exp.blocks
+++ b/tests/decompile-test/baselines/workspace_comments_exp.blocks
@@ -1,4 +1,3 @@
-
 <xml xmlns="http://www.w3.org/1999/xhtml">
 <block type="pxt-on-start">
 <statement name="HANDLER">
@@ -17,10 +16,13 @@
 <field name="NUM">1</field>
 </shadow>
 </value>
+<data>0</data>
 </block>
 </next>
 </block>
 </statement>
 </block>
-<comment h="120" w="160">More</comment>
+<comment h="120" w="160" data="0">
+More
+</comment>
 </xml>

--- a/tests/decompile-test/baselines/workspace_comments_parent.blocks
+++ b/tests/decompile-test/baselines/workspace_comments_parent.blocks
@@ -7,8 +7,11 @@
 <field name="BOOL">TRUE</field>
 </shadow>
 </value>
+<data>0</data>
 </block>
 </statement>
 </block>
-<comment h="120" w="160">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62; More</comment>
+<comment h="120" w="480" data="0">
+&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62; More
+</comment>
 </xml>

--- a/tests/decompile-test/baselines/workspace_comments_typescript.blocks
+++ b/tests/decompile-test/baselines/workspace_comments_typescript.blocks
@@ -3,8 +3,11 @@
 <statement name="HANDLER">
 <block type="typescript_statement">
 <mutation numlines="6" error="Functions with parameters not supported in blocks" line0="function doSomething&#40;arg&#58; number&#41; &#123;" line1="    &#47;&#42;&#42;" line2="     &#42; This is not" line3="     &#42;&#47;" line4="    let x &#61; 0&#59;" line5="&#125;" />
+<data>0</data>
 </block>
 </statement>
 </block>
-<comment h="120" w="160">This is a workspace comment</comment>
+<comment h="120" w="270" data="0">
+This is a workspace comment
+</comment>
 </xml>

--- a/tests/decompile-test/baselines/workspace_comments_var.blocks
+++ b/tests/decompile-test/baselines/workspace_comments_var.blocks
@@ -8,8 +8,11 @@
 <field name="NUM">1</field>
 </shadow>
 </value>
+<data>0</data>
 </block>
 </statement>
 </block>
-<comment h="120" w="160">More</comment>
+<comment h="120" w="160" data="0">
+More
+</comment>
 </xml>


### PR DESCRIPTION
Adds support for grouping workspace comments with event handlers. Any top level comment in Typescript will now be grouped with the nearest event upon decompilation/formatting. Comments are placed to the right of the event block and stacked vertically; I originally tried laying them out above the block but the right looks much more natural in practice. The formatting algorithm is pretty naïve so we could definitely improve upon it.

Likewise, the Blockly compiler now emits the comments above the nearest event handler in the blocks. The grouping from blocks -> TS is done with a heuristic based on distance and bounding boxes of comments and can probably also be improved but it handles the round-trip scenario pretty well.

Other nice fixes:
1. workspace comments no longer compile with too many newlines
2. the decompiler now does a rough estimate of the size of workspace comments
3. onStart is always placed in the top-left of the workspace
