### PR TITLE
Variable name defaults in block definition

### DIFF
--- a/docs/static/playground/samples/all.js
+++ b/docs/static/playground/samples/all.js
@@ -56,6 +56,12 @@
             path: "basic/enums"
         },
         {
+            chapter: "Basic",
+            name: "Setting Variable Names",
+            id: "basic-variable-names",
+            path: "basic/variable-names"
+        },
+        {
             chapter: "Field editors",
             name: "Range",
             id: "field-editors-range",

--- a/docs/static/playground/samples/basic/variable-names/sample.js
+++ b/docs/static/playground/samples/basic/variable-names/sample.js
@@ -1,0 +1,15 @@
+//
+// Set the default name given to a variable argument in the block string by
+// putting it in parentheses after the shadow block ID
+//
+
+//% color="#AA278D"
+namespace basic {
+    /**
+     * This API will have a variable shadow block with the name "someName" pre-filled
+     */
+    //% block="%x=variables_get(someName)"
+    export function foo(x: number) {
+
+    }
+}

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -884,6 +884,7 @@ ${output}</xml>`;
             }
 
             const attributes = attrs(callInfo);
+            blockId = attributes.blockId || blockId;
 
             if (attributes.blockCombine)
                 return getPropertyGetBlock(n)
@@ -910,7 +911,7 @@ ${output}</xml>`;
                 value = attributes.enumval;
             }
 
-            let idfn = blockId ? blocksInfo.blocksById[blockId] : blocksInfo.apis.byQName[attributes.blockIdentity];
+            let idfn = attributes.blockIdentity ? blocksInfo.apis.byQName[attributes.blockIdentity] : blocksInfo.blocksById[blockId];
             let f = /%([a-zA-Z0-9_]+)/.exec(idfn.attributes.block);
             const r = mkExpr(U.htmlEscape(idfn.attributes.blockId));
             r.fields = [{

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -118,11 +118,13 @@ namespace pxt.blocks {
         if (instance && hasBlockDef && defParameters.length) {
             const def = refMap[THIS_NAME] || defParameters[0];
             const defName = def.name;
+            const isVar = !def.shadowBlockId || def.shadowBlockId === "variables_get";
             res.thisParameter = {
                 actualName: THIS_NAME,
                 definitionName: defName,
                 shadowBlockId: def.shadowBlockId,
                 type: fn.namespace,
+                defaultValue: isVar ? def.varName : undefined,
 
                 // Normally we pass ths actual parameter name, but the "this" parameter doesn't have one
                 fieldEditor: fieldEditor(defName, THIS_NAME),
@@ -151,11 +153,12 @@ namespace pxt.blocks {
                     }
 
                     const defName = def ? def.name : (bInfo ? bInfo.params[defIndex++] : p.name);
+                    const isVar = (def && def.shadowBlockId) === "variables_get";
 
                     (res.parameters as BlockParameter[]).push({
                         actualName: p.name,
                         type: p.type,
-                        defaultValue: p.default,
+                        defaultValue: isVar ? (def.varName || p.default) :  p.default,
                         definitionName: defName,
                         shadowBlockId: def && def.shadowBlockId,
                         isOptional: defParameters ? defParameters.indexOf(def) >= optionalStart : false,

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -392,6 +392,11 @@ describe("comment attribute parser", () => {
                 parseDef("$hello|world", paramRef`hello`, brk(), `world`);
             });
 
+            it("should allow parameter names to be specified using parens", () => {
+                parseDef(`$hello=variables_get(someName)`, paramVar`hello=someName`);
+                parseDef(`$hello=variables_get(  `, paramRef`hello=variables_get`, `(  `);
+            });
+
             describe("errors", () => {
                 it("should not allow parameters with too many equals", () => {
                     parseDef("%no=good=")
@@ -440,6 +445,12 @@ function paramRef(parts: TemplateStringsArray): pxtc.BlockParameter {
     const res = param(parts);
     res.ref = true;
     return res;
+}
+
+function paramVar(parts: TemplateStringsArray): pxtc.BlockParameter {
+    const split = parts[0].split("=");
+
+    return { kind: "param", name: split[0], shadowBlockId: "variables_get", ref: true, varName: split[1] } as pxtc.BlockParameter;
 }
 
 function parseDef(def: string, ...expected: (string | pxtc.BlockPart)[]) {


### PR DESCRIPTION
We never really had a good way to set the default name for the variable shadow blocks that show up in the toolbox. This adds a little bit of syntax for doing so:

```TypeScript
//% block="%argument=variables_get(someName)"
function whatever(argument: number) {

}
```

That parentheses trick also works for "this" arguments so now we can change a default value without breaking the block definition. Previously we used whatever was in the block string to name the input in the Blockly XML so changing it was a breaking change.


For `blockCombine` blocks you can set the name using the `blockSetVariable` attribute.

This is not a breaking change.