### PR TITLE
Don't create a new project when the share page reloads

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2822,10 +2822,16 @@ function loadHeaderBySharedId(id: string) {
         .finally(() => core.hideLoading("loadingheader"));
 }
 
+const handleHashChange = (e: HashChangeEvent) => {
+    handleHash(parseHash(), false);
+}
+
 function initHashchange() {
-    window.addEventListener("hashchange", e => {
-        handleHash(parseHash(), false);
-    });
+    window.addEventListener("hashchange", handleHashChange);
+}
+
+function clearHashChange() {
+    window.removeEventListener("hashchange", handleHashChange)
 }
 
 function initExtensionsAsync(): Promise<void> {
@@ -2922,6 +2928,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const hash = parseHash();
     const appCacheUpdated = () => {
         try {
+            // Prevent us from stripping out the hash before the reload is complete
+            clearHashChange();
             // On embedded pages, preserve the loaded project
             if (pxt.BrowserUtils.isIFrame() && (hash.cmd === "pub" || hash.cmd === "sandbox")) {
                 location.hash = `#${hash.cmd}:${hash.arg}`;


### PR DESCRIPTION
When we push an editor release, the share page reloads and shows a blank project. I cannot find the issue anymore but you know the one I'm talking about.