### PR TITLE
optimize toolbox for non inverted themese

### DIFF
--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -39,4 +39,13 @@
     .blocklyTreeRow, .blocklyTreeRow.blocklyTreeSelected {
         box-shadow: 1px 1px #000;
     }
+
+    .pxtToolbox:not(.invertedToolbox) {
+        .blocklyTreeRow:not(.blocklyTreeSelected) {
+            background: white;
+            .blocklyTreeIcon, .blocklyTreeLabel {
+                color: black;
+            }
+        }
+    }
 }


### PR DESCRIPTION
In greenscreen, don't override background of toolbox in inverted mode
