### PR TITLE
Updates to LED matrix fill color

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -23,9 +23,9 @@ namespace pxtblockly {
         public isFieldCustom_ = true;
 
         private params: any;
-        private onColor = "#FF3130";
+        private onColor = "#FFFFFF";
         private offColor: string;
-        private static DEFAULT_OFF_COLOR = "#A0C9F0";
+        private static DEFAULT_OFF_COLOR = "#000000";
 
         // The number of columns
         private matrixWidth: number = 5;
@@ -190,9 +190,8 @@ namespace pxtblockly {
 
         private getColor(x: number, y: number) {
             if (!this.offColor) {
-                const primaryColour = (this.sourceBlock_.isShadow()) ?
-                    this.sourceBlock_.parentBlock_.getColour() : this.sourceBlock_.getColour();
-                this.offColor = goog.color.rgbArrayToHex(goog.color.lighten(goog.color.hexToRgb(primaryColour), 0.6));
+                this.offColor = (this.sourceBlock_.isShadow()) ?
+                    this.sourceBlock_.parentBlock_.getColourTertiary() : this.sourceBlock_.getColourTertiary();
             }
             return this.cellState[x][y] ? this.onColor : (this.offColor || FieldMatrix.DEFAULT_OFF_COLOR);
         }


### PR DESCRIPTION
Change led Matrix from red to white for fill with the block's tertiary color as the OFF color.

This fixes the Red Blue optical illusion issue we have described here: https://github.com/Microsoft/pxt-microbit/issues/1349

Here's what it looks like: 
![screen shot 2018-10-05 at 3 01 51 pm](https://user-images.githubusercontent.com/16690124/46562172-bff2ea00-c8af-11e8-8037-75843389665e.png)


Fixes https://github.com/Microsoft/pxt-microbit/issues/1349