### PR TITLE
Workaround for edge render bug on simulator reveal

### DIFF
--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -107,6 +107,10 @@ export class CoreDialog extends React.Component<core.PromptOptions, {}> {
 
 let currentDialog: CoreDialog;
 
+export function dialogIsShowing() {
+    return !!currentDialog;
+}
+
 export function renderConfirmDialogAsync(options: core.PromptOptions): Promise<void> {
     return Promise.resolve()
         .delay(10)

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -61,7 +61,8 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
 
                 if (pxt.BrowserUtils.isEdge() && coretsx.dialogIsShowing()) {
                     // Workaround for an Edge bug where when a dialog is open and the simulator is
-                    // revealed it somehow breaks the page render
+                    // revealed it somehow breaks the page render. See https://github.com/Microsoft/pxt/pull/4707
+                    // for more details
 
                     document.body.style.display = "none";
                     requestAnimationFrame(() => {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../localtypings/pxtparts.d.ts" />
 
 import * as core from "./core";
+import * as coretsx from "./coretsx";
 import U = pxt.U
 
 interface SimulatorConfig {
@@ -53,6 +54,17 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
             el.style.animationDuration = '500ms';
             const animationClasses = `${animation} visible transition animating`;
             pxsim.U.addClass(el, animationClasses);
+
+            if (pxt.BrowserUtils.isEdge() && coretsx.dialogIsShowing()) {
+                // Workaround for an Edge bug where when a dialog is open and the simulator is
+                // revealed it somehow breaks the page render
+
+                document.body.style.display = "none";
+                requestAnimationFrame(() => {
+                    document.body.style.display = "block";
+                });
+            }
+
             Promise.resolve().delay(500).then(() => {
                 pxsim.U.removeClass(el, animationClasses);
                 el.style.animationDuration = '';
@@ -115,7 +127,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
                 driver.resume(pxsim.SimulatorDebuggerCommand.StepInto);
                 return;
             }
-            // we had an expected but could not find a block            
+            // we had an expected but could not find a block
             if (!highlighted && brk.exceptionMessage) {
                 pxt.debug(`runtime error: ${brk.exceptionMessage}`);
                 pxt.debug(brk.exceptionStack);

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -55,19 +55,19 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
             const animationClasses = `${animation} visible transition animating`;
             pxsim.U.addClass(el, animationClasses);
 
-            if (pxt.BrowserUtils.isEdge() && coretsx.dialogIsShowing()) {
-                // Workaround for an Edge bug where when a dialog is open and the simulator is
-                // revealed it somehow breaks the page render
-
-                document.body.style.display = "none";
-                requestAnimationFrame(() => {
-                    document.body.style.display = "block";
-                });
-            }
-
             Promise.resolve().delay(500).then(() => {
                 pxsim.U.removeClass(el, animationClasses);
                 el.style.animationDuration = '';
+
+                if (pxt.BrowserUtils.isEdge() && coretsx.dialogIsShowing()) {
+                    // Workaround for an Edge bug where when a dialog is open and the simulator is
+                    // revealed it somehow breaks the page render
+
+                    document.body.style.display = "none";
+                    requestAnimationFrame(() => {
+                        document.body.style.display = "block";
+                    });
+                }
             })
         },
         removeElement: (el, completeHandler) => {


### PR DESCRIPTION
We are hitting a bug in Edge when the simulator is revealed while a dialog is open. It repros about 50% of the time but I've managed to hit it several times on accident and I know @abchatra and @Jaqster have as well. Here is a gif of the bug:

![edge_render_bug](https://user-images.githubusercontent.com/13754588/45851740-3ceb6480-bcf1-11e8-80b3-ab85bb5f6987.gif)

The only workaround I've been able to find is forcing the document to redraw by quickly blinking the page. It's definitely noticeable but I think it's acceptable given that I've guarded the code so that it only happens in a pretty specific scenario:

![edge_render_bug_fix](https://user-images.githubusercontent.com/13754588/45851965-44f7d400-bcf2-11e8-9225-0579053c485f.gif)

BTW this isn't micro:bit specific; you can repro it in all of our editors in Edge.
