### PR TITLE
Handle string += operator in decompiler

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -716,20 +716,7 @@ ${output}</xml>`;
 
             // Could be string concatenation
             if (isTextJoin(n)) {
-                const args: ts.Node[] = [];
-                collectTextJoinArgs(n, args);
-
-                const result = mkExpr("text_join");
-                result.mutation = {
-                    "items": args.length.toString()
-                };
-                result.inputs = [];
-
-                for (let i = 0; i < args.length; i++) {
-                    result.inputs.push(getValue("ADD" + i, args[i], stringType));
-                }
-
-                return result;
+                return getTextJoin(n);
             }
 
             const result = mkExpr(npp.type);
@@ -747,27 +734,44 @@ ${output}</xml>`;
 
             return result;
 
-            function isTextJoin(n: ts.Node): boolean {
-                if (n.kind === SK.BinaryExpression) {
-                    const b = n as ts.BinaryExpression;
-                    if (b.operatorToken.getText() === "+") {
-                        const info: BinaryExpressionInfo = (n as any).exprInfo;
-                        return !!info;
-                    }
-                }
+        }
 
-                return false;
+        function isTextJoin(n: ts.Node): boolean {
+            if (n.kind === SK.BinaryExpression) {
+                const b = n as ts.BinaryExpression;
+                if (b.operatorToken.getText() === "+" || b.operatorToken.kind == SK.PlusEqualsToken) {
+                    const info: BinaryExpressionInfo = (n as any).exprInfo;
+                    return !!info;
+                }
             }
 
-            function collectTextJoinArgs(n: ts.Node, result: ts.Node[]) {
-                if (isTextJoin(n)) {
-                    collectTextJoinArgs((n as ts.BinaryExpression).left, result);
-                    collectTextJoinArgs((n as ts.BinaryExpression).right, result)
-                }
-                else {
-                    result.push(n);
-                }
+            return false;
+        }
+
+        function collectTextJoinArgs(n: ts.Node, result: ts.Node[]) {
+            if (isTextJoin(n)) {
+                collectTextJoinArgs((n as ts.BinaryExpression).left, result);
+                collectTextJoinArgs((n as ts.BinaryExpression).right, result);
             }
+            else {
+                result.push(n);
+            }
+        }
+
+        function getTextJoin(n: ts.Node) {
+            const args: ts.Node[] = [];
+            collectTextJoinArgs(n, args);
+
+            const result = mkExpr("text_join");
+            result.mutation = {
+                "items": args.length.toString()
+            };
+            result.inputs = [];
+
+            for (let i = 0; i < args.length; i++) {
+                result.inputs.push(getValue("ADD" + i, args[i], stringType));
+            }
+            return result;
         }
 
         function getValue(name: string, contents: boolean | number | string | Node, shadowType?: string): ValueNode {
@@ -1175,6 +1179,15 @@ ${output}</xml>`;
                         return getArraySetBlock(n.left as ts.ElementAccessExpression, n.right);
                     }
                 case SK.PlusEqualsToken:
+                    if (isTextJoin(n)) {
+                        const r = mkStmt("variables_set");
+                        const renamed = getVariableName(n.left as ts.Identifier);
+                        trackVariableUsage(renamed, ReferenceType.InBlocksOnly);
+                        r.inputs = [mkValue("VALUE", getTextJoin(n), numberType)];
+                        r.fields = [getField("VAR", renamed)];
+                        return r;
+                    }
+
                     if (n.left.kind == SK.PropertyAccessExpression)
                         return getPropertySetBlock(n.left as ts.PropertyAccessExpression, n.right, "@change@");
                     else

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3413,8 +3413,8 @@ ${lbl}: .short 0xffff
             let lt = typeOf(node.left)
             let rt = typeOf(node.right)
 
-            if (node.operatorToken.kind == SK.PlusToken) {
-                if (isStringType(lt) || isStringType(rt)) {
+            if (node.operatorToken.kind == SK.PlusToken || node.operatorToken.kind == SK.PlusEqualsToken) {
+                if (isStringType(lt) || (isStringType(rt) && node.operatorToken.kind == SK.PlusToken)) {
                     (node as any).exprInfo = { leftType: checker.typeToString(lt), rightType: checker.typeToString(rt) } as BinaryExpressionInfo;
                 }
             }

--- a/tests/decompile-test/baselines/string_append.blocks
+++ b/tests/decompile-test/baselines/string_append.blocks
@@ -1,0 +1,94 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text">
+<field name="TEXT">hello</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">y</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text">
+<field name="TEXT">!</field>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="ADD1">
+<shadow type="text">
+<field name="TEXT"> world</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="math_number">
+<field name="NUM">1</field>
+</block>
+</value>
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">y</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/string_append.ts
+++ b/tests/decompile-test/cases/string_append.ts
@@ -1,0 +1,6 @@
+let x = "hello";
+let y = "!";
+
+x += " world";
+x += 1;
+x += y;


### PR DESCRIPTION
Handle += operator for strings in script ==> blocks conversion. Fixes #4634.

converts

```ts
let out = "hello ";
out += "world";
```

to the blocks for

```ts
let out = "hello ";
out = out + "world";
```

(previously assumed the values being +='d were numbers, so it would pass the check step and then fail to decompile for anything besides appending a number to the string)