### PR TITLE
Tweaks to UWP app to support microbit v1

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1485,6 +1485,17 @@ function buildFolderAsync(p: string, optional?: boolean, outputName?: string): P
         args: ["../node_modules/typescript/bin/tsc"],
         cwd: p
     })
+        .then(() => {
+            if (tsConfig.prepend) {
+                let files: string[] = tsConfig.prepend
+                files.push(tsConfig.compilerOptions.out)
+                let s = ""
+                for (let f of files) {
+                    s += fs.readFileSync(path.resolve(p, f), "utf8") + "\n"
+                }
+                fs.writeFileSync(path.resolve(p, tsConfig.compilerOptions.out), s)
+            }
+        })
 }
 
 function copyCommonSim() {

--- a/pxtwinrt/deploy.ts
+++ b/pxtwinrt/deploy.ts
@@ -49,9 +49,12 @@ namespace pxt.winrt {
         return pxt.winrt.promisify(savePicker.pickSaveFileAsync()
             .then((file) => {
                 if (file) {
-                    const fileContent = useUf2 ? res.outfiles[pxtc.BINARY_UF2] : res.outfiles[pxtc.BINARY_HEX];
+                    let fileContent = useUf2 ? res.outfiles[pxtc.BINARY_UF2] : res.outfiles[pxtc.BINARY_HEX];
+                    if (!pxt.isOutputText()) {
+                        fileContent = atob(fileContent);
+                    }
                     const ar: number[] = [];
-                    const bytes = Util.stringToUint8Array(atob(fileContent));
+                    const bytes = Util.stringToUint8Array(fileContent);
                     bytes.forEach((b) => ar.push(b));
                     return Windows.Storage.FileIO.writeBytesAsync(file, ar)
                         .then(() => true);

--- a/pxtwinrt/winrtworkspace.ts
+++ b/pxtwinrt/winrtworkspace.ts
@@ -148,9 +148,12 @@ namespace pxt.winrt.workspace {
             })
     }
 
-    function listPkgsAsync(): Promise<FsPkg[]> {
+    function listPkgsAsync(): Promise<FsPkgs> {
         return promisify(folder.getFoldersAsync())
-            .then(fds => Promise.all(fds.map(fd => readPkgAsync(fd.name, false))))
+            .then((fds) => Promise.map(fds, (fd) => readPkgAsync(fd.name, false)))
+            .then((fsPkgs) => {
+                return Promise.resolve({ pkgs: fsPkgs });
+            });
     }
 
     function resetAsync(): Promise<void> {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -357,7 +357,7 @@ export function initCommandsAsync(): Promise<void> {
                         core.infoNotification(lf("file saved!"));
                     }
                 })
-                .catch(() => core.errorNotification(lf("saving file failed...")));
+                .catch((e) => core.errorNotification(lf("saving file failed...")));
         };
     } else if (electron.isPxtElectron) {
         pxt.commands.deployCoreAsync = electron.driveDeployAsync;


### PR DESCRIPTION
- Fix the v1 build logic to support our `prepend` property, which was in v0
  - dap.js was being omitted from the v1 micro:bit build because of that
- Minor fix to the WinRT workspace to be compatible with the workspace revamp
- Fix UWP file saving for micro:bit v1