### PR TITLE
Display board image in multi-board target

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -313,6 +313,7 @@ declare namespace pxt {
 
     interface TargetBundle extends AppTarget {
         bundledpkgs: Map<Map<string>>;   // @internal use only (cache)
+        bundledcoresvgs: Map<string>;   // @internal use only (cache)
         bundleddirs: string[];
         versions: TargetVersions;        // @derived
     }

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -313,7 +313,7 @@ declare namespace pxt {
 
     interface TargetBundle extends AppTarget {
         bundledpkgs: Map<Map<string>>;   // @internal use only (cache)
-        bundledcoresvgs: Map<string>;   // @internal use only (cache)
+        bundledcoresvgs?: Map<string>;   // @internal use only (cache)
         bundleddirs: string[];
         versions: TargetVersions;        // @derived
     }

--- a/pxteditor/workspace.ts
+++ b/pxteditor/workspace.ts
@@ -6,6 +6,7 @@ namespace pxt.workspace {
         name: string;
         meta: pxt.Cloud.JsonScriptMeta;
         editor: string;
+        board?: string; // name of the package that contains the board.json info
         temporary?: boolean; // don't serialize project
         // older script might miss this
         target: string;

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -98,7 +98,7 @@ namespace pxt {
                             let boardimg = (<pxsim.BoardImageDefinition>boardjson.visual).image;
                             if (/^pkg:\/\//.test(boardimg))
                                 boardimg = files[boardimg.slice(6)];
-                            appTarget.bundledcoresvgs[id] = pxt.Util.toDataUri(boardimg);
+                            appTarget.bundledcoresvgs[id] = `data:image/svg+xml;base64,${ts.pxtc.encodeBase64(pxt.Util.toUTF8(boardimg))}`;
                         }
                     }
                 });

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -83,6 +83,26 @@ namespace pxt {
             if (config.icon) config.icon = pxt.BrowserUtils.patchCdn(config.icon);
             res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
         })
+
+        // find all core packages images
+        if (appTarget.simulator && appTarget.simulator.dynamicBoardDefinition) {
+            appTarget.bundledcoresvgs = {};
+            Object.keys(pxt.appTarget.bundledpkgs)
+                .map(id => {
+                    const files = pxt.appTarget.bundledpkgs[id];
+                    // builtin packages are guaranteed to parse out
+                    const pxtjson: pxt.PackageConfig = JSON.parse(files["pxt.json"]);
+                    if (pxtjson.core && files["board.json"]) {
+                        const boardjson = JSON.parse(files["board.json"]) as pxsim.BoardDefinition;
+                        if (boardjson && boardjson.visual && (<pxsim.BoardImageDefinition>boardjson.visual).image) {
+                            let boardimg = (<pxsim.BoardImageDefinition>boardjson.visual).image;
+                            if (/^pkg:\/\//.test(boardimg))
+                                boardimg = files[boardimg.slice(6)];
+                            appTarget.bundledcoresvgs[id] = pxt.Util.toDataUri(boardimg);
+                        }
+                    }
+                });
+        }
     }
 
     // this is set by compileServiceVariant in pxt.json

--- a/tests/format-test/formatrunner.ts
+++ b/tests/format-test/formatrunner.ts
@@ -28,6 +28,7 @@ pxt.setAppTarget({
     versions: undefined,
     description: "A toolkit to build JavaScript Blocks editors.",
     bundleddirs: [],
+    bundledcoresvgs: {},
     compile: {
         isNative: false,
         hasHex: false,

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -36,9 +36,15 @@
     }
 }
 
-.ui.card.github {
+.ui.card.file.github {
     .fileimage {
         background-image: @githubFileLogo;
+    }
+}
+
+.ui.card.file.board {
+    .fileimage {
+        background-image: unset;
     }
 }
 

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -96,10 +96,11 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             {card.label || card.blocksXml || card.typeScript || imageUrl || cardType == "file" ? <div className={"ui image"}>
                 {card.label ? <label className={`ui ${card.labelClass ? card.labelClass : "orange right ribbon"} label`}>{card.label}</label> : undefined}
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : undefined}
-                {imageUrl ? <div className="ui imagewrapper">
+                {card.cardType != "file" && imageUrl ? <div className="ui imagewrapper">
                     <div className={`ui cardimage`} data-src={imageUrl} ref="lazyimage" />
                 </div> : undefined}
                 {card.cardType == "file" && !imageUrl ? <div className="ui fileimage" /> : undefined}
+                {card.cardType == "file" && imageUrl ? <div className="ui fileimage" data-src={imageUrl} ref="lazyimage" /> : undefined}
             </div> : undefined}
             {card.icon || card.iconContent ?
                 <div className="ui imagewrapper"><div className={`ui button massive fluid ${card.iconColor} ${card.iconContent ? "iconcontent" : ""}`}>

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -99,7 +99,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                 {imageUrl ? <div className="ui imagewrapper">
                     <div className={`ui cardimage`} data-src={imageUrl} ref="lazyimage" />
                 </div> : undefined}
-                {card.cardType == "file" ? <div className="ui fileimage" /> : undefined}
+                {card.cardType == "file" && !imageUrl ? <div className="ui fileimage" /> : undefined}
             </div> : undefined}
             {card.icon || card.iconContent ?
                 <div className="ui imagewrapper"><div className={`ui button massive fluid ${card.iconColor} ${card.iconContent ? "iconcontent" : ""}`}>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -342,7 +342,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
     }
 
     fetchLocalData(): pxt.workspace.Header[] {
-        let headers: pxt.workspace.Header[] = this.getData("header:*")
+        const headers: pxt.workspace.Header[] = this.getData("header:*")
         return headers;
     }
 
@@ -455,6 +455,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
         } else {
             const headers = this.fetchLocalData();
             const showNewProject = pxt.appTarget.appTheme && !pxt.appTarget.appTheme.hideNewProjectButton;
+            const bundledcoresvgs = pxt.appTarget.bundledcoresvgs;
             return <carousel.Carousel bleedPercent={20}>
                 {showNewProject ? <div role="button" className="ui card link newprojectcard" title={lf("Creates a new empty project")}
                     onClick={this.newProject} onKeyDown={sui.fireClickOnEnter} >
@@ -463,19 +464,21 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                         <span className="header">{lf("New Project")}</span>
                     </div>
                 </div> : undefined}
-                {headers.map((scr, index) =>
-                    <ProjectsCodeCard
+                {headers.map((scr, index) => {
+                    const boardsvg = scr.board && bundledcoresvgs && bundledcoresvgs[scr.board];
+                    return <ProjectsCodeCard
                         key={'local' + scr.id + scr.recentUse}
                         // ref={(view) => { if (index === 1) this.latestProject = view }}
                         cardType="file"
-                        className={scr.githubId ? "file github" : "file"}
+                        className={boardsvg ? undefined : scr.board ? "" : scr.githubId ? "file github" : "file"}
+                        imageUrl={boardsvg}
                         name={scr.name}
                         time={scr.recentUse}
                         url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}
                         scr={scr}
                         onCardClick={this.handleCardClick}
-                    />
-                )}
+                    />;
+                })}
             </carousel.Carousel>
         }
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -470,7 +470,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                         key={'local' + scr.id + scr.recentUse}
                         // ref={(view) => { if (index === 1) this.latestProject = view }}
                         cardType="file"
-                        className={boardsvg ? undefined : scr.board ? "" : scr.githubId ? "file github" : "file"}
+                        className={boardsvg && scr.board ? "file board" : scr.githubId ? "file github" : "file"}
                         imageUrl={boardsvg}
                         name={scr.name}
                         time={scr.recentUse}

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -276,6 +276,15 @@ export function saveAsync(h: Header, text?: ScriptText, isCloud?: boolean): Prom
                 impl.deleteAsync ? impl.deleteAsync(h, e.version) : impl.setAsync(h, e.version, {})))
     }
 
+    // check if we have dynamic boards, store board info for home page rendering
+    const bundledcoresvgs = pxt.appTarget.bundledcoresvgs;
+    if (text && bundledcoresvgs) {
+        const pxtjson = JSON.parse(text["pxt.json"] || "{}") as pxt.PackageConfig;
+        if (pxtjson && pxtjson.dependencies)
+            h.board = Object.keys(pxtjson.dependencies)
+                .filter(p => !!bundledcoresvgs[p])[0];
+    }
+
     return headerQ.enqueue<void>(h.id, () =>
         fixupVersionAsync(e).then(() =>
             impl.setAsync(h, e.version, text ? e.text : null)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4175913/47132113-259f8880-d257-11e8-93a2-86084f3e889a.png)

When multi board are enabled and a visual is available, use that image instead of stock svg.