### PR TITLE
Honor the disableLiveTranslations pxtarget setting

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -810,7 +810,9 @@ namespace ts.pxtc.Util {
 
         _localizeLang = code;
         _localizeStrings = {};
-        localizeLive = true;
+        if (live) {
+            localizeLive = true;
+        }
         function mergeTranslations(tr: pxt.Map<string>) {
             if (!tr) return;
             Object.keys(tr)


### PR DESCRIPTION
For some reason in v0 we hardcode live localizations to true, even if pxtarget.json disables them. This prevents package authors from testing their package translations.

This change has no impact on production websites, because we never use the `disableLiveTranslations` flag in pxtarget.json. That setting is mostly meant for local serve.

Note that in master, this has already been fixed