### PR TITLE
Fixing iOS touch events for matrix field

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -141,6 +141,9 @@ namespace pxtblockly {
             pxsim.pointerEvents.down.forEach(evid => this.sourceBlock_.getSvgRoot().removeEventListener(evid, this.dontHandleMouseEvent_));
             this.sourceBlock_.getSvgRoot().removeEventListener(pxsim.pointerEvents.move, this.dontHandleMouseEvent_);
             document.removeEventListener(pxsim.pointerEvents.up, this.clearLedDragHandler);
+            document.removeEventListener(pxsim.pointerEvents.leave, this.clearLedDragHandler);
+
+            (Blockly as any).Touch.clearTouchIdentifier();
 
             ev.stopPropagation();
             ev.preventDefault();
@@ -170,6 +173,7 @@ namespace pxtblockly {
                 this.sourceBlock_.getSvgRoot().addEventListener(pxsim.pointerEvents.move, this.dontHandleMouseEvent_);
 
                 document.addEventListener(pxsim.pointerEvents.up, this.clearLedDragHandler);
+                document.addEventListener(pxsim.pointerEvents.leave, this.clearLedDragHandler);
 
                 ev.stopPropagation();
                 ev.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1095

The issue was that the event that ended the touch gesture in iOS was incorrect (we were subscribing to `mouseup` instead of `touchend`).

Tested in Edge, IE, Chrome, Firefox, Safari, and mobile Safari (via the simulator, not a real device). 
