### PR TITLE
Add snippet to package name

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3455,7 +3455,7 @@ function testSnippetsAsync(snippets: CodeSnippet[], re?: string): Promise<void> 
             return Promise.resolve();
         }
 
-        const pkg = new pxt.MainPackage(new SnippetHost(name, snippet.code, Object.keys(snippet.packages)));
+        const pkg = new pxt.MainPackage(new SnippetHost("snippet" + name, snippet.code, Object.keys(snippet.packages)));
         return pkg.getCompileOptionsAsync().then(opts => {
             opts.ast = true
             let resp = pxtc.compile(opts)


### PR DESCRIPTION
To stop the tests from breaking on `.md` files that start with a number