### PR TITLE
Fixing the color of the piano editor when not a shadow block

### DIFF
--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -416,12 +416,7 @@ namespace pxtblockly {
          * Create a piano under the note field.
          */
         showEditor_(opt_quietInput?: boolean): void {
-            if (!this.colour_) {
-                this.colour_ = ((this.sourceBlock_ as any).isShadow()) ?
-                    this.sourceBlock_.parentBlock_.getColour() : this.sourceBlock_.getColourTertiary();
-                this.colourBorder_ = ((this.sourceBlock_ as any).isShadow()) ?
-                    this.sourceBlock_.parentBlock_.getColourTertiary() : this.sourceBlock_.getColourTertiary();
-            }
+            this.updateColor();
 
             // If there is an existing drop-down someone else owns, hide it immediately and clear it.
             Blockly.DropDownDiv.hideWithoutAnimation();
@@ -833,5 +828,20 @@ namespace pxtblockly {
             (Blockly.DropDownDiv as any).hideIfOwner(this);
             Blockly.FieldTextInput.superClass_.dispose.call(this);
         }
+
+        private updateColor() {
+            if (this.sourceBlock_.parentBlock_ && (this.sourceBlock_.isShadow() || hasOnlyOneField(this.sourceBlock_))) {
+                this.colour_ = this.sourceBlock_.parentBlock_.getColour();
+                this.colourBorder_ = this.sourceBlock_.parentBlock_.getColourTertiary();
+            }
+            else {
+                this.colour_ = this.sourceBlock_.getColourTertiary();
+                this.colourBorder_ = this.sourceBlock_.getColourTertiary();
+            }
+        }
+    }
+
+    function hasOnlyOneField(block: Blockly.Block) {
+        return block.inputList.length === 1 && block.inputList[0].fieldRow.length === 1;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/931

Updating the logic for the piano field editor so that it matches its color with whatever block it is nested in. If a block has only one field then it also doesn't have a color because single-field blocks render just the field edge-to-edge. In that case we need to get the color from the parent block or else it ends up looking arbitrary.
