### PR TITLE
Fixing build sprites command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,6 +44,27 @@
 			"outFiles": []
 		},
 		{
+			"name": "BuildSprites",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/built/pxt.js",
+			"stopOnEntry": false,
+			"args": [
+				"buildsprites", "space"
+			],
+			"cwd": "${workspaceRoot}/../pxt-32/libs/device",
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"console": "integratedTerminal",
+			"sourceMaps": false,
+			"outFiles": []
+		},
+		{
 			"name": "BuildPackage",
 			"type": "node",
 			"request": "launch",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4160,7 +4160,7 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
         let mindelta = 0
         let idx = -1
         for (let i = alpha ? 1 : 0; i < palette.length; ++i) {
-            let delta = scale(palette[i][0] - buf[pix + 0]) + scale(palette[i][1] - buf[pix + 1]) + scale(palette[i][1] - buf[pix + 2])
+            let delta = scale(palette[i][0] - buf[pix + 0]) + scale(palette[i][1] - buf[pix + 1]) + scale(palette[i][2] - buf[pix + 2])
             if (idx < 0 || delta < mindelta) {
                 idx = i
                 mindelta = delta
@@ -4206,6 +4206,8 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
 
         for (let y = 0; y + info.height - 1 < sheet.height; y += info.height)
             for (let x = 0; x + info.width - 1 < sheet.width; x += info.width) {
+                if (info.frames && imgIdx >= info.frames.length) return;
+
                 let img = U.flatClone(sheet)
                 img.data = new Buffer(info.width * info.height * 4)
                 img.width = info.width


### PR DESCRIPTION
Fixes two bugs:

1. Wrong color channel was used in the closest color function
2. If you have a sprite sheet that isn't a complete grid, don't generate empty sprites