### PR TITLE
Ext search spinner

### DIFF
--- a/theme/scriptsearch.less
+++ b/theme/scriptsearch.less
@@ -19,6 +19,15 @@
     color: white;
 }
 
+.ui.searchdialog.modal .ui.inline.loader {
+    margin-top: 4em;
+}
+.ui.searchdialog.modal .ui.inline.loader:after,
+.ui.searchdialog.modal .ui.inline.loader:before {
+    width: 4rem;
+    height: 4rem;
+}
+
 /*******************************
         Modal Back Icon
 *******************************/
@@ -26,7 +35,7 @@
 .ui.modal .ui.button.labeled.icon.editorBack {
     color: white !important;
     position: absolute;
-    top: 0; 
+    top: 0;
     left: 0;
     height: 3.5rem;
     outline: none !important;

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -208,7 +208,7 @@ function lookup(path: string) {
     return cachedData[path]
 }
 
-function getCached<T>(component: AnyComponent, path: string): DataFetchResult<T> {
+function getCached(component: AnyComponent, path: string): DataFetchResult<any> {
     subscribe(component, path)
     let r = lookup(path)
     if (r.api.isSync)
@@ -217,7 +217,7 @@ function getCached<T>(component: AnyComponent, path: string): DataFetchResult<T>
             status: FetchStatus.Complete
         }
 
-    let fetchRes: DataFetchResult<T> = {
+    let fetchRes: DataFetchResult<any> = {
         data: r.data,
         status: FetchStatus.Complete
     };
@@ -299,17 +299,17 @@ export class Component<TProps, TState> extends React.Component<TProps, TState> {
     }
 
     getData(path: string) {
-        const fetchResult = this.getDataWithStatus<any>(path);
+        const fetchResult = this.getDataWithStatus(path);
         return fetchResult.data;
     }
 
     /**
      * Like getData, but the data is wrapped in a result object that indicates the status of the fetch operation
      */
-    getDataWithStatus<T>(path: string): DataFetchResult<T> {
+    getDataWithStatus(path: string): DataFetchResult<any> {
         if (!this.renderCoreOk)
             Util.oops("Override renderCore() not render()")
-        return getCached<T>(this, path)
+        return getCached(this, path)
     }
 
     componentWillUnmount(): void {

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -17,7 +17,12 @@ interface CacheEntry {
     api: VirtualApi;
 }
 
-export enum FetchStatus { Pending, Complete, Error, Offline };
+export enum FetchStatus {
+    Pending,
+    Complete,
+    Error,
+    Offline
+};
 
 export interface DataFetchResult<T> {
     data?: T;

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -279,10 +279,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const ghdata = this.fetchGhData();
         const urldata = this.fetchUrlData();
         const local = this.fetchLocal()
-
-        const isSearchingGh = ghdata.status === data.FetchStatus.Pending || ghdata.status === data.FetchStatus.Error;
-        const isSearchingUrl = urldata.status === data.FetchStatus.Pending || urldata.status === data.FetchStatus.Error;
-        const isSearching = this.state.searchFor && (isSearchingGh || isSearchingUrl);
+        const isSearching = this.state.searchFor && (ghdata.status === data.FetchStatus.Pending || urldata.status === data.FetchStatus.Pending);
 
         const coresFirst = (a: pxt.PackageConfig, b: pxt.PackageConfig) => {
             if (a.core != b.core)


### PR DESCRIPTION
Adds a spinner for search. This is especially important with our backend now indexing and caching packages, since it can take up to 8 seconds to perform a search (for the unlucky user that hits our backend cache reset, happens once every 5min).

Current experience:
![currentsearch](https://user-images.githubusercontent.com/14299377/44674274-ff99fc80-a9fa-11e8-95f8-e9c9aaa52f16.gif)

With this change:
![searchspinner](https://user-images.githubusercontent.com/14299377/44674282-06287400-a9fb-11e8-8b3a-51986e727bc5.gif)

Some notes:
- With this change, the search bar and button are disabled while a search is in progress
- For both the current experience and this change, subsequent searches are very fast

Fixes https://github.com/Microsoft/pxt-microbit/issues/1121
