### PR TITLE
Remove additionalFilePaths field when saving config (Fixes #4666)

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -95,8 +95,10 @@ namespace pxt {
         }
 
         saveConfig() {
-            const cfg = JSON.stringify(this.config, null, 4) || "\n"
-            this.host().writeFile(this, pxt.CONFIG_NAME, cfg)
+            const cfg = U.clone(this.config)
+            delete cfg.additionalFilePaths
+            const text = JSON.stringify(cfg, null, 4)
+            this.host().writeFile(this, pxt.CONFIG_NAME, text)
         }
 
         parseJRes(allres: Map<JRes> = {}) {


### PR DESCRIPTION
The field should never be present in `pxt.json` - it's temporary.
The `|| "\n"` didn't make any sense either - `JSON.stringify` never returns `null` or `""`