### PR TITLE
Open editor when migrating browser prefixes

### DIFF
--- a/webapp/src/browserworkspace.ts
+++ b/webapp/src/browserworkspace.ts
@@ -54,7 +54,9 @@ function migratePrefixesAsync(): Promise<void> {
                 .then((previousHeaders: pxt.workspace.Header[]) => {
                     return Promise.map(previousHeaders, (h) => copyProject(h));
                 })
-                .then(() => { });
+                .then(() => {
+                    if (!location.hash) location.hash = "#editor";
+                });
         });
 }
 


### PR DESCRIPTION
I tested this using the file workspace and it worked fine. Marking as "DO NOT MERGE" until a decision is reached. Also if merged needs to go into stable 4.1