### PR TITLE
Don't throw away comments on auto declarations in decompiler

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1687,7 +1687,11 @@ ${output}</xml>`;
             const isTopLevel = isTopLevelComment(node);
 
             for (const commentRange of commentRanges) {
-                const commentText = fileText.substr(commentRange.pos, commentRange.end - commentRange.pos)
+                let commentText = fileText.substr(commentRange.pos, commentRange.end - commentRange.pos)
+                if (commentText) {
+                    // Strip windows line endings because they break the regex we use to extract content
+                    commentText = commentText.replace(/\r\n/g, "\n");
+                }
                 if (commentRange.kind === SyntaxKind.SingleLineCommentTrivia) {
                     appendMatch(commentText, 1, 3, singleLineCommentRegex)
                 }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -924,6 +924,7 @@ ${output}</xml>`;
                             // never get used in the blocks (and thus won't be emitted again)
 
                             trackAutoDeclaration(decl);
+                            getComments(parent || node);
                             return getNext();
                         }
                         stmt = getVariableDeclarationStatement(node as ts.VariableDeclaration);
@@ -967,21 +968,7 @@ ${output}</xml>`;
                 }
             }
 
-            const commentRanges = ts.getLeadingCommentRangesOfNode(parent || node, file)
-            if (commentRanges) {
-                const wsCommentRefs: string[] = [];
-                const commentText = getCommentText(commentRanges, node, wsCommentRefs)
-
-                if (wsCommentRefs.length) {
-                    stmt.data = wsCommentRefs.join(";")
-                }
-                if (commentText && stmt) {
-                    stmt.comment = commentText;
-                }
-                else {
-                    // ERROR TODO
-                }
-            }
+            getComments(parent || node);
 
             return stmt;
 
@@ -990,6 +977,27 @@ ${output}</xml>`;
                     return getStatementBlock(next.shift(), next, undefined, false, topLevel);
                 }
                 return undefined;
+            }
+
+            function getComments(commented: Node) {
+                const commentRanges = ts.getLeadingCommentRangesOfNode(commented, file)
+                if (commentRanges) {
+                    const wsCommentRefs: string[] = [];
+                    const commentText = getCommentText(commentRanges, node, wsCommentRefs)
+
+                    if (stmt) {
+                        if (wsCommentRefs.length) {
+                            stmt.data = wsCommentRefs.join(";")
+                        }
+                        if (commentText && stmt) {
+                            stmt.comment = commentText;
+                        }
+                        else {
+                            // ERROR TODO
+                        }
+                    }
+                }
+
             }
         }
 

--- a/tests/decompile-test/baselines/workspace_comments_variable_statements.blocks
+++ b/tests/decompile-test/baselines/workspace_comments_variable_statements.blocks
@@ -1,0 +1,17 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</statement>
+</block>
+<comment h="120" w="160" data="0">
+
+</comment>
+</xml>

--- a/tests/decompile-test/baselines/workspace_comments_variable_statements.blocks
+++ b/tests/decompile-test/baselines/workspace_comments_variable_statements.blocks
@@ -12,6 +12,6 @@
 </statement>
 </block>
 <comment h="120" w="160" data="0">
-
+lakskdjfl&#59;askjdf
 </comment>
 </xml>

--- a/tests/decompile-test/cases/workspace_comments_variable_statements.ts
+++ b/tests/decompile-test/cases/workspace_comments_variable_statements.ts
@@ -1,0 +1,6 @@
+/**
+ * lakskdjfl;askjdf
+ */
+let x = 0
+
+x = 1;


### PR DESCRIPTION
For some reason, the baseline in the test case was generated without the actual comment content. I expect this has something to do with the decompiler test runner so don't worry about it. I've tested the same code in the browser and it works fine.