### PR TITLE
support for screensize specification

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -88,6 +88,7 @@ declare namespace pxt {
         extraBlocks?: BlockToolboxDefinition[];  // deprecated
         assetExtensions?: string[];
         palette?: string[];
+        screenSize?: Size;
     }
 
     interface AppAnalytics {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -13,6 +13,11 @@ declare namespace pxt {
         commits?: string; // URL
     }
 
+    interface Size {
+        width: number;
+        height: number;
+    }
+
     /**
      * The schema for the pxt.json package files
      */
@@ -37,6 +42,7 @@ declare namespace pxt {
         platformio?: PlatformIOConfig;
         compileServiceVariant?: string;
         palette?: string[];
+        screenSize?: Size;
         yotta?: YottaConfig;
         npmDependencies?: Map<string>;
         card?: CodeCard;

--- a/pxtblocks/fields/sprite/spriteFieldEditor.ts
+++ b/pxtblocks/fields/sprite/spriteFieldEditor.ts
@@ -326,17 +326,26 @@ namespace pxtblockly {
                     continue;
                 }
 
-                const width = parseInt(pair[0]);
-                const height = parseInt(pair[1]);
+                let width = parseInt(pair[0]);
+                let height = parseInt(pair[1]);
 
                 if (isNaN(width) || isNaN(height)) {
                     continue;
                 }
 
+                const screenSize = pxt.appTarget.runtime && pxt.appTarget.runtime.screenSize;
+                if (width < 0 && screenSize)
+                    width = screenSize.width;
+                if (height < 0 && screenSize)
+                    height = screenSize.height;
+
                 sizes.push([width, height]);
             }
-
-            parsed.sizes = sizes;
+            if (sizes.length > 0) {
+                parsed.sizes = sizes;
+                parsed.initWidth = sizes[0][0];
+                parsed.initHeight = sizes[0][1];
+            }
         }
 
         parsed.initColor = withDefault(opts.initColor, parsed.initColor);

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -456,6 +456,9 @@ namespace pxt {
                     // get paletter config loading deps, so the more higher level packages take precedence
                     if (this.config.palette && appTarget.runtime)
                         appTarget.runtime.palette = U.clone(this.config.palette)
+                    // get screen size loading deps, so the more higher level packages take precedence
+                    if (this.config.screenSize && appTarget.runtime)
+                        appTarget.runtime.screenSize = U.clone(this.config.screenSize);
 
                     if (this.level === 0) {
                         // Check for missing packages. We need to add them 1 by 1 in case they conflict with eachother.


### PR DESCRIPTION
Updates to support full screen sprite editor sizes.

- [x] Allows to specify a "screenSize" value in pxt.json.
- [x] sprite field editor replaces -1 with according size from pxt.json

(small fix around initial screen size)