### PR TITLE
Ensure unique target images in manifest

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1009,8 +1009,6 @@ function gitHash(buf: Buffer) {
 }
 
 function uploadCoreAsync(opts: UploadOptions) {
-    let liteId = "<none>"
-
     let targetConfig = readLocalPxTarget();
     let defaultLocale = targetConfig.appTheme.defaultLocale;
     let hexCache = path.join("built", "hexcache");
@@ -1026,7 +1024,7 @@ function uploadCoreAsync(opts: UploadOptions) {
     let logos = (targetConfig.appTheme as any as Map<string>);
     let targetImages = Object.keys(logos)
         .filter(k => /(logo|hero)$/i.test(k) && /^\.\//.test(logos[k]));
-    let targetImagesHashed = targetImages.map(k => uploadArtFile(logos[k]));
+    let targetImagesHashed = pxt.Util.unique(targetImages.map(k => uploadArtFile(logos[k])), url => url);
 
     let targetEditorJs = "";
     if (pxt.appTarget.appTheme && pxt.appTarget.appTheme.extendEditor)


### PR DESCRIPTION
Noticed that image entries had dups in manifest.

```


# target
https://pxt.azureedge.net/blob/ef119c4a79521b684911845e2db6574a1dfeac18/static/logo.svg
https://pxt.azureedge.net/blob/0f4500e3a481806886a11950e844bfe379a30019/static/logo.square.svg
https://pxt.azureedge.net/blob/0f4500e3a481806886a11950e844bfe379a30019/static/logo.square.svg
https://pxt.azureedge.net/blob/0f4500e3a481806886a11950e844bfe379a30019/static/logo.square.svg
https://pxt.azureedge.net/blob/ba8bdfefe4e4e94286a85b2bc83c62452a745bc0/static/icons/android-chrome-192x192.png
https://pxt.azureedge.net/blob/ba8bdfefe4e4e94286a85b2bc83c62452a745bc0/static/icons/android-chrome-192x192.png
https://pxt.azureedge.net/blob/f5f83b8c33d027642954f4f833432de810768249/static/Microsoft-logo_rgb_c-gray-square.png
https://pxt.azureedge.net/blob/e0a49fdb57be4b7e22d974e8e37171a47fa2fd0f/static/Microsoft-logo_rgb_c-white.png
https://pxt.azureedge.net/blob/6b966177121a86861a3610b5e5277cfe372b33f8/static/getting-started/getting-started.png

https://pxt.azureedge.net/blob/205ffa4fa13c7a9c1765ced7efeba45f92ca9923/target.js
```