### PR TITLE
added div warning flag

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5016,7 +5016,7 @@ function testGithubPackagesAsync(c?: commandParser.ParsedCommand): Promise<void>
     let errors = 0;
     let todo: string[];
     const repos: pxt.Map<{ fullname: string; tag: string }> = {};
-    const pkgsroot = path.join("built", "ghpkgs");
+    const pkgsroot = path.join("temp", "ghpkgs");
 
     function gitAsync(dir: string, ...args: string[]) {
         return nodeutil.spawnAsync({

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3644,7 +3644,7 @@ interface BuildCoreOptions {
     mode: BuildOption;
 
     debug?: boolean;
-    compat?: boolean;
+    warnDiv?: boolean;
 
     // docs
     locs?: boolean;
@@ -3672,7 +3672,7 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
     return prepBuildOptionsAsync(buildOpts.mode)
         .then((opts) => {
             compileOptions = opts;
-            if (buildOpts.compat) {
+            if (buildOpts.warnDiv) {
                 pxt.debug(`warning on division operators`);
                 opts.warnDiv = true;
             }
@@ -4246,8 +4246,8 @@ export function buildAsync(parsed: commandParser.ParsedCommand) {
     if (parsed.flags["debug"]) {
         mode = BuildOption.DebugSim;
     }
-    const compat = !!parsed.flags["compat"];
-    return buildCoreAsync({ mode, compat })
+    const warnDiv = !!parsed.flags["warndiv"];
+    return buildCoreAsync({ mode, warnDiv })
         .then((compileOpts) => { });
 }
 
@@ -5008,7 +5008,7 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
         pxt.log(`targetconfig.json not found`);
         return Promise.resolve();
     }
-    const compat = !!parsed.flags["compat"];
+    const warnDiv = !!parsed.flags["warndiv"];
     const targetConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
     const packages = targetConfig.packages;
     if (!packages) {
@@ -5049,7 +5049,7 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
         const pkgdir = path.join(pkgsroot, pkgpgh);
         return gitAsync(".", "clone", "-q", "-b", repos[pkgpgh].tag, `https://github.com/${pkgpgh}`, pkgdir)
             .then(() => pxtAsync(pkgdir, "install"))
-            .then(() => compat ? pxtAsync(pkgdir, "build", "--compat") : pxtAsync(pkgdir, "build"))
+            .then(() => warnDiv ? pxtAsync(pkgdir, "build", "--warndiv") : pxtAsync(pkgdir, "build"))
             .catch(e => {
                 errors++;
                 pxt.log(e);
@@ -5136,7 +5136,7 @@ function initCommands() {
         flags: {
             cloud: { description: "Force build to happen in the cloud" },
             debug: { description: "Emit debug information with build" },
-            compat: { description: "Perform additional compatilibity checks"}
+            warndiv: { description: "Warns about division operators"}
         }
     }, buildAsync);
 
@@ -5442,7 +5442,7 @@ function initCommands() {
         name: "testghpkgs",
         help: "Download and build approved github packages",
         flags: {
-            compat: { description: "Execute additional compat checks"}
+            warndiv: { description: "Warns about division operators"}
         }
     }, testGithubPackagesAsync);
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -354,6 +354,7 @@ declare namespace ts.pxtc {
         justMyCode?: boolean;
         computeUsedSymbols?: boolean;
         name?: string;
+        warnDiv?: boolean; // warn when emitting division operator
 
         alwaysDecompileOnStart?: boolean; // decompiler only
 

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -90,7 +90,7 @@ namespace ts.pxtc {
         console.log(stringKind(n))
     }
 
-    // next free error 9274
+    // next free error 9275
     function userError(code: number, msg: string, secondary = false): Error {
         let e = new Error(msg);
         (<any>e).ksEmitterUserError = true;
@@ -715,7 +715,7 @@ namespace ts.pxtc {
                     let subPropDecl = <PropertyDeclaration>find[0].valueDeclaration
                     // TODO: record the property on which we have a mismatch
                     let [retSub, msgSub] = checkSubtype(checker.getTypeAtLocation(subPropDecl), checker.getTypeAtLocation(superPropDecl))
-                    if (ret && !retSub)[ret, msg] = [retSub, msgSub]
+                    if (ret && !retSub) [ret, msg] = [retSub, msgSub]
                 } else if (find.length == 0) {
                     if (!(superProp.flags & SymbolFlags.Optional)) {
                         // we have a cast to an interface with more properties (unsound)
@@ -781,13 +781,13 @@ namespace ts.pxtc {
                     let subParamType = checker.getTypeAtLocation(subFun.parameters[i].valueDeclaration)
                     // Check parameter types (contra-variant)
                     let [retSub, msgSub] = checkSubtype(superParamType, subParamType)
-                    if (ret && !retSub)[ret, msg] = [retSub, msgSub]
+                    if (ret && !retSub) [ret, msg] = [retSub, msgSub]
                 }
                 // check return type (co-variant)
                 let superRetType = superFun.getReturnType()
                 let subRetType = superFun.getReturnType()
                 let [retSub, msgSub] = checkSubtype(subRetType, superRetType)
-                if (ret && !retSub)[ret, msg] = [retSub, msgSub]
+                if (ret && !retSub) [ret, msg] = [retSub, msgSub]
                 return insertSubtype(key, [ret, msg])
             }
         } else if (isInterfaceType(superType)) {
@@ -1070,13 +1070,21 @@ namespace ts.pxtc {
             emitSkipped: !!opts.noEmit
         }
 
-        function error(node: Node, code: number, msg: string, arg0?: any, arg1?: any, arg2?: any) {
+        function diag(category: DiagnosticCategory, node: Node, code: number, message: string, arg0?: any, arg1?: any, arg2?: any) {
             diagnostics.add(createDiagnosticForNode(node, <any>{
-                code: code,
-                message: msg,
-                key: msg.replace(/^[a-zA-Z]+/g, "_"),
-                category: DiagnosticCategory.Error,
+                code,
+                message,
+                key: message.replace(/^[a-zA-Z]+/g, "_"),
+                category,
             }, arg0, arg1, arg2));
+        }
+
+        function warning(node: Node, code: number, msg: string, arg0?: any, arg1?: any, arg2?: any) {
+            diag(DiagnosticCategory.Warning, node, code, msg, arg0, arg1, arg2);
+        }
+
+        function error(node: Node, code: number, msg: string, arg0?: any, arg1?: any, arg2?: any) {
+            diag(DiagnosticCategory.Error, node, code, msg, arg0, arg1, arg2);
         }
 
         function unhandled(n: Node, info?: string, code: number = 9202) {
@@ -3349,12 +3357,16 @@ ${lbl}: .short 0xffff
             proc.emit(st)
         }
 
-        function simpleInstruction(k: SyntaxKind) {
+        function simpleInstruction(node: Node, k: SyntaxKind) {
             switch (k) {
                 case SK.PlusToken: return "numops::adds";
                 case SK.MinusToken: return "numops::subs";
                 // we could expose __aeabi_idiv directly...
-                case SK.SlashToken: return "numops::div";
+                case SK.SlashToken: {
+                    if (opts.warnDiv)
+                        warning(node, 9274, "usage of / operator");
+                    return "numops::div";
+                }
                 case SK.PercentToken: return "numops::mod";
                 case SK.AsteriskToken: return "numops::muls";
                 case SK.AsteriskAsteriskToken: return "Math_::pow";
@@ -3416,7 +3428,7 @@ ${lbl}: .short 0xffff
 
             if (isNumericalType(lt) && isNumericalType(rt)) {
                 let noEq = stripEquals(node.operatorToken.kind)
-                let shimName = simpleInstruction(noEq || node.operatorToken.kind)
+                let shimName = simpleInstruction(node, noEq || node.operatorToken.kind)
                 if (!shimName)
                     unhandled(node.operatorToken, lf("unsupported numeric operator"), 9250)
                 if (noEq)
@@ -3458,7 +3470,7 @@ ${lbl}: .short 0xffff
                     case SK.GreaterThanEqualsToken:
                     case SK.GreaterThanToken:
                         return ir.rtcallMask(
-                            mapIntOpName(simpleInstruction(node.operatorToken.kind)),
+                            mapIntOpName(simpleInstruction(node, node.operatorToken.kind)),
                             opts.target.boxDebug ? 1 : 0,
                             ir.CallingConvention.Plain,
                             [fromInt(shim("String_::compare")), emitLit(0)])
@@ -3583,7 +3595,7 @@ ${lbl}: .short 0xffff
                 let lt = typeOf(be.left)
                 let rt = typeOf(be.right)
                 if ((lt.flags & TypeFlags.NumberLike) && (rt.flags & TypeFlags.NumberLike)) {
-                    let mapped = U.lookup(thumbCmpMap, simpleInstruction(be.operatorToken.kind))
+                    let mapped = U.lookup(thumbCmpMap, simpleInstruction(be, be.operatorToken.kind))
                     if (mapped) {
                         return ir.rtcall(mapped, [emitExpr(be.left), emitExpr(be.right)])
                     }


### PR DESCRIPTION
When running ``pxt build --compat``, the compiler will do additional changes that might have compatibility issues. The first one is detecting that a package is using /  which needs to be addressed for micro:bit