### PR TITLE
Assign current target version to CLI-loaded project

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,25 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": "DebugBuild",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/built/pxt.js",
+			"stopOnEntry": false,
+			"args": ["buildtarget"],
+			"cwd": "${workspaceRoot}/../pxt-adafruit",
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"console": "integratedTerminal",
+			"sourceMaps": false,
+			"outFiles": []
+		},
+		{
 			"name": "Launch",
 			"type": "node",
 			"request": "launch",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1198,7 +1198,11 @@ function readLocalPxTarget() {
         process.exit(1)
     }
     nodeutil.setTargetDir(process.cwd())
-    let cfg: pxt.TargetBundle = readJson("pxtarget.json")
+    const cfg: pxt.TargetBundle = readJson("pxtarget.json");
+    cfg.versions = {
+        target: readJson("package.json")["version"]
+    };
+
     return cfg
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1122,7 +1122,7 @@ function uploadCoreAsync(opts: UploadOptions) {
                             // path config before storing
                             const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
                             if (/^\//.test(config.icon)) config.icon = opts.localDir + "docs" + config.icon;
-                            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 2);
+                            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
                         })
                         data = new Buffer((isJs ? targetJsPrefix : '') + JSON.stringify(trg, null, 2), "utf8")
                     } else {
@@ -1143,7 +1143,7 @@ function uploadCoreAsync(opts: UploadOptions) {
                             if (config.icon) config.icon = uploadArtFile(config.icon);
                             res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 2);
                         })
-                        content = JSON.stringify(trg, null, 2);
+                        content = JSON.stringify(trg, null, 4);
                         if (isJs)
                             content = targetJsPrefix + content
                     }
@@ -1228,14 +1228,14 @@ function forEachBundledPkgAsync(f: (pkg: pxt.MainPackage, dirname: string) => Pr
                     .filter(f => fs.existsSync(f))
                     .forEach(f => host.fileOverrides[path.relative(overridePath, f)] = fs.readFileSync(f, "utf8"));
 
-                pxt.log(`file overrides: ${Object.keys(host.fileOverrides).join(', ')}`)
+                pxt.debug(`file overrides: ${Object.keys(host.fileOverrides).join(', ')}`)
             } else {
                 pxt.debug(`override folder ${overridePath} not present`);
             }
         }
 
         process.chdir(pkgPath);
-        mainPkg = new pxt.MainPackage(host)
+        mainPkg = new pxt.MainPackage(host);
         return f(mainPkg, dirname);
     })
         .finally(() => process.chdir(prev))
@@ -1903,7 +1903,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         .filter(ip => fs.existsSync("docs" + ip))
                         .forEach(ip => config.icon = ip);
 
-                res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 2);
+                res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
             })
 
 

--- a/cli/commandparser.ts
+++ b/cli/commandparser.ts
@@ -111,7 +111,7 @@ export class CommandParser {
                 if (!flagName) {
                     if (match[2] == "debug" || match[2] == "d") {
                         pxt.options.debug = true;
-                        pxt.debug = console.debug || console.log;
+                        pxt.debug = console.log;
                         continue;
                     }
                     throw new Error(`Unrecognized flag '${match[2]}' for command '${command.name}'`)

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -264,6 +264,7 @@ export function readPkgConfig(dir: string) {
             }
         }
     }
+    if (!js.targetVersions) js.targetVersions = pxt.appTarget.versions;
     return js
 }
 

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -5,7 +5,7 @@ declare namespace pxt {
 
     interface TargetVersions {
         target: string;
-        pxt: string;
+        pxt?: string;
         pxtCrowdinBranch?: string;
         targetCrowdinBranch?: string;
         tag?: string;

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -496,7 +496,7 @@ namespace pxt.BrowserUtils {
             // path config before storing
             const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
             if (config.icon) config.icon = patchCdn(config.icon);
-            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 2);
+            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
         })
     }
 


### PR DESCRIPTION
A side effect of applying upgrades on load (which are needed to handle multiple editor versions loading from the same local storage store), is that we were upgrading bundled projects -- in Adafruit in particular.

This change assumes that a project loaded from the CLI has the current target version (if omitted) to avoid any kind of accidental rewrite.

(Also consistently use 4 spaces to write pxt.json)