### PR TITLE
Arrow function typo and note

### DIFF
--- a/common-docs/javascript/functions.md
+++ b/common-docs/javascript/functions.md
@@ -43,9 +43,7 @@ TypeScript can figure the return type out by looking at the return statements, s
 
 ## Arrow Functions
 
-Arrow functions (also known as "lamba" functions) 
-provide a lightweight syntax for functions. Arrow functions are used extensively to provide event handlers for
-many APIs. For example:
+Arrow functions, also known as _lambda_, functions provide a lightweight syntax for functions. Arrow functions are used extensively to provide event handlers for many APIs. For example:
 
 ```typescript
 function foo(handler: Action) {
@@ -56,6 +54,8 @@ foo(() => { // arrow function!
    // do something
 })
 ```
+
+Often, a function like ``foo()`` will save the arrow function ``handler`` in a variable to use it later to run to code inside of it for certian conditions. Arrow functions serve as a kind of shortcut to provide extra code to run later without having to write a formal separate function for that purpose. In this way arrow, or lambda, functions are thought of as "anonymous" functions.
 
 [Read more about arrow functions...](http://devdocs.io/javascript/functions/arrow_functions)
 

--- a/common-docs/javascript/functions.md
+++ b/common-docs/javascript/functions.md
@@ -43,7 +43,7 @@ TypeScript can figure the return type out by looking at the return statements, s
 
 ## Arrow Functions
 
-Arrow functions, also known as _lambda_, functions provide a lightweight syntax for functions. Arrow functions are used extensively to provide event handlers for many APIs. For example:
+Arrow functions, also known as _lambda_ functions, provide a lightweight syntax for functions. Arrow functions are used extensively to provide event handlers for many APIs. For example:
 
 ```typescript
 function foo(handler: Action) {
@@ -55,7 +55,7 @@ foo(() => { // arrow function!
 })
 ```
 
-Often, a function like ``foo()`` will save the arrow function ``handler`` in a variable to use it later to run to code inside of it for certian conditions. Arrow functions serve as a kind of shortcut to provide extra code to run later without having to write a formal separate function for that purpose. In this way arrow, or lambda, functions are thought of as "anonymous" functions.
+Often, a function like ``foo()`` will save the arrow function ``handler`` in a variable to run the code inside the function later when a certain condition occurs. Arrow functions serve as a kind of shortcut to provide extra code to run without having to write a separate formal function for that purpose. In this way arrow, or lambda, functions are thought of as "anonymous" functions.
 
 [Read more about arrow functions...](http://devdocs.io/javascript/functions/arrow_functions)
 


### PR DESCRIPTION
RE: https://crowdin.com/translate/kindscript/719/en-tr#36138

- [x] Fix the spelling of 'lambda'.
- [x] Add a note for lambdas.
