### PR TITLE
Removing old mbit sim code

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -329,10 +329,6 @@ namespace pxsim {
                 case 'debugger': this.handleDebuggerMessage(msg as DebuggerMessage); break;
                 case 'toplevelcodefinished': if (this.options.onTopLevelCodeEnd) this.options.onTopLevelCodeEnd(); break;
                 default:
-                    if (msg.type == 'radiopacket') {
-                        // assign rssi noisy?
-                        (msg as pxsim.SimulatorRadioPacketMessage).rssi = 10;
-                    }
                     this.postMessage(msg, source);
                     break;
             }


### PR DESCRIPTION
We moved most of the micro:bit simulator code into pxt-microbit but I guess we missed this bit. This is part of the fix for https://github.com/Microsoft/pxt-microbit/issues/733