### PR TITLE
Fix issue with Safari not showing the right flyout heading labels.

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1119,8 +1119,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     protected showFlyoutHeadingLabel(ns: string, subns: string, icon: string, color: string) {
-        const categoryName = name ? name :
-            subns ? `${Util.capitalize(ns)} > ${Util.capitalize(subns)}` : Util.capitalize(ns);
+        const categoryName = subns ? `${Util.capitalize(ns)} > ${Util.capitalize(subns)}` : Util.capitalize(ns);
         const iconClass = `blocklyTreeIcon${icon ? ns.toLowerCase() : 'Default'}`.replace(/\s/g, '');
         let headingLabel = pxt.blocks.createFlyoutHeadingLabel(categoryName, color, icon, iconClass);
         this.flyoutXmlList.push(headingLabel);

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -5,8 +5,6 @@ import * as data from "./data"
 import * as editor from "./toolboxeditor"
 import * as sui from "./sui"
 import * as core from "./core"
-import * as snippets from "./monacoSnippets"
-import * as monaco from "./monaco"
 
 import Util = pxt.Util;
 


### PR DESCRIPTION
When in an iframe and on Safari, 
we're seeing "iframe" or the iframe iD as the name in the flyout. 

This fixes that. 

Screenshot of issue: 
![screen shot 2018-06-07 at 3 22 22 pm](https://user-images.githubusercontent.com/16690124/41129381-a1423978-6a66-11e8-9ce5-254dbac0c742.png)
