### PR TITLE
Green screen update.

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -245,7 +245,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const readOnly = pxt.shell.isReadOnly();
         const isController = pxt.shell.isControllerMode();
         const showSave = !readOnly && !isController && !!targetTheme.saveInMenu;
-        const showGreenScreen = (targetTheme.greenScreen || /greenscreen=1/.test(window.location.href))
+        const showGreenScreen = (targetTheme.greenScreen || /greenscreen=1/i.test(window.location.href))
             && greenscreen.isSupported();
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -104,7 +104,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
     render() {
         const { hasPrompt, devices } = this.state;
         return <div className="videoContainer">
-            <video ref={this.handleVideoRef} />
+            <video playsinline ref={this.handleVideoRef} />
             {hasPrompt ?
                 <sui.Modal isOpen={hasPrompt} onClose={this.handleClose} closeIcon={true}
                     dimmer={true} header={lf("Choose a camera")}>

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -102,6 +102,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
     }
 
     render() {
+        // playsInline required for iOS
         const { hasPrompt, devices } = this.state;
         return <div className="videoContainer">
             <video playsInline ref={this.handleVideoRef} />

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -104,7 +104,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
     render() {
         const { hasPrompt, devices } = this.state;
         return <div className="videoContainer">
-            <video playsinline ref={this.handleVideoRef} />
+            <video playsInline ref={this.handleVideoRef} />
             {hasPrompt ?
                 <sui.Modal isOpen={hasPrompt} onClose={this.handleClose} closeIcon={true}
                     dimmer={true} header={lf("Choose a camera")}>


### PR DESCRIPTION
- [x] Edge
- [x] FF
- [x] Chrome
- [x] IE (disable)
- [x] iOS fix (tested on iOS12)

```
On iPhone, <video playsinline> elements will now be allowed to play inline, and will not automatically enter fullscreen mode when playback begins.
<video> elements without playsinline attributes will continue to require fullscreen mode for playback on iPhone.
When exiting fullscreen with a pinch gesture, <video> elements without playsinline will continue to play inline.
```
