### PR TITLE
Support for copyright text in the footer

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -263,7 +263,8 @@ declare namespace pxt {
         defaultBlockGap?: number; // For targets to override block gap
         hideShareEmbed?: boolean; // don't show advanced embedding options in share dialog
         hideNewProjectButton?: boolean; // do not show the "new project" button in home page
-        fileNameExclusiveFilter?: string; // anything that does not match this regex is removed from the filename
+        fileNameExclusiveFilter?: string; // anything that does not match this regex is removed from the filename,
+        copyrightText?: string; // footer text for any copyright text to be included at the bottom of the home screen and about page
     }
 
     interface SocialOptions {

--- a/pxtblocks/fields/field_images.ts
+++ b/pxtblocks/fields/field_images.ts
@@ -134,7 +134,7 @@ namespace pxtblockly {
             }
         }
 
-        private createTextNode_(text: string) {
+        protected createTextNode_(text: string) {
             const textSpan = document.createElement('span');
             textSpan.setAttribute('class', 'blocklyDropdownTextLabel');
             textSpan.textContent = text;

--- a/theme/home.less
+++ b/theme/home.less
@@ -110,6 +110,11 @@
             font-size: 0.8rem !important;
             color: @homeFooterColor !important;
         }
+        .item.copyright {
+            display: block;
+            font-size: 0.7rem !important;
+            line-height: 15px !important;
+        }
     }
     .ui.card {
         margin-right: 5px;

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -36,10 +36,12 @@ export function showAboutDialogAsync() {
                     <a href={`${pxt.Util.htmlEscape("https://github.com/" + compileService.githubCorePackage + '/releases/tag/' + compileService.gittag)}`}
                         title={`${lf("{0} version: {1}", "C++ runtime", pxt.Util.htmlEscape(compileService.gittag))}`}
                         target="_blank" rel="noopener noreferrer">{pxt.Util.htmlEscape(compileService.gittag)}</a></p> : undefined}
+            <p><br /></p>
             <p>
                 {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
                 &nbsp;&nbsp;&nbsp; {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
             </p>
+            {targetTheme.copyrightText ? <p> {targetTheme.copyrightText} </p> : undefined}
         </div>
 
     }).done();

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -216,12 +216,13 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                     </div>
                 </div>
             )}
-            {targetTheme.organizationUrl || targetTheme.organizationUrl || targetTheme.privacyUrl ? <div className="ui horizontal small divided link list homefooter">
+            {targetTheme.organizationUrl || targetTheme.organizationUrl || targetTheme.privacyUrl || targetTheme.copyrightText ? <div className="ui horizontal small divided link list homefooter">
                 {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" rel="noopener noreferrer" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
                 {targetTheme.selectLanguage ? <sui.Link className="item" text={lf("Language")} onClick={this.showLanguagePicker} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
                 {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
                 {pxt.appTarget.versions ? <sui.Link className="item" text={`v${pxt.appTarget.versions.target}`} onClick={this.showAboutDialog} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {targetTheme.copyrightText ? <div className="ui item copyright">{targetTheme.copyrightText}</div> : undefined}
             </div> : undefined}
         </div>;
     }


### PR DESCRIPTION
Option to add footer / copyright text at the bottom of the Home screen and About dialog.

![screen shot 2018-05-30 at 3 33 53 pm](https://user-images.githubusercontent.com/16690124/40751162-e2d0a2ec-641e-11e8-9cdc-7dc9335f4adf.png)


![screen shot 2018-05-30 at 3 34 37 pm](https://user-images.githubusercontent.com/16690124/40751180-fb3b4e54-641e-11e8-9f4c-c80311d436ec.png)
