### PR TITLE
Emit string literals encoded in UTF8

### DIFF
--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -409,11 +409,12 @@ namespace ts.pxtc {
     function emitStrings(bin: Binary) {
         for (let s of Object.keys(bin.strings)) {
             let lbl = bin.strings[s]
+            let utf8_s = Util.toUTF8(s)
             // string representation of DAL - 0xffff in general for ref-counted objects means it's static and shouldn't be incr/decred
             bin.otherLiterals.push(`
 .balign 4
-${lbl}meta: .short 0xffff, ${s.length}
-${lbl}: .string ${stringLiteral(s)}
+${lbl}meta: .short 0xffff, ${utf8_s.length}
+${lbl}: .string ${stringLiteral(utf8_s)}
 `)
         }
     }


### PR DESCRIPTION
When string literals were being emitted, the generated byte strings
would use only the lowest byte per Unicode code point. For ASCII
characters this is not an issue, since they have code points < 256.
For code points that are above 256 (e.g. Greek characters), the
characters would alias to unrelated ones, since only the lowest
byte would be used.

This changeset encodes string literals according to UTF8 before they
get emitted. ASCII characters are not affected by this change, but
characters that would be misrepresented are now encoded into
multiple bytes, allowing their accurate decoding.