### PR TITLE
Fix docs link rendering

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -455,27 +455,29 @@ namespace pxt.docs {
 
         if (!markedInstance) {
             markedInstance = requireMarked();
-            let renderer = new markedInstance.Renderer()
-            setupRenderer(renderer);
-            const linkRenderer = renderer.link;
-            renderer.link = function (href: string, title: string, text: string) {
-                const relative = href.indexOf('/') == 0;
-                const target = !relative ? '_blank' : '';
-                if (relative && d.versionPath) href = `/${d.versionPath}${href}`;
-                const html = linkRenderer.call(renderer, href, title, text);
-                return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} rel="nofollow noopener" `);
-            }
-            markedInstance.setOptions({
-                renderer: renderer,
-                gfm: true,
-                tables: true,
-                breaks: false,
-                pedantic: false,
-                sanitize: true,
-                smartLists: true,
-                smartypants: true
-            })
+        }
+
+        // We have to re-create the renderer every time to avoid the link() function's closure capturing the opts
+        let renderer = new markedInstance.Renderer()
+        setupRenderer(renderer);
+        const linkRenderer = renderer.link;
+        renderer.link = function (href: string, title: string, text: string) {
+            const relative = href.indexOf('/') == 0;
+            const target = !relative ? '_blank' : '';
+            if (relative && d.versionPath) href = `/${d.versionPath}${href}`;
+            const html = linkRenderer.call(renderer, href, title, text);
+            return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} rel="nofollow noopener" `);
         };
+        markedInstance.setOptions({
+            renderer: renderer,
+            gfm: true,
+            tables: true,
+            breaks: false,
+            pedantic: false,
+            sanitize: true,
+            smartLists: true,
+            smartypants: true
+        });
 
         let markdown = opts.markdown
 


### PR DESCRIPTION
We had a closure variable capturing bug in our logic to render docs links

On [line 461](https://github.com/Microsoft/pxt/blob/master/pxtlib/docsrender.ts#L461) we initialize the `link()` function in a way that captures the state of the `d` object and keeps it forever. Subsequent calls to the `link` function do **not** use the updated `d` object that we set on [line 446](https://github.com/Microsoft/pxt/blob/master/pxtlib/docsrender.ts#L446), but rather the one from the function's closure

Fix is to re-assign the `renderer.link()` function every time, so it always uses the updated `d` object (and the updated `d.versionPath` value to correctly update the `href`s). 