### PR TITLE
fix display of shadow blocks with blockSetVariable

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -249,7 +249,6 @@ namespace pxt.blocks {
         const value = document.createElement("value");
         value.setAttribute("name", p.definitionName);
 
-        const shadowInfo = info.blocksById[shadowId];
         const shadow = document.createElement(isVariable ? "block" : "shadow");
         value.appendChild(shadow);
 
@@ -257,13 +256,6 @@ namespace pxt.blocks {
 
         shadow.setAttribute("type", shadowId || typeInfo && typeInfo.block || p.type);
         shadow.setAttribute("colour", (Blockly as any).Colours.textField);
-
-        if (shadowInfo && shadowInfo.attributes.blockSetVariable) {
-            // trivially 'fixes' it, but breaks blockSetVariable things
-            shadowInfo.attributes.blockSetVariable = undefined;
-            
-            return value; // probably don't return here in final version?
-        }
 
         if (typeInfo && (!shadowId || typeInfo.block === shadowId || shadowId === "math_number_minmax")) {
             const field = document.createElement("field");
@@ -300,6 +292,7 @@ namespace pxt.blocks {
                 shadow.appendChild(field);
             }
             else if (shadowId) {
+                const shadowInfo = info.blocksById[shadowId];
                 if (shadowInfo && shadowInfo.attributes._def && shadowInfo.attributes._def.parameters.length) {
                     const shadowParam = shadowInfo.attributes._def.parameters[0];
                     field.setAttribute("name", shadowParam.name);

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -249,6 +249,7 @@ namespace pxt.blocks {
         const value = document.createElement("value");
         value.setAttribute("name", p.definitionName);
 
+        const shadowInfo = info.blocksById[shadowId];
         const shadow = document.createElement(isVariable ? "block" : "shadow");
         value.appendChild(shadow);
 
@@ -256,6 +257,13 @@ namespace pxt.blocks {
 
         shadow.setAttribute("type", shadowId || typeInfo && typeInfo.block || p.type);
         shadow.setAttribute("colour", (Blockly as any).Colours.textField);
+
+        if (shadowInfo && shadowInfo.attributes.blockSetVariable) {
+            // trivially 'fixes' it, but breaks blockSetVariable things
+            shadowInfo.attributes.blockSetVariable = undefined;
+            
+            return value; // probably don't return here in final version?
+        }
 
         if (typeInfo && (!shadowId || typeInfo.block === shadowId || shadowId === "math_number_minmax")) {
             const field = document.createElement("field");
@@ -292,7 +300,6 @@ namespace pxt.blocks {
                 shadow.appendChild(field);
             }
             else if (shadowId) {
-                const shadowInfo = info.blocksById[shadowId];
                 if (shadowInfo && shadowInfo.attributes._def && shadowInfo.attributes._def.parameters.length) {
                     const shadowParam = shadowInfo.attributes._def.parameters[0];
                     field.setAttribute("name", shadowParam.name);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1300,7 +1300,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         mutatedBlocks.push(mutatedBlock);
                     });
                     return mutatedBlocks;
-                } else if (fn.attributes.blockSetVariable != undefined && fn.retType) {
+                } else if (fn.attributes.blockSetVariable != undefined && fn.retType && !shadow) {
                     // if requested, wrap block into a "set variable block"
                     const rawName = fn.attributes.blockSetVariable;
 


### PR DESCRIPTION
Fixes Microsoft/pxt-arcade#249

Only include the set block (for a block with blockSetVariable) if the requested block is not a shadow block

## broken

<img width="328" alt="screen shot 2018-10-19 at 10 19 34 am" src="https://user-images.githubusercontent.com/5615930/47234194-df971180-d389-11e8-9820-06fba5d1637f.png">
<img width="486" alt="screen shot 2018-10-19 at 10 19 19 am" src="https://user-images.githubusercontent.com/5615930/47234195-df971180-d389-11e8-92dd-d566e7327e69.png">

## fixed

<img width="362" alt="screen shot 2018-10-19 at 10 18 24 am" src="https://user-images.githubusercontent.com/5615930/47234220-f0e01e00-d389-11e8-9faf-a0dbcbf8cd6c.png">
<img width="605" alt="screen shot 2018-10-19 at 10 18 45 am" src="https://user-images.githubusercontent.com/5615930/47234208-e887e300-d389-11e8-82e6-ac1742087da4.png">
