### PR TITLE
Added syntax highlighting for typescript-ignore snippets

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -662,8 +662,10 @@ namespace pxt.runner {
             $(e).removeClass('lang-typescript');
         });
         $('code.lang-typescript-ignore').each((i, e) => {
-            render(e, true);
             $(e).removeClass('lang-typescript-ignore')
+            $(e).addClass('lang-typescript');
+            render(e, true);
+            $(e).removeClass('lang-typescript');
         });
     }
 


### PR DESCRIPTION
Previously, snippets as typescript-ignore wouldn't be styled. This makes it so that highlight.js renders them as it would typescript without breaking the travis build.

Fixes Microsoft/pxt-arcade#274