### PR TITLE
Update the 'offline' page

### DIFF
--- a/common-docs/offline.md
+++ b/common-docs/offline.md
@@ -19,3 +19,4 @@ When running on actual hardware, the code you write in JavaScript is compiled in
 ## Hosting MakeCode locally #local-serve
 
 The open source editions of MakeCode can be served locally on your own computer. More experienced users can download the entire [PXT Toolchain](https://github.com/Microsoft/pxt) and use the [command line interface](/cli) (CLI) to compile and deploy scripts locally. PXT provides a great out-of-the-box experience when used with [Visual Studio Code](/code), a lightweight cross-platform code editor. See the @githubUrl@ project page for instructions on setting up a MakeCode local server.
+

--- a/common-docs/offline.md
+++ b/common-docs/offline.md
@@ -2,7 +2,7 @@
 
 ## Web application
 
-**[MakeCode](@homeurl@)** is an **HTML5 web application** that's automatically cached locally when first viewed in your browser. After the web app is loaded and once the code blocks have compiled for the **first** time, you will have everything you need to continue working without an internet connection. This is true for the all of the blocks you see in the editor when it's first loaded. If you decide to add a [package](/packages), it's possible that you'll again need to connect to the internet to allow the code in the new package to compile.
+**[MakeCode](@homeurl@)** is an **HTML5 web application** that's automatically cached locally (saved to your computer or device) when first viewed in your browser. After the web app has loaded you will have everything you need to continue working without an internet connection. If you decide to add a [package](/packages), it's possible that you'll again need to connect to the internet to allow the code in the new package to compile.
 
 ### How does it work?
 

--- a/common-docs/offline.md
+++ b/common-docs/offline.md
@@ -16,6 +16,6 @@ When running on actual hardware, the code you write in JavaScript is compiled in
 
 ## #target-app
 
-## Hosting MakeCode locally
+## Hosting MakeCode locally #local-serve
 
-More experienced users can download the entire [PXT Toolchain](https://github.com/Microsoft/pxt) and use the [command line interface](/cli) (CLI) to compile and deploy your scripts locally. PXT provides a great out-of-the-box experience using [Visual Studio Code](/code), a lightweight cross-platform code editor. See the @githubUrl@ project page for instructions on setting up a MakeCode local server.
+The open source editions of MakeCode can be served locally on your own computer. More experienced users can download the entire [PXT Toolchain](https://github.com/Microsoft/pxt) and use the [command line interface](/cli) (CLI) to compile and deploy scripts locally. PXT provides a great out-of-the-box experience when used with [Visual Studio Code](/code), a lightweight cross-platform code editor. See the @githubUrl@ project page for instructions on setting up a MakeCode local server.

--- a/common-docs/offline.md
+++ b/common-docs/offline.md
@@ -4,6 +4,16 @@
 
 **[MakeCode](@homeurl@)** is an **HTML5 web application** that's automatically cached locally when first viewed in your browser. After the web app is loaded and once the code blocks have compiled for the **first** time, you will have everything you need to continue working without an internet connection. This is true for the all of the blocks you see in the editor when it's first loaded. If you decide to add a [package](/packages), it's possible that you'll again need to connect to the internet to allow the code in the new package to compile.
 
+### How does it work?
+
+The MakeCode editor, like other web applications, is created using HTML, JavaScript, and some style information. These parts of the editor are all downloaded as various files to your browser. The editor is designed to do as much of work as possible in the browser itself without needing to constantly have contact with the web server. To do this, it asks the browser to download and keep a number of service files which give the editor the same features provided by the **[MakeCode](@homeurl@)** web site. This allows the editor to fully function even when disconnected from the internet, no longer having contact with the web site.
+
+When the editor loads in your browser it tells it to keep the MakeCode service files in the browser's _application cache_. The cache is data storage area managed by the browser where a web application can keep additional files it needs.
+
+### Cloud compilation
+
+When running on actual hardware, the code you write in JavaScript is compiled into instructions which are understood by the processor on the board. Some of the files saved in the application cache are compiled code for the features on the board. To use the hardware features on your board, the editor provides blocks for them that you include in your programs. These blocks are available to your program when they're included as part of an added package. The code in a package is in TypeScript and sometimes also in C++. It's necessary to compile this code at least once on the server and then have the compiled files returned to the browser to get cached. Once, cached the editor can use them together with your code, even when offline. This one time compile process is called cloud compilation.
+
 ## #target-app
 
 ## Hosting MakeCode locally

--- a/common-docs/offline.md
+++ b/common-docs/offline.md
@@ -2,15 +2,10 @@
 
 ## Web application
 
-**@homeurl@ is an HTML5 web application** that automatically gets cached locally by your browser. 
-Once the web app is loaded and you have compiled at least once, you will have all the code needed to work without an internet connection.
+**[MakeCode](@homeurl@)** is an **HTML5 web application** that's automatically cached locally when first viewed in your browser. After the web app is loaded and once the code blocks have compiled for the **first** time, you will have everything you need to continue working without an internet connection. This is true for the all of the blocks you see in the editor when it's first loaded. If you decide to add a [package](/packages), it's possible that you'll again need to connect to the internet to allow the code in the new package to compile.
 
-## Command line interface
+## #target-app
 
-For more experience users, you can download the entire toolchain and use the [command line interface](/cli) (CLI) to compile 
-and deploy your scripts locally. PXT provides a great out-of-the-box experience using [Visual Studio Code](/code), 
-a lightweight cross-platform code editor.
+## Hosting MakeCode locally
 
-## Native clients
-
-There are no native clients available yet.
+More experienced users can download the entire [PXT Toolchain](https://github.com/Microsoft/pxt) and use the [command line interface](/cli) (CLI) to compile and deploy your scripts locally. PXT provides a great out-of-the-box experience using [Visual Studio Code](/code), a lightweight cross-platform code editor. See the @githubUrl@ project page for instructions on setting up a MakeCode local server.


### PR DESCRIPTION
Start of a discussion on what to add for this:

* Reconnect is sometimes necessary when packages are added?
* The 'Native Apps' section, I ditched it. What about Windows 10 apps for certain targets? Have an override section to include a mention of those?
* Are there concerns now about app cache constraints?
* Serving locally, keep this section but make it more friendly?
