### PR TITLE
Add a "change board" dialog element

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -222,6 +222,7 @@ namespace pxt.editor {
         showExitAndSaveDialog(): void;
 
         showPackageDialog(): void;
+        showBoardDialog(): void;
     }
 
     export interface IHexFileImporter {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1828,7 +1828,11 @@ export class ProjectView
     }
 
     showPackageDialog() {
-        this.scriptSearch.showAddPackages();
+        this.scriptSearch.showExtensions();
+    }
+
+    showBoardDialog() {
+        this.scriptSearch.showBoards();
     }
 
     showRenameProjectDialogAsync(): Promise<boolean> {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -142,6 +142,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
         this.openSettings = this.openSettings.bind(this);
         this.showPackageDialog = this.showPackageDialog.bind(this);
+        this.showBoardDialog = this.showBoardDialog.bind(this);
         this.removeProject = this.removeProject.bind(this);
         this.showReportAbuse = this.showReportAbuse.bind(this);
         this.showLanguagePicker = this.showLanguagePicker.bind(this);
@@ -161,6 +162,11 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     showPackageDialog() {
         pxt.tickEvent("menu.addpackage", undefined, { interactiveConsent: true });
         this.props.parent.showPackageDialog();
+    }
+
+    showBoardDialog() {
+        pxt.tickEvent("menu.changeboard", undefined, { interactiveConsent: true });
+        this.props.parent.showBoardDialog();
     }
 
     removeProject() {
@@ -227,13 +233,15 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     renderCore() {
         const { highContrast, greenScreen } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
-        const packages = pxt.appTarget.cloud && pxt.appTarget.cloud.packages;
+        const packages = pxt.appTarget.cloud && !!pxt.appTarget.cloud.packages;
+        const boards = pxt.appTarget.simulator && !!pxt.appTarget.simulator.dynamicBoardDefinition;
         const reportAbuse = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
         const isController = pxt.shell.isControllerMode();
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} tabIndex={-1} />
             {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} tabIndex={-1} /> : undefined}
+            {boards ? <sui.Item role="menuitem" icon="disk outline" text={lf("Change Board")} onClick={this.showBoardDialog} tabIndex={-1} /> : undefined}
             <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} tabIndex={-1} />
             {!isController ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={this.removeProject} tabIndex={-1} /> : undefined}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} tabIndex={-1} /> : undefined}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -241,7 +241,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} tabIndex={-1} />
             {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} tabIndex={-1} /> : undefined}
-            {boards ? <sui.Item role="menuitem" icon="disk outline" text={lf("Change Board")} onClick={this.showBoardDialog} tabIndex={-1} /> : undefined}
+            {boards ? <sui.Item role="menuitem" icon="microchip" text={lf("Change Board")} onClick={this.showBoardDialog} tabIndex={-1} /> : undefined}
             <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} tabIndex={-1} />
             {!isController ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={this.removeProject} tabIndex={-1} /> : undefined}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} tabIndex={-1} /> : undefined}


### PR DESCRIPTION
for multiboard scenarios. It reuses the Extensions dialog.
![image](https://user-images.githubusercontent.com/4175913/41232823-6e23aab2-6d3c-11e8-83ca-e6b86b5fea7e.png)
Currently boards are mixed with Extensions wich is confusing. Does not appear for editor that do not have multiple boards.
