### PR TITLE
Fix in editor check for card links (versioning)

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -421,7 +421,7 @@ namespace pxt.runner {
                 if (!card) return;
                 const mC = /^\/(v\d+)/.exec(card.url);
                 const mP = /^\/(v\d+)/.exec(window.location.pathname);
-                const inEditor = /#doc/i.test(window.location.pathname);
+                const inEditor = /#doc/i.test(window.location.href);
                 if (card.url && !mC && mP && !inEditor) card.url = `/${mP[1]}/${card.url}`;
                 ul.append(pxt.docs.codeCard.render(card, { hideHeader: true, shortName: true }));
             }
@@ -556,7 +556,7 @@ namespace pxt.runner {
                 // patch card url with version if necessary, we don't do this in the editor because that goes through the backend and passes the targetVersion then
                 const mC = /^\/(v\d+)/.exec(card.url);
                 const mP = /^\/(v\d+)/.exec(window.location.pathname);
-                const inEditor = /#doc/i.test(window.location.pathname);
+                const inEditor = /#doc/i.test(window.location.href);
                 if (card.url && !mC && mP && !inEditor) card.url = `/${mP[1]}${card.url}`;
                 const cardEl = pxt.docs.codeCard.render(card, options);
                 cd.appendChild(cardEl)


### PR DESCRIPTION
Fix in editor check for whether or not to append target version to card urls.

Previous PR https://github.com/Microsoft/pxt/pull/4420 didn't correctly check for inEditor. 