### PR TITLE
using npm tags

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -638,7 +638,7 @@ function tagReleaseAsync(parsed: commandParser.ParsedCommand) {
                     // verify that npm version exists
                     if (!registry.versions[v])
                         U.userError(`cannot find npm package ${npmPkg}@${v}`);
-                    nodeutil.runNpmAsync(`dist-tag rm ${npmPkg} dev`);
+                    return nodeutil.runNpmAsync(`dist-tag`, `rm`, `${npmPkg}`, `dev`);
                 })
         })
         // all good update ref file

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -497,9 +497,14 @@ function travisAsync() {
     console.log("uploadLocs:", uploadLocs);
     console.log("latest:", latest);
 
+    function npmPublishAsync() {
+        if (!npmPublish) return Promise.resolve();
+        return nodeutil.runNpmAsync("publish", "--tag=staged");
+    }
+
     let pkg = readJson("package.json")
     if (pkg["name"] == "pxt-core") {
-        let p = npmPublish ? nodeutil.runNpmAsync("publish") : Promise.resolve();
+        let p = npmPublishAsync();
         if (uploadLocs)
             p = p
                 .then(() => execCrowdinAsync("upload", "built/strings.json"))
@@ -510,7 +515,7 @@ function travisAsync() {
     } else {
         return internalBuildTargetAsync()
             .then(() => internalCheckDocsAsync(true))
-            .then(() => npmPublish ? nodeutil.runNpmAsync("publish") : Promise.resolve())
+            .then(() => npmPublishAsync())
             .then(() => {
                 if (!process.env["PXT_ACCESS_TOKEN"]) {
                     // pull request, don't try to upload target

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -638,7 +638,8 @@ function tagReleaseAsync(parsed: commandParser.ParsedCommand) {
                     // verify that npm version exists
                     if (!registry.versions[v])
                         U.userError(`cannot find npm package ${npmPkg}@${v}`);
-                    return nodeutil.runNpmAsync(`dist-tag`, `rm`, `${npmPkg}`, `dev`);
+                    const npmTag = tag == "index" ? "latest" : tag;
+                    return nodeutil.runNpmAsync(`dist-tag`, `add`, `${npmPkg}@v${v}`, npmTag);
                 })
         })
         // all good update ref file

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -609,6 +609,49 @@ function justBumpPkgAsync() {
         .then(() => nodeutil.runGitAsync("tag", "v" + mainPkg.config.version))
 }
 
+function tagReleaseAsync(parsed: commandParser.ParsedCommand) {
+    const tag = parsed.args[0] as string;
+    const version = parsed.args[1] as string;
+    const npm = !!parsed.flags["npm"];
+
+    // check that ...-ref.json exists for that tag
+    const fn = path.join('docs', tag + "-ref.json");
+    pxt.log(`checking ${fn}`)
+    if (!fn)
+        U.userError(`file ${fn} does not exist`);
+    const v = pxt.semver.normalize(version);
+    const npmPkg = `pxt-${pxt.appTarget.id}`;
+    if (!pxt.appTarget.appTheme.githubUrl)
+        U.userError('pxtarget theme missing "githubUrl" entry');
+    // check that tag exists in github
+    pxt.log(`checking github ${pxt.appTarget.appTheme.githubUrl} tag v${v}`);
+    return U.requestAsync({
+            url: pxt.appTarget.appTheme.githubUrl.replace(/\/$/, '') + "/releases/tag/v" + v,
+            method: "GET"
+        })
+        // check that release exists in npm
+        .then(() => {
+            if (!npm) return Promise.resolve();
+            pxt.log(`checking npm ${npmPkg} release`)
+            return nodeutil.npmRegistryAsync(npmPkg)
+                .then(registry => {
+                    // verify that npm version exists
+                    if (!registry.versions[v])
+                        U.userError(`cannot find npm package ${npmPkg}@${v}`);
+                    nodeutil.runNpmAsync(`dist-tag rm ${npmPkg} dev`);
+                })
+        })
+        // all good update ref file
+        .then(() => {
+            // update index file
+            fs.writeFileSync(fn, JSON.stringify({
+                "appref": "v" + v
+            }, null, 4))
+            // TODO commit changes
+            console.log(`please commit ${fn} changes`);
+        })
+}
+
 function bumpAsync(parsed?: commandParser.ParsedCommand) {
     const bumpPxt = parsed && parsed.flags["update"];
     const upload = parsed && parsed.flags["upload"];
@@ -5069,6 +5112,15 @@ function initCommands() {
             upload: { description: "(package only) Upload after bumping" }
         }
     }, bumpAsync);
+
+    p.defineCommand({
+        name: "tag",
+        help: "tags a release",
+        argString: "<tag> <version>",
+        flags: {
+            npm: { description: "updates tags on npm packages as well" }
+        }
+    }, tagReleaseAsync);
 
     p.defineCommand({
         name: "build",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -499,7 +499,7 @@ function travisAsync() {
 
     function npmPublishAsync() {
         if (!npmPublish) return Promise.resolve();
-        return nodeutil.runNpmAsync("publish", "--tag=staged");
+        return nodeutil.runNpmAsync("publish", "--tag=dev");
     }
 
     let pkg = readJson("package.json")

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -91,6 +91,18 @@ export function runNpmAsync(...args: string[]) {
     return runNpmAsyncWithCwd(".", ...args);
 }
 
+export interface NpmRegistry {
+    _id: string;
+    _name: string;
+    "dist-tags": pxt.Map<string>;
+    "versions": pxt.Map<any>;
+}
+
+export function npmRegistryAsync(pkg: string): Promise<NpmRegistry> {
+    // TODO: use token if available
+    return Util.httpGetJsonAsync(`https://registry.npmjs.org/${pkg}`);
+}
+
 export function runNpmAsyncWithCwd(cwd: string, ...args: string[]) {
     return spawnAsync({
         cmd: addCmd("npm"),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,6 +86,7 @@ where ``EMBEDURL`` is the published project URL.
 
 Run ``pxt help`` for the list of all commands. The following list of links contains more info on specific commands.
 
+* [target](/cli/target), downloads the editor tools
 * [build](/cli/build), builds the current project
 * [deploy](/cli/deploy), builds and deploys the current project
 * [login](/cli/login), store a GitHub token

--- a/docs/cli/target.md
+++ b/docs/cli/target.md
@@ -1,0 +1,33 @@
+# pxt-target Manual Page
+
+### @description Installs the editor files
+
+Installs the compiled editor files.
+
+## ~ hint
+
+This command only works for editors that have been open sourced.
+
+## ~
+
+```
+pxt target TARGET [tag]
+```
+
+## Description
+
+This commands runs ``npm`` and installs the packaged editor files. You'll need to run this command before being able to build or serve an editor locally.
+
+## Flags:
+
+### TARGETID
+
+This is the identifier for the editor. It is the value of the ``id`` field in the ``pxtarget.json`` file in each editor repository.
+
+* for micro:bit, ``microbit``
+* for Circuit Playground, ``adafruit``,
+* for Maker, ``maker``
+
+### tag (optional)
+
+Allows to specify an optional NPM distribution tag.

--- a/pxt-cli/cli.js
+++ b/pxt-cli/cli.js
@@ -56,11 +56,11 @@ function findPxtJs() {
     return goUp(process.cwd())
 }
 
-function target(n) {
+function target(n,t) {
     if (!fs.existsSync("node_modules"))
         fs.mkdirSync("node_modules")
     console.log(`Installing pxt-${n} locally; don't worry about package.json warnings.`)
-    child_process.execSync(`npm install pxt-${n}`, {
+    child_process.execSync(`npm install pxt-${n} ${t ? `--tag ${t}` : ''}`, {
         stdio: "inherit"
     })
     fs.writeFileSync("node_modules/pxtcli.json", JSON.stringify({
@@ -68,6 +68,8 @@ function target(n) {
     }, null, 4))
     console.log(`Installed PXT/${n}. To start server run:`)
     console.log(`    pxt serve`)
+    console.log(`To build a package, run:`)
+    console.log(`    pxt build`)
 }
 
 function link(dir) {
@@ -124,7 +126,7 @@ function main() {
     var args = process.argv.slice(2)
 
     if (args[0] == "target") {
-        target(args[1])
+        target(args[1], args[2])
         process.exit(0)
     }
     else if (args[0] == "link") {

--- a/pxtlib/semver.ts
+++ b/pxtlib/semver.ts
@@ -72,6 +72,10 @@ namespace pxt.semver {
         return null
     }
 
+    export function normalize(v: string): string {
+        return stringify(parse(v));
+    }
+
     export function stringify(v: Version) {
         let r = v.major + "." + v.minor + "." + v.patch
         if (v.pre.length)


### PR DESCRIPTION
We currently have an issue in microbit with npm modules. Our ``pxt target microbit`` picks up the latest released build under the "latest" npm tag. So dependency on whether we push the v1 branch or master branch, user are getting different builds of pxt-microbit.

This changes tries to address these issues by doing the following:

- [ ] always publish new npm packages to the "dev" npm tag
- [ ] new pxt command, "pxt tag CHANNEL VERSION" that will be used to update the "CHANNEL-ref.json" file. It checks the version syntax, that a github tag is available, add the corresponding npm tag
- [ ] support for npm tags in "pxt target" (requires pushing our cli into npm)
