### PR TITLE
Choose hardware dialog

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -110,8 +110,10 @@ declare namespace pxt {
         youTubeId?: string;
         time?: number;
         url?: string;
+        learnMoreUrl?: string;
+        buyUrl?: string;
         responsive?: boolean;
-        cardType?: "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package";
+        cardType?: "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw";
 
         header?: string;
         any?: number;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -220,6 +220,7 @@ namespace pxt.editor {
 
         showResetDialog(): void;
         showExitAndSaveDialog(): void;
+        showChooseHwDialog(): void;
 
         showPackageDialog(): void;
         showBoardDialog(): void;

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -111,6 +111,13 @@ namespace pxt {
             hwVariant = null
     }
 
+    export function getHwVariants(): PackageConfig[] {
+        if (!pxt.appTarget.variants)
+            return []
+        let hws = Object.keys(pxt.appTarget.bundledpkgs).filter(pkg => /^hw---/.test(pkg))
+        return hws.map(pkg => JSON.parse(pxt.appTarget.bundledpkgs[pkg][CONFIG_NAME]))
+    }
+
     export interface PxtOptions {
         debug?: boolean;
         light?: boolean; // low resource device

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -78,6 +78,7 @@ export class ProjectView
     languagePicker: lang.LanguagePicker;
     importDialog: projects.ImportDialog;
     exitAndSaveDialog: projects.ExitAndSaveDialog;
+    chooseHwDialog: projects.ChooseHwDialog;
     prevEditorId: string;
     screenshotHandler: (img: string) => void;
 
@@ -1292,13 +1293,26 @@ export class ProjectView
             });
     }
 
+    checkForHwVariant() {
+        if (pxt.hwVariant)
+            return false // already set
+        let variants = pxt.getHwVariants()
+        if (variants.length == 0)
+            return false
+        this.showChooseHwDialog()
+        return true
+    }
+
     beforeCompile() { }
 
     compile(saveOnly = false) {
         pxt.tickEvent("compile");
         pxt.debug('compiling...');
 
-        if (pxt.appTarget.compile.saveAsPNG) {
+        if (this.checkForHwVariant())
+            return;
+
+        if (pxt.appTarget.compile.saveAsPNG && !pxt.hwVariant) {
             this.saveAndCompile();
             return;
         }
@@ -1837,6 +1851,10 @@ export class ProjectView
         this.scriptSearch.showBoards();
     }
 
+    showChooseHwDialog() {
+        this.chooseHwDialog.show()
+    }
+
     showRenameProjectDialogAsync(): Promise<boolean> {
         if (!this.state.header) return Promise.resolve(false);
 
@@ -2047,6 +2065,10 @@ export class ProjectView
         this.languagePicker = c;
     }
 
+    private handleChooseHwDialogRef = (c: projects.ChooseHwDialog) => {
+        this.chooseHwDialog = c;
+    }
+
     ///////////////////////////////////////////////////////////
     ////////////             RENDER               /////////////
     ///////////////////////////////////////////////////////////
@@ -2163,6 +2185,7 @@ export class ProjectView
                 {sandbox ? undefined : <extensions.Extensions parent={this} ref={this.handleExtensionRef} />}
                 {inHome ? <projects.ImportDialog parent={this} ref={this.handleImportDialogRef} /> : undefined}
                 {sandbox ? undefined : <projects.ExitAndSaveDialog parent={this} ref={this.handleExitAndSaveDialogRef} />}
+                {sandbox ? undefined : <projects.ChooseHwDialog parent={this} ref={this.handleChooseHwDialogRef} />}
                 {sandbox || !sharingEnabled ? undefined : <share.ShareEditor parent={this} ref={this.handleShareEditorRef} />}
                 {selectLanguage ? <lang.LanguagePicker parent={this} ref={this.handleLanguagePickerRef} /> : undefined}
                 {sandbox ? <container.SandboxFooter parent={this} /> : undefined}

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -71,6 +71,8 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
         const cardType = card.cardType;
 
         const clickHandler = card.onClick ? (e: any) => {
+            if (e.target && e.target.tagName == "A")
+                return;
             pxt.analytics.enableCookies();
             card.onClick(e);
         } : undefined;
@@ -112,12 +114,23 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             {card.time ? <div className="meta">
                 {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span> : null}
             </div> : undefined}
-            {card.extracontent || card.tags ? <div className="extra content">
-                {card.extracontent}
-                {card.tags ? card.tags.map(tag =>
-                    <span key={`tag${tag.label}`} className={`ui label tiny ${tag.color}`}>{pxt.Util.rlf(tag.label)}</span>
-                ) : undefined}
-            </div> : undefined}
+            {card.extracontent || card.tags || card.learnMoreUrl || card.buyUrl ?
+                <div className="extra content">
+                    {card.extracontent}
+                    {card.tags ? card.tags.map(tag =>
+                        <span key={`tag${tag.label}`} className={`ui label tiny ${tag.color}`}>{pxt.Util.rlf(tag.label)}</span>
+                    ) : undefined}
+                    {card.buyUrl ?
+                        <a className="learnmore left floated" href={card.buyUrl}
+                            aria-label={lf("Buy")} target="_blank" rel="noopener noreferrer">
+                            {lf("Buy")}
+                        </a> : undefined}
+                    {card.learnMoreUrl ?
+                        <a className="learnmore right floated" href={card.learnMoreUrl}
+                            aria-label={lf("Learn more")} target="_blank" rel="noopener noreferrer">
+                            {lf("Learn more")}
+                        </a> : undefined}
+                </div> : undefined}
         </div>;
 
         if (!card.onClick && url) {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -813,7 +813,7 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                 </div>
                 <p>
                     <br /><br />
-                    {lf("No hardware? Or want add some?")}
+                    {lf("No hardware? Or want to add some?")}
                     {" "}
                     <a className="small" href={`/hardware`} target="_blank" rel="noopener noreferrer"
                         aria-label={lf("Learn more about hardware")}>{lf("Learn more!")}</a>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -804,6 +804,8 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                                 name={cfg.card.name}
                                 ariaLabel={cfg.card.name}
                                 description={cfg.card.description}
+                                learnMoreUrl={cfg.card.learnMoreUrl}
+                                buyUrl={cfg.card.buyUrl}
                                 onClick={() => this.setHwVariant(cfg)}
                             />
                         )}
@@ -811,11 +813,10 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                 </div>
                 <p>
                     <br /><br />
-                    <a href={`https://makecode.com/buy-hardware`} target="_blank" rel="noopener noreferrer"
-                        aria-label={lf("Buy hardware")}>{lf("Buy hardware")}</a>
-                    <br />
-                    <a href={`https://makecode.com/adding-board`} target="_blank" rel="noopener noreferrer"
-                        aria-label={lf("Adding custom hardware")}>{lf("Adding custom hardware")}</a>
+                    {lf("No hardware? Or want add some?")}
+                    {" "}
+                    <a className="small" href={`/hardware`} target="_blank" rel="noopener noreferrer"
+                        aria-label={lf("Learn more about hardware")}>{lf("Learn more!")}</a>
                 </p>
             </sui.Modal>
         )

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -788,6 +788,8 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                 v.card = {
                     name: v.description
                 }
+            let savedV = v
+            v.card.onClick = () => this.setHwVariant(savedV)
         }
 
         return (
@@ -806,7 +808,7 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                                 description={cfg.card.description}
                                 learnMoreUrl={cfg.card.learnMoreUrl}
                                 buyUrl={cfg.card.buyUrl}
-                                onClick={() => this.setHwVariant(cfg)}
+                                onClick={cfg.card.onClick}
                             />
                         )}
                     </div>


### PR DESCRIPTION
This adds a dialog when the user presses the "Download" button. The dialog currently appears one per session - we might want to store the setting and add some way of changing this.

The save button still saves a PNG.

<img width="818" alt="screen shot 2018-06-29 at 21 21 10" src="https://user-images.githubusercontent.com/10673976/42121365-80e0d274-7be2-11e8-9cdf-c1b212d4de22.png">
