### PR TITLE
Valid and invalid code snippets

### DIFF
--- a/docs/writing-docs/macros.md
+++ b/docs/writing-docs/macros.md
@@ -150,6 +150,26 @@ Renders one or more codecards as JSON into cards
 Append `-ignore` to any of the above to ignore a snippet in automated testing:
 
     ```typescript-ignore
+    // You can include illegal TS in here, e.g. to showcase concepts/psuedocode 
+    for (initialization; check; update) {
+        ...
+    }
+    ```
+
+### invalid
+
+You can use `typescript-invalid` to showcase typescript that is **incorrect**:
+
+    ```typescript-invalid
     // You can include illegal TS in here, e.g. to document syntax errors
     callFunction(;
+    ```
+
+### valid
+
+You can use `typescript-valid` to showcase typescript that is **correct**:
+
+    ```typescript-valid
+    // You can include any TS in here, e.g. to showcase correct syntax
+    callFunction();
     ```

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -673,8 +673,7 @@ namespace pxt.runner {
             render(e, true);
             $(e).removeClass('lang-typescript');
             $(e).parent('div').addClass('invalid');
-            var $icon = $("<i>", {"class": "icon ban"});
-            $(e).parent('div').prepend($icon);
+            $(e).parent('div').prepend($("<i>", {"class": "icon ban"}));
             $(e).addClass('invalid');
         });
         $('code.lang-typescript-valid').each((i, e) => {
@@ -683,8 +682,7 @@ namespace pxt.runner {
             render(e, true);
             $(e).removeClass('lang-typescript');
             $(e).parent('div').addClass('valid');
-            var $icon = $("<i>", {"class": "icon check"});
-            $(e).parent('div').prepend($icon);
+            $(e).parent('div').prepend($("<i>", {"class": "icon check"}));
             $(e).addClass('valid');
         });
     }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -673,6 +673,8 @@ namespace pxt.runner {
             render(e, true);
             $(e).removeClass('lang-typescript');
             $(e).parent('div').addClass('invalid');
+            var $icon = $("<i>", {"class": "icon ban"});
+            $(e).parent('div').prepend($icon);
             $(e).addClass('invalid');
         });
         $('code.lang-typescript-valid').each((i, e) => {
@@ -681,6 +683,8 @@ namespace pxt.runner {
             render(e, true);
             $(e).removeClass('lang-typescript');
             $(e).parent('div').addClass('valid');
+            var $icon = $("<i>", {"class": "icon check"});
+            $(e).parent('div').prepend($icon);
             $(e).addClass('valid');
         });
     }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -662,10 +662,26 @@ namespace pxt.runner {
             $(e).removeClass('lang-typescript');
         });
         $('code.lang-typescript-ignore').each((i, e) => {
-            $(e).removeClass('lang-typescript-ignore')
+            $(e).removeClass('lang-typescript-ignore');
             $(e).addClass('lang-typescript');
             render(e, true);
             $(e).removeClass('lang-typescript');
+        });
+        $('code.lang-typescript-invalid').each((i, e) => {
+            $(e).removeClass('lang-typescript-invalid');
+            $(e).addClass('lang-typescript');
+            render(e, true);
+            $(e).removeClass('lang-typescript');
+            $(e).parent('div').addClass('invalid');
+            $(e).addClass('invalid');
+        });
+        $('code.lang-typescript-valid').each((i, e) => {
+            $(e).removeClass('lang-typescript-valid');
+            $(e).addClass('lang-typescript');
+            render(e, true);
+            $(e).removeClass('lang-typescript');
+            $(e).parent('div').addClass('valid');
+            $(e).addClass('valid');
         });
     }
 

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -15,8 +15,8 @@
 
 /* Code segment */
 @docsSegementBackgroundColor: #f7f7f7;
-@docsSegementBackgroundColorValid: #cdffd8;
-@docsSegementBackgroundColorInvalid: #ffdce0;
+@docsSegementBackgroundColorValid: #edf9ef;
+@docsSegementBackgroundColorInvalid: #fbf3f4;
 
 /* Card */
 @docsCardBackgroundColor: white;
@@ -71,11 +71,30 @@
         box-shadow: none;
     }
     .mainbody div.codewidget.valid, code.valid{
-        background: @docsSegementBackgroundColorValid !important;
+        /*background: @docsSegementBackgroundColorValid !important;*/
     }
     .mainbody div.codewidget.invalid, code.invalid{
-        background: @docsSegementBackgroundColorInvalid !important;
+        /*background: @docsSegementBackgroundColorInvalid !important;*/
     }
+
+    .mainbody div.codewidget.valid, .mainbody div.codewidget.invalid {
+        overflow: auto;
+    }
+
+    .invalid i.icon, .valid i.icon {
+        float: right;
+        margin-top: 10px;
+        margin-right: 10px;
+        font-size: 30px;
+    }
+
+    .invalid i.icon {
+        color: #a31515;
+    }
+    .valid i.icon {
+        color: #008000;
+    }
+
     .avatar .ui.message {
         margin-left: 4em;
         margin-bottom: 1em;

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -71,10 +71,10 @@
         box-shadow: none;
     }
     .mainbody div.codewidget.valid, code.valid{
-        /*background: @docsSegementBackgroundColorValid !important;*/
+        background: @docsSegementBackgroundColorValid !important;
     }
     .mainbody div.codewidget.invalid, code.invalid{
-        /*background: @docsSegementBackgroundColorInvalid !important;*/
+        background: @docsSegementBackgroundColorInvalid !important;
     }
 
     .mainbody div.codewidget.valid, .mainbody div.codewidget.invalid {

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -15,6 +15,8 @@
 
 /* Code segment */
 @docsSegementBackgroundColor: #f7f7f7;
+@docsSegementBackgroundColorValid: #cdffd8;
+@docsSegementBackgroundColorInvalid: #ffdce0;
 
 /* Card */
 @docsCardBackgroundColor: white;
@@ -67,6 +69,12 @@
         border: 0 !important;
         margin-bottom: 1.275em;
         box-shadow: none;
+    }
+    .mainbody div.codewidget.valid, code.valid{
+        background: @docsSegementBackgroundColorValid !important;
+    }
+    .mainbody div.codewidget.invalid, code.invalid{
+        background: @docsSegementBackgroundColorInvalid !important;
     }
     .avatar .ui.message {
         margin-left: 4em;


### PR DESCRIPTION
There have been a few times writing course curriculum in which it is helpful to show bad code or code that doesn't work. I fear that students may skim through code examples and mistake bad code for code that they should copy and learn from. 

Some sort of distinction was requested in Microsoft/pxt-arcade#316

This emphasizes what bad and good code is by setting the background color to red or green (I used the same palette as GitHub). 

![valid-invalid-code](https://user-images.githubusercontent.com/13285164/47199294-b6449a00-d325-11e8-8346-8e01fcb7593f.PNG)


To use these snippets, the \```typescript-invalid and \```typescript-valid languages are specified in markdown.

The markdown used to create the sample above is as follows:

\# Valid and Invalid code snippets

\## Normal Code Snippet

\```typescript
// Normal Code
function printMessage() {
&nbsp;&nbsp;&nbsp;&nbsp;console.log("This is what a normal code snippet looks like")
}
\```

\## Invalid Code Snippet

\```typescript-invalid
// Invalid Code
function printMessage() {
&nbsp;&nbsp;&nbsp;&nbsp;console.log("This is what a invalid code snippet looks like")
}
\```

\## Valid Code Snippet

\```typescript-valid
// Valid Code
function printMessage() {
&nbsp;&nbsp;&nbsp;&nbsp;console.log("This is what a valid code snippet looks like")
}
\```


Both of these new snippets have the same behavior as ```typescript-ignore in that they are ignored by travis and do not have button to run them (or show/edit). 

Also, when printing, the background colors are removed and they look just like normal code snippets.