### PR TITLE
Fix save dialog

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1948,17 +1948,17 @@ export class ProjectView
     showRenameProjectDialogAsync(): Promise<boolean> {
         if (!this.state.header) return Promise.resolve(false);
 
-        const opts: core.ConfirmOptions = {
+        const opts: core.PromptOptions = {
             header: lf("Rename your project"),
             agreeLbl: lf("Save"),
             agreeClass: "green",
-            input: lf("Enter your project name here")
+            defaultValue: lf("Enter your project name here")
         };
-        return core.confirmAsync(opts).then(res => {
-            if (!res || !opts.inputValue) return Promise.resolve(false); // cancelled
+        return core.promptAsync(opts).then(res => {
+            if (!res) return Promise.resolve(false); // cancelled
 
             return new Promise<void>((resolve, reject) => {
-                this.setState({ projectName: opts.inputValue }, () => resolve());
+                this.setState({ projectName: res }, () => resolve());
             }).then(() => this.saveProjectNameAsync())
                 .then(() => true);
         });

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -153,8 +153,6 @@ export interface DialogOptions {
     body?: string;
     jsx?: JSX.Element;
     htmlBody?: string;
-    input?: string;
-    inputValue?: string; // set if input is enabled
     copyable?: string;
     size?: string; // defaults to "small"
     onLoaded?: (_: HTMLElement) => void;

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -96,10 +96,6 @@ export class CoreDialog extends React.Component<core.PromptOptions, {}> {
                 {options.jsx}
                 {options.body ? <p>{options.body}</p> : undefined}
                 {options.htmlBody ? <div dangerouslySetInnerHTML={{ __html: options.htmlBody }} /> : undefined}
-                {options.input ? <div className="ui fluid action input">
-                    <input className="userinput" spellCheck={false}
-                        placeholder={`${options.input}`} type="text" />
-                </div> : undefined}
                 {options.copyable ? <div className="ui fluid action input">
                     <input ref="linkinput" className="linkinput" readOnly spellCheck={false} type="text" value={`${options.copyable}`} />
                     <sui.Button ref="copybtn" labelPosition='right' color="teal" className='copybtn' data-content={lf("Copied!")} />


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1044

Also, the input option that was being passed to the confirm modal before had no way of getting the result (probably lost in some refactor somewhere) so I removed it. It was duplicating the functionality of the `promptAsync` anyhow.