### PR TITLE
Fixing the state management in the matrix field editor

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -36,6 +36,7 @@ namespace pxtblockly {
         private xAxisLabel: LabelMode = LabelMode.None;
 
         private cellState: boolean[][] = [];
+        private cells: SVGRectElement[][] = [];
         private elt: SVGSVGElement;
 
         private isMouseDown_: boolean;
@@ -82,13 +83,13 @@ namespace pxtblockly {
             // Initialize the matrix that holds the state
             for (let i = 0; i < this.matrixWidth; i++) {
                 this.cellState.push([])
+                this.cells.push([]);
                 for (let j = 0; j < this.matrixHeight; j++) {
                     this.cellState[i].push(false);
                 }
             }
 
             this.restoreStateFromString();
-            this.updateValue()
 
             // Create the cells of the matrix that is displayed
             for (let i = 0; i < this.matrixWidth; i++) {
@@ -96,6 +97,8 @@ namespace pxtblockly {
                     this.createCell(i, j);
                 }
             }
+
+            this.updateValue();
 
             if (this.xAxisLabel !== LabelMode.None) {
                 const y = this.matrixHeight * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_VERTICAL_MARGIN * 2 + FieldMatrix.BOTTOM_MARGIN
@@ -149,11 +152,10 @@ namespace pxtblockly {
 
             const cellG = pxsim.svg.child(this.elt, "g", { transform: `translate(${tx} ${ty})` }) as SVGGElement;
             const cellRect = pxsim.svg.child(cellG, "rect", { 'class': `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`, 'cursor': 'pointer', width: FieldMatrix.CELL_WIDTH, height: FieldMatrix.CELL_WIDTH, fill: this.getColor(x, y), rx: FieldMatrix.CELL_CORNER_RADIUS }) as SVGRectElement;
+            this.cells[x][y] = cellRect;
 
             const toggleRect = () => {
                 this.cellState[x][y] = this.currentDragState_;
-                cellRect.setAttribute("fill", this.getColor(x, y));
-                cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
                 this.updateValue();
             }
 
@@ -183,6 +185,25 @@ namespace pxtblockly {
 
         private getColor(x: number, y: number) {
             return this.cellState[x][y] ? this.onColor : this.offColor;
+        }
+
+        private updateCell(x: number, y: number) {
+            const cellRect = this.cells[x][y];
+            cellRect.setAttribute("fill", this.getColor(x, y));
+            cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
+        }
+
+        setValue(newValue: string | number, restoreState = true) {
+            super.setValue(newValue);
+            if (this.elt) {
+                if (restoreState) this.restoreStateFromString();
+
+                for (let x = 0; x < this.matrixWidth; x++) {
+                    for (let y = 0; y < this.matrixHeight; y++) {
+                        this.updateCell(x, y);
+                    }
+                }
+            }
         }
 
         render_() {
@@ -243,7 +264,7 @@ namespace pxtblockly {
             }
 
             // Blockly stores the state of the field as a string
-            this.setValue(res);
+            this.setValue(res, false);
         }
 
         private getYAxisWidth() {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/934

The UI for the matrix was only changed in response to UI events and not the actual value changed. That caused a few problems including undo/redo not toggling the cells