### PR TITLE
better support for interecpting invalid versioned elements

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -181,7 +181,7 @@ namespace pxt {
             if (this.config.targetVersions
                 && this.config.targetVersions.target
                 && semver.majorCmp(this.config.targetVersions.target, appTarget.versions.target) > 0)
-                U.userError(lf("Package {0} requires target version {1} (you are running {2})",
+                U.userError(lf("{0} requires target version {1} (you are running {2})",
                     this.config.name, this.config.targetVersions.target, appTarget.versions.target))
         }
 

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -464,12 +464,9 @@ export function loadPkgAsync(id: string, targetVersion?: string) {
         .catch(core.handleNetworkError)
         .then(() => JSON.parse(theHost.readFile(mainPkg, pxt.CONFIG_NAME)) as pxt.PackageConfig)
         .then(config => {
-            if (!config) return Promise.resolve();
+            if (!config) throw new Error(lf("invalid pxt.json file"));
             return mainPkg.installAllAsync(targetVersion)
-                .then(() => mainEditorPkg().afterMainLoadAsync())
-                .catch(e => {
-                    core.errorNotification(lf("Cannot load package: {0}", e.message))
-                })
+                .then(() => mainEditorPkg().afterMainLoadAsync());
         })
 }
 


### PR DESCRIPTION
- [x] Performs major version checks in import hex path.
- [x] gracefully handle any kind of failed loading for packages.

Integration of https://github.com/Microsoft/pxt/pull/4427 from v0.