### PR TITLE
Adding array.prototype.find as a polyfill for ie11

### DIFF
--- a/pxtsim/utils.ts
+++ b/pxtsim/utils.ts
@@ -47,6 +47,53 @@ namespace pxsim.util {
                 }
             });
         }
+
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+        if (!Array.prototype.find) {
+            Object.defineProperty(Array.prototype, 'find', {
+                writable: true,
+                enumerable: true,
+                value: function(predicate : (value: any, index: number, obj: any[] ) => boolean) {
+                    // 1. Let O be ? ToObject(this value).
+                    if (this == null) {
+                        throw new TypeError('"this" is null or not defined');
+                    }
+
+                    var o = Object(this);
+
+                    // 2. Let len be ? ToLength(? Get(O, "length")).
+                    var len = o.length >>> 0;
+
+                    // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+                    if (typeof predicate !== 'function') {
+                        throw new TypeError('predicate must be a function');
+                    }
+
+                    // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+                    var thisArg = arguments[1];
+
+                    // 5. Let k be 0.
+                    var k = 0;
+
+                    // 6. Repeat, while k < len
+                    while (k < len) {
+                        // a. Let Pk be ! ToString(k).
+                        // b. Let kValue be ? Get(O, Pk).
+                        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                        // d. If testResult is true, return kValue.
+                        var kValue = o[k];
+                        if (predicate.call(thisArg, kValue, k, o)) {
+                        return kValue;
+                        }
+                        // e. Increase k by 1.
+                        k++;
+                    }
+
+                    // 7. Return undefined.
+                    return undefined;
+                },
+            });
+        }
         // Polyfill for Uint8Array.slice for IE and Safari
         // https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.slice
         // TODO: Move this polyfill to a more appropriate file. It is left here for now because moving it causes a crash in IE; see PXT issue #1301.

--- a/pxtsim/utils.ts
+++ b/pxtsim/utils.ts
@@ -53,16 +53,16 @@ namespace pxsim.util {
             Object.defineProperty(Array.prototype, 'find', {
                 writable: true,
                 enumerable: true,
-                value: function(predicate : (value: any, index: number, obj: any[] ) => boolean) {
+                value: function(predicate: (value: any, index: number, obj: any[] ) => boolean) {
                     // 1. Let O be ? ToObject(this value).
                     if (this == null) {
                         throw new TypeError('"this" is null or not defined');
                     }
 
-                    var o = Object(this);
+                    let o = Object(this);
 
                     // 2. Let len be ? ToLength(? Get(O, "length")).
-                    var len = o.length >>> 0;
+                    const len = o.length >>> 0;
 
                     // 3. If IsCallable(predicate) is false, throw a TypeError exception.
                     if (typeof predicate !== 'function') {
@@ -70,10 +70,10 @@ namespace pxsim.util {
                     }
 
                     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-                    var thisArg = arguments[1];
+                    const thisArg = arguments[1];
 
                     // 5. Let k be 0.
-                    var k = 0;
+                    let k = 0;
 
                     // 6. Repeat, while k < len
                     while (k < len) {
@@ -81,7 +81,7 @@ namespace pxsim.util {
                         // b. Let kValue be ? Get(O, Pk).
                         // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
                         // d. If testResult is true, return kValue.
-                        var kValue = o[k];
+                        const kValue = o[k];
                         if (predicate.call(thisArg, kValue, k, o)) {
                         return kValue;
                         }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-ev3/issues/794 and https://github.com/Microsoft/pxt-ev3/issues/795
