### PR TITLE
Making the block definition parser a bit more forgiving

### DIFF
--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -277,25 +277,24 @@ describe("comment attribute parser", () => {
             });
 
             describe("errors", () => {
+                it("should not allow orphaned style tags", () => {
+                    parseDef("hello_world %arg", `hello_world `, param`arg`);
+                });
+
                 it("should not allow mismatched style tags", () => {
-                    parseDef("*hello_");
-                    parseDef("***hello_");
-                    parseDef("_hello***")
+                    parseDef("*hello_", `*hello_`);
+                    parseDef("***hello_", `***hello_`);
+                    parseDef("_hello***", `_hello***`)
                 });
 
                 it("should not allow style tags around pipes", () => {
-                    parseDef("*hello|world*");
-                    parseDef("***hello|world***");
+                    parseDef("*hello|world*", `*hello`, brk(), `world*`);
+                    parseDef("***hello|world***", `***hello`, brk(), `world***`);
                 });
 
                 it("should not allow style tags around parameters", () => {
-                    parseDef("*hello %the world*");
-                    parseDef("hello *%the* world");
-                });
-
-                it("should not allow style tags around pipes", () => {
-                    parseDef("*hello|world*");
-                    parseDef("***hello|world***");
+                    parseDef("*hello %the world*", `*hello `, param`the`, ` world*`);
+                    parseDef("hello *%the* world", `hello *`, param`the`, `* world`);
                 });
             })
         });
@@ -316,7 +315,7 @@ describe("comment attribute parser", () => {
 
             describe("errors", () => {
                 it("should not allow unterminated image markup", () => {
-                    parseDef("`I forgot to close it");
+                    parseDef("`I forgot to close it", "`I forgot to close it");
                 });
             });
         });
@@ -336,15 +335,15 @@ describe("comment attribute parser", () => {
 
             describe("errors", () => {
                 it("should not allow unclosed brackets", () => {
-                    parseDef("[some text(custom)")
+                    parseDef("[some text(custom)", `[some text(custom)`)
                 });
 
                 it("should not allow unclosed parens", () => {
-                    parseDef("[some text](custom")
+                    parseDef("[some text](custom", `[some text](custom`)
                 });
 
                 it("should not allow brackets that are not followed by parens", () => {
-                    parseDef("[some text] (custom)")
+                    parseDef("[some text] (custom)", `[some text] (custom)`)
                 });
             });
         });
@@ -399,8 +398,8 @@ describe("comment attribute parser", () => {
 
             describe("errors", () => {
                 it("should not allow parameters with too many equals", () => {
-                    parseDef("%no=good=")
-                    parseDef("%still=no=good")
+                    parseDef("%no=good=", `%no=good=`)
+                    parseDef("%still=no=good", `%still=no=good`)
                 });
             })
         });


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1090

Makes the block definition parser no longer error out if the definition is incorrect. Style marks still cannot go across any boundary that causes a new input to be added to the block (e.g. a parameter or a pipe) but now we'll leave in the old text and continue on instead of returning undefined.
