### PR TITLE
More versioning fixes

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1031,6 +1031,7 @@ function uploadCoreAsync(opts: UploadOptions) {
     if (opts.localDir) {
         let cfg: pxt.WebConfig = {
             "relprefix": opts.localDir,
+            "verprefix": "",
             "workerjs": opts.localDir + "worker.js",
             "monacoworkerjs": opts.localDir + "monacoworker.js",
             "pxtVersion": pxtVersion(),

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -310,9 +310,7 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
             });
     else if (cmd == "GET md" && pxt.appTarget.id + "/" == innerPath.slice(0, pxt.appTarget.id.length + 1)) {
         // innerpath start with targetid
-        const mdPath = innerPath.slice(pxt.appTarget.id.length + 1);
-        const m = /^(v\d+)\/(.*)/.exec(mdPath);
-        return Promise.resolve(readMd(m ? m[2] : mdPath))
+        return Promise.resolve(readMd(innerPath.slice(pxt.appTarget.id.length + 1)))
     }
     else if (cmd == "GET config" && new RegExp(`${pxt.appTarget.id}\/targetconfig(\/v[0-9.]+)?$`).test(innerPath)) {
         // target config

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -87,6 +87,7 @@ namespace pxt.Cloud {
 
     export function downloadMarkdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
         const packaged = pxt.webConfig && pxt.webConfig.isStatic;
+        const targetVersion = pxt.appTarget.versions && pxt.appTarget.versions.target || '?';
         let url: string;
 
         if (packaged) {
@@ -100,7 +101,7 @@ namespace pxt.Cloud {
                 url = `${url}.md`;
             }
         } else {
-            url = `md/${pxt.appTarget.id}/${docid.replace(/^\//, "")}?targetVersion=${encodeURIComponent(pxt.webConfig.targetVersion)}`;
+            url = `md/${pxt.appTarget.id}/${docid.replace(/^\//, "")}?targetVersion=${encodeURIComponent(targetVersion)}`;
         }
         if (!packaged && locale != "en") {
             url += `&lang=${encodeURIComponent(Util.userLanguage())}`

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -128,7 +128,6 @@ namespace pxt {
 
     export interface WebConfig {
         relprefix: string; // "/beta---",
-        verprefix: string; // "v1"
         workerjs: string;  // "/beta---worker",
         monacoworkerjs: string; // "/beta---monacoworker",
         pxtVersion: string; // "?",
@@ -146,6 +145,7 @@ namespace pxt {
         runUrl?: string; // "/beta---run"
         docsUrl?: string; // "/beta---docs"
         isStatic?: boolean;
+        verprefix?: string; // "v1"
     }
 
     export function localWebConfig() {

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -128,6 +128,7 @@ namespace pxt {
 
     export interface WebConfig {
         relprefix: string; // "/beta---",
+        verprefix: string; // "v1"
         workerjs: string;  // "/beta---worker",
         monacoworkerjs: string; // "/beta---monacoworker",
         pxtVersion: string; // "?",

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -34,6 +34,7 @@ pxt.setAppTarget({
 // Webworker needs this config to run
 pxt.webConfig = {
     relprefix: undefined,
+    verprefix: undefined,
     workerjs: WEB_PREFIX + "/blb/worker.js",
     monacoworkerjs: undefined,
     pxtVersion: undefined,

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -80,27 +80,25 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
             if (!/\/$/.test(shareUrl)) shareUrl += '/';
             let rootUrl = pxt.appTarget.appTheme.embedUrl
             if (!/\/$/.test(rootUrl)) rootUrl += '/';
-            const v = pxt.semver.tryParse(pxt.appTarget.versions.target);
-            if (v)
-                rootUrl += `v${v.major}/`;
             let currentPubId = (header ? header.pubId : undefined) || this.state.currentPubId;
+            const verPrefix = pxt.webConfig.verprefix || '';
 
             ready = (!!currentPubId && header.pubCurrent);
             if (ready) {
                 url = `${shareUrl}${currentPubId}`;
-                let editUrl = `${rootUrl}#pub:${currentPubId}`;
+                let editUrl = `${rootUrl}${verPrefix}#pub:${currentPubId}`;
                 switch (mode) {
                     case ShareMode.Code:
-                        embed = pxt.docs.codeEmbedUrl(rootUrl, header.pubId);
+                        embed = pxt.docs.codeEmbedUrl(`${rootUrl}${verPrefix}`, header.pubId);
                         break;
                     case ShareMode.Editor:
-                        embed = pxt.docs.embedUrl(rootUrl, "pub", header.pubId);
+                        embed = pxt.docs.embedUrl(`${rootUrl}${verPrefix}`, "pub", header.pubId);
                         break;
                     case ShareMode.Simulator:
                         let padding = '81.97%';
                         // TODO: parts aspect ratio
                         if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio).toPrecision(4) + '%';
-                        const runUrl = rootUrl + (pxt.webConfig.runUrl || "--run").replace(/^\//, '');
+                        const runUrl = rootUrl + (pxt.webConfig.runUrl || `${verPrefix}--run`).replace(/^\//, '');
                         embed = pxt.docs.runUrl(runUrl, padding, header.pubId);
                         break;
                     case ShareMode.Url:


### PR DESCRIPTION
Sharing: 
Initially we added the version on the client side in share.tsx as per https://github.com/Microsoft/pxt/pull/4329 but that introduces issues for Simulator share where runUrl already contains the version path and adding it again introduces an issue with duplicate vN in the url. Instead let the cloud handle this. Adding a parameter in webConfig that returns the version path and if it exists we prepend it to the url. 


Markdown versions: 
Initially I added the vN path into the url for docs and handled it by the backend, but it turns out the backend already handles custom doc versions by the client passing it the targetVersion. Although we were initially passing the backend the version it passes us through webConfig (targetVersion), but I think we should instead pass in the client's target version configured in appTarget.versions.target
