### PR TITLE
Fixing decompilation of setter blocks

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1324,8 +1324,19 @@ ${output}</xml>`;
             const setter = env.blocks.blocks.find(b => b.qName == qName)
             const r = right ? mkStmt(setter.attributes.blockId) : mkExpr(setter.attributes.blockId)
             const pp = setter.attributes._def.parameters;
+
+            let fieldValue = info.qName;
+            if (setter.combinedProperties) {
+                // getters/setters have annotations at the end of their names so look them up
+                setter.combinedProperties.forEach(pName => {
+                    if (pName.indexOf(info.qName) === 0 && pName.charAt(info.qName.length) === "@") {
+                        fieldValue = pName;
+                    }
+                })
+            }
+
             r.inputs = [getValue(pp[0].name, left.expression)];
-            r.fields = [getField(pp[1].name, info.qName)];
+            r.fields = [getField(pp[1].name, fieldValue)];
             if (right)
                 r.inputs.push(getValue(pp[2].name, right));
             return r;

--- a/tests/decompile-test/baselines/blockCombine.blocks
+++ b/tests/decompile-test/baselines/blockCombine.blocks
@@ -1,0 +1,77 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">bcTest</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="bc_create_test">
+</block>
+</value>
+<next>
+<block type="bc.Test_blockCombine_set">
+<field name="property">bc.Test.x</field>
+<value name="bc">
+<block type="variables_get">
+<field name="VAR">bcTest</field>
+</block>
+</value>
+<value name="value">
+<shadow type="math_number">
+<field name="NUM">12</field>
+</shadow>
+</value>
+<next>
+<block type="bc.Test_blockCombine_set">
+<field name="property">bc.Test.z&#64;set</field>
+<value name="bc">
+<block type="variables_get">
+<field name="VAR">bcTest</field>
+</block>
+</value>
+<value name="value">
+<shadow type="math_number">
+<field name="NUM">13</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">bcTestX</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="bc.Test_blockCombine_get">
+<field name="property">bc.Test.x</field>
+<value name="bc">
+<block type="variables_get">
+<field name="VAR">bcTest</field>
+</block>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">bcTestZ</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="bc.Test_blockCombine_get">
+<field name="property">bc.Test.z</field>
+<value name="bc">
+<block type="variables_get">
+<field name="VAR">bcTest</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;blockCombine.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/blockCombine.ts
+++ b/tests/decompile-test/cases/blockCombine.ts
@@ -1,0 +1,7 @@
+/// <reference path="./testBlocks/blockCombine.ts" />
+
+let bcTest = bc.createTest();
+bcTest.x = 12;
+bcTest.z = 13;
+let bcTestX = bcTest.x;
+let bcTestZ = bcTest.z;

--- a/tests/decompile-test/cases/testBlocks/blockCombine.ts
+++ b/tests/decompile-test/cases/testBlocks/blockCombine.ts
@@ -1,0 +1,27 @@
+namespace bc {
+    /**
+     * test class
+     **/
+    //% blockNamespace=bc color="#4B7BEC" blockGap=8
+    export class Test {
+        //% group="Properties"
+        //% blockCombine block="x (horizontal position)"
+        x: number
+
+        //% group="Properties"
+        //% blockCombine block="z (depth)"
+        get z(): number {
+            return 0;
+        }
+
+        //% group="Properties"
+        //% blockCombine block="z (depth)"
+        set z(value: number) {
+        }
+    }
+
+    //% blockId=bc_create_test block="create test"
+    export function createTest(): Test {
+        return new Test();
+    }
+}

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -3,6 +3,7 @@
     "description": "Project that defines a variety of blocks to be used in decopmiler test cases",
     "files": [
         "basic.ts",
+        "blockCombine.ts",
         "enums.ts",
         "mb.ts",
         "expandableBlocks.ts",


### PR DESCRIPTION
The decompilation of getters/setters that use `blockCombine` was writing the wrong field value to the output blocks XML. The generated blocks file still worked due to a quirk in our Blockly Compiler but it caused the blocks to look wrong so here's a fix.