### PR TITLE
Fixing events and icons of sprite editor in safari

### DIFF
--- a/pxtblocks/fields/sprite/buttons.ts
+++ b/pxtblocks/fields/sprite/buttons.ts
@@ -179,7 +179,6 @@ namespace pxtblockly {
         cx: number;
         cy: number;
         root: svg.Group;
-        inDom = false;
         clickHandler: () => void;
 
         constructor(root: svg.Group, cx: number, cy: number) {
@@ -188,14 +187,6 @@ namespace pxtblockly {
             this.cy = cy;
             this.root.onClick(() => this.clickHandler && this.clickHandler());
             this.root.appendClass("sprite-editor-button");
-            this.root.el.addEventListener("animationstart", () => {
-                this.inDom = true;
-                this.layout();
-            });
-
-            // This animation does nothing, but the above event will fire once the
-            // node has definitely been added to the DOM
-            this.root.el.style.animation = "dom-test";
         }
 
         public getElement() {
@@ -251,15 +242,13 @@ namespace pxtblockly {
             this.textEl = mkText(text)
                 .appendClass(className);
 
+            this.textEl.moveTo(this.cx, this.cy);
+
             this.root.appendChild(this.textEl);
         }
 
         setText(text: string) {
             this.textEl.text(text);
-            if (this.inDom) this.layout();
-        }
-
-        layout() {
             this.textEl.moveTo(this.cx, this.cy);
         }
     }

--- a/pxtblocks/fields/sprite/canvasGrid.ts
+++ b/pxtblocks/fields/sprite/canvasGrid.ts
@@ -293,7 +293,7 @@ namespace pxtblockly {
             if (!this.gesture) {
                 this.gesture = new GestureState();
 
-                this.paintLayer.addEventListener("pointermove", (ev: MouseEvent) => {
+                this.paintLayer.addEventListener(pxsim.pointerEvents.move, (ev: MouseEvent) => {
                     const [col, row] = this.clientToCell(ev.clientX, ev.clientY);
                     if (ev.buttons & 1) {
                         this.gesture.handle(InputEvent.Down, col, row);
@@ -301,23 +301,26 @@ namespace pxtblockly {
                     this.gesture.handle(InputEvent.Move, col, row);
                 });
 
-                this.paintLayer.addEventListener("pointerdown", (ev: MouseEvent) => {
-                    const [col, row] = this.clientToCell(ev.clientX, ev.clientY);
-                    this.gesture.handle(InputEvent.Down, col, row);
-                });
+                pxsim.pointerEvents.down.forEach(evId => {
+                    this.paintLayer.addEventListener(evId, (ev: MouseEvent) => {
+                        const [col, row] = this.clientToCell(ev.clientX, ev.clientY);
+                        this.gesture.handle(InputEvent.Down, col, row);
+                    });
+                })
 
-                this.paintLayer.addEventListener("pointerup", (ev: MouseEvent) => {
+
+                this.paintLayer.addEventListener(pxsim.pointerEvents.up, (ev: MouseEvent) => {
                     const [col, row] = this.clientToCell(ev.clientX, ev.clientY);
                     this.gesture.handle(InputEvent.Up, col, row);
                 });
 
-                this.paintLayer.addEventListener("pointerclick", (ev: MouseEvent) => {
+                this.paintLayer.addEventListener("click", (ev: MouseEvent) => {
                     const [col, row] = this.clientToCell(ev.clientX, ev.clientY);
                     this.gesture.handle(InputEvent.Down, col, row);
                     this.gesture.handle(InputEvent.Up, col, row);
                 });
 
-                this.paintLayer.addEventListener("pointerleave", ev => {
+                this.paintLayer.addEventListener(pxsim.pointerEvents.leave, (ev: MouseEvent) => {
                     const [col, row] = this.clientToCell(ev.clientX, ev.clientY);
                     this.gesture.handle(InputEvent.Leave, col, row);
                 });

--- a/pxtblocks/fields/sprite/spriteEditor.ts
+++ b/pxtblocks/fields/sprite/spriteEditor.ts
@@ -468,21 +468,6 @@ namespace pxtblockly {
                     .size(5, 5)
                     .fill("#dedede");
             })
-
-            // This is used for detecting when text nodes are in the dom.
-            // getComputedTextLength() requires the node to be in the dom so
-            // by listening when this animation begins we can tell if the
-            // node is rendered or not
-            this.group.style().content(`
-            @keyframes dom-test {
-                0% {
-                    transform: translateX(0px);
-                }
-                100% {
-                    transform: translateX(0px);
-                }
-            }
-            `);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/204

Fixes the sprite editor icons and mouse/touch events in Safari.

My other fix for IE and Edge meant that I could just delete the whole dom-test hack. I tested this in Safari and Chrome, but not on mobile.