### PR TITLE
Allow any two types to be compared in blocks

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1553,6 +1553,9 @@ namespace pxt.blocks {
                 that._selectedItem.addSelect();
             }
         };
+
+        // Get rid of bumping behavior
+        (Blockly as any).Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN.onchange = function () {}
     }
 
     function initOnStart() {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1050

Removes the type bumping behavior of the Blockly comparison block.

Where once there was this:
![old_comparison](https://user-images.githubusercontent.com/13754588/44430616-19959400-a550-11e8-9498-309410a74361.gif)


Now there is this:

![new_comparison](https://user-images.githubusercontent.com/13754588/44430620-1c908480-a550-11e8-914e-961756a1abab.gif)


The weird outline bug is unrelated
