### PR TITLE
Support localstorage prefixes for different major versions

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -268,6 +268,7 @@ declare namespace pxt {
         fileNameExclusiveFilter?: string; // anything that does not match this regex is removed from the filename,
         copyrightText?: string; // footer text for any copyright text to be included at the bottom of the home screen and about page
         appFlashingTroubleshoot?: string; // Path to the doc about troubleshooting UWP app flashing failures, e.g. /device/windows-app/troubleshoot
+        browserDbPrefixes?: { [majorVersion: number]: string }; // Prefix used when storing projects in the DB to allow side-by-side projects of different major versions
     }
 
     interface SocialOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1430,6 +1430,12 @@
         "randomfill": "1.0.4"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
+      "dev": true
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",

--- a/webapp/src/browserworkspace.ts
+++ b/webapp/src/browserworkspace.ts
@@ -7,67 +7,64 @@ type Header = pxt.workspace.Header;
 type ScriptText = pxt.workspace.ScriptText;
 type WorkspaceProvider = pxt.workspace.WorkspaceProvider;
 
-let initPromise: Promise<void>;
+function migratePrefixesAsync(): Promise<void> {
+    const currentVersion = pxt.semver.parse(pxt.appTarget.versions.target);
+    const currentMajor = currentVersion.major;
+    const currentDbPrefix = pxt.appTarget.appTheme.browserDbPrefixes && pxt.appTarget.appTheme.browserDbPrefixes[currentMajor];
 
-function initAsync(): Promise<void> {
-    if (!initPromise) {
-        const currentVersion = pxt.semver.parse(pxt.appTarget.versions.target);
-        const currentMajor = currentVersion.major;
-        const currentDbPrefix = pxt.appTarget.appTheme.browserDbPrefixes && pxt.appTarget.appTheme.browserDbPrefixes[currentMajor];
-
-        if (!currentDbPrefix) {
-            // This version does not use a prefix for storing projects, so just use default tables
-            headers = new db.Table("header");
-            texts = new db.Table("text");
-            initPromise = Promise.resolve();
-            return initPromise;
-        }
-
-        headers = new db.Table(`${currentDbPrefix}-header`);
-        texts = new db.Table(`${currentDbPrefix}-text`);
-
-        initPromise = headers.getAllAsync()
-            .then((allDbHeaders) => {
-                if (allDbHeaders.length) {
-                    // There are already scripts using the prefix, so a migration has already happened
-                    return Promise.resolve();
-                }
-
-                // No headers using this prefix yet, attempt to migrate headers from previous major version (or default tables)
-                const previousMajor = currentMajor - 1;
-                const previousDbPrefix = previousMajor < 0 ? "" : pxt.appTarget.appTheme.browserDbPrefixes && pxt.appTarget.appTheme.browserDbPrefixes[previousMajor];
-                let previousHeaders = new db.Table("header");
-                let previousTexts = new db.Table("text");
-
-                if (previousDbPrefix) {
-                    previousHeaders = new db.Table(`${previousDbPrefix}-header`);
-                    previousTexts = new db.Table(`${previousDbPrefix}-text`);
-                }
-
-                const copyProject = (h: pxt.workspace.Header): Promise<string> => {
-                    return previousTexts.getAsync(h.id)
-                        .then((resp) => setAsync(h, undefined, resp.files, /* skipInit */ true)); // undefined _rev because it's a new document
-                };
-
-                return previousHeaders.getAllAsync()
-                    .then((previousHeaders: pxt.workspace.Header[]) => {
-                        return Promise.map(previousHeaders, (h) => copyProject(h));
-                    })
-                    .then(() => { });
-            });
+    if (!currentDbPrefix) {
+        // This version does not use a prefix for storing projects, so just use default tables
+        headers = new db.Table("header");
+        texts = new db.Table("text");
+        return Promise.resolve();
     }
 
-    return initPromise;
+    headers = new db.Table(`${currentDbPrefix}-header`);
+    texts = new db.Table(`${currentDbPrefix}-text`);
+
+    return headers.getAllAsync()
+        .then((allDbHeaders) => {
+            if (allDbHeaders.length) {
+                // There are already scripts using the prefix, so a migration has already happened
+                return Promise.resolve();
+            }
+
+            // No headers using this prefix yet, attempt to migrate headers from previous major version (or default tables)
+            const previousMajor = currentMajor - 1;
+            const previousDbPrefix = previousMajor < 0 ? "" : pxt.appTarget.appTheme.browserDbPrefixes && pxt.appTarget.appTheme.browserDbPrefixes[previousMajor];
+            let previousHeaders = new db.Table("header");
+            let previousTexts = new db.Table("text");
+
+            if (previousDbPrefix) {
+                previousHeaders = new db.Table(`${previousDbPrefix}-header`);
+                previousTexts = new db.Table(`${previousDbPrefix}-text`);
+            }
+
+            const copyProject = (h: pxt.workspace.Header): Promise<string> => {
+                return previousTexts.getAsync(h.id)
+                    .then((resp) => {
+                        // Delete database metadata of the previous script so they get re-generated for the copy
+                        delete (<any>h)._id;
+                        delete (<any>h)._rev;
+                        return setAsync(h, undefined, resp.files, /* skipInit */ true);
+                    }); // undefined _rev because it's a new document
+            };
+
+            return previousHeaders.getAllAsync()
+                .then((previousHeaders: pxt.workspace.Header[]) => {
+                    return Promise.map(previousHeaders, (h) => copyProject(h));
+                })
+                .then(() => { });
+        });
 }
 
 function listAsync(): Promise<pxt.workspace.Header[]> {
-    return initAsync()
+    return migratePrefixesAsync()
         .then(() => headers.getAllAsync());
 }
 
 function getAsync(h: Header): Promise<pxt.workspace.File> {
-    return initAsync()
-        .then(() => texts.getAsync(h.id))
+    return texts.getAsync(h.id)
         .then(resp => ({
             header: h,
             text: resp.files,
@@ -77,15 +74,14 @@ function getAsync(h: Header): Promise<pxt.workspace.File> {
 
 function setAsync(h: Header, prevVer: any, text?: ScriptText, skipInit?: boolean) {
     let retrev = ""
-    return (skipInit ? Promise.resolve() : initAsync())
-        .then(() => (!text ? Promise.resolve() :
-            texts.setAsync({
-                id: h.id,
-                files: text,
-                _rev: prevVer
-            }).then(rev => {
-                retrev = rev
-            })))
+    return (!text ? Promise.resolve() :
+        texts.setAsync({
+            id: h.id,
+            files: text,
+            _rev: prevVer
+        }).then(rev => {
+            retrev = rev
+        }))
         .then(() => headers.setAsync(h))
         .then(rev => {
             h._rev = rev
@@ -94,8 +90,7 @@ function setAsync(h: Header, prevVer: any, text?: ScriptText, skipInit?: boolean
 }
 
 function deleteAsync(h: Header, prevVer: any) {
-    return initAsync()
-        .then(() => headers.deleteAsync(h))
+    return headers.deleteAsync(h)
         .then(() => texts.deleteAsync({ id: h.id, _rev: h._rev }));
 }
 

--- a/webapp/src/browserworkspace.ts
+++ b/webapp/src/browserworkspace.ts
@@ -43,11 +43,11 @@ function migratePrefixesAsync(): Promise<void> {
             const copyProject = (h: pxt.workspace.Header): Promise<string> => {
                 return previousTexts.getAsync(h.id)
                     .then((resp) => {
-                        // Delete database metadata of the previous script so they get re-generated for the copy
+                        // Ignore metadata of the previous script so they get re-generated for the new copy
                         delete (<any>h)._id;
                         delete (<any>h)._rev;
                         return setAsync(h, undefined, resp.files, /* skipInit */ true);
-                    }); // undefined _rev because it's a new document
+                    });
             };
 
             return previousHeaders.getAllAsync()
@@ -72,7 +72,7 @@ function getAsync(h: Header): Promise<pxt.workspace.File> {
         }));
 }
 
-function setAsync(h: Header, prevVer: any, text?: ScriptText, skipInit?: boolean) {
+function setAsync(h: Header, prevVer: any, text?: ScriptText) {
     let retrev = ""
     return (!text ? Promise.resolve() :
         texts.setAsync({

--- a/webapp/src/browserworkspace.ts
+++ b/webapp/src/browserworkspace.ts
@@ -1,50 +1,107 @@
 import * as db from "./db";
 
-let headers = new db.Table("header")
-let texts = new db.Table("text")
+let headers: db.Table;
+let texts: db.Table;
 
 type Header = pxt.workspace.Header;
 type ScriptText = pxt.workspace.ScriptText;
 type WorkspaceProvider = pxt.workspace.WorkspaceProvider;
 
-function listAsync() {
-    return headers.getAllAsync()
+let initPromise: Promise<void>;
+
+function initAsync(): Promise<void> {
+    if (!initPromise) {
+        const currentVersion = pxt.semver.parse(pxt.appTarget.versions.target);
+        const currentMajor = currentVersion.major;
+        const currentDbPrefix = pxt.appTarget.appTheme.browserDbPrefixes && pxt.appTarget.appTheme.browserDbPrefixes[currentMajor];
+
+        if (!currentDbPrefix) {
+            // This version does not use a prefix for storing projects, so just use default tables
+            headers = new db.Table("header");
+            texts = new db.Table("text");
+            initPromise = Promise.resolve();
+            return initPromise;
+        }
+
+        headers = new db.Table(`${currentDbPrefix}-header`);
+        texts = new db.Table(`${currentDbPrefix}-text`);
+
+        initPromise = headers.getAllAsync()
+            .then((allDbHeaders) => {
+                if (allDbHeaders.length) {
+                    // There are already scripts using the prefix, so a migration has already happened
+                    return Promise.resolve();
+                }
+
+                // No headers using this prefix yet, attempt to migrate headers from previous major version (or default tables)
+                const previousMajor = currentMajor - 1;
+                const previousDbPrefix = previousMajor < 0 ? "" : pxt.appTarget.appTheme.browserDbPrefixes && pxt.appTarget.appTheme.browserDbPrefixes[previousMajor];
+                let previousHeaders = new db.Table("header");
+                let previousTexts = new db.Table("text");
+
+                if (previousDbPrefix) {
+                    previousHeaders = new db.Table(`${previousDbPrefix}-header`);
+                    previousTexts = new db.Table(`${previousDbPrefix}-text`);
+                }
+
+                const copyProject = (h: pxt.workspace.Header): Promise<string> => {
+                    return previousTexts.getAsync(h.id)
+                        .then((resp) => setAsync(h, undefined, resp.files, /* skipInit */ true)); // undefined _rev because it's a new document
+                };
+
+                return previousHeaders.getAllAsync()
+                    .then((previousHeaders: pxt.workspace.Header[]) => {
+                        return Promise.map(previousHeaders, (h) => copyProject(h));
+                    })
+                    .then(() => { });
+            });
+    }
+
+    return initPromise;
+}
+
+function listAsync(): Promise<pxt.workspace.Header[]> {
+    return initAsync()
+        .then(() => headers.getAllAsync());
 }
 
 function getAsync(h: Header): Promise<pxt.workspace.File> {
-    return texts.getAsync(h.id)
+    return initAsync()
+        .then(() => texts.getAsync(h.id))
         .then(resp => ({
             header: h,
             text: resp.files,
             version: resp._rev
-        }))
+        }));
 }
 
-function setAsync(h: Header, prevVer: any, text?: ScriptText) {
+function setAsync(h: Header, prevVer: any, text?: ScriptText, skipInit?: boolean) {
     let retrev = ""
-    return (!text ? Promise.resolve() :
-        texts.setAsync({
-            id: h.id,
-            files: text,
-            _rev: prevVer
-        }).then(rev => {
-            retrev = rev
-        }))
+    return (skipInit ? Promise.resolve() : initAsync())
+        .then(() => (!text ? Promise.resolve() :
+            texts.setAsync({
+                id: h.id,
+                files: text,
+                _rev: prevVer
+            }).then(rev => {
+                retrev = rev
+            })))
         .then(() => headers.setAsync(h))
         .then(rev => {
             h._rev = rev
             return retrev
-        })
+        });
 }
 
 function deleteAsync(h: Header, prevVer: any) {
-    return headers.deleteAsync(h)
-        .then(() => texts.deleteAsync({ id: h.id, _rev: h._rev }))
+    return initAsync()
+        .then(() => headers.deleteAsync(h))
+        .then(() => texts.deleteAsync({ id: h.id, _rev: h._rev }));
 }
 
 function resetAsync() {
     // workspace.resetAsync already clears all tables
-    return Promise.resolve()
+    return Promise.resolve();
 }
 
 export const provider: WorkspaceProvider = {

--- a/webapp/src/browserworkspace.ts
+++ b/webapp/src/browserworkspace.ts
@@ -46,7 +46,7 @@ function migratePrefixesAsync(): Promise<void> {
                         // Ignore metadata of the previous script so they get re-generated for the new copy
                         delete (<any>h)._id;
                         delete (<any>h)._rev;
-                        return setAsync(h, undefined, resp.files, /* skipInit */ true);
+                        return setAsync(h, undefined, resp.files);
                     });
             };
 

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -81,7 +81,32 @@ export class Table {
     setAsync(obj: any): Promise<string> {
         if (obj.id && !obj._id)
             obj._id = this.name + "--" + obj.id
-        return getDbAsync().then(db => db.put(obj)).then((resp: any) => resp.rev)
+        // return getDbAsync().then(db => db.put(obj)).then((resp: any) => resp.rev)
+        //     .catch((e) => pxt.reportException(e));
+        let db: any;
+        return getDbAsync()
+            .then((d) => {
+                db = d;
+                return this.getAllAsync();
+            })
+            .then((a) => {
+            //     return db.get(obj._id);
+            // })
+            // .then((o) => {
+            //     return db.remove(o);
+            // })
+            // .then(() => {
+            //     return this.getAllAsync();
+            // })
+            // .then(() => {
+                return db.put(obj);
+            })
+            .then((resp) => {
+                return resp.rev;
+            })
+            .catch((e) => {
+                console.log(e);
+            });
     }
 }
 

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -81,32 +81,7 @@ export class Table {
     setAsync(obj: any): Promise<string> {
         if (obj.id && !obj._id)
             obj._id = this.name + "--" + obj.id
-        // return getDbAsync().then(db => db.put(obj)).then((resp: any) => resp.rev)
-        //     .catch((e) => pxt.reportException(e));
-        let db: any;
-        return getDbAsync()
-            .then((d) => {
-                db = d;
-                return this.getAllAsync();
-            })
-            .then((a) => {
-            //     return db.get(obj._id);
-            // })
-            // .then((o) => {
-            //     return db.remove(o);
-            // })
-            // .then(() => {
-            //     return this.getAllAsync();
-            // })
-            // .then(() => {
-                return db.put(obj);
-            })
-            .then((resp) => {
-                return resp.rev;
-            })
-            .catch((e) => {
-                console.log(e);
-            });
+        return getDbAsync().then(db => db.put(obj)).then((resp: any) => resp.rev)
     }
 }
 


### PR DESCRIPTION
Allows side by side of projects from different major versions

First time a user goes to a major version for which there are no scripts, we check if there are projects from the previous major version. If there are, the scripts are copied as-is using a new DB key that has a prefix (specified in pxtarget.json). From that point on we use the prefixed IDs for all project-related local storage operations, meaning projects from the previous version are unaffected. If we detect projects with prefixed IDs, then we assume the migration has already happened and don't migrate again.

This essentially forks all user projects from a previous major version, into new projects on the current major version. Projects are completely independent from that point on.