### PR TITLE
Support override apptheme with preconfigured url regex

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -46,6 +46,7 @@ declare namespace pxt {
         compileService?: TargetCompileService;
         ignoreDocsErrors?: boolean;
         variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
+        queryVariants?: Map<AppTheme>; // patches on top of the current AppTheme using query url regex
     }
 
     interface ProjectTemplate {

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -103,6 +103,22 @@ namespace pxt {
                     }
                 });
         }
+
+        // patch any pre-configured query url appTheme overrides
+        if (appTarget.queryVariants && typeof window !== 'undefined') {
+            const href = window.location.href;
+            Object.keys(appTarget.queryVariants).forEach(queryRegex => {
+                const regex = new RegExp(queryRegex, "i");
+                const match = regex.exec(href);
+                if (match) {
+                    // Apply any appTheme overrides
+                    let v = appTarget.queryVariants[queryRegex];
+                    if (v) {
+                        U.jsonMergeFrom(appTarget.appTheme, v);
+                    }
+                }
+            });
+        }
     }
 
     // this is set by compileServiceVariant in pxt.json


### PR DESCRIPTION
Support for pre-configured overrides of the appTheme using query url flags.

This allows us to setup pre-configured regex matches to the url that will enable or disable certain appTheme flags. 