### PR TITLE
Minor fix to not resize cell content to full width

### DIFF
--- a/theme/fieldeditors.less
+++ b/theme/fieldeditors.less
@@ -96,10 +96,6 @@
     margin-top: -0.2rem;
 }
 
-.blocklyWidgetDiv .blocklyGridPickerRow {
-    display: table-row;
-}
-
 .blocklyWidgetDiv .blocklyGridPickerMenu .goog-menuitem {
     background: white;
     cursor: pointer;


### PR DESCRIPTION
Minor fix to the grid picker's layout logic to not resize cell items to full width when the items are less than 8. (ie: in search). 

Fixes https://github.com/Microsoft/pxt-minecraft/issues/716