### PR TITLE
Updates for Chrome Autoplay policy

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -121,6 +121,7 @@ namespace pxsim {
             const frame = document.createElement('iframe') as HTMLIFrameElement;
             frame.id = 'sim-frame-' + this.nextId()
             frame.allowFullscreen = true;
+            frame.setAttribute('allow', 'autoplay');
             frame.setAttribute('sandbox', 'allow-same-origin allow-scripts');
             frame.sandbox.value = "allow-scripts allow-same-origin"
             let simUrl = this.options.simUrl || ((window as any).pxtConfig || {}).simUrl || "/sim/simulator.html"


### PR DESCRIPTION
Chrome autoplay policy affects how we play the sim. Since the simulator is in an iframe and under a separate domain, we need to explicitly allow autoplay on the sim iframes so that if autoplay is granted to the parent iframe (after user interaction), the sim frame would share that permission. 

see https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
```Example 4: MyMovieReviewBlog.com embeds an iframe with a movie trailer to go along with their review. The user interacted with the domain to get to the specific blog, so autoplay is allowed. However, the blog needs to explicitly delegate that privilege to the iframe in order for the content to autoplay.```