### PR TITLE
Fix embedded --run iframe on iOS

### DIFF
--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -6,6 +6,16 @@
     <title>simulator</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <style>
+        #wrap {
+            position: fixed;
+            top: 0;
+            right:0;
+            bottom:0;
+            left: 0;
+            overflow-y: scroll;
+            -webkit-overflow-scrolling: touch;
+        }
+
         html {
             width: 100%;
             height: 100%;
@@ -71,6 +81,7 @@
 </head>
 
 <body>
+    <div id="wrap">
     <div id='loading' style='font-size: 25px; font-family:monospace; margin: 20% auto; width: 200px;'>
         loading...
     </div>
@@ -78,6 +89,7 @@
     </div>
     <footer id="footer" style="display:none;">
     </footer>
+</div>
 
     <script>
         // This line gets patched up by the cloud

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -12,7 +12,7 @@
             right:0;
             bottom:0;
             left: 0;
-            overflow-y: scroll;
+            overflow-y: hidden;
             -webkit-overflow-scrolling: touch;
         }
 

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -6,6 +6,7 @@
     <title>simulator</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <style>
+        /* fix for iOS; see https://github.com/PierBover/ios-iframe-fix */
         #wrap {
             position: fixed;
             top: 0;


### PR DESCRIPTION
https://github.com/PierBover/ios-iframe-fix

Tested in Chrome, Firefox, Edge, IE, and iOS Safari. Also tested the micro:bit embed to make sure I didn't break it, and everything seems fine. I didn't test that on iOS because I didn't have the dev environment set up for pxt-microbit.