### PR TITLE
only compare major versions for checking minimum target version load

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -179,7 +179,7 @@ namespace pxt {
                 U.userError("Invalid package name: " + this.config.name)
             if (this.config.targetVersions
                 && this.config.targetVersions.target
-                && semver.strcmp(this.config.targetVersions.target, appTarget.versions.target) > 0)
+                && semver.majorCmp(this.config.targetVersions.target, appTarget.versions.target) > 0)
                 U.userError(lf("Package {0} requires target version {1} (you are running {2})",
                     this.config.name, this.config.targetVersions.target, appTarget.versions.target))
         }


### PR DESCRIPTION
Only consider the major version when deciding if a script is too old to be loaded in the current target.