### PR TITLE
Use the same renderer that we use for the docs in the tutorial marked engine

### DIFF
--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -355,7 +355,7 @@ namespace __internal {
       * @param ms time duration in milliseconds, eg: 500, 1000
       */
     //% blockId=timePicker block="%ms"
-    //% blockHidden=true
+    //% blockHidden=true shim=TD_ID
     //% colorSecondary="#FFFFFF"
     //% ms.fieldEditor="numberdropdown" ms.fieldOptions.decompileLiterals=true
     //% ms.fieldOptions.data='[["100 ms", 100], ["200 ms", 200], ["500 ms", 500], ["1 second", 1000], ["2 seconds", 2000]]'

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -363,7 +363,7 @@ namespace pxt.docs {
         throwOnError?: boolean; // check for missing macros
     }
 
-    export function setupRenderer(renderer: marked.Renderer) {
+    export function setupRenderer(d: RenderData, renderer: marked.Renderer) {
         renderer.image = function (href: string, title: string, text: string) {
             let out = '<img class="ui centered image" src="' + href + '" alt="' + text + '"';
             if (title) {
@@ -464,7 +464,7 @@ namespace pxt.docs {
         if (!markedInstance) {
             markedInstance = requireMarked();
             let renderer = new markedInstance.Renderer()
-            setupRenderer(renderer);
+            setupRenderer(d, renderer);
             markedInstance.setOptions({
                 renderer: renderer,
                 gfm: true,

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -363,7 +363,7 @@ namespace pxt.docs {
         throwOnError?: boolean; // check for missing macros
     }
 
-    export function setupRenderer(d: RenderData, renderer: marked.Renderer) {
+    export function setupRenderer(renderer: marked.Renderer) {
         renderer.image = function (href: string, title: string, text: string) {
             let out = '<img class="ui centered image" src="' + href + '" alt="' + text + '"';
             if (title) {
@@ -376,14 +376,6 @@ namespace pxt.docs {
             const m = /^\s*\[( |x)\]/i.exec(text);
             if (m) return `<li class="${m[1] == ' ' ? 'unchecked' : 'checked'}">` + text.slice(m[0].length) + '</li>\n'
             return '<li>' + text + '</li>\n';
-        }
-        const linkRenderer = renderer.link;
-        renderer.link = function (href: string, title: string, text: string) {
-            const relative = href.indexOf('/') == 0;
-            const target = !relative ? '_blank' : '';
-            if (relative && d.versionPath) href = `/${d.versionPath}${href}`;
-            const html = linkRenderer.call(renderer, href, title, text);
-            return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} rel="nofollow noopener" `);
         }
         renderer.heading = function (text: string, level: number, raw: string) {
             let m = /(.*)#([\w\-]+)\s*$/.exec(text)
@@ -464,7 +456,15 @@ namespace pxt.docs {
         if (!markedInstance) {
             markedInstance = requireMarked();
             let renderer = new markedInstance.Renderer()
-            setupRenderer(d, renderer);
+            setupRenderer(renderer);
+            const linkRenderer = renderer.link;
+            renderer.link = function (href: string, title: string, text: string) {
+                const relative = href.indexOf('/') == 0;
+                const target = !relative ? '_blank' : '';
+                if (relative && d.versionPath) href = `/${d.versionPath}${href}`;
+                const html = linkRenderer.call(renderer, href, title, text);
+                return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} rel="nofollow noopener" `);
+            }
             markedInstance.setOptions({
                 renderer: renderer,
                 gfm: true,

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -111,8 +111,13 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         // replace pre-template in markdown
         markdown = markdown.replace(/@([a-z]+)@/ig, (m, param) => pubinfo[param] || 'unknown macro')
 
+        // create a custom renderer
+        let renderer = new marked.Renderer()
+        pxt.docs.setupRenderer(renderer);
+
         // Set markdown options
         marked.setOptions({
+            renderer: renderer,
             sanitize: true
         })
 

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -113,7 +113,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         // create a custom renderer
         let renderer = new marked.Renderer()
-        pxt.docs.setupRenderer(renderer);
+        pxt.docs.setupRenderer({},renderer);
 
         // Set markdown options
         marked.setOptions({

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -113,7 +113,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         // create a custom renderer
         let renderer = new marked.Renderer()
-        pxt.docs.setupRenderer({}, renderer);
+        pxt.docs.setupRenderer(renderer);
 
         // Set markdown options
         marked.setOptions({

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -113,7 +113,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         // create a custom renderer
         let renderer = new marked.Renderer()
-        pxt.docs.setupRenderer({},renderer);
+        pxt.docs.setupRenderer({}, renderer);
 
         // Set markdown options
         marked.setOptions({


### PR DESCRIPTION
Use the same renderer that we use for the docs in the tutorial marked engine. 

This also as a product solves the issue with not having centered images in the tutorial dialogs. 

Fixes https://github.com/Microsoft/pxt-minecraft/issues/582