### PR TITLE
Determine the OFF colour of leds based on the parent block's primary colour.

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -67,6 +67,7 @@ declare namespace goog {
     }
 
     namespace color {
+        function lighten(rgb: number[], factor: number): number[];
         function darken(rgb: number[], factor: number): number[];
         function rgbArrayToHex(rgb: number[]): string;
         function hexToRgb(hex: string): number[];

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -24,7 +24,8 @@ namespace pxtblockly {
 
         private params: any;
         private onColor = "#FF3130";
-        private offColor = "#A0C9F0";
+        private offColor: string;
+        private static DEFAULT_OFF_COLOR = "#A0C9F0";
 
         // The number of columns
         private matrixWidth: number = 5;
@@ -188,7 +189,12 @@ namespace pxtblockly {
         }
 
         private getColor(x: number, y: number) {
-            return this.cellState[x][y] ? this.onColor : this.offColor;
+            if (!this.offColor) {
+                const primaryColour = (this.sourceBlock_.isShadow()) ?
+                    this.sourceBlock_.parentBlock_.getColour() : this.sourceBlock_.getColour();
+                this.offColor = goog.color.rgbArrayToHex(goog.color.lighten(goog.color.hexToRgb(primaryColour), 0.6));
+            }
+            return this.cellState[x][y] ? this.onColor : (this.offColor || FieldMatrix.DEFAULT_OFF_COLOR);
         }
 
         private updateCell(x: number, y: number) {


### PR DESCRIPTION
Determine the OFF colour of leds based on the parent block's primary colour.

Instead of having a static default colour, this change uses the block's primary colour and lighten's it by 60% in order to determine the LED matrix's OFF colour. 

Here's an example: 
![screen shot 2018-10-01 at 10 07 34 am](https://user-images.githubusercontent.com/16690124/46304402-7038b980-c563-11e8-9247-5fa7e12ba073.png)

Notice how the colours of the leds are different when the parent block's colour is blue vs purple. 

https://github.com/Microsoft/pxt-microbit/issues/1317