### PR TITLE
always remove dal.d.ts from new project

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -137,11 +137,11 @@ cache:
     export function packageFiles(name: string) {
         let prj = pxt.appTarget.tsprj || pxt.appTarget.blocksprj;
         let config = U.clone(prj.config);
-        // remove blocks file
+        // remove blocks file and dal.d.ts
         Object.keys(prj.files)
-            .filter(f => /\.blocks$/.test(f))
+            .filter(f => /\.blocks$/.test(f) || f == pxt.DAL_DTS)
             .forEach(f => delete prj.files[f]);
-        config.files = config.files.filter(f => !/\.blocks$/.test(f));
+        config.files = config.files.filter(f => !(/\.blocks$/.test(f) || f == pxt.DAL_DTS));
 
         config.name = name;
         // by default, projects are not public

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -325,6 +325,7 @@ namespace pxt {
     }
 
     export const CONFIG_NAME = "pxt.json"
+    export const DAL_DTS = "dal.d.ts"
     export const SERIAL_EDITOR_FILE = "serial.txt"
     export const CLOUD_ID = "pxt/"
     export const BLOCKS_PROJECT_NAME = "blocksprj";


### PR DESCRIPTION
the blocksprj in pxt-maker had an extra dal.d.ts that got included in the pxt.json.... 412 errors!

This change filters out that file.