### PR TITLE
Increase the default zoom level

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -836,7 +836,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 maxScale: 2.5,
                 minScale: .2,
                 scaleSpeed: 1.05,
-                startScale: pxt.BrowserUtils.isMobile() ? 0.7 : 0.8
+                startScale: pxt.BrowserUtils.isMobile() ? 0.7 : 0.9
             },
             rtl: Util.isUserLanguageRtl()
         };


### PR DESCRIPTION
This is in order to account for changes in the rendering between v0 and v1 that makes the block sizes bigger (for larger touch targets) and in turn the perceived font size is smaller. 

To account for these changes, I'm tweaking the default zoom level a tad.

These are the microbit defaults side by side: 
![screen shot 2018-09-28 at 1 54 44 pm](https://user-images.githubusercontent.com/16690124/46233038-1bf4c600-c326-11e8-94a6-daaf8bf79422.png)
![screen shot 2018-09-28 at 1 54 37 pm](https://user-images.githubusercontent.com/16690124/46233040-1c8d5c80-c326-11e8-8405-56208035cb9e.png)

Fixes https://github.com/Microsoft/pxt-microbit/issues/1230
