### PR TITLE
Handle top level blocks after a variable declaration list

### DIFF
--- a/tests/decompile-test/baselines/enum_user_defined_with_var.blocks
+++ b/tests/decompile-test/baselines/enum_user_defined_with_var.blocks
@@ -1,0 +1,20 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<variables>
+<variable type="PlainOldEnum">0A</variable>
+<variable type="PlainOldEnum">1B</variable>
+<variable type="PlainOldEnum">2C</variable>
+</variables>
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">varEnumTest</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="enum_user_shim">
+<field name="MEMBER">A</field>
+</block>
+</value>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/enum_user_defined_with_var.ts
+++ b/tests/decompile-test/cases/enum_user_defined_with_var.ts
@@ -1,0 +1,11 @@
+/// <reference path="./testBlocks/enums.ts" />
+
+let varEnumTest = 0;
+
+enum PlainOldEnum {
+    A,
+    B,
+    C
+}
+
+varEnumTest = PlainOldEnum.A


### PR DESCRIPTION
Some TS statements will only be decompiled if they are top-level (like enum declarations). This fixes a bug where the decompiler would treat any statements after a variable declaration list as not-top-level.

That bug might sound bad but it only really affected enums because events and function declarations are special-cased by the decompiler.