### PR TITLE
Port over accessibility menu from master

### DIFF
--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -13,7 +13,7 @@
 
 <body id='root' class='root'>
 
-<div id="accessibleMenu" role="menubar">
+<div id="accessibleMenu" class="ui accessibleMenu borderless fixed menu"  role="menubar">
     @accMenu@
 </div>
 

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -187,11 +187,13 @@ svg {
 }
 
 #accessibleMenu .ui.item.link {
+    position: absolute;
     height: 4em;
     line-height: 4em;
     font-size: 1em;
     text-align: center;
-    color: white;
+    color: #387894;
+    background: hsla(0,0%,100%,.9)!important;
 }
 
 /* Styling the table of contents much like the Semantic UI documentation site: http://semantic-ui.com/introduction/getting-started.html */

--- a/theme/accessibility.less
+++ b/theme/accessibility.less
@@ -8,6 +8,11 @@
 /*******************************
           Accessibility
 *******************************/
+
+@accessibleMenuBackground: rgba(255,255,255,.9);
+@accessibleMenuColor: #387894;
+
+
 *[tabindex='0']:focus,
 *[tabindex*='d1']:focus,
 *[tabindex*='d2']:focus, /* Takes items with a defined tabIndex from 0 to 29. */
@@ -59,28 +64,33 @@ textarea:not([tabindex='-1']):focus,
     clip: rect(0 0 0 0);
 }
 
-#accessibleMenu {
-    position: absolute;
-    z-index: 1001;
-    top: -20em;
+.ui.menu.accessibleMenu, #accessibleMenu {
+    z-index: 1001 !important;
+    top: -20em !important;
     padding: 0;
     margin: 0;
     width: 100%;
+    border: 0;
 
     .ui.item.link {
         position: absolute;
         width: 100%;
-        color: rgba(255, 255, 255, 0.9);
+        color: @accessibleMenuColor;
+        background: @accessibleMenuBackground !important;
     }
-
+    .ui.item.link:hover {
+        color: @accessibleMenuColor;
+    }
     .ui.item.link:focus {
-        top:20em;
+        top: 20em !important;
+        box-shadow: 3px 3px 5px #aaa;
+        border-radius: 0px !important;
     }
 }
 
 /* <= Tablet (Mobile + Tablet) */
 @media only screen and (max-width: @largestTabletScreen) {
-    #menubar #accessibleMenu {
+    .menubar .ui.menu.accessibleMenu, #accessibleMenu {
         height: @mobileMenuHeight !important;
         min-height: @mobileMenuHeight !important;
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -342,11 +342,9 @@ div.simframe > iframe {
 }
 
 /* Icon and text */
-.ui.menu > .menu > .ui.item > .icon-and-text.icon {
-    margin: 0em auto;
-}
-.ui.menu > .menu > .ui.item > .icon-and-text.icon ~ span.ui.text {
-    margin-left: 0.6em;
+.ui.item.icon > .icon-and-text.icon ~ .ui.text,
+.ui.button.icon > .icon-and-text.icon ~ .ui.text {
+    margin-left: 0.5em !important;
 }
 
 /*******************************

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1738,7 +1738,7 @@ ${compileService ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${Util.html
             <div id='root' className={rootClasses}>
                 {hideMenuBar ? undefined :
                     <header id="menubar" role="banner" className={"ui menu"}>
-                        <div id="accessibleMenu" role="menubar">
+                        <div id="accessibleMenu" className="ui accessibleMenu borderless fixed menu" role="menubar">
                             <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon js" text={lf("Skip to JavaScript editor")} onClick={uiHandler(this.openJavaScript)} />
                             {selectLanguage ? <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={uiHandler(this.selectLang)} /> : undefined}
                             {targetTheme.highContrast ? <sui.Item class={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" text={this.state.highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={uiHandler(this.toggleHighContrast)} /> : undefined}


### PR DESCRIPTION
Note: this is a minor UI change for accessible users.

The semantic.css shared in pxt-deployment-config is used by docs.html in both v0 and master. 
A recent change to update that drop with a new semantic.css snap from master broke the accessibility menu in v0. 

Attempt to fix https://github.com/Microsoft/pxt/issues/2807

Porting over the new accessibility menu from master, so they can share the same structure and semantic.css

Here's what the old one looked like: 
<img width="1532" alt="screen shot 2018-05-01 at 10 56 56 am" src="https://user-images.githubusercontent.com/16690124/39477817-6ea76da8-4d2e-11e8-80b8-1075b47bd8f4.png">

Here's what the new one we're using in master looks like: 
<img width="1049" alt="screen shot 2018-05-01 at 10 56 22 am" src="https://user-images.githubusercontent.com/16690124/39477825-75df12ec-4d2e-11e8-8a36-1b1c43f823dd.png">

and in docs: 
<img width="1057" alt="screen shot 2018-05-01 at 10 56 36 am" src="https://user-images.githubusercontent.com/16690124/39477831-7adf35f6-4d2e-11e8-8da3-d5eb03d4cf24.png">

The styling and color used matches the MDN accessibility page. 

