### PR TITLE
Fix localization in built in toolbox categories

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -293,7 +293,7 @@ namespace pxt.editor {
         /**
          * The display name for the category
          */
-        name?: string;
+        name?: () => string;
 
         /**
          * The icon of this category

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -977,7 +977,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     getBuiltinCategory(ns: string): toolbox.ToolboxCategory {
-        return snippets.getBuiltinCategory(ns);
+        const builtinCategory = (snippets.getBuiltinCategory(ns) as any);
+        builtinCategory.name = builtinCategory.name();
+        return builtinCategory;
     }
 
     isBuiltIn(ns: string): boolean {

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -783,7 +783,7 @@ function blockToJson(b: BlockDefinition): pxt.editor.ToolboxBlockDefinition {
 
 function categoryToJson(c: BuiltinCategoryDefinition): pxt.editor.ToolboxCategoryDefinition {
     return {
-        name: c.name(),
+        name: c.name,
         icon: c.attributes.icon,
         color: c.attributes.color,
         weight: c.attributes.weight,

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -3,7 +3,7 @@ import { BuiltinCategoryDefinition, BlockDefinition } from "./toolbox";
 import * as blocks from "./blocks";
 
 export const loops: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Loops"),
+    name: function () { return lf("{id:category}Loops") },
     nameid: 'loops',
     blocks: [
         {
@@ -79,7 +79,7 @@ export const loops: BuiltinCategoryDefinition = {
 };
 
 export const logic: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Logic"),
+    name: function () { return lf("{id:category}Logic") },
     nameid: 'logic',
     groups: [lf("Conditionals"), lf("Comparison"), lf("Boolean"), "other"],
     blocks: [
@@ -209,7 +209,7 @@ export const logic: BuiltinCategoryDefinition = {
 };
 
 export const variables: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Variables"),
+    name: function () { return lf("{id:category}Variables") },
     nameid: 'variables',
     blocks: undefined,
     custom: true,
@@ -226,7 +226,7 @@ export const variables: BuiltinCategoryDefinition = {
 };
 
 export const maths: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Math"),
+    name: function () { return lf("{id:category}Math") },
     nameid: 'math',
     blocks: [
         {
@@ -408,7 +408,7 @@ export const maths: BuiltinCategoryDefinition = {
 };
 
 export const functions: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Functions"),
+    name: function () { return lf("{id:category}Functions") },
     nameid: 'functions',
     blocks: [],
     custom: true,
@@ -426,7 +426,7 @@ export const functions: BuiltinCategoryDefinition = {
 };
 
 export const arrays: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Arrays"),
+    name: function () { return lf("{id:category}Arrays") },
     nameid: "arrays",
     blocks: [
         {
@@ -545,7 +545,7 @@ export const arrays: BuiltinCategoryDefinition = {
 }
 
 export const text: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Text"),
+    name: function () { return lf("{id:category}Text") },
     nameid: 'text',
     blocks: [
         {
@@ -599,7 +599,7 @@ export const text: BuiltinCategoryDefinition = {
 }
 
 export const extensions: BuiltinCategoryDefinition = {
-    name: pxt.toolbox.addPackageTitle(),
+    name: pxt.toolbox.addPackageTitle,
     nameid: 'addpackage',
     blocks: [],
     custom: true,
@@ -783,7 +783,7 @@ function blockToJson(b: BlockDefinition): pxt.editor.ToolboxBlockDefinition {
 
 function categoryToJson(c: BuiltinCategoryDefinition): pxt.editor.ToolboxCategoryDefinition {
     return {
-        name: c.name,
+        name: c.name(),
         icon: c.attributes.icon,
         color: c.attributes.color,
         weight: c.attributes.weight,

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -871,7 +871,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     getBuiltinCategory(ns: string): toolbox.ToolboxCategory {
-        return snippets.getBuiltinCategory(ns);
+        const builtinCategory = (snippets.getBuiltinCategory(ns) as any);
+        builtinCategory.name = builtinCategory.name();
+        return builtinCategory;
     }
 
     isBuiltIn(ns: string): boolean {

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -3,7 +3,7 @@ import { BuiltinCategoryDefinition, BlockDefinition } from "./toolbox";
 import * as monaco from "./monaco";
 
 export const loops: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Loops"),
+    name: function () { return lf("{id:category}Loops") },
     nameid: 'loops',
     blocks: [
         {
@@ -36,7 +36,7 @@ export const loops: BuiltinCategoryDefinition = {
 };
 
 export const logic: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Logic"),
+    name: function () { return lf("{id:category}Logic") },
     nameid: 'logic',
     blocks: [
         {
@@ -84,7 +84,7 @@ export const logic: BuiltinCategoryDefinition = {
 };
 
 export const variables: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Variables"),
+    name: function () { return lf("{id:category}Variables") },
     nameid: 'variables',
     blocks: [
         {
@@ -127,7 +127,7 @@ export const variables: BuiltinCategoryDefinition = {
 };
 
 export const maths: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Math"),
+    name: function () { return lf("{id:category}Math") },
     nameid: 'math',
     blocks: [
         {
@@ -243,7 +243,7 @@ export const maths: BuiltinCategoryDefinition = {
 };
 
 export const functions: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Functions"),
+    name: function () { return lf("{id:category}Functions") },
     nameid: 'functions',
     blocks: [
         {
@@ -275,7 +275,7 @@ export const functions: BuiltinCategoryDefinition = {
 };
 
 export const arrays: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Arrays"),
+    name: function () { return lf("{id:category}Arrays") },
     nameid: "arrays",
     custom: true,
     blocks: [
@@ -423,7 +423,7 @@ export const arrays: BuiltinCategoryDefinition = {
 }
 
 export const text: BuiltinCategoryDefinition = {
-    name: lf("{id:category}Text"),
+    name: function () { return lf("{id:category}Text") },
     nameid: 'text',
     custom: true,
     blocks: [
@@ -500,7 +500,7 @@ export const text: BuiltinCategoryDefinition = {
 }
 
 export const extensions: BuiltinCategoryDefinition = {
-    name: pxt.toolbox.addPackageTitle(),
+    name: pxt.toolbox.addPackageTitle,
     nameid: 'addpackage',
     blocks: [],
     custom: true,
@@ -702,7 +702,7 @@ function blockToJson(b: BlockDefinition): pxt.editor.ToolboxBlockDefinition {
 
 function categoryToJson(c: BuiltinCategoryDefinition): pxt.editor.ToolboxCategoryDefinition {
     return {
-        name: c.name,
+        name: c.name(),
         icon: c.attributes.icon,
         color: c.attributes.color,
         weight: c.attributes.weight,

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -702,7 +702,7 @@ function blockToJson(b: BlockDefinition): pxt.editor.ToolboxBlockDefinition {
 
 function categoryToJson(c: BuiltinCategoryDefinition): pxt.editor.ToolboxCategoryDefinition {
     return {
-        name: c.name(),
+        name: c.name,
         icon: c.attributes.icon,
         color: c.attributes.color,
         weight: c.attributes.weight,

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -49,7 +49,7 @@ export interface ButtonDefinition {
 }
 
 export interface BuiltinCategoryDefinition {
-    name: string;
+    name: () => string;
     nameid: string;
     blocks: (BlockDefinition | ButtonDefinition)[];
     groups?: string[];


### PR DESCRIPTION
lf in blocksnippets and monacosnippets run before the localization files are loaded, converting the name to a function ensures that it doesn't run until the toolbox is getting created. 

@guillaumejenkins thoughts on this solution?