### PR TITLE
Fix project names from examples

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -130,8 +130,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
 
     chgCode(scr: pxt.CodeCard, loadBlocks: boolean, prj?: pxt.ProjectTemplate) {
         core.showLoading("changingcode", lf("loading..."));
-        const name = scr.name.toLowerCase().replace(/\W/, '');
-        pxt.gallery.loadExampleAsync(name, scr.url)
+        pxt.gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
             .done((opts: pxt.editor.ProjectCreationOptions) => {
                 if (opts) {
                     if (prj) opts.prj = prj;


### PR DESCRIPTION
Removes the sanitization logic of generating project name from an example, because:

1. micro:bit v0 didn't have it and we never had an issue
2. It wasn't completely working (having more than 1 space, or weird characters, would still slip through)
3. It should be up to consumers of the project name to do proper sanitization for their needs (e.g. file workspace converting it to a name suitable for the file system)

Fixes https://github.com/Microsoft/pxt-microbit/issues/870