### PR TITLE
Do not inject targetversion when using "pxt build"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,26 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "DebugBuild",
+			"name": "DebugBuildTarget",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/built/pxt.js",
+			"stopOnEntry": false,
+			"args": ["buildtarget"],
+			"cwd": "${workspaceRoot}/../pxt-adafruit",
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"console": "integratedTerminal",
+			"sourceMaps": false,
+			"outFiles": []
+		},
+		{
+			"name": "DebugBuildPackage",
 			"type": "node",
 			"request": "launch",
 			"program": "${workspaceRoot}/built/pxt.js",

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -203,7 +203,7 @@ export function buildHexAsync(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
             if (fs.existsSync(fn))
                 existing = fs.readFileSync(fn, "utf8")
             if (existing !== v)
-                fs.writeFileSync(fn, v)
+                nodeutil.writeFileSync(fn, v)
         })
     }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3697,7 +3697,7 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
                 }));
             }
 
-            pxt.debug(`package built; written to ${pxt.outputName()}; size: ${(res.outfiles[pxt.outputName()] || "").length}`)
+            pxt.log(`package built; written to ${pxt.outputName()}`);
 
             switch (buildOpts.mode) {
                 case BuildOption.GenDocs:

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1834,7 +1834,9 @@ function updateDefaultProjects(cfg: pxt.TargetBundle) {
                 }
 
                 if (fileName === pxt.CONFIG_NAME) {
-                    newProject.config = nodeutil.readPkgConfig(projectPath)
+                    newProject.config = nodeutil.readPkgConfig(projectPath);
+                    if (!newProject.config.targetVersions)
+                        newProject.config.targetVersions = pxt.appTarget.versions;
                     U.iterMap(newProject.config.dependencies, (k, v) => {
                         if (/^file:/.test(v)) {
                             newProject.config.dependencies[k] = "*";

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1834,8 +1834,6 @@ function updateDefaultProjects(cfg: pxt.TargetBundle) {
 
                 if (fileName === pxt.CONFIG_NAME) {
                     newProject.config = nodeutil.readPkgConfig(projectPath);
-                    if (!newProject.config.targetVersions)
-                        newProject.config.targetVersions = pxt.appTarget.versions;
                     U.iterMap(newProject.config.dependencies, (k, v) => {
                         if (/^file:/.test(v)) {
                             newProject.config.dependencies[k] = "*";

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -626,9 +626,9 @@ function tagReleaseAsync(parsed: commandParser.ParsedCommand) {
     // check that tag exists in github
     pxt.log(`checking github ${pxt.appTarget.appTheme.githubUrl} tag v${v}`);
     return U.requestAsync({
-            url: pxt.appTarget.appTheme.githubUrl.replace(/\/$/, '') + "/releases/tag/v" + v,
-            method: "GET"
-        })
+        url: pxt.appTarget.appTheme.githubUrl.replace(/\/$/, '') + "/releases/tag/v" + v,
+        method: "GET"
+    })
         // check that release exists in npm
         .then(() => {
             if (!npm) return Promise.resolve();
@@ -2414,7 +2414,6 @@ class Host
             }
         }
         check(p)
-
         if (U.endsWith(filename, ".uf2"))
             fs.writeFileSync(p, contents, { encoding: "base64" })
         else if (U.endsWith(filename, ".elf"))
@@ -2424,6 +2423,8 @@ class Host
             })
         else
             fs.writeFileSync(p, contents, { encoding: "utf8" })
+        const stats = fs.statSync(filename);
+        pxt.log(`  + ${filename} ${stats.size > 1000000 ? (stats.size / 1000000).toFixed(2) + ' m' : stats.size > 1000 ? (stats.size / 1000).toFixed(2) + 'k' : stats.size}b`)
     }
 
     getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<any> {
@@ -3668,6 +3669,7 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
     let compileOptions: pxtc.CompileOptions;
     let compileResult: pxtc.CompileResult;
     ensurePkgDir();
+    pxt.log(`building ${process.cwd()}`)
     return prepBuildOptionsAsync(buildOpts.mode)
         .then((opts) => {
             compileOptions = opts;

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -109,7 +109,7 @@ function mkHomeDirs() {
 
 function saveConfig() {
     mkHomeDirs()
-    fs.writeFileSync(configPath(), JSON.stringify(globalConfig, null, 4) + "\n")
+    nodeutil.writeFileSync(configPath(), JSON.stringify(globalConfig, null, 4) + "\n")
 }
 
 function initConfigAsync(): Promise<void> {
@@ -311,7 +311,7 @@ export function execCrowdinAsync(cmd: string, ...args: string[]): Promise<void> 
                                 nodeutil.mkdirP(path.join(args[1], k));
                                 const outf = path.join(args[1], k, fn);
                                 console.log(`writing ${outf}`)
-                                fs.writeFileSync(
+                                nodeutil.writeFileSync(
                                     outf,
                                     rtranslations,
                                     { encoding: "utf8" });
@@ -356,7 +356,7 @@ function langStatsCrowdinAsync(prj: string, key: string, lang: string): Promise<
                 }
             })
             const fn = `crowdinstats.csv`;
-            fs.writeFileSync(fn, r, { encoding: "utf8" });
+            nodeutil.writeFileSync(fn, r, { encoding: "utf8" });
         })
 }
 
@@ -573,7 +573,7 @@ function bumpPxtCoreDepAsync(): Promise<void> {
                     U.userError(`Trying to automatically update major version, please edit package.json manually.`)
                 }
                 pkg["dependencies"][knownPackage] = newVer
-                fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n")
+                nodeutil.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n")
                 commitMsg += `bump ${knownPackage} to ${newVer}, `;
             })
     })
@@ -645,7 +645,7 @@ function tagReleaseAsync(parsed: commandParser.ParsedCommand) {
         // all good update ref file
         .then(() => {
             // update index file
-            fs.writeFileSync(fn, JSON.stringify({
+            nodeutil.writeFileSync(fn, JSON.stringify({
                 "appref": "v" + v
             }, null, 4))
             // TODO commit changes
@@ -1331,8 +1331,8 @@ function ghpInitAsync() {
         .catch((e: any) => ghpGitAsync("checkout", "--orphan", "gh-pages"))
         .then(() => ghpGitAsync("rm", "-rf", "."))
         .then(() => {
-            fs.writeFileSync("gh-pages/index.html", "Under construction.")
-            fs.writeFileSync("gh-pages/.gitattributes",
+            nodeutil.writeFileSync("gh-pages/index.html", "Under construction.")
+            nodeutil.writeFileSync("gh-pages/.gitattributes",
                 `# enforce unix style line endings
 *.ts text eol=lf
 *.tsx text eol=lf
@@ -1651,8 +1651,8 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
 
     // write files
     nodeutil.mkdirP("built");
-    fs.writeFileSync("built/theme.json", JSON.stringify(cfg.appTheme, null, 2))
-    fs.writeFileSync("built/target-strings.json", JSON.stringify(targetStringsSorted, null, 2))
+    nodeutil.writeFileSync("built/theme.json", JSON.stringify(cfg.appTheme, null, 2))
+    nodeutil.writeFileSync("built/target-strings.json", JSON.stringify(targetStringsSorted, null, 2))
 }
 
 function buildSemanticUIAsync(parsed?: commandParser.ParsedCommand) {
@@ -1692,7 +1692,7 @@ function buildSemanticUIAsync(parsed?: commandParser.ParsedCommand) {
         const iconsFile = (pkg["name"] == "pxt-core") ? 'built/web/icons.css' : 'node_modules/pxt-core/built/web/icons.css';
         const iconsCss = fs.readFileSync(iconsFile, "utf-8");
         semCss = semCss + "\n" + iconsCss;
-        fs.writeFileSync('built/web/semantic.css', semCss);
+        nodeutil.writeFileSync('built/web/semantic.css', semCss);
     }).then(() => {
         // generate blockly css
         if (!fs.existsSync(path.join("theme", "blockly.less")))
@@ -1730,7 +1730,7 @@ function buildSemanticUIAsync(parsed?: commandParser.ParsedCommand) {
                             // process rtl css
                             postcss([rtlcss])
                                 .process(result.css, { from: `built/web/${cssFile}`, to: `built/web/rtl${cssFile}` }).then((result2: any) => {
-                                    fs.writeFileSync(`built/web/rtl${cssFile}`, result2.css, { encoding: "utf8" });
+                                    nodeutil.writeFileSync(`built/web/rtl${cssFile}`, result2.css, { encoding: "utf8" });
                                 });
                         });
                     });
@@ -1742,7 +1742,7 @@ function buildSemanticUIAsync(parsed?: commandParser.ParsedCommand) {
 function buildWebStringsAsync() {
     if (pxt.appTarget.id != "core") return Promise.resolve();
 
-    fs.writeFileSync("built/webstrings.json", JSON.stringify(webstringsJson(), null, 4))
+    nodeutil.writeFileSync("built/webstrings.json", JSON.stringify(webstringsJson(), null, 4))
     return Promise.resolve()
 }
 
@@ -1798,8 +1798,7 @@ ${license}
     tpn += `
 ------------- End of ThirdPartyNotices --------------------------------------------------- */`;
 
-    fs.writeFileSync("THIRD-PARTY-NOTICES.txt", tpn, { encoding: 'utf8' });
-    pxt.log('written THIRD-PARTY-NOTICES.txt');
+    nodeutil.writeFileSync("THIRD-PARTY-NOTICES.txt", tpn, { encoding: 'utf8' });
     return Promise.resolve();
 }
 
@@ -1940,7 +1939,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         if (fs.existsSync(hexFile)) {
                             pxt.log(`native image already in offline cache for project ${dirname}: ${hexFile}`);
                         } else {
-                            fs.writeFileSync(hexFile, hex.join(os.EOL));
+                            nodeutil.writeFileSync(hexFile, hex.join(os.EOL));
                             pxt.log(`created native image in offline cache for project ${dirname}: ${hexFile}`);
                         }
                     }
@@ -1976,17 +1975,16 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
 
             const webmanifest = buildWebManifest(cfg)
             const targetjson = JSON.stringify(cfg, null, 2)
-            fs.writeFileSync("built/target.json", targetjson)
-            fs.writeFileSync("built/target.js", targetJsPrefix + targetjson)
-            console.log(`size of target.json is ${Buffer.byteLength(targetjson, 'utf8') / 1000} kb`);
+            nodeutil.writeFileSync("built/target.json", targetjson)
+            nodeutil.writeFileSync("built/target.js", targetJsPrefix + targetjson)
             pxt.setAppTarget(cfg) // make sure we're using the latest version
             let targetlight = U.flatClone(cfg)
             delete targetlight.bundleddirs
             delete targetlight.bundledpkgs
             delete targetlight.appTheme
             const targetlightjson = JSON.stringify(targetlight, null, 2);
-            fs.writeFileSync("built/targetlight.json", targetlightjson)
-            fs.writeFileSync("built/sim.webmanifest", JSON.stringify(webmanifest, null, 2))
+            nodeutil.writeFileSync("built/targetlight.json", targetlightjson)
+            nodeutil.writeFileSync("built/sim.webmanifest", JSON.stringify(webmanifest, null, 2))
         })
         .then(() => {
             console.log("target.json built.")
@@ -2114,7 +2112,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
             let str = buf.toString("utf8")
             if (/\.md$/.test(f)) {
                 str = nodeutil.resolveMd(".", f.substr(5, f.length - 8));
-                fs.writeFileSync(dd, str, { encoding: "utf8" });
+                nodeutil.writeFileSync(dd, str, { encoding: "utf8" });
             }
             let html = ""
             if (U.endsWith(f, ".md")) {
@@ -2133,7 +2131,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
             buf = new Buffer(html, "utf8")
             dd = dd.slice(0, dd.length - 3) + ".html"
         }
-        fs.writeFileSync(dd, buf)
+        nodeutil.writeFileSync(dd, buf)
     }
     console.log("Docs written.")
 }
@@ -2417,16 +2415,14 @@ class Host
         }
         check(p)
         if (U.endsWith(filename, ".uf2"))
-            fs.writeFileSync(p, contents, { encoding: "base64" })
+            nodeutil.writeFileSync(p, contents, { encoding: "base64" })
         else if (U.endsWith(filename, ".elf"))
-            fs.writeFileSync(p, contents, {
+            nodeutil.writeFileSync(p, contents, {
                 encoding: "base64",
                 mode: 0o777
             })
         else
-            fs.writeFileSync(p, contents, { encoding: "utf8" })
-        const stats = fs.statSync(filename);
-        pxt.log(`  + ${filename} ${stats.size > 1000000 ? (stats.size / 1000000).toFixed(2) + ' m' : stats.size > 1000 ? (stats.size / 1000).toFixed(2) + 'k' : stats.size}b`)
+            nodeutil.writeFileSync(p, contents, { encoding: "utf8" })
     }
 
     getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<any> {
@@ -2453,8 +2449,7 @@ class Host
             }
 
             const fn = "built/dockerreq.json"
-            fs.writeFileSync(fn, JSON.stringify(dockerReq, null, 4))
-            pxt.log("wrote " + fn)
+            nodeutil.writeFileSync(fn, JSON.stringify(dockerReq, null, 4))
         }
 
         if (!forceLocalBuild && (extInfo.onlyPublic || forceCloudBuild))
@@ -2521,7 +2516,7 @@ export function installAsync(parsed?: commandParser.ParsedCommand) {
             .then(() => {
                 let tscfg = "tsconfig.json"
                 if (!fs.existsSync(tscfg) && !fs.existsSync("../" + tscfg)) {
-                    fs.writeFileSync(tscfg, defaultFiles[tscfg])
+                    nodeutil.writeFileSync(tscfg, defaultFiles[tscfg])
                 }
             })
     }
@@ -2678,8 +2673,7 @@ function addFile(name: string, cont: string) {
         }
         vars["ns"] = mainPkg.config.name.replace(/[^a-zA-Z0-9]/g, "_")
         cont = cont.replace(/@([a-z]+)@/g, (f, k) => U.lookup(vars, k) || "")
-        fs.writeFileSync(name, cont)
-        console.log(U.lf("Wrote {0}.", name))
+        nodeutil.writeFileSync(name, cont)
     } else {
         console.log(U.lf("Not overwriting {0}.", name))
     }
@@ -2830,7 +2824,7 @@ export function initAsync(parsed: commandParser.ParsedCommand) {
             U.iterMap(files, (k, v) => {
                 v = v.replace(/@([A-Z]+)@/g, (f, n) => configMap[n.toLowerCase()] || "")
                 nodeutil.mkdirP(path.dirname(k))
-                fs.writeFileSync(k, v)
+                nodeutil.writeFileSync(k, v)
             })
         })
         .then(() => installAsync())
@@ -2936,7 +2930,7 @@ export function formatAsync(parsed: commandParser.ParsedCommand) {
                     if (expected == null)
                         expected = input
                     if (formatted != expected) {
-                        fs.writeFileSync(fn, formatted, { encoding: "utf8" })
+                        nodeutil.writeFileSync(fn, formatted, { encoding: "utf8" })
                         console.log("format test FAILED; written:", fn)
                         numErr++;
                     } else {
@@ -2948,10 +2942,10 @@ export function formatAsync(parsed: commandParser.ParsedCommand) {
                     if (!inPlace)
                         fs.unlink(fn, err => { })
                 } else if (inPlace) {
-                    fs.writeFileSync(f, formatted, { encoding: "utf8" })
+                    nodeutil.writeFileSync(f, formatted, { encoding: "utf8" })
                     console.log("replaced:", f)
                 } else {
-                    fs.writeFileSync(fn, formatted, { encoding: "utf8" })
+                    nodeutil.writeFileSync(fn, formatted, { encoding: "utf8" })
                     console.log("written:", fn)
                 }
 
@@ -3160,7 +3154,7 @@ function simshimAsync() {
         let fn = "libs/" + s + "/" + filename
         if (fs.readFileSync(fn, "utf8") != cont) {
             pxt.debug(`updating ${fn}`)
-            fs.writeFileSync(fn, cont)
+            nodeutil.writeFileSync(fn, cont)
         }
     }
     return Promise.resolve()
@@ -3293,7 +3287,7 @@ function testDirAsync(parsed: commandParser.ParsedCommand) {
                 .then(testAsync)
                 .then(() => {
                     if (pxt.appTarget.compile.hasHex)
-                        fs.writeFileSync(hexPath, fs.readFileSync(`built/binary.${pxt.appTarget.compile.useUF2 ? "uf2" : "hex"}`))
+                    nodeutil.writeFileSync(hexPath, fs.readFileSync(`built/binary.${pxt.appTarget.compile.useUF2 ? "uf2" : "hex"}`))
                 })
         } else {
             let start = Date.now()
@@ -3343,7 +3337,7 @@ function testDirAsync(parsed: commandParser.ParsedCommand) {
                         } else {
                             let hex = res.outfiles["binary.hex"]
                             if (hex) {
-                                fs.writeFileSync(hexPath, hex)
+                                nodeutil.writeFileSync(hexPath, hex)
                                 console.log(`wrote hex: ${hexPath} ${hex.length} bytes; ${Date.now() - start}ms`)
                             }
                         }
@@ -3446,8 +3440,7 @@ function decompileAsync(parsed: commandParser.ParsedCommand) {
         const outFile = replaceFileExtension(f, ".blocks")
         return decompileAsyncWorker(f, parsed.flags["dep"] as string)
             .then(result => {
-                fs.writeFileSync(outFile, result)
-                console.log("Wrote " + outFile)
+                nodeutil.writeFileSync(outFile, result)
             })
     })
         .then(() => {
@@ -3543,14 +3536,14 @@ function testSnippetsAsync(snippets: CodeSnippet[], re?: string): Promise<void> 
                 Object.keys(resp.outfiles).forEach(outfile => {
                     const ofn = path.join(dir, "built", outfile);
                     pxt.debug(`writing ${ofn}`);
-                    fs.writeFileSync(ofn, resp.outfiles[outfile], 'utf8')
+                    nodeutil.writeFileSync(ofn, resp.outfiles[outfile], 'utf8')
                 })
                 pkg.filesToBePublishedAsync()
                     .then(files => {
                         Object.keys(files).forEach(f => {
                             const fn = path.join(dir, f);
                             pxt.debug(`writing ${fn}`);
-                            fs.writeFileSync(fn, files[f], 'utf8');
+                            nodeutil.writeFileSync(fn, files[f], 'utf8');
                         })
                     })
             }
@@ -3908,7 +3901,7 @@ export function downloadTargetTranslationsAsync(parsed: commandParser.ParsedComm
                                 const tf = path.join(tfdir, fn);
                                 nodeutil.mkdirP(tfdir)
                                 pxt.log(`writing ${tf}`);
-                                fs.writeFileSync(tf, langTranslations, { encoding: "utf8" });
+                                nodeutil.writeFileSync(tf, langTranslations, { encoding: "utf8" });
 
                                 locFiles[path.relative(projectdir, tf).replace(/\\/g, '/')] = "1";
                             })
@@ -3922,7 +3915,7 @@ export function downloadTargetTranslationsAsync(parsed: commandParser.ParsedComm
                             let local: pxt.PackageConfig = nodeutil.readJson(pxtJsonf)
                             local.files = pxtJson.files
                             pxt.log(`writing ${pxtJsonf}`);
-                            fs.writeFileSync(pxtJsonf, JSON.stringify(local, null, 4), { encoding: "utf8" });
+                            nodeutil.writeFileSync(pxtJsonf, JSON.stringify(local, null, 4), { encoding: "utf8" });
                         }
                         return nextFileAsync()
                     });
@@ -4079,8 +4072,8 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
     ts += "}\n"
 
     pxt.log(`save ${metaInfo.basename}.jres and .ts`)
-    fs.writeFileSync(metaInfo.basename + ".jres", JSON.stringify(jresources, null, 2));
-    fs.writeFileSync(metaInfo.basename + ".ts", ts);
+    nodeutil.writeFileSync(metaInfo.basename + ".jres", JSON.stringify(jresources, null, 2));
+    nodeutil.writeFileSync(metaInfo.basename + ".ts", ts);
 
     return Promise.resolve()
 
@@ -4232,7 +4225,7 @@ export function buildJResAsync(parsed: commandParser.ParsedCommand) {
             const newjr = JSON.stringify(jresources, null, 2);
             if (oldjr != newjr) {
                 pxt.log(`updating ${f}`)
-                fs.writeFileSync(f, newjr);
+                nodeutil.writeFileSync(f, newjr);
             }
         })
     return Promise.resolve();
@@ -4487,7 +4480,7 @@ export function hex2uf2Async(c: commandParser.ParsedCommand) {
         pxtc.UF2.writeHex(f, buf)
         let uf2buf = new Buffer(pxtc.UF2.serializeFile(f), "binary")
         let uf2fn = filename.replace(/(\.hex)?$/i, ".uf2")
-        fs.writeFileSync(uf2fn, uf2buf)
+        nodeutil.writeFileSync(uf2fn, uf2buf)
         console.log("Wrote: " + uf2fn)
     }
     return Promise.resolve()
@@ -4507,8 +4500,7 @@ function writeProjects(prjs: SavedProject[], outDir: string): string[] {
             fn = fn.replace(/[\/]/g, "-")
             const fullname = path.join(fdir, fn)
             nodeutil.mkdirP(path.dirname(fullname));
-            fs.writeFileSync(fullname, prj.files[fn])
-            pxt.debug("wrote " + fullname)
+            nodeutil.writeFileSync(fullname, prj.files[fn])
         }
         // add default files if not present
         const configMap: pxt.Map<string> = {
@@ -4526,8 +4518,7 @@ function writeProjects(prjs: SavedProject[], outDir: string): string[] {
 
             const src = defaultFiles[fn].replace(/@([A-Z]+)@/g, (f, n) => configMap[n.toLowerCase()] || "")
 
-            fs.writeFileSync(fullname, src)
-            pxt.debug("wrote " + fullname)
+            nodeutil.writeFileSync(fullname, src)
         }
 
         // start installing in the background
@@ -4614,7 +4605,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
                 });
                 if (md != newmd) {
                     pxt.log(`patching ${f}`)
-                    fs.writeFileSync(f, newmd, { encoding: "utf8" })
+                    nodeutil.writeFileSync(f, newmd, { encoding: "utf8" })
                 }
             });
     }
@@ -4624,7 +4615,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
         const dir = path.join("temp/snippets", snippet.type);
         const fn = `${dir}/${entryPath.replace(/^\//, '').replace(/\//g, '-').replace(/\.\w+$/, '')}-${snipIndex}.${snippet.ext}`;
         nodeutil.mkdirP(dir);
-        fs.writeFileSync(fn, snippet.code);
+        nodeutil.writeFileSync(fn, snippet.code);
         snippet.file = fn;
     }
 
@@ -4726,7 +4717,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
     }
 
     nodeutil.mkdirP("temp");
-    fs.writeFileSync("temp/noSUMMARY.md", noTOCs.sort().map(p => `${Array(p.split(/[\/\\]/g).length - 1).join('     ')}* [${pxt.Util.capitalize(p.split(/[\/\\]/g).reverse()[0].split('-').join(' '))}](${p})`).join('\n'), { encoding: "utf8" });
+    nodeutil.writeFileSync("temp/noSUMMARY.md", noTOCs.sort().map(p => `${Array(p.split(/[\/\\]/g).length - 1).join('     ')}* [${pxt.Util.capitalize(p.split(/[\/\\]/g).reverse()[0].split('-').join(' '))}](${p})`).join('\n'), { encoding: "utf8" });
 
     let p = Promise.resolve();
     // test targetconfig
@@ -4993,7 +4984,7 @@ function extractLocStringsAsync(output: string, dirs: string[]): Promise<void> {
     tr.forEach(function (k) { strings[k] = k; });
 
     nodeutil.mkdirP('built');
-    fs.writeFileSync(`built/${output}.json`, JSON.stringify(strings, null, 2));
+    nodeutil.writeFileSync(`built/${output}.json`, JSON.stringify(strings, null, 2));
 
     pxt.log("log strings: " + fileCnt + " files; " + tr.length + " strings -> " + output + ".json");
     if (errCnt > 0)

--- a/cli/commandparser.ts
+++ b/cli/commandparser.ts
@@ -96,7 +96,6 @@ export class CommandParser {
 
         for (let i = 1; i < args.length; i++) {
             const match = argRegex.exec(args[i]);
-
             if (!match) {
                 continue;
             }
@@ -107,15 +106,16 @@ export class CommandParser {
                 }
 
                 const flagName = command._aliasMap[match[2]];
-
-                if (!flagName) {
-                    if (match[2] == "debug" || match[2] == "d") {
-                        pxt.options.debug = true;
-                        pxt.debug = console.log;
+                const debugFlag = flagName || match[2];
+                if (debugFlag == "debug" || debugFlag == "d" || debugFlag == "dbg") {
+                    pxt.options.debug = true;
+                    pxt.debug = console.log;
+                    pxt.log(`debug mode`);
+                    if (!flagName)
                         continue;
-                    }
-                    throw new Error(`Unrecognized flag '${match[2]}' for command '${command.name}'`)
                 }
+                if (!flagName)
+                    throw new Error(`Unrecognized flag '${match[2]}' for command '${command.name}'`)
 
                 const flagDefinition = command.flags[flagName];
 

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -276,7 +276,9 @@ export function readPkgConfig(dir: string) {
             }
         }
     }
-    if (!js.targetVersions) js.targetVersions = pxt.appTarget.versions;
+    // don't inject version number
+    // as they get serialized later on
+    // if (!js.targetVersions) js.targetVersions = pxt.appTarget.versions;
     return js
 }
 

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -357,6 +357,12 @@ export function existsDirSync(name: string): boolean {
     }
 }
 
+export function writeFileSync(path: string, data: any, options?: { encoding?: string | null; mode?: number | string; flag?: string; } | string | null) {
+    fs.writeFileSync(path, data, options);
+    const stats = fs.statSync(path);
+    pxt.log(`  + ${path} ${stats.size > 1000000 ? (stats.size / 1000000).toFixed(2) + ' m' : stats.size > 1000 ? (stats.size / 1000).toFixed(2) + 'k' : stats.size}b`)
+}
+
 export function openUrl(startUrl: string, browser: string) {
     if (!/^[a-z0-9A-Z#=\.\-\\\/%:\?_&]+$/.test(startUrl)) {
         console.error("invalid URL to open: " + startUrl)

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -359,8 +359,10 @@ export function existsDirSync(name: string): boolean {
 
 export function writeFileSync(path: string, data: any, options?: { encoding?: string | null; mode?: number | string; flag?: string; } | string | null) {
     fs.writeFileSync(path, data, options);
-    const stats = fs.statSync(path);
-    pxt.log(`  + ${path} ${stats.size > 1000000 ? (stats.size / 1000000).toFixed(2) + ' m' : stats.size > 1000 ? (stats.size / 1000).toFixed(2) + 'k' : stats.size}b`)
+    if (pxt.options.debug) {
+        const stats = fs.statSync(path);
+        pxt.log(`  + ${path} ${stats.size > 1000000 ? (stats.size / 1000000).toFixed(2) + ' m' : stats.size > 1000 ? (stats.size / 1000).toFixed(2) + 'k' : stats.size}b`)
+    }
 }
 
 export function openUrl(startUrl: string, browser: string) {

--- a/cli/pyconv.ts
+++ b/cli/pyconv.ts
@@ -1955,7 +1955,7 @@ export function convertAsync(fns: string[]) {
         .then(buf => {
             pxt.debug(`analyzing python AST (${buf.length} bytes)`)
             let js = JSON.parse(buf.toString("utf8"))
-            fs.writeFileSync("pyast.json", JSON.stringify(js, null, 2), { encoding: "utf8" })
+            nodeutil.writeFileSync("pyast.json", JSON.stringify(js, null, 2), { encoding: "utf8" })
             const rec = (v: any): any => {
                 if (Array.isArray(v)) {
                     for (let i = 0; i < v.length; ++i)

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -349,7 +349,7 @@ namespace pxt {
                     }
                 }
             }
-            if (targetVersion) {
+            if (targetVersion && !this.config.targetVersions) {
                 this.config.targetVersions = {
                     target: targetVersion
                 };
@@ -412,13 +412,12 @@ namespace pxt {
             if (isInstall)
                 initPromise = initPromise.then(() => this.downloadAsync())
 
-            initPromise = initPromise.then(() => {
-                if (this.level == 0) {
+            if (isInstall && this.level == 0)
+                initPromise = initPromise.then(() => {
                     pxt.debug(`upgrading files, target version ${this.targetVersion()}`)
                     this.getFiles().filter(fn => /\.ts$/.test(fn))
                         .forEach(file => this.upgradeFile(file, this.readFile(file)));
-                }
-            })
+                })
 
             if (appTarget.simulator && appTarget.simulator.dynamicBoardDefinition) {
                 if (this.level == 0)
@@ -759,6 +758,7 @@ namespace pxt {
                     let cfg = U.clone(this.config)
                     delete cfg.installedVersion
                     delete cfg.additionalFilePath
+                    if (!cfg.targetVersions) cfg.targetVersions = pxt.appTarget.versions;
                     U.iterMap(cfg.dependencies, (k, v) => {
                         if (!v || /^file:/.test(v) || /^workspace:/.test(v)) {
                             cfg.dependencies[k] = "*"

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -349,7 +349,7 @@ namespace pxt {
                     }
                 }
             }
-            if (targetVersion && !this.config.targetVersions) {
+            if (targetVersion) {
                 this.config.targetVersions = {
                     target: targetVersion
                 };


### PR DESCRIPTION
Background: applying upgrade rules to Adafruit bundled projects leads to stack overflow issues. Upgrade rules should not be applied to bundled packages.

- [x] inject targetversion when saving project
- [x] log every file write with size (in debug)

In order to track down what goes on in the build, I've added a lot on every written file. This helps debugging when someone funny happens.