### PR TITLE
fixing theme colors for serial charts

### DIFF
--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -26,9 +26,9 @@ export class Editor extends srceditor.Editor {
     maxBufferLength: number = 10000;
     csvHeaders: string[] = [];
 
-    lineColors = ["#f00", "#00f", "#0f0", "#ff0"]
-    hcLineColors = ["000"]
-    currentLineColors = this.lineColors
+    lineColors: string[];
+    hcLineColors: string[];
+    currentLineColors: string[];
     highContrast: boolean = false
 
     //refs
@@ -88,7 +88,9 @@ export class Editor extends srceditor.Editor {
         super(parent)
         window.addEventListener("message", this.processEvent.bind(this), false)
         const serialTheme = pxt.appTarget.serial && pxt.appTarget.serial.editorTheme;
-        this.lineColors = (serialTheme && serialTheme.lineColors) || this.lineColors;
+        this.lineColors = (serialTheme && serialTheme.lineColors) || ["#e00", "#00e", "#0e0"];
+        this.hcLineColors = ["#000"];
+        this.currentLineColors = this.lineColors;
 
         this.goBack = this.goBack.bind(this);
         this.toggleRecording = this.toggleRecording.bind(this);


### PR DESCRIPTION
Turns out that the serial.editorTheme.lineColors entry of pxtarget was ignore by the serial editor.
Fix for https://github.com/Microsoft/pxt-microbit/issues/1380