### PR TITLE
Lazy load native dependencies

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -147,32 +147,27 @@ interface KeyTar {
     deletePassword(service: string, account: string): Promise<void>;
 }
 
+function requireKeyTarAsync(): Promise<KeyTar> {
+    return nodeutil.lazyRequireAsync("keytar")
+        .then(k => k as KeyTar);
+}
+
 function passwordGetAsync(account: string): Promise<string> {
-    try {
-        const keytar = require("keytar") as KeyTar;
-        return keytar.getPassword("pxt/" + pxt.appTarget.id, account)
-    } catch (e) {
-        return Promise.resolve(undefined);
-    }
+    return requireKeyTarAsync()
+        .then(keytar => keytar.getPassword("pxt/" + pxt.appTarget.id, account))
+        .catch(e => undefined)
 }
 
 function passwordDeleteAsync(account: string): Promise<void> {
-    try {
-        const keytar = require("keytar") as KeyTar;
-        return keytar.deletePassword("pxt/" + pxt.appTarget.id, account);
-    } catch (e) {
-        return Promise.resolve(undefined);
-    }
+    return requireKeyTarAsync()
+        .then(keytar => keytar.deletePassword("pxt/" + pxt.appTarget.id, account))
+        .catch(e => undefined);
 }
 
 function passwordUpdateAsync(account: string, password: string): Promise<void> {
-    try {
-        const keytar = require("keytar") as KeyTar;
-        return keytar.setPassword("pxt/" + pxt.appTarget.id, account, password);
-    } catch (e) {
-        console.error(e)
-        return Promise.resolve(undefined)
-    }
+    return requireKeyTarAsync()
+        .then(keytar => keytar.setPassword("pxt/" + pxt.appTarget.id, account, password))
+        .catch(e => undefined);
 }
 
 const PXT_KEY = "pxt";

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -147,25 +147,24 @@ interface KeyTar {
     deletePassword(service: string, account: string): Promise<void>;
 }
 
-function requireKeyTarAsync(install = false): Promise<KeyTar> {
-    return nodeutil.lazyRequireAsync("keytar")
-        .then(k => k as KeyTar);
+function requireKeyTar(install = false): Promise<KeyTar> {
+    return Promise.resolve(nodeutil.lazyRequire("keytar") as KeyTar);
 }
 
 function passwordGetAsync(account: string): Promise<string> {
-    return requireKeyTarAsync()
+    return requireKeyTar()
         .then(keytar => keytar.getPassword("pxt/" + pxt.appTarget.id, account))
         .catch(e => undefined)
 }
 
 function passwordDeleteAsync(account: string): Promise<void> {
-    return requireKeyTarAsync()
+    return requireKeyTar()
         .then(keytar => keytar.deletePassword("pxt/" + pxt.appTarget.id, account))
         .catch(e => undefined);
 }
 
 function passwordUpdateAsync(account: string, password: string): Promise<void> {
-    return requireKeyTarAsync(true)
+    return requireKeyTar(true)
         .then(keytar => keytar.setPassword("pxt/" + pxt.appTarget.id, account, password))
         .catch(e => undefined);
 }

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -24,6 +24,7 @@ export function listAsync() {
 }
 
 export function serialAsync() {
+    if (!requireHID()) return Promise.resolve();
     return initAsync()
         .then(d => {
             d.autoReconnect = true

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -67,7 +67,7 @@ export function getHF2DevicesAsync(): Promise<HidDevice[]> {
 }
 
 export function hf2ConnectAsync(path: string, raw = false) {
-    if (!requireHID()) return undefined;
+    if (!requireHID()) return Promise.resolve(undefined);
     // in .then() to make sure we catch errors
     let h = new HF2.Wrapper(new HidIO(path))
     h.rawMode = raw

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -19,9 +19,9 @@ export interface HidDevice {
     release: number; // 0x4201
 }
 
-function listAsync() {
+export function listAsync() {
     return getHF2DevicesAsync()
-        .then(devices => devices.forEach(device => console.log(device)));
+        .then(devices => devices.forEach(device => pxt.log(device)));
 }
 
 export function serialAsync() {

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -5,7 +5,7 @@ import * as nodeutil from './nodeutil';
 let HID: any = undefined;
 function requireHIDAsync(): Promise<any> {
     if (HID) return Promise.resolve(HID);
-    return nodeutil.lazyRequireAsync("node-hid")
+    return nodeutil.lazyRequireAsync("node-hid", true)
         .then(hid => HID = hid);
 }
 

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -8,7 +8,7 @@ function getHID(): any {
         try {
             HID = require("node-hid")
         } catch (e) {
-            pxt.log('node-hid failed to load, ignoring...')
+            pxt.log('node-hid package failed to load, skipping...')
             HID = null;
         }
     }

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -488,33 +488,26 @@ export function resolveMd(root: string, pathname: string): string {
     return undefined;
 }
 
-export function lazyRequireAsync(name: string): Promise<any> {
+export function lazyDependencies(): pxt.Map<string> {
+    // find pxt-core package
+    const deps: pxt.Map<string> = {};
+    [path.join("node_modules", "pxt-core", "package.json"), "package.json"]
+        .filter(f => fs.existsSync(f))
+        .map(f => readJson(f))
+        .forEach(config => config && config.lazyDependencies && Util.jsonMergeFrom(deps, config.lazyDependencies))
+    return deps;
+}
+
+export function lazyRequireAsync(name: string, install = false): Promise<any> {
     /* tslint:disable:non-literal-require */
+    if (!lazyDependencies()[name])
+        Util.userError(`lazy dependency ${name} not listed in package.json`);
     try {
         return Promise.resolve(require(name));
     } catch (e) {
-        pxt.log(`${name} package failed to load, installing...`)
-        // find pxt-core package
-        const lazyDependencies: pxt.Map<string> = {};
-        [path.join("node_modules", "pxt_core", "package.json"), "package.json"]
-            .filter(f => fs.existsSync(f))
-            .map(f => readJson(f))
-            .forEach(config => config && config.lazyDependencies && Util.jsonMergeFrom(lazyDependencies, config.lazyDependencies))
-        const version = lazyDependencies[name];
-        if (!version)
-            Util.userError(`lazy dependency ${name} not listed in package.json`);
-
-        return spawnAsync({
-            cmd: "npm",
-            args: ["install", `${name}@${version}`]
-        }).then(() => {
-            try {
-                return Promise.resolve(require(name));
-            } catch (e) {
-                pxt.log(`failed to load or install ${name}`);
-                return undefined;
-            }
-        })
+        if (install)
+            pxt.log(`package "${name}" failed to load, run "pxt npm-install-native" to install native depencencies`)
+        return Promise.resolve(undefined);
     }
     /* tslint:enable:non-literal-require */
 }

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -498,16 +498,16 @@ export function lazyDependencies(): pxt.Map<string> {
     return deps;
 }
 
-export function lazyRequireAsync(name: string, install = false): Promise<any> {
+export function lazyRequire(name: string, install = false): any {
     /* tslint:disable:non-literal-require */
     if (!lazyDependencies()[name])
         Util.userError(`lazy dependency ${name} not listed in package.json`);
     try {
-        return Promise.resolve(require(name));
+        return require(name);
     } catch (e) {
         if (install)
             pxt.log(`package "${name}" failed to load, run "pxt npm-install-native" to install native depencencies`)
-        return Promise.resolve(undefined);
+        return undefined;
     }
     /* tslint:enable:non-literal-require */
 }

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -488,4 +488,25 @@ export function resolveMd(root: string, pathname: string): string {
     return undefined;
 }
 
+export function lazyRequireAsync(name: string): Promise<any> {
+    /* tslint:disable:non-literal-require */
+    try {
+        return Promise.resolve(require(name));
+    } catch (e) {
+        pxt.log(`${name} package failed to load, installing...`)
+        return spawnAsync({
+            cmd: "npm",
+            args: ["install", name]
+        }).then(() => {
+            try {
+                return Promise.resolve(require(name));
+            } catch (e) {
+                pxt.log(`failed to load or install ${name}`);
+                return undefined;
+            }
+        })
+    }
+    /* tslint:enable:non-literal-require */
+}
+
 init();

--- a/cli/serial.ts
+++ b/cli/serial.ts
@@ -11,7 +11,7 @@ import U = pxt.Util;
 import Cloud = pxt.Cloud;
 
 function requireSerialPortAsync(): Promise<any> {
-    return nodeutil.lazyRequireAsync("serialport@6.2.0");
+    return nodeutil.lazyRequireAsync("serialport");
 }
 
 export interface SerialPortInfo {

--- a/cli/serial.ts
+++ b/cli/serial.ts
@@ -10,6 +10,10 @@ import * as commandParser from './commandparser';
 import U = pxt.Util;
 import Cloud = pxt.Cloud;
 
+function requireSerialPortAsync(): Promise<any> {
+    return nodeutil.lazyRequireAsync("serialport@6.2.0");
+}
+
 export interface SerialPortInfo {
     comName: string;
     pnpId: string;
@@ -29,59 +33,56 @@ export function monitorSerial(onData: (info: SerialPortInfo, buffer: Buffer) => 
 
     console.log('serial: monitoring ports...')
 
-    let SerialPort: any;
-    try {
-        SerialPort = require("serialport");
-    } catch (er) {
-        console.warn('serial-port package failed to load, skipping...');
-        return;
-    }
-    const serialPorts: pxt.Map<SerialPortInfo> = {};
-    function close(info: SerialPortInfo) {
-        console.log('serial: closing ' + info.pnpId);
-        delete serialPorts[info.pnpId];
-    }
+    requireSerialPortAsync().then(serialPort => {
+        if (!serialPort)
+            return;
+        const serialPorts: pxt.Map<SerialPortInfo> = {};
+        function close(info: SerialPortInfo) {
+            console.log('serial: closing ' + info.pnpId);
+            delete serialPorts[info.pnpId];
+        }
 
-    function open(info: SerialPortInfo) {
-        console.log(`serial: connecting to ${info.comName} by ${info.manufacturer} (${info.pnpId})`);
-        serialPorts[info.pnpId] = info;
-        info.port = new SerialPort(info.comName, {
-            baudRate: 115200,
-            autoOpen: false
-        }); // this is the openImmediately flag [default is true]
-        info.port.open(function (error: any) {
-            if (error) {
-                console.log('failed to open: ' + error);
-                close(info);
-            } else {
-                console.log(`serial: connected to ${info.comName} by ${info.manufacturer} (${info.pnpId})`);
-                info.opened = true;
-                info.port.on('data', (buffer: Buffer) => onData(info, buffer));
-                info.port.on('error', function () { close(info); });
-                info.port.on('close', function () { close(info); });
-            }
-        });
-    }
+        function open(info: SerialPortInfo) {
+            console.log(`serial: connecting to ${info.comName} by ${info.manufacturer} (${info.pnpId})`);
+            serialPorts[info.pnpId] = info;
+            info.port = new serialPort(info.comName, {
+                baudRate: 115200,
+                autoOpen: false
+            }); // this is the openImmediately flag [default is true]
+            info.port.open(function (error: any) {
+                if (error) {
+                    console.log('failed to open: ' + error);
+                    close(info);
+                } else {
+                    console.log(`serial: connected to ${info.comName} by ${info.manufacturer} (${info.pnpId})`);
+                    info.opened = true;
+                    info.port.on('data', (buffer: Buffer) => onData(info, buffer));
+                    info.port.on('error', function () { close(info); });
+                    info.port.on('close', function () { close(info); });
+                }
+            });
+        }
 
-    const vendorFilter = pxt.appTarget.serial.vendorId ? parseInt(pxt.appTarget.serial.vendorId, 16) : undefined;
-    const productFilter = pxt.appTarget.serial.productId ? parseInt(pxt.appTarget.serial.productId, 16) : undefined;
+        const vendorFilter = pxt.appTarget.serial.vendorId ? parseInt(pxt.appTarget.serial.vendorId, 16) : undefined;
+        const productFilter = pxt.appTarget.serial.productId ? parseInt(pxt.appTarget.serial.productId, 16) : undefined;
 
-    function filterPort(info: SerialPortInfo): boolean {
-        let retVal = true;
-        if (vendorFilter)
-            retVal = retVal && (vendorFilter == parseInt(info.vendorId, 16));
-        if (productFilter)
-            retVal = retVal && (productFilter == parseInt(info.productId, 16));
-        return retVal;
-    }
+        function filterPort(info: SerialPortInfo): boolean {
+            let retVal = true;
+            if (vendorFilter)
+                retVal = retVal && (vendorFilter == parseInt(info.vendorId, 16));
+            if (productFilter)
+                retVal = retVal && (productFilter == parseInt(info.productId, 16));
+            return retVal;
+        }
 
-    setInterval(() => {
-        SerialPort.list(function (err: any, ports: SerialPortInfo[]) {
-            ports.filter(filterPort)
-                .filter(info => !serialPorts[info.pnpId])
-                .forEach((info) => open(info));
-        });
-    }, 5000);
+        setInterval(() => {
+            serialPort.list(function (err: any, ports: SerialPortInfo[]) {
+                ports.filter(filterPort)
+                    .filter(info => !serialPorts[info.pnpId])
+                    .forEach((info) => open(info));
+            });
+        }, 5000);
+    });
 }
 
 class Serial {
@@ -92,9 +93,8 @@ class Serial {
     lock = new U.PromiseQueue()
     openpromise: Promise<void>;
 
-    constructor(public info: SerialPortInfo) {
-        let SerialPort = require("serialport");
-        info.port = new SerialPort(info.comName, {
+    constructor(public serialPort: any, public info: SerialPortInfo) {
+        info.port = new serialPort(info.comName, {
             baudrate: 115200,
             autoOpen: false
         }); // this is the openImmediately flag [default is true]
@@ -200,70 +200,72 @@ function sambaCmd(ch: string, addr: number, len?: number) {
     return r + "#"
 }
 export function flashSerialAsync(c: commandParser.ParsedCommand) {
-    let SerialPort = require("serialport");
-    let listAsync: () => Promise<SerialPortInfo[]> = Promise.promisify(SerialPort.list) as any
+    return requireSerialPortAsync()
+        .then(serialPort => {
+            let listAsync: () => Promise<SerialPortInfo[]> = Promise.promisify(serialPort.list) as any
 
-    let f = fs.readFileSync(c.args[0])
-    let blocks = pxtc.UF2.parseFile(f as any)
-    let s: Serial
+            let f = fs.readFileSync(c.args[0])
+            let blocks = pxtc.UF2.parseFile(f as any)
+            let s: Serial
 
-    let writeMemAsync = (addr: number, buf: Buffer) =>
-        s.writeAsync(sambaCmd("S", addr, buf.length))
-            .then(() => s.writeAsync(buf))
+            let writeMemAsync = (addr: number, buf: Buffer) =>
+                s.writeAsync(sambaCmd("S", addr, buf.length))
+                    .then(() => s.writeAsync(buf))
 
-    let pingAsync = () =>
-        s.writeAsync(sambaCmd("R", 0, 4))
-            .then(() => s.readBlockingAsync(4))
+            let pingAsync = () =>
+                s.writeAsync(sambaCmd("R", 0, 4))
+                    .then(() => s.readBlockingAsync(4))
 
-    let currApplet: number[] = null
-    let goCmd = ""
+            let currApplet: number[] = null
+            let goCmd = ""
 
-    let saveAppletAsync = (appl: number[]) => {
-        if (currApplet == appl) return Promise.resolve()
-        currApplet = appl
-        let writeBuf = new Buffer(appl.length * 4 + 8)
-        for (let i = 0; i < appl.length; i++)
-            pxt.HF2.write32(writeBuf, i * 4, appl[i])
-        let code = 0x20008000 - 512
-        pxt.HF2.write32(writeBuf, appl.length * 4, 0x20007ff0) // stack
-        pxt.HF2.write32(writeBuf, appl.length * 4 + 4, code + 1) // start addr (+1 for Thumb)
-        goCmd = sambaCmd("G", code + writeBuf.length - 8)
-        return writeMemAsync(code, writeBuf)
-    }
+            let saveAppletAsync = (appl: number[]) => {
+                if (currApplet == appl) return Promise.resolve()
+                currApplet = appl
+                let writeBuf = new Buffer(appl.length * 4 + 8)
+                for (let i = 0; i < appl.length; i++)
+                    pxt.HF2.write32(writeBuf, i * 4, appl[i])
+                let code = 0x20008000 - 512
+                pxt.HF2.write32(writeBuf, appl.length * 4, 0x20007ff0) // stack
+                pxt.HF2.write32(writeBuf, appl.length * 4 + 4, code + 1) // start addr (+1 for Thumb)
+                goCmd = sambaCmd("G", code + writeBuf.length - 8)
+                return writeMemAsync(code, writeBuf)
+            }
 
-    let runAppletAsync = (appl: number[]) =>
-        saveAppletAsync(appl)
-            .then(() => s.writeAsync(goCmd))
+            let runAppletAsync = (appl: number[]) =>
+                saveAppletAsync(appl)
+                    .then(() => s.writeAsync(goCmd))
 
-    let writeBlockAsync = (b: pxtc.UF2.Block) => {
-        let hd = new Buffer(8)
-        pxt.HF2.write32(hd, 0, b.targetAddr)
-        pxt.HF2.write32(hd, 4, 1)
-        return writeMemAsync(0x20006000, Buffer.concat([hd, b.data as any]))
-            .then(() => runAppletAsync(samd21.flash))
-            .then(pingAsync)
-    }
+            let writeBlockAsync = (b: pxtc.UF2.Block) => {
+                let hd = new Buffer(8)
+                pxt.HF2.write32(hd, 0, b.targetAddr)
+                pxt.HF2.write32(hd, 4, 1)
+                return writeMemAsync(0x20006000, Buffer.concat([hd, b.data as any]))
+                    .then(() => runAppletAsync(samd21.flash))
+                    .then(pingAsync)
+            }
 
-    let readWordsAsync = (addr: number, len: number) => {
-        return s.writeAsync(sambaCmd("R", addr, len * 4))
-            .then(() => s.readBlockingAsync(len * 4))
-    }
+            let readWordsAsync = (addr: number, len: number) => {
+                return s.writeAsync(sambaCmd("R", addr, len * 4))
+                    .then(() => s.readBlockingAsync(len * 4))
+            }
 
-    return listAsync()
-        .then(ports => {
-            let p = ports.filter(p => /Arduino|Adafruit/i.test(p.manufacturer))[0]
-            s = new Serial(p)
-            return pxt.HF2.onlyChangedBlocksAsync(blocks, readWordsAsync)
-                .then(lessBlocks => {
-                    console.log(`flash ${blocks.length} pages -> ${lessBlocks.length} pages`)
-                    return Promise.mapSeries(lessBlocks, writeBlockAsync)
-                        .then(() => {
-                            console.log("all done; resetting...")
-                            return runAppletAsync(samd21.reset)
+            return listAsync()
+                .then(ports => {
+                    let p = ports.filter(p => /Arduino|Adafruit/i.test(p.manufacturer))[0]
+                    s = new Serial(serialPort, p);
+                    return pxt.HF2.onlyChangedBlocksAsync(blocks, readWordsAsync)
+                        .then(lessBlocks => {
+                            console.log(`flash ${blocks.length} pages -> ${lessBlocks.length} pages`)
+                            return Promise.mapSeries(lessBlocks, writeBlockAsync)
+                                .then(() => {
+                                    console.log("all done; resetting...")
+                                    return runAppletAsync(samd21.reset)
+                                })
+                                .then(() => s.close())
                         })
-                        .then(() => s.close())
                 })
-        })
+        });
 }
 
 

--- a/cli/serial.ts
+++ b/cli/serial.ts
@@ -33,7 +33,7 @@ export function monitorSerial(onData: (info: SerialPortInfo, buffer: Buffer) => 
     try {
         SerialPort = require("serialport");
     } catch (er) {
-        console.warn('serial: failed to load, skipping...');
+        console.warn('serial-port package failed to load, skipping...');
         return;
     }
     const serialPorts: pxt.Map<SerialPortInfo> = {};

--- a/cli/serial.ts
+++ b/cli/serial.ts
@@ -11,7 +11,7 @@ import U = pxt.Util;
 import Cloud = pxt.Cloud;
 
 function requireSerialPortAsync(): Promise<any> {
-    return nodeutil.lazyRequireAsync("serialport");
+    return nodeutil.lazyRequireAsync("serialport", true);
 }
 
 export interface SerialPortInfo {

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -475,9 +475,9 @@ function initSocketServer(wsPort: number, hostname: string) {
                                         .then(res => ({ data: U.toHex(res) }))
                                 });
                             case "sendserial":
-                                return hio.sendSerialAsync(U.fromHex(msg.arg.data), msg.arg.isError)
+                                return hio.sendSerialAsync(U.fromHex(msg.arg.data), msg.arg.isError);
                             case "list":
-                                return { devices: hid.getHF2Devices() } as any
+                                return hid.getHF2DevicesAsync().then(devices => { return { devices } as any; });
                         }
                     })
                     .done(resp => {

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -477,7 +477,11 @@ function initSocketServer(wsPort: number, hostname: string) {
                             case "sendserial":
                                 return hio.sendSerialAsync(U.fromHex(msg.arg.data), msg.arg.isError);
                             case "list":
-                                return hid.getHF2DevicesAsync().then(devices => { return { devices } as any; });
+                                return hid.getHF2DevicesAsync()
+                                    .then(devices => { return { devices } as any; });
+                            default: // unknown message
+                                pxt.log(`unknown hid message ${msg.op}`)
+                                return null;
                         }
                     })
                     .done(resp => {

--- a/docs/cli/hidserial.md
+++ b/docs/cli/hidserial.md
@@ -8,6 +8,12 @@ Monitors serial output from certain boards (in particular SAMD21 ones)
 pxt hidserial
 ```
 
+## Installation
+
+This command relies on ``node-hid``, a native package for Node.JS. To install this package, run
+
+    pxt npm-install-native
+
 ## Description
 
 When using Codal runtime, PXT sends data from `serial.writeLine()` and friends

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,262 +265,15 @@
       "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
       "dev": true
     },
-    "ansi-bgblack": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
-      "integrity": "sha1-poulAHiHcBtqr74/oNrf36juPKI=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgblue": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
-      "integrity": "sha1-Z73ATtybm1J4lp2hlt6j11yMNhM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgcyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
-      "integrity": "sha1-WEiUJWAL3p9VBwaN2Wnr/bUP52g=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bggreen": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
-      "integrity": "sha1-TjGRJIUplD9DIelr8THRwTgWr0k=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgmagenta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
-      "integrity": "sha1-myhDLAduqpmUGGcqPvvhk5HCx6E=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgred": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
-      "integrity": "sha1-p2+Sg4OCukMpCmwXeEJPmE1vEEE=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgwhite": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
-      "integrity": "sha1-ZQRlE3elim7OzQMxmU5IAljhG6g=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bgyellow": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
-      "integrity": "sha1-w/4usIzUdmSAKeaHTRWgs49h1E8=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-black": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
-      "integrity": "sha1-9hheiJNgslRaHsUMC/Bj/EMDJFM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-blue": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
-      "integrity": "sha1-FbgEmQ6S/JyoxUds6PaZd3wh7b8=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-bold": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
-      "integrity": "sha1-PmOVCvWswq4uZw5vZ96xFdGl9QU=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-colors": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
-      "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
-      "requires": {
-        "ansi-bgblack": "0.1.1",
-        "ansi-bgblue": "0.1.1",
-        "ansi-bgcyan": "0.1.1",
-        "ansi-bggreen": "0.1.1",
-        "ansi-bgmagenta": "0.1.1",
-        "ansi-bgred": "0.1.1",
-        "ansi-bgwhite": "0.1.1",
-        "ansi-bgyellow": "0.1.1",
-        "ansi-black": "0.1.1",
-        "ansi-blue": "0.1.1",
-        "ansi-bold": "0.1.1",
-        "ansi-cyan": "0.1.1",
-        "ansi-dim": "0.1.1",
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "ansi-grey": "0.1.1",
-        "ansi-hidden": "0.1.1",
-        "ansi-inverse": "0.1.1",
-        "ansi-italic": "0.1.1",
-        "ansi-magenta": "0.1.1",
-        "ansi-red": "0.1.1",
-        "ansi-reset": "0.1.1",
-        "ansi-strikethrough": "0.1.1",
-        "ansi-underline": "0.1.1",
-        "ansi-white": "0.1.1",
-        "ansi-yellow": "0.1.1",
-        "lazy-cache": "2.0.2"
-      }
-    },
-    "ansi-cyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-dim": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
-      "integrity": "sha1-QN5MYDqoCG2Oeoa4/5mNXDbu/Ww=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-gray": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-green": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-      "integrity": "sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-grey": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
-      "integrity": "sha1-WdmLasK6GfilF5jphT+6eDOaM8E=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-hidden": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
-      "integrity": "sha1-7WpMSY0rt8uyidvyqNHcyFZ/rg8=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-inverse": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
-      "integrity": "sha1-tq9Fgm/oJr+1KKbHmIV5Q1XM0mk=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-italic": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
-      "integrity": "sha1-EEdDRj9iXBQqA2c5z4XtpoiYbyM=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-magenta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
-      "integrity": "sha1-BjtboW+z8j4c/aKwfAqJ3hHkMK4=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-red": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
-    "ansi-reset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
-      "integrity": "sha1-5+cSksPH3c1NYu9KbHwFmAkRw7c=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-strikethrough": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
-      "integrity": "sha1-2Eh3FAss/wfRyT685pkE9oiF5Wg=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
-    "ansi-underline": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
-      "integrity": "sha1-38kg9Ml7WXfqFi34/7mIMIqqcaQ=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-white": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
-      "integrity": "sha1-nHe3wZPF7pkuYBHTbsTJIbRXiUQ=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
-    },
-    "ansi-yellow": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
-      "integrity": "sha1-y5NW8vRscy8OMZnmEClVp32oPB0=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
     },
     "anymatch": {
       "version": "1.3.2",
@@ -535,12 +288,14 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "dev": true,
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.6"
@@ -572,16 +327,8 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "arr-swap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arr-swap/-/arr-swap-1.0.1.tgz",
-      "integrity": "sha1-FHWQ7WX8gVvAf+8Jl8Llgj1kNTQ=",
-      "optional": true,
-      "requires": {
-        "is-number": "3.0.0"
-      }
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "array-filter": {
       "version": "0.0.1",
@@ -677,12 +424,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
-    },
-    "assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "optional": true
     },
     "ast-types": {
       "version": "0.9.6",
@@ -861,7 +602,8 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "dev": true
     },
     "bitsyntax": {
       "version": "0.0.4",
@@ -877,6 +619,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "dev": true,
       "requires": {
         "readable-stream": "2.3.6",
         "safe-buffer": "5.1.1"
@@ -1304,28 +1047,6 @@
         }
       }
     },
-    "choices-separator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/choices-separator/-/choices-separator-2.0.0.tgz",
-      "integrity": "sha1-kv0XYxgteQM/XFxR0Lo1LlVnxpY=",
-      "optional": true,
-      "requires": {
-        "ansi-dim": "0.1.1",
-        "debug": "2.6.9",
-        "strip-color": "0.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1347,6 +1068,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true,
       "optional": true
     },
     "cipher-base": {
@@ -1398,24 +1120,6 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
-    "clone-deep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-1.0.0.tgz",
-      "integrity": "sha512-hmJRX8x1QOJVV+GUjOBzi6iauhPqc9hIF6xitWRBbiPZOBb6vGo/mDRIK9P74RTKSQK7AE8B0DDWY/vpRrPmQw==",
-      "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "5.1.0",
-        "shallow-clone": "1.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1432,17 +1136,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "optional": true,
-      "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
-      }
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color": {
       "version": "0.11.4",
@@ -1570,7 +1265,8 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
@@ -1628,7 +1324,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -1651,12 +1348,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
-    },
-    "copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "optional": true
     },
     "core-js": {
       "version": "2.5.5",
@@ -1862,6 +1553,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1870,15 +1562,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "optional": true,
-      "requires": {
-        "mimic-response": "1.0.0"
-      }
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -1901,6 +1584,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true,
       "optional": true
     },
     "deep-is": {
@@ -1928,14 +1612,6 @@
             "xtend": "4.0.1"
           }
         }
-      }
-    },
-    "define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-      "requires": {
-        "is-descriptor": "1.0.2"
       }
     },
     "defined": {
@@ -1972,7 +1648,8 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -1999,12 +1676,6 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.1"
       }
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
     },
     "detective": {
       "version": "4.7.1",
@@ -2130,6 +1801,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -2221,11 +1893,6 @@
       "requires": {
         "prr": "1.0.1"
       }
-    },
-    "error-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
-      "integrity": "sha1-Ck2uN9YA0VopukU9jvkg8YRDM/Y="
     },
     "es3ify": {
       "version": "0.2.2",
@@ -2443,20 +2110,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
       "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
+      "dev": true,
       "optional": true
     },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "requires": {
-        "is-extendable": "0.1.1"
-      }
     },
     "extglob": {
       "version": "0.3.2",
@@ -2682,15 +2342,8 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "foreach": {
       "version": "2.0.5",
@@ -3408,6 +3061,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
       "requires": {
         "aproba": "1.2.0",
         "console-control-strings": "1.1.0",
@@ -3508,6 +3162,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true,
       "optional": true
     },
     "glob": {
@@ -3676,7 +3331,8 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "hash-base": {
       "version": "3.0.4",
@@ -3996,11 +3652,6 @@
         "wrappy": "1.0.2"
       }
     },
-    "info-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
-      "integrity": "sha1-J4QdcoZ920JCzWEtecEGM4gcang="
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -4010,6 +3661,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true,
       "optional": true
     },
     "inline-process-browser": {
@@ -4088,21 +3740,6 @@
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
     },
-    "is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-      "requires": {
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
-    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -4116,38 +3753,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-      "requires": {
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
-    },
-    "is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-      "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -4167,7 +3772,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
@@ -4179,6 +3785,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -4215,6 +3822,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -4223,14 +3831,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "3.0.1"
-      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -4269,11 +3869,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4290,11 +3885,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -4709,28 +4299,14 @@
         "minimist": "1.2.0"
       }
     },
-    "keytar": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.2.1.tgz",
-      "integrity": "sha1-igamV3/fY3PgqmsRInfmPex3/RI=",
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "prebuild-install": "2.5.3"
-      }
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
-    },
-    "koalas": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/koalas/-/koalas-1.0.2.tgz",
-      "integrity": "sha1-MYQz8HQjXbePrlZhoCqMpT7ilc0="
     },
     "labeled-stream-splicer": {
       "version": "2.0.1",
@@ -4747,14 +4323,6 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
           "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA=="
         }
-      }
-    },
-    "lazy-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-      "requires": {
-        "set-getter": "0.1.0"
       }
     },
     "less": {
@@ -5163,29 +4731,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
-    "log-ok": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
-      "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
-      "requires": {
-        "ansi-green": "0.1.1",
-        "success-symbol": "0.1.0"
-      }
-    },
-    "log-utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
-      "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
-      "requires": {
-        "ansi-colors": "0.2.0",
-        "error-symbol": "0.1.0",
-        "info-symbol": "0.1.0",
-        "log-ok": "0.1.1",
-        "success-symbol": "0.1.0",
-        "time-stamp": "1.1.0",
-        "warning-symbol": "0.1.0"
-      }
-    },
     "log4js": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.3.tgz",
@@ -5532,15 +5077,6 @@
         }
       }
     },
-    "map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "optional": true,
-      "requires": {
-        "object-visit": "1.0.1"
-      }
-    },
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
@@ -5643,12 +5179,6 @@
         "mime-db": "1.33.0"
       }
     },
-    "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
-      "optional": true
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5671,22 +5201,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "mixin-object": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
-      },
-      "dependencies": {
-        "for-in": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
-        }
-      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -5794,17 +5308,14 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true
     },
     "neatequal": {
       "version": "1.0.0",
@@ -5833,15 +5344,6 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
-    },
-    "node-abi": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.3.0.tgz",
-      "integrity": "sha512-zwm6vU3SsVgw3e9fu48JBaRBCJGIvAgysDsqtf5+vEexFE71bEOtaMWb5zr/zODZNzTPtQlqUUpC79k68Hspow==",
-      "optional": true,
-      "requires": {
-        "semver": "5.5.0"
-      }
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -5880,17 +5382,6 @@
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
-      }
-    },
-    "node-hid": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-0.5.7.tgz",
-      "integrity": "sha512-dwwpOetL2+MGYgivbO22ML+45ieCGbueWv1rYxRgBoEc2QMp6UF6ZucEkYts1IA3YPWJNkmpGh6dqQ85n19szw==",
-      "optional": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.8.0",
-        "prebuild-install": "2.5.3"
       }
     },
     "node-ninja": {
@@ -6047,6 +5538,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true,
       "optional": true
     },
     "nopt": {
@@ -6087,6 +5579,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
         "console-control-strings": "1.1.0",
@@ -6108,7 +5601,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -6126,78 +5620,11 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
-    "object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "optional": true,
-      "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "optional": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "optional": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "optional": true
-            }
-          }
-        }
-      }
-    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "requires": {
-        "isobject": "3.0.1"
-      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -6287,7 +5714,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -6404,60 +5832,6 @@
         "better-assert": "1.0.2"
       }
     },
-    "parser-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parser-byte-length/-/parser-byte-length-1.0.2.tgz",
-      "integrity": "sha512-RaI2vekkZ0iZiORVFQdvOXx7szbYaGlkXUUh+qjuJpkDhD/GgoG3OmC51/Rob/Ogjy9l4S+8Tey+xiH0ol14XA==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "parser-cctalk": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parser-cctalk/-/parser-cctalk-1.0.2.tgz",
-      "integrity": "sha512-Q/9Zz4rSQLiZyxOsVYDlkny3+dh/xxv7sYdrPQdaFprRXImzjB2vpBZZqUQZpBWn+5PX9mnCVn23o22ClNHKSQ==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "parser-delimiter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parser-delimiter/-/parser-delimiter-1.0.2.tgz",
-      "integrity": "sha512-w7XmCahMtT4GUIgxbfyXgrhRfrxfo4ftg7zFJGb4G3Fp1ZqMvC/3gXm7W0N1/NaYlcoNv2nL4nIXFNbh+gcjBw==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "parser-readline": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parser-readline/-/parser-readline-1.0.2.tgz",
-      "integrity": "sha512-JYA2+Kg5IBgruq5ogeMnuh3AjVp5RIJht5/K1KQsdS25OFU+Sx+BvBOBhlEhsU3Uw3IwxuhXgrYb/QwZgJNARA==",
-      "optional": true,
-      "requires": {
-        "parser-delimiter": "1.0.2",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "parser-ready": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parser-ready/-/parser-ready-1.0.2.tgz",
-      "integrity": "sha512-u76Ai1y+kNSVByGEvOPZac8VFqn9+D6tZDZmOfwGDX1DhNe8T9ZX/FzO3qrESsynuqSRV8WBCPnUvKrGkfoi0Q==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "parser-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parser-regex/-/parser-regex-1.0.2.tgz",
-      "integrity": "sha512-SXSANkKVQfsDQTsZoHtfjbcHI3CPxHjUbHdSgAejbrfbvCBAx2pNvUV4JnDm2jge9UViFNERzj+MBt5yh6ocdQ==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
@@ -6558,12 +5932,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.2.tgz",
       "integrity": "sha512-bVNd3LMXRzdo6s4ehr4XW2wFMu9cb40nPgHEjSSppm8/++Xc+g0b2QQb+SeDesgfANXbjydOr1or9YQ+pcCZPQ=="
-    },
-    "pointer-symbol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pointer-symbol/-/pointer-symbol-1.0.0.tgz",
-      "integrity": "sha1-YPkRAgTqepKbYmRKITFVQ8uz1Ec=",
-      "optional": true
     },
     "postcss": {
       "version": "6.0.21",
@@ -7554,29 +6922,6 @@
         }
       }
     },
-    "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.0",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.3.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.6",
-        "simple-get": "2.7.0",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7610,168 +6955,12 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
-    "promirepl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promirepl/-/promirepl-1.0.1.tgz",
-      "integrity": "sha1-KVGq66K/P+InT/Y6FtlMBMpghy4=",
-      "optional": true
-    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "2.0.6"
-      }
-    },
-    "prompt-actions": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prompt-actions/-/prompt-actions-3.0.2.tgz",
-      "integrity": "sha512-dhz2Fl7vK+LPpmnQ/S/eSut4BnH4NZDLyddHKi5uTU/2PDn3grEMGkgsll16V5RpVUh/yxdiam0xsM0RD4xvtg==",
-      "optional": true,
-      "requires": {
-        "debug": "2.6.9"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "prompt-base": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/prompt-base/-/prompt-base-4.1.0.tgz",
-      "integrity": "sha512-svGzgLUKZoqomz9SGMkf1hBG8Wl3K7JGuRCXc/Pv7xw8239hhaTBXrmjt7EXA9P/QZzdyT8uNWt9F/iJTXq75g==",
-      "optional": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "koalas": "1.0.2",
-        "log-utils": "0.2.1",
-        "prompt-actions": "3.0.2",
-        "prompt-question": "5.0.2",
-        "readline-ui": "2.2.3",
-        "readline-utils": "2.2.3",
-        "static-extend": "0.1.2"
-      }
-    },
-    "prompt-checkbox": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/prompt-checkbox/-/prompt-checkbox-2.2.0.tgz",
-      "integrity": "sha512-T/QWgkdUmKjRSr0FQlV8O+LfgmBk8PwDbWhzllm7mwWNAjs3qOVuru5Y1gV4/14L73zCncqcuwGwvnDyVcVgvA==",
-      "optional": true,
-      "requires": {
-        "ansi-cyan": "0.1.1",
-        "debug": "2.6.9",
-        "prompt-base": "4.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "prompt-choices": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/prompt-choices/-/prompt-choices-4.0.6.tgz",
-      "integrity": "sha512-JfXujJo79TKG6KUHE+1S4tYLUEMRLM/mW9Bz49qrGKxVpnBGsQSv9lPiLKZgHtGEzXH7nG2kfMvWBEaKQs+JkQ==",
-      "optional": true,
-      "requires": {
-        "arr-flatten": "1.1.0",
-        "arr-swap": "1.0.1",
-        "choices-separator": "2.0.0",
-        "clone-deep": "1.0.0",
-        "collection-visit": "1.0.0",
-        "debug": "3.1.0",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "kind-of": "5.1.0",
-        "koalas": "1.0.2",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "pointer-symbol": "1.0.0",
-        "radio-symbol": "2.0.0",
-        "set-value": "2.0.0",
-        "strip-color": "0.1.0",
-        "terminal-paginator": "2.0.2",
-        "toggle-array": "1.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "optional": true
-        }
-      }
-    },
-    "prompt-list": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/prompt-list/-/prompt-list-3.1.2.tgz",
-      "integrity": "sha512-5ezD3usudKMQVpMFLV5R0RTpUF0T+VRvQvmQyDz8Rpz274lKwabZO4ozTR8tq2X4HuovqZb3kGqFZmJeXjAyDw==",
-      "optional": true,
-      "requires": {
-        "ansi-cyan": "0.1.1",
-        "ansi-dim": "0.1.1",
-        "debug": "3.1.0",
-        "prompt-radio": "1.2.1"
-      }
-    },
-    "prompt-question": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/prompt-question/-/prompt-question-5.0.2.tgz",
-      "integrity": "sha512-wreaLbbu8f5+7zXds199uiT11Ojp59Z4iBi6hONlSLtsKGTvL2UY8VglcxQ3t/X4qWIxsNCg6aT4O8keO65v6Q==",
-      "optional": true,
-      "requires": {
-        "clone-deep": "1.0.0",
-        "debug": "3.1.0",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "kind-of": "5.1.0",
-        "koalas": "1.0.2",
-        "prompt-choices": "4.0.6"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "optional": true
-        }
-      }
-    },
-    "prompt-radio": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prompt-radio/-/prompt-radio-1.2.1.tgz",
-      "integrity": "sha512-vH1iAkgbWyvZBC1BTajydiHmwJP4F1b684gq0fm2wOjPVW1zaDo01OXWr/Dske0XdoHhtZFNMOXNj/ZUSRBywg==",
-      "optional": true,
-      "requires": {
-        "debug": "2.6.9",
-        "prompt-checkbox": "2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "prop-types": {
@@ -7852,16 +7041,6 @@
         "pull-core": "1.0.0"
       }
     },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "optional": true,
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
-      }
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -7907,17 +7086,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
-    },
-    "radio-symbol": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/radio-symbol/-/radio-symbol-2.0.0.tgz",
-      "integrity": "sha1-eqm/xQSFY21S3XbWqOYxspB5muE=",
-      "optional": true,
-      "requires": {
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "is-windows": "1.0.2"
-      }
     },
     "randomatic": {
       "version": "1.1.7",
@@ -8005,6 +7173,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+      "dev": true,
       "optional": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -8090,76 +7259,6 @@
         "minimatch": "3.0.4",
         "readable-stream": "2.3.6",
         "set-immediate-shim": "1.0.1"
-      }
-    },
-    "readline-ui": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/readline-ui/-/readline-ui-2.2.3.tgz",
-      "integrity": "sha512-ix7jz0PxqQqcIuq3yQTHv1TOhlD2IHO74aNO+lSuXsRYm1d+pdyup1yF3zKyLK1wWZrVNGjkzw5tUegO2IDy+A==",
-      "optional": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "readline-utils": "2.2.3",
-        "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "optional": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "optional": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "optional": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
-    "readline-utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/readline-utils/-/readline-utils-2.2.3.tgz",
-      "integrity": "sha1-b4R9a48ZFcORtYHDZ81HhzhiNRo=",
-      "requires": {
-        "arr-flatten": "1.1.0",
-        "extend-shallow": "2.0.1",
-        "is-buffer": "1.1.6",
-        "is-number": "3.0.0",
-        "is-windows": "1.0.2",
-        "koalas": "1.0.2",
-        "mute-stream": "0.0.7",
-        "strip-color": "0.1.0",
-        "window-size": "1.1.0"
       }
     },
     "recast": {
@@ -8431,74 +7530,20 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-    },
-    "serialport": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-6.2.0.tgz",
-      "integrity": "sha512-y6Bdr+1kazPIMlZQYB1nQhiSbC8xEL8cyuSd79nJ29JwTh7NR0SUxjseoY8DcLRGuta5sifqQhP4CGcI3S/V4Q==",
-      "optional": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
-        "nan": "2.10.0",
-        "parser-byte-length": "1.0.2",
-        "parser-cctalk": "1.0.2",
-        "parser-delimiter": "1.0.2",
-        "parser-readline": "1.0.2",
-        "parser-ready": "1.0.2",
-        "parser-regex": "1.0.2",
-        "prebuild-install": "2.5.3",
-        "promirepl": "1.0.1",
-        "prompt-list": "3.1.2",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "optional": true
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-          "optional": true
-        }
-      }
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
-    },
-    "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-      "optional": true,
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
-      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -8519,23 +7564,6 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      }
-    },
-    "shallow-clone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-      "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
-      "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "5.1.0",
-        "mixin-object": "2.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
       }
     },
     "shasum": {
@@ -8561,24 +7589,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-      "optional": true
-    },
-    "simple-get": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
-      "optional": true,
-      "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
-      }
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "simple-mime": {
       "version": "0.1.0",
@@ -8756,36 +7768,6 @@
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-2.0.2.tgz",
       "integrity": "sha1-N7djhHdjrn56zvLKUjPQHmSaeLc=",
       "dev": true
-    },
-    "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "optional": true,
-      "requires": {
-        "extend-shallow": "3.0.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "optional": true,
-          "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "optional": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -9818,84 +8800,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "optional": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "optional": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "optional": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "optional": true
-        }
-      }
-    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -9962,6 +8866,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -9998,11 +8903,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "strip-color": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
-      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -10071,11 +8971,6 @@
           }
         }
       }
-    },
-    "success-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-      "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc="
     },
     "supports-color": {
       "version": "3.2.3",
@@ -10204,6 +9099,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
       "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "chownr": "1.0.1",
@@ -10216,6 +9112,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "dev": true,
           "optional": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -10228,33 +9125,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "dev": true,
       "requires": {
         "bl": "1.2.2",
         "end-of-stream": "1.4.1",
         "readable-stream": "2.3.6",
         "xtend": "4.0.1"
-      }
-    },
-    "terminal-paginator": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/terminal-paginator/-/terminal-paginator-2.0.2.tgz",
-      "integrity": "sha512-IZMT5ECF9p4s+sNCV8uvZSW9E1+9zy9Ji9xz2oee8Jfo7hUFpauyjxkhfRcIH6Lu3Wdepv5D1kVRc8Hx74/LfQ==",
-      "optional": true,
-      "requires": {
-        "debug": "2.6.9",
-        "extend-shallow": "2.0.1",
-        "log-utils": "0.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "through": {
@@ -10277,11 +9153,6 @@
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
       "dev": true,
       "optional": true
-    },
-    "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
     },
     "timers-browserify": {
       "version": "1.4.2",
@@ -10323,23 +9194,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
-    },
-    "to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "toggle-array": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toggle-array/-/toggle-array-1.0.1.tgz",
-      "integrity": "sha1-y/WEB5K9UJfzMReugkyTKv/ofVg=",
-      "optional": true,
-      "requires": {
-        "isobject": "3.0.1"
-      }
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -10901,11 +9755,6 @@
         "loose-envify": "1.3.1"
       }
     },
-    "warning-symbol": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz",
-      "integrity": "sha1-uzHdEbeg+dZ6su2V9Fe2WCW7rSE="
-    },
     "webfonts-generator": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
@@ -10996,27 +9845,13 @@
         "isexe": "2.0.0"
       }
     },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "optional": true
-    },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "dev": true,
       "requires": {
         "string-width": "1.0.2"
-      }
-    },
-    "window-size": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-1.1.0.tgz",
-      "integrity": "sha1-O0AtMkTzVWHbLJdhrZ0eUoawei0=",
-      "requires": {
-        "define-property": "1.0.0",
-        "is-number": "3.0.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -86,11 +86,6 @@
     "less": "2.7.3",
     "semantic-ui-less": "2.2.14"
   },
-  "optionalDependencies": {
-    "keytar": "4.2.1",
-    "node-hid": "^0.5.2",
-    "serialport": "^6.0.5"
-  },
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
   },
   "lazyDependencies": {
     "keytar": "4.2.1",
-    "node-hid": "^0.5.2",
-    "serialport": "^6.0.5"
+    "node-hid": "^0.7.2",
+    "serialport": "^6.2.0"
   },
   "devDependencies": {
     "monaco-editor": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
     "less": "2.7.3",
     "semantic-ui-less": "2.2.14"
   },
+  "lazyDependencies": {
+    "keytar": "4.2.1",
+    "node-hid": "^0.5.2",
+    "serialport": "^6.0.5"
+  },
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.5",


### PR DESCRIPTION
Most of our native dependencies are not needed for compilation or other tasks. They do create a ton of warnings or fail the installation -- or simply fails in OS like Windows 7 when precompiled images are not available.

- [x] This PR moves those depencencies into a "lazyDependencies" section in package.json
- [x] they are not installed by default, one has to run ``pxt npm-install-native``
- [x] when missing an error message with the instruction above is displayed
- [x] upgrading serialport and node-hid