### PR TITLE
Top blocks (Basic)

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -279,6 +279,7 @@ declare namespace pxt {
         bluetoothUartConsole?: boolean; // pair with BLE UART services and pipe console output
         bluetoothUartFilters?: { name?: string; namePrefix?: string; }[]; // device name prefix -- required
         bluetoothPartialFlashing?: boolean; // enable partial flashing over BLE
+        topBlocks?: boolean; // show a top blocks category in the editor
     }
 
     interface SocialOptions {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -348,13 +348,13 @@ namespace pxt.blocks {
         return button;
     }
 
-    export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, comp: pxt.blocks.BlockCompileInfo): HTMLElement {
+    export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, comp: pxt.blocks.BlockCompileInfo, ignoregap?: boolean): HTMLElement {
         //
         // toolbox update
         //
         let block = document.createElement("block");
         block.setAttribute("type", fn.attributes.blockId);
-        if (fn.attributes.blockGap)
+        if (fn.attributes.blockGap && !ignoregap)
             block.setAttribute("gap", fn.attributes.blockGap);
         else if (pxt.appTarget.appTheme && pxt.appTarget.appTheme.defaultBlockGap)
             block.setAttribute("gap", pxt.appTarget.appTheme.defaultBlockGap.toString());

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -162,6 +162,8 @@ namespace ts.pxtc {
         whenUsed?: boolean;
         jres?: string;
         useLoc?: string; // The qName of another API whose localization will be used if this API is not translated and if both block definitions are identical
+        topblock?: boolean;
+        topblockWeight?: number;
         // On namepspace
         subcategories?: string[];
         groups?: string[];
@@ -693,7 +695,7 @@ namespace ts.pxtc {
         return r;
     }
 
-    const numberAttributes = ["weight", "imageLiteral"]
+    const numberAttributes = ["weight", "imageLiteral", "topblockWeight"]
     const booleanAttributes = [
         "advanced",
         "handlerStatement",
@@ -704,7 +706,8 @@ namespace ts.pxtc {
         "blockCombine",
         "enumIsBitMask",
         "decompileIndirectFixedInstances",
-        "draggableParameters"
+        "draggableParameters",
+        "topblock"
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -12,7 +12,8 @@ namespace pxt.toolbox {
         addpackage: '#717171',
         search: '#000',
         debug: '#e03030',
-        default: '#dddddd'
+        default: '#dddddd',
+        topblocks: '#aa8f00'
     }
 
     export const blockIcons: Map<number | string> = {
@@ -29,7 +30,8 @@ namespace pxt.toolbox {
         addpackage: '\uf055',
         search: '\uf002',
         debug: '\uf111',
-        default: '\uf12e'
+        default: '\uf12e',
+        topblocks: '\uf005'
     }
 
     let toolboxStyle: HTMLStyleElement;

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -171,6 +171,7 @@ span.blocklyTreeIcon {
     height: 100%;
     display: none;
     vertical-align: middle;
+    user-select: none;
 }
 
 div.blocklyTreeIcon span {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -916,6 +916,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private partitionBlocks() {
         const res: pxt.Map<toolbox.BlockDefinition[]> = {};
+        this.topBlocks = [];
 
         const that = this;
         function setSubcategory(ns: string, subcat: string) {
@@ -939,6 +940,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 setSubcategory(ns, lf("more"));
             } else if (subcat) {
                 setSubcategory(ns, subcat);
+            }
+
+            if (fn.attributes.topblock) {
+                this.topBlocks.push(fn);
             }
         });
 
@@ -1107,6 +1112,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             return;
         }
 
+        if (ns == 'topblocks') {
+            this.showTopBlocksFlyout();
+            return;
+        }
+
         this.flyoutXmlList = [];
         if (this.flyoutBlockXmlCache[ns + subns]) {
             pxt.debug("showing flyout with blocks from flyout blocks xml cache");
@@ -1159,7 +1169,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const searchBlocks = this.toolbox.getSearchBlocks();
 
         searchBlocks.forEach((block) => {
-            const blockXmlList = this.getBlockXml(block);
+            const blockXmlList = this.getBlockXml(block, true);
             if (blockXmlList) this.flyoutXmlList = this.flyoutXmlList.concat(blockXmlList);
         })
 
@@ -1167,6 +1177,26 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             let label = goog.dom.createDom('label');
             label.setAttribute('text', lf("No search results..."));
             this.flyoutXmlList.push(label);
+        }
+        this.showFlyoutInternal_(this.flyoutXmlList);
+    }
+
+    private showTopBlocksFlyout() {
+        this.flyoutXmlList = [];
+        const topBlocks = this.getTopBlocks();
+        if (topBlocks.length == 0) {
+            let label = goog.dom.createDom('label');
+            label.setAttribute('text', lf("No basic blocks..."));
+            this.flyoutXmlList.push(label);
+        } else {
+            // Show a heading
+            this.showFlyoutHeadingLabel('topblocks', lf("{id:category}Basic"), null,
+                pxt.toolbox.getNamespaceIcon('topblocks'), pxt.toolbox.getNamespaceColor('topblocks'));
+
+            topBlocks.forEach((block) => {
+                const blockXmlList = this.getBlockXml(block, true);
+                if (blockXmlList) this.flyoutXmlList = this.flyoutXmlList.concat(blockXmlList);
+            })
         }
         this.showFlyoutInternal_(this.flyoutXmlList);
     }
@@ -1208,7 +1238,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     ////////////          Block methods           /////////////
     ///////////////////////////////////////////////////////////
 
-    private getBlockXml(block: toolbox.BlockDefinition, shadow?: boolean): Element[] {
+    private getBlockXml(block: toolbox.BlockDefinition, ignoregap?: boolean, shadow?: boolean): Element[] {
         const that = this;
         let blockXml: Element;
         // Check if the block is built in, ignore it as it's already defined in snippets
@@ -1228,14 +1258,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     return `<field name="${field}">${value}<\/field>`;
                 });
             }
-            return builtin ? this.getBlockXml(builtin) : undefined;
+            return builtin ? this.getBlockXml(builtin, ignoregap) : undefined;
         }
         if (!block.blockXml) {
             let fn = pxt.blocks.blockSymbol(block.attributes.blockId);
             if (fn) {
                 if (!shouldShowBlock(fn)) return undefined;
                 let comp = pxt.blocks.compileInfo(fn);
-                blockXml = pxt.blocks.createToolboxBlock(this.blockInfo, fn, comp);
+                blockXml = pxt.blocks.createToolboxBlock(this.blockInfo, fn, comp, ignoregap);
 
                 if (fn.attributes.optionalVariableArgs && fn.attributes.toolboxVariableArgs) {
                     const handlerArgs = comp.handlerArgs;
@@ -1285,9 +1315,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     else {
                         varName = Util.htmlEscape(rawName);
                     }
-
+                    const defaultBlockGap = pxt.appTarget.appTheme && pxt.appTarget.appTheme.defaultBlockGap.toString() || 8;
                     const setblock = Blockly.Xml.textToDom(`
-<block type="variables_set" gap="${Util.htmlEscape((fn.attributes.blockGap || 8) + "")}">
+<block type="variables_set" gap="${Util.htmlEscape((!ignoregap ? fn.attributes.blockGap || defaultBlockGap : defaultBlockGap) + "")}">
 <field name="VAR" variabletype="">${varName}</field>
 </block>`);
                     {
@@ -1305,6 +1335,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         } else {
             blockXml = Blockly.Xml.textToDom(block.blockXml);
+            if (ignoregap) {
+                blockXml.setAttribute("gap", `${pxt.appTarget.appTheme && pxt.appTarget.appTheme.defaultBlockGap.toString() || 8}`);
+            }
         }
         if (blockXml) {
             pxt.Util.toArray(blockXml.querySelectorAll('shadow'))
@@ -1312,7 +1345,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 .forEach((shadow, i) => {
                     let type = shadow.getAttribute('type');
                     const builtin = snippets.allBuiltinBlocks()[type];
-                    let b = this.getBlockXml(builtin ? builtin : { name: type, attributes: { blockId: type } }, true);
+                    let b = this.getBlockXml(builtin ? builtin : { name: type, attributes: { blockId: type } }, ignoregap, true);
                     /* tslint:disable:no-inner-html setting one element's contents to the other */
                     if (b && b.length > 0 && b[0]) shadow.innerHTML = b[0].innerHTML;
                     /* tslint:enable:no-inner-html */

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -22,6 +22,7 @@ export const enum CategoryNameID {
 // this is a supertype of pxtc.SymbolInfo (see partitionBlocks)
 export interface BlockDefinition {
     name: string;
+    namespace?: string;
     type?: string;
     snippet?: string;
     snippetName?: string;
@@ -39,6 +40,7 @@ export interface BlockDefinition {
         blockHidden?: boolean;
         group?: string;
         subcategory?: string;
+        topblockWeight?: number;
     };
     noNamespace?: boolean;
     retType?: string;
@@ -373,6 +375,8 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         const { showAdvanced, visible, loading, selectedItem, expandedItem, hasSearch, showSearchBox, hasError } = this.state;
         if (!visible) return <div style={{ display: 'none' }} />
 
+        const hasTopBlocks = !!pxt.appTarget.appTheme.topBlocks;
+
         if (loading || hasError) return <div>
             <div className="blocklyTreeRoot">
                 <div className="blocklyTreeRow" style={{ opacity: 0 }} />
@@ -395,6 +399,12 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         this.items = this.getAllCategoriesList();
 
         const searchTreeRow = ToolboxSearch.getSearchTreeRow();
+        const topBlocksTreeRow = {
+            nameid: 'topblocks',
+            name: lf("{id:category}Basic"),
+            color: pxt.toolbox.getNamespaceColor('topblocks'),
+            icon: pxt.toolbox.getNamespaceIcon('topblocks')
+        };
 
         const appTheme = pxt.appTarget.appTheme;
         const classes = sui.cx([
@@ -410,6 +420,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
             <div className="blocklyTreeRoot">
                 <div role="tree">
                     {hasSearch ? <CategoryItem key={"search"} toolbox={this} index={index++} selected={selectedItem == "search"} treeRow={searchTreeRow} onCategoryClick={this.setSelection} /> : undefined}
+                    {hasTopBlocks ? <CategoryItem key={"topblocks"} toolbox={this} selected={selectedItem == "topblocks"} treeRow={topBlocksTreeRow} onCategoryClick={this.setSelection} /> : undefined}
                     {nonAdvancedCategories.map((treeRow) => (
                         <CategoryItem key={treeRow.nameid}  toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection}>
                             {treeRow.subcategories ? treeRow.subcategories.map((subTreeRow) => (

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -279,6 +279,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
 
     protected extensionsMap: pxt.Map<pxt.PackageConfig> = {};
     protected subcategoryMap: pxt.Map<pxt.Map<boolean>> = {};
+    protected topBlocks: toolbox.BlockDefinition[] = [];
 
     // To be extended by editor
     getNamespaceAttrs(ns: string): pxtc.CommentAttrs {
@@ -315,5 +316,15 @@ export abstract class ToolboxEditor extends srceditor.Editor {
             }
         })
         return namespaces;
+    }
+
+    getTopBlocks(): toolbox.BlockDefinition[] {
+        // Order top blocks by weight
+        return this.topBlocks.sort((fn1, fn2) => {
+            // sort by fn weight
+            const w1 = fn1.attributes.topblockWeight || fn1.attributes.weight || 50;
+            const w2 = fn2.attributes.topblockWeight || fn2.attributes.weight || 50;
+            return w2 >= w1 ? 1 : -1;
+        });
     }
 }


### PR DESCRIPTION
Add a number of hand-picked top blocks to the a category called "Basic".

This feature is hidden behind an app theme flag and can be used for Experiments. Flag is: 
```
appTheme.topBlocks: true
```

To mark a block as a top block. Just add an annotation ``topblock`` and if you want to control the weight use ``topblockWeight`` otherwise it will resort to the block weight when calculating order. 
Gap is ignored in this category & the search category. 

![screen shot 2018-10-15 at 2 43 15 pm](https://user-images.githubusercontent.com/16690124/46980197-acead180-d088-11e8-8503-8cf894518ecc.png)
