### PR TITLE
Always load translations

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -821,7 +821,7 @@ namespace ts.pxtc.Util {
                 if (errorCount === stringFiles.length || !translations) {
                     // Retry with non-live translations by setting live to false
                     pxt.tickEvent("translations.livetranslationsfailed");
-                    return downloadTranslationsAsync(targetId, simulator, baseUrl, code, pxtBranch, targetBranch, false);
+                    return downloadTranslationsAsync(targetId, baseUrl, code, pxtBranch, targetBranch, false);
                 }
 
                 return Promise.resolve(translations);

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -752,12 +752,12 @@ namespace ts.pxtc.Util {
         return pxt.appTarget.appTheme && pxt.appTarget.appTheme.availableLocales && pxt.appTarget.appTheme.availableLocales.indexOf(code) > -1;
     }
 
-    export function updateLocalizationAsync(targetId: string, simulator: boolean, baseUrl: string, code: string, pxtBranch: string, targetBranch: string, live?: boolean, force?: boolean): Promise<void> {
+    export function updateLocalizationAsync(targetId: string, baseUrl: string, code: string, pxtBranch: string, targetBranch: string, live?: boolean, force?: boolean): Promise<void> {
         code = normalizeLanguageCode(code);
         if (code === userLanguage() || (!isLocaleEnabled(code) && !force))
             return Promise.resolve();
 
-        return downloadTranslationsAsync(targetId, simulator, baseUrl, code, pxtBranch, targetBranch, live)
+        return downloadTranslationsAsync(targetId, baseUrl, code, pxtBranch, targetBranch, live)
             .then((translations) => {
                 if (translations) {
                     setUserLanguage(code);
@@ -775,22 +775,21 @@ namespace ts.pxtc.Util {
         if (code === userLanguage() || (!isLocaleEnabled(code) && !force))
             return Promise.resolve<pxt.Map<string>>(undefined);
 
-        return downloadTranslationsAsync(targetId, true, baseUrl, code, pxtBranch, targetBranch, live)
+        return downloadTranslationsAsync(targetId, baseUrl, code, pxtBranch, targetBranch, live)
     }
 
-    export function downloadTranslationsAsync(targetId: string, simulator: boolean, baseUrl: string, code: string, pxtBranch: string, targetBranch: string, live?: boolean): Promise<pxt.Map<string>> {
+    export function downloadTranslationsAsync(targetId: string, baseUrl: string, code: string, pxtBranch: string, targetBranch: string, live?: boolean): Promise<pxt.Map<string>> {
         code = normalizeLanguageCode(code);
-        let translationsCacheId = `${code}/${live}/${simulator}`;
+        let translationsCacheId = `${code}/${live}`;
         if (translationsCache()[translationsCacheId]) {
             return Promise.resolve(translationsCache()[translationsCacheId]);
         }
 
-        const stringFiles: { branch: string, path: string }[] = simulator
-            ? [{ branch: targetBranch, path: targetId + "/sim-strings.json" }]
-            : [
-                { branch: pxtBranch, path: "strings.json" },
-                { branch: targetBranch, path: targetId + "/target-strings.json" }
-            ];
+        const stringFiles: { branch: string, path: string }[] = [
+            { branch: pxtBranch, path: "strings.json" },
+            { branch: targetBranch, path: targetId + "/target-strings.json" },
+            { branch: targetBranch, path: targetId + "/sim-strings.json" }
+        ];
         let translations: pxt.Map<string>;
 
         function mergeTranslations(tr: pxt.Map<string>) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -154,7 +154,6 @@ namespace pxt.runner {
         const cfg = pxt.webConfig
         return Util.updateLocalizationAsync(
             pxt.appTarget.id,
-            true,
             cfg.commitCdnUrl, lang,
             versions ? versions.pxtCrowdinBranch : "",
             versions ? versions.targetCrowdinBranch : "",
@@ -301,7 +300,6 @@ namespace pxt.runner {
             editorLocale = locale;
             return pxt.Util.updateLocalizationAsync(
                 pxt.appTarget.id,
-                true,
                 pxt.webConfig.commitCdnUrl,
                 editorLocale.replace(localeLiveRx, ''),
                 pxt.appTarget.versions.pxtCrowdinBranch,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2831,7 +2831,6 @@ document.addEventListener("DOMContentLoaded", () => {
             const force = !!mlang && !!mlang[2];
             return Util.updateLocalizationAsync(
                 pxt.appTarget.id,
-                false,
                 config.commitCdnUrl,
                 useLang,
                 pxt.appTarget.versions.pxtCrowdinBranch,


### PR DESCRIPTION
Docs pages only load sim strings which breaks translations of snippets. Simplify logic. FIx for https://github.com/Microsoft/pxt-ev3/issues/765