### PR TITLE
Draggable option for handler parameters

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1202,18 +1202,7 @@ namespace pxt.blocks {
             argumentDeclaration = b.mutation.compileMutation(e, comments);
         }
         else if (stdfun.comp.handlerArgs.length) {
-            let handlerArgs: string[] = []; // = stdfun.handlerArgs.map(arg => escapeVarName(b.getFieldValue("HANDLER_" + arg.name), e));
-            for (let i = 0; i < stdfun.comp.handlerArgs.length; i++) {
-                const arg = stdfun.comp.handlerArgs[i];
-                const varField = b.getField("HANDLER_" + arg.name);
-                const varName = varField && varField.getText();
-                if (varName !== null) {
-                    handlerArgs.push(escapeVarName(varName, e));
-                }
-                else {
-                    break;
-                }
-            }
+            let handlerArgs = getEscapedCBParameters(b, stdfun, e);
             argumentDeclaration = mkText(`function (${handlerArgs.join(", ")})`)
         }
 
@@ -1483,14 +1472,13 @@ namespace pxt.blocks {
 
             if (stdFunc && stdFunc.comp.handlerArgs.length) {
                 let foundIt = false;
-                stdFunc.comp.handlerArgs.forEach(arg => {
+                const names = getEscapedCBParameters(b, stdFunc, e);
+                names.forEach(varName => {
                     if (foundIt) return;
-                    const varField = b.getField("HANDLER_" + arg.name);
-                    let varName = varField && varField.getText();
-                    if (varName != null && escapeVarName(varName, e) === name) {
+                    if (varName === name) {
                         foundIt = true;
                     }
-                });
+                })
                 if (foundIt) {
                     return true;
                 }
@@ -1533,11 +1521,10 @@ namespace pxt.blocks {
 
             let stdFunc = e.stdCallTable[b.type];
             if (stdFunc && stdFunc.comp.handlerArgs.length) {
-                stdFunc.comp.handlerArgs.forEach(arg => {
-                    const varField = b.getField("HANDLER_" + arg.name)
-                    let varName = varField && varField.getText();
+                const names = getEscapedCBParameters(b, stdFunc, e);
+                names.forEach((varName, index) => {
                     if (varName != null) {
-                        trackLocalDeclaration(escapeVarName(varName, e), arg.type);
+                        trackLocalDeclaration(escapeVarName(varName, e), stdFunc.comp.handlerArgs[index].type);
                     }
                 });
             }
@@ -1858,6 +1845,37 @@ namespace pxt.blocks {
         });
 
         return res;
+    }
+
+    function getEscapedCBParameters(b: Blockly.Block, stdfun: StdFunc, e: Environment) {
+        let handlerArgs: string[] = [];
+        if (stdfun.attrs.draggableParameters) {
+            for (let i = 0; i < stdfun.comp.handlerArgs.length; i++) {
+                const arg = stdfun.comp.handlerArgs[i];
+                const varBlock = getInputTargetBlock(b, "HANDLER_DRAG_PARAM_" + arg.name) as Blockly.Block;
+                const varName = varBlock && varBlock.getField("VAR").getText();
+                if (varName !== null) {
+                    handlerArgs.push(escapeVarName(varName, e));
+                }
+                else {
+                    break;
+                }
+            }
+        }
+        else {
+            for (let i = 0; i < stdfun.comp.handlerArgs.length; i++) {
+                const arg = stdfun.comp.handlerArgs[i];
+                const varField = b.getField("HANDLER_" + arg.name);
+                const varName = varField && varField.getText();
+                if (varName !== null) {
+                    handlerArgs.push(escapeVarName(varName, e));
+                }
+                else {
+                    break;
+                }
+            }
+        }
+        return handlerArgs;
     }
 
     interface Rect {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -789,6 +789,11 @@ ${output}</xml>`;
             return r;
         }
 
+        function getDraggableVariableBlock(valueName: string, varName: string) {
+            return mkValue(valueName,
+                getFieldBlock("variables_get_reporter", "VAR", varName, true), "variables_get_reporter");
+        }
+
         function getField(name: string, value: string): FieldNode {
             return {
                 kind: "field",
@@ -1180,8 +1185,7 @@ ${output}</xml>`;
                 r.fields = [];
                 r.inputs = [];
                 r.handlers = [];
-                r.inputs = [mkValue("VAR",
-                    getFieldBlock("variables_get_reporter", "VAR", renamed, true), "variables_get_reporter")];
+                r.inputs = [getDraggableVariableBlock("VAR", renamed)];
 
                 if (condition.operatorToken.kind === SK.LessThanToken) {
                     const ex = mkExpr("math_arithmetic");
@@ -1437,6 +1441,8 @@ ${output}</xml>`;
                         }
                         else {
                             let arrow = e as ArrowFunction;
+                            const sym = blocksInfo.blocksById[attributes.blockId];
+                            const paramDesc = sym.parameters[comp.thisParameter ? i - 1 : i];
                             if (arrow.parameters.length) {
                                 if (attributes.optionalVariableArgs) {
                                     r.mutation = {
@@ -1447,12 +1453,24 @@ ${output}</xml>`;
                                     });
                                 }
                                 else {
-                                    const sym = blocksInfo.blocksById[attributes.blockId];
-                                    const paramDesc = sym.parameters[comp.thisParameter ? i - 1 : i];
                                     arrow.parameters.forEach((parameter, i) => {
                                         const arg = paramDesc.handlerParameters[i];
-                                        addField(getField("HANDLER_" + arg.name, (parameter.name as ts.Identifier).text));
+                                        if (attributes.draggableParameters) {
+                                            addInput(getDraggableVariableBlock("HANDLER_DRAG_PARAM_" + arg.name, (parameter.name as ts.Identifier).text));
+                                        }
+                                        else {
+                                            addField(getField("HANDLER_" + arg.name, (parameter.name as ts.Identifier).text));
+                                        }
                                     });
+
+                                }
+                            }
+                            if (attributes.draggableParameters) {
+                                if (arrow.parameters.length < paramDesc.handlerParameters.length) {
+                                    for (let i = arrow.parameters.length; i < paramDesc.handlerParameters.length; i++) {
+                                        const arg = paramDesc.handlerParameters[i];
+                                        addInput(getDraggableVariableBlock("HANDLER_DRAG_PARAM_" + arg.name, arg.name));
+                                    }
                                 }
                             }
                         }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -160,7 +160,7 @@ namespace ts.pxtc {
         groupIcons?: string[];
         labelLineWidth?: string;
         handlerStatement?: boolean; // indicates a block with a callback that can be used as a statement
-        blockHandlerKey?: string; // optional field for explicitly declaring the handler key to use to compare duplicate events 
+        blockHandlerKey?: string; // optional field for explicitly declaring the handler key to use to compare duplicate events
         afterOnStart?: boolean; // indicates an event that should be compiled after on start when converting to typescript
 
         // on interfaces
@@ -174,6 +174,7 @@ namespace ts.pxtc {
         mutatePropertyEnum?: string;
         inlineInputMode?: string; // can be inline, external, or auto
         expandableArgumentMode?: string; // can be disabled, enabled, or toggle
+        draggableParameters?: boolean;
 
         optionalVariableArgs?: boolean;
         toolboxVariableArgs?: string;
@@ -591,7 +592,8 @@ namespace ts.pxtc {
         "blockHidden",
         "constantShim",
         "blockCombine",
-        "decompileIndirectFixedInstances"
+        "decompileIndirectFixedInstances",
+        "draggableParameters"
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {

--- a/tests/blocklycompiler-test/baselines/draggable_parameters.ts
+++ b/tests/blocklycompiler-test/baselines/draggable_parameters.ts
@@ -1,0 +1,17 @@
+let d = 0;
+
+testNamespace.callbackWithDraggableParams((hello, goodbye) => {
+
+})
+
+testNamespace.callbackWithDraggableParams(function (sure, whatever) {
+
+})
+
+testNamespace.callbackWithDraggableParams(function (okay) {
+
+})
+
+testNamespace.callbackWithDraggableParams(function () {
+
+})

--- a/tests/blocklycompiler-test/baselines/draggable_parameters.ts
+++ b/tests/blocklycompiler-test/baselines/draggable_parameters.ts
@@ -1,6 +1,6 @@
-let d = 0;
+let d = 0
 
-testNamespace.callbackWithDraggableParams((hello, goodbye) => {
+testNamespace.callbackWithDraggableParams(function (hello, goodbye) {
 
 })
 
@@ -8,10 +8,10 @@ testNamespace.callbackWithDraggableParams(function (sure, whatever) {
 
 })
 
-testNamespace.callbackWithDraggableParams(function (okay) {
+testNamespace.callbackWithDraggableParams(function (okay, d) {
 
 })
 
-testNamespace.callbackWithDraggableParams(function () {
+testNamespace.callbackWithDraggableParams(function (c, d) {
 
 })

--- a/tests/blocklycompiler-test/cases/draggable_parameters.blocks
+++ b/tests/blocklycompiler-test/cases/draggable_parameters.blocks
@@ -1,0 +1,58 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+    <block type="test_handler_arguments3">
+    <value name="HANDLER_DRAG_PARAM_c">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">hello</field>
+    </shadow>
+    </value>
+    <value name="HANDLER_DRAG_PARAM_d">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">goodbye</field>
+    </shadow>
+    </value>
+    <statement name="HANDLER">
+    </statement>
+    </block>
+    <block type="test_handler_arguments3">
+    <value name="HANDLER_DRAG_PARAM_c">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">sure</field>
+    </shadow>
+    </value>
+    <value name="HANDLER_DRAG_PARAM_d">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">whatever</field>
+    </shadow>
+    </value>
+    <statement name="HANDLER">
+    </statement>
+    </block>
+    <block type="test_handler_arguments3">
+    <value name="HANDLER_DRAG_PARAM_c">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">okay</field>
+    </shadow>
+    </value>
+    <value name="HANDLER_DRAG_PARAM_d">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">d</field>
+    </shadow>
+    </value>
+    <statement name="HANDLER">
+    </statement>
+    </block>
+    <block type="test_handler_arguments3">
+    <value name="HANDLER_DRAG_PARAM_c">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">c</field>
+    </shadow>
+    </value>
+    <value name="HANDLER_DRAG_PARAM_d">
+    <shadow type="variables_get_reporter">
+    <field name="VAR">d</field>
+    </shadow>
+    </value>
+    <statement name="HANDLER">
+    </statement>
+    </block>
+    </xml>

--- a/tests/blocklycompiler-test/test-library/expandableBlocks.ts
+++ b/tests/blocklycompiler-test/test-library/expandableBlocks.ts
@@ -37,3 +37,9 @@ namespace exp {
         return res
     }
 }
+
+namespace testNamespace {
+    //% blockId=test_handler_arguments3 draggableParameters=1 blockAllowMultiple=1
+    //% block="Handler with draggable arguments"
+    export function callbackWithDraggableParams(cb: (c: number, d: number) => void) {}
+}

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -219,6 +219,10 @@ function blockTestAsync(name: string) {
             const compiledTs = res.source.trim().replace(/\s+/g, " ");
             const baselineTs = tsFile.trim().replace(/\s+/g, " ");
 
+            if (compiledTs !== baselineTs) {
+                console.log(compiledTs);
+            }
+
             chai.assert(compiledTs === baselineTs, "Compiled result did not match baseline");
         }, err => fail('Compiling blocks failed'));
 }
@@ -355,6 +359,10 @@ describe("blockly compiler", function() {
 
         it("should implicitly convert arguments marked as toString to a string", done => {
             blockTestAsync("to_string_arg").then(done, done);
+        });
+
+        it("should convert handler parameters to draggable variables", done => {
+            blockTestAsync("draggable_parameters").then(done, done);
         });
     });
 

--- a/tests/decompile-test/baselines/draggable_parameters.blocks
+++ b/tests/decompile-test/baselines/draggable_parameters.blocks
@@ -1,0 +1,59 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="test_handler_arguments3">
+<value name="HANDLER_DRAG_PARAM_c">
+<shadow type="variables_get_reporter">
+<field name="VAR">hello</field>
+</shadow>
+</value>
+<value name="HANDLER_DRAG_PARAM_d">
+<shadow type="variables_get_reporter">
+<field name="VAR">goodbye</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+</block>
+<block type="test_handler_arguments3">
+<value name="HANDLER_DRAG_PARAM_c">
+<shadow type="variables_get_reporter">
+<field name="VAR">sure</field>
+</shadow>
+</value>
+<value name="HANDLER_DRAG_PARAM_d">
+<shadow type="variables_get_reporter">
+<field name="VAR">whatever</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_handler_arguments3">
+<value name="HANDLER_DRAG_PARAM_c">
+<shadow type="variables_get_reporter">
+<field name="VAR">okay</field>
+</shadow>
+</value>
+<value name="HANDLER_DRAG_PARAM_d">
+<shadow type="variables_get_reporter">
+<field name="VAR">d</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+<block type="test_handler_arguments3">
+<value name="HANDLER_DRAG_PARAM_c">
+<shadow type="variables_get_reporter">
+<field name="VAR">c</field>
+</shadow>
+</value>
+<value name="HANDLER_DRAG_PARAM_d">
+<shadow type="variables_get_reporter">
+<field name="VAR">d</field>
+</shadow>
+</value>
+<statement name="HANDLER">
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/draggable_parameters.ts
+++ b/tests/decompile-test/cases/draggable_parameters.ts
@@ -1,0 +1,17 @@
+/// <reference path="./testBlocks/basic.ts" />
+
+testNamespace.callbackWithDraggableParams((hello, goodbye) => {
+
+})
+
+testNamespace.callbackWithDraggableParams(function (sure, whatever) {
+
+})
+
+testNamespace.callbackWithDraggableParams(function (okay) {
+
+})
+
+testNamespace.callbackWithDraggableParams(function () {
+
+})

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -99,6 +99,10 @@ namespace testNamespace {
     //% block="Handler with optioinal arguments"
     export function callbackWithIgnoredArguments(cb: (c: number, d: number) => void) {}
 
+    //% blockId=test_handler_arguments3 draggableParameters=1
+    //% block="Handler with draggable arguments"
+    export function callbackWithDraggableParams(cb: (c: number, d: number) => void) {}
+
     /**
      * Enum value function
      */


### PR DESCRIPTION
Instead of the variable dropdown you get a drag-out-able variable. Right now the flag enables this behavior and I will invert it once I have done testing/prs across targets.