### PR TITLE
Fixing monaco snippets for fixed instances, enums, and block definitions

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -874,22 +874,7 @@ namespace ts.pxtc.service {
                 case SK.BooleanKeyword: return "false";
                 case SK.ArrayType: return "[]";
                 case SK.TypeReference:
-                    if (checker) {
-                        const type = checker.getTypeAtLocation(param);
-                        if (type) {
-                            if (type.flags & ts.TypeFlags.Enum) {
-                                if (type.symbol) {
-                                    const decl = type.symbol.valueDeclaration as ts.EnumDeclaration;
-                                    if (decl.members.length && decl.members[0].name.kind === SK.Identifier) {
-                                        return `${type.symbol.name}.${(decl.members[0].name as ts.Identifier).text}`;
-                                    }
-                                }
-                                return `0`;
-                            } else if (type.flags & (ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral)) {
-                                return `0`;
-                            }
-                        }
-                    }
+                    // handled below
                     break;
                 case SK.FunctionType:
                     const tn = typeNode as ts.FunctionTypeNode;
@@ -902,12 +887,20 @@ namespace ts.pxtc.service {
 
             const type = checker ? checker.getTypeAtLocation(param) : undefined;
             if (type) {
-                if (isObjectType(type) && type.objectFlags & ts.ObjectFlags.Anonymous) {
-                    const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
-                    if (sigs.length) {
-                        return getFunctionString(sigs[0]);
+                if (isObjectType(type)) {
+                    if (type.objectFlags & ts.ObjectFlags.Anonymous) {
+                        const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
+                        if (sigs.length) {
+                            return getFunctionString(sigs[0]);
+                        }
+                        return `function () {}`;
                     }
-                    return `function () {}`;
+                }
+                if (type.flags & ts.TypeFlags.EnumLike) {
+                    return getDefaultEnumValue(type, checker);
+                }
+                if (type.flags & ts.TypeFlags.NumberLike) {
+                    return "0";
                 }
             }
             return "null";
@@ -938,5 +931,28 @@ namespace ts.pxtc.service {
 
             return `function ${functionArgument} {\n    ${returnValue}\n}`
         }
+    }
+
+    function getDefaultEnumValue(t: Type, checker: TypeChecker) {
+        // Note: AFAIK this is NOT guranteed to get the same default as you get in
+        // blocks. That being said, it should get the first declared value. Only way
+        // to guarantee an API has the same default in blocks and in TS is to actually
+        // set a default on the parameter in its comment attributes
+        if (t.symbol && t.symbol.declarations && t.symbol.declarations.length) {
+            for (let i = 0; i < t.symbol.declarations.length; i++) {
+                const decl = t.symbol.declarations[i];
+                if (decl.kind === SK.EnumDeclaration) {
+                    const enumDeclaration = decl as EnumDeclaration;
+                    for (let j = 0; j < enumDeclaration.members.length; j++) {
+                        const member = enumDeclaration.members[i];
+                        if (member.name.kind === SK.Identifier) {
+                            return checker.getFullyQualifiedName(checker.getSymbolAtLocation(member.name));
+                        }
+                    }
+                }
+            }
+        }
+
+        return "0";
     }
 }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1231,12 +1231,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     // first try to get fixed instances whose retType matches nsInfo.name
                     // e.g., DigitalPin
                     let exactInstances = fixedInstances.filter(value =>
-                        value.retType == nsInfo.name)
+                        value.retType == nsInfo.qName)
                         .sort((v1, v2) => v1.name.localeCompare(v2.name));
                     // second choice: use fixed instances whose retType extends type of nsInfo.name
                     // e.g., nsInfo.name == AnalogPin and instance retType == PwmPin
                     let extendedInstances = fixedInstances.filter(value =>
-                        getExtendsTypesFor(nsInfo.name).indexOf(value.retType) !== -1)
+                        getExtendsTypesFor(nsInfo.qName).indexOf(value.retType) !== -1)
                         .sort((v1, v2) => v1.name.localeCompare(v2.name));
                     if (exactInstances.length) {
                         snippetPrefix = `${exactInstances[0].name}`
@@ -1248,7 +1248,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
                 else if (element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Property) {
                     const params = pxt.blocks.compileInfo(element);
-                    snippetPrefix = params.thisParameter.definitionName;
+                    snippetPrefix = params.thisParameter.defaultValue || params.thisParameter.definitionName;
                     isInstance = true;
                 }
                 else if (nsInfo.kind === pxtc.SymbolKind.Class) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/925

This PR fixes three issues:
1. Enum arguments were always being replaced as 0 or null (now we grab the first declared member)
2. Fixed instances of types with qualified names exported from a namespace (e.g. `input.Button` rather than top-level `Button`) were generating weird snippets with the namespace showing up twice

3. The Monaco toolbox was ignoring default values for variable blocks. This was affecting a few of the changes I recently made in pxt-microbit for the image and game blocks