### PR TITLE
Microsoft logo is missing even when setting @includePoweredByLogos

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -644,6 +644,7 @@ p.ui.font.small {
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
     #editorlogo > .poweredbylogo {
+        .includePoweredByLogos(); // set the @poweredByLarge variable
         background-image: @poweredByLarge;
     }
 }
@@ -651,6 +652,7 @@ p.ui.font.small {
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
     #editorlogo > .poweredbylogo {
+        .includePoweredByLogos(); // set the @poweredByLarge variable
         background-image: @poweredByLarge;
     }
 }
@@ -663,6 +665,7 @@ p.ui.font.small {
     #editorlogo > .poweredbylogo {
         height: 12px;
         bottom: 3px;
+        .includePoweredByLogos(); // set the @poweredBySmall variable
         background-image: @poweredBySmall;
     }
 }
@@ -675,6 +678,7 @@ p.ui.font.small {
     #editorlogo > .poweredbylogo {
         height: 13px;
         bottom: 3px;
+        .includePoweredByLogos(); // set the @poweredBySmall variable
         background-image: @poweredBySmall;
     }
 }


### PR DESCRIPTION
Microsoft logo is missing https://github.com/playi/pxt-wonder/issues/302

Root Cause:
Microsoft made a change to only show the 'Powered by Microsoft' logo when a certain variable is set. (Microsoft@65b8393#diff-9cebd1b4c653e57f52e3047257bc1adf)

However, in the 'poweredbylogo' .less classes that adjust the logo for various media, the @poweredBySmall and @poweredByLarge variables that set the background-image links are still set to be 'none'. To set these variables to actual urls based on the 'includePoweredByLogos' value, we need to call the .includePoweredByLogos() in each style block.

(FYI. I tried having the .includePoweredByLogos() outside of each specific poweredbylogo class, calling that function immediately after defining it in pxt code site.variables file, and calling that function after copying all those variables + function to the pxt-wonder version of site.variables. None of those places will set the variables so the background-image url is actually valid (they are always 'none').
The only place where calling the .includePoweredByLogos() function properly sets the variables is in each #editorlogo > .poweredbylogo class. )