### PR TITLE
Enable local build in a docker container

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -52,6 +52,19 @@ export const buildEngines: Map<BuildEngine> = {
         appPath: "source"
     },
 
+    dockeryotta: {
+        updateEngineAsync: () => runDockerAsync(["yotta", "update"]),
+        buildAsync: () => runDockerAsync(["yotta", "build"]),
+        setPlatformAsync: () =>
+            runDockerAsync(["yotta", "target", pxt.appTarget.compileService.yottaTarget]),
+        patchHexInfo: patchYottaHexInfo,
+        prepBuildDirAsync: noopAsync,
+        buildPath: "built/dockeryt",
+        moduleConfig: "module.json",
+        deployAsync: msdDeployCoreAsync,
+        appPath: "source"
+    },
+
     platformio: {
         updateEngineAsync: noopAsync,
         buildAsync: () => runPlatformioAsync(["run"]),
@@ -117,13 +130,17 @@ export const buildEngines: Map<BuildEngine> = {
 export let thisBuild = buildEngines['yotta']
 
 export function setThisBuild(b: BuildEngine) {
-    if (b === buildEngines["codal"] && pxt.appTarget.compileService.dockerImage)
-        b = buildEngines["dockercodal"];
+    if (pxt.appTarget.compileService.dockerImage) {
+        if (b === buildEngines["codal"])
+            b = buildEngines["dockercodal"];
+        if (b === buildEngines["yotta"])
+            b = buildEngines["dockeryotta"];
+    }
     thisBuild = b;
 }
 
 function patchYottaHexInfo(extInfo: pxtc.ExtensionInfo) {
-    let buildEngine = buildEngines['yotta']
+    let buildEngine = thisBuild
     let hexPath = buildEngine.buildPath + "/build/" + pxt.appTarget.compileService.yottaTarget
         + "/source/" + pxt.appTarget.compileService.yottaBinary;
 

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -76,6 +76,18 @@ export const buildEngines: Map<BuildEngine> = {
         appPath: "pxtapp"
     },
 
+    dockercodal: {
+        updateEngineAsync: updateCodalBuildAsync,
+        buildAsync: () => runDockerAsync(["python", "build.py"]),
+        setPlatformAsync: noopAsync,
+        patchHexInfo: patchCodalHexInfo,
+        prepBuildDirAsync: prepCodalBuildDirAsync,
+        buildPath: "built/dockercodal",
+        moduleConfig: "codal.json",
+        deployAsync: msdDeployCoreAsync,
+        appPath: "pxtapp"
+    },
+
     dockermake: {
         updateEngineAsync: () => runBuildCmdAsync(nodeutil.addCmd("npm"), "install"),
         buildAsync: () => runDockerAsync(["make"]),
@@ -105,6 +117,8 @@ export const buildEngines: Map<BuildEngine> = {
 export let thisBuild = buildEngines['yotta']
 
 export function setThisBuild(b: BuildEngine) {
+    if (b === buildEngines["codal"] && pxt.appTarget.compileService.dockerImage)
+        b = buildEngines["dockercodal"];
     thisBuild = b;
 }
 

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -175,7 +175,7 @@ namespace pxt.cpp {
 
         const isCSharp = compile.nativeType == pxtc.NATIVE_TYPE_CS
         const isPlatformio = !!compileService.platformioIni;
-        const isCodal = compileService.buildEngine == "codal"
+        const isCodal = compileService.buildEngine == "codal" || compileService.buildEngine == "dockercodal"
         const isDockerMake = compileService.buildEngine == "dockermake"
         const isYotta = !isCSharp && !isPlatformio && !isCodal && !isDockerMake
         if (isPlatformio)


### PR DESCRIPTION
This enables docker build if `appTarget.compileService.dockerImage` is set - no need to install `cmake` or ARM toolchain. Works for CPX and microbit