### PR TITLE
Markdown caching

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -89,7 +89,8 @@ namespace pxt.Cloud {
         })
     }
 
-    const MARKDOWN_EXPIRATION = 60 * 1000;
+    // 1h check on markdown content
+    const MARKDOWN_EXPIRATION = 1 * 60 * 60 * 1000;
     export function markdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
         return ts.pxtc.Util.translationDbAsync()
             .then(db => db.getAsync(locale, docid, "")

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -92,7 +92,7 @@ namespace pxt.Cloud {
     // 1h check on markdown content
     const MARKDOWN_EXPIRATION = 1 * 60 * 60 * 1000;
     export function markdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
-        const branch = pxt.appTarget.versions && pxt.appTarget.versions.target || '?';
+        const branch = "";
         return ts.pxtc.Util.translationDbAsync()
             .then(db => db.getAsync(locale, docid, "")
                 .then(entry => {

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -92,13 +92,14 @@ namespace pxt.Cloud {
     // 1h check on markdown content
     const MARKDOWN_EXPIRATION = 1 * 60 * 60 * 1000;
     export function markdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
+        const branch = pxt.appTarget.versions && pxt.appTarget.versions.target || '?';
         return ts.pxtc.Util.translationDbAsync()
             .then(db => db.getAsync(locale, docid, "")
                 .then(entry => {
                     if (entry && Date.now() - entry.time > MARKDOWN_EXPIRATION)
                         // background update, 
                         downloadMarkdownAsync(docid, locale, live, entry.etag)
-                            .then(r => db.setAsync(locale, docid, "", r.etag, undefined, r.md || entry.md))
+                            .then(r => db.setAsync(locale, docid, branch, r.etag, undefined, r.md || entry.md))
                             .catch(() => { }) // swallow errors
                             .done();
                     // return cached entry
@@ -106,7 +107,7 @@ namespace pxt.Cloud {
                         return entry.md;
                     // download and cache
                     else return downloadMarkdownAsync(docid, locale, live)
-                        .then(r => db.setAsync(locale, docid, "", r.etag, undefined, r.md)
+                        .then(r => db.setAsync(locale, docid, branch, r.etag, undefined, r.md)
                             .then(() => r.md))
                         .catch(() => ""); // no translation
                 }))

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -89,12 +89,12 @@ namespace pxt.gallery {
     }
 
     export function loadGalleryAsync(name: string): Promise<Gallery[]> {
-        return pxt.Cloud.downloadMarkdownAsync(name, pxt.Util.userLanguage(), pxt.Util.localizeLive)
+        return pxt.Cloud.markdownAsync(name, pxt.Util.userLanguage(), pxt.Util.localizeLive)
             .then(md => parseGalleryMardown(md))
     }
 
     export function loadExampleAsync(name: string, path: string): Promise<GalleryProject> {
-        return pxt.Cloud.downloadMarkdownAsync(path, pxt.Util.userLanguage(), pxt.Util.localizeLive)
+        return pxt.Cloud.markdownAsync(path, pxt.Util.userLanguage(), pxt.Util.localizeLive)
             .then(md => parseExampleMarkdown(name, md))
     }
 }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -605,7 +605,7 @@ ${linkString}
 
     function renderDocAsync(content: HTMLElement, docid: string): Promise<void> {
         docid = docid.replace(/^\//, "");
-        return pxt.Cloud.downloadMarkdownAsync(docid, editorLocale, pxt.Util.localizeLive)
+        return pxt.Cloud.markdownAsync(docid, editorLocale, pxt.Util.localizeLive)
             .then(md => renderMarkdownAsync(content, md, { path: docid }))
     }
 
@@ -621,7 +621,7 @@ ${linkString}
         // start the work
         let toc: TOCMenuEntry[];
         return Promise.delay(100)
-            .then(() => pxt.Cloud.downloadMarkdownAsync(summaryid, editorLocale, pxt.Util.localizeLive))
+            .then(() => pxt.Cloud.markdownAsync(summaryid, editorLocale, pxt.Util.localizeLive))
             .then(summary => {
                 toc = pxt.docs.buildTOC(summary);
                 pxt.log(`TOC: ${JSON.stringify(toc, null, 2)}`)
@@ -629,7 +629,7 @@ ${linkString}
                 pxt.docs.visitTOC(toc, entry => {
                     if (!/^\//.test(entry.path) || /^\/pkg\//.test(entry.path)) return;
                     tocsp.push(
-                        pxt.Cloud.downloadMarkdownAsync(entry.path, editorLocale, pxt.Util.localizeLive)
+                        pxt.Cloud.markdownAsync(entry.path, editorLocale, pxt.Util.localizeLive)
                             .then(md => {
                                 entry.markdown = md;
                             }, e => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2055,7 +2055,7 @@ export class ProjectView
         let tutorialmd: string;
 
         return Promise.resolve()
-            .then(() => pxt.Cloud.downloadMarkdownAsync(tutorialId))
+            .then(() => pxt.Cloud.markdownAsync(tutorialId))
             .then(md => {
                 if (!md)
                     throw new Error("tutorial not found");


### PR DESCRIPTION
Uses translation database to cache Markdown sources in indexeddb. This is shared between editor and sidedocs.
- [x] use etag
- [x] background every refresh at most every hour