### PR TITLE
Fix sanitize regex and add several forbidden characters

### DIFF
--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -450,7 +450,7 @@ export function mainEditorPkg() {
 
 export function genFileName(extension: string): string {
     /* tslint:disable:no-control-regex */
-    let sanitizedName = mainEditorPkg().header.name.replace(/[()\\\/.,?*^:<>!;'#$%^&|"@+=«»°{}\[\]¾½¼³²¦¬¤¢£~­¯¸``±\x00-\x1F ]/g, '');
+    let sanitizedName = mainEditorPkg().header.name.replace(/[()\\\/.,?*^:<>!;'#$%^&|"@+=«»°{}\[\]¾½¼³²¦¬¤¢£~­¯¸`±\x00-\x1F ]/g, '');
     /* tslint:enable:no-control-regex */
     if (pxt.appTarget.appTheme && pxt.appTarget.appTheme.fileNameExclusiveFilter) {
         const rx = new RegExp(pxt.appTarget.appTheme.fileNameExclusiveFilter, 'g');

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -450,7 +450,7 @@ export function mainEditorPkg() {
 
 export function genFileName(extension: string): string {
     /* tslint:disable:no-control-regex */
-    let sanitizedName = mainEditorPkg().header.name.replace(/[()\\\/.,?*^:<>!;'#$%^&|"\x00-\x1F ]\s/g, '');
+    let sanitizedName = mainEditorPkg().header.name.replace(/[()\\\/.,?*^:<>!;'#$%^&|"@+=«»°{}\[\]¾½¼³²¦¬¤¢£~­¯¸``±\x00-\x1F ]/g, '');
     /* tslint:enable:no-control-regex */
     if (pxt.appTarget.appTheme && pxt.appTarget.appTheme.fileNameExclusiveFilter) {
         const rx = new RegExp(pxt.appTarget.appTheme.fileNameExclusiveFilter, 'g');


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/906

There was an extra `\s` at the end of the regex which meant that special characters had to be followed by a space in order to be successfully sanitized. I got rid of that `\s`.

I also took the opportunity to add a bunch of characters we want to sanitize.