### PR TITLE
popup boards dialog after create project

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -275,6 +275,7 @@ declare namespace pxt {
         browserDbPrefixes?: { [majorVersion: number]: string }; // Prefix used when storing projects in the DB to allow side-by-side projects of different major versions
         editorVersionPaths?: { [majorVersion: number]: string }; // A map of major editor versions to their corresponding paths (alpha, v1, etc.)
         experiments?: string[]; // list of experiment ids, also enables this feature
+        chooseBoardOnNewProject?: boolean; // when multiple boards are support, show board dialog on "new project"
     }
 
     interface SocialOptions {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -82,6 +82,7 @@ namespace pxt.editor {
         inTutorial?: boolean;
         dependencies?: pxt.Map<string>;
         tsOnly?: boolean;
+        changeBoardOnLoad?: boolean; // if applicable, pop up the "boards" dialog after creating the project
     }
 
     export interface ProjectFilters {

--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -61,15 +61,15 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
     }
 
     renderCore() {
-        const {highContrast} = this.props.parent.state;
+        const { highContrast } = this.props.parent.state;
         const targetTheme = pxt.appTarget.appTheme;
         const hasHome = !pxt.shell.isControllerMode();
 
         return <div className="ui accessibleMenu borderless fixed menu" role="menubar">
-            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon js" text={lf("Skip to JavaScript editor") } onClick={this.openJavaScript} />
-            {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language") } onClick={this.showLanguagePicker} /> : undefined}
-            {targetTheme.highContrast ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On") } onClick={this.toggleHighContrast} /> : undefined}
-            {hasHome ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="home" text={lf("Go Home") } onClick={this.goHome} /> : undefined}
+            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon js" text={lf("Skip to JavaScript editor")} onClick={this.openJavaScript} />
+            {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={this.showLanguagePicker} /> : undefined}
+            {targetTheme.highContrast ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
+            {hasHome ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="home" text={lf("Go Home")} onClick={this.goHome} /> : undefined}
         </div>;
     }
 }
@@ -98,7 +98,7 @@ export class HomeAccessibilityMenu extends data.Component<HomeAccessibilityMenuP
 
     newProject() {
         pxt.tickEvent("accmenu.home.new", undefined, { interactiveConsent: true });
-        this.props.parent.newProject();
+        this.props.parent.newProject({ changeBoardOnLoad: true });
     }
 
     importProjectDialog() {
@@ -129,13 +129,13 @@ export class HomeAccessibilityMenu extends data.Component<HomeAccessibilityMenuP
     }
 
     renderCore() {
-        const {highContrast} = this.state;
+        const { highContrast } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
         return <div className="ui accessibleMenu borderless fixed menu" role="menubar">
-            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="add circle" text={lf("New Project") } onClick={this.newProject} />
-            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="upload" text={lf("Import Project") } onClick={this.importProjectDialog} />
-            {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language") } onClick={this.showLanguagePicker} /> : undefined}
-            {targetTheme.highContrast ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On") } onClick={this.toggleHighContrast} /> : undefined}
+            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="add circle" text={lf("New Project")} onClick={this.newProject} />
+            <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="upload" text={lf("Import Project")} onClick={this.importProjectDialog} />
+            {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={this.showLanguagePicker} /> : undefined}
+            {targetTheme.highContrast ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
         </div>;
     }
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -348,7 +348,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
 
     newProject() {
         pxt.tickEvent("projects.new", undefined, { interactiveConsent: true });
-        this.props.parent.newProject();
+        this.props.parent.newProject({ changeBoardOnLoad: true });
     }
 
     closeDetail() {


### PR DESCRIPTION
After creating a new empty project, pop up the "change board" dialog to pick which board to use. Small change, good reuse of existing UI. It only happens when the user creates new project, not when starting tutorials or other occurences. Turned on by a flag.

![openboards](https://user-images.githubusercontent.com/4175913/46450724-a2a30c00-c747-11e8-8848-dd553eaa0679.gif)
