### PR TITLE
Fix gesture field selection

### DIFF
--- a/pxtblocks/fields/field_imagedropdown.ts
+++ b/pxtblocks/fields/field_imagedropdown.ts
@@ -152,6 +152,7 @@ namespace pxtblockly {
          */
         protected buttonClick_ = function (e: any) {
             let value = e.target.getAttribute('data-value');
+            if (!value) return;
             this.setValue(value);
             this.setText(value);
             Blockly.DropDownDiv.hide();

--- a/pxtblocks/fields/field_images.ts
+++ b/pxtblocks/fields/field_images.ts
@@ -39,8 +39,7 @@ namespace pxtblockly {
             const options = this.getOptions();
             if (this.shouldSort_) options.sort();
             for (let i = 0; i < options.length; i++) {
-                const option = options[i];
-                let content = (options[i] as any)[0]; // Human-readable text or image.
+                const content = (options[i] as any)[0]; // Human-readable text or image.
                 const value = (options[i] as any)[1]; // Language-neutral value.
                 // Icons with the type property placeholder take up space but don't have any functionality
                 // Use for special-case layouts
@@ -91,7 +90,7 @@ namespace pxtblockly {
                 button.appendChild(buttonImg);
                 if (this.addLabel_) {
                     const buttonText = this.createTextNode_(content.alt);
-                    buttonText.setAttribute('data-value', content.alt);
+                    buttonText.setAttribute('data-value', value);
                     button.appendChild(buttonText);
                 }
                 contentDiv.appendChild(button);


### PR DESCRIPTION
The field images field editor supports showing text labels for each of the images. This PR fixes the issue when clicking on the label to select an item it uses the text as the value which cases problems in the generated Javascript. 

Fixes https://github.com/Microsoft/pxt-microbit/issues/1458