### PR TITLE
Touch fixes for image pickers

### DIFF
--- a/pxtblocks/fields/field_imagedropdown.ts
+++ b/pxtblocks/fields/field_imagedropdown.ts
@@ -94,14 +94,6 @@ namespace pxtblockly {
                 button.style.backgroundColor = backgroundColor;
                 button.style.borderColor = this.borderColour_;
                 Blockly.bindEvent_(button, 'click', this, this.buttonClick_);
-                Blockly.bindEvent_(button, 'mouseup', this, this.buttonClick_);
-                // These are applied manually instead of using the :hover pseudoclass
-                // because Android has a bad long press "helper" menu and green highlight
-                // that we must prevent with ontouchstart preventDefault
-                Blockly.bindEvent_(button, 'mousedown', button, function (e) {
-                    this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
-                    e.preventDefault();
-                });
                 Blockly.bindEvent_(button, 'mouseover', button, function () {
                     this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
                     contentDiv.setAttribute('aria-activedescendant', this.id);

--- a/pxtblocks/fields/field_images.ts
+++ b/pxtblocks/fields/field_images.ts
@@ -73,14 +73,6 @@ namespace pxtblockly {
                 button.style.backgroundColor = backgroundColor;
                 button.style.borderColor = this.sourceBlock_.getColourTertiary();
                 Blockly.bindEvent_(button, 'click', this, this.buttonClick_);
-                Blockly.bindEvent_(button, 'mouseup', this, this.buttonClick_);
-                // These are applied manually instead of using the :hover pseudoclass
-                // because Android has a bad long press "helper" menu and green highlight
-                // that we must prevent with ontouchstart preventDefault
-                Blockly.bindEvent_(button, 'mousedown', button, function (e) {
-                    this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
-                    e.preventDefault();
-                });
                 Blockly.bindEvent_(button, 'mouseover', button, function () {
                     this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
                     contentDiv.setAttribute('aria-activedescendant', this.id);

--- a/pxtblocks/fields/sprite/gallery.ts
+++ b/pxtblocks/fields/sprite/gallery.ts
@@ -129,17 +129,8 @@ namespace pxtblockly {
             button.style.backgroundColor = backgroundColor;
             button.style.borderColor = this.itemBorderColor;
             Blockly.bindEvent_(button, 'click', this, () => this.handleSelection(value));
-            Blockly.bindEvent_(button, 'mouseup', this, () => this.handleSelection(value));
 
             const parentDiv = this.contentDiv;
-
-            // These are applied manually instead of using the :hover pseudoclass
-            // because Android has a bad long press "helper" menu and green highlight
-            // that we must prevent with ontouchstart preventDefault
-            Blockly.bindEvent_(button, 'mousedown', button, function (e) {
-                this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover sprite-editor-card');
-                e.preventDefault();
-            });
             Blockly.bindEvent_(button, 'mouseover', button, function () {
                 this.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover sprite-editor-card');
                 parentDiv.setAttribute('aria-activedescendant', this.id);

--- a/theme/common.less
+++ b/theme/common.less
@@ -18,11 +18,13 @@ html {
 
 body {
     height: 100%;
+    width: 100%;
     padding: 0;
     overflow: auto;
     margin: 0;
     -webkit-overflow-scrolling: touch;
     overflow-scrolling: touch;
+    position: fixed;
 }
 
 * {


### PR DESCRIPTION
Touch fixes for the image dropdown picker and a few other pickers on IOS and Android.
Fixing issues with scrolling these pickers on many skews.

Tested locally and on IOS (iPhone and iPad) as well as Android. 

