### PR TITLE
Load icons first

### DIFF
--- a/theme/pxtsemantic.less
+++ b/theme/pxtsemantic.less
@@ -15,12 +15,12 @@
 & { @import "definitions/globals/site"; }
 
 /* Elements */
+& { @import "definitions/elements/icon"; }
 & { @import "definitions/elements/button"; }
 & { @import "definitions/elements/container"; }
 & { @import "definitions/elements/divider"; }
 //& { @import "definitions/elements/flag"; }
 & { @import "definitions/elements/header"; }
-& { @import "definitions/elements/icon"; }
 & { @import "definitions/elements/image"; }
 & { @import "definitions/elements/input"; }
 & { @import "definitions/elements/label"; }


### PR DESCRIPTION
We're too fast now that you see icons loading when you load the page as they're being read by the browser. Moving icons to the top of the semantic css file so that they load first. 

