### PR TITLE
Header versioning fix

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -335,7 +335,7 @@ namespace pxt {
             return updatedCont;
         }
 
-        private parseConfig(cfgSrc: string, targetVersion: string) {
+        private parseConfig(cfgSrc: string, targetVersion?: string) {
             const cfg = <PackageConfig>JSON.parse(cfgSrc);
             this.config = cfg;
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -335,7 +335,7 @@ namespace pxt {
             return updatedCont;
         }
 
-        private parseConfig(cfgSrc: string) {
+        private parseConfig(cfgSrc: string, targetVersion: string) {
             const cfg = <PackageConfig>JSON.parse(cfgSrc);
             this.config = cfg;
 
@@ -348,6 +348,11 @@ namespace pxt {
                         this.config.dependencies[value] = "*";
                     }
                 }
+            }
+            if (targetVersion) {
+                this.config.targetVersions = {
+                    target: targetVersion
+                };
             }
             if (JSON.stringify(this.config) != currentConfig) {
                 this.saveConfig();
@@ -379,7 +384,7 @@ namespace pxt {
             }
         }
 
-        loadAsync(isInstall = false): Promise<void> {
+        loadAsync(isInstall = false, targetVersion?: string): Promise<void> {
             if (this.isLoaded) return Promise.resolve();
 
             let initPromise = Promise.resolve()
@@ -397,8 +402,11 @@ namespace pxt {
                 initPromise = initPromise.then(() => this.downloadAsync())
 
             initPromise = initPromise.then(() => {
-                this.getFiles().filter(fn => /\.ts$/.test(fn))
-                    .forEach(file => this.upgradeFile(file, this.readFile(file)));
+                if (this.level == 0) {
+                    pxt.debug(`upgrading files, target version ${this.targetVersion()}`)
+                    this.getFiles().filter(fn => /\.ts$/.test(fn))
+                        .forEach(file => this.upgradeFile(file, this.readFile(file)));
+                }
             })
 
             if (appTarget.simulator && appTarget.simulator.dynamicBoardDefinition) {
@@ -582,8 +590,8 @@ namespace pxt {
             this.deps[this.id] = this;
         }
 
-        installAllAsync() {
-            return this.loadAsync(true)
+        installAllAsync(targetVersion?: string) {
+            return this.loadAsync(true, targetVersion);
         }
 
         sortedDeps() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -708,6 +708,7 @@ export class ProjectView
         if (!h)
             return Promise.resolve()
 
+        pxt.debug(`loading ${h.id} (pxt v${h.targetVersion})`);
         this.stopSimulator(true);
         this.clearSerial()
 

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -456,7 +456,7 @@ export function notifySyncDone(updated: pxt.Map<number>) {
 
 }
 
-export function loadPkgAsync(id: string) {
+export function loadPkgAsync(id: string, targetVersion?: string) {
     mainPkg = new pxt.MainPackage(theHost)
     mainPkg._verspec = "workspace:" + id;
 
@@ -464,8 +464,8 @@ export function loadPkgAsync(id: string) {
         .catch(core.handleNetworkError)
         .then(() => JSON.parse(theHost.readFile(mainPkg, pxt.CONFIG_NAME)) as pxt.PackageConfig)
         .then(config => {
-            if (!config) return Promise.resolve()
-            return mainPkg.installAllAsync()
+            if (!config) return Promise.resolve();
+            return mainPkg.installAllAsync(targetVersion)
                 .then(() => mainEditorPkg().afterMainLoadAsync())
                 .catch(e => {
                     core.errorNotification(lf("Cannot load package: {0}", e.message))


### PR DESCRIPTION
When loading a header, we use the target version information to decide whether upgrade rules are applied.

- [x] properly propagate the target version information during load
- [x] do not apply rewrite rules to dependency sources (only level 0)