### PR TITLE
Parse local targetconfig versions properly

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -311,7 +311,7 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
     else if (cmd == "GET md" && pxt.appTarget.id + "/" == innerPath.slice(0, pxt.appTarget.id.length + 1)) {
         // innerpath start with targetid
         const mdPath = innerPath.slice(pxt.appTarget.id.length + 1);
-        const m = /^\/(v\d+)(.*)/.exec(mdPath);
+        const m = /^(v\d+)\/(.*)/.exec(mdPath);
         return Promise.resolve(readMd(m ? m[2] : mdPath))
     }
     else if (cmd == "GET config" && pxt.appTarget.id + "/targetconfig" == innerPath) {


### PR DESCRIPTION
I was parsing them incorrectly. 

targetconfig paths are in the format: 
```
projects 
v1/projects
```

Note: this is just for local pxt serve 