### PR TITLE
Changes to decompiler to support tutorials

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -360,7 +360,7 @@ namespace ts.pxtc.decompiler {
 
         const getCommentRef = (() => { let currentCommentId = 0; return () => `${currentCommentId++}` })();
 
-        ts.forEachChild(file, topLevelNode => {
+        const checkTopNode = (topLevelNode: Node) => {
             if (topLevelNode.kind === SK.FunctionDeclaration && !checkStatement(topLevelNode, env, false, true)) {
                 env.declaredFunctions[getVariableName((topLevelNode as ts.FunctionDeclaration).name)] = true;
             }
@@ -377,7 +377,12 @@ namespace ts.pxtc.decompiler {
                     });
                 });
             }
-        })
+            else if (topLevelNode.kind === SK.Block) {
+                ts.forEachChild(topLevelNode, checkTopNode);
+            }
+        };
+
+        ts.forEachChild(file, checkTopNode);
 
         if (enumMembers.length) {
             write("<variables>")
@@ -445,7 +450,10 @@ ${output}</xml>`;
             if (blockInfo) {
                 return blockInfo.attributes;
             }
-            return undefined;
+            return {
+                paramDefl: {},
+                callingConvention: ir.CallingConvention.Plain
+            };
         }
 
         function countBlock() {


### PR DESCRIPTION
This fixes two tutorial issues:

1. The first pass by the decompiler (which pulls out functions and enums) wasn't running for tutorial snippets because we put each snippet in a code block to prevent name collisions
2. Reference errors were being thrown because not every symbol in the snippet code was making it into the API info passed to the decompiler (the API info is created with the user's code, not the snippet code). Usually we shove in fake comment attributes for these symbols so I replicated that behavior here.