### PR TITLE
Fix `question not found` section

### DIFF
--- a/common-docs/faq.md
+++ b/common-docs/faq.md
@@ -36,6 +36,6 @@ When you share a project it's saved to the public cloud for MakeCode. Anyone can
 * You can save the project and copy it to a class website or to an approved location on the class or school network.
 * You can copy code from and paste code into the JavaScript view of the editor. This let's you move code between MakeCode and other applications on your computer or device.
 
-## I can't my answer here. What's next?
+## I don't see my question here. What's next?
 
 Can't find your question? Please see our [support](/support) page.


### PR DESCRIPTION
Typo in the 'can't find question' section heading.