### PR TITLE
Fix hover flickering issue

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -477,7 +477,7 @@ declare namespace goog {
 declare namespace Blockly {
     let selected: any;
     function bindEvent_(node: any, eventName: string, target: any, fn: (e: any) => void): void;
-    function bindEventWithChecks_(node: any, eventName: string, target: any, fn: (e: any) => void, nocapture?: boolean): any;
+    function bindEventWithChecks_(node: any, eventName: string, target: any, fn: (e: any) => void, nocapture?: boolean, noPreventDefault?: boolean): any;
     function unbindEvent_(bindData: any): Function;
     function svgResize(workspace: Blockly.Workspace): void;
     function hueToRgb(hue: number): string;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1525,32 +1525,6 @@ namespace pxt.blocks {
             }
         };
 
-        // TODO: look into porting this code over to pxt-blockly
-        // Fix highlighting bug in edge
-        (<any>Blockly).Flyout.prototype.addBlockListeners_ = function (root: any, block: any, rect: any) {
-            this.listeners_.push(Blockly.bindEventWithChecks_(root, 'mousedown', null,
-                this.blockMouseDown_(block)));
-            this.listeners_.push(Blockly.bindEventWithChecks_(rect, 'mousedown', null,
-                this.blockMouseDown_(block)));
-            this.listeners_.push(Blockly.bindEvent_(root, 'mouseover', block,
-                block.addSelect));
-            this.listeners_.push(Blockly.bindEvent_(root, 'mouseout', block,
-                block.removeSelect));
-            this.listeners_.push(Blockly.bindEvent_(rect, 'mouseover', block,
-                block.addSelect));
-            this.listeners_.push(Blockly.bindEvent_(rect, 'mouseout', block,
-                block.removeSelect));
-
-            const that = this;
-            function select() {
-                if (that._selectedItem && that._selectedItem.svgGroup_) {
-                    that._selectedItem.removeSelect();
-                }
-                that._selectedItem = block;
-                that._selectedItem.addSelect();
-            }
-        };
-
         // Get rid of bumping behavior
         (Blockly as any).Constants.Logic.LOGIC_COMPARE_ONCHANGE_MIXIN.onchange = function () {}
     }


### PR DESCRIPTION
Blockly build: https://github.com/Microsoft/pxt/pull/4842 pulled in changes that should've fixed the flickering issue when hovering on the border of a block in the flyout. Turns out we monkey patch some code that overwrites the fix. 

Tested on Chrome, Safari, Edge and IE. 