### PR TITLE
Do not provide non-sensical symbol information for implicit 'this' parameter.

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2580,7 +2580,7 @@ ${output}</xml>`;
             if (comp.thisParameter) {
                 res.push({
                     value: unwrapNode(info.args[0]) as Expression,
-                    info: sym.parameters[0],
+                    info: null,
                     param: comp.thisParameter
                 });
             }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt/issues/4313.