### PR TITLE
Show equality comparitor in toolbox

### DIFF
--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -113,14 +113,13 @@ export const logic: BuiltinCategoryDefinition = {
             </value>
         </block>`
         }, {
-            name: "logic_compare_gt",
+            name: "logic_compare_eq",
             attributes: {
                 blockId: "logic_compare",
                 group: lf("Comparison"),
                 weight: 47
             },
             blockXml: `<block type="logic_compare" gap="8">
-            <field name="OP">GT</field>
             <value name="A">
                 <shadow type="math_number">
                     <field name="NUM">0</field>


### PR DESCRIPTION
Show eq and less than block compare snippets in toolbox

We were showing the less than and greater than. 
Note: these are just defaults it was still possible to get to the eq but this makes more sense. 

Before: 
![screen shot 2018-05-18 at 1 26 04 pm](https://user-images.githubusercontent.com/16690124/40256366-0c89ff36-5a9f-11e8-894b-699be5a83879.png)

After:
![screen shot 2018-05-18 at 1 24 27 pm](https://user-images.githubusercontent.com/16690124/40256494-89a402e6-5a9f-11e8-8b31-d05073732a00.png)
