### PR TITLE
consistent naming of simulator eventbus message

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -65,7 +65,7 @@ namespace pxsim {
     }
 
     export interface SimulatorEventBusMessage extends SimulatorMessage {
-        type: "event";
+        type: "eventbus";
         id: number;
         eventid: number;
         value?: number;


### PR DESCRIPTION
Using "eventbus" instead of "event" which is way overloaded in our messages.