### PR TITLE
fix url encoding in about page

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -21,21 +21,16 @@ export function showAboutDialogAsync() {
             {githubUrl && versions ?
                 <p>
                     {lf("{0} version:", pxt.Util.htmlEscape(pxt.appTarget.name))} &nbsp;
-                    <a href={`${pxt.Util.htmlEscape(githubUrl)}/releases/tag/v${pxt.Util.htmlEscape(versions.target)}`}
+                    <a href={encodeURI(`${githubUrl}/releases/tag/v${versions.target}`)}
                         title={`${lf("{0} version : {1}", pxt.Util.htmlEscape(pxt.appTarget.name), pxt.Util.htmlEscape(versions.target))}`}
                         target="_blank" rel="noopener noreferrer">{pxt.Util.htmlEscape(pxt.appTarget.versions.target)}</a>
                 </p> : undefined}
             {versions ?
                 <p>{lf("{0} version:", "Microsoft MakeCode")} &nbsp;
-                    <a href={`https://github.com/Microsoft/pxt/releases/tag/v${pxt.Util.htmlEscape(versions.pxt)}`}
+                    <a href={encodeURI(`https://github.com/Microsoft/pxt/releases/tag/v${versions.pxt}`)}
                         title={`${lf("{0} version: {1}", "Microsoft MakeCode", pxt.Util.htmlEscape(versions.pxt))}`}
                         target="_blank" rel="noopener noreferrer">{pxt.Util.htmlEscape(versions.pxt)}</a>
                 </p> : undefined}
-            {compileService && compileService.githubCorePackage && compileService.gittag ?
-                <p>{lf("{0} version:", "C++ runtime")} &nbsp;
-                    <a href={`${pxt.Util.htmlEscape("https://github.com/" + compileService.githubCorePackage + '/releases/tag/' + compileService.gittag)}`}
-                        title={`${lf("{0} version: {1}", "C++ runtime", pxt.Util.htmlEscape(compileService.gittag))}`}
-                        target="_blank" rel="noopener noreferrer">{pxt.Util.htmlEscape(compileService.gittag)}</a></p> : undefined}
             <p><br /></p>
             <p>
                 {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}


### PR DESCRIPTION
- [x] fixing wrong encoding of release urls
- [x] removing C++ link (it was poiting to CODAL, not the CODAL target)