### PR TITLE
Allow reusing translations of other APIs

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -265,13 +265,12 @@ namespace ts.pxtc {
 
         const locStrings: pxt.Map<string> = {};
         const jsdocStrings: pxt.Map<string> = {};
-        const nameToFilename = (n: string) => n.replace(/([A-Z])/g, function (m) { return '-' + m.toLowerCase(); });
         const writeLoc = (si: SymbolInfo) => {
             if (!options.locs || !si.qName) {
                 return;
             }
-            if (si.attributes.deprecated || /^__/.test(si.name))
-                return; // skip deprecated or function starting with __
+            if (/^__/.test(si.name))
+                return; // skip functions starting with __
             pxt.debug(`loc: ${si.qName}`)
             // must match blockly loader
             if (si.kind != SymbolKind.EnumMember) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -165,6 +165,8 @@ namespace ts.pxtc {
         group?: string;
         whenUsed?: boolean;
         jres?: string;
+        useLoc?: string; // The qName of another API whose localization will be used if this API is not translated and if both block definitions are identical
+        untranslatedBlock?: string; // The block definition before it was translated
         // On namepspace
         subcategories?: string[];
         groups?: string[];
@@ -498,7 +500,7 @@ namespace ts.pxtc {
                 }
                 ex.attributes.block =
                     isGet ? `%${paramName} %property` :
-                    isSet ? `set %${paramName} %property to %${paramValue}` :
+                        isSet ? `set %${paramName} %property to %${paramValue}` :
                             `change %${paramName} %property by %${paramValue}`
                 updateBlockDef(ex.attributes)
                 blocks.push(ex)
@@ -632,7 +634,21 @@ namespace ts.pxtc {
                         fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || pi.description);
                 }
                 const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
-                const locBlock = loc[`${fn.qName}|block`];
+                let locBlock = loc[`${fn.qName}|block`];
+
+                if (!locBlock && fn.attributes.useLoc) {
+                    const otherFn = apis.byQName[fn.attributes.useLoc];
+
+                    if (otherFn) {
+                        const otherTranslation = loc[`${otherFn.qName}|block`];
+                        const isSameBlockDef = fn.attributes.block === (otherFn.attributes.untranslatedBlock || otherFn.attributes.block);
+
+                        if (isSameBlockDef && !!otherTranslation) {
+                            locBlock = otherTranslation;
+                        }
+                    }
+                }
+
                 if (nsDoc) {
                     // Check for "friendly namespace"
                     if (fn.attributes.block) {
@@ -645,6 +661,7 @@ namespace ts.pxtc {
                     const ps = pxt.blocks.compileInfo(fn);
                     const oldBlock = fn.attributes.block;
                     fn.attributes.block = pxt.blocks.normalizeBlock(locBlock);
+                    fn.attributes.untranslatedBlock = oldBlock;
                     if (oldBlock != fn.attributes.block) {
                         const locps = pxt.blocks.compileInfo(fn);
                         if (JSON.stringify(ps) != JSON.stringify(locps)) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -166,7 +166,6 @@ namespace ts.pxtc {
         whenUsed?: boolean;
         jres?: string;
         useLoc?: string; // The qName of another API whose localization will be used if this API is not translated and if both block definitions are identical
-        untranslatedBlock?: string; // The block definition before it was translated
         // On namepspace
         subcategories?: string[];
         groups?: string[];
@@ -208,6 +207,7 @@ namespace ts.pxtc {
         _source?: string;
         _def?: ParsedBlockDef;
         _expandedDef?: ParsedBlockDef;
+        _untranslatedBlock?: string; // The block definition before it was translated
         jsDoc?: string;
         paramHelp?: pxt.Map<string>;
         // foo.defl=12 -> paramDefl: { foo: "12" }
@@ -641,7 +641,7 @@ namespace ts.pxtc {
 
                     if (otherFn) {
                         const otherTranslation = loc[`${otherFn.qName}|block`];
-                        const isSameBlockDef = fn.attributes.block === (otherFn.attributes.untranslatedBlock || otherFn.attributes.block);
+                        const isSameBlockDef = fn.attributes.block === (otherFn.attributes._untranslatedBlock || otherFn.attributes.block);
 
                         if (isSameBlockDef && !!otherTranslation) {
                             locBlock = otherTranslation;
@@ -661,7 +661,7 @@ namespace ts.pxtc {
                     const ps = pxt.blocks.compileInfo(fn);
                     const oldBlock = fn.attributes.block;
                     fn.attributes.block = pxt.blocks.normalizeBlock(locBlock);
-                    fn.attributes.untranslatedBlock = oldBlock;
+                    fn.attributes._untranslatedBlock = oldBlock;
                     if (oldBlock != fn.attributes.block) {
                         const locps = pxt.blocks.compileInfo(fn);
                         if (JSON.stringify(ps) != JSON.stringify(locps)) {


### PR DESCRIPTION
Needed for https://github.com/Microsoft/pxt-microbit/issues/907 and other scenarios where we deprecate APIs and replace them with different APIs that have the same block definition. This lets us leverage existing translations.

Note that this partially undoes https://github.com/Microsoft/pxt-microbit/issues/907, but it wasn't clear why we stopped extracting deprecated API strings, as those blocks can still appear in user projects. Maybe @pelikhan can explain when he's back?