### PR TITLE
Fix blocksembed

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -381,8 +381,7 @@ namespace pxt.runner {
             const msg = jobQueue.shift();
             if (!msg) return; // no more work
 
-            let options = msg.options as pxt.blocks.BlocksRenderOptions;
-            if (!options) options = {};
+            const options = (msg.options || {}) as pxt.blocks.BlocksRenderOptions;
             options.splitSvg = false; // don't split when requesting rendered images
             pxt.tickEvent("renderer.job")
             jobPromise = pxt.BrowserUtils.loadBlocklyAsync()

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -381,7 +381,8 @@ namespace pxt.runner {
             const msg = jobQueue.shift();
             if (!msg) return; // no more work
 
-            const options = msg.options as pxt.blocks.BlocksRenderOptions;
+            let options = msg.options as pxt.blocks.BlocksRenderOptions;
+            if (!options) options = {};
             options.splitSvg = false; // don't split when requesting rendered images
             pxt.tickEvent("renderer.job")
             jobPromise = pxt.BrowserUtils.loadBlocklyAsync()


### PR DESCRIPTION
Options isn't guaranteed to be passed in. 
Create a new object in that case.

Fixes https://github.com/Microsoft/pxt-microbit/issues/1511
Note: cherry pick to master once integrated