### PR TITLE
Disabling file import dialog on all iOs

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -20,6 +20,10 @@ namespace pxt.BrowserUtils {
         return hasNavigator() && /(Win32|Win64|WOW64)/i.test(navigator.platform) && /Windows NT 10/i.test(navigator.userAgent);
     }
 
+    export function isIos(): boolean {
+        return hasNavigator() && /(iPad|iPhone|iPod)/i.test(navigator.platform);
+    }
+
     export function isMobile(): boolean {
         return hasNavigator() && /mobi/i.test(navigator.userAgent);
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -650,7 +650,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
             >
                 <div className={pxt.github.token ? "ui three cards" : "ui two cards"}>
-                    {pxt.appTarget.compile ?
+                    {pxt.appTarget.compile && !pxt.BrowserUtils.isIos() ?
                         <codecard.CodeCardView
                             ariaLabel={lf("Open files from your computer")}
                             role="button"


### PR DESCRIPTION
There is no support for files and they don't work today. We will reevaluate later if necessary