### PR TITLE
Turn off playground sounds

### DIFF
--- a/docs/playground-runner.html
+++ b/docs/playground-runner.html
@@ -177,7 +177,7 @@
                             {
                                 scrollbars: true,
                                 media: pxt.webConfig.commitCdnUrl + "blockly/media/",
-                                sound: true,
+                                sound: false,
                                 trashcan: false,
                                 collapse: false,
                                 comments: true,


### PR DESCRIPTION
Since we don't host mp3 files properly in /docs. 

<img width="634" alt="screen shot 2018-06-05 at 8 14 04 am" src="https://user-images.githubusercontent.com/16690124/40985212-78c3eb7e-6898-11e8-9a12-702c123cdb82.png">

Avoid the problem for now.