### PR TITLE
support for parse-float / parse to number

### DIFF
--- a/common-docs/reference/math/from-char-code.md
+++ b/common-docs/reference/math/from-char-code.md
@@ -42,4 +42,4 @@ for (let code of secret) {
 
 ## See also
 
-[parse int](/reference/text/parse-int)
+[parse float](/reference/text/parse-float)

--- a/common-docs/reference/string.md
+++ b/common-docs/reference/string.md
@@ -12,4 +12,4 @@ parseInt("");
 ## See also
 
 [char at](/reference/text/char-at), [compare](/reference/text/compare),
-[substr](/reference/text/substr), [parse int](/reference/text/parse-int)
+[substr](/reference/text/substr), [parse float](/reference/text/parse-float)

--- a/common-docs/reference/text.md
+++ b/common-docs/reference/text.md
@@ -6,10 +6,12 @@ Functions to combine, split, and search text strings.
 "".charAt(0);
 "".compare("");
 "".substr(0, 0);
+parseFloat("");
 parseInt("");
 ```
 
 ## See also
 
 [char at](/reference/text/char-at), [compare](/reference/text/compare),
-[substr](/reference/text/substr), [parse int](/reference/text/parse-int)
+[substr](/reference/text/substr), [parse int](/reference/text/parse-int), 
+[parse float](/reference/text/parse-float)

--- a/common-docs/reference/text/parse-float.md
+++ b/common-docs/reference/text/parse-float.md
@@ -15,6 +15,6 @@ parseFloat("0.5");
 Take the first digits of PI from the sentence and turn it into a number.
 
 ```blocks
-let pi = "pi is 3.14...";
-let freezing = parseFloat(pi.substr(6, 3));
+let text = "pi is 3.14...";
+let pi = parseFloat(text.substr(6, 3));
 ```

--- a/common-docs/reference/text/parse-float.md
+++ b/common-docs/reference/text/parse-float.md
@@ -1,0 +1,20 @@
+# parse Float
+
+Turn text that has just number characters into a floating point number value.
+
+```sig
+parseFloat("0.5");
+```
+
+## Returns
+
+* a [number](/types/string) value for the text number in the string.
+
+## Example #exsection
+
+Take the temperature text from the sentence and turn it into a number.
+
+```blocks
+let pi = "pi is 3.14...";
+let freezing = parseFloat(pi.substr(6, 3));
+```

--- a/common-docs/reference/text/parse-float.md
+++ b/common-docs/reference/text/parse-float.md
@@ -12,7 +12,7 @@ parseFloat("0.5");
 
 ## Example #exsection
 
-Take the temperature text from the sentence and turn it into a number.
+Take the first digits of PI from the sentence and turn it into a number.
 
 ```blocks
 let pi = "pi is 3.14...";

--- a/common-docs/reference/text/parse-int.md
+++ b/common-docs/reference/text/parse-int.md
@@ -1,6 +1,6 @@
 # parse Int
 
-Turn text that has just number characters into a real number value. The number is an integer.
+Turn text that has just number characters into an integer number value.
 
 ```sig
 parseInt("0");
@@ -21,6 +21,6 @@ attempt at converting to a number. So, try not to mix number characters with let
 Take the temperature text from the sentence and turn it into a number.
 
 ```blocks
-let frozenWater = "The freezing temprature of water is 32 degrees Fahrenheit.";
-let freezing = parseInt(frozenWater.substr(36, 2));
+let frozenWater = "The freezing temperature of water is 32 degrees Fahrenheit.";
+let freezing = parseInt(frozenWater.substr(37, 2));
 ```

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -241,14 +241,14 @@ declare interface String {
 }
 
 /**
-  * Convert a string to an integer.
+  * Convert a string to a number.
   * @param s A string to convert into a number. eg: 123
   */
 //% shim=String_::toNumber
-//% help=text/parse-int
-//% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
+//% help=text/parse-float
+//% blockId="string_parsefloat" block="parse to number %text" blockNamespace="text"
 //% text.defl="123"
-declare function parseInt(text: string): number;
+declare function parseFloat(text: string): number;
 
 interface Object { }
 interface Function { }

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -1,5 +1,18 @@
 type Action = () => void;
 
+
+/**
+  * Convert a string to an integer.
+  * @param s A string to convert into an integral number. eg: 123
+  */
+//% help=text/parse-int
+//% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
+//% text.defl="123"
+//% blockHidden=1
+function parseInt(text: string): number {
+    return parseFloat(text) >> 0;
+}
+
 namespace helpers {
     export function arraySplice<T>(arr: T[], start: number, len: number) {
         if (start < 0) {

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -241,14 +241,14 @@ declare interface String {
 }
 
 /**
-  * Convert a string to an integer.
+  * Convert a string to a number.
   * @param s A string to convert into a number. eg: 123
   */
 //% shim=String_::toNumber
-//% help=text/parse-int
-//% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
+//% help=text/parse-float
+//% blockId="string_parsefloat" block="parse to number %text" blockNamespace="text"
 //% text.defl="123"
-declare function parseInt(text: string): number;
+declare function parseFloat(text: string): number;
 
 interface Object { }
 interface Function { }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -1,5 +1,18 @@
 type Action = () => void;
 
+
+/**
+  * Convert a string to an integer.
+  * @param s A string to convert into an integral number. eg: 123
+  */
+//% help=text/parse-int
+//% blockId="string_parseint" block="parse to integer %text" blockNamespace="text"
+//% text.defl="123"
+//% blockHidden=1
+function parseInt(text: string): number {
+    return parseFloat(text) >> 0;
+}
+
 namespace helpers {
     export function arraySplice<T>(arr: T[], start: number, len: number) {
         if (start < 0) {

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -335,10 +335,6 @@ namespace pxsim {
             return initString(String.fromCharCode(code));
         }
 
-        export function toInt(s: string) {
-            return parseInt(s);
-        }
-
         export function toNumber(s: string) {
             return parseFloat(s);
         }

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -335,8 +335,12 @@ namespace pxsim {
             return initString(String.fromCharCode(code));
         }
 
-        export function toNumber(s: string) {
+        export function toInt(s: string) {
             return parseInt(s);
+        }
+
+        export function toNumber(s: string) {
+            return parseFloat(s);
         }
 
         // TODO check edge-conditions


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-microbit/issues/1028

Adds support for "parseFloat" (which is renamed to "parse to number"  in blocks). Currently, parseInt does not fully follow the JS semantic, i.e. parseInt("1e1") in JS is 1 while it would be 10 in MakeCode. Our simulator and C++ have the same behavior so I assume this is fine.

The String_::toNumber function in MakeCode microbit v1 already actually parses floating point numbers (https://github.com/Microsoft/pxt-microbit/blob/v1/libs/core/core.cpp#L251) 