### PR TITLE
Handle to string for union types

### DIFF
--- a/tests/compile-test/compilerunner.ts
+++ b/tests/compile-test/compilerunner.ts
@@ -158,18 +158,22 @@ function runCoreAsync(res: pxtc.CompileResult) {
     return new Promise<void>((resolve, reject) => {
         let f = res.outfiles[pxtc.BINARY_JS]
         if (f) {
+            let timeout = setTimeout(() => {
+                reject(new Error("Simulating code timed out"))
+            }, 5000);
             let r = new pxsim.Runtime({ type: "run", code: f })
             r.errorHandler = (e) => {
+                clearTimeout(timeout);
                 reject(e);
             }
             r.run(() => {
-                // console.log("DONE")
+                clearTimeout(timeout);
                 pxsim.dumpLivePointers();
                 resolve()
             })
         }
         else {
-            reject("No compiled js");
+            reject(new Error("No compiled js"));
         }
     })
 }

--- a/tests/compile-test/lang-test0/45enumtostring.ts
+++ b/tests/compile-test/lang-test0/45enumtostring.ts
@@ -1,0 +1,17 @@
+msg("test enum to string")
+
+function getABoolean() {
+    return !!true;
+}
+
+enum SomeEnum {
+    One = 1,
+    Two = 2
+}
+
+let enumTest = getABoolean() ? SomeEnum.One : SomeEnum.Two;
+
+assert(`${enumTest}` === "2", "enum tostring in template")
+assert(enumTest + "" === "1", "enum tostring in concatenation")
+
+msg("test OK!")

--- a/tests/compile-test/lang-test0/45enumtostring.ts
+++ b/tests/compile-test/lang-test0/45enumtostring.ts
@@ -11,7 +11,7 @@ enum SomeEnum {
 
 let enumTest = getABoolean() ? SomeEnum.One : SomeEnum.Two;
 
-assert(`${enumTest}` === "2", "enum tostring in template")
+assert(`${enumTest}` === "1", "enum tostring in template")
 assert(enumTest + "" === "1", "enum tostring in concatenation")
 
 msg("test OK!")


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1156

Here's a snippet that shows the issue:

```typescript
enum Switch {
    On,
    Off
}

let x = Math.randomBoolean() ? Switch.On : Switch.Off;
basic.showString(`${x}`)
```


The Typescript compiler interprets the type of x as `Switch.On | Switch.Off`