### PR TITLE
Added circle and line tools to the sprite editor

### DIFF
--- a/pxtblocks/fields/sprite/sidebar.ts
+++ b/pxtblocks/fields/sprite/sidebar.ts
@@ -184,12 +184,10 @@ namespace pxtblockly {
 
         getButtonForTool(tool: PaintTool) {
             switch (tool) {
-                case PaintTool.Normal: return this.pencilTool;
                 case PaintTool.Normal:
                 case PaintTool.Line: return this.pencilTool;
                 case PaintTool.Erase: return this.eraseTool;
                 case PaintTool.Fill: return this.fillTool;
-                case PaintTool.Rectangle: return this.rectangleTool;
                 case PaintTool.Rectangle:
                 case PaintTool.Circle: return this.rectangleTool;
                 default: return undefined;

--- a/pxtblocks/fields/sprite/sidebar.ts
+++ b/pxtblocks/fields/sprite/sidebar.ts
@@ -100,7 +100,10 @@ namespace pxtblockly {
             const buttonGroup = new CursorMultiButton(this.sizeGroup, TOOLBAR_WIDTH);
             buttonGroup.onSelected(index => {
                 this.setCursorSize(1 + (index * 2));
-            })
+            });
+            // Sets the first button to show as selected
+            buttonGroup.selected = 0;
+            buttonGroup.buttons[0].setSelected(true);
         }
 
         protected initTools() {

--- a/pxtblocks/fields/sprite/sidebar.ts
+++ b/pxtblocks/fields/sprite/sidebar.ts
@@ -183,7 +183,7 @@ namespace pxtblockly {
         }
 
         getButtonForTool(tool: PaintTool) {
-             switch (tool) {
+            switch (tool) {
                 case PaintTool.Normal: return this.pencilTool;
                 case PaintTool.Normal:
                 case PaintTool.Line: return this.pencilTool;
@@ -193,7 +193,7 @@ namespace pxtblockly {
                 case PaintTool.Rectangle:
                 case PaintTool.Circle: return this.rectangleTool;
                 default: return undefined;
-             }
-         }
+            }
+        }
     }
 }

--- a/pxtblocks/fields/sprite/sidebar.ts
+++ b/pxtblocks/fields/sprite/sidebar.ts
@@ -179,14 +179,18 @@ namespace pxtblockly {
             return btn;
         }
 
-        protected getButtonForTool(tool: PaintTool) {
-            switch (tool) {
+        getButtonForTool(tool: PaintTool) {
+             switch (tool) {
                 case PaintTool.Normal: return this.pencilTool;
+                case PaintTool.Normal:
+                case PaintTool.Line: return this.pencilTool;
                 case PaintTool.Erase: return this.eraseTool;
                 case PaintTool.Fill: return this.fillTool;
                 case PaintTool.Rectangle: return this.rectangleTool;
+                case PaintTool.Rectangle:
+                case PaintTool.Circle: return this.rectangleTool;
                 default: return undefined;
-            }
-        }
+             }
+         }
     }
 }

--- a/pxtblocks/fields/sprite/spriteEditor.ts
+++ b/pxtblocks/fields/sprite/spriteEditor.ts
@@ -298,9 +298,11 @@ namespace pxtblockly {
             if (tool == PaintTool.Rectangle) {
                 //Change icon back to square
                 btn.setText("\uf096");
+                btn.title(lf("Rectangle"));
             } else if (tool == PaintTool.Normal) {
                 //Change icon back to pencil
                 btn.setText("\uf040");
+                btn.title(lf("Pencil"));
             }
             btn.onClick(() => this.sidebar.setTool(tool));
             if ((this.activeTool == PaintTool.Circle && tool == PaintTool.Rectangle)
@@ -314,6 +316,7 @@ namespace pxtblockly {
                 if (!this.controlDown) {
                     let btn = (this.sidebar.getButtonForTool(PaintTool.Rectangle) as TextButton);
                     btn.setText("\uf10c");
+                    btn.title(lf("Circle"));
                     btn.onClick(() => this.sidebar.setTool(PaintTool.Circle));
                     if (this.activeTool == PaintTool.Rectangle) {
                         this.setActiveTool(PaintTool.Circle);
@@ -324,6 +327,7 @@ namespace pxtblockly {
                 if (!this.shiftDown) {
                     let btn = (this.sidebar.getButtonForTool(PaintTool.Normal) as TextButton);
                     btn.setText("\uf07e");
+                    btn.title(lf("Line"));
                     btn.onClick(() => this.sidebar.setTool(PaintTool.Line));
                     if (this.activeTool == PaintTool.Normal) {
                         this.setActiveTool(PaintTool.Line);

--- a/pxtblocks/fields/sprite/spriteEditor.ts
+++ b/pxtblocks/fields/sprite/spriteEditor.ts
@@ -69,6 +69,10 @@ namespace pxtblockly {
         private rows: number = 16;
         private colors: string[];
 
+
+        private controlDown: boolean = false;
+        private shiftDown: boolean = false;
+        private mouseDown: boolean = false;
         constructor(bitmap: Bitmap, blocksInfo: pxtc.BlocksInfo, protected lightMode = false) {
             this.colors = pxt.appTarget.runtime.palette.slice(1);
 
@@ -92,10 +96,18 @@ namespace pxtblockly {
             this.paintSurface.up((col, row) => {
                 this.debug("gesture end (" + PaintTool[this.activeTool] + ")");
                 this.commit();
+                this.mouseDown = false;
+                if (this.activeTool == PaintTool.Circle && !this.controlDown) {
+                    this.switchIconBack(PaintTool.Rectangle);
+                }
+                if (this.activeTool == PaintTool.Line && !this.shiftDown) {
+                    this.switchIconBack(PaintTool.Normal);
+                }
             });
 
             this.paintSurface.down((col, row) => {
                 this.setCell(col, row, this.color, false);
+                this.mouseDown = true;
             });
 
             this.paintSurface.move((col, row) => {
@@ -279,6 +291,73 @@ namespace pxtblockly {
 
         hideGallery() {
             this.gallery.hide();
+        }
+
+        switchIconBack(tool: PaintTool) {
+            let btn = (this.sidebar.getButtonForTool(tool) as TextButton);
+            if (tool == PaintTool.Rectangle) {
+                //Change icon back to square
+                btn.setText("\uf096");
+            } else if (tool == PaintTool.Normal) {
+                //Change icon back to pencil
+                btn.setText("\uf040");
+            }
+            btn.onClick(() => this.sidebar.setTool(tool));
+            if ((this.activeTool == PaintTool.Circle && tool == PaintTool.Rectangle)
+                    || (this.activeTool == PaintTool.Line && tool == PaintTool.Normal)) {
+                this.setActiveTool(tool);
+            }
+        }
+
+        private keyDown = (event: KeyboardEvent) => {
+            if (event.keyCode == 17) { // Control
+                if (!this.controlDown) {
+                    let btn = (this.sidebar.getButtonForTool(PaintTool.Rectangle) as TextButton);
+                    btn.setText("\uf10c");
+                    btn.onClick(() => this.sidebar.setTool(PaintTool.Circle));
+                    if (this.activeTool == PaintTool.Rectangle) {
+                        this.setActiveTool(PaintTool.Circle);
+                    }
+                }
+                this.controlDown = true;
+            } else if (event.keyCode == 16) { // Shift
+                if (!this.shiftDown) {
+                    let btn = (this.sidebar.getButtonForTool(PaintTool.Normal) as TextButton);
+                    btn.setText("\uf07e");
+                    btn.onClick(() => this.sidebar.setTool(PaintTool.Line));
+                    if (this.activeTool == PaintTool.Normal) {
+                        this.setActiveTool(PaintTool.Line);
+                    }
+                }
+                this.shiftDown = true;
+            }
+
+        }
+
+        private keyUp = (event: KeyboardEvent) => {
+            if (event.keyCode == 17) { // Control
+                this.controlDown = false;
+                // If not drawing a circle, switch back to Rectangle
+                if (!(this.mouseDown && this.activeTool == PaintTool.Circle)) {
+                    this.switchIconBack(PaintTool.Rectangle);
+                }
+            } else if (event.keyCode == 16) { // Shift
+                this.shiftDown = false;
+                // If not drawing a line, switch back to Pencil
+                if (!(this.mouseDown && this.activeTool == PaintTool.Line)) {
+                    this.switchIconBack(PaintTool.Normal);
+                }
+            }
+        }
+
+        addKeyListeners() {
+            document.addEventListener("keydown", this.keyDown);
+            document.addEventListener("keyup", this.keyUp);
+        }
+
+        removeKeyListeners() {
+            document.removeEventListener("keydown", this.keyDown);
+            document.removeEventListener("keyup", this.keyUp);
         }
 
         private afterResize(showOverlay: boolean) {

--- a/pxtblocks/fields/sprite/spriteEditor.ts
+++ b/pxtblocks/fields/sprite/spriteEditor.ts
@@ -203,10 +203,10 @@ namespace pxtblockly {
 
                 // If the user is erasing, go back to pencil
                 if (this.activeTool === PaintTool.Erase) {
-                    this.activeTool = PaintTool.Normal;
+                    this.sidebar.setTool(PaintTool.Normal);
+                } else {
+                    this.edit = this.newEdit(this.color);
                 }
-
-                this.edit = this.newEdit(this.color);
             }
         }
 

--- a/pxtblocks/fields/sprite/spriteFieldEditor.ts
+++ b/pxtblocks/fields/sprite/spriteFieldEditor.ts
@@ -120,9 +120,11 @@ namespace pxtblockly {
                 goog.style.setWidth(contentDiv, null);
                 goog.style.setStyle(contentDiv, "overflow", null);
                 goog.style.setStyle(contentDiv, "max-height", null);
-                (goog.dom.classlist as any).remove(contentDiv.parentElement, "sprite-editor-dropdown")
+                (goog.dom.classlist as any).remove(contentDiv.parentElement, "sprite-editor-dropdown");
+                this.editor.removeKeyListeners();
             });
 
+            this.editor.addKeyListeners();
             this.editor.layout();
         }
 

--- a/pxtblocks/fields/sprite/tools.ts
+++ b/pxtblocks/fields/sprite/tools.ts
@@ -237,9 +237,11 @@ namespace pxtblockly {
 
         // https://en.wikipedia.org/wiki/Midpoint_circle_algorithm
         midpoint(cx: number, cy: number, radius: number, bitmap: Bitmap) {
-            let x = radius;
+            let x = radius - 1;
             let y = 0;
-            let err = 0;
+            let dx = 1;
+            let dy = 1;
+            let err = dx - (radius * 2);
             while (x >= y) {
                 bitmap.set(cx + x, cy + y, this.color);
                 bitmap.set(cx + x, cy - y, this.color);
@@ -250,12 +252,14 @@ namespace pxtblockly {
                 bitmap.set(cx - x, cy + y, this.color);
                 bitmap.set(cx - x, cy - y, this.color);
                 if (err <= 0) {
-                    y += 1;
-                    err += 2 * y + 1;
+                    y++;
+                    err += dy;
+                    dy += 2;
                 }
                 if (err > 0) {
-                    x -= 1;
-                    err -= 2 * x + 1;
+                    x--;
+                    dx += 2;
+                    err += dx - (radius * 2);
                 }
             }
         }

--- a/pxtblocks/fields/sprite/tools.ts
+++ b/pxtblocks/fields/sprite/tools.ts
@@ -222,15 +222,10 @@ namespace pxtblockly {
             const br = this.bottomRight();
             const dx = br[0] - tl[0];
             const dy = br[1] - tl[1];
-            if (dx < dy) {
-                br[1] = tl[1] + dx;
-            }
-            else {
-                br[0] = tl[0] + dy;
-            }
-            const radius = Math.floor((br[0] - tl[0]) / 2);
-            const cx = tl[0] + radius;
-            const cy = tl[1] + radius;
+
+            const radius = Math.floor(Math.hypot(dx, dy));
+            const cx = this.startCol;
+            const cy = this.startRow;
 
             this.midpoint(cx, cy, radius, bitmap);
         }


### PR DESCRIPTION
This adds the ability to use circle and line tools in the sprite editor. By holding down shift, the pencil tool turns into the line tool, and by holding down control, the rectangle tool becomes the circle tool.

![new-sprite-editor](https://user-images.githubusercontent.com/13285164/47279710-a9bf7c00-d587-11e8-8cb0-08e979c2d386.gif)

Also fixes the following bugs:
* Pencil tool not showing as selected after color is chosen while eraser tool is selected
* Tool width not showing selected on opening the editor
* Circles were previously more pointy. Changed algorithm to better reflect the Midpoint Circle Algorithm

The main bits that I think need to be discussed is which keys should change which tools and also whether or not the first click should set the circles center rather than the upper-left of the circle.

I think it should be the upper-left of the circle because that allows for future implementations of ovals and even-width circles.

