### PR TITLE
Make groups and subcategories localizable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "3.22.4",
+  "version": "3.22.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -285,6 +285,8 @@ namespace ts.pxtc {
                 locStrings[`${si.qName}|block`] = si.attributes.block;
             if (si.attributes.group)
                 locStrings[`{id:group}${si.attributes.group}`] = si.attributes.group;
+            if (si.attributes.subcategory)
+                locStrings[`{id:subcategory}${si.attributes.subcategory}`] = si.attributes.subcategory;
             if (si.parameters)
                 si.parameters.filter(pi => !!pi.description).forEach(pi => {
                     jsdocStrings[`${si.qName}|param|${pi.name}`] = pi.description;

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -639,7 +639,22 @@ namespace pxt {
                                 if (!loc[k]) loc[k] = depLoc[k];
                             })
                     })))
-                .then(() => loc);
+                .then(() => {
+                    // Subcategories and groups are translated in their respective package, but are not really APIs so
+                    // there's no way for the translation to be saved with a block. To work around this, we copy the
+                    // translations to the editor translations.
+                    const strings = U.getLocalizedStrings();
+                    Object.keys(loc).forEach((l) => {
+                        if (l.startsWith("{id:subcategory}") || l.startsWith("{id:group}")) { // aaaa
+                            if (!strings[l]) {
+                                strings[l] = loc[l];
+                            }
+                        }
+                    });
+                    U.setLocalizedStrings(strings);
+
+                    return Promise.resolve(loc);
+                });
         }
 
         getTargetOptions(): CompileTarget {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1124,7 +1124,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     protected showFlyoutHeadingLabel(ns: string, name: string, subns: string, icon: string, color: string) {
-        const categoryName = subns ? `${Util.capitalize(name || ns)} > ${Util.capitalize(subns)}` : Util.capitalize(name || ns);
+        const categoryName = name || Util.capitalize(subns || ns);
         const iconClass = `blocklyTreeIcon${icon ? ns.toLowerCase() : 'Default'}`.replace(/\s/g, '');
         let headingLabel = pxt.blocks.createFlyoutHeadingLabel(categoryName, color, icon, iconClass);
         this.flyoutXmlList.push(headingLabel);

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -981,8 +981,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     protected showFlyoutHeadingLabel(ns: string, name: string, subns: string, icon: string, color: string) {
-        const categoryName = name ? name :
-            `${subns ? `${Util.capitalize(name || ns)} > ${Util.capitalize(subns)}` : Util.capitalize(name || ns)}`;
+        const categoryName = name || Util.capitalize(subns || ns);
         const iconClass = `blocklyTreeIcon${icon ? (ns || icon).toLowerCase() : 'Default'}`.replace(/\s/g, '');
 
         this.getMonacoLabel(categoryName,

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -407,7 +407,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                     {nonAdvancedCategories.map((treeRow) => (
                         <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection}>
                             {treeRow.subcategories ? treeRow.subcategories.map((subTreeRow) => (
-                                <CategoryItem key={subTreeRow.nameid} index={index++} toolbox={this} selected={selectedItem == (subTreeRow.nameid + subTreeRow.subns)} treeRow={subTreeRow} onCategoryClick={this.setSelection} />
+                                <CategoryItem key={subTreeRow.nameid + subTreeRow.subns} index={index++} toolbox={this} selected={selectedItem == (subTreeRow.nameid + subTreeRow.subns)} treeRow={subTreeRow} onCategoryClick={this.setSelection} />
                             )) : undefined}
                         </CategoryItem>
                     ))}

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -127,8 +127,10 @@ export abstract class ToolboxEditor extends srceditor.Editor {
                 const blocks = that.getBlocksForCategory(ns, subns).filter(block => that.shouldShowBlock(block.attributes.blockId, ns));
                 if (!blocks.length) return undefined;
 
+                const name = pxt.Util.rlf(`{id:subcategory}${subns}`);
                 return {
                     nameid: ns,
+                    name,
                     subns: subns,
                     color: md.color,
                     icon: md.icon,


### PR DESCRIPTION
- Extract subcategories strings
- Copy groups and subcategories translations to the main editor translations so they can be used
- Fix React duplicate key bug with subcategories
- Fix flyout headers of subcategories by showing only the localized subcategory name
  - Previously, it was showing the non-translated category, followed by the non-translated subcategory

Fixes https://github.com/Microsoft/pxt-microbit/issues/958