### PR TITLE
Vertical separators in block authoring

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -574,6 +574,10 @@ declare namespace Blockly {
         forceRerender(): void;
     }
 
+    class FieldVerticalSeparator extends Field {
+        constructor();
+    }
+
     class FieldVariable extends Field {
         constructor(d: any);
     }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -414,9 +414,11 @@ namespace pxt.blocks {
         return true;
     }
 
-    function newLabel(part: pxtc.BlockLabel | pxtc.BlockImage): Blockly.Field {
+    function newLabel(part: pxtc.BlockLabel | pxtc.BlockImage | pxtc.BlockSeparator): Blockly.Field {
         if (part.kind === "image") {
             return iconToFieldImage(part.uri);
+        } else if (part.kind == "separator") {
+            return new Blockly.FieldVerticalSeparator();
         }
 
         const txt = removeOuterSpace(part.text)
@@ -2570,6 +2572,9 @@ namespace pxt.blocks {
                     break;
                 case "image":
                 case "label":
+                    current.push(part);
+                    break;
+                case "separator":
                     current.push(part);
                     break;
             }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -195,7 +195,7 @@ namespace ts.pxtc {
     }
 
 
-    export type BlockContentPart = BlockLabel | BlockParameter | BlockImage;
+    export type BlockContentPart = BlockLabel | BlockParameter | BlockImage | BlockSeparator;
     export type BlockPart = BlockContentPart | BlockBreak;
 
     export interface BlockLabel {
@@ -218,6 +218,10 @@ namespace ts.pxtc {
     export interface BlockImage {
         kind: "image";
         uri: string;
+    }
+
+    export interface BlockSeparator {
+        kind: "separator";
     }
 
     export interface ParsedBlockDef {
@@ -325,6 +329,7 @@ namespace ts.pxtc {
         Word = 1 << 7,
         Image = 1 << 8,
         TaggedText = 1 << 9,
+        Hash = 1 << 10,
 
         TripleUnderscore = SingleUnderscore | DoubleUnderscore,
         TripleAsterisk = SingleAsterisk | DoubleAsterisk,
@@ -762,6 +767,9 @@ namespace ts.pxtc {
                 case "|":
                     newToken = { kind: TokenKind.Pipe };
                     break;
+                case "#":
+                    newToken = { kind: TokenKind.Hash };
+                    break;
                 case "\\":
                     if (strIndex < (def.length - 1)) newToken = { kind: TokenKind.Escape, content: def[1 + (strIndex++)] };
                     break;
@@ -871,6 +879,9 @@ namespace ts.pxtc {
             }
             else if (token == TokenKind.Pipe) {
                 parts.push({ kind: "break" });
+            }
+            else if (token == TokenKind.Hash) {
+                parts.push({ kind: "separator" } as BlockSeparator);
             }
         }
 


### PR DESCRIPTION
With this change we can add vertical separators in our block authoring. 
This allows us to do things like this when referring to objects (OO model): 

<img width="933" alt="screen shot 2018-05-02 at 7 11 45 pm" src="https://user-images.githubusercontent.com/16690124/39557508-fb4d81fc-4e3c-11e8-8f20-c5a37ac2b5f3.png">

@Jaqster @abchatra @riknoll @pelikhan @guillaumejenkins this is what I was talking about today. 


Before:
<img width="714" alt="screen shot 2018-05-02 at 7 22 25 pm" src="https://user-images.githubusercontent.com/16690124/39557688-2c021bb8-4e3e-11e8-9b97-1b2de4b13145.png">


After:
<img width="933" alt="screen shot 2018-05-02 at 7 11 45 pm" src="https://user-images.githubusercontent.com/16690124/39557526-39f056a0-4e3d-11e8-998f-1adc1cdf10ef.png">

We're running out of characters to use for our authoring. Since Pipe was already used, I'm using the Hash character (#, Pound key for the Americans) to indicate we want a separator. Open to other suggestions.
