### PR TITLE
Fix tutorials in IE

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -199,7 +199,7 @@ namespace pxt.editor {
         loadBlocklyAsync(): Promise<void>;
         isBlocksEditor(): boolean;
         isTextEditor(): boolean;
-        renderBlocksAsync(req: EditorMessageRenderBlocksRequest): Promise<string>;
+        renderBlocksAsync(req: EditorMessageRenderBlocksRequest): Promise<any>;
 
         toggleHighContrast(): void;
         pair(): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -303,7 +303,7 @@ namespace pxt.editor {
                         case "renderblocks": {
                             const rendermsg = data as EditorMessageRenderBlocksRequest;
                             p = p.then(() => projectView.renderBlocksAsync(rendermsg))
-                                .then((img: string) => { resp = img; });
+                                .then((r: any) => { resp = r.xml; });
                             break;
                         }
                         case "toggletrace": {

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -166,6 +166,12 @@ i.icon.avatar-image {
     background-image: @avatarImage;
 }
 
+/* Tutorial blocks */
+
+.ui.segment .blocklyPreview {
+    width: 100%;
+}
+
 /******************************
     Hint button
 ******************************/

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1538,15 +1538,18 @@ export class ProjectView
         this.importDialog.show();
     }
 
-    renderBlocksAsync(req: pxt.editor.EditorMessageRenderBlocksRequest): Promise<string> {
+    renderBlocksAsync(req: pxt.editor.EditorMessageRenderBlocksRequest): Promise<any> {
         return compiler.getBlocksAsync()
             .then(blocksInfo => compiler.decompileSnippetAsync(req.ts, blocksInfo))
             .then(resp => {
                 const svg = pxt.blocks.render(resp, { snippetMode: true, layout: pxt.blocks.BlockLayout.Align });
                 // TODO: what if svg is undefined? handle that scenario
                 const viewBox = svg.getAttribute("viewBox").split(/\s+/).map(d => parseInt(d));
-                return pxt.blocks.layout.blocklyToSvgAsync(svg, viewBox[0], viewBox[1], viewBox[2], viewBox[3]);
-            }).then(re => re.xml);
+                return {
+                    svg: svg,
+                    xml: pxt.blocks.layout.blocklyToSvgAsync(svg, viewBox[0], viewBox[1], viewBox[2], viewBox[3])
+                }
+            });
     }
 
     launchFullEditor() {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -44,27 +44,26 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         pxt.Util.toArray(content.querySelectorAll(`.lang-blocks`))
             .forEach((langBlock: HTMLElement) => {
-                const code = langBlock.innerText;
+                const code = langBlock.innerHTML;
                 const wrapperDiv = document.createElement('div');
                 langBlock.innerHTML = '';
                 langBlock.appendChild(wrapperDiv);
                 wrapperDiv.className = 'ui segment raised loading';
                 if (MarkedContent.blockSnippetCache[code]) {
                     // Use cache
-                    const imgDiv = document.createElement('img');
-                    imgDiv.src = MarkedContent.blockSnippetCache[code];
-                    wrapperDiv.appendChild(imgDiv);
+                    const svg = Blockly.Xml.textToDom(MarkedContent.blockSnippetCache[code]);
+                    wrapperDiv.appendChild(svg);
                     pxsim.U.removeClass(wrapperDiv, 'loading');
                 } else {
                     parent.renderBlocksAsync({
                         action: "renderblocks", ts: code
                     } as pxt.editor.EditorMessageRenderBlocksRequest)
-                        .done((datauri) => {
-                            if (datauri) {
-                                MarkedContent.blockSnippetCache[code] = datauri;
-                                const imgDiv = document.createElement('img');
-                                imgDiv.src = MarkedContent.blockSnippetCache[code];
-                                wrapperDiv.appendChild(imgDiv);
+                        .done((resp: any) => {
+                            const svg = resp.svg;
+                            if (svg) {
+                                svg.setAttribute('height', `${svg.getAttribute('viewBox').split(' ')[3]}px`);
+                                MarkedContent.blockSnippetCache[code] = Blockly.Xml.domToPrettyText(svg);
+                                wrapperDiv.appendChild(svg);
                                 pxsim.U.removeClass(wrapperDiv, 'loading');
                             } else {
                                 // An error occured, show alternate message


### PR DESCRIPTION
Use blockly XML in the tutorial instead of images. Use innerHTML instead of InnerText so that IE doesn't escape new line characters in <code> blocks