### PR TITLE
microbit v1 support

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -330,15 +330,16 @@ function updateCodalBuildAsync() {
     let cs = pxt.appTarget.compileService
     return codalGitAsync("checkout", cs.gittag)
         .then(
-        () => /^v\d+/.test(cs.gittag) ? Promise.resolve() : codalGitAsync("pull"),
-        e =>
-            codalGitAsync("checkout", "master")
-                .then(() => codalGitAsync("pull")))
+            () => /^v\d+/.test(cs.gittag) ? Promise.resolve() : codalGitAsync("pull"),
+            e =>
+                codalGitAsync("checkout", "master")
+                    .then(() => codalGitAsync("pull")))
         .then(() => codalGitAsync("checkout", cs.gittag))
 }
 
 // TODO: DAL specific code should be lifted out
-export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage, force = false) {
+export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage, rebuild = false,
+    create = false) {
     let constName = "dal.d.ts"
     let vals: Map<string> = {}
     let done: Map<string> = {}
@@ -431,8 +432,8 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
         return outp
     }
 
-    if (mainPkg && (force ||
-        (mainPkg.getFiles().indexOf(constName) >= 0 && !fs.existsSync(constName)))) {
+    if (mainPkg && (create ||
+        (mainPkg.getFiles().indexOf(constName) >= 0 && (rebuild || !fs.existsSync(constName))))) {
         pxt.log(`rebuilding ${constName}...`)
         let files: string[] = []
         let foundConfig = false

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3588,7 +3588,7 @@ function gdbAsync(c: commandParser.ParsedCommand) {
 function buildDalDTSAsync() {
     ensurePkgDir()
     return mainPkg.loadAsync()
-        .then(() => build.buildDalConst(build.thisBuild, mainPkg, true))
+        .then(() => build.buildDalConst(build.thisBuild, mainPkg, true, true))
 }
 
 function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult> {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -310,6 +310,7 @@ declare namespace ts.pxtc {
         useMkcd?: boolean;
         useELF?: boolean;
         saveAsPNG?: boolean;
+        noSourceInFlash?: boolean;
         useModulator?: boolean;
         webUSB?: boolean; // use WebUSB when supported
         hexMimeType?: string;

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -4334,6 +4334,7 @@ ${lbl}: .short 0xffff
         checksumBlock: number[];
         numStmts = 1;
         commSize = 0;
+        packedSource: string;
 
         strings: pxt.Map<string> = {};
         hexlits: pxt.Map<string> = {};

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3322,6 +3322,7 @@ ${lbl}: .short 0xffff
         }
 
         function emitBrk(node: Node) {
+            bin.numStmts++
             if (!opts.breakpoints)
                 return
             let src = getSourceFileOfNode(node)
@@ -4349,6 +4350,7 @@ ${lbl}: .short 0xffff
             this.strings = {}
             this.hexlits = {}
             this.doubles = {}
+            this.numStmts = 0
         }
 
         addProc(proc: ir.Procedure) {

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -823,7 +823,6 @@ __flash_checksums:
 `
         }
         bin.writeFile(pxtc.BINARY_ASM, src)
-        bin.numStmts = cres.breakpoints.length
         let res = assemble(opts.target, bin, src)
         if (res.thumbFile.commPtr)
             bin.commSize = res.thumbFile.commPtr - hex.commBase

--- a/pxtcompiler/emitter/thumb.ts
+++ b/pxtcompiler/emitter/thumb.ts
@@ -507,6 +507,14 @@ namespace ts.pxtc.thumb {
                 // RULE: beq .next; b .somewhere; .next: -> bne .somewhere
                 ln.update("bne " + lnNext.words[1])
                 lnNext.update("")
+            } else if (lnop == "push" && ln.numArgs[0] == 0x4000 && lnNext.getOp() == "push") {
+                // RULE: push {lr}; push {X, ...} -> push {lr, X, ...}
+                ln.update(lnNext.text.replace("{", "{lr, "))
+                lnNext.update("")
+            } else if (lnop == "pop" && lnNext.getOp() == "pop" && lnNext.numArgs[0] == 0x8000) {
+                // RULE: pop {X, ...}; pop {pc} -> push {X, ..., pc}
+                ln.update(ln.text.replace("}", ", pc}"))
+                lnNext.update("")
             } else if (lnop == "push" && lnNext.getOp() == "pop" && ln.numArgs[0] == lnNext.numArgs[0]) {
                 // RULE: push {X}; pop {X} -> nothing
                 assert(ln.numArgs[0] > 0)

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -445,6 +445,7 @@ namespace pxt.cpp {
                         return "boolean";
                     case "StringData*": return "string";
                     case "String": return "string";
+                    case "ImageLiteral_": return "string";
                     case "ImageLiteral": return "string";
                     case "Action": return "() => void";
 
@@ -478,6 +479,9 @@ namespace pxt.cpp {
                     case "TValue": return "T";
                     case "bool": return "B";
                     case "double": return "D"
+
+                    case "ImageLiteral_":
+                        return "T"
 
                     default:
                         if (U.lookup(knownEnums, tp))

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -38,6 +38,8 @@ namespace pxt {
         }
         if (!comp.vtableShift)
             comp.vtableShift = 2
+        if (!comp.useUF2 && !comp.useELF && comp.noSourceInFlash == undefined)
+            comp.noSourceInFlash = true // no point putting sources in hex to be flashed
         if (!appTarget.appTheme) appTarget.appTheme = {}
         if (!appTarget.appTheme.embedUrl)
             appTarget.appTheme.embedUrl = appTarget.appTheme.homeUrl

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -546,7 +546,7 @@ namespace ts.pxtc.Util {
         return res;
     }
 
-    export function uint8ArrayToString(input: Uint8Array) {
+    export function uint8ArrayToString(input: ArrayLike<number>) {
         let len = input.length;
         let res = ""
         for (let i = 0; i < len; ++i)


### PR DESCRIPTION
* don't flash sources on the device for `.hex` targets (there's no read-back there anyway)
* stop creating `dal.d.ts` except when `pxt builddaldts`
* some ARM peephole improvements
* fixes for size stats