### PR TITLE
patch apptarget when setting variants

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -478,26 +478,6 @@ namespace pxt.BrowserUtils {
                 }
             }
         }
-
-        const sim = pxt.appTarget.simulator;
-        if (sim
-            && sim.boardDefinition
-            && sim.boardDefinition.visual) {
-            let boardDef = sim.boardDefinition.visual as pxsim.BoardImageDefinition;
-            if (boardDef.image) {
-                boardDef.image = patchCdn(boardDef.image)
-                if (boardDef.outlineImage) boardDef.outlineImage = patchCdn(boardDef.outlineImage)
-            }
-        }
-
-        // patch icons in bundled packages
-        Object.keys(pxt.appTarget.bundledpkgs).forEach(pkgid => {
-            const res = pxt.appTarget.bundledpkgs[pkgid];
-            // path config before storing
-            const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-            if (config.icon) config.icon = patchCdn(config.icon);
-            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
-        })
     }
 
     /**


### PR DESCRIPTION
Whenever we assign a new apptarget (this happen once on load and every time we load a new board), we apply the patching logic.

Fixes lost images in maker extensions dialog.