### PR TITLE
Added check so that search bar doesn't crash if no results are returned

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1337,7 +1337,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
         if (blockXml) {
             if (ignoregap) {
-                blockXml.setAttribute("gap", `${pxt.appTarget.appTheme && pxt.appTarget.appTheme.defaultBlockGap.toString() || 8}`);
+                blockXml.setAttribute("gap", `${pxt.appTarget.appTheme && pxt.appTarget.appTheme.defaultBlockGap && pxt.appTarget.appTheme.defaultBlockGap.toString() || 8}`);
             }
             pxt.Util.toArray(blockXml.querySelectorAll('shadow'))
                 .filter(shadow => !shadow.innerHTML)


### PR DESCRIPTION
Fixes Microsoft/pxt-arcade#318

The toolbox disappears if your search for blocks returns no results. Confirmed this on both arcade (issue is on the live site) and adafruit (served locally with latest pxt).

Looks like the issue is related to #4846, but I am unsure if this fixes the the root of the bug or just hides it better.