### PR TITLE
Add doc version in doc cards

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -310,7 +310,9 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
             });
     else if (cmd == "GET md" && pxt.appTarget.id + "/" == innerPath.slice(0, pxt.appTarget.id.length + 1)) {
         // innerpath start with targetid
-        return Promise.resolve(readMd(innerPath.slice(pxt.appTarget.id.length + 1)))
+        const mdPath = innerPath.slice(pxt.appTarget.id.length + 1);
+        const m = /^\/(v\d+)(.*)/.exec(mdPath);
+        return Promise.resolve(readMd(m ? m[2] : mdPath))
     }
     else if (cmd == "GET config" && pxt.appTarget.id + "/targetconfig" == innerPath) {
         // target config
@@ -892,6 +894,8 @@ export function serveAsync(options: ServeOptions) {
                 sendFile(webFile)
             }
         } else {
+            const m = /^\/(v\d+)(.*)/.exec(pathname);
+            if (m) pathname = m[2];
             let md = readMd(pathname)
             let html = pxt.docs.renderMarkdown({
                 template: expandDocFileTemplate("docs.html"),

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -419,6 +419,9 @@ namespace pxt.runner {
             ul.attr("role", "listbox");
             const addItem = (card: pxt.CodeCard) => {
                 if (!card) return;
+                const mC = /^\/(v\d+)/.exec(card.url);
+                const mP = /^\/(v\d+)/.exec(window.location.pathname);
+                if (card.url && !mC && mP) card.url = `/${mP[1]}/${card.url}`;
                 ul.append(pxt.docs.codeCard.render(card, { hideHeader: true, shortName: true }));
             }
             stmts.forEach(stmt => {
@@ -549,6 +552,10 @@ namespace pxt.runner {
             cd.className = "ui cards";
             cd.setAttribute("role", "listbox")
             cards.forEach(card => {
+                // patch card url with version if necessary
+                const mC = /^\/(v\d+)/.exec(card.url);
+                const mP = /^\/(v\d+)/.exec(window.location.pathname);
+                if (card.url && !mC && mP) card.url = `/${mP[1]}${card.url}`;
                 const cardEl = pxt.docs.codeCard.render(card, options);
                 cd.appendChild(cardEl)
                 // automitcally display package icon for approved packages


### PR DESCRIPTION
Two things: 
- Added CLI support to ignore /vN/docs for markdown files (as we don't have local versions)
- Doc cards are rendered on the client so if we're in a doc version, we'd have to detect it from the pathname and patch it in.

Tested for: 
http://localhost:3232/v1/projects
http://localhost:3232/v1/blocks/loops