### PR TITLE
Fix function category icon

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -83,7 +83,7 @@ task('clean', function () {
                 console.log("cannot unlink:", f, e.message)
             }
         })
-        jake.rmRf(d)    
+        jake.rmRf(d)
     })
 })
 
@@ -495,6 +495,13 @@ file('built/web/icons.css', expand(["svgicons"]), { async: true }, function () {
         templateOptions: {
             classPrefix: name + ".",
             baseClass: name
+        },
+        // The following icons have fixed code points because they are referenced in the code
+        codepoints: {
+            function: 0xf109,
+            bucket: 0xf102,
+            undo: 0xf118,
+            redo: 0xf111
         },
         writeFiles: false,
     }, function (error, res) {


### PR DESCRIPTION
We generate a font for the icons included in the `svgicons/` directory and they get assigned random codepoints in alphabetical order. Usually that's fine because we create a css file and it has classes that hide you from having to know the codepoint (just like what semantic does for fontawesome). However, it turns out we reference the codepoint directly in the Blockly toolbox so when I recently added an icon it changed the function category's icon into something else.

This change sets the codepoints for all of the icons that we reference in that manner. The values are pretty arbitrary and all of the other icons will still get random codepoints based on alphabetic order.
