### PR TITLE
High contrast fixes

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -12,10 +12,6 @@ svg.blocklySvg {
     background-color: @blocklySvgColor !important;
 }
 
-.hc svg.blocklySvg {
-    background-color: black !important;
-}
-
 #maineditor, #blocksEditor > div.loading {
     background: @blocklySvgColor;
 }

--- a/theme/common.less
+++ b/theme/common.less
@@ -173,32 +173,6 @@ body {
     text-align: center;
 }
 
-/* Cookie Message */
-#cookiemsg {
-   position: absolute;
-   right: 2rem;
-   bottom: 12rem;
-   width: 18rem;
-   text-align: left;
-   z-index: @aboveEverythingZIndex;
-}
-
-#cookiemsg > a {
-   color: white;
-   text-decoration: underline;
-}
-
-#cookiemsg > .ui.button.icon.clear {
-    color: white !important;
-}
-#cookiemsg > .ui.button.icon.clear:hover, #cookiemsg > .ui.button.icon.clear:focus {
-    color: darken(white, 20%) !important;
-}
-
-.collapsedEditorTools #cookiemsg {
-   bottom: 6rem;
-}
-
 /* Simulator */
 div.simframe {
     border:none;
@@ -728,9 +702,6 @@ p.ui.font.small {
     .collapsedEditorTools #maineditor {
         left: 0;
     }
-    #cookiemsg {
-        bottom: 7.5rem;
-    }
 
     /* Full screen */
     .fullscreensim #filelist {
@@ -974,9 +945,6 @@ p.ui.font.small {
         .sandbox #msg {
         bottom: 1.5rem !important;
     }
-    .sandbox #cookiemsg {
-        bottom: 3rem;
-    }
     .sandbox #editortools {
         display: none;
     }
@@ -1054,15 +1022,6 @@ p.ui.font.small {
     }
     .simView div.simframe:only-child > iframe {
         max-width: 100%;
-    }
-    .sandbox #cookiemsg {
-        left: 0;
-        right: 0;
-        margin-left: 0.2rem;
-        margin-right: 0.2rem;
-        width: inherit;
-        bottom: 1.5rem;
-        padding: 0.3rem;
     }
 }
 

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -9,6 +9,10 @@
         High Contrast
 *******************************/
 
+@selected: #10C8CD;
+@disabled: #3ff23f;
+@hcYellow: yellow;
+
 /* Messages */
 #msg .hc {
     background-color: black !important;
@@ -17,11 +21,32 @@
     color: white !important;
 }
 
+@HCRootBackground: black;
+@HCblocklySvgColor: black;
+@HCsimulatorBackground: black;
+@HCblocklySvgColor: black;
+
+@HCmainMenuBackground: white;
+@HCmainMenuTextColor: black;
+@HCmainMenuInverseTextColor: white;
+
+@HCblocklyToolboxColor: white;
+@HCblocklyTreeLabelColor: black;
+@HCblocklyTreeLabelSelectedColor: white;
+
+@HCeditorToolsBackground: black;
+
+@HCbuttonBackground: white;
+@HCbuttonTextColor: black;
+
+@HChomeScreenBackground: black;
+
+@HCaccessibleMenuBackground: black;
+@HCaccessibleMenuColor: white;
+
 .hc {
 
-@selected: #10C8CD;
-@disabled: #3ff23f;
-@hcYellow: yellow;
+    /* Focus */
 
     *[tabindex='0']:focus,
     *[tabindex*='d1']:focus,
@@ -56,18 +81,51 @@
         outline: none !important;
     }
 
-    /* root */
-    #root {
-        background: black !important;
+    /* Blockly toolbox */
+    .pxtToolbox:not(.invertedToolbox) {
+        span.blocklyTreeLabel {
+            color: @HCblocklyTreeLabelColor;
+        }
+        .blocklyTreeSelected span.blocklyTreeLabel {
+            color: @HCblocklyTreeLabelSelectedColor;
+        }
     }
 
-    /* Simulator */
+    /* Blockly flyout */
+    path.blocklyFlyoutBackground {
+        fill: @HCblocklySvgColor !important;
+        fill-opacity: 1 !important;
+        stroke-width: 4px;
+        stroke: white;
+    }
+    .monacoFlyout {
+        background: @HCblocklySvgColor !important;
+        border-right: 4px solid white !important;
+    }
+
+    /* Main editor areas */
+
+    #root {
+        background: @HCRootBackground !important;
+    }
     #filelist {
-        background: black !important;
+        background: @HCsimulatorBackground !important;
 
         #boardview {
-            background: black !important;
+            background: @HCsimulatorBackground !important;
         }
+    }
+    svg.blocklySvg {
+        background-color: @HCblocklySvgColor !important;
+    }
+
+    .blocklyMainBackground {
+        fill: transparent !important;
+    }
+
+    .blocklyToolboxDiv, .monacoToolboxDiv {
+        background: @HCblocklyToolboxColor !important;
+        border-right: 0px !important;
     }
 
     /* Menu bar */
@@ -76,41 +134,57 @@
         color: @selected !important;
     }
 
-    .menubar .editor-menuitem {
-        border: none !important;
-    }
+    #mainmenu:not(.inverted), #homemenu:not(.inverted) {
+        background-color: @HCmainMenuBackground !important;
+        color: @HCmainMenuTextColor !important;
+        border-bottom: 4px solid white;
 
-    .menubar .accessibleMenu > .item:focus,
-    .menubar .editor-menuitem > .item:focus:not(.active) {
-        i, span {
-            color: @selected !important;
+        .ui.item {
+            color: @HCmainMenuTextColor;
+        }
+        .item.editor-menuitem .ui.grid {
+            border: 1px solid black !important;
+        }
+    }
+    #mainmenu.inverted, #homemenu.inverted {
+        background-color: @HCmainMenuTextColor !important;
+        color: @HCmainMenuBackground !important;
+        border-bottom: 4px solid white;
+
+        .ui.item {
+            color: @HCmainMenuBackground;
+        }
+        .item.editor-menuitem .ui.grid {
+            border: 1px solid white !important;
         }
     }
 
-    .menubar .ui.inverted.menu, .menubar .accessibleMenu .ui.item.link.inverted:hover {
+    /* Editor switch toggle */
+    .menubar .ui.menu.fixed .item.editor-menuitem .ui.grid {
         background: black !important;
-        border-bottom: 1px solid white;
-    }
-
-    .menubar .ui.menu.inverted.fixed .ui.item.editor-menuitem .active.item {
-        color: white !important;
-    }
-
-    .menubar .accessibleMenu .ui.item.link {
-        color: white !important;
+        .item:not(.active) {
+            opacity: 1 !important;
+            color: @HCmainMenuInverseTextColor !important;
+        }
+        .item.active {
+            background: white !important;
+            color: @HCmainMenuTextColor !important;
+        }
     }
 
     /* Editor toolbar */
+    #editortools, #downloadArea {
+        background: @HCeditorToolsBackground !important;
+    }
     #editortools {
-        background: black !important;
-        border-top: 1px solid white;
+        border-top: 4px solid white;
     }
 
     /* Buttons */
     .ui.button {
-        background: black !important;
-        color: white !important;
-        border: 1px solid white !important;
+        background: @HCbuttonBackground !important;
+        color: @HCbuttonTextColor !important;
+        border: 1px solid @HCbuttonTextColor !important;
 
         &:focus {
             color: @selected !important;
@@ -119,6 +193,10 @@
             i, span {
                 color: @selected !important;
             }
+        }
+
+        .inverted.icon {
+            color: @HCbuttonTextColor !important;
         }
     }
 
@@ -131,32 +209,126 @@
         }
     }
 
-    .ui.button.download-button:hover > span,
-    .ui.button.download-button:hover > i {
-        color: white !important;
-    }
-
     /* Inputs */
     .ui.input input {
-        background: black !important;
-        color: white !important;
-        border: 1px solid white !important;
+        background: white !important;
+        color: black !important;
+        border: 1px solid black !important;
     }
     input::placeholder {
-        color: @hcYellow !important;
+        color: @selected !important;
+    }
+
+    /* Home screen */
+    .projectsdialog, .projectsdialog .tabsegment {
+        background: @HChomeScreenBackground !important;
+        color: white !important;
+        border-color: white !important;
+
+        .header {
+            opacity: 1 !important;
+            color: white;
+        }
+
+        .homefooter a {
+            color: white !important
+        }
+    }
+
+    /* Cards */
+    .card {
+        background: black !important;
+        border: 2px solid white !important;
+        border-radius: initial !important;
+        box-shadow: initial !important;
+
+        .header, .description, .meta {
+            color: white !important;
+        }
+
+        &:hover {
+            .header, .description, .meta {
+                color: @hcYellow !important;
+            }
+        }
+
+        &:focus {
+            .header, .description, .meta {
+                color: @selected !important;
+            }
+        }
+
+        .ui.orange.labels .label, .ui.orange.label {
+            background: @disabled !important;
+            border-color: @disabled !important;
+            color: black !important;
+        }
+    }
+
+    /* File menu */
+    .filemenu {
+        .item, .ui.button {
+            background: black !important;
+            color: white !important;
+            border: 1px solid white !important;
+        }
+        .item:focus, .item.active {
+            background: @selected !important;
+
+            span {
+                color: black !important;
+            }
+        }
+    }
+
+    /* PxtJson */
+    #maineditor {
+        border-left: 1px solid white !important;
+    }
+
+    /* Serial editor */
+
+    #serialPreview div {
+        color: white;
+    }
+
+    #serialCharts .ui.segment {
+        background-color: #fff;
+    }
+
+    #serialEditor {
+        background-color: #000;
+    }
+
+    #serialHeader .ui.header {
+        color: black;
+    }
+
+    #serialConsole {
+        background-color: #000;
+        color: #fff;
+        border-color: #fff;
+    }
+
+    #serialPreview .label {
+        border: 10px solid #fff !important;
+        &:hover {
+            border-color: darken(#fff, 10.0) !important;
+        }
+    }
+
+    .ui.button.labeled.icon.editorBack {
+        background: white !important;
     }
 
     /* Hyperlinks */
     a {
-        color: @hcYellow !important;
+        color: @selected !important;
     }
 
     #sidedocsbar {
-        background-color: black !important;
-
         a {
-            color: white !important;
-            outline: 1px solid white !important;
+            color: black !important;
 
             &:focus {
                 color: @selected !important;
@@ -168,26 +340,14 @@
         }
     }
 
-    /** Top menu **/
-    #mainmenu, #downloadArea {
-        background-color: black !important;
-        color: white !important;
-    }
-    
-    /* Items */
-    .ui.item {
-        background: black !important;
-        color: white !important;
-    }
-
     /* Dropdown */
     .ui.menu .ui.dropdown .menu {
         border: 1px solid white !important;
     }
 
     .ui.menu .ui.dropdown .menu, .ui.menu .ui.dropdown .menu > .item {
-        background: black !important;
-        color: white !important;
+        background: white !important;
+        color: black !important;
 
         &:focus {
             color: @selected !important;
@@ -205,31 +365,9 @@
         border-top: 1px solid white !important;
     }
 
-    /* Editor switch toggle */
-    .menubar .ui.menu .item.editor-menuitem {
-        border: 1px solid white !important;
-    }
-
-    .menubar .ui.menu .item.editor-menuitem .active {
-        background: @selected !important;
-        color: black !important;
-    }
-
-    /* Modals */
-    .ui.modal {
-        border: 2px solid white !important;
-        border-radius: initial !important;
-        box-shadow: initial !important;
-    }
-
-    .ui.modal, .ui.modal > .header, .ui.modal > .content, .ui.modal > .actions, .ui.modal > .segment {
-        background: black !important;
-        color: white !important;
-    }
-
     /* Tab list in Modals*/
     .ui.secondary.menu > .item:not(.active), .ui.secondary.pointing.menu > .item:not(.active), .ui.secondary.inverted.menu .link.item:not(.active) {
-        color: white !important;
+        color: black !important;
         border: 1px solid white !important;
     }
 
@@ -239,47 +377,6 @@
         border: 2px solid @selected !important;
         border-radius: initial !important;
         box-shadow: initial !important;
-    }
-
-    .projectsdialog .tabsegment, .ui.modal .ui.inverted.segment, .ui.modal .ui.primary.inverted.segment {
-        background: black !important;
-        color: white !important;
-        border-color: white !important;
-
-        .header {
-            opacity: 1 !important;
-            color: white;
-        }
-    }
-
-    /* Cards */
-    .card {
-        background: black !important;
-        border: 2px solid white !important;
-        border-radius: initial !important;
-        box-shadow: initial !important;
-
-        .header, .description, .meta {
-            color: white !important;
-        }
-
-        &:focus {
-            .header, .description, .meta {
-                color: @selected !important;
-            }
-        }
-
-        .ui.orange.labels .label, .ui.orange.label {
-            background: @disabled !important;
-            border-color: @disabled !important;
-            color: black !important;
-        }
-    }
-
-    #cookiemsg {
-        background: black !important;
-        border-radius: 0em;
-        border: 1px solid white !important;
     }
 
     /* Tutorial */
@@ -307,105 +404,37 @@
         border-color: @selected !important;
     }
 
-    /* Blockly / Monaco toolbox */
-    .blocklyTreeSelected {
-        background: @selected !important;
-    }
 
-    .blocklyToolboxDiv, .monacoToolboxDiv {
-        background: black !important;
-        border-left: 1px solid white !important;
-        border-right: 1px solid white !important;
-    }
+    /* Modals */
+    .ui.modal {
+        border: 2px solid black !important;
+        border-radius: initial !important;
+        box-shadow: initial !important;
 
-    .blocklyTreeLabel, .blocklyTreeIcon {
-        color: white !important;
-    }
-
-    .blocklyFlyoutButtonBackground {
-        fill: black !important;
-    }
-
-    .monacoFlyout {
-        background: black !important;
-        border-right: 1px solid white !important;
-    }
-
-    /* Editor toolbox */
-    .filemenu {
-        .item {
-            background: black !important;
-            color: white !important;
-            border: 1px solid white !important;
-        }
-
-        .item:focus, .item.active {
-            background: @selected !important;
-
-            span {
-                color: black !important;
-            }
+        > .closeIcon .close {
+            color: black !important;
         }
     }
 
-    /* PxtJson */
-    #maineditor {
-        border-left: 1px solid white !important;
+    .ui.modal, .ui.modal > .header, .ui.modal > .content, .ui.modal > .actions, .ui.modal > .segment {
+        background: white !important;
+        color: black !important;
     }
 
-    #maineditor, .ui.segment.form {
-        background: black !important;
-
-        label {
-            color: white !important;
+    /* Accessible menu */
+    .ui.menu.accessibleMenu, #accessibleMenu {
+        .ui.item.link {
+            color: @HCaccessibleMenuColor !important;
+            background: @HCaccessibleMenuBackground !important;
         }
     }
+}
 
-    #serialPreview div {
-        color: #fff;
-    }
-
-    #serialCharts .ui.segment {
-        background-color: #fff;
-    }
-
-    #serialEditor {
-        background-color: #000;
-    }
-
-    #serialHeader .ui.header {
-        color: #fff;
-    }
-
-    #serialConsole {
-        background-color: #000;
-        color: #fff;
-        border-color: #fff;
-    }
-
-    #serialPreview .label {
-        border: 10px solid #fff !important;
-        &:hover {
-            border-color: darken(#fff, 10.0) !important;
-        }
-    }
-
-    /* Blockly blocks */
-    .blocklyPath {
-        stroke-width: 4px !important;
-        fill: black;
-    }
-    .blocklyBlockBackground {
-        stroke-width: 2px;
-        fill: black;
-    }
-    .blocklyText {
-        fill: white;
-    }
-    path.blocklyFlyoutBackground {
-        fill: black !important;
-        stroke-width: 1px;
-        stroke: white;
-        border-right: 1px solid white !important;
+/* > Small Monitor */
+@media only screen and (min-width: @computerBreakpoint) {
+    /* Hide the editor toolbor in tutorial mode */
+    .hc.tutorial #editortools  {
+        background: transparent !important;
+        border-top: 0px;
     }
 }

--- a/theme/home.less
+++ b/theme/home.less
@@ -19,10 +19,6 @@
     z-index: @homeScreenZIndex;
 }
 
-.inHome > *:not(#homescreen):not(#cookiemsg) {
-    visibility: hidden;
-}
-
 .projectsdialog {
     background: @homeScreenBackground;
     position: relative;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -92,12 +92,15 @@ export class ProjectView
         this.settings = JSON.parse(pxt.storage.getLocal("editorSettings") || "{}")
         const shouldShowHomeScreen = this.shouldShowHomeScreen();
         const isSandbox = pxt.shell.isSandboxMode() || pxt.shell.isReadOnly();
+        const isHighContrast = /hc=(\w+)/.test(window.location.href);
+        if (isHighContrast) core.setHighContrast(true);
 
         this.state = {
             showFiles: false,
             home: shouldShowHomeScreen,
             active: document.visibilityState == 'visible',
-            collapseEditorTools: pxt.appTarget.simulator.headless || (!isSandbox && pxt.BrowserUtils.isMobile())
+            collapseEditorTools: pxt.appTarget.simulator.headless || (!isSandbox && pxt.BrowserUtils.isMobile()),
+            highContrast: isHighContrast
         };
         if (!this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 19;
         if (!this.settings.fileHistory) this.settings.fileHistory = [];

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -923,6 +923,10 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             'modal transition visible active',
             className
         ]);
+        const portalClassName = cx([
+            core.highContrast ? 'hc' : '',
+            mountClasses
+        ])
         const closeIconName = closeIcon === true ? 'close' : closeIcon as string;
         const aria = {
             labelledby: header ? this.id + 'title' : undefined,
@@ -942,7 +946,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             shouldReturnFocusAfterClose={true} shouldFocusAfterRender={shouldFocusAfterRender}
             shouldCloseOnEsc={shouldCloseOnEsc || closeOnEscape}
             shouldCloseOnOverlayClick={shouldCloseOnOverlayClick || (closeOnDocumentClick || closeOnDimmerClick)}
-            portalClassName={mountClasses}
+            portalClassName={portalClassName}
             overlayClassName={`ui page modals dimmer transition ${isOpen ? 'visible active' : ''}`}
             className={classes}
             style={customStyles}

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -366,8 +366,15 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
         const searchTreeRow = ToolboxSearch.getSearchTreeRow();
 
+        const appTheme = pxt.appTarget.appTheme;
+        const classes = sui.cx([
+            'pxtToolbox',
+            appTheme.invertedToolbox ? 'invertedToolbox' : '',
+            appTheme.coloredToolbox ? 'coloredToolbox' : ''
+        ])
+
         let index = 0;
-        return <div ref={e => this.rootElement = e} id={`${editorname}EditorToolbox`}>
+        return <div ref={e => this.rootElement = e} className={classes} id={`${editorname}EditorToolbox`}>
             <ToolboxStyle categories={this.items} />
             {showSearchBox ? <ToolboxSearch ref="searchbox" parent={parent} toolbox={this} editorname={editorname} /> : undefined}
             <div className="blocklyTreeRoot">

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -157,17 +157,12 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
         }
 
         const isRtl = pxt.Util.isUserLanguageRtl();
-        const actions: sui.ModalButton[] = [tutorialUnplugged ? {
-            label: lf("Next"),
-            onclick: next,
-            icon: `${isRtl ? 'left' : 'right'} chevron`,
+        const actions: sui.ModalButton[] = [{
+            label: lf("Ok"),
+            onclick: tutorialUnplugged ? next : hide,
+            icon: 'check',
             className: 'green'
-        } : {
-                label: lf("Ok"),
-                onclick: hide,
-                icon: 'check',
-                className: 'green'
-            }]
+        }]
 
         return <sui.Modal isOpen={visible} className="hintdialog"
             closeIcon={true} header={header} buttons={actions}

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -303,6 +303,7 @@ export class TutorialCard extends data.Component<ISettingsProps, TutorialCardSta
 
         const currentStep = tutorialStep;
         const maxSteps = tutorialStepInfo.length;
+        const hasPrevious = tutorialReady && currentStep != 0;
         const hasNext = tutorialReady && currentStep != maxSteps - 1;
         const hasFinish = currentStep == maxSteps - 1;
         const hasHint = this.hasHint();
@@ -314,6 +315,7 @@ export class TutorialCard extends data.Component<ISettingsProps, TutorialCardSta
         const isRtl = pxt.Util.isUserLanguageRtl();
         return <div id="tutorialcard" className={`ui ${tutorialReady ? 'tutorialReady' : ''}`} >
             <div className='ui buttons'>
+                {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron`} className={`prevbutton right attached green ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="landscape only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={() => this.previousTutorialStep()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">
                     <div className='avatar-image' onClick={() => this.showHint()} onKeyDown={sui.fireClickOnEnter}></div>
                     {hasHint ? <sui.Button className="mini blue hintbutton hidelightbox" text={lf("Hint")} tabIndex={-1} onClick={() => this.showHint()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
@@ -325,7 +327,7 @@ export class TutorialCard extends data.Component<ISettingsProps, TutorialCardSta
                     </div>
                     <sui.Button ref="tutorialok" id="tutorialOkButton" className="large green okbutton showlightbox" text={lf("Ok")} onClick={() => this.closeLightbox()} onKeyDown={sui.fireClickOnEnter} />
                 </div>
-                {hasNext ? <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron`} rightIcon className={`nextbutton right attached green ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} ariaLabel={lf("Go to the next step of the tutorial.")} onClick={() => this.nextTutorialStep()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {hasNext ? <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron`} rightIcon className={`nextbutton right attached green ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} textClass="landscape only" ariaLabel={lf("Go to the next step of the tutorial.")} onClick={() => this.nextTutorialStep()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 {hasFinish ? <sui.Button icon="left checkmark" className={`orange right attached ${!tutorialReady ? 'disabled' : ''}`} text={lf("Finish")} ariaLabel={lf("Finish the tutorial.")} onClick={() => this.finishTutorial()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
             </div>
         </div>;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -149,16 +149,18 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
 
         const hide = () => this.setState({ visible: false });
         const next = () => {
+            hide();
             const nextStep = tutorialStep + 1;
             options.tutorialStep = nextStep;
             pxt.tickEvent(`tutorial.hint.next`, { tutorial: options.tutorial, step: nextStep });
             this.props.parent.setTutorialStep(nextStep);
         }
 
+        const isRtl = pxt.Util.isUserLanguageRtl();
         const actions: sui.ModalButton[] = [tutorialUnplugged ? {
             label: lf("Next"),
             onclick: next,
-            icon: 'check',
+            icon: `${isRtl ? 'left' : 'right'} chevron`,
             className: 'green'
         } : {
                 label: lf("Ok"),
@@ -169,7 +171,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
 
         return <sui.Modal isOpen={visible} className="hintdialog"
             closeIcon={true} header={header} buttons={actions}
-            onClose={hide} dimmer={true} longer={true}
+            onClose={tutorialUnplugged ? next : hide} dimmer={true} longer={true}
             closeOnDimmerClick closeOnDocumentClick closeOnEscape>
             <md.MarkedContent markdown={tutorialHint} parent={this.props.parent} />
         </sui.Modal>;


### PR DESCRIPTION
- adding option to access hc directly with a flag ?hc=1
- Reverting Halo mode. 
- High contrast difference between simulator, toolbox, and then blocks / JS. 
- Always show the same theme across all editors regardless of light / dark theme. 

Adafruit:
<img width="1150" alt="screen shot 2018-05-03 at 11 49 45 pm" src="https://user-images.githubusercontent.com/16690124/39641128-f5b5cff6-4f81-11e8-841c-ecdb03c76836.png">

Chibitronics:
<img width="1150" alt="screen shot 2018-05-03 at 11 47 43 pm" src="https://user-images.githubusercontent.com/16690124/39641136-011d925c-4f82-11e8-86c1-b22e04fbbf57.png">

Fixes https://github.com/Microsoft/pxt-adafruit/issues/667
Fixes https://github.com/Microsoft/pxt-adafruit/issues/645
Fixes https://github.com/Microsoft/pxt-adafruit/issues/608
Fixes https://github.com/Microsoft/pxt-adafruit/issues/602