### PR TITLE
Let targets remove categories from blocks

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -89,6 +89,7 @@ declare namespace pxt {
         assetExtensions?: string[];
         palette?: string[];
         screenSize?: Size;
+        bannedCategories?: string[]; // a list of categories to exclude blocks from
     }
 
     interface AppAnalytics {

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -212,13 +212,13 @@ namespace ts.pxtc {
         return res
     }
 
-    export function decompile(opts: CompileOptions, fileName: string, includeGreyBlockMessages = false) {
+    export function decompile(opts: CompileOptions, fileName: string, includeGreyBlockMessages = false, bannedCategories?: string[]) {
         const resp = compile(opts);
         if (!resp.success) return resp;
 
         let file = resp.ast.getSourceFile(fileName);
         const apis = getApiInfo(opts, resp.ast);
-        const blocksInfo = pxtc.getBlocksInfo(apis);
+        const blocksInfo = pxtc.getBlocksInfo(apis, bannedCategories);
         const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, { snippetMode: false, alwaysEmitOnStart: opts.alwaysDecompileOnStart, includeGreyBlockMessages }, pxtc.decompiler.buildRenameMap(resp.ast, file))
         return bresp;
     }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -573,15 +573,15 @@ namespace ts.pxtc.service {
         isJsDocTagName: boolean;
     }
 
-    const blocksInfoOp = (apisInfoLocOverride?: pxtc.ApisInfo) => {
+    const blocksInfoOp = (apisInfoLocOverride?: pxtc.ApisInfo, bannedCategories?: string[]) => {
         if (apisInfoLocOverride) {
             if (!lastLocBlocksInfo) {
-                lastLocBlocksInfo = getBlocksInfo(apisInfoLocOverride);
+                lastLocBlocksInfo = getBlocksInfo(apisInfoLocOverride, bannedCategories);
             }
             return lastLocBlocksInfo;
         } else {
             if (!lastBlocksInfo) {
-                lastBlocksInfo = getBlocksInfo(lastApiInfo);
+                lastBlocksInfo = getBlocksInfo(lastApiInfo, bannedCategories);
             }
             return lastBlocksInfo;
         }
@@ -625,7 +625,8 @@ namespace ts.pxtc.service {
             return compile(v.options)
         },
         decompile: v => {
-            return decompile(v.options, v.fileName);
+            const bannedCategories = v.blocks ? v.blocks.bannedCategories : undefined;
+            return decompile(v.options, v.fileName, false, bannedCategories);
         },
         assemble: v => {
             return {
@@ -672,7 +673,8 @@ namespace ts.pxtc.service {
         apiSearch: v => {
             const SEARCH_RESULT_COUNT = 7;
             const search = v.search;
-            const blockInfo = blocksInfoOp(search.localizedApis); // cache
+            const bannedCategories = v.blocks ? v.blocks.bannedCategories : undefined;
+            const blockInfo = blocksInfoOp(search.localizedApis, bannedCategories); // cache
 
             if (search.localizedStrings) {
                 pxt.Util.setLocalizedStrings(search.localizedStrings);

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -411,8 +411,8 @@ namespace ts.pxtc {
         return n ? Util.capitalize(n.split('.')[0]) : undefined;
     }
 
-    export function getBlocksInfo(info: ApisInfo): BlocksInfo {
-        const blocks: SymbolInfo[] = []
+    export function getBlocksInfo(info: ApisInfo, categoryFilters?: string[]): BlocksInfo {
+        let blocks: SymbolInfo[] = []
         const combinedSet: pxt.Map<SymbolInfo> = {}
         const combinedGet: pxt.Map<SymbolInfo> = {}
         const combinedChange: pxt.Map<SymbolInfo> = {}
@@ -584,11 +584,28 @@ namespace ts.pxtc {
             }
         }
 
+        if (pxt.appTarget && pxt.appTarget.runtime && Array.isArray(pxt.appTarget.runtime.bannedCategories)) {
+            filterCategories(pxt.appTarget.runtime.bannedCategories)
+        }
+
+        if (categoryFilters) {
+            filterCategories(categoryFilters);
+        }
+
         return {
             apis: info,
             blocks,
             blocksById: pxt.Util.toDictionary(blocks, b => b.attributes.blockId),
             enumsByName
+        }
+
+        function filterCategories(banned: string[]) {
+            if (banned.length) {
+                blocks = blocks.filter(b => {
+                    let ns = (b.attributes.blockNamespace || b.namespace).split('.')[0];
+                    return banned.indexOf(ns) === -1;
+                });
+            }
         }
     }
 
@@ -1353,6 +1370,7 @@ namespace ts.pxtc.service {
         options?: CompileOptions;
         search?: SearchOptions;
         format?: FormatOptions;
+        blocks?: BlocksOptions;
     }
 
     export interface SearchOptions {
@@ -1377,6 +1395,10 @@ namespace ts.pxtc.service {
         field?: [string, string];
         localizedCategory?: string;
         builtinBlock?: boolean;
+    }
+
+    export interface BlocksOptions {
+        bannedCategories?: string[];
     }
 }
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -161,7 +161,7 @@ export function decompileSnippetAsync(code: string, blockInfo?: ts.pxtc.BlocksIn
 }
 
 function decompileCoreAsync(opts: pxtc.CompileOptions, fileName: string): Promise<pxtc.CompileResult> {
-    return workerOpAsync("decompile", { options: opts, fileName: fileName })
+    return workerOpAsync("decompile", { options: opts, fileName: fileName, blocks: blocksOptions() })
 }
 
 export function workerOpAsync(op: string, arg: pxtc.service.OpArg) {
@@ -196,7 +196,7 @@ export function apiSearchAsync(searchFor: pxtc.service.SearchOptions) {
         .then(() => {
             searchFor.localizedApis = cachedApis;
             searchFor.localizedStrings = pxt.Util.getLocalizedStrings();
-            return workerOpAsync("apiSearch", { search: searchFor })
+            return workerOpAsync("apiSearch", { search: searchFor, blocks: blocksOptions() });
         });
 }
 
@@ -237,4 +237,11 @@ export function newProject() {
     cachedApis = null;
     cachedBlocks = null;
     workerOpAsync("reset", {}).done();
+}
+
+function blocksOptions(): pxtc.service.BlocksOptions {
+    if (pxt.appTarget && pxt.appTarget.runtime && pxt.appTarget.runtime.bannedCategories && pxt.appTarget.runtime.bannedCategories.length) {
+        return { bannedCategories: pxt.appTarget.runtime.bannedCategories };
+    }
+    return undefined;
 }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -961,7 +961,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let monacoFlyout = this.createMonacoFlyout();
 
         if (ns == 'search') {
-            this.showSearchFlyout();
+            try {
+                this.showSearchFlyout();
+            }
+            catch (e) {
+                pxt.reportException(e);
+                pxsim.U.clear(monacoFlyout);
+                this.addNoSearchResultsLabel();
+            }
             return;
         }
 
@@ -1047,8 +1054,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.attachMonacoBlockAccessibility(monacoBlocks);
 
         if (monacoBlocks.length == 0) {
-            this.getMonacoLabel(lf("No search results..."), 'monacoFlyoutLabel');
+            this.addNoSearchResultsLabel();
         }
+    }
+
+    private addNoSearchResultsLabel() {
+        this.getMonacoLabel(lf("No search results..."), 'monacoFlyoutLabel');
     }
 
     private getMonacoFlyout() {

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -129,7 +129,9 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
         };
         _cachedBuiltinCategories[CategoryNameID.Maths] = {
             name: lf("{id:category}Math"),
-            nameid: 'math',
+            // Unlike the other categories, this namespace is actually capitalized in
+            // the source so the nameid must be capitalized also
+            nameid: 'Math',
             blocks: [
                 {
                     name: "Math.plus",


### PR DESCRIPTION
This is a (long overdue) feature for targets that lets them exclude certain categories from appearing in blocks. For example, we recently were adding blocks for some image APIs and that accidentally caused them to appear in the EV3 editor where we didn't want them. Now you can just add "image" to this list instead of doing the complicated "file override dance" that we usually do.

This PR also fixes an unrelated bug where typing any string into the search bar in JavaScript that matched certain blocks in the Math namespace would cause the entire webpage to disappear (I kid you not).

Note: banned categories will not only be removed from the toolbox but their blocks will cease to be loaded by BlocklyLoader, so adding a name to the list in a target is a breaking change