### PR TITLE
print fixes

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -734,6 +734,7 @@ declare namespace Blockly {
         getColourSecondary(): string;
         getColourTertiary(): string;
         getDescendants(): Block[];
+        getStartHat(): boolean;
         initSvg(): void;
         removeInput(name: string, opt_quiet?: boolean): void;
         dispose(healGap: boolean): void;
@@ -758,6 +759,7 @@ declare namespace Blockly {
         setShadow(shadow: boolean): void;
         setTitleValue(newValue: string, name: string): void;
         setTooltip(newTip: string | (() => void)): void;
+        setStartHat(on: boolean): void;
         // Passing null will delete current text
         setWarningText(text: string): void;
         setHighlightWarning(isHighlightingWarning: boolean): void;

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -59,7 +59,10 @@ namespace pxt.blocks.layout {
             y += emPixels; //buffer
         })
         let blocks = ws.getTopBlocks(true);
-        blocks.forEach(block => {
+        blocks.forEach((block, bi) => {
+            // TODO: REMOVE THIS WHEN FIXED IN PXT-BLOCKLY
+            if (block.getStartHat())
+                y += emPixels; // hat height
             block.moveBy(0, y)
             y += block.getHeightWidth().height
             y += emPixels; //buffer

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -23,7 +23,7 @@ namespace pxt.blocks {
         useViewWidth?: boolean;
     }
 
-    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 14, layout: BlockLayout.Flow }): SVGSVGElement {
+    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 14, layout: BlockLayout.Align }): SVGSVGElement {
         if (!workspace) {
             blocklyDiv = document.createElement("div");
             blocklyDiv.style.position = "absolute";

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -51,7 +51,7 @@ namespace pxt.blocks {
 
             switch (options.layout) {
                 case BlockLayout.Align:
-                    pxt.blocks.layout.verticalAlign(workspace, options.emPixels || 16); break;
+                    pxt.blocks.layout.verticalAlign(workspace, options.emPixels || 18); break;
                 case BlockLayout.Flow:
                     pxt.blocks.layout.flow(workspace, { ratio: options.aspectRatio, useViewWidth: options.useViewWidth }); break;
                 case BlockLayout.Clean:
@@ -75,8 +75,8 @@ namespace pxt.blocks {
             svg.removeAttribute('height');
 
             if (options.emPixels) {
-                svg.style.width = (metrics.contentWidth / options.emPixels) + 'rem';
-                svg.style.height = (metrics.contentHeight / options.emPixels) + 'rem';
+                svg.style.width = (metrics.contentWidth / options.emPixels) + 'em';
+                svg.style.height = (metrics.contentHeight / options.emPixels) + 'em';
             }
 
             return svg as any;

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -23,7 +23,7 @@ namespace pxt.blocks {
         useViewWidth?: boolean;
     }
 
-    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 16, layout: BlockLayout.Align }): SVGSVGElement {
+    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 18, layout: BlockLayout.Align }): SVGSVGElement {
         if (!workspace) {
             blocklyDiv = document.createElement("div");
             blocklyDiv.style.position = "absolute";

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -23,7 +23,7 @@ namespace pxt.blocks {
         useViewWidth?: boolean;
     }
 
-    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 14, layout: BlockLayout.Align }): SVGSVGElement {
+    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 16, layout: BlockLayout.Align }): SVGSVGElement {
         if (!workspace) {
             blocklyDiv = document.createElement("div");
             blocklyDiv.style.position = "absolute";
@@ -51,7 +51,7 @@ namespace pxt.blocks {
 
             switch (options.layout) {
                 case BlockLayout.Align:
-                    pxt.blocks.layout.verticalAlign(workspace, options.emPixels || 14); break;
+                    pxt.blocks.layout.verticalAlign(workspace, options.emPixels || 16); break;
                 case BlockLayout.Flow:
                     pxt.blocks.layout.flow(workspace, { ratio: options.aspectRatio, useViewWidth: options.useViewWidth }); break;
                 case BlockLayout.Clean:
@@ -75,8 +75,8 @@ namespace pxt.blocks {
             svg.removeAttribute('height');
 
             if (options.emPixels) {
-                svg.style.width = (metrics.contentWidth / options.emPixels) + 'em';
-                svg.style.height = (metrics.contentHeight / options.emPixels) + 'em';
+                svg.style.width = (metrics.contentWidth / options.emPixels) + 'rem';
+                svg.style.height = (metrics.contentHeight / options.emPixels) + 'rem';
             }
 
             return svg as any;

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -161,7 +161,7 @@ namespace pxt.runner {
         let $el = $("." + cls).first();
         if (!$el[0]) return Promise.resolve();
 
-        if (!options.emPixels) options.emPixels = 16;
+        if (!options.emPixels) options.emPixels = 18;
         if (!options.layout) options.layout = pxt.blocks.BlockLayout.Align;
 
         return pxt.runner.decompileToBlocksAsync($el.text(), options)
@@ -260,7 +260,7 @@ namespace pxt.runner {
             let $el = $("." + cls).first();
             if (!$el[0]) return Promise.resolve();
 
-            if (!options.emPixels) options.emPixels = 16;
+            if (!options.emPixels) options.emPixels = 18;
             return pxt.runner.compileBlocksAsync($el.text(), options)
                 .then((r) => {
                     try {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -161,7 +161,7 @@ namespace pxt.runner {
         let $el = $("." + cls).first();
         if (!$el[0]) return Promise.resolve();
 
-        if (!options.emPixels) options.emPixels = 14;
+        if (!options.emPixels) options.emPixels = 16;
         if (!options.layout) options.layout = pxt.blocks.BlockLayout.Align;
 
         return pxt.runner.decompileToBlocksAsync($el.text(), options)
@@ -260,7 +260,7 @@ namespace pxt.runner {
             let $el = $("." + cls).first();
             if (!$el[0]) return Promise.resolve();
 
-            if (!options.emPixels) options.emPixels = 14;
+            if (!options.emPixels) options.emPixels = 16;
             return pxt.runner.compileBlocksAsync($el.text(), options)
                 .then((r) => {
                     try {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -162,7 +162,7 @@ namespace pxt.runner {
         if (!$el[0]) return Promise.resolve();
 
         if (!options.emPixels) options.emPixels = 14;
-        if (!options.layout) options.layout = pxt.blocks.BlockLayout.Flow;
+        if (!options.layout) options.layout = pxt.blocks.BlockLayout.Align;
 
         return pxt.runner.decompileToBlocksAsync($el.text(), options)
             .then((r) => {

--- a/theme/print.less
+++ b/theme/print.less
@@ -79,14 +79,15 @@
     /** blockly **/
     .blocklyPath {
         stroke-width: 3px !important;
-        stroke: black;
-        fill: white;
+        stroke: black !important;
+        fill: white !important;
     }
     .blocklyBlockBackground {
-        stroke-width: 2px;
-        fill: white;
+        stroke-width: 2px !important;
+        stroke: black !important;
+        fill: white !important;        
     }
-    .blocklyText {
-        fill: black;
+    .blocklyText, .blocklyDropdownText {
+        fill: black !important;
     }
 }

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -167,7 +167,7 @@ i.icon.avatar-image {
 
 /* Tutorial blocks */
 
-.ui.segment .blocklyPreview {
+.hintdialog .ui.segment .blocklyPreview {
     width: 100%;
     @media only screen and (min-height: 400px) {
         max-height: 50vh;


### PR DESCRIPTION
Tested in Edge, IE, Chrome, FF / Windows.
- [x]  drop downs are bw
![image](https://user-images.githubusercontent.com/4175913/45652483-9a7d7800-ba89-11e8-86fe-db86b7ed0140.png)
- [x] default to vertical layout (impacts all rendered docs)
- [x] temporary patch for function to account for incorrect size computation in pxt-blockly
![image](https://user-images.githubusercontent.com/4175913/45655301-45932f00-ba94-11e8-9950-66d54a5a7385.png)
- [x] fix SVG height computation (see game of life below in IE)
![image](https://user-images.githubusercontent.com/4175913/45655521-83dd1e00-ba95-11e8-8b27-b9f482f750f3.png)

This PR does not solve the "sidedocs" printing issue introduced by the "go back" button.