### PR TITLE
Made the emoji change when the user names their project

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -699,6 +699,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
 
 export interface ExitAndSaveDialogState {
     visible?: boolean;
+    emoji?: string;
     projectName?: string;
 }
 
@@ -707,7 +708,8 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
     constructor(props: ISettingsProps) {
         super(props);
         this.state = {
-            visible: false
+            visible: false,
+            emoji: "😞"
         }
 
         this.hide = this.hide.bind(this);
@@ -748,10 +750,10 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
     handleChange(name: string) {
         this.setState({ projectName: name });
         let header = document.getElementsByClassName("exitandsave").item(0).firstChild as HTMLElement;
-        if (name === "" || name === "Untitled") {
-            header.innerText = header.innerText.replace("😊", "😞");
+        if (name === "" || name === lf("Untitled")) {
+            this.setState({emoji: "😞"})
         } else {
-            header.innerText = header.innerText.replace("😞", "😊");
+            this.setState({emoji: "😊"})
         }
     }
 
@@ -775,7 +777,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
     }
 
     renderCore() {
-        const { visible, projectName } = this.state;
+        const { visible, emoji, projectName } = this.state;
 
         const actions: sui.ModalButton[] = [{
             label: lf("Done"),
@@ -787,7 +789,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         return (
             <sui.Modal isOpen={visible} className="exitandsave" size="tiny"
                 onClose={this.hide} dimmer={true} buttons={actions}
-                closeIcon={true} header={lf("Project has no name {0}", "😞")}
+                closeIcon={true} header={lf("Project has no name {0}", emoji)}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 modalDidOpen={this.modalDidOpen}
             >

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -749,9 +749,9 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         this.setState({ projectName: name });
         let header = document.getElementsByClassName("exitandsave").item(0).firstChild as HTMLElement;
         if (name === "" || name === "Untitled") {
-            header.innerHTML = header.innerHTML.replace("😊", "😞");
+            header.innerText = header.innerText.replace("😊", "😞");
         } else {
-            header.innerHTML = header.innerHTML.replace("😞", "😊");
+            header.innerText = header.innerText.replace("😞", "😊");
         }
     }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -747,6 +747,12 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
 
     handleChange(name: string) {
         this.setState({ projectName: name });
+        let header = document.getElementsByClassName("exitandsave").item(0).firstChild as HTMLElement;
+        if (name === "" || name === "Untitled") {
+            header.innerHTML = header.innerHTML.replace("😊", "😞");
+        } else {
+            header.innerHTML = header.innerHTML.replace("😞", "😊");
+        }
     }
 
     cancel() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -749,7 +749,6 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
 
     handleChange(name: string) {
         this.setState({ projectName: name });
-        let header = document.getElementsByClassName("exitandsave").item(0).firstChild as HTMLElement;
         if (name === "" || name === lf("Untitled")) {
             this.setState({emoji: "😞"})
         } else {


### PR DESCRIPTION
I feel that the emoji that is shown when users are told that their project has no name is a little too sad. It makes me feel really bad when I forget to name my project before going to the homepage.
![sad-save-screen](https://user-images.githubusercontent.com/13285164/47125673-a51e5f00-d239-11e8-864c-da2502ac1e74.png)

This changes the emoji when the user enters a name other than "" and "Untitled".
![sad-save-screen](https://user-images.githubusercontent.com/13285164/47125675-b0718a80-d239-11e8-83f6-dbe544269861.gif)



I also think this could be a fun way to add easter eggs into PXT. Like saving your project as certain names causes certain emojis to appear.