### PR TITLE
Pinned releases

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5107,7 +5107,7 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
             // remove dups
             fullnames = U.unique(fullnames, f => f.toLowerCase());
             pxt.log(`found ${fullnames.length} approved packages`);
-            fullnames.forEach(fn => pxt.log(`  ${fn}`));
+            pxt.log(JSON.stringify(fullnames, null, 2));
             return Promise.all(fullnames.map(fullname => pxt.github.listRefsAsync(fullname)
                 .then(tags => {
                     const tag = tags.reverse()[0] || "master";

--- a/docs/extensions/versioning.md
+++ b/docs/extensions/versioning.md
@@ -41,3 +41,19 @@ To update, the user has to take explicit action (currently, remove and re-add th
 
 Be aware that if you just fork an existing extension, the **fork won't show up in search**.
 You have to create a new repo.
+
+## Freezing extensions
+
+It is possible to freeze an approved extension to a particular tag in github per editor major version. This is useful in a servicing scenario where an older (incompatible) editor is kept online in parallel with a new editor.
+The editor author can run ``pxt testghpkgs`` to generate the list of current packages and tags and save them in the ``pxtargetconfig.json`` to freeze those versions.
+
+```
+{
+    "packages": {
+        "releases": {
+            "v0": [
+                company/project#v0.0.1
+            ]
+        }
+}
+```

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -20,7 +20,8 @@ declare namespace pxt {
 
     interface PackagesConfig {
         approvedOrgs?: string[];
-        approvedRepos?: string[];
+        approvedRepos?: string[]; // list of company/project
+        approvedReleases?: pxt.Map<string[]>;  // per major version list of approved company/project#tag
         bannedOrgs?: string[];
         bannedRepos?: string[];
         allowUnapproved?: boolean;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -21,7 +21,7 @@ declare namespace pxt {
     interface PackagesConfig {
         approvedOrgs?: string[];
         approvedRepos?: string[]; // list of company/project
-        approvedReleases?: pxt.Map<string[]>;  // per major version list of approved company/project#tag
+        releases?: pxt.Map<string[]>;  // per major version list of approved company/project#tag
         bannedOrgs?: string[];
         bannedRepos?: string[];
         allowUnapproved?: boolean;

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -643,9 +643,8 @@ namespace pxt.github {
 
                         // check if the version has been frozen for this release
                         const targetVersion = pxt.appTarget.versions && pxt.semver.tryParse(pxt.appTarget.versions.target);
-                        const approvedReleases = config.approvedReleases;
-                        if (approvedReleases && targetVersion && approvedReleases["v" + targetVersion.major]) {
-                            const release = approvedReleases["v" + targetVersion.major]
+                        if (targetVersion && config.releases && config.releases["v" + targetVersion.major]) {
+                            const release = config.releases["v" + targetVersion.major]
                                 .map(repo => pxt.github.parseRepoId(repo))
                                 .filter(repo => repo.fullName.toLowerCase() == parsed.fullName.toLowerCase())
                                 [0];


### PR DESCRIPTION
Allow to specify specific package releases for packages per major version of the editor.

In micro:bit, allows us to snap all approved packages to a particular version for v0.