### PR TITLE
 Add 'pxt dumplog' to dump codal's log

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -130,7 +130,7 @@ export const buildEngines: Map<BuildEngine> = {
 export let thisBuild = buildEngines['yotta']
 
 export function setThisBuild(b: BuildEngine) {
-    if (pxt.appTarget.compileService.dockerImage) {
+    if (pxt.appTarget.compileService.dockerImage && !process.env["PXT_NODOCKER"]) {
         if (b === buildEngines["codal"])
             b = buildEngines["dockercodal"];
         if (b === buildEngines["yotta"])

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3520,6 +3520,12 @@ function gdbAsync(c: commandParser.ParsedCommand) {
         .then(() => gdb.startAsync(c.args))
 }
 
+function dumplogAsync(c: commandParser.ParsedCommand) {
+    ensurePkgDir()
+    return mainPkg.loadAsync()
+        .then(() => gdb.dumplogAsync())
+}
+
 function buildDalDTSAsync() {
     ensurePkgDir()
     return mainPkg.loadAsync()
@@ -5354,6 +5360,13 @@ function initCommands() {
         advanced: true,
         onlineHelp: true
     }, gdbAsync);
+
+    p.defineCommand({
+        name: "dumplog",
+        help: "attempt to dump log using openocd",
+        argString: "",
+        advanced: true,
+    }, dumplogAsync);
 
     p.defineCommand({
         name: "builddaldts",

--- a/cli/gdb.ts
+++ b/cli/gdb.ts
@@ -155,9 +155,10 @@ export function startAsync(gdbArgs: string[]) {
     let toolPaths = getOpenOcdPath()
     let oargs = toolPaths.args
 
+    // use / not \ for paths on Windows; otherwise gdb has issue starting openocd
     fs.writeFileSync("built/openocd.gdb",
         `
-target remote | ${oargs.map(s => `"${s}"`).join(" ")}
+target remote | ${oargs.map(s => `"${s.replace(/\\/g, "/")}"`).join(" ")}
 define rst
   set {int}(0x20008000-4) = 0xf02669ef
   monitor reset halt

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2170,7 +2170,7 @@ ${lbl}: .short 0xffff
                     let d = getDecl(e)
                     if (d && (d.kind == SK.EnumMember || d.kind == SK.VariableDeclaration))
                         return getFullName(checker, d.symbol)
-                    else if (e.kind == SK.StringLiteral)
+                    else if (e && e.kind == SK.StringLiteral)
                         return (e as StringLiteral).text
                     else return "*"
                 }).join(",")


### PR DESCRIPTION
Also:
* use a pipe instead of a socket to invoke gdb; now tested on mac and win
* allow setting `PXT_NODOCKER` to force non-docker build
* bugfix for compilation failure in Adafruit (neopixel init)
