### PR TITLE
Treat enums as numbers in blocks

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -170,6 +170,10 @@ namespace ts.pxtc {
                     }
             }
 
+            if (kind == SymbolKind.Enum || kind === SymbolKind.EnumMember) {
+                (extendsTypes || (extendsTypes = [])).push("Number");
+            }
+
             let r: SymbolInfo = {
                 kind,
                 namespace: m ? m[1] : "",


### PR DESCRIPTION
You can't compare enums to numbers in blocks because Blockly only lets you compare two blocks with matching "checks" on their outputs. We just assign the return type of a function to the check so functions that return enum values have their check set to "WhateverEnumIsNamed" instead of "Number" which is what you usually want.