### PR TITLE
Fixing some iframe workspace bugs

### DIFF
--- a/webapp/src/iframeworkspace.ts
+++ b/webapp/src/iframeworkspace.ts
@@ -39,12 +39,15 @@ function getAsync(h: Header): Promise<pxt.workspace.File> {
 
 function setAsync(h: Header, prevVer: any, text?: ScriptText) {
     return mem.provider.setAsync(h, prevVer, text)
-        .then(() => pxt.editor.postHostMessageAsync(<pxt.editor.EditorWorkspaceSaveRequest>{
-            type: "pxthost",
-            action: "workspacesave",
-            project: { h, text },
-            response: false
-        })).then(() => { })
+        .then(() => {
+            const projectText = (text || (mem.projects[h.id] && mem.projects[h.id].text));
+            return pxt.editor.postHostMessageAsync(<pxt.editor.EditorWorkspaceSaveRequest>{
+                    type: "pxthost",
+                    action: "workspacesave",
+                    project: { header: h, text: projectText },
+                    response: false
+                })
+        }).then(() => { })
 }
 
 function resetAsync(): Promise<void> {

--- a/webapp/src/memoryworkspace.ts
+++ b/webapp/src/memoryworkspace.ts
@@ -11,6 +11,9 @@ export function merge(prj: Project) {
     let h: Header = prj.header;
     if (!h) {
         prj.header = h = pxt.workspace.freshHeader(lf("Untitled"), U.nowSeconds())
+        if (prj.text && prj.text["main.blocks"]) {
+            prj.header.editor = pxt.BLOCKS_PROJECT_NAME;
+        }
     }
     projects[prj.header.id] = prj;
 }


### PR DESCRIPTION
In the workspace refactor there were a few accidental breaking changes in the `workspacesync` message. This restores the old behavior.

I will also open this PR against stable 3.22