### PR TITLE
Board features

### DIFF
--- a/docs/writing-docs/macros.md
+++ b/docs/writing-docs/macros.md
@@ -53,6 +53,16 @@ Simple provide a list of package name using the ``package`` macro.
     microbit-bluetooth
     ```
 
+### features
+
+You can specify required "features" for a given documentation page. In the case of a multi-board editor,
+MakeCode will match the feature set with existing boards.
+
+    ```config
+    feature=pinsled
+    feature=pinsd1
+    ```
+
 ### blocks
 
 The **blocks** language renders a JavaScript snippet into blocks and provide a simulator if needed.

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -58,7 +58,6 @@ declare namespace pxt {
             includeDirs: string[];
             excludePrefix?: string[];
         };
-        features?: string; // used for compatility check with examples, tutorias
     }
 
     interface PackageExtension {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -58,6 +58,7 @@ declare namespace pxt {
             includeDirs: string[];
             excludePrefix?: string[];
         };
+        features?: string; // used for compatility check with examples, tutorias
     }
 
     interface PackageExtension {
@@ -133,6 +134,8 @@ declare namespace pxt {
 
         target?: string;
         className?: string;
+
+        features?: string[]; // core required features
     }
 
     interface CodeCardTag {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -58,6 +58,7 @@ declare namespace pxt {
             includeDirs: string[];
             excludePrefix?: string[];
         };
+        features?: string[];
     }
 
     interface PackageExtension {

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -133,8 +133,6 @@ declare namespace pxt {
 
         target?: string;
         className?: string;
-
-        features?: string[]; // core required features
     }
 
     interface CodeCardTag {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -242,7 +242,7 @@ namespace pxt.editor {
         showExperimentsDialog(): void;
 
         showPackageDialog(): void;
-        showBoardDialog(): void;
+        showBoardDialogAsync(): Promise<void>;
 
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;
     }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -242,7 +242,7 @@ namespace pxt.editor {
         showExperimentsDialog(): void;
 
         showPackageDialog(): void;
-        showBoardDialogAsync(): Promise<void>;
+        showBoardDialogAsync(features?: string[]): Promise<void>;
 
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;
     }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -82,8 +82,13 @@ namespace pxt.editor {
         inTutorial?: boolean;
         dependencies?: pxt.Map<string>;
         tsOnly?: boolean;
-        changeBoardOnLoad?: boolean; // if applicable, pop up the "boards" dialog after creating the project
-        features?: string[]; // features required by core package
+    }
+
+    export interface ExampleImportOptions {
+        name: string;
+        path: string;
+        loadBlocks?: boolean;
+        prj?: ProjectTemplate;
     }
 
     export interface ProjectFilters {
@@ -147,6 +152,7 @@ namespace pxt.editor {
         newEmptyProject(name?: string, documentation?: string): void;
         newProject(options?: ProjectCreationOptions): void;
         createProjectAsync(options: ProjectCreationOptions): Promise<void>;
+        importExampleAsync(options: ExampleImportOptions): Promise<void>;
         importProjectDialog(): void;
         removeProject(): void;
         editText(): void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -223,7 +223,7 @@ namespace pxt.editor {
 
         editor: IEditor;
 
-        startTutorial(tutorialId: string, tutorialTitle?: string, features?: string[]): void;
+        startTutorial(tutorialId: string, tutorialTitle?: string): void;
         showLightbox(): void;
         hideLightbox(): void;
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -83,6 +83,7 @@ namespace pxt.editor {
         dependencies?: pxt.Map<string>;
         tsOnly?: boolean;
         changeBoardOnLoad?: boolean; // if applicable, pop up the "boards" dialog after creating the project
+        features?: string[]; // features required by core package
     }
 
     export interface ProjectFilters {
@@ -222,7 +223,7 @@ namespace pxt.editor {
 
         editor: IEditor;
 
-        startTutorial(tutorialId: string, tutorialTitle?: string): void;
+        startTutorial(tutorialId: string, tutorialTitle?: string, features?: string[]): void;
         showLightbox(): void;
         hideLightbox(): void;
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -9,6 +9,7 @@ namespace pxt.gallery {
         name: string;
         filesOverride: pxt.Map<string>;
         dependencies: pxt.Map<string>;
+        features?: string[];
     }
 
     export function parsePackagesFromMarkdown(md: string): pxt.Map<string> {
@@ -23,6 +24,16 @@ namespace pxt.gallery {
         return dependencies;
     }
 
+    export function parseFeaturesFromMarkdown(md: string): string[] {
+        const pm = /```config\s+((.|\s)+?)\s*```/i.exec(md);
+        let features: string[] = [];
+        pm[1].split('\n').map(s => s.replace(/\s*/g, '')).filter(s => !!s)
+            .map(l => l.split('='))
+            .filter(kv => kv[0] == "feature" && !!kv[2])
+            .forEach(kv => features.push(kv[1]));
+        return features.length ? features : undefined;
+    }
+
     export function parseExampleMarkdown(name: string, md: string): GalleryProject {
         if (!md) return undefined;
 
@@ -30,26 +41,16 @@ namespace pxt.gallery {
         if (!m) return undefined;
 
         const dependencies = parsePackagesFromMarkdown(md);
-        let src = m[2];
-
-        // extract text between first sample and title
-//        let comment = md.substring(0, m.index)
-//            .replace(/^(#+.*|\s*)$/igm, '')
-//            .trim();
-//        if (comment) {
-//            src = `/**
-//${comment.split('\n').map(line => '* ' + line).join('\n')}
-//*/
-//` + src;
-//        }
-
+        const src = m[2];
+        const features = parseFeaturesFromMarkdown(md);
         return {
             name,
             filesOverride: {
                 "main.blocks": `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`,
                 "main.ts": src
             },
-            dependencies
+            dependencies,
+            features
         };
     }
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -29,7 +29,7 @@ namespace pxt.gallery {
         let features: string[] = [];
         pm[1].split('\n').map(s => s.replace(/\s*/g, '')).filter(s => !!s)
             .map(l => l.split('='))
-            .filter(kv => kv[0] == "feature" && !!kv[2])
+            .filter(kv => kv[0] == "feature" && !!kv[1])
             .forEach(kv => features.push(kv[1]));
         return features.length ? features : undefined;
     }

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -27,10 +27,12 @@ namespace pxt.gallery {
     export function parseFeaturesFromMarkdown(md: string): string[] {
         const pm = /```config\s+((.|\s)+?)\s*```/i.exec(md);
         let features: string[] = [];
-        pm[1].split('\n').map(s => s.replace(/\s*/g, '')).filter(s => !!s)
-            .map(l => l.split('='))
-            .filter(kv => kv[0] == "feature" && !!kv[1])
-            .forEach(kv => features.push(kv[1]));
+        if (pm) {
+            pm[1].split('\n').map(s => s.replace(/\s*/g, '')).filter(s => !!s)
+                .map(l => l.split('='))
+                .filter(kv => kv[0] == "feature" && !!kv[1])
+                .forEach(kv => features.push(kv[1]));
+        }
         return features.length ? features : undefined;
     }
 

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -636,6 +636,7 @@ namespace pxt.runner {
             if (options.snippetReplaceParent) $c = $c.parent();
             $c.remove();
         });
+        $('.lang-config').remove();
     }
 
     function renderTypeScript(options?: ClientRenderOptions) {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -636,7 +636,11 @@ namespace pxt.runner {
             if (options.snippetReplaceParent) $c = $c.parent();
             $c.remove();
         });
-        $('.lang-config').remove();
+        $('.lang-config').each((i, c) => {
+            let $c = $(c);
+            if (options.snippetReplaceParent) $c = $c.parent();
+            $c.remove();
+        })
     }
 
     function renderTypeScript(options?: ClientRenderOptions) {

--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -98,7 +98,7 @@ export class HomeAccessibilityMenu extends data.Component<HomeAccessibilityMenuP
 
     newProject() {
         pxt.tickEvent("accmenu.home.new", undefined, { interactiveConsent: true });
-        this.props.parent.newProject({ changeBoardOnLoad: true });
+        this.props.parent.newProject();
     }
 
     importProjectDialog() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2151,18 +2151,18 @@ export class ProjectView
     ////////////             Tutorials            /////////////
     ///////////////////////////////////////////////////////////
 
-    startTutorial(tutorialId: string, tutorialTitle?: string, features?: string[]) {
+    startTutorial(tutorialId: string, tutorialTitle?: string) {
         pxt.tickEvent("tutorial.start");
         // Check for Internet access
         if (!pxt.Cloud.isNavigatorOnline()) {
             core.errorNotification(lf("No Internet access, please connect and try again."));
         } else {
             core.showLoading("tutorial", lf("starting tutorial..."));
-            this.startTutorialAsync(tutorialId, tutorialTitle, features);
+            this.startTutorialAsync(tutorialId, tutorialTitle);
         }
     }
 
-    startTutorialAsync(tutorialId: string, tutorialTitle?: string, features?: string[]): Promise<void> {
+    startTutorialAsync(tutorialId: string, tutorialTitle?: string): Promise<void> {
         let title = tutorialTitle || tutorialId.split('/').reverse()[0].replace('-', ' '); // drop any kind of sub-paths
 
         sounds.initTutorial(); // pre load sounds
@@ -2175,11 +2175,11 @@ export class ProjectView
                     throw new Error("tutorial not found");
                 tutorialmd = md;
                 const dependencies = pxt.gallery.parsePackagesFromMarkdown(md);
+                const features = pxt.gallery.parseFeaturesFromMarkdown(md);
                 return this.createProjectAsync({
                     name: title,
                     inTutorial: true,
-                    dependencies,
-                    features
+                    dependencies
                 });
             })
             .then(() => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1373,6 +1373,9 @@ export class ProjectView
             .then(hd => this.loadHeaderAsync(hd, { filters: options.filters }, options.inTutorial));
     }
 
+    // in multiboard targets, allow use to pick a different board
+    // after the project is loaded
+    // this could be done prior to the project creation too
     private autoChooseBoardAsync(features?: string[]): Promise<void> {
         if (pxt.appTarget.appTheme.chooseBoardOnNewProject
             && pxt.appTarget.simulator

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1348,11 +1348,6 @@ export class ProjectView
             .then(() => Promise.delay(500))
             .done(() => {
                 core.hideLoading("newproject")
-                if (pxt.appTarget.appTheme.chooseBoardOnNewProject
-                    && pxt.appTarget.simulator
-                    && !!pxt.appTarget.simulator.dynamicBoardDefinition
-                    && (options.changeBoardOnLoad || options.features))
-                    this.showBoardDialog(options.features);
             });
     }
 
@@ -1381,7 +1376,16 @@ export class ProjectView
             target: pxt.appTarget.id,
             targetVersion: pxt.appTarget.versions.target,
             temporary: options.temporary
-        }, files).then(hd => this.loadHeaderAsync(hd, { filters: options.filters }, options.inTutorial))
+        }, files)
+            .then(hd => this.loadHeaderAsync(hd, { filters: options.filters }, options.inTutorial))
+            .then(() => {
+                if (pxt.appTarget.appTheme.chooseBoardOnNewProject
+                    && pxt.appTarget.simulator
+                    && !!pxt.appTarget.simulator.dynamicBoardDefinition
+                    && (options.changeBoardOnLoad || options.features))
+                    return this.showBoardDialogAsync(options.features);
+                return Promise.resolve();
+            })
     }
 
     switchTypeScript() {
@@ -2102,8 +2106,8 @@ export class ProjectView
         this.scriptSearch.showExtensions();
     }
 
-    showBoardDialog(features?: string[]) {
-        this.scriptSearch.showBoards(features);
+    showBoardDialogAsync(features?: string[]): Promise<void> {
+        return this.scriptSearch.showBoardsAsync(features);
     }
 
     showModalDialogAsync(options: pxt.editor.ModalDialogOptions) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -320,10 +320,8 @@ export class ProjectView
         // any other editeable .ts or pxt.json
         else if (this.isAnyEditeableJavaScriptOrPackageActive()) {
             this.saveFileAsync()
-                .then(() => {
-                    compiler.newProject();
-                    return compiler.getBlocksAsync()
-                })
+                .then(() => compiler.newProjectAsync())
+                .then(() => compiler.getBlocksAsync())
                 .done((bi: pxtc.BlocksInfo) => {
                     pxt.blocks.initializeAndInject(bi);
                     this.blocksEditor.updateBlocksInfo(bi);
@@ -852,9 +850,8 @@ export class ProjectView
                     this.showPackageErrorsOnNextTypecheck();
                 }
                 simulator.makeDirty();
-                compiler.newProject();
-                return compiler.applyUpgrades();
-            })
+                return compiler.newProjectAsync();
+            }).then(() => compiler.applyUpgradesAsync())
             .then(() => {
                 let e = this.settings.fileHistory.filter(e => e.id == h.id)[0]
                 let main = pkg.getEditorPkg(pkg.mainPkg)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1348,9 +1348,11 @@ export class ProjectView
             .then(() => Promise.delay(500))
             .done(() => {
                 core.hideLoading("newproject")
-                if (options.changeBoardOnLoad && pxt.appTarget.appTheme.chooseBoardOnNewProject &&
-                    pxt.appTarget.simulator && !!pxt.appTarget.simulator.dynamicBoardDefinition)
-                    this.showBoardDialog();
+                if (pxt.appTarget.appTheme.chooseBoardOnNewProject
+                    && pxt.appTarget.simulator
+                    && !!pxt.appTarget.simulator.dynamicBoardDefinition
+                    && (options.changeBoardOnLoad || options.features))
+                    this.showBoardDialog(options.features);
             });
     }
 
@@ -2100,8 +2102,8 @@ export class ProjectView
         this.scriptSearch.showExtensions();
     }
 
-    showBoardDialog() {
-        this.scriptSearch.showBoards();
+    showBoardDialog(features?: string[]) {
+        this.scriptSearch.showBoards(features);
     }
 
     showModalDialogAsync(options: pxt.editor.ModalDialogOptions) {
@@ -2145,18 +2147,18 @@ export class ProjectView
     ////////////             Tutorials            /////////////
     ///////////////////////////////////////////////////////////
 
-    startTutorial(tutorialId: string, tutorialTitle?: string) {
+    startTutorial(tutorialId: string, tutorialTitle?: string, features?: string[]) {
         pxt.tickEvent("tutorial.start");
         // Check for Internet access
         if (!pxt.Cloud.isNavigatorOnline()) {
             core.errorNotification(lf("No Internet access, please connect and try again."));
         } else {
             core.showLoading("tutorial", lf("starting tutorial..."));
-            this.startTutorialAsync(tutorialId, tutorialTitle);
+            this.startTutorialAsync(tutorialId, tutorialTitle, features);
         }
     }
 
-    startTutorialAsync(tutorialId: string, tutorialTitle?: string): Promise<void> {
+    startTutorialAsync(tutorialId: string, tutorialTitle?: string, features?: string[]): Promise<void> {
         let title = tutorialTitle || tutorialId.split('/').reverse()[0].replace('-', ' '); // drop any kind of sub-paths
 
         sounds.initTutorial(); // pre load sounds
@@ -2172,7 +2174,8 @@ export class ProjectView
                 return this.createProjectAsync({
                     name: title,
                     inTutorial: true,
-                    dependencies
+                    dependencies,
+                    features
                 });
             })
             .then(() => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2179,7 +2179,8 @@ export class ProjectView
                 return this.createProjectAsync({
                     name: title,
                     inTutorial: true,
-                    dependencies
+                    dependencies,
+                    features
                 });
             })
             .then(() => {

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -246,7 +246,7 @@ export interface UpgradeResult {
     errorCodes?: pxt.Map<number>;
 }
 
-export function applyUpgrades(): Promise<UpgradeResult> {
+export function applyUpgradesAsync(): Promise<UpgradeResult> {
     const mainPkg = pkg.mainPkg;
     const epkg = pkg.getEditorPkg(mainPkg);
     const pkgVersion = pxt.semver.parse(epkg.header.targetVersion || "0.0.0");
@@ -434,10 +434,8 @@ export function updatePackagesAsync(packages: pkg.EditorPackage[], token?: pxt.U
                 })
         )
         .then(() => pkg.loadPkgAsync(epkg.header.id))
-        .then(() => {
-            newProject();
-            return checkPatchAsync();
-        })
+        .then(() => newProjectAsync())
+        .then(() => checkPatchAsync())
         .then(() => {
             if (token) token.throwIfCancelled();
             delete epkg.header.backupRef;
@@ -465,11 +463,11 @@ export function updatePackagesAsync(packages: pkg.EditorPackage[], token?: pxt.U
 }
 
 
-export function newProject() {
+export function newProjectAsync() {
     firstTypecheck = null;
     cachedApis = null;
     cachedBlocks = null;
-    workerOpAsync("reset", {}).done();
+    return workerOpAsync("reset", {});
 }
 
 export function getPackagesWithErrors(): pkg.EditorPackage[] {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -175,7 +175,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     showBoardDialog() {
         pxt.tickEvent("menu.changeboard", undefined, { interactiveConsent: true });
-        this.props.parent.showBoardDialog();
+        this.props.parent.showBoardDialogAsync().done();
     }
 
     saveProject() {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -106,7 +106,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
     private renderOthers(content: HTMLElement) {
         // remove package blocks
-        pxt.Util.toArray(content.querySelectorAll(`.lang-package`))
+        pxt.Util.toArray(content.querySelectorAll(`.lang-package,.lang-config`))
             .forEach((langBlock: HTMLElement) => {
                 langBlock.parentNode.removeChild(langBlock);
             });

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -129,30 +129,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     }
 
     chgCode(scr: pxt.CodeCard, loadBlocks: boolean, prj?: pxt.ProjectTemplate) {
-        core.showLoading("changingcode", lf("loading..."));
-        pxt.gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
-            .then((opts: pxt.editor.ProjectCreationOptions) => {
-                if (!opts) return Promise.resolve();
-                if (prj) opts.prj = prj;
-                if (loadBlocks) {
-                    return this.props.parent.createProjectAsync(opts)
-                        .then(() => {
-                            return compiler.getBlocksAsync()
-                                .then(blocksInfo => compiler.decompileAsync("main.ts", blocksInfo))
-                                .then(resp => {
-                                    pxt.debug(`example decompilation: ${resp.success}`)
-                                    if (resp.success) {
-                                        this.props.parent.overrideBlocksFile(resp.outfiles["main.blocks"])
-                                    }
-                                })
-                        });
-                } else {
-                    opts.tsOnly = true
-                    return this.props.parent.createProjectAsync(opts)
-                        .then(() => Promise.delay(500));
-                }
-            })
-            .finally(() => core.hideLoading("changingcode"))
+        return this.props.parent.importExampleAsync({ name: scr.name,  path: scr.url, loadBlocks, prj });
     }
 
     importProject() {
@@ -343,7 +320,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
 
     newProject() {
         pxt.tickEvent("projects.new", undefined, { interactiveConsent: true });
-        this.props.parent.newProject({ changeBoardOnLoad: true });
+        this.props.parent.newProject();
     }
 
     closeDetail() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -132,32 +132,27 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         core.showLoading("changingcode", lf("loading..."));
         pxt.gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
             .then((opts: pxt.editor.ProjectCreationOptions) => {
-                if (opts) {
-                    if (prj) opts.prj = prj;
-                    if (loadBlocks) {
-                        return this.props.parent.createProjectAsync(opts)
-                            .then(() => {
-                                return compiler.getBlocksAsync()
-                                    .then(blocksInfo => compiler.decompileAsync("main.ts", blocksInfo))
-                                    .then(resp => {
-                                        pxt.debug(`example decompilation: ${resp.success}`)
-                                        if (resp.success) {
-                                            this.props.parent.overrideBlocksFile(resp.outfiles["main.blocks"])
-                                        }
-                                    })
-                            })
-                            .done(() => {
-                                core.hideLoading("changingcode");
-                            })
-                    } else {
-                        opts.tsOnly = true
-                        return this.props.parent.createProjectAsync(opts)
-                            .then(() => Promise.delay(500))
-                            .done(() => core.hideLoading("changingcode"));
-                    }
+                if (!opts) return Promise.resolve();
+                if (prj) opts.prj = prj;
+                if (loadBlocks) {
+                    return this.props.parent.createProjectAsync(opts)
+                        .then(() => {
+                            return compiler.getBlocksAsync()
+                                .then(blocksInfo => compiler.decompileAsync("main.ts", blocksInfo))
+                                .then(resp => {
+                                    pxt.debug(`example decompilation: ${resp.success}`)
+                                    if (resp.success) {
+                                        this.props.parent.overrideBlocksFile(resp.outfiles["main.blocks"])
+                                    }
+                                })
+                        });
+                } else {
+                    opts.tsOnly = true
+                    return this.props.parent.createProjectAsync(opts)
+                        .then(() => Promise.delay(500));
                 }
-                core.hideLoading("changingcode");
-            }).done(() => { });
+            })
+            .finally(() => core.hideLoading("changingcode"))
     }
 
     importProject() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -134,7 +134,6 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             .then((opts: pxt.editor.ProjectCreationOptions) => {
                 if (opts) {
                     if (prj) opts.prj = prj;
-                    opts.features = scr.features;
                     if (loadBlocks) {
                         return this.props.parent.createProjectAsync(opts)
                             .then(() => {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -108,7 +108,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             case "side":
                 this.props.parent.newEmptyProject(scr.name, scr.url);
                 break;
-            case "tutorial": this.props.parent.startTutorial(scr.url, scr.name); break;
+            case "tutorial": this.props.parent.startTutorial(scr.url, scr.name, scr.features); break;
             default:
                 const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(scr.url); // Tutorial
                 if (m) this.props.parent.startTutorial(m[1]);
@@ -134,6 +134,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             .done((opts: pxt.editor.ProjectCreationOptions) => {
                 if (opts) {
                     if (prj) opts.prj = prj;
+                    opts.features = scr.features;
                     if (loadBlocks) {
                         return this.props.parent.createProjectAsync(opts)
                             .then(() => {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -131,7 +131,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     chgCode(scr: pxt.CodeCard, loadBlocks: boolean, prj?: pxt.ProjectTemplate) {
         core.showLoading("changingcode", lf("loading..."));
         pxt.gallery.loadExampleAsync(scr.name.toLowerCase(), scr.url)
-            .done((opts: pxt.editor.ProjectCreationOptions) => {
+            .then((opts: pxt.editor.ProjectCreationOptions) => {
                 if (opts) {
                     if (prj) opts.prj = prj;
                     opts.features = scr.features;
@@ -158,7 +158,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                     }
                 }
                 core.hideLoading("changingcode");
-            });
+            }).done(() => { });
     }
 
     importProject() {
@@ -754,9 +754,9 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
     handleChange(name: string) {
         this.setState({ projectName: name });
         if (name === "" || name === lf("Untitled")) {
-            this.setState({emoji: "😞"})
+            this.setState({ emoji: "😞" })
         } else {
-            this.setState({emoji: "😊"})
+            this.setState({ emoji: "😊" })
         }
     }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -108,7 +108,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             case "side":
                 this.props.parent.newEmptyProject(scr.name, scr.url);
                 break;
-            case "tutorial": this.props.parent.startTutorial(scr.url, scr.name, scr.features); break;
+            case "tutorial": this.props.parent.startTutorial(scr.url, scr.name); break;
             default:
                 const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(scr.url); // Tutorial
                 if (m) this.props.parent.startTutorial(m[1]);

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -28,6 +28,7 @@ interface ScriptSearchState {
     mode?: ScriptSearchMode;
     experimentsState?: string;
     features?: string[];
+    resolve?: () => void;
 }
 
 export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
@@ -50,26 +51,38 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     }
 
     hide() {
-        this.setState({ visible: false });
+        const r = this.state.resolve;
+        this.setState({ visible: false, resolve: undefined });
         // something changed?
         if (this.state.mode == ScriptSearchMode.Experiments &&
             this.state.experimentsState !== pxt.editor.experiments.state())
             this.props.parent.reloadEditor();
+        // resolve?
+        if (r) r();
     }
 
     showExtensions() {
-        this.setState({ visible: true, searchFor: '', mode: ScriptSearchMode.Extensions, features: undefined })
+        this.setState({ visible: true, searchFor: '', mode: ScriptSearchMode.Extensions, features: undefined, resolve: undefined })
     }
 
-    showBoards(features?: string[]) {
-        this.setState({ visible: true, searchFor: '', mode: ScriptSearchMode.Boards, features })
+    showBoardsAsync(features?: string[]): Promise<void> {
+        return new Promise((resolve) => {
+            this.setState({
+                visible: true,
+                searchFor: '',
+                mode: ScriptSearchMode.Boards,
+                features,
+                resolve
+            })
+        });
     }
 
     showExperiments() {
         this.setState({
             visible: true, searchFor: '', mode: ScriptSearchMode.Experiments,
             experimentsState: pxt.editor.experiments.state(),
-            features: undefined
+            features: undefined,
+            resolve: undefined
         });
     }
 

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -327,10 +327,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                         }
                         return Promise.resolve();
                     });
-            }).then(() => {
-                if (this.state.resolve)
-                    this.state.resolve();
-            })
+            });
     }
 
     toggleExperiment(experiment: pxt.editor.experiments.Experiment) {

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -27,6 +27,7 @@ interface ScriptSearchState {
     visible?: boolean;
     mode?: ScriptSearchMode;
     experimentsState?: string;
+    features?: string[];
 }
 
 export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchState> {
@@ -57,17 +58,18 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     }
 
     showExtensions() {
-        this.setState({ visible: true, searchFor: '', mode: ScriptSearchMode.Extensions })
+        this.setState({ visible: true, searchFor: '', mode: ScriptSearchMode.Extensions, features: undefined })
     }
 
-    showBoards() {
-        this.setState({ visible: true, searchFor: '', mode: ScriptSearchMode.Boards })
+    showBoards(features?: string[]) {
+        this.setState({ visible: true, searchFor: '', mode: ScriptSearchMode.Boards, features })
     }
 
     showExperiments() {
         this.setState({
             visible: true, searchFor: '', mode: ScriptSearchMode.Experiments,
-            experimentsState: pxt.editor.experiments.state()
+            experimentsState: pxt.editor.experiments.state(),
+            features: undefined
         });
     }
 
@@ -137,12 +139,14 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const query = this.state.searchFor;
         const bundled = pxt.appTarget.bundledpkgs;
         const boards = this.state.mode == ScriptSearchMode.Boards;
+        const features = this.state.features;
         return Object.keys(bundled).filter(k => !/prj$/.test(k))
             .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig)
             .filter(pk => !query || pk.name.toLowerCase().indexOf(query.toLowerCase()) > -1) // search filter
             .filter(pk => boards || !pkg.mainPkg.deps[pk.name]) // don't show package already referenced in extensions
             .filter(pk => !/---/.test(pk.name)) //filter any package with ---, these are part of common-packages such as core---linux or music---pwm
-            .filter(pk => boards == !!pk.core); // show core in "boards" mode
+            .filter(pk => boards == !!pk.core) // show core in "boards" mode
+            .filter(pk => !features || features.every(f => pk.features && pk.features.indexOf(f) > -1)); // ensure features are supported
 
     }
 


### PR DESCRIPTION
* A board package can declare a set of supported features (pinsled)
* A tutorial/example markdown can declare a set of required board features (blinky needs pinsled)
* If multi board, allow to select compatible boards when opening a tutorial/example based on features
* compiler.newProject -> compiler.newProjectAsync (this function is async)
* moved a few "hideLoading" to .finally clause to always close up

(github does not seem to update this PR)
