### PR TITLE
Thou shalt not load a script from an editor 1 major version above

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -325,7 +325,7 @@ declare namespace ts.pxtc {
         flashEnd?: number;
         flashUsableEnd?: number;
         flashChecksumAddr?: number;
-        patches?: pxt.Map<UpgradePolicy[]>; // semver range -> upgrade policies
+        patches?: pxt.Map<UpgradePolicy[]>; // semver range -> upgrade policies        
         openocdScript?: string;
         onStartText?: boolean;
         stackAlign?: number; // 1 word (default), or 2

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -712,7 +712,9 @@ export class ProjectView
                 body: lf("This project was created in a newer version of this editor. Please try again in that editor."),
                 disagreeLbl: lf("Ok"),
                 buttons
-            }).then(() => this.openHome());
+            })
+            // TODO: find a better recovery for this.
+            .then(() => this.openHome());
         }
 
         Util.jsonMergeFrom(editorState || {}, this.state.editorState || {});

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -695,6 +695,26 @@ export class ProjectView
 
         this.stopSimulator(true);
         this.clearSerial()
+
+        // version check
+        if (h.targetVersion && pxt.semver.majorCmp(h.targetVersion, pxt.appTarget.versions.target) == 0) {
+            // the script is a major version ahead, need to redirect
+            pxt.tickEvent('patch.maxversion');
+            const buttons: sui.ModalButton[] = [];
+            if (pxt.appTarget && pxt.appTarget.appTheme && pxt.appTarget.appTheme.homeUrl)
+                buttons.push({
+                    label: lf("Get latest"),
+                    icon: "external alternate",
+                    url: pxt.appTarget.appTheme.homeUrl,
+                    buttons
+                })
+            return core.dialogAsync({
+                header: lf("Oops, this project is too new!"),
+                body: lf("This project was created in a newer version of this editor. Please try again in that editor."),
+                disagreeLbl: lf("Ok")
+            }).then(() => this.openHome());
+        }
+
         Util.jsonMergeFrom(editorState || {}, this.state.editorState || {});
         return pkg.loadPkgAsync(h.id)
             .then(() => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -699,7 +699,7 @@ export class ProjectView
         // version check, you should not load a script from 1 major version above.
         if (h.targetVersion && pxt.semver.majorCmp(h.targetVersion, pxt.appTarget.versions.target) < 0) {
             // the script is a major version ahead, need to redirect
-            pxt.tickEvent('patch.maxversion');
+            pxt.tickEvent('patch.maxversion', { targetVersion: h.targetVersion });
             const buttons: sui.ModalButton[] = [];
             if (pxt.appTarget && pxt.appTarget.appTheme && pxt.appTarget.appTheme.homeUrl)
                 buttons.push({

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -705,13 +705,13 @@ export class ProjectView
                 buttons.push({
                     label: lf("Get latest"),
                     icon: "external alternate",
-                    url: pxt.appTarget.appTheme.homeUrl,
-                    buttons
+                    url: pxt.appTarget.appTheme.homeUrl
                 })
             return core.dialogAsync({
                 header: lf("Oops, this project is too new!"),
                 body: lf("This project was created in a newer version of this editor. Please try again in that editor."),
-                disagreeLbl: lf("Ok")
+                disagreeLbl: lf("Ok"),
+                buttons
             }).then(() => this.openHome());
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -696,8 +696,8 @@ export class ProjectView
         this.stopSimulator(true);
         this.clearSerial()
 
-        // version check
-        if (h.targetVersion && pxt.semver.majorCmp(h.targetVersion, pxt.appTarget.versions.target) == 0) {
+        // version check, you should not load a script from 1 major version above.
+        if (h.targetVersion && pxt.semver.majorCmp(h.targetVersion, pxt.appTarget.versions.target) < 0) {
             // the script is a major version ahead, need to redirect
             pxt.tickEvent('patch.maxversion');
             const buttons: sui.ModalButton[] = [];


### PR DESCRIPTION
Following the semver semantic, if the editor detects a script with a major version greater than current, refuse to load.
This PR will go in v0 as well.