### PR TITLE
added css styles for tables

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -58,19 +58,6 @@ li code:before, li code:after {
     content: "\00a0";
 }
 
-table {
-    border-collapse: collapse;
-}
-
-table tr th, table tr td {
-    border: 1px solid #333;
-    padding: 6px 13px; 
-}
-
-table tr:nth-child(2n) {
-    background-color: #f8f8f8; 
-}
-
 code.hljs {
     padding: 0 !important;
 }

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -58,6 +58,19 @@ li code:before, li code:after {
     content: "\00a0";
 }
 
+table {
+    border-collapse: collapse;
+}
+
+table tr th, table tr td {
+    border: 1px solid #333;
+    padding: 6px 13px; 
+}
+
+table tr:nth-child(2n) {
+    background-color: #f8f8f8; 
+}
+
 code.hljs {
     padding: 0 !important;
 }

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -148,6 +148,16 @@
         color: #aeaeae;
         cursor: not-allowed;
     }
+    table {
+        border-collapse: collapse;
+    }
+    table tr th, table tr td {
+        border: 1px solid #333;
+        padding: 6px 13px;
+    }
+    table tr:nth-child(2n) {
+        background-color: #f8f8f8;
+    }
 }
 
 .sideDocs #sidedocsbar a {


### PR DESCRIPTION
Added CSS styles for tables that better defines cells with grid lines. Also, changes the background color of every other row.

Before:
![pizza-table-before](https://user-images.githubusercontent.com/13285164/46431336-63050180-c700-11e8-807e-fbfdf414cd86.png)

After
![pizza-table-after](https://user-images.githubusercontent.com/13285164/46431339-65675b80-c700-11e8-8ecb-4b2bacb276ee.png)


I wasn't sure what the pxt color scheme was, so I just went with what I thought looked best.