### PR TITLE
Print code fix

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -71,6 +71,7 @@ div.blocks-svg-list > svg {
     margin-right: 1rem;
     margin-bottom: 1rem;
     page-break-before: avoid;
+    vertical-align: top;
 }
 
 code {

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -67,6 +67,12 @@ code.hljs {
     background:transparent !important;
 }
 
+div.blocks-svg-list > svg {
+    margin-right: 1rem;
+    margin-bottom: 1rem;
+    page-break-before: avoid;
+}
+
 code {
         white-space: pre-wrap;
 }

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -70,7 +70,7 @@ code.hljs {
 div.blocks-svg-list > svg {
     margin-right: 1rem;
     margin-bottom: 1rem;
-    page-break-before: avoid;
+    page-break-inside: avoid;
     vertical-align: top;
 }
 

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -54,7 +54,7 @@ namespace pxt.blocks.layout {
      * Splits a blockly SVG AFTER a vertical layout. This function relies on the ordering
      * of blocks / comments to get as getTopBlock(true)/getTopComment(true)
      */
-    export function splitSvg(svg: SVGSVGElement, ws: Blockly.Workspace, emPixels: number): Element {
+    export function splitSvg(svg: SVGSVGElement, ws: Blockly.Workspace, emPixels: number = 18): Element {
         const div = document.createElement("div") as HTMLDivElement;
         div.className = "blocks-svg-list"
 
@@ -95,8 +95,16 @@ namespace pxt.blocks.layout {
             .forEach((comment, commenti) => extract('blocklyBubbleCanvas', 'blocklyBlockCanvas',
                 commenti, comment.getHeightWidth(), { x: 0, y: 0 }));
         ws.getTopBlocks(true)
-            .forEach((block, blocki) => extract('blocklyBlockCanvas', 'blocklyBubbleCanvas',
-                blocki, block.getHeightWidth(), { x: 0, y: 0 }));
+            .forEach((block, blocki) => {
+                const size = block.getHeightWidth();
+                const translate = { x: 0, y: 0 };
+                if (block.getStartHat()) {
+                    size.height += emPixels;
+                    translate.y += emPixels;
+                }
+                extract('blocklyBlockCanvas', 'blocklyBubbleCanvas',
+                blocki, size, translate)
+            });
         return div;
     }
 

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -74,11 +74,11 @@ namespace pxt.blocks.layout {
             // remove all but the block we care about
             blocksSvg.filter(g => g != blockSvg)
                 .forEach(g => {
-                    g.remove()
+                    g.parentNode.removeChild(g);
                 });
             // clear transform, remove other group
             parentSvg.removeAttribute("transform");
-            otherSvg.remove();
+            otherSvg.parentNode.removeChild(otherSvg);
             // patch size
             blockSvg.setAttribute("transform", `translate(${translate.x}, ${translate.y})`)
             const width = (size.width / emPixels) + "em";

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -55,6 +55,12 @@ namespace pxt.blocks.layout {
      * of blocks / comments to get as getTopBlock(true)/getTopComment(true)
      */
     export function splitSvg(svg: SVGSVGElement, ws: Blockly.Workspace, emPixels: number = 18): Element {
+        const comments = ws.getTopComments(true);
+        const blocks = ws.getTopBlocks(true)
+        // don't split for a single block
+        if (comments.length + blocks.length < 2)
+            return svg;
+
         const div = document.createElement("div") as HTMLDivElement;
         div.className = "blocks-svg-list"
 
@@ -91,11 +97,9 @@ namespace pxt.blocks.layout {
             div.appendChild(svgclone);
         }
 
-        ws.getTopComments(true)
-            .forEach((comment, commenti) => extract('blocklyBubbleCanvas', 'blocklyBlockCanvas',
-                commenti, comment.getHeightWidth(), { x: 0, y: 0 }));
-        ws.getTopBlocks(true)
-            .forEach((block, blocki) => {
+        comments.forEach((comment, commenti) => extract('blocklyBubbleCanvas', 'blocklyBlockCanvas',
+            commenti, comment.getHeightWidth(), { x: 0, y: 0 }));
+        blocks.forEach((block, blocki) => {
                 const size = block.getHeightWidth();
                 const translate = { x: 0, y: 0 };
                 if (block.getStartHat()) {
@@ -103,7 +107,7 @@ namespace pxt.blocks.layout {
                     translate.y += emPixels;
                 }
                 extract('blocklyBlockCanvas', 'blocklyBubbleCanvas',
-                blocki, size, translate)
+                    blocki, size, translate)
             });
         return div;
     }

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -21,9 +21,10 @@ namespace pxt.blocks {
         package?: string;
         snippetMode?: boolean;
         useViewWidth?: boolean;
+        splitSvg?: boolean;
     }
 
-    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 18, layout: BlockLayout.Align }): SVGSVGElement {
+    export function render(blocksXml: string, options: BlocksRenderOptions = { emPixels: 18, layout: BlockLayout.Align }): Element {
         if (!workspace) {
             blocklyDiv = document.createElement("div");
             blocklyDiv.style.position = "absolute";
@@ -49,7 +50,8 @@ namespace pxt.blocks {
             Blockly.Xml.domToWorkspace(xml, workspace);
             Blockly.Events.enable();
 
-            switch (options.layout) {
+            const layout = options.splitSvg ? BlockLayout.Align : options.layout;
+            switch (layout) {
                 case BlockLayout.Align:
                     pxt.blocks.layout.verticalAlign(workspace, options.emPixels || 18); break;
                 case BlockLayout.Flow:
@@ -79,7 +81,9 @@ namespace pxt.blocks {
                 svg.style.height = (metrics.contentHeight / options.emPixels) + 'em';
             }
 
-            return svg as any;
+            return options.splitSvg
+                ? pxt.blocks.layout.splitSvg(svg, workspace, options.emPixels)
+                : svg;
         } catch (e) {
             pxt.reportException(e);
 

--- a/pxtblocks/codecardrenderer.ts
+++ b/pxtblocks/codecardrenderer.ts
@@ -64,7 +64,7 @@ namespace pxt.docs.codeCard {
         }
 
         if (card.blocksXml) {
-            let svg = pxt.blocks.render(card.blocksXml);
+            const svg = pxt.blocks.render(card.blocksXml);
             if (!svg) {
                 console.error("failed to render blocks");
                 pxt.debug(card.blocksXml);

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -263,6 +263,7 @@ namespace pxt.runner {
             if (!$el[0]) return Promise.resolve();
 
             if (!options.emPixels) options.emPixels = 18;
+            options.splitSvg = true;
             return pxt.runner.compileBlocksAsync($el.text(), options)
                 .then((r) => {
                     try {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -60,7 +60,7 @@ namespace pxt.runner {
         let images = cdn + "images"
         let $h = $('<div class="ui bottom attached tabular icon small compact menu hideprint">'
             + ' <div class="right icon menu"></div></div>');
-        let $c = $('<div class="ui top attached segment nobreak"></div>');
+        let $c = $('<div class="ui top attached segment codewidget"></div>');
         let $menu = $h.find('.right.menu');
 
         const theme = pxt.appTarget.appTheme || {};
@@ -185,7 +185,7 @@ namespace pxt.runner {
             return renderNextSnippetAsync(options.snippetClass, (c, r) => {
                 const s = r.blocksSvg;
                 if (options.snippetReplaceParent) c = c.parent();
-                const segment = $('<div class="ui segment"/>').append(s);
+                const segment = $('<div class="ui segment codewidget"/>').append(s);
                 c.replaceWith(segment);
             }, { package: options.package, snippetMode: false, aspectRatio: options.blocksAspectRatio });
         }
@@ -248,7 +248,7 @@ namespace pxt.runner {
         return renderNextSnippetAsync(options.blocksClass, (c, r) => {
             const s = r.blocksSvg;
             if (options.snippetReplaceParent) c = c.parent();
-            const segment = $('<div class="ui segment"/>').append(s);
+            const segment = $('<div class="ui segment codewidget"/>').append(s);
             c.replaceWith(segment);
         }, { package: options.package, snippetMode: true, aspectRatio: options.blocksAspectRatio });
     }
@@ -279,7 +279,7 @@ namespace pxt.runner {
         return renderNextXmlAsync(cls, (c, r) => {
             const s = r.blocksSvg;
             if (opts.snippetReplaceParent) c = c.parent();
-            const segment = $('<div class="ui segment"/>').append(s);
+            const segment = $('<div class="ui segment codewidget"/>').append(s);
             c.replaceWith(segment);
         }, { package: opts.package, snippetMode: true, aspectRatio: opts.blocksAspectRatio });
     }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -23,7 +23,8 @@ namespace pxt.runner {
         package?: string;
         showEdit?: boolean;
         showJavaScript?: boolean; // default is to show blocks first
-        downloadScreenshots?: boolean
+        downloadScreenshots?: boolean;
+        split?: boolean; // split in multiple divs if too big
     }
 
     export interface WidgetOptions {
@@ -163,6 +164,7 @@ namespace pxt.runner {
 
         if (!options.emPixels) options.emPixels = 18;
         if (!options.layout) options.layout = pxt.blocks.BlockLayout.Align;
+        options.splitSvg = true;
 
         return pxt.runner.decompileToBlocksAsync($el.text(), options)
             .then((r) => {
@@ -233,7 +235,7 @@ namespace pxt.runner {
             let block = Blockly.Blocks[symbolInfo.attributes.blockId];
             let xml = block && block.codeCard ? block.codeCard.blocksXml : undefined;
 
-            let s = xml ? $(pxt.blocks.render(xml)) : r.compileBlocks && r.compileBlocks.success ? $(r.blocksSvg) : undefined;
+            const s = xml ? $(pxt.blocks.render(xml)) : r.compileBlocks && r.compileBlocks.success ? $(r.blocksSvg) : undefined;
             let sig = info.decl.getText().replace(/^export/, '');
             sig = sig.slice(0, sig.indexOf('{')).trim() + ';';
             let js = $('<code class="lang-typescript highlight"/>').text(sig);

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -571,9 +571,12 @@ ${files[f]}
 
         if (cfg && cfg.dependencies && Util.values(cfg.dependencies).some(v => v != '*')) {
             md += `
-## Packages
+## ${lf("Extensions")}
 
-${Object.keys(cfg.dependencies).map(k => `* ${k}, ${cfg.dependencies[k]}`).join('\n')}
+${Object.keys(cfg.dependencies)
+    .filter(k => k != pxt.appTarget.corepkg)
+    .map(k => `* ${k}, ${cfg.dependencies[k]}`)
+    .join('\n')}
 
 \`\`\`package
 ${Object.keys(cfg.dependencies).map(k => `${k}=${cfg.dependencies[k]}`).join('\n')}
@@ -588,7 +591,7 @@ ${Object.keys(cfg.dependencies).map(k => `${k}=${cfg.dependencies[k]}`).join('\n
                 linkString = "`" + linkString + "`";
             }
             md += `
-* url: ${linkString}
+${linkString}
 
 `;
         }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -545,7 +545,7 @@ namespace pxt.runner {
             md += files[readme].replace(/^#+/, "$0#") + '\n'; // bump all headers down 1
 
         cfg.files.filter(f => f != pxt.CONFIG_NAME && f != readme)
-            .filter(f => editorLanguageMode != LanguageMode.Blocks || /\.blocks?$/.test(f))
+            .filter(f => (editorLanguageMode == LanguageMode.Blocks) == /\.blocks?$/.test(f))
             .forEach(f => {
                 if (!/^main\.(ts|blocks)$/.test(f))
                     md += `

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -581,14 +581,17 @@ ${Object.keys(cfg.dependencies).map(k => `${k}=${cfg.dependencies[k]}`).join('\n
 `;
         }
 
-        let linkString = projectid ? (pxt.appTarget.appTheme.shareUrl || "https://makecode.com/" + projectid) : pxt.appTarget.appTheme.homeUrl;
-        if (escapeLinks) {
-            // If printing the link will show up twice if it's an actual link
-            linkString = "`" + linkString + "`";
-        }
-        md += `* ${linkString}
+        if (projectid) {
+            let linkString = (pxt.appTarget.appTheme.shareUrl || "https://makecode.com/") + projectid;
+            if (escapeLinks) {
+                // If printing the link will show up twice if it's an actual link
+                linkString = "`" + linkString + "`";
+            }
+            md += `
+* url: ${linkString}
 
 `;
+        }
         const options: RenderMarkdownOptions = {
             print: true
         }

--- a/theme/print.less
+++ b/theme/print.less
@@ -39,7 +39,10 @@
             font-size: 12pt;
             line-height: 1.3;
         }
-        /* lists */
+        /* hide videos */
+        div.ui.embed.mdvid {
+            display: none !important;
+        }
         /* links */
         a:link, a:visited {
             color: #000;
@@ -66,6 +69,23 @@
         .ui.image {
             max-width: 60%;
         }
+
+        .mainbody .ui.segment, pre {
+            background: none !important;
+        }
+
+        /* inline blocks*/
+        span.docs.inlineblock {
+            background: none !important;
+            border: black 2px solid !important;        
+        }
+        /* avatar */
+        .avatar .avatar-image, .avatar .ui.compact.message::after {
+            display: none !important;
+        }
+        .avatar .ui.compact.message {
+            border: black 2px solid !important;
+        }
     }
 
     /* page margins */
@@ -74,11 +94,6 @@
         margin-left: 2.5cm;
         margin-right: 2.5cm;
         margin-bottom: 2cm;
-    }
-
-    #docs .mainbody .ui.segment,
-    #docs pre {
-        background: none !important;
     }
 
     /** blockly **/
@@ -105,10 +120,5 @@
     }
     .blocklyCommentTarget, .blocklyCommentHandleTarget, .blocklyResizeSE {
         display: none !important;
-    }
-    /* inline blocks*/
-    #docs span.docs.inlineblock {
-        background: none !important;
-        border: black 2px solid !important;        
     }
 }

--- a/theme/print.less
+++ b/theme/print.less
@@ -107,7 +107,7 @@
         display: none !important;
     }
     /* inline blocks*/
-    span.docs.inlineblock {
+    #docs span.docs.inlineblock {
         background: none !important;
         border: black 2px solid !important;        
     }

--- a/theme/print.less
+++ b/theme/print.less
@@ -90,4 +90,15 @@
     .blocklyText, .blocklyDropdownText {
         fill: black !important;
     }
+    /* comments */
+    .blocklyCommentRect {
+        fill: white !important;
+        stroke: black !important;
+    }
+    .blocklyCommentTextarea {
+        overflow: hidden !important;
+    }
+    .blocklyCommentTarget, .blocklyCommentHandleTarget, .blocklyResizeSE {
+        display: none !important;
+    }
 }

--- a/theme/print.less
+++ b/theme/print.less
@@ -76,6 +76,11 @@
         margin-bottom: 2cm;
     }
 
+    #docs .mainbody .ui.segment,
+    #docs pre {
+        background: none !important;
+    }
+
     /** blockly **/
     .blocklyPath {
         stroke-width: 3px !important;
@@ -100,5 +105,10 @@
     }
     .blocklyCommentTarget, .blocklyCommentHandleTarget, .blocklyResizeSE {
         display: none !important;
+    }
+    /* inline blocks*/
+    span.docs.inlineblock {
+        background: none !important;
+        border: black 2px solid !important;        
     }
 }

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -34,6 +34,14 @@
             max-height: calc(100% - 1em);
         }
 
+        
+        div.blocks-svg-list > svg {
+            margin-right: 1rem;
+            margin-bottom: 1rem;
+            page-break-inside: avoid;
+            vertical-align: top;
+        }
+
         code {
             white-space: pre-wrap;
         }

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -76,7 +76,7 @@
         <i class="ui icon left arrow"></i>
         <span id="back-label"></span>
     </div>
-    <div class="ui divider"></div>
+    <div id="sidedocs-back-button-divider" class="ui divider"></div>
     <div id='loading' class="ui active inverted dimmer">
         <div class="ui loader"></div>
     </div>
@@ -94,12 +94,19 @@
     <script type="text/javascript">
         (function () {
         var backButton = document.getElementById('sidedocs-back-button');
+        // don't show 'go back' for printing
+        if (/print:/.test(window.location.href)) {
+            $(backButton).remove(); backButton = undefined;
+            $('#sidedocs-back-button-divider').remove();
+        }
         var loading = document.getElementById('loading');
         var content = document.getElementById('content');
         ksRunnerReady(function() {
             pxt.BrowserUtils.initTheme();
             pxt.docs.requireMarked = function() { return marked; }
-            document.getElementById('back-label').textContent = pxt.Util.lf("Go back")
+            var backLabel = document.getElementById('back-label');
+            if (backLabel)
+                backLabel.textContent = pxt.Util.lf("Go back")
             var projectid = /projectid=([^&?]+)/i.exec(window.location.href);
             var project = /project=([^&?]+)/i.exec(window.location.href);
             var code = /code=([^&?]+)/i.exec(window.location.href);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1789,7 +1789,11 @@ export class ProjectView
         return compiler.getBlocksAsync()
             .then(blocksInfo => compiler.decompileSnippetAsync(req.ts, blocksInfo))
             .then(resp => {
-                const svg = pxt.blocks.render(resp, { snippetMode: true, layout: pxt.blocks.BlockLayout.Align });
+                const svg = pxt.blocks.render(resp, {
+                    snippetMode: true,
+                    layout: pxt.blocks.BlockLayout.Align,
+                    splitSvg: false
+                }) as SVGSVGElement;
                 // TODO: what if svg is undefined? handle that scenario
                 const viewBox = svg.getAttribute("viewBox").split(/\s+/).map(d => parseInt(d));
                 return {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1664,7 +1664,7 @@ export class ProjectView
         const files = p.getAllFiles();
         // render in sidedocs
         const docsUrl = pxt.webConfig.docsUrl || '/--docs';
-        const mode = "blocks"
+        const mode = theEditor.isBlocksActive() ? "blocks" : "typescript";
         window.localStorage["printjob"] = JSON.stringify(files);
         const url = `${docsUrl}#print:job:${mode}:${pxt.Util.localeInfo()}`;
 


### PR DESCRIPTION
Various blocks docs/print optimizations. Tested in Edge, IE, Chrome, FF on Windows. It fix most of the print issues of game of life.

![demo](https://user-images.githubusercontent.com/4175913/45700019-5a1d0900-bb20-11e8-8de9-ba5b65d0a9ad.gif)

- [x] don't show go back in print mode
- [x] show blocks if editor is blocks, show TS otherwise
- [x]  show URL only if projectid available
- [x] don't show dependencies unless special package used
- [x] don't show "main.blocks/ts" name
![image](https://user-images.githubusercontent.com/4175913/45668698-a93c4d00-bad2-11e8-96ac-f960869b3c72.png)
- [x] split blocks in separate SVG to allow browser to flow the blocks
- [x] fix translate for function hats
- [x] handle IE
- [x] fix comment colors (comment sizes need to be better computed)
![image](https://user-images.githubusercontent.com/4175913/45706146-56917e00-bb30-11e8-830a-d69aee740446.png)
- [x] fix for "print code" option