### PR TITLE
Use textContent and not innerHTML for getting code from marked

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -44,7 +44,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         pxt.Util.toArray(content.querySelectorAll(`.lang-blocks`))
             .forEach((langBlock: HTMLElement) => {
-                const code = langBlock.innerHTML;
+                // Can't use innerHTML here because it escapes certain characters (e.g. < and >)
+                // Also can't use innerText because IE strips out the newlines from the code
+                // textContent seems to work in all browsers and return the "pure" text
+                const code = langBlock.textContent;
+
                 const wrapperDiv = document.createElement('div');
                 pxsim.U.clear(langBlock);
                 langBlock.appendChild(wrapperDiv);


### PR DESCRIPTION
This fixes an issue where any tutorial snippet that had a "<" character was failing to compile because we were getting the escaped text out of the DOM instead of the unescaped text. Tested in Chrome, Firefox, IE, end Edge.

@pelikhan proof that it's impossible to test snippets 100% in the CLI :wink:
