### PR TITLE
New syntax for setting shadow values

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -103,7 +103,7 @@ type = string
 * the function parameter are mapped **in order** to `%parameter` argument. The loader automatically builds
 a mapping between the block field names and the function names.
 * the block will automatically switch to external inputs when enough parameters are detected
-* A block type `=type` can be specified optionally for each parameter. It will be used to populate the shadow type.
+* Using `=type` in the block string for shadow blocks is deprecated. See "Specifying shadow blocks" for more details.
 
 ## Supported types
 
@@ -114,6 +114,25 @@ The following [types](/playground#basic-types) are supported in function signatu
 * enums (see below)
 * custom classes that are also exported
 * arrays of the above
+
+## Specifying shadow blocks
+
+A "shadow" block is a block which cannot be removed from its parent but can have
+other blocks placed on top. They are used to ensure that block inputs always have
+valid values instead of leaving a "hole" behind when a block is removed. All parameters
+are given shadow blocks in PXT for the supported types (listed above). To specify a shadow block
+for an unsupported type or to override a default shadow, use the following syntax:
+
+```typescript-ignore
+//% block="$myParam"
+//% myParam.shadow="myShadowBlockID"
+function myFunction(myParam: number): void {}
+```
+
+If an existing block definition specifies the shadow block id within the block string,
+the value can be changed using the above syntax without altering the block string. This
+allows the shadow block to be changed without invalidating the localization of the block.
+Setting the shadow id to `unset` will remove any existing shadow value.
 
 ## Specifying min and max values
 

--- a/docs/static/playground/samples/basic/inline/sample.js
+++ b/docs/static/playground/samples/basic/inline/sample.js
@@ -1,14 +1,14 @@
 // use the inlineInputMode=inline to force inputs to appear on a single line
 namespace sample {
-    //% block="map %value|from low %fromLow|high %fromHigh|to low %toLow|high %toHigh"
+    //% block="map $value|from low $fromLow|high $fromHigh|to low $toLow|high $toHigh"
     export function mapBig(value: number, fromLow: number, fromHigh: number, toLow: number, toHigh: number): number {
         return ((value - fromLow) * (toHigh - toLow)) / (fromHigh - fromLow) + toLow;
-    }    
+    }
 
 
-    //% block="map %value|from low %fromLow|high %fromHigh|to low %toLow|high %toHigh"
+    //% block="map $value|from low $fromLow|high $fromHigh|to low $toLow|high $toHigh"
     //% inlineInputMode=inline
     export function map(value: number, fromLow: number, fromHigh: number, toLow: number, toHigh: number): number {
         return ((value - fromLow) * (toHigh - toLow)) / (fromHigh - fromLow) + toLow;
-    }    
+    }
 }

--- a/docs/static/playground/samples/field-editors/color/sample.js
+++ b/docs/static/playground/samples/field-editors/color/sample.js
@@ -1,17 +1,20 @@
 
 //% color="#D063CF"
 namespace rgb {
-    //% block="show color %color=colorNumberPicker"
+    //% block="show color $color"
+    //% color.shadow="colorNumberPicker"
     export function showColor(color: number) {
 
     }
 
-    //% block="show wheel %color=colorWheelPicker"
+    //% block="show wheel $color"
+    //% color.shadow="colorWheelPicker"
     export function showColorWheel(color: number) {
 
     }
 
-   //% block="show wheel hsv %color=colorWheelHsvPicker"
+   //% block="show wheel hsv $color"
+   //% color.shadow="colorWheelHsvPicker"
    export function showColorWheelHsv(color: number) {
 
 }

--- a/docs/static/playground/samples/field-editors/dropdowns/sample.js
+++ b/docs/static/playground/samples/field-editors/dropdowns/sample.js
@@ -2,7 +2,8 @@
 //% color="#FFAB19"
 namespace control {
 
-    //% block="pause %ms=timePicker"
+    //% block="pause $ms"
+    //% ms.shadow="timePicker"
     export function pause(ms: number) {
 
     }
@@ -15,7 +16,7 @@ namespace control {
       * Get the word field editor
       * @param word eg: Hello
       */
-    //% blockId=wordPicker block="%word"
+    //% blockId=wordPicker block="$word"
     //% blockHidden=true
     //% colorSecondary="#FFFFFF"
     //% word.fieldEditor="textdropdown" word.fieldOptions.decompileLiterals=true
@@ -23,9 +24,10 @@ namespace control {
     export function __wordPicker(word: string): string {
         return word;
     }
-    
 
-    //% block="say %word=wordPicker"
+
+    //% block="say $word"
+    //% word.shadow="wordPicker"
     export function say(word: string) {
 
     }

--- a/docs/static/playground/samples/field-editors/note/sample.js
+++ b/docs/static/playground/samples/field-editors/note/sample.js
@@ -7,7 +7,8 @@ namespace music {
      * @param note pitch of the tone to play in Hertz (Hz), eg: Note.C
      */
     //% blockId=music_play_note
-    //% block="play tone %note=device_note tone"
+    //% block="play tone $note tone"
+    //% note.shadow="device_note"
     export function playTone(note: number) {
 
     }
@@ -16,7 +17,7 @@ namespace music {
      * Get the frequency of a note.
      * @param note the note name, eg: Note.C
      */
-    //% blockId=device_note block="%note"
+    //% blockId=device_note block="$note"
     //% shim=TD_ID
     //% color="#ffffff" colorSecondary="#ffffff" colorTertiary="#D83B01"
     //% note.fieldEditor="note" note.defl="262"

--- a/docs/static/playground/samples/field-editors/protractor/sample.js
+++ b/docs/static/playground/samples/field-editors/protractor/sample.js
@@ -4,7 +4,8 @@ namespace turtle {
     /**
      * Turns by an angle between 0 and 180
      */
-    //% block="turn %angle=protractorPicker"
+    //% block="turn $angle"
+    //% angle.shadow="protractorPicker"
     export function turn(angle: number) {
 
     }

--- a/docs/static/playground/samples/field-editors/speed/sample.js
+++ b/docs/static/playground/samples/field-editors/speed/sample.js
@@ -2,7 +2,8 @@ namespace motors {
     /**
      * Runs the motor at the given speed
      */
-    //% block="crickit run at %speed=speedPicker \\%"
+    //% block="crickit run at $speed \\%"
+    //% speed.shadow="speedPicker"
     export function run(speed: number) {
 
     }

--- a/docs/static/playground/samples/field-editors/toggle/sample.js
+++ b/docs/static/playground/samples/field-editors/toggle/sample.js
@@ -3,7 +3,8 @@ namespace sample {
     /**
      * Render a boolean as a down/up toggle
      */
-    //% block="%down=toggleDownUp"
+    //% block="$down"
+    //% down.shadow="toggleDownUp"
     export function downUp(down: boolean): boolean {
         return down;
     }
@@ -11,7 +12,8 @@ namespace sample {
     /**
      * Render a boolean as an up/down toggle
      */
-    //% block="%up=toggleUpDown"
+    //% block="$up"
+    //% up.shadow="toggleUpDown"
     export function upDown(up: boolean): boolean {
         return up;
     }
@@ -19,7 +21,8 @@ namespace sample {
     /**
      * Render a boolean as a high/low toggle
      */
-    //% block="%high=toggleHighLow"
+    //% block="$high"
+    //% high.shadow="toggleHighLow"
     export function highLow(high: boolean): boolean {
         return high;
     }
@@ -28,7 +31,8 @@ namespace sample {
     /**
      * Render a boolean as a on/off toggle
      */
-    //%  block="%on=toggleOnOff"
+    //% block="$on"
+    //% on.shadow="toggleOnOff"
     export function onOff(on: boolean): boolean {
         return on;
     }
@@ -36,7 +40,8 @@ namespace sample {
     /**
      * Render a boolean as a yes/no toggle
      */
-    //% block="%yes=toggleYesNo"
+    //% block="$yes"
+    //% yes.shadow="toggleYesNo"
     export function yesNo(yes: boolean): boolean {
         return yes;
     }

--- a/docs/static/playground/samples/field-editors/turnratio/sample.js
+++ b/docs/static/playground/samples/field-editors/turnratio/sample.js
@@ -2,8 +2,9 @@ namespace motors {
     /**
      * Steers two motors by the given ratio
      */
-    //% block="steer %turnRatio=turnRatioPicker"
-    //% turnRatio.min=-200 turnRatio=200
+    //% block="steer $turnRatio"
+    //% turnRatio.min=-200 turnRatio.max=200
+    //% turnratio.shadow=turnRatioPicker
     export function steer(turnRatio: number) {
     }
 }

--- a/docs/static/playground/samples/language/create-enums/sample.js
+++ b/docs/static/playground/samples/language/create-enums/sample.js
@@ -36,7 +36,7 @@ namespace language {
      */
     //% shim=ENUM_GET
     //% blockId=color_enum_shim
-    //% block="Color %arg"
+    //% block="Color $arg"
     //% enumName="Colors"
     //% enumMemberName="color"
     //% enumPromptHint="e.g. Green, Orange, ..."
@@ -62,7 +62,7 @@ namespace language {
      */
     //% shim=ENUM_GET
     //% blockId=flag_enum_shim
-    //% block="Flag %arg"
+    //% block="Flag $arg"
     //% enumName="Flags"
     //% enumMemberName="flag"
     //% enumPromptHint="e.g. B, C, ..."
@@ -80,7 +80,8 @@ namespace language {
      * should be of type "number" (not the enum type)
      */
     //% blockId=show_color
-    //% block="show $color=color_enum_shim"
+    //% block="show $color"
+    //% color.shadow="color_enum_shim"
     export function showColor(color: number) {
 
     }

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -404,6 +404,50 @@ describe("comment attribute parser", () => {
             })
         });
     });
+
+    it("should allow overrides of shadow values in the block string", () => {
+        const parsed = pxtc.parseCommentString(`
+            /**
+             * Configures the Pulse-width modulation (PWM) of the analog
+             * output to the
+             * @param micros period in micro seconds. eg:20000
+             * @param whatever period in milli seconds.
+             */
+            //% block="$micros $whatever=oldShadowBlock"
+            //% micros.shadow="shadowBlock1"
+            //% whatever.shadow="shadowBlock2"
+        `)._def;
+
+        checkParam("micros", "shadowBlock1");
+        checkParam("whatever", "shadowBlock2")
+
+        function checkParam(name: string, shadow: string) {
+            chai.assert(parsed.parameters.filter(p => p.name === name && p.shadowBlockId == shadow).length == 1);
+            chai.assert(parsed.parts.filter(p => p.kind === "param" && p.name === name && p.shadowBlockId == shadow).length === 1);
+        }
+    });
+
+    it("should allow shadow values in the block string to be unset", () => {
+        const parsed = pxtc.parseCommentString(`
+            /**
+             * Configures the Pulse-width modulation (PWM) of the analog
+             * output to the
+             * @param micros period in micro seconds. eg:20000
+             * @param whatever period in milli seconds.
+             */
+            //% block="$micros $whatever=oldShadowBlock"
+            //% whatever.shadow="unset"
+            //% micros.shadow="unset"
+        `)._def;
+
+        checkParam("micros", undefined);
+        checkParam("whatever", undefined);
+
+        function checkParam(name: string, shadow: string) {
+            chai.assert(parsed.parameters.filter(p => p.name === name && p.shadowBlockId == shadow).length == 1);
+            chai.assert(parsed.parts.filter(p => p.kind === "param" && p.name === name && p.shadowBlockId == shadow).length === 1);
+        }
+    });
 });
 
 function brk(): pxtc.BlockBreak {


### PR DESCRIPTION
Adding some syntax for setting shadow block ids outside of the block string. Hopefully this will make changing shadow blocks without breaking localizations a bit easier. The new syntax overrides the old syntax and I would say the old syntax should be considered "deprecated".

The proposed syntax:

```typescript
//% block="whatever $param=oldShadow"
//% param.shadow="newShadow"
```

Related: https://github.com/Microsoft/pxt/issues/4757
