### PR TITLE
Don't lowercase namespace when searching for blocks

### DIFF
--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -70,7 +70,6 @@ export abstract class ToolboxEditor extends srceditor.Editor {
             // Go through all blocks and apply filter
             this.blockInfo.blocks.forEach(fn => {
                 let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
-                ns = ns.toLowerCase();
 
                 if (fn.attributes.debug && !pxt.options.debug) return;
                 if (fn.attributes.deprecated || fn.attributes.blockHidden) return;


### PR DESCRIPTION
Noticed I missed this when I did the namespace casing PR: https://github.com/Microsoft/pxt/pull/4505
