### PR TITLE
Working around some browser exceptions in IE that break tutorials

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -119,7 +119,14 @@ namespace pxt.blocks.layout {
             cvs.width = width * pixelDensity;
             cvs.height = height * pixelDensity;
             img.onload = function () {
-                ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
+                try {
+                    ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
+                }
+                catch (e) {
+                    // IE 11 throws an exception
+                    reject(e);
+                    return;
+                }
                 let canvasdata = cvs.toDataURL("image/png");
                 // if the generated image is too big, shrink image
                 while (canvasdata.length > MAX_SCREENSHOT_SIZE) {
@@ -262,6 +269,7 @@ namespace pxt.blocks.layout {
                         imageIconCache[svgUri] = href;
                         image.setAttributeNS(XLINK_NAMESPACE, "href", href);
                     })
+                    .catch(() => { /* Ignore conversion errors from IE */ })
             });
         return Promise.all(p).then(() => { })
     }

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -119,14 +119,7 @@ namespace pxt.blocks.layout {
             cvs.width = width * pixelDensity;
             cvs.height = height * pixelDensity;
             img.onload = function () {
-                try {
-                    ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
-                }
-                catch (e) {
-                    // IE 11 throws an exception
-                    reject(e);
-                    return;
-                }
+                ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
                 let canvasdata = cvs.toDataURL("image/png");
                 // if the generated image is too big, shrink image
                 while (canvasdata.length > MAX_SCREENSHOT_SIZE) {
@@ -252,7 +245,7 @@ namespace pxt.blocks.layout {
     function convertIconsToPngAsync(xsg: Document): Promise<void> {
         if (!imageIconCache) imageIconCache = {};
 
-        if (!(BrowserUtils.isIE() || BrowserUtils.isEdge())) return Promise.resolve();
+        if (!BrowserUtils.isEdge()) return Promise.resolve();
 
         const images = xsg.getElementsByTagName("image") as NodeListOf<Element>;
         const p = pxt.Util.toArray(images)
@@ -269,7 +262,6 @@ namespace pxt.blocks.layout {
                         imageIconCache[svgUri] = href;
                         image.setAttributeNS(XLINK_NAMESPACE, "href", href);
                     })
-                    .catch(() => { /* Ignore conversion errors from IE */ })
             });
         return Promise.all(p).then(() => { })
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2111,13 +2111,23 @@ export class ProjectView
     completeTutorial() {
         pxt.tickEvent("tutorial.complete");
         core.showLoading("leavingtutorial", lf("leaving tutorial..."));
-        this.exitTutorialAsync()
-            .then(() => {
-                let curr = pkg.mainEditorPkg().header;
-                return this.loadHeaderAsync(curr);
-            }).done(() => {
-                core.hideLoading("leavingtutorial");
-            })
+
+        if (pxt.BrowserUtils.isIE()) {
+            // For some reason, going from a tutorial straight to the editor in
+            // IE causes the JavaScript runtime to go bad. In order to work around
+            // the issue we go to the homescreen instead of the to the editor. See
+            // https://github.com/Microsoft/pxt-microbit/issues/1249 for more info.
+            this.exitTutorial();
+        }
+        else {
+            this.exitTutorialAsync()
+                .then(() => {
+                    let curr = pkg.mainEditorPkg().header;
+                    return this.loadHeaderAsync(curr);
+                }).done(() => {
+                    core.hideLoading("leavingtutorial");
+                });
+        }
     }
 
     exitTutorial(removeProject?: boolean) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1249 (kinda)

Fixing a couple of exceptions for IE in tutorials. The first one was caused by a change I made to fix screenshots in Edge. IE throws an exception but it can be safely ignored.

The second bug causes the site to freeze when exiting a tutorial and loading the editor. The browser crashes on a call to `Date.now()` saying that `Date` is undefined. @abchatra and I spent a while debugging but it sure looks like this is an IE bug. Instead of devoting more time to a proper fix we decided to just avoid the codepath in IE and go to the home screen instead of opening the editor.
