### PR TITLE
Support project tags in home screen.

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1650,8 +1650,19 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
     walkDocs(theme.docMenu);
     if (nodeutil.fileExistsSync("targetconfig.json")) {
         const targetConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
-        if (targetConfig && targetConfig.galleries)
-            Object.keys(targetConfig.galleries).forEach(k => targetStrings[k] = k);
+        if (targetConfig && targetConfig.galleries) {
+            Object.keys(targetConfig.galleries).forEach(k => {
+                targetStrings[k] = k;
+                const docsRoot = nodeutil.targetDir;
+                const gallerymd = nodeutil.resolveMd(docsRoot, targetConfig.galleries[k]);
+                const gallery = pxt.gallery.parseGalleryMardown(gallerymd);
+                gallery.forEach(cards => cards.cards
+                    .filter(card => card.tags)
+                    .forEach(card => card.tags.forEach(tag => {
+                        targetStrings[tag.label] = tag.label;
+                    })))
+            });
+        }
     }
     let targetStringsSorted: pxt.Map<string> = {};
     Object.keys(targetStrings).sort().map(k => targetStringsSorted[k] = k);

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -97,7 +97,8 @@ declare namespace pxt {
         ariaLabel?: string;
         label?: string;
         labelClass?: string;
-        tabIndex?: number
+        tags?: CodeCardTag[];
+        tabIndex?: number;
 
         color?: string; // one of semantic ui colors
         description?: string;
@@ -127,6 +128,11 @@ declare namespace pxt {
 
         target?: string;
         className?: string;
+    }
+
+    interface CodeCardTag {
+        label?: string;
+        color?: string;
     }
 
     interface JRes {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -97,7 +97,7 @@ declare namespace pxt {
         ariaLabel?: string;
         label?: string;
         labelClass?: string;
-        tags?: CodeCardTag[];
+        tags?: CodeCardTag[]; // tags shown in home screen, eg: [{ "label": "Beginner", "color": "blue" }]
         tabIndex?: number;
 
         color?: string; // one of semantic ui colors

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -131,7 +131,7 @@ declare namespace pxt {
     }
 
     interface CodeCardTag {
-        label?: string;
+        label: string;
         color?: string;
     }
 

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -115,7 +115,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             {card.extracontent || card.tags ? <div className="extra content">
                 {card.extracontent}
                 {card.tags ? card.tags.map(tag =>
-                    <span key={`tag${tag.label}`} className={`ui label tiny ${tag.color}`}>{tag.label}</span>
+                    <span key={`tag${tag.label}`} className={`ui label tiny ${tag.color}`}>{pxt.Util.rlf(tag.label)}</span>
                 ) : undefined}
             </div> : undefined}
         </div>;

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -112,7 +112,12 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             {card.time ? <div className="meta">
                 {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span> : null}
             </div> : undefined}
-            {card.extracontent ? <div className="extra content"> {card.extracontent} </div> : undefined}
+            {card.extracontent || card.tags ? <div className="extra content">
+                {card.extracontent}
+                {card.tags ? card.tags.map(tag =>
+                    <span key={`tag${tag.label}`} className={`ui label ${tag.color}`}>{tag.label}</span>
+                ) : undefined}
+            </div> : undefined}
         </div>;
 
         if (!card.onClick && url) {

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -115,7 +115,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             {card.extracontent || card.tags ? <div className="extra content">
                 {card.extracontent}
                 {card.tags ? card.tags.map(tag =>
-                    <span key={`tag${tag.label}`} className={`ui label ${tag.color}`}>{tag.label}</span>
+                    <span key={`tag${tag.label}`} className={`ui label tiny ${tag.color}`}>{tag.label}</span>
                 ) : undefined}
             </div> : undefined}
         </div>;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -409,6 +409,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                                 youTubeId={scr.youTubeId}
                                 label={scr.label}
                                 labelClass={scr.labelClass}
+                                tags={scr.tags}
                                 scr={scr} index={index}
                                 onCardClick={this.handleCardClick}
                             />
@@ -485,7 +486,7 @@ class ProjectsCodeCard extends sui.StatelessUIElement<ProjectsCodeCardProps> {
 
     renderCore() {
         const { scr, onCardClick, onClick, ...rest } = this.props;
-        return <codecard.CodeCardView {...rest} onClick={this.handleClick} />
+        return <codecard.CodeCardView {...rest} onClick={this.handleClick}/>
     }
 }
 


### PR DESCRIPTION
Support for project tags in home screen, like so: 
<img width="1578" alt="screen shot 2018-06-19 at 11 37 02 am" src="https://user-images.githubusercontent.com/16690124/41617373-26b97902-73b5-11e8-88d5-78dc032d2d5f.png">


- Supports multiple tags
- You can choose a color associated with the tag label (it must be one of the semantic colors). 

Example of the authoring: 
```
  "tags": [{ "label": "Beginner" }],
```
```
  "tags": [{ "label": "Beginner", "color": "blue" }],
```
```
  "tags": [{ "label": "Beginner", "color": "blue" }, { "label": "Fun", "color": "green" }],
```

Note: tags don't appear in the docs, just in the home screen.