### PR TITLE
Fix tutorial cache in Safari

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -146,9 +146,12 @@ namespace pxt.blocks.layout {
     }
 
     export function serializeNode(sg: Node): string {
-        const xmlString = new XMLSerializer().serializeToString(sg)
+        return serializeSvg(new XMLSerializer().serializeToString(sg));
+    }
+
+    export function serializeSvg(xmlString: string): string {
+        return xmlString
             .replace(new RegExp('&nbsp;','g'), '&#160;'); // Replace &nbsp; with &#160; as a workaround for having nbsp missing from SVG xml
-        return xmlString;
     }
 
     export interface BlockSvg {

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -146,10 +146,10 @@ namespace pxt.blocks.layout {
     }
 
     export function serializeNode(sg: Node): string {
-        return serializeSvg(new XMLSerializer().serializeToString(sg));
+        return serializeSvgString(new XMLSerializer().serializeToString(sg));
     }
 
-    export function serializeSvg(xmlString: string): string {
+    export function serializeSvgString(xmlString: string): string {
         return xmlString
             .replace(new RegExp('&nbsp;','g'), '&#160;'); // Replace &nbsp; with &#160; as a workaround for having nbsp missing from SVG xml
     }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -55,7 +55,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 wrapperDiv.className = 'ui segment raised loading';
                 if (MarkedContent.blockSnippetCache[code]) {
                     // Use cache
-                    const svg = Blockly.Xml.textToDom(MarkedContent.blockSnippetCache[code]);
+                    const svg = Blockly.Xml.textToDom(pxt.blocks.layout.serializeSvg(cachedSvgString));
                     wrapperDiv.appendChild(svg);
                     pxsim.U.removeClass(wrapperDiv, 'loading');
                 } else {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -55,7 +55,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 wrapperDiv.className = 'ui segment raised loading';
                 if (MarkedContent.blockSnippetCache[code]) {
                     // Use cache
-                    const svg = Blockly.Xml.textToDom(pxt.blocks.layout.serializeSvg(cachedSvgString));
+                    const svg = Blockly.Xml.textToDom(pxt.blocks.layout.serializeSvgString(MarkedContent.blockSnippetCache[code]));
                     wrapperDiv.appendChild(svg);
                     pxsim.U.removeClass(wrapperDiv, 'loading');
                 } else {


### PR DESCRIPTION
We need to serialize the SVG before reusing it from cache in tutorials for Safari.

Fixes https://github.com/Microsoft/pxt-microbit/issues/842