### PR TITLE
Fix missing 'the' in dl filename hint

### DIFF
--- a/common-docs/about/editor-features.md
+++ b/common-docs/about/editor-features.md
@@ -74,7 +74,7 @@ The **Download** button will copy your program to a drive on your computer. You 
 
 **Project name and download filename**
 
-When you download the program for your project, the name you gave the project becomes part of the download file. If you decide to rename the download file, the name you chose for the project, not the current filename, is used and displayed by editor.
+When you download the program for your project, the name you gave the project becomes part of the download file. If you decide to rename the download file, the name you chose for the project, not the current filename, is used and displayed by the editor.
 
 #### ~
 

--- a/common-docs/faq.md
+++ b/common-docs/faq.md
@@ -44,7 +44,7 @@ When you share a project it's saved to the public cloud for MakeCode. Anyone can
 
 ## Why does the editor still use the previous project name if I renamed the download file?
 
-When you download the program for your project, the name you gave the project becomes part of the download file. If you decide to rename the download file, the name you chose for the project, not the current filename, is used and displayed by editor.
+When you download the program for your project, the name you gave the project becomes part of the download file. If you decide to rename the download file, the name you chose for the project, not the current filename, is used and displayed by the editor.
 
 ## I don't see my question here. What's next?
 


### PR DESCRIPTION
Left out a 'the' in that last description sentence.