### PR TITLE
Resize editor again on IOS

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -24,6 +24,10 @@ namespace pxt.BrowserUtils {
         return hasNavigator() && /mobi/i.test(navigator.userAgent);
     }
 
+    export function isIOS(): boolean {
+        return hasNavigator() && /iPad|iPhone|iPod/.test(navigator.userAgent);
+    }
+
     //MacIntel on modern Macs
     export function isMac(): boolean {
         return hasNavigator() && /Mac/i.test(navigator.platform);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3086,8 +3086,16 @@ document.addEventListener("DOMContentLoaded", () => {
             theEditor.saveSettings()
     });
     window.addEventListener("resize", ev => {
-        if (theEditor && theEditor.editor)
-            theEditor.editor.resize(ev)
+        if (theEditor && theEditor.editor) {
+            theEditor.editor.resize(ev);
+
+            // The order of WebView resize in IOS is a little weird, so we'll resize it again after a second
+            if (pxt.BrowserUtils.isIOS()) {
+                setTimeout(() => {
+                    theEditor.editor.resize(ev);
+                }, 1000);
+            }
+        }
     }, false);
 
     const ipcRenderer = (window as any).ipcRenderer;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3089,7 +3089,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (theEditor && theEditor.editor) {
             theEditor.editor.resize(ev);
 
-            // The order of WebView resize in IOS is a little weird, so we'll resize it again after a second
+            // The order WKWebView resize events on IOS is weird, resize again to be sure
             if (pxt.BrowserUtils.isIOS()) {
                 setTimeout(() => {
                     theEditor.editor.resize(ev);


### PR DESCRIPTION
Resize the editor again after 1 second on IOS as the order of resize events doesn't always give us the correct height / width bounds. 
We resize again to be sure.

Fixes https://github.com/Microsoft/pxt-minecraft/issues/709