### PR TITLE
pxt serve uses cloud by default

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -29,11 +29,11 @@ import * as gitfs from './gitfs';
 
 const rimraf: (f: string, opts: any, cb: (err: any, res: any) => void) => void = require('rimraf');
 
-let forceCloudBuild = process.env["KS_FORCE_CLOUD"] === "yes"
+//let forceCloudBuild = process.env["KS_FORCE_CLOUD"] === "yes"
+let forceCloudBuild = true
 let forceLocalBuild = process.env["PXT_FORCE_LOCAL"] === "yes"
 
 function parseBuildInfo(parsed?: commandParser.ParsedCommand) {
-    if (!parsed) return;
     forceCloudBuild = !parsed || !parsed.flags["localbuild"];
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -29,12 +29,14 @@ import * as gitfs from './gitfs';
 
 const rimraf: (f: string, opts: any, cb: (err: any, res: any) => void) => void = require('rimraf');
 
-//let forceCloudBuild = process.env["KS_FORCE_CLOUD"] === "yes"
-let forceCloudBuild = true
+let forceCloudBuild = process.env["KS_FORCE_CLOUD"] !== "no";
 let forceLocalBuild = process.env["PXT_FORCE_LOCAL"] === "yes"
 
 function parseBuildInfo(parsed?: commandParser.ParsedCommand) {
-    forceCloudBuild = !parsed || !parsed.flags["localbuild"];
+    if (parsed && parsed.flags["localbuild"]) {
+        forceCloudBuild = false;
+        forceLocalBuild = true;
+    }
 }
 
 const p = new commandParser.CommandParser();

--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -12,6 +12,12 @@ pxt build
 
 Builds the PXT project in the current folder.
 
+## Options
+
+### localbuild
+
+Force build native images with local tooling
+
 ## See Also
 
 [pxt](/cli) tool

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -10,6 +10,10 @@ pxt serve
 
 ## Options
 
+### localbuild
+
+Force build native images with local tooling
+
 ### browser <chrome|ie|firefox|safari> 
 
 Set the browser to launch on web server start

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1298,11 +1298,13 @@ namespace pxt.hex {
                             .then(ret => new Promise<string>((resolve, reject) => {
                                 let tryGet = () => {
                                     let url = ret.hex.replace(/\.hex/, ".json")
-                                    pxt.log("polling at " + url)
+                                    pxt.log(`polling C++ build ${url}`)
                                     return Util.httpGetJsonAsync(url)
                                         .then(json => {
-                                            if (!json.success)
-                                                U.userError(JSON.stringify(json, null, 1))
+                                            pxt.log(`build log ${url.replace(/\.json$/, ".log")}`);
+                                            if (!json.success) {
+                                                U.userError(JSON.stringify(json, null, 1));
+                                            }
                                             else {
                                                 pxt.log("fetching " + hexurl + ".hex")
                                                 resolve(U.httpGetTextAsync(hexurl + ".hex"))

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1244,30 +1244,20 @@ int main() {
 }
 
 namespace pxt.hex {
-    let downloadCache: Map<Promise<any>> = {};
+    const downloadCache: Map<Promise<pxtc.HexInfo>> = {};
     let cdnUrlPromise: Promise<string>;
 
     export let showLoading: (msg: string) => void = (msg) => { };
     export let hideLoading: () => void = () => { };
 
-    function downloadHexInfoAsync(extInfo: pxtc.ExtensionInfo) {
-        let cachePromise = Promise.resolve();
-
-        if (!downloadCache.hasOwnProperty(extInfo.sha)) {
-            cachePromise = downloadHexInfoCoreAsync(extInfo)
-                .then((hexFile) => {
-                    downloadCache[extInfo.sha] = hexFile;
-                });
-        }
-
-        return cachePromise
-            .then(() => {
-                return downloadCache[extInfo.sha];
-            });
+    function downloadHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo> {
+        if (!downloadCache.hasOwnProperty(extInfo.sha))
+            downloadCache[extInfo.sha] = downloadHexInfoCoreAsync(extInfo);
+        return downloadCache[extInfo.sha];
     }
 
     function getCdnUrlAsync() {
-        if (cdnUrlPromise) return cdnUrlPromise
+        if (cdnUrlPromise) return cdnUrlPromise;
         else {
             let curr = getOnlineCdnUrl()
             if (curr) return (cdnUrlPromise = Promise.resolve(curr))
@@ -1277,7 +1267,7 @@ namespace pxt.hex {
         }
     }
 
-    function downloadHexInfoCoreAsync(extInfo: pxtc.ExtensionInfo) {
+    function downloadHexInfoCoreAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo> {
         let hexurl = ""
 
         showLoading(pxt.U.lf("Compiling (this may take a minute)..."));
@@ -1303,7 +1293,10 @@ namespace pxt.hex {
                                         .then(json => {
                                             pxt.log(`build log ${url.replace(/\.json$/, ".log")}`);
                                             if (!json.success) {
-                                                U.userError(JSON.stringify(json, null, 1));
+                                                pxt.log(`build failed`);
+                                                if (json.mbedresponse && json.mbedresponse.result && json.mbedresponse.result.exception)
+                                                    pxt.log(json.mbedresponse.result.exception);
+                                                resolve(null);
                                             }
                                             else {
                                                 pxt.log("fetching " + hexurl + ".hex")
@@ -1320,9 +1313,7 @@ namespace pxt.hex {
                     .then(text => {
                         hideLoading();
                         return {
-                            enums: [],
-                            functions: [],
-                            hex: text.split(/\r?\n/)
+                            hex: text && text.split(/\r?\n/)
                         };
                     })
             }).finally(() => {
@@ -1330,7 +1321,7 @@ namespace pxt.hex {
             })
     }
 
-    function downloadHexInfoLocalAsync(extInfo: pxtc.ExtensionInfo): Promise<any> {
+    function downloadHexInfoLocalAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo> {
         if (pxt.webConfig && pxt.webConfig.isStatic) {
             return Util.requestAsync({
                 url: `${pxt.webConfig.cdnUrl}hexcache/${extInfo.sha}.hex`
@@ -1354,20 +1345,19 @@ namespace pxt.hex {
         }
 
         if (!Cloud.localToken || !window || !Cloud.isLocalHost()) {
-            return Promise.resolve();
+            return Promise.resolve(undefined);
         }
 
         return apiAsync("compile/" + extInfo.sha)
             .then((json) => {
                 if (!json || json.notInOfflineCache || !json.hex) {
-                    return Promise.resolve();
+                    return Promise.resolve(undefined);
                 }
-
                 json.hex = json.hex.split(/\r?\n/);
                 return json;
             })
             .catch((e) => {
-                return Promise.resolve();
+                return Promise.resolve(undefined);
             });
     }
 


### PR DESCRIPTION
This is a shift from favoring local native to cloud native build. The reason is that local builds often fail because of configuration issue. We do have a cloud which makes the experience much more seamless (and slower). New flag --local to force local build.
Better log output of failed builds.
Fixed some incorrect caching of promises.