### PR TITLE
Make extension errors more visible

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -269,6 +269,7 @@ declare namespace pxt {
         copyrightText?: string; // footer text for any copyright text to be included at the bottom of the home screen and about page
         appFlashingTroubleshoot?: string; // Path to the doc about troubleshooting UWP app flashing failures, e.g. /device/windows-app/troubleshoot
         browserDbPrefixes?: { [majorVersion: number]: string }; // Prefix used when storing projects in the DB to allow side-by-side projects of different major versions
+        editorVersionPaths?: { [majorVersion: number]: string }; // A map of major editor versions to their corresponding paths (alpha, v1, etc.)
     }
 
     interface SocialOptions {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -37,6 +37,7 @@ namespace pxt.editor {
         sideDocsLoadUrl?: string; // set once to load the side docs frame
         sideDocsCollapsed?: boolean;
         projectName?: string;
+        suppressPackageWarning?: boolean;
 
         tutorialOptions?: TutorialOptions;
         lightbox?: boolean;

--- a/pxteditor/workspace.ts
+++ b/pxteditor/workspace.ts
@@ -15,6 +15,7 @@ namespace pxt.workspace {
         pubCurrent: boolean; // is this exactly pubId, or just based on it
         githubId?: string;
         githubCurrent?: boolean;
+        originalTargetVersion?: string; // the version of the target the project was created in (present if imported into newer version)
     }
 
     export interface Header extends InstallHeader {
@@ -54,7 +55,7 @@ namespace pxt.workspace {
     }
 
     export interface WorkspaceProvider {
-        listAsync(): Promise<Header[]>; // called from workspace.syncAsync (including upon startup)        
+        listAsync(): Promise<Header[]>; // called from workspace.syncAsync (including upon startup)
         getAsync(h: Header): Promise<File>;
         setAsync(h: Header, prevVersion: Version, text?: ScriptText): Promise<Version>;
         deleteAsync?: (h: Header, prevVersion: Version) => Promise<void>;

--- a/theme/common.less
+++ b/theme/common.less
@@ -15,7 +15,7 @@ html {
     overflow: hidden;
     font-size:16px;
 }
-  
+
 body {
     height: 100%;
     padding: 0;
@@ -535,6 +535,28 @@ Field editors
 .social-icons a.twitter {
     color: white;
     background-color: #00aced;
+}
+
+/*******************************
+    Extension Error Dialog
+*******************************/
+
+.package-diagnostics {
+    -webkit-transition: opacity 0.2s, height 0.2s 0.2s; /* Safari */
+    -moz-transition: opacity 0.2s, height 0.2s 0.2s; /* Mozilla */
+    -webkit-transition-timing-function: linear; /* Mozilla */
+    -o-transition: opacity 0.2s, height 0.2s 0.2s; /* Opera */
+    transition: opacity 0.2s, height 0.2s 0.2s;
+    transition-timing-function: linear;
+    height: 0px;
+    opacity: 0;
+    visibility: hidden;
+}
+
+.package-diagnostics.expanded-list {
+    height: unset;
+    visibility: visible;
+    opacity: 1;
 }
 
 /*******************************

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -405,16 +405,18 @@ export class ProjectView
                 const headerVersion = pxt.semver.parse(h.targetVersion);
 
                 let openHandler: () => void;
-                if (currentVersion.major !== headerVersion.major) {
+                if (workspace.isBrowserWorkspace() && currentVersion.major !== headerVersion.major) {
                     openHandler = () => {
                         this.openProjectInLegacyEditor(headerVersion.major);
                     };
                 }
 
-                dialogs.showPackageErrorDialogAsync(badPackages, id => {
-                    return pkg.mainEditorPkg().removeDepAsync(id)
-                    .then(() => this.reloadHeaderAsync())
-                }, openHandler);
+                dialogs.showPackageErrorDialogAsync(badPackages, pkg.mainEditorPkg(), openHandler)
+                    .then(didChange => {
+                        if (didChange) {
+                            this.reloadHeaderAsync();
+                        }
+                    });
                 return true;
             }
         }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -46,12 +46,7 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
     }
 
     if (!resp.success) {
-        return core.confirmAsync({
-            header: lf("Compilation failed"),
-            body: lf("Ooops, looks like there are errors in your program."),
-            hideAgree: true,
-            disagreeLbl: lf("Close")
-        }).then(() => { });
+        return Promise.resolve();
     }
 
     if (resp.saveOnly && userContext) return pxt.commands.showUploadInstructionsAsync(fn, url, core.confirmAsync); // save does the same as download as far iOS is concerned

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -239,6 +239,21 @@ export function newProject() {
     workerOpAsync("reset", {}).done();
 }
 
+export function getPackagesWithErrors(): pkg.EditorPackage[] {
+    const badPackages: pxt.Map<pkg.EditorPackage> = {};
+
+    const topPkg = pkg.mainEditorPkg();
+    if (topPkg) {
+        topPkg.forEachFile(file => {
+            if (file.diagnostics && file.diagnostics.length && file.epkg && !file.epkg.isTopLevel() &&
+                    file.diagnostics.some(d => d.category === ts.pxtc.DiagnosticCategory.Error)) {
+                badPackages[file.epkg.getPkgId()] = file.epkg;
+            }
+        });
+    }
+    return pxt.Util.values(badPackages);
+}
+
 function blocksOptions(): pxtc.service.BlocksOptions {
     if (pxt.appTarget && pxt.appTarget.runtime && pxt.appTarget.runtime.bannedCategories && pxt.appTarget.runtime.bannedCategories.length) {
         return { bannedCategories: pxt.appTarget.runtime.bannedCategories };

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -112,20 +112,25 @@ export function renderConfirmDialogAsync(options: core.PromptOptions): Promise<v
         .delay(10)
         .then(() => {
             const wrapper = document.body.appendChild(document.createElement('div'));
-            currentDialog = ReactDOM.render(React.createElement(CoreDialog, options), wrapper);
+            const newDialog = ReactDOM.render(React.createElement(CoreDialog, options), wrapper);
+            currentDialog = newDialog;
 
             function cleanup() {
                 ReactDOM.unmountComponentAtNode(wrapper);
                 setTimeout(() => {
                     wrapper.parentElement.removeChild(wrapper);
+                    if (newDialog === currentDialog) currentDialog = undefined;
                 })
             }
-            return currentDialog.promise.finally(() => cleanup());
+            return newDialog.promise.finally(() => cleanup());
         });
 }
 
 export function hideDialog() {
-    if (currentDialog) currentDialog.hide();
+    if (currentDialog)  {
+        currentDialog.hide();
+        currentDialog = undefined;
+    }
 }
 
 export interface LoadingDimmerProps {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -7,6 +7,7 @@ import * as core from "./core";
 import * as cloudsync from "./cloudsync";
 
 import Cloud = pxt.Cloud;
+import { EditorPackage } from "./package";
 
 
 interface PlainCheckboxProps {
@@ -193,7 +194,104 @@ function renderVersionLink(name: string, version: string, url: string) {
     </p>;
 }
 
+export function showPackageErrorDialogAsync(badPackages: EditorPackage[]) {
+    core.confirmAsync({
+        header: lf("Extension Errors"),
+        hideCancel: true,
+        agreeLbl: lf("Ok"),
+        agreeClass: "positive",
+        jsx: <div>
+                <p>{pxt.Util.lf("The following extensions are preventing the project from compiling:")}</p>
+                <div className="ui relaxed divided list">
+                {
+                    badPackages.map(epkg => <PackageErrorListItem package={epkg} key={epkg.getPkgId()}></PackageErrorListItem>)
+                }
+            </div>
+            <div className="ui message">
+                <p>{pxt.Util.lf("If this project was made in an older version of the editor, it may not be compatible with the latest version.")} <a>{pxt.Util.lf("Learn More")}</a></p>
+            </div>
+        </div>
+    }).done();
+}
 
+interface PackageErrorListItemProps {
+    package: EditorPackage;
+}
+
+interface PackageErrorListItemState {
+    expanded: boolean;
+}
+
+class PackageErrorListItem extends React.Component<PackageErrorListItemProps, PackageErrorListItemState> {
+
+    toggle() {
+        this.setState({ expanded: !(this.state && this.state.expanded) });
+    }
+
+    render() {
+        const epkg = this.props.package;
+        const kspkg = epkg.getKsPkg();
+        const protocol = kspkg.verProtocol();
+
+        let displayName = epkg.getPkgId();
+        let displayVersion = kspkg.version();
+        let url: string;
+        let icon: JSX.Element;
+
+        switch (protocol) {
+            case "github":
+                displayVersion = kspkg.verArgument();
+                const parsed = pxt.github.parseRepoId(displayVersion);
+                url = pxt.Util.pathJoin("https://github.com", parsed.fullName);
+                icon = <i className="large github middle aligned icon"></i>;
+                break;
+            case "pub":
+                url = pxt.Util.pathJoin(pxt.appTarget.appTheme.shareUrl || "https://makecode.com/", kspkg.verArgument());
+                displayVersion = lf("shared script {0}", kspkg.verArgument());
+                icon = <i className="large share alternate middle aligned icon"></i>;
+                break;
+        }
+
+        const errors = collectErrors(epkg);
+        const isExpanded = this.state && this.state.expanded;
+
+        return <div className="item" key={pxt.Util.htmlEscape(epkg.getPkgId())}>
+            <div className="right floated content">
+                <div className="ui button">{pxt.Util.lf("Remove")}</div>
+            </div>
+            { icon }
+            <div className="content">
+                <a className="header" href={url} >{`${displayName} (${displayVersion})`}</a>
+                <div className="description" onClick={this.toggle.bind(this)}>
+                    {errors.length > 1 ? lf("Found {0} errors", errors.length) : lf("Found {0} error", errors.length) }
+                    <i className={`small middle aligned icon caret ${isExpanded ? "down" : "right"}`}></i>
+                </div>
+                <div className={`list package-diagnostics ${isExpanded ? "expanded-list" : ""}`}>
+                    {
+                        errors.map((d, index) => <div className="extra" key={index}>
+                            {`${formatErrorPath(d.fileName)} (line ${d.line + 1}) TS${d.code}: ${ts.pxtc.flattenDiagnosticMessageText(d.messageText, "\n")}`}
+                        </div>)
+                    }
+                </div>
+            </div>
+        </div>
+    }
+}
+
+function collectErrors(epkg: EditorPackage) {
+    const result: pxtc.KsDiagnostic[] = [];
+    pxt.Util.values(epkg.files).forEach(f => f.diagnostics && f.diagnostics.forEach(d => d.category === ts.pxtc.DiagnosticCategory.Error && result.push(d)));
+    return result;
+}
+
+function formatErrorPath(fileName: string) {
+    const parts = fileName.split(/[\\\/]/);
+    if (parts.length > 2) {
+        // The first two parts are pxt_modules and the name of the package
+        return parts.splice(2).join("/");
+    }
+    return fileName;
+}
 
 export function showCommitDialogAsync(repo: string) {
     let input: HTMLInputElement;

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -234,15 +234,15 @@ interface PackageErrorListItemState {
 
 class PackageErrorListItem extends React.Component<PackageErrorListItemProps, PackageErrorListItemState> {
 
-    toggle() {
+    toggle = () => {
         this.setState({ expanded: !(this.state && this.state.expanded) });
     }
 
-    pendingRemoval() {
+    pendingRemoval = () => {
         this.setState({ pendingRemoval: true });
     }
 
-    clearPending() {
+    clearPending = () => {
         this.setState({ pendingRemoval: false });
     }
 
@@ -279,9 +279,9 @@ class PackageErrorListItem extends React.Component<PackageErrorListItemProps, Pa
             { isPending ?
                 <div>
                     <button className="ui button negative" onClick={this.props.removePackage}>{pxt.Util.lf("Remove")}</button>
-                    <button className="ui button" onClick={this.clearPending.bind(this)}>{pxt.Util.lf("Cancel")}</button>
+                    <button className="ui button" onClick={this.clearPending}>{pxt.Util.lf("Cancel")}</button>
                 </div> :
-                <button className="ui icon button" onClick={this.pendingRemoval.bind(this)}>
+                <button className="ui icon button" onClick={this.pendingRemoval}>
                     <i className="trash icon"></i>
                 </button>
             }
@@ -289,7 +289,7 @@ class PackageErrorListItem extends React.Component<PackageErrorListItemProps, Pa
             { icon }
             <div className="content">
                 <a className="header" href={url} >{`${displayName} (${displayVersion})`}</a>
-                <div className="description" onClick={this.toggle.bind(this)}>
+                <div className="description" onClick={this.toggle} role="button">
                     {errors.length > 1 ? lf("Found {0} errors", errors.length) : lf("Found {0} error", errors.length) }
                     <i className={`small middle aligned icon caret ${isExpanded ? "down" : "right"}`}></i>
                 </div>

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -195,7 +195,7 @@ function renderVersionLink(name: string, version: string, url: string) {
     </p>;
 }
 
-export function showPackageErrorDialogAsync(badPackages: EditorPackage[], removePackage: (id: string) => Promise<void>) {
+export function showPackageErrorDialogAsync(badPackages: EditorPackage[], removePackage: (id: string) => Promise<void>, openLegacyEditor?: () => void) {
     core.confirmAsync({
         header: lf("Extension Errors"),
         hideCancel: true,
@@ -208,9 +208,7 @@ export function showPackageErrorDialogAsync(badPackages: EditorPackage[], remove
                     badPackages.map(epkg => <PackageErrorListItem package={epkg} key={epkg.getPkgId()} removePackage={curryRemove(epkg.getPkgId())}></PackageErrorListItem>)
                 }
             </div>
-            <div className="ui message">
-                <p>{pxt.Util.lf("If this project was made in an older version of the editor, it may not be compatible with the latest version.")} <a>{pxt.Util.lf("Learn More")}</a></p>
-            </div>
+            { openLegacyEditor ? renderEditorVersionMessage(openLegacyEditor) : undefined }
         </div>
     }).done();
 
@@ -220,6 +218,12 @@ export function showPackageErrorDialogAsync(badPackages: EditorPackage[], remove
             return removePackage(id)
         }
     }
+}
+
+export function renderEditorVersionMessage(onClick: () => void) {
+    return <div className="ui message">
+        <p>{pxt.Util.lf("This project was made in an older version of the editor and may not be compatible with the latest version. To open the project in the old editor,")} <a onClick={onClick}>{pxt.Util.lf("Click here")}.</a></p>
+    </div>
 }
 
 interface PackageErrorListItemProps {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -44,7 +44,7 @@ export function gitsha(data: string) {
 }
 
 export function copyProjectToLegacyEditor(header: Header, majorVersion: number): Promise<Header> {
-    if (impl != cloudworkspace.provider) {
+    if (!isBrowserWorkspace()) {
         return Promise.reject("Copy operation only works in browser workspace");
     }
     return cloudworkspace.copyProjectToLegacyEditor(header, majorVersion);
@@ -666,6 +666,10 @@ export function listAssetsAsync(id: string): Promise<pxt.workspace.Asset[]> {
     if (impl.listAssetsAsync)
         return impl.listAssetsAsync(id)
     return Promise.resolve([])
+}
+
+export function isBrowserWorkspace() {
+    return impl === cloudworkspace.provider;
 }
 
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -43,6 +43,13 @@ export function gitsha(data: string) {
     return (sha1("blob " + U.toUTF8(data).length + "\u0000" + data) + "")
 }
 
+export function copyProjectToLegacyEditor(header: Header, majorVersion: number): Promise<Header> {
+    if (impl != cloudworkspace.provider) {
+        return Promise.reject("Copy operation only works in browser workspace");
+    }
+    return cloudworkspace.copyProjectToLegacyEditor(header, majorVersion);
+}
+
 export function setupWorkspace(id: string) {
     U.assert(!impl, "workspace set twice");
     pxt.debug(`workspace: ${id}`);
@@ -193,10 +200,10 @@ export function saveAsync(h: Header, text?: ScriptText, isCloud?: boolean): Prom
             h.pubCurrent = false
             h.blobCurrent = false
             h.modificationTime = U.nowSeconds();
-            h.targetVersion = pxt.appTarget.versions.target;
+            h.targetVersion = h.targetVersion || pxt.appTarget.versions.target;
         }
         h.saveId = null
-        // update version on save    
+        // update version on save
     }
 
     // perma-delete


### PR DESCRIPTION
If an extension you add to your project contains errors it's pretty difficult to determine where the error preventing compilation is coming from. The current experience just gives a toast that says "compilation failed, please check your code for errors", which is at best unhelpful and at worst misleading (if the errors aren't actually in your code). The only way to determine that a package contains errors is to switch to JavaScript and expand the file explorer.

This PR adds a new dialog that indicates when the errors are not your fault:

![ext_dialog_final](https://user-images.githubusercontent.com/13754588/44678627-a6779c00-a9ed-11e8-9a1f-219b58a7d635.gif)

Works for both Github packages and for shared URLs added as extensions. The dialog shows when you load a project, attempt to download/save, or attempt to start the simulator.


Currently the "Learn More" link doesn't lead anywhere (hence the DO NOT MERGE). @ganicke @jaustin is there a page describing the migration from v0 to master that I should be linking to?
