### PR TITLE
Accessibility issue with "read more" links in the Blog

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -23,14 +23,12 @@ A servicing release for the micro:bit editor.
 January 26th, 2018 by Ryuta Hosaka
 
 A team of Japanese from the Seattle area translated the Introduction to Computer Science course for the micro:bit...
-**[Read more](/blog/microbit/csintro-japanese)**
 
 ## [Hello 2018](/blog/bett/01-22-2018)
 
 January 22nd, 2018 by [Jaqster](https://github.com/jaqster)
 
 Wow, hard to believe it’s 2018 already. We’re announcing some very cool stuff to kick off the new year...
-**[Read more](/blog/bett/01-22-2018)**
 
 ## [Micro:bit v0.13.52](/blog/microbit/v0.13.52)
 
@@ -43,70 +41,60 @@ A servicing release for the micro:bit editor.
 November 14th, 2017 by [riknoll](https://github.com/riknoll)
 
 The Microsoft MakeCode Team is excited to announce the beta release of a new editor...
-**[Read more](/blog/seeed/v0.2.10)**
 
 ## [Adafruit Circuit Playground Express Editor v0.20.13](/blog/adafruit-circuit-playground-express/v0.20.13)
 
 November 13th, 2017 by [pelikhan](https://github.com/pelikhan)
 
 We are happy to announce that the Circuit Playground Express editor is coming out of beta!
-**[Read more](/blog/adafruit-circuit-playground-express/v0.20.13)**
 
 ## [Microsoft MakeCode for Minecraft for Windows 10](/blog/minecraft/10-18-2017)
 
 October 18th, 2017
 
 Today, we are happy to announce MakeCode editor designed for **Minecraft for Windows 10**.
-**[Read more](/blog/minecraft/10-18-2017)**
 
 ## [Bootloader with a fork](/blog/uf2-for-arduino-uno)
 
 October 17th, 2017 by [mmoskal](https://github.com/mmoskal)
 
 UF2 bootloader for Arduino UNO allows for driver-less flashing of the vintage board.
-**[Read more](/blog/uf2-for-arduino-uno)**
 
 ## [Chibitronics Editor v0.1.40 (Scratch blocks)](/blog/chibitronics/v0.1.40)
 
 October 8th, 2017 by [microsoftsam](https://github.com/microsoftsam)
 
 A big release for our Chibitronics editor!
-**[Read more](/blog/chibitronics/v0.1.40)**
 
 ## [Microbit Editor v0.13.20 (Accessibility)](/blog/microbit/v0.13.20)
 
 September 8th, 2017
 
 Microsoft MakeCode adds more accessibility support...
-**[Read more](/blog/microbit/v0.13.20)**
 
 ## [Microbit Editor v0.12.64 (Function Block)](/blog/microbit/v0.12.58)
 
 August 11th, 2017
 
 Another release...
-**[Read more](/blog/microbit/v0.12.58)**
 
 ## [Timing Adventures in Infrared](/blog/timing-adventures-in-infrared)
 
 June 20, 2017 by [mmoskal](https://github.com/mmoskal)
 
 Circuit Playground Express boards can now talk to each other over IR! How was it done?
-**[Read more](/blog/timing-adventures-in-infrared)**
 
 ## [Microbit Editor v0.12.35](/blog/microbit/v0.12.35)
 
 June 13th, 2017
 
 Migrating https://pxt.microbit.org to https://makecode.microbit.org...
-**[Read more](/blog/microbit/v0.12.35)**
 
 ## [Microbit Editor v0.12.23](/blog/microbit/v0.12.23)
 
 May 30th, 2017
 
 Release notes for the micro:bit editor...
-**[Read more](/blog/microbit/v0.12.23)**
 
 ## [Adafruit Circuit Playground Express](/blog/adafruit-cplay-express)
 
@@ -114,14 +102,12 @@ May 19, 2017 by [Jaqster](https://github.com/Jaqster)
 
 The Microsoft MakeCode team is proud to announce a great partnership
 with our good friends over at Adafruit Industries.
-**[Read more](/blog/adafruit-cplay-express)**
 
 ## [Minecraft Code Builder](/blog/minecraft-code-builder)
 
 May 2, 2017 by [Jaqster](https://github.com/Jaqster)
 
 Learn to code using Microsoft MakeCode and Minecraft Education!
-**[Read more](/blog/minecraft-code-builder)**
 
 ## [Programming the micro:bit on the Apple II](/blog/appleII)
 
@@ -129,21 +115,18 @@ April 1, 2017 by [tballmsft](https://github.com/tballmsft)
 
 The Microsoft MakeCode team has worked hard to bring a beginning programming experience
 for the micro:bit to everyone...
-**[Read more](/blog/appleII)**
 
 ## [Microbit Editor v0.9.77](/blog/microbit/v0.9.77)
 
 March 30, 2017
 
 Release notes for the micro:bit editor...
-**[Read more](/blog/microbit/v0.9.77)**
 
 ## [Microsoft MakeCode Overview](/blog/makecode-overview)
 
 March 30, 2017 by [tballmsft](https://github.com/tballmsft)
 
 Overview of the main features of the Microsoft MakeCode web app...
-**[Read more](/blog/makecode-overview)**
 
 ## [One chip to flash them all](/blog/one-chip-to-flash-them-all)
 
@@ -151,12 +134,10 @@ March 29, 2017 by [mmoskal](https://github.com/mmoskal)
 
 MakeCode team introduces driver-less flashing of boards without an interface chip
 using file format dubbed UF2...
-**[Read more](/blog/one-chip-to-flash-them-all)**
 
 ## [Hello World](/blog/hello-world)
 
 March 29, 2017
 
 Welcome to the official release and developer blog of Microsoft MakeCode, also known as PXT...
-**[Read more](/blog/hello-world)**
 

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -5,30 +5,35 @@
 March 5th, 2018
 
 Announcing Microsoft MakeCode for Cue!
+**[Continue reading this blog post](/blog/wonder-workshop/03-05-2018)**
 
 ## [Hello Maker!](/blog/maker/hello)
 
 February 27th, 2018 by Daryl Zuniga
 
 Introducing a new (beta) editor for bread-board friendly maker boards.
+**[Continue reading this blog post](/blog/maker/hello)**
 
 ## [Micro:bit v0.14.18](/blog/microbit/v0.14.18)
 
 February 23rd, 2018
 
 A servicing release for the micro:bit editor.
+**[Continue reading this blog post](/blog/microbit/v0.14.18)**
 
 ## [# マイクロビット はじめてのコンピュータサイエンス (CS Intro)が日本語になりました](/blog/microbit/csintro-japanese)
 
 January 26th, 2018 by Ryuta Hosaka
 
 A team of Japanese from the Seattle area translated the Introduction to Computer Science course for the micro:bit...
+**[Continue reading this blog post](/blog/microbit/csintro-japanese)**
 
 ## [Hello 2018](/blog/bett/01-22-2018)
 
 January 22nd, 2018 by [Jaqster](https://github.com/jaqster)
 
 Wow, hard to believe it’s 2018 already. We’re announcing some very cool stuff to kick off the new year...
+**[Continue reading this blog post](/blog/bett/01-22-2018)**
 
 ## [Micro:bit v0.13.52](/blog/microbit/v0.13.52)
 
@@ -41,60 +46,70 @@ A servicing release for the micro:bit editor.
 November 14th, 2017 by [riknoll](https://github.com/riknoll)
 
 The Microsoft MakeCode Team is excited to announce the beta release of a new editor...
+**[Continue reading this blog post](/blog/seeed/v0.2.10)**
 
 ## [Adafruit Circuit Playground Express Editor v0.20.13](/blog/adafruit-circuit-playground-express/v0.20.13)
 
 November 13th, 2017 by [pelikhan](https://github.com/pelikhan)
 
 We are happy to announce that the Circuit Playground Express editor is coming out of beta!
+**[Continue reading this blog post](/blog/adafruit-circuit-playground-express/v0.20.13)**
 
 ## [Microsoft MakeCode for Minecraft for Windows 10](/blog/minecraft/10-18-2017)
 
 October 18th, 2017
 
 Today, we are happy to announce MakeCode editor designed for **Minecraft for Windows 10**.
+**[Continue reading this blog post](/blog/minecraft/10-18-2017)**
 
 ## [Bootloader with a fork](/blog/uf2-for-arduino-uno)
 
 October 17th, 2017 by [mmoskal](https://github.com/mmoskal)
 
 UF2 bootloader for Arduino UNO allows for driver-less flashing of the vintage board.
+**[Continue reading this blog post](/blog/uf2-for-arduino-uno)**
 
 ## [Chibitronics Editor v0.1.40 (Scratch blocks)](/blog/chibitronics/v0.1.40)
 
 October 8th, 2017 by [microsoftsam](https://github.com/microsoftsam)
 
 A big release for our Chibitronics editor!
+**[Continue reading this blog post](/blog/chibitronics/v0.1.40)**
 
 ## [Microbit Editor v0.13.20 (Accessibility)](/blog/microbit/v0.13.20)
 
 September 8th, 2017
 
 Microsoft MakeCode adds more accessibility support...
+**[Continue reading this blog post](/blog/microbit/v0.13.20)**
 
 ## [Microbit Editor v0.12.64 (Function Block)](/blog/microbit/v0.12.58)
 
 August 11th, 2017
 
 Another release...
+**[Continue reading this blog post](/blog/microbit/v0.12.58)**
 
 ## [Timing Adventures in Infrared](/blog/timing-adventures-in-infrared)
 
 June 20, 2017 by [mmoskal](https://github.com/mmoskal)
 
 Circuit Playground Express boards can now talk to each other over IR! How was it done?
+**[Continue reading this blog post](/blog/timing-adventures-in-infrared)**
 
 ## [Microbit Editor v0.12.35](/blog/microbit/v0.12.35)
 
 June 13th, 2017
 
 Migrating https://pxt.microbit.org to https://makecode.microbit.org...
+**[Continue reading this blog post](/blog/microbit/v0.12.35)**
 
 ## [Microbit Editor v0.12.23](/blog/microbit/v0.12.23)
 
 May 30th, 2017
 
 Release notes for the micro:bit editor...
+**[Continue reading this blog post](/blog/microbit/v0.12.23)**
 
 ## [Adafruit Circuit Playground Express](/blog/adafruit-cplay-express)
 
@@ -102,12 +117,14 @@ May 19, 2017 by [Jaqster](https://github.com/Jaqster)
 
 The Microsoft MakeCode team is proud to announce a great partnership
 with our good friends over at Adafruit Industries.
+**[Continue reading this blog post](/blog/adafruit-cplay-express)**
 
 ## [Minecraft Code Builder](/blog/minecraft-code-builder)
 
 May 2, 2017 by [Jaqster](https://github.com/Jaqster)
 
 Learn to code using Microsoft MakeCode and Minecraft Education!
+**[Continue reading this blog post](/blog/minecraft-code-builder)**
 
 ## [Programming the micro:bit on the Apple II](/blog/appleII)
 
@@ -115,18 +132,21 @@ April 1, 2017 by [tballmsft](https://github.com/tballmsft)
 
 The Microsoft MakeCode team has worked hard to bring a beginning programming experience
 for the micro:bit to everyone...
+**[Continue reading this blog post](/blog/appleII)**
 
 ## [Microbit Editor v0.9.77](/blog/microbit/v0.9.77)
 
 March 30, 2017
 
 Release notes for the micro:bit editor...
+**[Continue reading this blog post](/blog/microbit/v0.9.77)**
 
 ## [Microsoft MakeCode Overview](/blog/makecode-overview)
 
 March 30, 2017 by [tballmsft](https://github.com/tballmsft)
 
 Overview of the main features of the Microsoft MakeCode web app...
+**[Continue reading this blog post](/blog/makecode-overview)**
 
 ## [One chip to flash them all](/blog/one-chip-to-flash-them-all)
 
@@ -134,10 +154,12 @@ March 29, 2017 by [mmoskal](https://github.com/mmoskal)
 
 MakeCode team introduces driver-less flashing of boards without an interface chip
 using file format dubbed UF2...
+**[Continue reading this blog post](/blog/one-chip-to-flash-them-all)**
 
 ## [Hello World](/blog/hello-world)
 
 March 29, 2017
 
 Welcome to the official release and developer blog of Microsoft MakeCode, also known as PXT...
+**[Continue reading this blog post](/blog/hello-world)**
 


### PR DESCRIPTION
Resolve issue with read more links in the blog page by removing them. 

There's an inherent accessibility issue with using Read more links in that you need to either be more descriptive in the link text (which is clunky and repetitive for most users), or use aria-label to describe the link text further. 

Since we use markdown for authoring, we're unable to add aria-labels specifically for links (unless we hack around marked), so the two options are: 
- be more descriptive with the read more links. 
- or remove them altogether. 

Opted in for the first option: 
<img width="806" alt="screen shot 2018-05-01 at 11 17 26 am" src="https://user-images.githubusercontent.com/16690124/39478789-5d76db2e-4d31-11e8-8c49-6548177c4ac7.png">

Attempt to resolve:
https://github.com/Microsoft/pxt/issues/2647

http://www.washington.edu/accessibility/links/ describing the issue more