### PR TITLE
live compile for app if online

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1280,7 +1280,8 @@ namespace pxt.hex {
         else {
             let curr = getOnlineCdnUrl()
             if (curr) return (cdnUrlPromise = Promise.resolve(curr))
-            return (cdnUrlPromise = Cloud.privateGetAsync("clientconfig").then(r => r.primaryCdnUrl));
+            return (cdnUrlPromise = Cloud.privateGetAsync("clientconfig", /* forceLiveEndpoint */ pxt.webConfig.isStatic)
+                .then(r => r.primaryCdnUrl));
         }
     }
 


### PR DESCRIPTION
If hex is not found in local cache, attempt to hit live endpoint. This PR accomplishes this by forcing live endpoint to get the CDN url, which is then used for /compile endpoint