### PR TITLE
Fix tutorial perf

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -169,7 +169,8 @@ namespace pxt.blocks.layout {
         const svgXml = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="${XLINK_NAMESPACE}" width="${width}" height="${height}" viewBox="${x} ${y} ${width} ${height}">${xmlString}</svg>`;
         const xsg = new DOMParser().parseFromString(svgXml, "image/svg+xml");
         const cssLink = xsg.createElementNS("http://www.w3.org/1999/xhtml", "style");
-        const customCssHref = (document.getElementById("style-blockly.css") as HTMLLinkElement).href;
+        const isRtl = Util.isUserLanguageRtl();
+        const customCssHref = (document.getElementById(`style-${isRtl ? 'rtl' : ''}blockly.css`) as HTMLLinkElement).href;
         return pxt.BrowserUtils.loadAjaxAsync(customCssHref)
             .then((customCss) => {
                 const blocklySvg = Util.toArray(document.head.querySelectorAll("style"))

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -5,16 +5,6 @@ namespace pxt.blocks {
     let workspace: Blockly.Workspace;
     let blocklyDiv: HTMLElement;
 
-    function align(ws: Blockly.Workspace, emPixels: number) {
-        let blocks = ws.getTopBlocks(true);
-        let y = 0
-        blocks.forEach(block => {
-            block.moveBy(0, y)
-            y += block.getHeightWidth().height
-            y += emPixels; //buffer
-        })
-    }
-
     export enum BlockLayout {
         Align = 1,
         // Shuffle deprecated
@@ -59,7 +49,7 @@ namespace pxt.blocks {
 
             switch (options.layout) {
                 case BlockLayout.Align:
-                    pxt.blocks.layout.verticalAlign(workspace, options.emPixels); break;
+                    pxt.blocks.layout.verticalAlign(workspace, options.emPixels || 14); break;
                 case BlockLayout.Flow:
                     pxt.blocks.layout.flow(workspace, { ratio: options.aspectRatio, useViewWidth: options.useViewWidth }); break;
                 case BlockLayout.Clean:
@@ -67,7 +57,6 @@ namespace pxt.blocks {
                         (<any>workspace).cleanUp_();
                     break;
             }
-
 
             let metrics = workspace.getMetrics();
 
@@ -89,9 +78,13 @@ namespace pxt.blocks {
             }
 
             return svg as any;
-
         } catch (e) {
             pxt.reportException(e);
+
+            // We re-use the workspace across renders, catch any errors so we know to 
+            // create a new workspace if there was an error
+            if (workspace) workspace.dispose();
+            workspace = undefined;
             return undefined;
         }
     }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -99,10 +99,8 @@ namespace pxt.editor {
         // no coding
         unplugged?: boolean;
         hasHint?: boolean;
-        content?: string;
-        titleContent?: string;
-        headerContent?: string;
-        ariaLabel?: string;
+        contentMd?: string;
+        headerContentMd?: string;
     }
 
     export interface TutorialOptions {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -122,9 +122,8 @@ namespace pxsim {
     export interface TutorialStepInfo {
         fullscreen?: boolean;
         hasHint?: boolean;
-        content?: string;
-        headerContent?: string;
-        ariaLabel?: string;
+        contentMd?: string;
+        headerContentMd?: string;
     }
 
     export interface TutorialLoadedMessage extends TutorialMessage {

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -204,7 +204,6 @@ span.docs.inlinebutton {
     border-radius: 0.2rem;
     white-space: nowrap;
     background-color: @primaryColor;
-    border: 1px solid lighten(@primaryColor, 20%);
     color: @white;
 }
 
@@ -232,6 +231,13 @@ code.lang-filterblocks {
 .ui.modal.hintdialog .content p {
     font-size: 16px;
     line-height: 25px;
+}
+
+.ui.modal.hintdialog {
+    .ui.segment {
+        display: flex;
+        min-height: 100px;
+    }
 }
 
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1668,7 +1668,7 @@ export class ProjectView
             .then(() => pxt.Cloud.downloadMarkdownAsync(tutorialId))
             .then(tutorialmd => {
                 const stepInfo = tutorial.parseTutorialSteps(tutorialId, tutorialmd);
-                return tutorial.getUsedBlocks(tutorialId, tutorialmd)
+                return tutorial.getUsedBlocksAsync(tutorialId, tutorialmd)
                     .then((usedBlocks) => {
                         this.setState({
                             editorState: {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -826,6 +826,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         // no toolbox when readonly
         if (pxt.shell.isReadOnly()) return;
 
+        // Dont show toolbox if we're in tutorial mode and we're not ready
+        if (this.parent.state.tutorialOptions != undefined &&
+            !this.parent.state.tutorialOptions.tutorialReady) {
+            return;
+        }
+
         this.clearCaches();
 
         const hasCategories = this.shouldShowCategories();

--- a/webapp/src/dialogs.ts
+++ b/webapp/src/dialogs.ts
@@ -11,9 +11,9 @@ export function showAboutDialogAsync() {
         header: lf("About"),
         hideCancel: true,
         agreeLbl: lf("Ok"),
-        agreeClass: "positive focused",
+        agreeClass: "positive",
         htmlBody: `
-${githubUrl ? `<p>${lf("{0} version:", pxt.Util.htmlEscape(pxt.appTarget.name))} <a class="focused" href="${pxt.Util.htmlEscape(githubUrl)}/releases/tag/v${pxt.Util.htmlEscape(pxt.appTarget.versions.target)}" aria-label="${lf("{0} version : {1}", pxt.Util.htmlEscape(pxt.appTarget.name), pxt.Util.htmlEscape(pxt.appTarget.versions.target))}" target="_blank">${pxt.Util.htmlEscape(pxt.appTarget.versions.target)}</a></p>` : ``}
+${githubUrl ? `<p>${lf("{0} version:", pxt.Util.htmlEscape(pxt.appTarget.name))} <a href="${pxt.Util.htmlEscape(githubUrl)}/releases/tag/v${pxt.Util.htmlEscape(pxt.appTarget.versions.target)}" aria-label="${lf("{0} version : {1}", pxt.Util.htmlEscape(pxt.appTarget.name), pxt.Util.htmlEscape(pxt.appTarget.versions.target))}" target="_blank">${pxt.Util.htmlEscape(pxt.appTarget.versions.target)}</a></p>` : ``}
 <p>${lf("{0} version:", "Microsoft MakeCode")} <a href="https://github.com/Microsoft/pxt/releases/tag/v${pxt.Util.htmlEscape(pxt.appTarget.versions.pxt)}" aria-label="${lf("{0} version: {1}", "Microsoft MakeCode", pxt.Util.htmlEscape(pxt.appTarget.versions.pxt))}" target="_blank">${pxt.Util.htmlEscape(pxt.appTarget.versions.pxt)}</a></p>
 ${compileService && compileService.githubCorePackage && compileService.gittag ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${pxt.Util.htmlEscape("https://github.com/" + compileService.githubCorePackage + '/releases/tag/' + compileService.gittag)}" aria-label="${lf("{0} version: {1}", "C++ runtime", pxt.Util.htmlEscape(compileService.gittag))}" target="_blank">${pxt.Util.htmlEscape(compileService.gittag)}</a></p>` : ""}
 `

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -131,6 +131,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             saveButtonClasses = "disabled";
         }
 
+        const isRtl = pxt.Util.isUserLanguageRtl();
         return <div className="ui equal width grid right aligned padded">
             <div className="column mobile only">
                 {collapsed ?
@@ -306,7 +307,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     <div id="downloadArea" className="ui column items">{headless ?
                         <div className="ui item">
                             <div className="ui icon large buttons">
-                                {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} className={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer')} /> : undefined}
+                                {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle ' + (isRtl ? 'left' : 'right') : 'toggle ' + (isRtl ? 'right' : 'left')}`} className={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer')} /> : undefined}
                                 {run ? <sui.Button role="menuitem" className={`large play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onClick={() => this.startStopSimulator('computer')} /> : undefined}
                                 {restart ? <sui.Button key='restartbtn' className={`large restart-button`} icon="refresh" title={restartTooltip} onClick={() => this.restartSimulator('computer')} /> : undefined}
                                 {trace ? <sui.Button key='tracebtn' className={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon trace" title={traceTooltip} onClick={() => this.toggleTrace('computer')} /> : undefined}
@@ -315,7 +316,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                             </div>
                         </div> :
                         <div className="ui item">
-                            {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle right' : 'toggle left'}`} className={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer')} /> : undefined}
+                            {showCollapsed ? <sui.Button icon={`${collapseEditorTools ? 'toggle ' + (isRtl ? 'left' : 'right') : 'toggle ' + (isRtl ? 'right' : 'left')}`} className={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onClick={() => this.toggleCollapse('computer')} /> : undefined}
                             {debug ? <sui.Button key='debugbtn' icon="xicon bug" className={`large debug-button ${debugging ? 'orange' : ''}`} title={debugTooltip} onClick={() => this.toggleDebugging('computer')} /> : undefined}
                             {compileBtn ? <sui.Button icon={downloadIcon} className={`primary huge fluid download-button ${downloadButtonClasses}`} text={downloadText} title={compileTooltip} onClick={() => this.compile('computer')} /> : undefined}
                         </div>

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -107,6 +107,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         // replace pre-template in markdown
         markdown = markdown.replace(/@([a-z]+)@/ig, (m, param) => pubinfo[param] || 'unknown macro')
 
+        // Set markdown options
+        marked.setOptions({
+            sanitize: true
+        })
+
         // Render the markdown and add it to the content div
         content.innerHTML = marked(markdown);
 

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -22,48 +22,17 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         this.blockSnippetCache = {};
     }
 
-    // This should probably be moved into some shared util between docsrenderer and the webapp
-    private replaceAll(replIn: string, x: string, y: string) {
-        return replIn.split(x).join(y)
-    }
-
-    private htmlQuote(s: string): string {
-        s = this.replaceAll(s, "&", "&amp;")
-        s = this.replaceAll(s, "<", "&lt;")
-        s = this.replaceAll(s, ">", "&gt;")
-        s = this.replaceAll(s, "\"", "&quot;")
-        s = this.replaceAll(s, "\'", "&#39;")
-        return s;
-    }
-
-    // the input already should be HTML-quoted but we want to make sure, and also quote quotes
-    private html2Quote(s: string) {
-        if (!s) return s;
-        return this.htmlQuote(s.replace(/\&([#a-z0-9A-Z]+);/g, (f, ent) => {
-            switch (ent) {
-                case "amp": return "&";
-                case "lt": return "<";
-                case "gt": return ">";
-                case "quot": return "\"";
-                default:
-                    if (ent[0] == "#")
-                        return String.fromCharCode(parseInt(ent.slice(1)));
-                    else return f
-            }
-        }))
-    }
-
     private getBuiltinMacros() {
         const params: pxt.Map<string> = {};
         const theme = pxt.appTarget.appTheme;
         if (theme.boardName)
-            params["boardname"] = this.html2Quote(theme.boardName);
+            params["boardname"] = pxt.Util.htmlEscape(theme.boardName);
         if (theme.boardNickname)
-            params["boardnickname"] = this.html2Quote(theme.boardNickname);
+            params["boardnickname"] = pxt.Util.htmlEscape(theme.boardNickname);
         if (theme.driveDisplayName)
-            params["drivename"] = this.html2Quote(theme.driveDisplayName);
+            params["drivename"] = pxt.Util.htmlEscape(theme.driveDisplayName);
         if (theme.homeUrl)
-            params["homeurl"] = this.html2Quote(theme.homeUrl);
+            params["homeurl"] = pxt.Util.htmlEscape(theme.homeUrl);
         params["targetid"] = theme.id || "???";
         params["targetname"] = theme.name || "Microsoft MakeCode";
         params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui mini image" src="${theme.docsLogo}" />` : "";

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -58,7 +58,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                             if (xml) {
                                 langBlock.innerHTML = `<div class="ui segment raised">
                                     <img src="${pxt.Util.htmlEscape(xml)}" /></div>`;
-                                MarkedContent.blockSnippetCache[code] = xml;
+                                MarkedContent.blockSnippetCache[code] = pxt.Util.htmlEscape(xml);
                             } else {
                                 // An error occured, show alternate message
                                 langBlock.innerHTML = `<div class="ui segment raised">

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -1,0 +1,142 @@
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import * as data from "./data";
+import * as marked from "marked";
+
+type ISettingsProps = pxt.editor.ISettingsProps;
+
+interface MarkedContentProps extends ISettingsProps {
+    markdown: string;
+}
+
+interface MarkedContentState {
+}
+
+export class MarkedContent extends data.Component<MarkedContentProps, MarkedContentState> {
+
+    // Local cache for images, cleared when we create a new project.
+    // Stores code => data-uri image of decompiled result
+    private static blockSnippetCache: pxt.Map<string> = {};
+    public static clearBlockSnippetCache() {
+        this.blockSnippetCache = {};
+    }
+
+    // This should probably be moved into some shared util between docsrenderer and the webapp
+    private replaceAll(replIn: string, x: string, y: string) {
+        return replIn.split(x).join(y)
+    }
+
+    private htmlQuote(s: string): string {
+        s = this.replaceAll(s, "&", "&amp;")
+        s = this.replaceAll(s, "<", "&lt;")
+        s = this.replaceAll(s, ">", "&gt;")
+        s = this.replaceAll(s, "\"", "&quot;")
+        s = this.replaceAll(s, "\'", "&#39;")
+        return s;
+    }
+
+    // the input already should be HTML-quoted but we want to make sure, and also quote quotes
+    private html2Quote(s: string) {
+        if (!s) return s;
+        return this.htmlQuote(s.replace(/\&([#a-z0-9A-Z]+);/g, (f, ent) => {
+            switch (ent) {
+                case "amp": return "&";
+                case "lt": return "<";
+                case "gt": return ">";
+                case "quot": return "\"";
+                default:
+                    if (ent[0] == "#")
+                        return String.fromCharCode(parseInt(ent.slice(1)));
+                    else return f
+            }
+        }))
+    }
+
+    private getBuiltinMacros() {
+        const params: pxt.Map<string> = {};
+        const theme = pxt.appTarget.appTheme;
+        if (theme.boardName)
+            params["boardname"] = this.html2Quote(theme.boardName);
+        if (theme.boardNickname)
+            params["boardnickname"] = this.html2Quote(theme.boardNickname);
+        if (theme.driveDisplayName)
+            params["drivename"] = this.html2Quote(theme.driveDisplayName);
+        if (theme.homeUrl)
+            params["homeurl"] = this.html2Quote(theme.homeUrl);
+        params["targetid"] = theme.id || "???";
+        params["targetname"] = theme.name || "Microsoft MakeCode";
+        params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui mini image" src="${theme.docsLogo}" />` : "";
+        return params;
+    }
+
+    private renderSnippetsAsync(content: HTMLElement) {
+        const { parent } = this.props;
+
+        pxt.Util.toArray(document.querySelectorAll(`.lang-blocks`))
+            .forEach((langBlock: HTMLElement) => {
+                const code = langBlock.innerText;
+                langBlock.innerHTML = `<div class="ui segment raised loading"></div>`;
+                if (MarkedContent.blockSnippetCache[code]) {
+                    // Use cache
+                    langBlock.innerHTML = `<div class="ui segment raised">
+                                <img src="${MarkedContent.blockSnippetCache[code]}" /></div>`;
+                } else {
+                    parent.renderBlocksAsync({
+                        action: "renderblocks", ts: code
+                    } as pxt.editor.EditorMessageRenderBlocksRequest)
+                        .then((xml) => {
+                            langBlock.innerHTML = `<div class="ui segment raised">
+                                <img src="${xml}" /></div>`;
+                            MarkedContent.blockSnippetCache[code] = xml;
+                        })
+                }
+            })
+    }
+
+    private renderInlineBlocksAsync(content: HTMLElement) {
+        pxt.Util.toArray(document.querySelectorAll(`:not(pre) > code`))
+            .forEach((inlineBlock: HTMLElement) => {
+                const text = inlineBlock.innerText;
+                const mbtn = /^(\|+)([^\|]+)\|+$/.exec(text);
+                if (mbtn) {
+                    const mtxt = /^(([^\:\.]*?)[\:\.])?(.*)$/.exec(mbtn[2]);
+                    const ns = mtxt[2] ? mtxt[2].trim().toLowerCase() : '';
+                    const txt = mtxt[3].trim();
+                    const lev = mbtn[1].length == 1 ? `docs inlinebutton ui button ${txt.toLowerCase()}-button` : `docs inlineblock ${ns}`;
+                    inlineBlock.innerHTML = `<span class="${lev}">${pxt.U.rlf(txt)}</span>`
+                }
+            })
+    }
+
+    renderMarkdown(markdown: string) {
+        const content = this.refs["marked-content"] as HTMLDivElement;
+        const pubinfo = this.getBuiltinMacros();
+
+        // replace pre-template in markdown
+        markdown = markdown.replace(/@([a-z]+)@/ig, (m, param) => pubinfo[param] || 'unknown macro')
+
+        // Render the markdown and add it to the content div
+        content.innerHTML = marked(markdown);
+
+        // We'll go through a series of adjustments here, rendering inline blocks, blocks and snippets as needed
+        this.renderInlineBlocksAsync(content);
+        this.renderSnippetsAsync(content);
+    }
+
+    componentDidMount() {
+        const { markdown } = this.props;
+        this.renderMarkdown(markdown);
+    }
+
+    componentWillReceiveProps(newProps: MarkedContentProps) {
+        const { markdown } = newProps;
+        if (this.props.markdown != newProps.markdown) {
+            this.renderMarkdown(markdown);
+        }
+    }
+
+    renderCore() {
+        return <div ref="marked-content" />;
+    }
+}

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -73,7 +73,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     private renderSnippets(content: HTMLElement) {
         const { parent } = this.props;
 
-        pxt.Util.toArray(document.querySelectorAll(`.lang-blocks`))
+        pxt.Util.toArray(content.querySelectorAll(`.lang-blocks`))
             .forEach((langBlock: HTMLElement) => {
                 const code = langBlock.innerText;
                 langBlock.innerHTML = `<div class="ui segment raised loading"></div>`;
@@ -88,7 +88,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         .done((xml) => {
                             if (xml) {
                                 langBlock.innerHTML = `<div class="ui segment raised">
-                                    <img src="${this.html2Quote(xml)}" /></div>`;
+                                    <img src="${pxt.Util.htmlEscape(xml)}" /></div>`;
                                 MarkedContent.blockSnippetCache[code] = xml;
                             } else {
                                 // An error occured, show alternate message
@@ -101,7 +101,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     }
 
     private renderInlineBlocks(content: HTMLElement) {
-        pxt.Util.toArray(document.querySelectorAll(`:not(pre) > code`))
+        pxt.Util.toArray(content.querySelectorAll(`:not(pre) > code`))
             .forEach((inlineBlock: HTMLElement) => {
                 const text = inlineBlock.innerText;
                 const mbtn = /^(\|+)([^\|]+)\|+$/.exec(text);
@@ -110,7 +110,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     const ns = mtxt[2] ? mtxt[2].trim().toLowerCase() : '';
                     const txt = mtxt[3].trim();
                     const lev = mbtn[1].length == 1 ? `docs inlinebutton ui button ${txt.toLowerCase()}-button` : `docs inlineblock ${ns}`;
-                    inlineBlock.innerHTML = `<span class="${lev}">${this.html2Quote(pxt.U.rlf(txt))}</span>`
+                    inlineBlock.innerHTML = `<span class="${lev}">${pxt.Util.htmlEscape(pxt.U.rlf(txt))}</span>`
                 }
             })
     }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -70,7 +70,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         return params;
     }
 
-    private renderSnippetsAsync(content: HTMLElement) {
+    private renderSnippets(content: HTMLElement) {
         const { parent } = this.props;
 
         pxt.Util.toArray(document.querySelectorAll(`.lang-blocks`))
@@ -85,16 +85,22 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     parent.renderBlocksAsync({
                         action: "renderblocks", ts: code
                     } as pxt.editor.EditorMessageRenderBlocksRequest)
-                        .then((xml) => {
-                            langBlock.innerHTML = `<div class="ui segment raised">
-                                <img src="${xml}" /></div>`;
-                            MarkedContent.blockSnippetCache[code] = xml;
+                        .done((xml) => {
+                            if (xml) {
+                                langBlock.innerHTML = `<div class="ui segment raised">
+                                    <img src="${this.html2Quote(xml)}" /></div>`;
+                                MarkedContent.blockSnippetCache[code] = xml;
+                            } else {
+                                // An error occured, show alternate message
+                                langBlock.innerHTML = `<div class="ui segment raised">
+                                    <span>${lf("Oops, something went wrong trying to render this block snippet.")}</span></div>`;
+                            }
                         })
                 }
             })
     }
 
-    private renderInlineBlocksAsync(content: HTMLElement) {
+    private renderInlineBlocks(content: HTMLElement) {
         pxt.Util.toArray(document.querySelectorAll(`:not(pre) > code`))
             .forEach((inlineBlock: HTMLElement) => {
                 const text = inlineBlock.innerText;
@@ -104,7 +110,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     const ns = mtxt[2] ? mtxt[2].trim().toLowerCase() : '';
                     const txt = mtxt[3].trim();
                     const lev = mbtn[1].length == 1 ? `docs inlinebutton ui button ${txt.toLowerCase()}-button` : `docs inlineblock ${ns}`;
-                    inlineBlock.innerHTML = `<span class="${lev}">${pxt.U.rlf(txt)}</span>`
+                    inlineBlock.innerHTML = `<span class="${lev}">${this.html2Quote(pxt.U.rlf(txt))}</span>`
                 }
             })
     }
@@ -120,8 +126,8 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         content.innerHTML = marked(markdown);
 
         // We'll go through a series of adjustments here, rendering inline blocks, blocks and snippets as needed
-        this.renderInlineBlocksAsync(content);
-        this.renderSnippetsAsync(content);
+        this.renderInlineBlocks(content);
+        this.renderSnippets(content);
     }
 
     componentDidMount() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -203,11 +203,11 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 </div>
             )}
             {targetTheme.organizationUrl || targetTheme.organizationUrl || targetTheme.privacyUrl ? <div className="ui horizontal small divided link list homefooter">
-                {targetTheme.organizationUrl && targetTheme.organization ? <a className="item focused" target="_blank" rel="noopener" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
-                {targetTheme.selectLanguage ? <sui.Link className="item focused" text={lf("Language")} onClick={() => showLanguagePicker()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
-                {targetTheme.termsOfUseUrl ? <a target="_blank" className="item focused" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use")}</a> : undefined}
-                {targetTheme.privacyUrl ? <a target="_blank" className="item focused" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy")}</a> : undefined}
-                {pxt.appTarget.versions ? <sui.Link className="item focused"  text={`v${pxt.appTarget.versions.target}`} onClick={() => showAboutDialogAsync()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" rel="noopener" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
+                {targetTheme.selectLanguage ? <sui.Link className="item" text={lf("Language")} onClick={() => showLanguagePicker()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use")}</a> : undefined}
+                {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy")}</a> : undefined}
+                {pxt.appTarget.versions ? <sui.Link className="item" text={`v${pxt.appTarget.versions.target}`} onClick={() => showAboutDialogAsync()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
             </div> : undefined}
         </div>;
     }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -368,6 +368,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
         let index = 0;
         return <div ref={e => this.rootElement = e} id={`${editorname}EditorToolbox`}>
+            <ToolboxStyle categories={this.items} />
             {showSearchBox ? <ToolboxSearch ref="searchbox" parent={parent} toolbox={this} editorname={editorname} /> : undefined}
             <div className="blocklyTreeRoot">
                 <div role="tree">
@@ -747,5 +748,25 @@ export class ToolboxTrashIcon extends data.Component<{}, {}> {
         return <div id="blocklyTrashIcon" style={{ opacity: 0, display: 'none' }}>
             <i className="trash icon" aria-hidden="true"></i>
         </div>
+    }
+}
+
+interface ToolboxStyleProps {
+    categories: ToolboxCategory[];
+}
+
+export class ToolboxStyle extends data.Component<ToolboxStyleProps, {}> {
+    renderCore() {
+        const { categories } = this.props;
+        // Add inline CSS for each category used so that the tutorial engine is able to render blocks
+        // and assosiate them with a specific category
+        return <style>
+            {categories.filter(c => !!c.color).map(category =>
+                `span.docs.inlineblock.${category.nameid} {
+                    background-color: ${category.color};
+                    border-color: ${pxt.toolbox.fadeColor(category.color, 0.1, false)};
+                }`
+            )}
+        </style>
     }
 }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -41,8 +41,8 @@ export function parseTutorialSteps(tutorialId: string, tutorialmd: string) {
     for (let i = 0; i < steps.length; i++) {
         const stepContent = steps[i].trim();
         const contentLines = stepContent.split('\n');
-        stepInfo[i].headerContent = contentLines[0];
-        stepInfo[i].content = stepContent;
+        stepInfo[i].headerContentMd = contentLines[0];
+        stepInfo[i].contentMd = stepContent;
         stepInfo[i].hasHint = contentLines.length > 1;
     }
     return stepInfo;
@@ -141,11 +141,11 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
         if (!tutorialReady) return <div />;
 
         const step = tutorialStepInfo[tutorialStep];
-        const tutorialHint = step.content;
+        const tutorialHint = step.contentMd;
         const tutorialFullscreen = step.fullscreen;
         const tutorialUnplugged = !!step.unplugged && tutorialStep < tutorialStepInfo.length - 1;
 
-        const header = tutorialFullscreen ? (step.titleContent || tutorialName) : lf("Hint");
+        const header = tutorialFullscreen ? tutorialName : lf("Hint");
 
         const hide = () => this.setState({ visible: false });
         const next = () => {
@@ -301,7 +301,7 @@ export class TutorialCard extends data.Component<ISettingsProps, TutorialCardSta
         const options = this.props.parent.state.tutorialOptions;
         const { tutorialReady, tutorialStepInfo, tutorialStep } = options;
         if (!tutorialReady) return <div />
-        const tutorialCardContent = tutorialStepInfo[tutorialStep].headerContent;
+        const tutorialCardContent = tutorialStepInfo[tutorialStep].headerContentMd;
         let tutorialAriaLabel = '';
 
         const currentStep = tutorialStep;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -52,7 +52,7 @@ export function parseTutorialSteps(tutorialId: string, tutorialmd: string) {
  * We'll run this step when we first start the tutorial to figure out what blocks are used so we can
  * filter the toolbox. 
  */
-export function getUsedBlocks(tutorialId: string, tutorialmd: string): Promise<{ [index: string]: number }> {
+export function getUsedBlocksAsync(tutorialId: string, tutorialmd: string): Promise<{ [index: string]: number }> {
     tutorialmd = tutorialmd.replace(/((?!.)\s)+/g, "\n");
 
     const regex = /```(sim|block|blocks|filterblocks)\s*\n([\s\S]*?)\n```/gmi;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -76,8 +76,10 @@ export function getUsedBlocksAsync(tutorialId: string, tutorialmd: string): Prom
                             let blk = allblocks[bi];
                             usedBlocks[blk.type] = 1;
                         }
+                        return usedBlocks;
+                    } else {
+                        throw new Error("Empty blocksXml, failed to decompile");
                     }
-                    return usedBlocks;
                 }).catch(() => {
                     pxt.log(`Failed to decompile tutorial: ${tutorialId}`);
                     throw new Error(`Failed to decompile tutorial: ${tutorialId}`);

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -314,6 +314,7 @@ export class TutorialCard extends data.Component<ISettingsProps, TutorialCardSta
             tutorialAriaLabel += lf("Press Space or Enter to show a hint.");
         }
 
+        const isRtl = pxt.Util.isUserLanguageRtl();
         return <div id="tutorialcard" className={`ui ${tutorialReady ? 'tutorialReady' : ''}`} >
             <div className='ui buttons'>
                 <div className="ui segment attached tutorialsegment">
@@ -327,7 +328,7 @@ export class TutorialCard extends data.Component<ISettingsProps, TutorialCardSta
                     </div>
                     <sui.Button ref="tutorialok" id="tutorialOkButton" className="large green okbutton showlightbox" text={lf("Ok")} onClick={() => this.closeLightbox()} onKeyDown={sui.fireClickOnEnter} />
                 </div>
-                {hasNext ? <sui.Button icon="right chevron" rightIcon className={`nextbutton right attached green ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} ariaLabel={lf("Go to the next step of the tutorial.")} onClick={() => this.nextTutorialStep()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {hasNext ? <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron`} rightIcon className={`nextbutton right attached green ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} ariaLabel={lf("Go to the next step of the tutorial.")} onClick={() => this.nextTutorialStep()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 {hasFinish ? <sui.Button icon="left checkmark" className={`orange right attached ${!tutorialReady ? 'disabled' : ''}`} text={lf("Finish")} ariaLabel={lf("Finish the tutorial.")} onClick={() => this.finishTutorial()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
             </div>
         </div>;


### PR DESCRIPTION
We used to load the tutorial page in an iframe of the doc pages and then split it up based on some predefined format and just displayed it in the relevant parts of the editor. 

This meant that we had to re-load all editor resources in the iframe (which were already loaded in the editor and could be re-used).
Marked was also already included in the package so I decided to make use of that and just render the blocks on an as needed bases (ie: when the user clicks on the hint). 

Instead, here's what I'm doing: 
- User starts the tutorial engine
- We download the markdown from /docs. We parse it and store it in the state
- We then look for any block / snippet tags used and concat them into one snippet that we decompile in order to find the toolbox blocks used. 
- Update the toolbox with the blocks filtered
- We then render the first step inline (markdown react component). 
- When a user clicks on a hint, we also have an inline react component but this time we have the entire step's markdown in there which could include block tags, any block tags that we see, we call renderBlocks in the editor and get the block SVG. 
(In the meantime, we show a loading snipper as they're being decompiled)

 