### PR TITLE
Fix editor bar for targets with a sim background

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -177,7 +177,7 @@ i.icon.avatar-image {
 
 #tutorialcard .ui.button.hintbutton {
     position: absolute;
-    bottom: 2rem; 
+    bottom: 2rem;
     left: 4rem;
     font-size: 0.8rem;
     border-radius: 0.28571429rem;
@@ -253,7 +253,7 @@ code.lang-filterblocks {
 @media only screen and (min-width: @computerBreakpoint) {
     /* Hide the editor toolbor in tutorial mode */
     .tutorial #editortools  {
-        background: transparent;
+        background: transparent !important;
     }
     .tutorial #maineditor > div.full-abs {
         bottom: 0;


### PR DESCRIPTION
Sim backgrounds were taking precedence over removing the editor bar's background in tutorial mode

Fixes https://github.com/Microsoft/pxt-microbit/issues/935