### PR TITLE
Add mode check to scriptsearch helpPath

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -333,7 +333,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const description = mode == ScriptSearchMode.Boards ? lf("Change development board")
             : mode == ScriptSearchMode.Experiments ? lf("Turn on and off experimental features")
                 : lf("Add an extension to the project");
-        const helpPath = ScriptSearchMode.Boards ? "/boards"
+        const helpPath = mode == ScriptSearchMode.Boards ? "/boards"
             : mode == ScriptSearchMode.Experiments ? "/experiments"
                 : "/extensions";
 


### PR DESCRIPTION
Extensions help using ``"/boards"`` due to missing ``mode`` check for ``helpPath``. Check for ``mode`` added.

RE: https://github.com/Microsoft/pxt-microbit/issues/1362