### PR TITLE
Fix playground sound option

### DIFF
--- a/docs/playground-runner.html
+++ b/docs/playground-runner.html
@@ -177,7 +177,7 @@
                             {
                                 scrollbars: true,
                                 media: pxt.webConfig.commitCdnUrl + "blockly/media/",
-                                sound: false,
+                                sounds: false,
                                 trashcan: false,
                                 collapse: false,
                                 comments: true,


### PR DESCRIPTION
Turns out the flag is sounds not sound, this is also broken else but has no sideeffects, will on the next Blockly push.

It's sounds not sound.