### PR TITLE
Changing the exit dialog to give just one option

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -776,21 +776,17 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
             onclick: this.save,
             icon: 'check',
             className: 'approve positive'
-        }, {
-            label: lf("Cancel"),
-            icon: 'cancel',
-            onclick: this.cancel
         }]
 
         return (
             <sui.Modal isOpen={visible} className="exitandsave" size="tiny"
                 onClose={this.hide} dimmer={true} buttons={actions}
-                closeIcon={true} header={lf("Exit Project")}
+                closeIcon={true} header={lf("Project has no name") + " 😞"}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 modalDidOpen={this.modalDidOpen}
             >
                 <div className="ui form">
-                    <sui.Input ref="filenameinput" autoFocus id={"projectNameInput"} label={lf("Project Name")}
+                    <sui.Input ref="filenameinput" autoFocus id={"projectNameInput"} label={lf("Name")}
                         ariaLabel={lf("Type a name for your project")}
                         value={projectName || ''} onChange={this.handleChange} />
                 </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -781,7 +781,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         return (
             <sui.Modal isOpen={visible} className="exitandsave" size="tiny"
                 onClose={this.hide} dimmer={true} buttons={actions}
-                closeIcon={true} header={lf("Project has no name") + " 😞"}
+                closeIcon={true} header={lf("Project has no name {0}", "😞")}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 modalDidOpen={this.modalDidOpen}
             >


### PR DESCRIPTION
Feedback from the designer.
- If the intent is for name the project, say so in the dialog
- Give only one option Done
- Close (x) should still go back to the previous state

New
![image](https://user-images.githubusercontent.com/6107272/46834200-9b8b8780-cd5f-11e8-8c0d-0501c4d11c51.png)

Old
![image](https://user-images.githubusercontent.com/6107272/46834244-bbbb4680-cd5f-11e8-99d7-eee304deb485.png)


