### PR TITLE
Blockly context menu style

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -223,6 +223,27 @@ text.blocklyCheckbox {
     stroke: @blocklyScrollbarColor;
 }
 
+/*******************************
+        Context menu
+*******************************/
+
+.blocklyWidgetDiv .goog-menu {
+    border: 1px solid rgba(34,36,38,.15);
+    box-shadow: 0 1px 2px 0 rgba(34,36,38,.15) !important;
+    padding: 0 !important;
+}
+
+.blocklyWidgetDiv .goog-menuitem {
+    margin: 0 !important;
+    padding: .92857143em 1.14285714em !important;
+    font: normal 13px @pageFont !important;
+}
+
+.blocklyWidgetDiv .goog-menuitem-highlight, .blocklyWidgetDiv .goog-menuitem-hover {
+    border: none !important;
+    padding: .92857143em 1.14285714em !important;
+    background: rgba(0,0,0,.05) !important;
+}
 
 /*******************************
         Media Adjustments


### PR DESCRIPTION
Update the style of the Blockly context menu to match menus in semantic css.

<img width="285" alt="screen shot 2018-10-15 at 9 24 13 am" src="https://user-images.githubusercontent.com/16690124/46964114-389a3900-d05c-11e8-8168-3282a7973150.png">
