### PR TITLE
Fix crash during initialization in micro:bit V1 UWP app

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2149,7 +2149,10 @@ function initLogin() {
 }
 
 function initSerial() {
-    if (!pxt.appTarget.serial || !pxt.winrt.isWinRT() && (!Cloud.isLocalHost() || !Cloud.localToken))
+    const isHF2WinRTSerial = pxt.appTarget.serial && pxt.appTarget.serial.useHF2 && pxt.winrt.isWinRT();
+    const isValidLocalhostSerial = pxt.appTarget.serial && Cloud.isLocalHost() && !!Cloud.localToken;
+
+    if (!isHF2WinRTSerial && !isValidLocalhostSerial)
         return;
 
     if (hidbridge.shouldUse()) {


### PR DESCRIPTION
In v0 we simply removed the call to `initSerial()`. In v1 we must adjust the conditions to return early.

Fixes https://github.com/Microsoft/pxt-microbit/issues/843