### PR TITLE
Fix favicon not showing

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -435,7 +435,7 @@ namespace pxt.BrowserUtils {
     }
 
     export function patchCdn(url: string): string {
-        if (!url) return url;
+        if (!url || !pxt.getOnlineCdnUrl()) return url;
         return url.replace("@cdnUrl@", pxt.getOnlineCdnUrl());
     }
 


### PR DESCRIPTION
Favicons were not showing because we were doing a pass on ``@appLogo@`` and ``@cardLogo@`` during the upload step and were patching the ``@cdnUrl@`` to null, this avoids that, and it maintains the url as ``@cdnUrl@/blob/....`` for the cloud to patch.
