### PR TITLE
Skip patching version in rendered cards when in editor

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -553,7 +553,7 @@ namespace pxt.runner {
             cd.className = "ui cards";
             cd.setAttribute("role", "listbox")
             cards.forEach(card => {
-                // patch card url with version if necessary
+                // patch card url with version if necessary, we don't do this in the editor because that goes through the backend and passes the targetVersion then
                 const mC = /^\/(v\d+)/.exec(card.url);
                 const mP = /^\/(v\d+)/.exec(window.location.pathname);
                 const inEditor = /#doc/i.test(window.location.pathname);

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -421,7 +421,8 @@ namespace pxt.runner {
                 if (!card) return;
                 const mC = /^\/(v\d+)/.exec(card.url);
                 const mP = /^\/(v\d+)/.exec(window.location.pathname);
-                if (card.url && !mC && mP) card.url = `/${mP[1]}/${card.url}`;
+                const inEditor = /#doc/i.test(window.location.pathname);
+                if (card.url && !mC && mP && !inEditor) card.url = `/${mP[1]}/${card.url}`;
                 ul.append(pxt.docs.codeCard.render(card, { hideHeader: true, shortName: true }));
             }
             stmts.forEach(stmt => {
@@ -555,7 +556,8 @@ namespace pxt.runner {
                 // patch card url with version if necessary
                 const mC = /^\/(v\d+)/.exec(card.url);
                 const mP = /^\/(v\d+)/.exec(window.location.pathname);
-                if (card.url && !mC && mP) card.url = `/${mP[1]}${card.url}`;
+                const inEditor = /#doc/i.test(window.location.pathname);
+                if (card.url && !mC && mP && !inEditor) card.url = `/${mP[1]}${card.url}`;
                 const cardEl = pxt.docs.codeCard.render(card, options);
                 cd.appendChild(cardEl)
                 // automitcally display package icon for approved packages


### PR DESCRIPTION
We don't need to patch the cards in the editor because that goes through a different path to rendering the docs (it already goes through the backend which is passed targetVersion and returns the versioned docs that way)

Partly fixes https://github.com/Microsoft/pxt-microbit/issues/841 for cards