### PR TITLE
Fixing CSS for notification and cookie banners

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -32,6 +32,10 @@ html, body {
     position: relative;
 }
 
+#mainmenu {
+    position: relative !important;
+}
+
 #filelist,
 #maineditor,
 #sidedocs {
@@ -405,7 +409,6 @@ div.simframe > iframe {
     border-radius: 0 !important;
 }
 
-.notificationBannerVisible #filelist,
 .notificationBannerVisible #maineditor,
 .notificationBannerVisible #sidedocs,
 .notificationBannerVisible  #getting-started-btn {
@@ -413,6 +416,7 @@ div.simframe > iframe {
 }
 
 .notificationBannerVisible #mainmenu {
+    position: absolute !important;
     top: @bannerHeight;
     margin: 0;
 }
@@ -725,6 +729,10 @@ Avatar
 
 /* >= Small Monitor (Small Monitor + Large Monitor + Wide Monitor) */
 @media only screen and (min-width: @computerBreakpoint) {
+    .notificationBannerVisible #filelist {
+        top: calc(@mainMenuHeight + @bannerHeight);
+    }
+
     .collapsedEditorTools #filelist {
         display: none;
     }


### PR DESCRIPTION
Note this is a v0 pull request! @abchatra and I made a change to support the notification banner in V0 and it ended up affecting the cookie banner as well. This fixes that issue along with a another I found while testing (the simulator was positioned incorrectly when the notification banner shows on tablet/mobile view)

Fixes https://github.com/Microsoft/pxt-microbit/issues/1000
Fixes https://github.com/Microsoft/pxt-microbit/issues/997