### PR TITLE
Unicode names

### DIFF
--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -457,6 +457,8 @@ export function genFileName(extension: string): string {
         const rx = new RegExp(pxt.appTarget.appTheme.fileNameExclusiveFilter, 'g');
         sanitizedName = sanitizedName.replace(rx, '');
     }
+    if (!sanitizedName)
+        sanitizedName = "Untitled"; // do not translate to avoid unicode issues
     const fn = `${pxt.appTarget.nickname || pxt.appTarget.id}-${sanitizedName}${extension}`;
     return fn;
 }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -227,7 +227,9 @@ export function saveAsync(h: Header, text?: ScriptText, isCloud?: boolean): Prom
 }
 
 function computePath(h: Header) {
-    let path = h.name.replace(/[^a-zA-Z0-9]+/g, " ").trim().replace(/ /g, "-")
+    let path = h.name.replace(/[^a-zA-Z0-9\u0000-\u007F]+/g, " ").trim().replace(/ /g, "-")
+    if (!path)
+        path = "Untitled"; // do not translate
     if (lookup(path)) {
         let n = 2
         while (lookup(path + "-" + n))

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -227,7 +227,7 @@ export function saveAsync(h: Header, text?: ScriptText, isCloud?: boolean): Prom
 }
 
 function computePath(h: Header) {
-    let path = h.name.replace(/[^a-zA-Z0-9\u0000-\u007F]+/g, " ").trim().replace(/ /g, "-")
+    let path = h.name.replace(/[^a-zA-Z0-9]+/g, " ").trim().replace(/ /g, "-")
     if (!path)
         path = "Untitled"; // do not translate
     if (lookup(path)) {


### PR DESCRIPTION
workspace.computePath strips out all non-ascii character so for script languages, nothing is left. We need a better fix in the future.