### PR TITLE
Smaller inline blocks to avoid overlapping other text

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -217,11 +217,10 @@ span.docs.inlinebutton {
 }
 
 span.docs.inlineblock {
-    padding: .2rem .5rem;
+    padding: 0.0rem .2rem;
     border-radius: .2rem;
     white-space: nowrap;
     background-color: @inlineBlockColor;
-    border: 1px solid darken(@inlineBlockColor, 0.2);
     color: @white;
     font-family: @blocklyFont !important;
     font-size: 1em !important;

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -217,7 +217,7 @@ span.docs.inlinebutton {
 }
 
 span.docs.inlineblock {
-    padding: 0.0rem .2rem;
+    padding: 0.05rem .2rem;
     border-radius: .2rem;
     white-space: nowrap;
     background-color: @inlineBlockColor;


### PR DESCRIPTION
When using inline blocks, the padding and border can make the block overlap the adjacent lines.

# In course

## Current

<img width="793" alt="screen shot 2018-09-20 at 10 38 54 am" src="https://user-images.githubusercontent.com/5615930/45836462-c71bd480-bcc1-11e8-887c-0fcde5e653df.png">

<img width="771" alt="screen shot 2018-09-20 at 10 45 58 am" src="https://user-images.githubusercontent.com/5615930/45836724-748ee800-bcc2-11e8-83fb-8d92ce076577.png">

## PR

<img width="787" alt="screen shot 2018-09-20 at 10 39 33 am" src="https://user-images.githubusercontent.com/5615930/45836424-b23f4100-bcc1-11e8-9f60-bf8d0407b344.png">

<img width="781" alt="screen shot 2018-09-20 at 10 46 20 am" src="https://user-images.githubusercontent.com/5615930/45836731-79ec3280-bcc2-11e8-9d9e-df9d149b88be.png">

# In tutorials

## Current

<img width="684" alt="screen shot 2018-09-20 at 10 47 51 am" src="https://user-images.githubusercontent.com/5615930/45836828-b455cf80-bcc2-11e8-93ee-a13dd4b7e902.png">

## PR

<img width="683" alt="screen shot 2018-09-20 at 10 48 14 am" src="https://user-images.githubusercontent.com/5615930/45836838-b91a8380-bcc2-11e8-9ae1-2938d8a55384.png">
