### PR TITLE
Support a /sim directory with no TSC but /sim/public content.

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2047,8 +2047,8 @@ function buildFailed(msg: string, e: any) {
 }
 
 function buildAndWatchTargetAsync(includeSourceMaps = false) {
-    if (!fs.existsSync("sim/tsconfig.json")) {
-        console.log("No sim/tsconfig.json; assuming npm installed package")
+    if (!(fs.existsSync(path.join("sim", "tsconfig.json")) || nodeutil.existsDirSync("sim/public"))) {
+        console.log("No sim/tsconfig.json nor sim/public/; assuming npm installed package")
         return Promise.resolve()
     }
 
@@ -3137,8 +3137,8 @@ function testForBuildTargetAsync(useNative: boolean): Promise<pxtc.CompileOption
 
 function simshimAsync() {
     pxt.debug("looking for shim annotations in the simulator.")
-    if (!nodeutil.existsDirSync("sim")) {
-        pxt.debug("no sim folder, skipping.")
+    if (!fs.existsSync(path.join("sim", "tsconfig.json"))) {
+        pxt.debug("no sim/tsconfig.json; skipping")
         return Promise.resolve();
     }
     let prog = pxtc.plainTsc(path.resolve("sim"))


### PR DESCRIPTION
This change allows a target build script to build a simulator sim.js outside of PXT. Why?

Well in my case I'm going a bit rogue and creating my own shim .d.ts files and going from there. Given my heavy use of npm packages etc. it just makes more sense to go this route so I can use whatever browser-ify toolchain I choose vs. the PXT route.

This build path does lose,

- PXT generated shim .d.ts files for the simulator.
- PXT generated sim-strings .json file for `lf()` based localization.

Other TSC project builds are still performed by PXT, e.g. cmds/, fieldeditors/, editor/, libs/ etc.

Changes are,

- Don't skip the already optional 'sim' build step if there is a sim/public/ even though no sim/tsconfig.json exists.
- In the simulator shim creation look for sim/tsconfig.tson else bail. This function relies on a tsconfig.json existing anyway (it crashes otherwise) so may as well check for that specifically.
- Use path.join() for forming the tsconfig.json path. Why? No technical reason beyond I saw all the other code doing the same so I changed this to make it consistent.