### PR TITLE
Expose confirmAsync to extensions' deployCore method

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -193,6 +193,7 @@ namespace ts.pxtc {
         saveOnly?: boolean;
         userContextWindow?: Window;
         downloadFileBaseName?: string;
+        confirmAsync?: (confirmOptions: {}) => Promise<number>;
     }
 
     export interface Breakpoint extends LocationInfo {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1089,6 +1089,7 @@ export class ProjectView
                 resp.saveOnly = saveOnly
                 resp.userContextWindow = userContextWindow;
                 resp.downloadFileBaseName = pkg.genFileName("");
+                resp.confirmAsync = core.confirmAsync;
                 if (saveOnly) {
                     return pxt.commands.saveOnlyAsync(resp);
                 }


### PR DESCRIPTION
Required to port UWP app flashing timeout popup to v0