### PR TITLE
Adding idiv and imul to the math operation block

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1388,7 +1388,13 @@ ${output}</xml>`;
                     const r = mkExpr("math_js_op");
                     r.inputs = info.args.map((arg, index) => mkValue("ARG" + index, getOutputBlock(arg), "math_number"))
                     r.fields = [getField("OP", op)];
-                    r.mutation = { "op-type": info.args.length == 2 ? "binary" : "unary" };
+
+                    let opType: string;
+                    if (isUnaryMathFunction(op)) opType = "unary";
+                    else if (isInfixMathFunction(op)) opType = "infix";
+                    else opType = "binary";
+
+                    r.mutation = { "op-type": opType };
                     return r;
                 }
             }
@@ -2827,6 +2833,15 @@ ${output}</xml>`;
     }
 
     function isSupportedMathFunction(op: string) {
-        return pxt.blocks.MATH_FUNCTIONS.unary.indexOf(op) !== -1 || pxt.blocks.MATH_FUNCTIONS.binary.indexOf(op) !== -1;
+        return isUnaryMathFunction(op) || isInfixMathFunction(op) ||
+            pxt.blocks.MATH_FUNCTIONS.binary.indexOf(op) !== -1;
+    }
+
+    function isUnaryMathFunction(op: string) {
+        return pxt.blocks.MATH_FUNCTIONS.unary.indexOf(op) !== -1
+    }
+
+    function isInfixMathFunction(op: string) {
+        return pxt.blocks.MATH_FUNCTIONS.infix.indexOf(op) !== -1;
     }
 }

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -7,7 +7,8 @@ namespace pxt.blocks {
     // determines the order of the dropdown in the math_js_op block
     export const MATH_FUNCTIONS = {
         unary: ["sqrt", "sin", "cos", "tan", "round", "ceil", "floor", "trunc"],
-        binary: ["atan2", "idiv", "imul"]
+        binary: ["atan2"],
+        infix: ["idiv", "imul"]
     };
 
     export interface BlockParameter {

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -7,7 +7,7 @@ namespace pxt.blocks {
     // determines the order of the dropdown in the math_js_op block
     export const MATH_FUNCTIONS = {
         unary: ["sqrt", "sin", "cos", "tan", "round", "ceil", "floor", "trunc"],
-        binary: ["atan2"]
+        binary: ["atan2", "idiv", "imul"]
     };
 
     export interface BlockParameter {
@@ -392,10 +392,12 @@ namespace pxt.blocks {
                     "ceil": Util.lf("Returns the lowest integer value greater than or equal to the argument"),
                     "floor": Util.lf("Returns the highest integer value lesser than or equal to the argument"),
                     "trunc": Util.lf("Returns the highest integer value lesser than or equal to the argument"),
+                    "idiv": Util.lf("Returns the integer portion of the division operation on the two arguments"),
+                    "imul": Util.lf("Returns the integer portion of the multiplication operation on the two arguments")
                 },
                 url: '/blocks/math',
                 operators: {
-                    'OP': ["sqrt", "sin", "cos", "tan", "atan2", "round", "ceil", "floor", "trunc"]
+                    'OP': ["sqrt", "sin", "cos", "tan", "atan2", "round", "ceil", "floor", "trunc", "idiv", "imul"]
                 },
                 category: 'math',
                 block: {
@@ -408,6 +410,8 @@ namespace pxt.blocks {
                     "ceil": Util.lf("{id:op}ceiling"),
                     "floor": Util.lf("{id:op}floor"),
                     "trunc": Util.lf("{id:op}truncate"),
+                    "idiv": Util.lf("{id:op}integer ÷"),
+                    "imul": Util.lf("{id:op}integer ×"),
                 }
             },
             'variables_change': {

--- a/tests/decompile-test/baselines/math_infix_ops.blocks
+++ b/tests/decompile-test/baselines/math_infix_ops.blocks
@@ -1,0 +1,48 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">idiv_test</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="infix" />
+<field name="OP">idiv</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">2</field>
+</shadow>
+</value>
+<value name="ARG1">
+<shadow type="math_number">
+<field name="NUM">3</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">imul_test</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_js_op">
+<mutation op-type="infix" />
+<field name="OP">imul</field>
+<value name="ARG0">
+<shadow type="math_number">
+<field name="NUM">4</field>
+</shadow>
+</value>
+<value name="ARG1">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+</block>
+</value>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/math_infix_ops.ts
+++ b/tests/decompile-test/cases/math_infix_ops.ts
@@ -1,0 +1,2 @@
+let idiv_test = Math.idiv(2, 3);
+let imul_test = Math.imul(4, 5);


### PR DESCRIPTION
We are getting to the point where it might make sense to add some code to filter what appears in this block so it can be controlled per-target


Part of https://github.com/Microsoft/pxt-microbit/issues/1062