### PR TITLE
use same domain /api for translations / caching

### DIFF
--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -119,8 +119,10 @@ namespace ts.pxtc.Util {
                 const store = transaction.objectStore(IndexedDbTranslationDb.TABLE);
                 const request = store.get(id);
                 request.onsuccess = () => {
-                    this.mem.set(lang, filename, branch, request.result.etag, request.result.strings);
-                    resolve(this.mem.get(lang, filename, branch));
+                    if (request.result) {
+                        this.mem.set(lang, filename, branch, request.result.etag, request.result.strings);
+                        resolve(this.mem.get(lang, filename, branch));
+                    } else resolve(undefined);
                 }
                 request.onerror = () => resolve(undefined);
             });

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -119,9 +119,11 @@ namespace ts.pxtc.Util {
                 const store = transaction.objectStore(IndexedDbTranslationDb.TABLE);
                 const request = store.get(id);
                 request.onsuccess = () => {
-                    if (request.result) {
-                        this.mem.set(lang, filename, branch, request.result.etag, request.result.strings);
-                        resolve(this.mem.get(lang, filename, branch));
+                    const entry: ITranslationDbEntry = request.result;
+                    if (entry) {
+                        // store in-memory so that we don't try to download again
+                        this.mem.set(lang, filename, branch, entry.etag, entry.strings);
+                        resolve(entry);
                     } else resolve(undefined);
                 }
                 request.onerror = () => resolve(undefined);

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -1,7 +1,8 @@
 namespace pxt.Cloud {
     import Util = pxtc.Util;
 
-    export let apiRoot = "https://makecode.com/api/";
+    // hit /api/ to stay on same domain and avoid CORS
+    export let apiRoot = "/api/";
     export let accessToken = "";
     export let localToken = "";
     let _isOnline = true;
@@ -41,8 +42,11 @@ namespace pxt.Cloud {
         if (!Cloud.isOnline()) {
             return offlineError(options.url);
         }
-        if (accessToken) {
-            if (!options.headers) options.headers = {}
+        if (!options.headers) options.headers = {}
+        if (pxt.Cloud.isLocalHost()) {
+            if (Cloud.localToken)
+                options.headers["Authorization"] = Cloud.localToken;
+        } else if (accessToken) {
             options.headers["x-td-access-token"] = accessToken
         }
         return Util.requestAsync(options)

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -700,7 +700,7 @@ namespace ts.pxtc.Util {
         function downloadFromCloudAsync() {
             pxt.debug(`downloading translations for ${lang} ${filename} ${branch || ""}`);
             // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
-            let url = `${/^http:\/\/localhost(:\d+)\/?/i.test(window.location.href) ? "https://makecode.com" : ""}/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
+            let url = `${pxt.Cloud.isLocalHost() ? "https://makecode.com" : ""}/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
             if (branch) url += '&branch=' + encodeURIComponent(branch);
             const headers: pxt.Map<string> = {};
             if (etag) headers["If-None-Match"] = etag;

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -700,7 +700,7 @@ namespace ts.pxtc.Util {
         function downloadFromCloudAsync() {
             pxt.debug(`downloading translations for ${lang} ${filename} ${branch || ""}`);
             // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
-            let url = `https://makecode.com/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
+            let url = `${/^http:\/\/localhost(:\d+)\/?/i.test(window.location.href) ? "https://makecode.com" : ""}/api/translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
             if (branch) url += '&branch=' + encodeURIComponent(branch);
             const headers: pxt.Map<string> = {};
             if (etag) headers["If-None-Match"] = etag;
@@ -710,7 +710,7 @@ namespace ts.pxtc.Util {
                     return undefined;
                 else if (resp.statusCode == 200) {
                     // store etag and translations
-                    etag = resp.headers["ETag"] as string || "";
+                    etag = resp.headers["etag"] as string || "";
                     return translationDb.setAsync(lang, filename, branch, etag, resp.json)
                         .then(() => resp.json);
                 }
@@ -946,7 +946,8 @@ namespace ts.pxtc.BrowserImpl {
                         buffer: (client as any).responseBody || client.response,
                         text: options.responseArrayBuffer ? undefined : client.responseText,
                     }
-                    client.getAllResponseHeaders().split(/\r?\n/).forEach(l => {
+                    const allHeaders = client.getAllResponseHeaders();
+                    allHeaders.split(/\r?\n/).forEach(l => {
                         let m = /^\s*([^:]+): (.*)/.exec(l)
                         if (m) res.headers[m[1].toLowerCase()] = m[2]
                     })

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -711,7 +711,8 @@ namespace ts.pxtc.Util {
                 else if (resp.statusCode == 200) {
                     // store etag and translations
                     etag = resp.headers["etag"] as string || "";
-                    return translationDb.setAsync(lang, filename, branch, etag, resp.json)
+                    return translationDbAsync()
+                        .then(db => db.setAsync(lang, filename, branch, etag, resp.json))
                         .then(() => resp.json);
                 }
 
@@ -723,7 +724,8 @@ namespace ts.pxtc.Util {
         }
 
         // check for cache
-        return translationDb.getAsync(lang, filename, branch)
+        return translationDbAsync()
+            .then(db => db.getAsync(lang, filename, branch))
             .then((entry: ts.pxtc.Util.ITranslationDbEntry) => {
                 // if cached, return immediately
                 if (entry) {

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -90,61 +90,6 @@ export class Table {
     }
 }
 
-class TranslationDb implements ts.pxtc.Util.ITranslationDb {
-    table: Table;
-    memCache: pxt.Map<ts.pxtc.Util.ITranslationDbEntry> = {};
-
-    constructor() {
-        this.table = new Table("translations");
-    }
-
-    private key(lang: string, filename: string, branch: string) {
-        return `${lang}-${filename}-${branch || ""}`;
-    }
-
-    getAsync(lang: string, filename: string, branch?: string): Promise<ts.pxtc.Util.ITranslationDbEntry> {
-        const id = this.key(lang, filename, branch);
-        // only update once per session
-        const entry = this.memCache[id];
-        if (entry) {
-            pxt.debug(`translation cache live hit ${id}`);
-            return Promise.resolve(entry);
-        }
-
-        // load from pouchdb
-        pxt.debug(`translation cache: load ${id}`)
-        return this.table.getAsync(id).then(
-            v => {
-                pxt.debug(`translation cache hit ${id}`);
-                return v;
-            },
-            e => {
-                pxt.debug(`translation cache miss ${id}`);
-                return undefined;
-            } // not found
-        );
-    }
-    setAsync(lang: string, filename: string, branch: string, etag: string, strings: pxt.Map<string>): Promise<void> {
-        const id = this.key(lang, filename, branch);
-        const entry: ts.pxtc.Util.ITranslationDbEntry = {
-            id,
-            etag,
-            strings
-        };
-        pxt.debug(`translation cache: save ${id}-${etag}`)
-        const mem = pxt.Util.clone(entry);
-        mem.cached = true;
-        delete (<any>mem)._rev;
-        this.memCache[id] = mem;
-        return this.table.forceSetAsync(entry).then(() => { }, e => {
-            pxt.log(`translate cache: conflict for ${id}`);
-        });
-    }
-
-}
-
-ts.pxtc.Util.translationDb = new TranslationDb();
-
 class GithubDb implements pxt.github.IGithubDb {
     // in memory cache
     private mem = new pxt.github.MemoryGithubDb();


### PR DESCRIPTION
- [x] Hit ``/api/translations...`` from client to avoid CORS issues. Also fix "ETag" -> "etag".
- [x] store translations in indexeddb to share them with editor. Translations are stored in PouchDB which is not available in docs.

The translations are stored in a db, along with the ETag. There is a 5 minute expiration in the db after which the ETag might be tested again. ETag is only checked once per browser sessions (once per 24h) to avoid requesting it multiple times during a single sesion.

This should not impact the cloud.

