### PR TITLE
Fix issue with modal showing up half height on the screen

### DIFF
--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -7,6 +7,7 @@
 .modals.dimmer .ui.fullscreen.modal,
 .modals.dimmer .ui.fullscreen.scrolling.modal {
     position: absolute !important;
+    top: 0 !important;
     margin: 0 !important;
     padding: 0 !important;
     border: 0 !important;


### PR DESCRIPTION
There's some sort of race that ends up in this situation.

![image](https://user-images.githubusercontent.com/16690124/46227264-88b29500-c313-11e8-87e4-bf9597c1f75d.png)
