### PR TITLE
Fixing some bugs with iframe controller scenario and adding settracestate

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -169,6 +169,7 @@ namespace pxt.editor {
         toggleSimulatorFullscreen(): void;
         proxySimulatorMessage(content: string): void;
         toggleTrace(intervalSpeed?: number): void;
+        setTrace(enabled: boolean, intervalSpeed?: number): void;
         toggleMute(): void;
         openInstructions(): void;
         closeFlyout(): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -50,6 +50,7 @@ namespace pxt.editor {
         | "setscale"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
+        | "settracestate" // EditorMessageSetTraceStateRequest
 
         | "workspacesync" // EditorWorspaceSyncRequest
         | "workspacereset"
@@ -184,6 +185,13 @@ namespace pxt.editor {
         intervalSpeed?: number;
     }
 
+    export interface EditorMessageSetTraceStateRequest extends EditorMessageRequest {
+        action: "settracestate";
+        enabled: boolean;
+        // interval speed for the execution trace
+        intervalSpeed?: number;
+    }
+
     export interface PackageExtensionData {
         ts: string;
         json?: any;
@@ -216,7 +224,7 @@ namespace pxt.editor {
      * The response (EditorMessageResponse) contains the request id and result.
      * Some commands may be async, use the ``id`` field to correlate to the original request.
      */
-    export function bindEditorMessages(projectView: IProjectView) {
+    export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) {
         const allowEditorMessages = (pxt.appTarget.appTheme.allowParentController || pxt.shell.isControllerMode())
                                     && pxt.BrowserUtils.isIFrame();
         const allowExtensionMessages = pxt.appTarget.appTheme.allowPackageExtensions;
@@ -230,7 +238,9 @@ namespace pxt.editor {
 
             if (data.type === "pxtpkgext" && allowExtensionMessages) {
                 // Messages sent to the editor iframe from a child iframe containing an extension
-                projectView.handleExtensionRequest(data as ExtensionRequest);
+                getEditorAsync().then(projectView => {
+                    projectView.handleExtensionRequest(data as ExtensionRequest);
+                })
             }
             else if (data.type === "pxtsim" && allowSimTelemetry) {
                 const event = data as EditorMessageEventRequest;
@@ -255,66 +265,73 @@ namespace pxt.editor {
                         p = p.then(() => req.resolve(data as EditorMessageResponse));
                     }
                 } else if (data.type == "pxteditor") { // request from the editor
-                    const req = data as EditorMessageRequest;
-                    pxt.debug(`pxteditor: ${req.action}`);
-                    switch (req.action.toLowerCase()) {
-                        case "switchjavascript": p = p.then(() => projectView.openJavaScript()); break;
-                        case "switchblocks": p = p.then(() => projectView.openBlocks()); break;
-                        case "startsimulator": p = p.then(() => projectView.startSimulator()); break;
-                        case "restartsimulator": p = p.then(() => projectView.restartSimulator()); break;
-                        case "hidesimulator": p = p.then(() => projectView.collapseSimulator()); break;
-                        case "showsimulator": p = p.then(() => projectView.expandSimulator()); break;
-                        case "closeflyout": p = p.then(() => projectView.closeFlyout()); break;
-                        case "redo": p = p.then(() => {
-                            const editor = projectView.editor;
-                            if (editor && editor.hasRedo())
-                                editor.redo();
-                        }); break;
-                        case "undo": p = p.then(() => {
-                            const editor = projectView.editor;
-                            if (editor && editor.hasUndo())
-                                editor.undo();
-                        }); break;
-                        case "setscale": {
-                            const zoommsg = data as EditorMessageSetScaleRequest;
-                            p = p.then(() => projectView.editor.setScale(zoommsg.scale));
-                            break;
+                    getEditorAsync().then(projectView => {
+                        const req = data as EditorMessageRequest;
+                        pxt.debug(`pxteditor: ${req.action}`);
+                        switch (req.action.toLowerCase()) {
+                            case "switchjavascript": p = p.then(() => projectView.openJavaScript()); break;
+                            case "switchblocks": p = p.then(() => projectView.openBlocks()); break;
+                            case "startsimulator": p = p.then(() => projectView.startSimulator()); break;
+                            case "restartsimulator": p = p.then(() => projectView.restartSimulator()); break;
+                            case "hidesimulator": p = p.then(() => projectView.collapseSimulator()); break;
+                            case "showsimulator": p = p.then(() => projectView.expandSimulator()); break;
+                            case "closeflyout": p = p.then(() => projectView.closeFlyout()); break;
+                            case "redo": p = p.then(() => {
+                                const editor = projectView.editor;
+                                if (editor && editor.hasRedo())
+                                    editor.redo();
+                            }); break;
+                            case "undo": p = p.then(() => {
+                                const editor = projectView.editor;
+                                if (editor && editor.hasUndo())
+                                    editor.undo();
+                            }); break;
+                            case "setscale": {
+                                const zoommsg = data as EditorMessageSetScaleRequest;
+                                p = p.then(() => projectView.editor.setScale(zoommsg.scale));
+                                break;
+                            }
+                            case "stopsimulator": {
+                                const stop = data as EditorMessageStopRequest;
+                                p = p.then(() => projectView.stopSimulator(stop.unload));
+                                break;
+                            }
+                            case "newproject": {
+                                const create = data as EditorMessageNewProjectRequest;
+                                p = p.then(() => projectView.newProject(create.options));
+                                break;
+                            }
+                            case "importproject": {
+                                const load = data as EditorMessageImportProjectRequest;
+                                p = p.then(() => projectView.importProjectAsync(load.project, {
+                                    filters: load.filters,
+                                    searchBar: load.searchBar
+                                }));
+                                break;
+                            }
+                            case "proxytosim": {
+                                const simmsg = data as EditorMessageSimulatorMessageProxyRequest;
+                                p = p.then(() => projectView.proxySimulatorMessage(simmsg.content));
+                                break;
+                            }
+                            case "renderblocks": {
+                                const rendermsg = data as EditorMessageRenderBlocksRequest;
+                                p = p.then(() => projectView.renderBlocksAsync(rendermsg))
+                                    .then((r: any) => { resp = r.xml; });
+                                break;
+                            }
+                            case "toggletrace": {
+                                const togglemsg = data as EditorMessageToggleTraceRequest;
+                                p = p.then(() => projectView.toggleTrace(togglemsg.intervalSpeed));
+                                break;
+                            }
+                            case "settracestate": {
+                                const trcmsg = data as EditorMessageSetTraceStateRequest;
+                                p = p.then(() => projectView.setTrace(trcmsg.enabled, trcmsg.intervalSpeed));
+                                break;
+                            }
                         }
-                        case "stopsimulator": {
-                            const stop = data as EditorMessageStopRequest;
-                            p = p.then(() => projectView.stopSimulator(stop.unload));
-                            break;
-                        }
-                        case "newproject": {
-                            const create = data as EditorMessageNewProjectRequest;
-                            p = p.then(() => projectView.newProject(create.options));
-                            break;
-                        }
-                        case "importproject": {
-                            const load = data as EditorMessageImportProjectRequest;
-                            p = p.then(() => projectView.importProjectAsync(load.project, {
-                                filters: load.filters,
-                                searchBar: load.searchBar
-                            }));
-                            break;
-                        }
-                        case "proxytosim": {
-                            const simmsg = data as EditorMessageSimulatorMessageProxyRequest;
-                            p = p.then(() => projectView.proxySimulatorMessage(simmsg.content));
-                            break;
-                        }
-                        case "renderblocks": {
-                            const rendermsg = data as EditorMessageRenderBlocksRequest;
-                            p = p.then(() => projectView.renderBlocksAsync(rendermsg))
-                                .then((r: any) => { resp = r.xml; });
-                            break;
-                        }
-                        case "toggletrace": {
-                            const togglemsg = data as EditorMessageToggleTraceRequest;
-                            p = p.then(() => projectView.toggleTrace(togglemsg.intervalSpeed));
-                            break;
-                        }
-                    }
+                    });
                 }
                 p.done(() => sendResponse(data, resp, true, undefined),
                     (err) => sendResponse(data, resp, false, err))

--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -88,6 +88,9 @@
         } else if (action == 'toggletrace') {
             msg.intervalSpeed = 1000;
         }
+        else if (action == 'settracestate') {
+            msg.enabled = true;
+        }
         if (msg.response)
             pendingMsgs[msg.id] = msg;
         editor.postMessage(msg, "*")
@@ -162,7 +165,8 @@
         <button class="ui button" onclick="sendMessage('newproject')">newproject</button>
         <button class="ui button" onclick="sendMessage('importproject')">importproject</button>
         <button class="ui button" onclick="toggleFilters()">filter</button>
-        <button class="ui button" onclick="sendMessage('toggletrace')">trace</button>
+        <button class="ui button" onclick="sendMessage('toggletrace')">toggle trace</button>
+        <button class="ui button" onclick="sendMessage('settracestate')">trace on</button>
         <button class="ui button" onclick="sendMessage('undo')">undo</button>
         <button class="ui button" onclick="sendMessage('redo')">redo</button>
         <button class="ui button" onclick="sendMessage('renderblocks')">renderblocks</button>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -61,6 +61,26 @@ import Util = pxt.Util;
 pxsim.util.injectPolyphils();
 
 let theEditor: ProjectView;
+let pendingEditorRequests: ((p: ProjectView) => void)[];
+
+function getEditorAsync() {
+    if (theEditor) return Promise.resolve(theEditor);
+    if (!pendingEditorRequests) pendingEditorRequests = [];
+    return new Promise<ProjectView>(resolve => {
+        pendingEditorRequests.push(resolve);
+    });
+}
+
+function setEditor(editor: ProjectView) {
+    theEditor = editor;
+    if (pendingEditorRequests) {
+        while (pendingEditorRequests.length) {
+            const resolve = pendingEditorRequests.shift();
+            resolve(editor);
+        }
+        pendingEditorRequests = undefined;
+    }
+}
 
 export class ProjectView
     extends data.Component<IAppProps, IAppState>
@@ -1527,6 +1547,16 @@ export class ProjectView
         this.restartSimulator();
     }
 
+    setTrace(enabled: boolean, intervalSpeed?: number) {
+        if (this.state.tracing !== enabled) {
+            this.toggleTrace(intervalSpeed);
+        }
+        else if (this.state.tracing) {
+            simulator.setTraceInterval(intervalSpeed != undefined ? intervalSpeed : simulator.SLOW_TRACE_INTERVAL);
+            this.restartSimulator();
+        }
+    }
+
     startSimulator(debug?: boolean) {
         pxt.tickEvent('simulator.start')
         this.saveFileAsync()
@@ -2178,7 +2208,7 @@ export class ProjectView
     ///////////////////////////////////////////////////////////
 
     renderCore() {
-        theEditor = this;
+        setEditor(this);
 
         //  ${targetTheme.accentColor ? "inverted accent " : ''}
         const targetTheme = pxt.appTarget.appTheme;
@@ -2744,7 +2774,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const isSandbox = pxt.shell.isSandboxMode() || pxt.shell.isReadOnly();
     const isController = pxt.shell.isControllerMode();
     if (ws) workspace.setupWorkspace(ws[1]);
-    else if (pxt.appTarget.appTheme.allowParentController || isController) workspace.setupWorkspace("iframe");
+    else if ((pxt.appTarget.appTheme.allowParentController || isController) && pxt.BrowserUtils.isIFrame()) workspace.setupWorkspace("iframe");
     else if (isSandbox) workspace.setupWorkspace("mem");
     else if (pxt.winrt.isWinRT()) workspace.setupWorkspace("uwp");
     else if (Cloud.isLocalHost() || electron.isPxtElectron) workspace.setupWorkspace("fs");
@@ -2798,7 +2828,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 || pxt.appTarget.appTheme.allowPackageExtensions
                 || pxt.appTarget.appTheme.allowSimulatorTelemetry
                 || pxt.shell.isControllerMode())
-                pxt.editor.bindEditorMessages(this);
+                pxt.editor.bindEditorMessages(getEditorAsync);
 
             return workspace.initAsync()
         })


### PR DESCRIPTION
Adding a pxt controller command for setting the trace state in the editor (the only one that was surfaced was a toggle).

Also fixes a race condition with binding the editor messages and a bug where any target that had `allowParentController` set to true can only be served in an iFrame. Previously you could serve both in and out of an iFrame but the new iFrame workspace provider blocks on a message from the host.

I probably should have done this in separate commits...

@dragonx 
