### PR TITLE
Use opacity for OFF led fill so that it works when the block is disabled

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -189,16 +189,17 @@ namespace pxtblockly {
         }
 
         private getColor(x: number, y: number) {
-            if (!this.offColor) {
-                this.offColor = (this.sourceBlock_.isShadow()) ?
-                    this.sourceBlock_.parentBlock_.getColourTertiary() : this.sourceBlock_.getColourTertiary();
-            }
             return this.cellState[x][y] ? this.onColor : (this.offColor || FieldMatrix.DEFAULT_OFF_COLOR);
+        }
+
+        private getOpacity(x: number, y: number) {
+            return this.cellState[x][y] ? '1.0' : '0.2';
         }
 
         private updateCell(x: number, y: number) {
             const cellRect = this.cells[x][y];
             cellRect.setAttribute("fill", this.getColor(x, y));
+            cellRect.setAttribute("fill-opacity", this.getOpacity(x, y));
             cellRect.setAttribute('class', `blocklyLed${this.cellState[x][y] ? 'On' : 'Off'}`);
         }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1317#issuecomment-428014581

![screen shot 2018-10-10 at 1 28 06 pm](https://user-images.githubusercontent.com/16690124/46764540-89431800-cc91-11e8-9dd3-30381c670ec1.png)
