### PR TITLE
Surface simulator methods to targets

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -179,11 +179,12 @@ namespace pxt.editor {
 
         anonymousPublishAsync(): Promise<string>;
 
-        startStopSimulator(): void;
+        startStopSimulator(clickTrigger?: boolean): void;
         stopSimulator(unload?: boolean): void;
         restartSimulator(debug?: boolean): void;
         startSimulator(debug?: boolean): void;
         runSimulator(): void;
+        isSimulatorRunning(): boolean;
         expandSimulator(): void;
         collapseSimulator(): void;
         toggleSimulatorCollapse(): void;
@@ -281,6 +282,7 @@ namespace pxt.editor {
     export interface ExtensionOptions {
         blocklyToolbox: ToolboxDefinition;
         monacoToolbox: ToolboxDefinition;
+        projectView: IProjectView;
     }
 
     export interface IToolboxOptions {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -18,6 +18,7 @@ namespace pxsim {
         cdnUrl?: string;
         localizedStrings?: Map<string>;
         version?: string;
+        clickTrigger?: boolean;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -43,6 +43,7 @@ namespace pxsim {
         localizedStrings?: pxsim.Map<string>;
         refCountingDebug?: boolean;
         version?: string;
+        clickTrigger?: boolean;
     }
 
     export interface HwDebugger {
@@ -268,7 +269,8 @@ namespace pxsim {
                 cdnUrl: opts.cdnUrl,
                 localizedStrings: opts.localizedStrings,
                 refCountingDebug: opts.refCountingDebug,
-                version: opts.version
+                version: opts.version,
+                clickTrigger: opts.clickTrigger
             }
 
             this.applyAspectRatio();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -155,7 +155,7 @@ export class ProjectView
         let active = document.visibilityState == 'visible';
         pxt.debug(`page visibility: ${active}`)
         this.setState({ active: active })
-        if (!active) {
+        if (!active && pxt.appTarget.simulator.autoRun) {
             if (this.state.running) {
                 this.stopSimulator();
                 this.setState({ resumeOnVisibility: true });
@@ -1665,12 +1665,18 @@ export class ProjectView
     ////////////             Simulator            /////////////
     ///////////////////////////////////////////////////////////
 
-    startStopSimulator() {
+    shouldStartSimulator() {
+        const hasHome = !pxt.shell.isControllerMode();
+        if (!hasHome) return true;
+        return !this.state.home;
+    }
+
+    startStopSimulator(clickTrigger?: boolean) {
         if (this.state.running) {
             this.stopSimulator()
         } else {
             this.maybeShowPackageErrors(true);
-            this.startSimulator();
+            this.startSimulator(undefined, clickTrigger);
         }
     }
 
@@ -1701,10 +1707,14 @@ export class ProjectView
         }
     }
 
-    startSimulator(debug?: boolean) {
-        pxt.tickEvent('simulator.start')
+    startSimulator(debug?: boolean, clickTrigger?: boolean) {
+        pxt.tickEvent('simulator.start');
+        if (!this.shouldStartSimulator()) {
+            pxt.log("Tried to start simulator when we shouldn't");
+            return;
+        }
         this.saveFileAsync()
-            .then(() => this.runSimulator(debug ? { debug: true } : {}));
+            .then(() => this.runSimulator(debug ? { debug: true } : {}, clickTrigger));
     }
 
     stopSimulator(unload?: boolean) {
@@ -1823,7 +1833,11 @@ export class ProjectView
         if (devIndicator) devIndicator.clear()
     }
 
-    runSimulator(opts: compiler.CompileOptions = {}) {
+    isSimulatorRunning() {
+        return this.state.running;
+    }
+
+    runSimulator(opts: compiler.CompileOptions = {}, clickTrigger?: boolean) {
         const editorId = this.editor ? this.editor.getId().replace(/Editor$/, '') : "unknown";
         if (opts.background) {
             pxt.tickActivity("autorun", "autorun." + editorId);
@@ -1844,7 +1858,7 @@ export class ProjectView
                 this.clearSerial();
                 this.editor.setDiagnostics(this.editorFile, state)
                 if (resp.outfiles[pxtc.BINARY_JS]) {
-                    simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute, this.state.highContrast, pxt.options.light)
+                    simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute, this.state.highContrast, pxt.options.light, clickTrigger)
                     this.setState({ running: true, showParts: simulator.driver.runOptions.parts.length > 0 })
                 } else if (!opts.background) {
                     core.warningNotification(lf("Oops, we could not run this project. Please check your code for errors."))
@@ -2840,7 +2854,8 @@ function initExtensionsAsync(): Promise<void> {
     pxt.debug('loading editor extensions...');
     const opts: pxt.editor.ExtensionOptions = {
         blocklyToolbox: blocklyToolbox.getToolboxDefinition(),
-        monacoToolbox: monacoToolbox.getToolboxDefinition()
+        monacoToolbox: monacoToolbox.getToolboxDefinition(),
+        projectView: theEditor
     };
     return pxt.BrowserUtils.loadScriptAsync("editor.js")
         .then(() => pxt.editor.initExtensionsAsync(opts))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -155,7 +155,7 @@ export class ProjectView
         let active = document.visibilityState == 'visible';
         pxt.debug(`page visibility: ${active}`)
         this.setState({ active: active })
-        if (!active && pxt.appTarget.simulator.autoRun) {
+        if (!active && (pxt.appTarget.simulator && pxt.appTarget.simulator.autoRun)) {
             if (this.state.running) {
                 this.stopSimulator();
                 this.setState({ resumeOnVisibility: true });

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -61,7 +61,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
 
     startStopSimulator(view?: string) {
         pxt.tickEvent("editortools.startStopSimulator", { view: view, collapsed: this.getCollapsedState(), headless: this.getHeadlessState() }, { interactiveConsent: true });
-        this.props.parent.startStopSimulator();
+        this.props.parent.startStopSimulator(true);
     }
 
     restartSimulator(view?: string) {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -242,7 +242,10 @@ export function isDirty(): boolean { // in need of a restart?
     return dirty;
 }
 
-export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResult, mute?: boolean, highContrast?: boolean, light?: boolean) {
+export function run(pkg: pxt.MainPackage, debug: boolean,
+    res: pxtc.CompileResult, mute?: boolean,
+    highContrast?: boolean, light?: boolean,
+    clickTrigger?: boolean) {
     makeClean();
     const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
@@ -263,7 +266,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean, res: pxtc.CompileResul
         cdnUrl: pxt.webConfig.commitCdnUrl,
         localizedStrings: simTranslations,
         refCountingDebug: pxt.options.debug,
-        version: pkg.version()
+        version: pkg.version(),
+        clickTrigger: clickTrigger
     }
     postSimEditorEvent("started");
 


### PR DESCRIPTION
Add a way to tell if the simulator is running from the project view. ``isSimulatorRunning``
Surface the projectView to targets that extend the editor.
Don't autorun unless the simulator is configured to autorun
Pipe whether or not the simulator was started with a click trigger or not to the simulator itself.
