### PR TITLE
be more specific about highlight macro (clashes with sni[ppets)

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -522,7 +522,8 @@ Avatar
     filter: blur(1);
 }
 
-.highlight {
+// clashes with highlighted typescript code snippets
+svg .highlight {
     border-bottom: 2px solid #FFC107;
 }
 


### PR DESCRIPTION
More specific about CSS rule used for simulators.
![image](https://user-images.githubusercontent.com/4175913/40208893-065a2996-59f1-11e8-9d7e-27874511cc48.png)
