### PR TITLE
Support custom handler key

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1263,6 +1263,7 @@ namespace pxt.blocks {
         isExpression?: boolean;
         imageLiteral?: number;
         hasHandler?: boolean;
+        handlerKey?: string;
         property?: boolean;
         namespace?: string;
         isIdentity?: boolean; // TD_ID shim
@@ -1460,6 +1461,7 @@ namespace pxt.blocks {
                         isExpression: fn.retType && fn.retType !== "void",
                         imageLiteral: fn.attributes.imageLiteral,
                         hasHandler: !!comp.handlerArgs.length || fn.parameters && fn.parameters.some(p => (p.type == "() => void" || !!p.properties)),
+                        handlerKey: fn.attributes.blockHandlerKey,
                         property: !fn.parameters,
                         isIdentity: fn.attributes.shim == "TD_ID"
                     }
@@ -1709,7 +1711,7 @@ namespace pxt.blocks {
             else if (call && call.hasHandler && !call.attrs.handlerStatement) {
                 // compute key that identifies event call
                 // detect if same event is registered already
-                const key = callKey(e, b);
+                const key = call.handlerKey || callKey(e, b);
                 flagDuplicate(key, b);
             } else {
                 // all non-events are disabled

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1263,7 +1263,6 @@ namespace pxt.blocks {
         isExpression?: boolean;
         imageLiteral?: number;
         hasHandler?: boolean;
-        handlerKey?: string;
         property?: boolean;
         namespace?: string;
         isIdentity?: boolean; // TD_ID shim
@@ -1461,7 +1460,6 @@ namespace pxt.blocks {
                         isExpression: fn.retType && fn.retType !== "void",
                         imageLiteral: fn.attributes.imageLiteral,
                         hasHandler: !!comp.handlerArgs.length || fn.parameters && fn.parameters.some(p => (p.type == "() => void" || !!p.properties)),
-                        handlerKey: fn.attributes.blockHandlerKey,
                         property: !fn.parameters,
                         isIdentity: fn.attributes.shim == "TD_ID"
                     }
@@ -1711,7 +1709,7 @@ namespace pxt.blocks {
             else if (call && call.hasHandler && !call.attrs.handlerStatement) {
                 // compute key that identifies event call
                 // detect if same event is registered already
-                const key = call.handlerKey || callKey(e, b);
+                const key = call.attrs.blockHandlerKey || callKey(e, b);
                 flagDuplicate(key, b);
             } else {
                 // all non-events are disabled

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -160,6 +160,7 @@ namespace ts.pxtc {
         groupIcons?: string[];
         labelLineWidth?: string;
         handlerStatement?: boolean; // indicates a block with a callback that can be used as a statement
+        blockHandlerKey?: string; // optional field for explicitly declaring the handler key to use to compare duplicate events 
         afterOnStart?: boolean; // indicates an event that should be compiled after on start when converting to typescript
 
         // on interfaces


### PR DESCRIPTION
Support block authoring a custom handler key to use when comparing block event duplicates.