### PR TITLE
Use URL macro in 'blocks-embed' example

### DIFF
--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -255,13 +255,13 @@ for (let i = 0; i < 10; i++) {
 </div>
 
 <script>
-var makecodeUrl = "@name@";
+var makecodeUrl = "@homeUrl@";
 var blocksClass = "blocks";
 
 var injectRenderer = function () {
     var f = $("<iframe>", {
         id: "makecoderenderer",
-        src: `https://${makecodeUrl}/--docs?render=1&lang=${$('html').attr('lang')}`
+        src: `${makecodeUrl}--docs?render=1&lang=${$('html').attr('lang')}`
     });
     f.css("position", "absolute");
     f.css("left", 0);


### PR DESCRIPTION
Use `@homeUrl@` macro to base the URL in the example.

Re: https://github.com/Microsoft/pxt/pull/4813