### PR TITLE
Add an error guard around app

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -60,6 +60,7 @@ namespace pxt.editor {
         highContrast?: boolean;
 
         home?: boolean;
+        hasError?: boolean;
     }
 
     export interface EditorState {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -444,6 +444,10 @@ export class ProjectView
         this.setState({ hasError: true });
         // Log critical error
         pxt.tickEvent('pxt.criticalerror', { error, info });
+        // Reload the page in 2 seconds
+        setTimeout(() => {
+            location.reload();
+        }, 2000)
     }
 
     private pickEditorFor(f: pkg.File): srceditor.Editor {
@@ -1774,9 +1778,9 @@ export class ProjectView
             return <div id="root" className="ui middle aligned center aligned grid" style={{ height: '100%', alignItems: 'center' }}>
                 <div className="ui raised segment inverted purple">
                     <h2>{lf("Oops") + "  😞😞😞"}</h2>
-                    {lf("This doesn't happen often, but looks like we messed up..")}
+                    {lf("This doesn't happen often, but looks like we've run into a problem..")}
                     <br /> <br />
-                    {lf("We're going to need you to refresh your page.")}
+                    {lf("Refreshing your page...")}
                 </div>
             </div>
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -439,20 +439,23 @@ export class ProjectView
 
     // Add an error guard for the entire application
     componentDidCatch(error: any, info: any) {
-        core.killLoadingQueue();
-        pxsim.U.remove(document.getElementById('loading'));
-        this.setState({ hasError: true });
-        // Log critical error
-        pxt.tickEvent('pxt.criticalerror', { error, info });
-        // Reload the page in 2 seconds
-        const lastCriticalError = pxt.storage.getLocal("lastcriticalerror") ?
-            Date.parse(pxt.storage.getLocal("lastcriticalerror")) : Date.now();
-        // don't refresh if we refreshed in the last minute
-        if (Date.now() - lastCriticalError > 60 * 1000) {
-            pxt.storage.setLocal("lastcriticalerror", new Date().toISOString());
-            setTimeout(() => {
-                location.reload();
-            }, 2000)
+        try {
+            core.killLoadingQueue();
+            pxsim.U.remove(document.getElementById('loading'));
+            this.setState({ hasError: true });
+            // Log critical error
+            pxt.tickEvent('pxt.criticalerror', { error, info });
+            // Reload the page in 2 seconds
+            const lastCriticalError = pxt.storage.getLocal("lastcriticalerror") ?
+                Date.parse(pxt.storage.getLocal("lastcriticalerror")) : Date.now();
+            // don't refresh if we refreshed in the last minute
+            if (Date.now() - lastCriticalError > 60 * 1000) {
+                pxt.storage.setLocal("lastcriticalerror", new Date().toISOString());
+                setTimeout(() => {
+                    location.reload();
+                }, 2000)
+            }
+        } catch (e) {
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -445,9 +445,15 @@ export class ProjectView
         // Log critical error
         pxt.tickEvent('pxt.criticalerror', { error, info });
         // Reload the page in 2 seconds
-        setTimeout(() => {
-            location.reload();
-        }, 2000)
+        const lastCriticalError = pxt.storage.getLocal("lastcriticalerror") ?
+            Date.parse(pxt.storage.getLocal("lastcriticalerror")) : Date.now();
+        // don't refresh if we refreshed in the last minute
+        if (Date.now() - lastCriticalError > 60 * 1000) {
+            pxt.storage.setLocal("lastcriticalerror", new Date().toISOString());
+            setTimeout(() => {
+                location.reload();
+            }, 2000)
+        }
     }
 
     private pickEditorFor(f: pkg.File): srceditor.Editor {
@@ -1777,10 +1783,8 @@ export class ProjectView
         if (this.state.hasError) {
             return <div id="root" className="ui middle aligned center aligned grid" style={{ height: '100%', alignItems: 'center' }}>
                 <div className="ui raised segment inverted purple">
-                    <h2>{lf("Oops") + "  😞😞😞"}</h2>
-                    {lf("This doesn't happen often, but looks like we've run into a problem..")}
-                    <br /> <br />
-                    {lf("Refreshing your page...")}
+                    <h2>{lf("Oops")}</h2>
+                    {lf("We detected a problem and we will reload the editor in a few seconds..")}
                 </div>
             </div>
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -437,6 +437,15 @@ export class ProjectView
         this.forceUpdate(); // we now have editors prepared
     }
 
+    // Add an error guard for the entire application
+    componentDidCatch(error: any, info: any) {
+        core.killLoadingQueue();
+        pxsim.U.remove(document.getElementById('loading'));
+        this.setState({ hasError: true });
+        // Log critical error
+        pxt.tickEvent('pxt.criticalerror', { error, info });
+    }
+
     private pickEditorFor(f: pkg.File): srceditor.Editor {
         return this.allEditors.filter(e => e.acceptsFile(f))[0]
     }
@@ -1760,6 +1769,17 @@ export class ProjectView
             'full-abs'
         ];
         const rootClasses = sui.cx(rootClassList);
+
+        if (this.state.hasError) {
+            return <div id="root" className="ui middle aligned center aligned grid" style={{ height: '100%', alignItems: 'center' }}>
+                <div className="ui raised segment inverted purple">
+                    <h2>{lf("Oops") + "  😞😞😞"}</h2>
+                    {lf("This doesn't happen often, but looks like we messed up..")}
+                    <br /> <br />
+                    {lf("We're going to need you to refresh your page.")}
+                </div>
+            </div>
+        }
         return (
             <div id='root' className={rootClasses}>
                 {hideMenuBar ? undefined :

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -449,7 +449,7 @@ export class ProjectView
             const lastCriticalError = pxt.storage.getLocal("lastcriticalerror") ?
                 Date.parse(pxt.storage.getLocal("lastcriticalerror")) : Date.now();
             // don't refresh if we refreshed in the last minute
-            if (Date.now() - lastCriticalError > 60 * 1000) {
+            if (!isNaN(lastCriticalError) && Date.now() - lastCriticalError > 60 * 1000) {
                 pxt.storage.setLocal("lastcriticalerror", new Date().toISOString());
                 setTimeout(() => {
                     location.reload();

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -48,6 +48,17 @@ export function hideLoading(id: string) {
     }
 }
 
+export function killLoadingQueue() {
+    // Use this with care, only when you want to kill the loading queue
+    // and force close them all
+    loadingQueue = [];
+    loadingQueueMsg = {};
+    // Hide loading
+    if (dimmerInitialized && loadingDimmer) {
+        loadingDimmer.hide();
+    }
+}
+
 export function showLoading(id: string, msg: string) {
     pxt.debug("showloading: " + id);
     if (loadingQueueMsg[id]) return; // already loading?

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -33,6 +33,7 @@ export function setTranslations(translations: pxt.Map<string>) {
 }
 
 export function init(root: HTMLElement, cfg: SimulatorConfig) {
+    if (!root) return;
     root.innerHTML =
         `
         <div id="simulators" class='simulator'>


### PR DESCRIPTION
React no has support for error boundaries: https://reactjs.org/docs/error-boundaries.html

This would mean that if an unhandled error occurs somewhere in the React components, we can display a message like so, and get users to reload the page, log the error etc. 

<img width="770" alt="screen shot 2018-04-26 at 2 02 21 pm" src="https://user-images.githubusercontent.com/16690124/39323558-eb94a0d8-495a-11e8-9875-5095d6bbb88c.png">

Alternatively, we can just reload the page for them but I feel like that's a little intrusive. 

thoughts?