### PR TITLE
Decompiler shouldn't decompile banned categories

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -450,7 +450,12 @@ ${output}</xml>`;
         function attrs(callInfo: pxtc.CallInfo): pxtc.CommentAttrs {
             const blockInfo = blocksInfo.apis.byQName[callInfo.qName];
             if (blockInfo) {
-                return blockInfo.attributes;
+                const attributes = blockInfo.attributes;
+
+                // Check to make sure this block wasn't filtered out (bannedCategories)
+                if (!attributes.blockId || blocksInfo.blocksById[attributes.blockId] || attributes.blockId === pxtc.PAUSE_UNTIL_TYPE) {
+                    return blockInfo.attributes;
+                }
             }
             return {
                 paramDefl: {},

--- a/tests/decompile-test/baselines/banned_category.blocks
+++ b/tests/decompile-test/baselines/banned_category.blocks
@@ -1,0 +1,9 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="typescript_statement">
+<mutation numlines="1" error="Function call not supported in the blocks" line0="banned.shouldNotDecompile&#40;&#41;&#59;" />
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/banned_category.ts
+++ b/tests/decompile-test/cases/banned_category.ts
@@ -1,0 +1,1 @@
+banned.shouldNotDecompile();

--- a/tests/decompile-test/cases/testBlocks/banned.ts
+++ b/tests/decompile-test/cases/testBlocks/banned.ts
@@ -1,0 +1,5 @@
+namespace banned {
+    //% blockId=banned_test
+    //% block="I should be filtered"
+    export function shouldNotDecompile(): void {}
+}

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -3,6 +3,7 @@
     "description": "Project that defines a variety of blocks to be used in decopmiler test cases",
     "files": [
         "basic.ts",
+        "banned.ts",
         "blockCombine.ts",
         "enums.ts",
         "mb.ts",

--- a/tests/decompile-test/decompilerunner.ts
+++ b/tests/decompile-test/decompilerunner.ts
@@ -41,7 +41,8 @@ pxt.setAppTarget({
     tsprj: undefined,
     blocksprj: undefined,
     runtime: {
-        pauseUntilBlock: { category: "Loops", color: "0x0000ff" }
+        pauseUntilBlock: { category: "Loops", color: "0x0000ff" },
+        bannedCategories: ["banned"]
     },
     corepkg: undefined
 });


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/212