### PR TITLE
Don't use template literals in HTML files

### DIFF
--- a/webapp/public/codeembed.html
+++ b/webapp/public/codeembed.html
@@ -57,7 +57,7 @@
             pxtFrame.style.bottom = 0;
             pxtFrame.style.width = "1px";
             pxtFrame.style.height = "1px";
-            pxtFrame.src =  `${pxtConfig ? pxtConfig.docsUrl : '---docs'}?render=1`;
+            pxtFrame.src =  (pxtConfig ? pxtConfig.docsUrl : '---docs') + '?render=1';
             document.body.appendChild(pxtFrame);
         }
 

--- a/webapp/public/extension.html
+++ b/webapp/public/extension.html
@@ -38,7 +38,7 @@
 
     function formatResponse(resp) {
         if (!resp.id)
-            return `\n${resp.event}, ${JSON.stringify(resp.body, null, 2).replace('\n', '')}`;
+            return '\n' + resp.event + ', ' + JSON.stringify(resp.body, null, 2).replace('\n', '');
 
         var action = idToType[resp.id];
         return "\n< " + action + " (response) s=" + resp.success + " "


### PR DESCRIPTION
Don't use template literals in html and JS files as IE 11 doesn't support them.
