### PR TITLE
Adding max-height for tutorial hint previews

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -169,7 +169,11 @@ i.icon.avatar-image {
 
 .ui.segment .blocklyPreview {
     width: 100%;
+    @media only screen and (min-height: 400px) {
+        max-height: 50vh;
+    }
 }
+
 
 /******************************
     Hint button


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/932


`50vh === 50% of viewport height`
