### PR TITLE
Cherry pick copyright text change into stable3.13

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -261,7 +261,8 @@ declare namespace pxt {
         defaultBlockGap?: number; // For targets to override block gap
         hideShareEmbed?: boolean; // don't show advanced embedding options in share dialog
         hideNewProjectButton?: boolean; // do not show the "new project" button in home page
-        fileNameExclusiveFilter?: string; // anything that does not match this regex is removed from the filename
+        fileNameExclusiveFilter?: string; // anything that does not match this regex is removed from the filename,
+        copyrightText?: string; // footer text for any copyright text to be included at the bottom of the home screen and about page
     }
 
     interface SocialOptions {

--- a/theme/home.less
+++ b/theme/home.less
@@ -109,6 +109,11 @@
             font-size: 0.8rem !important;
             color: @homeFooterColor !important;
         }
+        .item.copyright {
+            display: block;
+            font-size: 0.7rem !important;
+            line-height: 15px !important;
+        }
     }
     .ui.card {
         margin-right: 5px;

--- a/webapp/src/dialogs.ts
+++ b/webapp/src/dialogs.ts
@@ -7,6 +7,7 @@ export function showAboutDialogAsync() {
     const compileService = pxt.appTarget.compileService;
     const description = pxt.appTarget.description || pxt.appTarget.title;
     const githubUrl = pxt.appTarget.appTheme.githubUrl;
+    const targetTheme = pxt.appTarget.appTheme;
     core.confirmAsync({
         header: lf("About"),
         hideCancel: true,
@@ -16,6 +17,7 @@ export function showAboutDialogAsync() {
 ${githubUrl ? `<p>${lf("{0} version:", pxt.Util.htmlEscape(pxt.appTarget.name))} <a href="${pxt.Util.htmlEscape(githubUrl)}/releases/tag/v${pxt.Util.htmlEscape(pxt.appTarget.versions.target)}" aria-label="${lf("{0} version : {1}", pxt.Util.htmlEscape(pxt.appTarget.name), pxt.Util.htmlEscape(pxt.appTarget.versions.target))}" target="_blank">${pxt.Util.htmlEscape(pxt.appTarget.versions.target)}</a></p>` : ``}
 <p>${lf("{0} version:", "Microsoft MakeCode")} <a href="https://github.com/Microsoft/pxt/releases/tag/v${pxt.Util.htmlEscape(pxt.appTarget.versions.pxt)}" aria-label="${lf("{0} version: {1}", "Microsoft MakeCode", pxt.Util.htmlEscape(pxt.appTarget.versions.pxt))}" target="_blank">${pxt.Util.htmlEscape(pxt.appTarget.versions.pxt)}</a></p>
 ${compileService && compileService.githubCorePackage && compileService.gittag ? `<p>${lf("{0} version:", "C++ runtime")} <a href="${pxt.Util.htmlEscape("https://github.com/" + compileService.githubCorePackage + '/releases/tag/' + compileService.gittag)}" aria-label="${lf("{0} version: {1}", "C++ runtime", pxt.Util.htmlEscape(compileService.gittag))}" target="_blank">${pxt.Util.htmlEscape(compileService.gittag)}</a></p>` : ""}
+${targetTheme.copyrightText ? `<p> ${targetTheme.copyrightText} </p>` : undefined}
 `
     }).done();
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -208,6 +208,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener">{lf("Terms of Use")}</a> : undefined}
                 {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener">{lf("Privacy")}</a> : undefined}
                 {pxt.appTarget.versions ? <sui.Link className="item" text={`v${pxt.appTarget.versions.target}`} onClick={() => showAboutDialogAsync()} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {targetTheme.copyrightText ? <div className="ui item copyright">{targetTheme.copyrightText}</div> : undefined}
             </div> : undefined}
         </div>;
     }


### PR DESCRIPTION
Cherry pick (kinda) the copyright text change to stable3.13 for Lego. 

I say kinda because dialogs have changed in master and I've had to somewhat reimplement it in this stable branch. Not a big change tho