### PR TITLE
render block as bw outlines

### DIFF
--- a/theme/print.less
+++ b/theme/print.less
@@ -75,4 +75,18 @@
         margin-right: 2.5cm;
         margin-bottom: 2cm;
     }
+
+    /** blockly **/
+    .blocklyPath {
+        stroke-width: 3px !important;
+        stroke: black;
+        fill: white;
+    }
+    .blocklyBlockBackground {
+        stroke-width: 2px;
+        fill: white;
+    }
+    .blocklyText {
+        fill: black;
+    }
 }


### PR DESCRIPTION
Render blocks in bw to maximize readability in low-res printers.
![image](https://user-images.githubusercontent.com/4175913/45188479-5a94d600-b1e9-11e8-9d44-2d255f0eb559.png)
