### PR TITLE
Some fixes for the sprite editor in edge

### DIFF
--- a/pxtblocks/fields/sprite/buttons.ts
+++ b/pxtblocks/fields/sprite/buttons.ts
@@ -119,19 +119,15 @@ namespace pxtblockly {
 
             // Draw the left option
             this.leftElement = this.root.group();
-            this.leftText = this.leftElement.draw("text")
-                .fill(this.props.selectedTextColor)
-                .text(this.props.leftText)
-                .setAttribute("dominant-baseline", "middle")
-                .setAttribute("dy", 0);
+            this.leftText = mkText(this.props.leftText)
+                .fill(this.props.selectedTextColor);
+            this.leftElement.appendChild(this.leftText);
 
             // Draw the right option
             this.rightElement = this.root.group();
-            this.rightText = this.rightElement.draw("text")
-                .fill(this.props.unselectedTextColor)
-                .text(this.props.rightText)
-                .setAttribute("dominant-baseline", "middle")
-                .setAttribute("dy", 0);
+            this.rightText = mkText(this.props.rightText)
+                .fill(this.props.unselectedTextColor);
+            this.rightElement.appendChild(this.rightText);
 
             this.root.onClick(() => this.toggle());
         }
@@ -162,12 +158,8 @@ namespace pxtblockly {
 
         layout() {
             const centerOffset = (TOGGLE_WIDTH - TOGGLE_BORDER_WIDTH * 2) / 4;
-
-            const lWidth = this.leftText.el.getComputedTextLength();
-            this.leftText.moveTo(centerOffset + TOGGLE_BORDER_WIDTH - lWidth / 2, TOGGLE_HEIGHT / 2);
-
-            const rWidth = this.rightText.el.getComputedTextLength();
-            this.rightText.moveTo(TOGGLE_WIDTH - TOGGLE_BORDER_WIDTH - centerOffset - rWidth / 2, TOGGLE_HEIGHT / 2)
+            this.leftText.moveTo(centerOffset + TOGGLE_BORDER_WIDTH, TOGGLE_HEIGHT / 2);
+            this.rightText.moveTo(TOGGLE_WIDTH - TOGGLE_BORDER_WIDTH - centerOffset, TOGGLE_HEIGHT / 2)
         }
 
         translate(x: number, y: number) {
@@ -256,11 +248,10 @@ namespace pxtblockly {
         constructor(root: svg.Group, cx: number, cy: number, text: string, className: string) {
             super(root, cx, cy);
 
-            this.textEl = this.root.draw("text")
-                .text(text)
-                .appendClass(className)
-                .setAttribute("dominant-baseline", "middle")
-                .setAttribute("dy", 2);
+            this.textEl = mkText(text)
+                .appendClass(className);
+
+            this.root.appendChild(this.textEl);
         }
 
         setText(text: string) {
@@ -269,8 +260,7 @@ namespace pxtblockly {
         }
 
         layout() {
-            const width = this.textEl.el.getComputedTextLength();
-            this.textEl.moveTo(this.cx - width / 2, this.cy);
+            this.textEl.moveTo(this.cx, this.cy);
         }
     }
 
@@ -563,5 +553,12 @@ namespace pxtblockly {
         }
 
         return result;
+    }
+
+    export function mkText(text: string) {
+        return new svg.Text(text)
+            .anchor("middle")
+            .setAttribute("dominant-baseline", "middle")
+            .setAttribute("dy", (pxt.BrowserUtils.isIE() || pxt.BrowserUtils.isEdge()) ? "0.3em" : "0")
     }
 }


### PR DESCRIPTION
Fixes the buttons in the sprite editor.

Also fixes the blurry images in the gallery by scaling small images in Edge and IE. A factor of three seemed to be the lowest that still looked decent; I didn't do it for monochrome sprites because those seem to render fine without it 🤷‍♂️. This also fixes the previews in the image dropdown.