### PR TITLE
Docs faster

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -86,7 +86,8 @@ code.lang-block::before,
 code.lang-sim::before,
 code.lang-cards::before,
 code.lang-namespaces::before,
-code.lang-codecard::before
+code.lang-codecard::before,
+code.lang-shadow::before
 {
     content:"...";
     position: absolute;
@@ -101,7 +102,8 @@ code.lang-block,
 code.lang-sim,
 code.lang-cards,
 code.lang-namespaces,
-code.lang-codecard
+code.lang-codecard,
+code.lang-shadow
 {
     background-color: rgba(0,0,0,0.04);
     color:transparent;

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -154,7 +154,7 @@ namespace pxt.runner {
         }
     }
 
-    const renderQueue: {
+    let renderQueue: {
         el: JQuery;
         source: string;
         options: blocks.BlocksRenderOptions;
@@ -196,20 +196,7 @@ namespace pxt.runner {
 
         renderQueue.push({ el: $el, source: $el.text(), options, render, cls });
         $el.removeClass(cls);
-        return Promise.delay(1, renderNextSnippetAsync(cls, render, options));
-        /*
-        return pxt.runner.decompileToBlocksAsync($el.text(), options)
-            .then((r) => {
-                try {
-                    render($el, r);
-                } catch (e) {
-                    console.error('error while rendering ' + $el.html())
-                    $el.append($('<div/>').addClass("ui segment warning").text(e.message));
-                }
-                $el.removeClass(cls);
-                return Promise.delay(1, renderNextSnippetAsync(cls, render, options));
-            })
-        */
+        return renderNextSnippetAsync(cls, render, options);
     }
 
     function renderSnippetsAsync(options: ClientRenderOptions): Promise<void> {
@@ -730,6 +717,7 @@ namespace pxt.runner {
             });
         }
 
+        renderQueue = [];
         renderTypeScript(options);
         return Promise.resolve()
             .then(() => renderNextCodeCardAsync(options.codeCardClass, options))

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -175,7 +175,7 @@ namespace pxt.runner {
                     console.error('error while rendering ' + el.html())
                     el.append($('<div/>').addClass("ui segment warning").text(e.message));
                 }
-                el.removeClass(cls);
+                el.removeClass("lang-shadow");
                 return consumeRenderQueueAsync();
             })
         });
@@ -195,6 +195,7 @@ namespace pxt.runner {
         options.splitSvg = true;
 
         renderQueue.push({ el: $el, source: $el.text(), options, render, cls });
+        $el.addClass("lang-shadow");
         $el.removeClass(cls);
         return renderNextSnippetAsync(cls, render, options);
     }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -186,16 +186,33 @@ namespace pxt.runner {
         console.error(msg)
     }
 
+    let previousMainPackage: pxt.MainPackage = undefined;
     function loadPackageAsync(id: string, code?: string) {
-        let host = mainPkg.host();
-        mainPkg = new pxt.MainPackage(host)
-        mainPkg._verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj"
+        const verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj";
+        let host: pxt.Host;
+        let downloadPackagePromise: Promise<void>;
+        let installPromise: Promise<void>;
+        if (previousMainPackage && previousMainPackage._verspec == verspec) {
+            mainPkg = previousMainPackage;
+            host = mainPkg.host();
+            downloadPackagePromise = Promise.resolve();
+            installPromise = Promise.resolve();
+        } else {
+            host = mainPkg.host();
+            mainPkg = new pxt.MainPackage(host)
+            mainPkg._verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj"
+            downloadPackagePromise = host.downloadPackageAsync(mainPkg);
+            installPromise = mainPkg.installAllAsync()
+            // cache previous package
+            previousMainPackage = mainPkg;
+        }
 
-        return host.downloadPackageAsync(mainPkg)
+
+        return downloadPackagePromise
             .then(() => host.readFile(mainPkg, pxt.CONFIG_NAME))
             .then(str => {
                 if (!str) return Promise.resolve()
-                return mainPkg.installAllAsync().then(() => {
+                return installPromise.then(() => {
                     if (code) {
                         //Set the custom code if provided for docs.
                         let epkg = getEditorPkg(mainPkg);

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -54,7 +54,8 @@
         code.lang-sim::before,
         code.lang-cards::before,
         code.lang-namespaces::before,
-        code.lang-codecard::before {
+        code.lang-codecard::before,
+        code.lang-shadow::before {
             content: "...";
             position: absolute;
             top: calc(50% - 0.5em);
@@ -68,7 +69,8 @@
         code.lang-sim,
         code.lang-cards,
         code.lang-namespaces,
-        code.lang-codecard {
+        code.lang-codecard,
+        code.lang-shadow {
             color: transparent;
         }
     </style>


### PR DESCRIPTION
- [x] queue block rendering to the end of rendering
- [x] don't reload project each time

Performance audits are very confused by our page but I'm not seeing a massive fail. It looks like most of the time is spent loading a ton of JS