### PR TITLE
Add option to hide "save" in gearwheel

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -265,6 +265,7 @@ declare namespace pxt {
         defaultBlockGap?: number; // For targets to override block gap
         hideShareEmbed?: boolean; // don't show advanced embedding options in share dialog
         hideNewProjectButton?: boolean; // do not show the "new project" button in home page
+        saveInMenu?: boolean; // move save icon under gearwheel menu
         fileNameExclusiveFilter?: string; // anything that does not match this regex is removed from the filename,
         copyrightText?: string; // footer text for any copyright text to be included at the bottom of the home screen and about page
         appFlashingTroubleshoot?: string; // Path to the doc about troubleshooting UWP app flashing failures, e.g. /device/windows-app/troubleshoot

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -144,6 +144,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         this.showPackageDialog = this.showPackageDialog.bind(this);
         this.showBoardDialog = this.showBoardDialog.bind(this);
         this.removeProject = this.removeProject.bind(this);
+        this.saveProject = this.saveProject.bind(this);
         this.showReportAbuse = this.showReportAbuse.bind(this);
         this.showLanguagePicker = this.showLanguagePicker.bind(this);
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
@@ -167,6 +168,11 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     showBoardDialog() {
         pxt.tickEvent("menu.changeboard", undefined, { interactiveConsent: true });
         this.props.parent.showBoardDialog();
+    }
+
+    saveProject() {
+        pxt.tickEvent("menu.saveproject", undefined, { interactiveConsent: true });
+        this.props.parent.saveAndCompile();
     }
 
     removeProject() {
@@ -236,13 +242,16 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const packages = pxt.appTarget.cloud && !!pxt.appTarget.cloud.packages;
         const boards = pxt.appTarget.simulator && !!pxt.appTarget.simulator.dynamicBoardDefinition;
         const reportAbuse = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
+        const readOnly = pxt.shell.isReadOnly();
         const isController = pxt.shell.isControllerMode();
+        const showSave = !readOnly && !isController && !!targetTheme.saveInMenu;
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} tabIndex={-1} />
             {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} tabIndex={-1} /> : undefined}
             {boards ? <sui.Item role="menuitem" icon="microchip" text={lf("Change Board")} onClick={this.showBoardDialog} tabIndex={-1} /> : undefined}
             <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} tabIndex={-1} />
+            {showSave ? <sui.Item role="menuitem" icon="save" text={lf("Save Project")} onClick={this.saveProject} tabIndex={-1} /> : undefined}
             {!isController ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={this.removeProject} tabIndex={-1} /> : undefined}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} tabIndex={-1} /> : undefined}
             <div className="ui divider"></div>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -106,6 +106,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         if (!isEditor) return <div />;
 
         const targetTheme = pxt.appTarget.appTheme;
+        const showSave = !readOnly && !isController && !!targetTheme.saveInMenu;
         const compile = pxt.appTarget.compile;
         const compileBtn = compile.hasHex || compile.saveAsPNG;
         const simOpts = pxt.appTarget.simulator;
@@ -163,7 +164,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         <div className="right aligned column">
                             {!readOnly ?
                                 <div className="ui icon small buttons">
-                                    <EditorToolbarButton icon='save' className={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='mobile' />
+                                    {showSave ? <EditorToolbarButton icon='save' className={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='mobile' /> : undefined}
                                     {showUndoRedo ? <EditorToolbarButton icon='xicon undo' className={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo")} onButtonClick={this.undo} view='mobile' /> : undefined}
                                 </div> : undefined}
                         </div>
@@ -233,8 +234,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 </div>
                             </div>}
                         <div className="column four wide">
-                            {readOnly ? undefined :
-                                <EditorToolbarButton icon='save' className={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='tablet' />}
+                            {showSave ? <EditorToolbarButton icon='save' className={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='tablet' />
+                                : undefined}
                         </div>
                         <div className="column six wide right aligned">
                             {showUndoRedo ?
@@ -282,7 +283,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                                     placeholder={lf("Pick a name...")}
                                                     value={projectName || ''}
                                                     onChangeValue={this.saveProjectName} view='tablet' />
-                                                <EditorToolbarButton icon='save' className={`large right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='tablet' />
+                                                {showSave ? <EditorToolbarButton icon='save' className={`large right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='tablet' /> : undefined}
                                             </div>
                                         </div>
                                     </div> : undefined}
@@ -345,7 +346,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     placeholder={lf("Pick a name...")}
                                     value={projectName || ''}
                                     onChangeValue={this.saveProjectName} />
-                                <EditorToolbarButton icon='save' className={`small right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='computer' />
+                                {showSave ? <EditorToolbarButton icon='save' className={`small right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='computer' /> : undefined}
                             </div>
                         </div> : undefined}
                     <div className="column right aligned">

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -106,7 +106,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         if (!isEditor) return <div />;
 
         const targetTheme = pxt.appTarget.appTheme;
-        const showSave = !readOnly && !isController && !!targetTheme.saveInMenu;
+        const showSave = !readOnly && !isController && !targetTheme.saveInMenu;
         const compile = pxt.appTarget.compile;
         const compileBtn = compile.hasHex || compile.saveAsPNG;
         const simOpts = pxt.appTarget.simulator;
@@ -275,7 +275,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 {showProjectRename ?
                                     <div className="row" style={compileBtn ? { paddingTop: 0 } : {}}>
                                         <div className="column">
-                                            <div className="ui item large right labeled fluid input projectname-input projectname-tablet" title={lf("Pick a name for your project")}>
+                                            <div className={`ui item large right ${showSave ? "labeled" : ""} fluid input projectname-input projectname-tablet`} title={lf("Pick a name for your project")}>
                                                 <label htmlFor="fileNameInput1" id="fileNameInputLabel1" className="accessible-hidden">{lf("Type a name for your project")}</label>
                                                 <EditorToolbarSaveInput id="fileNameInput1"
                                                     type="text"
@@ -338,7 +338,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     </div>
                     {showProjectRename ?
                         <div className="column left aligned">
-                            <div className={`ui right labeled input projectname-input projectname-computer`} title={lf("Pick a name for your project")}>
+                            <div className={`ui right ${showSave ? "labeled" : ""} input projectname-input projectname-computer`} title={lf("Pick a name for your project")}>
                                 <label htmlFor="fileNameInput2" id="fileNameInputLabel2" className="accessible-hidden">{lf("Type a name for your project")}</label>
                                 <EditorToolbarSaveInput id="fileNameInput2" view='computer'
                                     type="text"


### PR DESCRIPTION
Requested by LEGO. Flag "saveInMenu" hides the save icon.

![image](https://user-images.githubusercontent.com/4175913/45233964-37216800-b289-11e8-819b-361e2b8b142b.png)
![image](https://user-images.githubusercontent.com/4175913/45233976-3d174900-b289-11e8-886b-249758dcf24e.png)
![image](https://user-images.githubusercontent.com/4175913/45233981-3ee10c80-b289-11e8-94f5-9f70117ff74d.png)
![image](https://user-images.githubusercontent.com/4175913/45233982-40aad000-b289-11e8-9257-bad98611159b.png)
