### PR TITLE
A tutorial menu item should open the tutorial.

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -24,7 +24,7 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 
 function openTutorial(parent: pxt.editor.IProjectView, path: string) {
     pxt.tickEvent(`docs`, { path }, { interactiveConsent: true });
-    parent.setSideDoc(path);
+    parent.startTutorial(path);
 }
 
 function openDocs(parent: pxt.editor.IProjectView, path: string) {


### PR DESCRIPTION
@pelikhan not sure why this was done for https://github.com/Microsoft/pxt/pull/3924
but some menuitems can be configured to be a "tutorial" link and thus should start the tutorial rather than show the side menu. 
