### PR TITLE
Change jump to toolbox accessibility shortcut

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -27,7 +27,7 @@ These keyboard shortcuts are used in the [JavaScript editor](#javascript-editor)
 
 * By default, pressing ``Tab`` in the editor will insert the tab character.
 * Toggle this behavior by pressing ``Control+M`` on **Windows** or ``⌘+M`` on **Mac**.
-* In order to jump to the toolbox from the editor. Press ``Control+T`` on **Windows** or ``⌘+T`` on **Mac**.
+* In order to jump to the toolbox from the editor. Press ``Control+Alt+T`` on **Windows** or ``⌘+Alt+T`` on **Mac**.
 
 ### Drop-down menu
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -27,6 +27,7 @@ These keyboard shortcuts are used in the [JavaScript editor](#javascript-editor)
 
 * By default, pressing ``Tab`` in the editor will insert the tab character.
 * Toggle this behavior by pressing ``Control+M`` on **Windows** or ``⌘+M`` on **Mac**.
+* In order to jump to the toolbox from the editor. Press ``Control+T`` on **Windows** or ``⌘+T`` on **Mac**.
 
 ### Drop-down menu
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -367,7 +367,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.editor.addAction({
                 id: "jumptoolbox",
                 label: lf("Jump to Toolbox"),
-                keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_T],
+                keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KEY_T],
                 keybindingContext: "!editorReadonly",
                 precondition: "!editorReadonly",
                 run: () => Promise.resolve(this.moveFocusToToolbox())

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -364,11 +364,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
 
             // Accessibility shortcut, add a way to quickly jump to the monaco toolbox
-            const arrow = Util.isUserLanguageRtl() ? monaco.KeyCode.RightArrow : monaco.KeyCode.LeftArrow;
             this.editor.addAction({
                 id: "jumptoolbox",
                 label: lf("Jump to Toolbox"),
-                keybindings: [monaco.KeyMod.CtrlCmd | arrow],
+                keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_T],
                 keybindingContext: "!editorReadonly",
                 precondition: "!editorReadonly",
                 run: () => Promise.resolve(this.moveFocusToToolbox())


### PR DESCRIPTION
Someone pointed out that Ctrl+Left / Right arrows were already used in the monaco editor to jump around the code which is true. I was using that as a shortcut to get into the monaco toolbox. 
I'm changing the shortcut to jump to the toolbox to Ctrl/Cmd + Alt + T instead.

Updated the accessibility documentation to reflect that.

Fixes https://github.com/Microsoft/pxt-microbit/issues/1461