### PR TITLE
Use address in blocks-embed sample

### DIFF
--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -255,7 +255,7 @@ for (let i = 0; i < 10; i++) {
 </div>
 
 <script>
-var makecodeUrl = "@name@";
+var makecodeUrl = "makecode.microbit.org";
 var blocksClass = "blocks";
 
 var injectRenderer = function () {


### PR DESCRIPTION
Use literal address string instead of macro.