### PR TITLE
Toolbox namespace casing

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -497,7 +497,7 @@ namespace pxt.blocks {
             (fn.attributes.blockNamespace && nsinfo && nsinfo.attributes.color)
             || fn.attributes.color
             || (nsinfo && nsinfo.attributes.color)
-            || pxt.toolbox.getNamespaceColor(ns.toLowerCase())
+            || pxt.toolbox.getNamespaceColor(ns)
             || 255;
 
         if (fn.attributes.help)

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -60,6 +60,7 @@ namespace pxt.toolbox {
     }
 
     export function getNamespaceColor(ns: string): string {
+        ns = ns.toLowerCase();
         if (pxt.appTarget.appTheme.blockColors && pxt.appTarget.appTheme.blockColors[ns])
             return pxt.appTarget.appTheme.blockColors[ns] as string;
         if (pxt.toolbox.blockColors[ns])
@@ -68,6 +69,7 @@ namespace pxt.toolbox {
     }
 
     export function getNamespaceIcon(ns: string): string {
+        ns = ns.toLowerCase();
         if (pxt.appTarget.appTheme.blockIcons && pxt.appTarget.appTheme.blockIcons[ns]) {
             return pxt.appTarget.appTheme.blockIcons[ns] as string;
         }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -988,7 +988,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     getNamespaceAttrs(ns: string) {
         const builtin = snippets.getBuiltinCategory(ns);
         if (builtin) {
-            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid.toLowerCase());
+            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid);
             return builtin.attributes;
         }
         if (!this.blockInfo) return undefined;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -925,7 +925,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         pxt.blocks.injectBlocks(this.blockInfo).forEach(fn => {
             let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
-            ns = ns.toLowerCase();
 
             if (!res[ns]) {
                 res[ns] = [];
@@ -989,7 +988,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     getNamespaceAttrs(ns: string) {
         const builtin = snippets.getBuiltinCategory(ns);
         if (builtin) {
-            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid);
+            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid.toLowerCase());
             return builtin.attributes;
         }
         if (!this.blockInfo) return undefined;
@@ -1044,8 +1043,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let cat = snippets.getBuiltinCategory(ns);
         let blocks: toolbox.BlockDefinition[] = cat.blocks || [];
         blocks.forEach(b => { b.noNamespace = true })
-        if (!cat.custom && this.nsMap[ns.toLowerCase()]) {
-            blocks = this.filterBlocks(subns, blocks.concat(this.nsMap[ns.toLowerCase()]));
+        if (!cat.custom && this.nsMap[ns]) {
+            blocks = this.filterBlocks(subns, blocks.concat(this.nsMap[ns]));
         }
         return blocks;
     }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -823,7 +823,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         this.blockInfo.blocks.forEach(fn => {
             let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
-            ns = ns.toLowerCase();
 
             // Don't add the block if there exists a block with the same definition
             if (builtInBlocks[fn.qName]) return;
@@ -881,7 +880,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     getNamespaceAttrs(ns: string) {
         const builtin = snippets.getBuiltinCategory(ns);
         if (builtin) {
-            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid);
+            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid.toLowerCase());
             return builtin.attributes;
         }
         if (!this.blockInfo) return undefined;
@@ -950,7 +949,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let cat = snippets.getBuiltinCategory(ns);
         let blocks = cat.blocks || [];
         blocks.forEach(b => { b.noNamespace = true })
-        if (!cat.custom && this.nsMap[ns.toLowerCase()]) blocks = blocks.concat(this.nsMap[ns.toLowerCase()].filter(block => !(block.attributes.blockHidden || block.attributes.deprecated)));
+        if (!cat.custom && this.nsMap[ns]) blocks = blocks.concat(this.nsMap[ns].filter(block => !(block.attributes.blockHidden || block.attributes.deprecated)));
         return this.filterBlocks(subns, blocks);
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -880,7 +880,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     getNamespaceAttrs(ns: string) {
         const builtin = snippets.getBuiltinCategory(ns);
         if (builtin) {
-            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid.toLowerCase());
+            builtin.attributes.color = pxt.toolbox.getNamespaceColor(builtin.nameid);
             return builtin.attributes;
         }
         if (!this.blockInfo) return undefined;
@@ -1005,7 +1005,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             const nsinfo = that.blockInfo.apis.byQName[ns];
             const color =
                 (nsinfo ? nsinfo.attributes.color : undefined)
-                || pxt.toolbox.getNamespaceColor(ns.toLowerCase())
+                || pxt.toolbox.getNamespaceColor(ns)
                 || `255`;
             return color;
         }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -12,7 +12,7 @@ export const enum CategoryNameID {
     Loops = "loops",
     Logic = "logic",
     Variables = "variables",
-    Maths = "math",
+    Maths = "Math",
     Functions = "functions",
     Arrays = "arrays",
     Text = "text",


### PR DESCRIPTION
Match TS behaviour by not converting namespace to lowercase in the toolbox.

Fixes https://github.com/Microsoft/pxt-adafruit/issues/782
Fixes https://github.com/Microsoft/pxt-microbit/issues/879

When I re-did the toolbox, I made the assumption that TS merged all namespace names regardless of case, but that's not true. This change allows two categories with different cases to appear in different toolbox categories (just like TS).
