### PR TITLE
Support extension <-> package duality

### DIFF
--- a/common-docs/extensions.md
+++ b/common-docs/extensions.md
@@ -1,0 +1,18 @@
+# Extensions
+
+## #gallery
+
+## Using extensions
+
+In the web editor, click on ``Settings`` then ``Extensions`` to search and add extensions to the project.
+The Blocks and JavaScript definitions will be automatically loaded in the editor.
+
+## Custom extensions
+
+The [Build Your Own Extension](/extensions/build-your-own) manual is for advanced users who want to publish their own extension.
+
+## ~ hint
+
+Extensions are also known, and referred to, as _packages_. The term _package_ is currently used in the MakeCode documentation for developing and deploying extensions.
+
+## ~

--- a/common-docs/extensions/approval.md
+++ b/common-docs/extensions/approval.md
@@ -1,0 +1,14 @@
+# Extension Approval
+
+Only approved extensions may be surfaced in search results in the ``Extensions`` dialog.
+GitHub Organizations or GitHub repos can be approved.
+
+Banned extensions are not allowed to be loaded.
+
+## #approval
+
+## ~ hint
+
+Extensions are also known, and referred to, as _packages_. The term _package_ is currently used in the MakeCode documentation for developing and deploying extensions.
+
+## ~

--- a/common-docs/extensions/build-your-own.md
+++ b/common-docs/extensions/build-your-own.md
@@ -1,3 +1,9 @@
 ## Building your own extension
 
 Content has moved [here](http://www.makecode.com/packages/getting-started)
+
+## ~ hint
+
+Extensions are also known, and referred to, as _packages_. The term _package_ is currently used in the MakeCode documentation for developing and deploying extensions.
+
+## ~

--- a/common-docs/extensions/build-your-own.md
+++ b/common-docs/extensions/build-your-own.md
@@ -1,0 +1,3 @@
+## Building your own extension
+
+Content has moved [here](http://www.makecode.com/packages/getting-started)

--- a/common-docs/extensions/versioning.md
+++ b/common-docs/extensions/versioning.md
@@ -1,0 +1,9 @@
+## Package versioning
+
+Content has moved [here](http://www.makecode.com/extensions/versioning)
+
+## ~ hint
+
+Extensions are also known, and referred to, as _packages_. The term _package_ is currently used in the MakeCode documentation for developing and deploying extensions.
+
+## ~

--- a/common-docs/extensions/versioning.md
+++ b/common-docs/extensions/versioning.md
@@ -1,6 +1,6 @@
 ## Package versioning
 
-Content has moved [here](http://www.makecode.com/extensions/versioning)
+Content has moved [here](http://www.makecode.com/packages/versioning)
 
 ## ~ hint
 


### PR DESCRIPTION
Add an _./extensions_ doc tree to support duality of terms. This maybe temporary with _./packages_ eventually being removed.
- [ ] add redirect for previous files (using -ref.json files)
- [ ] add hint in various places explaining that "Add package" is now "Extensions"

RE: https://github.com/Microsoft/pxt-microbit/issues/1120