### PR TITLE
More toolbar config

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -283,6 +283,15 @@ declare namespace pxt {
         bluetoothPartialFlashing?: boolean; // enable partial flashing over BLE
         topBlocks?: boolean; // show a top blocks category in the editor
         pairingButton?: boolean; // display a pairing button
+
+        /**
+         * Internal and temporary flags:
+         * These flags may be removed without notice, please don't take a dependency on them
+         */
+        simCollapseInMenu?: boolean; // don't show any of the collapse / uncollapse buttons down the bottom, instead show it in the menu
+        bigRunButton?: boolean; // show the run button as a big button on the right
+        transparentEditorToolbar?: boolean; // make the editor toolbar float with a transparent background
+        hideProjectRename?: boolean; // Temporary flag until we figure out a better way to show the name
     }
 
     interface SocialOptions {

--- a/theme/common.less
+++ b/theme/common.less
@@ -108,6 +108,10 @@ body {
     background-color: @editorToolsBackground;
 }
 
+.transparentEditorTools #editortools {
+    background-color: transparent;
+}
+
 #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #filelist {
     bottom: @editorToolsCollapsedHeight;
 }
@@ -154,6 +158,10 @@ body {
     margin-top: 0 !important;
     padding-top: 0.55rem;
     background-color: @simulatorBackground;
+}
+
+.transparentEditorTools #downloadArea {
+    background-color: transparent !important;
 }
 
 .filemenu {

--- a/theme/themes/pxt/elements/button.overrides
+++ b/theme/themes/pxt/elements/button.overrides
@@ -5,3 +5,17 @@
 .ui.dropdown, .ui.buttons {
     margin-right: 0.25rem;
 }
+
+/* Big play button */
+#editortools .big-play-button-wrapper {
+    display: inline-flex;
+    vertical-align: bottom;
+    margin-top: -2rem;
+    margin-left: 0.5rem;
+    .ui.button.big-play-button {
+        padding: 1.45rem !important;
+        i.icon {
+            font-size: 1.5rem;
+        }
+    }
+}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2417,7 +2417,7 @@ export class ProjectView
         const { lightbox, greenScreen } = this.state;
         const simDebug = !!targetTheme.debugger;
 
-        const { hideMenuBar, hideEditorToolbar } = targetTheme;
+        const { hideMenuBar, hideEditorToolbar, transparentEditorToolbar } = targetTheme;
         const isHeadless = simOpts && simOpts.headless;
         const selectLanguage = targetTheme.selectLanguage;
         const showEditorToolbar = inEditor && !hideEditorToolbar && this.editor.hasEditorToolbar();
@@ -2435,6 +2435,7 @@ export class ProjectView
             lightbox ? 'dimmable dimmed' : 'dimmable',
             shouldHideEditorFloats ? " hideEditorFloats" : '',
             shouldCollapseEditorTools ? " collapsedEditorTools" : '',
+            transparentEditorToolbar ? " transparentEditorTools" : '',
             this.state.fullscreen ? 'fullscreensim' : '',
             this.state.highContrast ? 'hc' : '',
             showSideDoc ? 'sideDocs' : '',
@@ -2444,7 +2445,7 @@ export class ProjectView
             pxt.options.light ? 'light' : '',
             pxt.BrowserUtils.isTouchEnabled() ? 'has-touch' : '',
             hideMenuBar ? 'hideMenuBar' : '',
-            !showEditorToolbar ? 'hideEditorToolbar' : '',
+            !showEditorToolbar || transparentEditorToolbar ? 'hideEditorToolbar' : '',
             this.state.bannerVisible ? "notificationBannerVisible" : "",
             this.state.debugging ? "debugging" : "",
             sandbox && this.isEmbedSimActive() ? 'simView' : '',

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -146,6 +146,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         this.showBoardDialog = this.showBoardDialog.bind(this);
         this.removeProject = this.removeProject.bind(this);
         this.saveProject = this.saveProject.bind(this);
+        this.toggleCollapse = this.toggleCollapse.bind(this);
         this.showReportAbuse = this.showReportAbuse.bind(this);
         this.showLanguagePicker = this.showLanguagePicker.bind(this);
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
@@ -186,6 +187,11 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     removeProject() {
         pxt.tickEvent("menu.removeproject", undefined, { interactiveConsent: true });
         this.props.parent.removeProject();
+    }
+
+    toggleCollapse() {
+        pxt.tickEvent("menu.toggleSim", undefined, { interactiveConsent: true });
+        this.props.parent.toggleSimulatorCollapse();
     }
 
     showReportAbuse() {
@@ -260,6 +266,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const readOnly = pxt.shell.isReadOnly();
         const isController = pxt.shell.isControllerMode();
         const showSave = !readOnly && !isController && !!targetTheme.saveInMenu;
+        const showSimCollapse = !readOnly && !isController && !!targetTheme.simCollapseInMenu;
         const showGreenScreen = (targetTheme.greenScreen || /greenscreen=1/i.test(window.location.href))
             && greenscreen.isSupported();
 
@@ -270,6 +277,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             {targetTheme.print ? <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} tabIndex={-1} /> : undefined}
             {showSave ? <sui.Item role="menuitem" icon="save" text={lf("Save Project")} onClick={this.saveProject} tabIndex={-1} /> : undefined}
             {!isController ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={this.removeProject} tabIndex={-1} /> : undefined}
+            {showSimCollapse ? <sui.Item role="menuitem" icon='toggle right' text={lf("Toggle the simulator")} onClick={this.toggleCollapse} tabIndex={-1} /> : undefined}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} tabIndex={-1} /> : undefined}
             <div className="ui divider"></div>
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} tabIndex={-1} /> : undefined}

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -177,7 +177,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 </div> : undefined}
                             {targetTheme.bigRunButton ?
                                 <div className="big-play-button-wrapper">
-                                    <EditorToolbarButton role="menuitem" tooltip={bigRunButtonTooltip} tooltipId="startbtn-mobile" tooltipDelayShow={500} tooltipPlace={"top"} className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='mobile' />
+                                    <EditorToolbarButton role="menuitem" className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='mobile' />
                                 </div> : undefined}
                         </div>
                     </div> :
@@ -255,7 +255,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 </div> : undefined}
                             {targetTheme.bigRunButton ?
                                 <div className="big-play-button-wrapper">
-                                    <EditorToolbarButton role="menuitem" tooltip={bigRunButtonTooltip} tooltipId="startbtn-tablet" tooltipDelayShow={500} tooltipPlace={"top"} className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='tablet' />
+                                    <EditorToolbarButton role="menuitem" className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='tablet' />
                                 </div> : undefined}
                         </div>
                     </div>
@@ -371,7 +371,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                             </div> : undefined}
                         {targetTheme.bigRunButton ?
                             <div className="big-play-button-wrapper">
-                                <EditorToolbarButton role="menuitem" tooltip={bigRunButtonTooltip} tooltipId="startbtn-computer" tooltipDelayShow={500} tooltipPlace={"top"} className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='computer' />
+                                <EditorToolbarButton role="menuitem" className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='computer' />
                             </div> : undefined}
                     </div>
                 </div>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -97,6 +97,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
 
         if (home) return <div />; // Don't render if we're in the home screen
 
+        const targetTheme = pxt.appTarget.appTheme;
         const sandbox = pxt.shell.isSandboxMode();
         const isController = pxt.shell.isControllerMode();
         const readOnly = pxt.shell.isReadOnly();
@@ -105,7 +106,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const isEditor = this.props.parent.isBlocksEditor() || this.props.parent.isTextEditor();
         if (!isEditor) return <div />;
 
-        const targetTheme = pxt.appTarget.appTheme;
         const showSave = !readOnly && !isController && !targetTheme.saveInMenu;
         const compile = pxt.appTarget.compile;
         const compileBtn = compile.hasHex || compile.saveAsPNG;
@@ -121,12 +121,12 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const hasUndo = this.props.parent.editor.hasUndo();
         const hasRedo = this.props.parent.editor.hasRedo();
 
-        const showCollapsed = !tutorial && !sandbox;
-        const showProjectRename = !tutorial && !readOnly && !isController;
+        const showCollapsed = !tutorial && !sandbox && !targetTheme.simCollapseInMenu;
+        const showProjectRename = !tutorial && !readOnly && !isController && !targetTheme.hideProjectRename;
         const showUndoRedo = !tutorial && !readOnly;
         const showZoomControls = !tutorial;
 
-        const run = true;
+        const run = !targetTheme.bigRunButton;
         const restart = run && !simOpts.hideRestart;
         const trace = !!targetTheme.enableTrace;
         const tracing = this.props.parent.state.tracing;
@@ -136,6 +136,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const debugTooltip = debugging ? lf("Disable Debugging") : lf("Debugging")
         const downloadIcon = pxt.appTarget.appTheme.downloadIcon || "download";
         const downloadText = pxt.appTarget.appTheme.useUploadMessage ? lf("Upload") : lf("Download");
+
+        const bigRunButtonTooltip = running ? lf("Stop") : lf("Run Code in Game");
 
         let downloadButtonClasses = "";
         let saveButtonClasses = "";
@@ -151,29 +153,31 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         return <div className="ui equal width grid right aligned padded">
             <div className="column mobile only">
                 {collapsed ?
-                    <div className="ui equal width grid">
-                        <div className="left aligned column">
+                    <div className="ui grid">
+                        {!targetTheme.bigRunButton ? <div className="left aligned column six wide">
                             <div className="ui icon small buttons">
-                                <EditorToolbarButton icon={`${collapsed ? 'toggle up' : 'toggle down'}`} className={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onButtonClick={this.toggleCollapse} view='mobile' />
+                                {showCollapsed ? <EditorToolbarButton icon={`${collapsed ? 'toggle up' : 'toggle down'}`} className={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onButtonClick={this.toggleCollapse} view='mobile' /> : undefined}
                                 {headless && run ? <EditorToolbarButton className={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onButtonClick={this.startStopSimulator} view='mobile' /> : undefined}
                                 {headless && restart ? <EditorToolbarButton key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onButtonClick={this.restartSimulator} view='mobile' /> : undefined}
                                 {headless && trace ? <EditorToolbarButton key='tracebtn' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onButtonClick={this.toggleTrace} view='mobile' /> : undefined}
                                 {headless && debug ? <EditorToolbarButton key='debugbtn' className={`debug-button ${debugging ? 'orange' : ''}`} icon="xicon bug" title={debugTooltip} onButtonClick={this.toggleDebugging} view='mobile' /> : undefined}
                                 {compileBtn ? <EditorToolbarButton className={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} ariaLabel={lf("Download your code")} onButtonClick={this.compile} view='mobile' /> : undefined}
                             </div>
-                        </div>
-                        <div className="right aligned column">
+                        </div> : undefined}
+                        <div className={`column right aligned ${targetTheme.bigRunButton ? 'sixteen' : 'ten'} wide`}>
                             {!readOnly ?
                                 <div className="ui icon small buttons">
                                     {showSave ? <EditorToolbarButton icon='save' className={`editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='mobile' /> : undefined}
                                     {showUndoRedo ? <EditorToolbarButton icon='xicon undo' className={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo")} onButtonClick={this.undo} view='mobile' /> : undefined}
                                 </div> : undefined}
-                        </div>
-                        <div className="right aligned column">
                             {showZoomControls ?
                                 <div className="ui icon small buttons">
                                     <EditorToolbarButton icon='plus circle' className="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onButtonClick={this.zoomIn} view='mobile' />
                                     <EditorToolbarButton icon='minus circle' className="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onButtonClick={this.zoomOut} view='mobile' />
+                                </div> : undefined}
+                            {targetTheme.bigRunButton ?
+                                <div className="big-play-button-wrapper">
+                                    <EditorToolbarButton role="menuitem" tooltip={bigRunButtonTooltip} tooltipId="startbtn-mobile" tooltipDelayShow={500} tooltipPlace={"top"} className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='mobile' />
                                 </div> : undefined}
                         </div>
                     </div> :
@@ -221,24 +225,24 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         {headless ?
                             <div className="left aligned six wide column">
                                 <div className="ui icon buttons">
-                                    <EditorToolbarButton icon={`${collapsed ? 'toggle up' : 'toggle down'}`} className={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onButtonClick={this.toggleCollapse} view='tablet' />
+                                    {showCollapsed ? <EditorToolbarButton icon={`${collapsed ? 'toggle up' : 'toggle down'}`} className={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onButtonClick={this.toggleCollapse} view='tablet' /> : undefined}
                                     {run ? <EditorToolbarButton role="menuitem" className={`play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={runTooltip} onButtonClick={this.startStopSimulator} view='tablet' /> : undefined}
                                     {restart ? <EditorToolbarButton key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onButtonClick={this.restartSimulator} view='tablet' /> : undefined}
+                                    {trace ? <EditorToolbarButton key='tracebtn' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onButtonClick={this.toggleTrace} view='tablet' /> : undefined}
                                     {debug ? <EditorToolbarButton key='debug' className={`debug-button ${debugging ? 'orange' : ''}`} icon="xicon bug" title={debugTooltip} onButtonClick={this.toggleDebugging} view='tablet' /> : undefined}
                                     {compileBtn ? <EditorToolbarButton className={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} onButtonClick={this.compile} view='tablet' /> : undefined}
                                 </div>
                             </div> :
                             <div className="left aligned six wide column">
                                 <div className="ui icon buttons">
-                                    <EditorToolbarButton icon={`${collapsed ? 'toggle up' : 'toggle down'}`} className={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onButtonClick={this.toggleCollapse} view='tablet' />
+                                    {showCollapsed ? <EditorToolbarButton icon={`${collapsed ? 'toggle up' : 'toggle down'}`} className={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} title={collapseTooltip} onButtonClick={this.toggleCollapse} view='tablet' /> : undefined}
                                     {compileBtn ? <EditorToolbarButton className={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} text={downloadText} title={compileTooltip} onButtonClick={this.compile} view='tablet' /> : undefined}
                                 </div>
                             </div>}
-                        <div className="column four wide">
-                            {showSave ? <EditorToolbarButton icon='save' className={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='tablet' />
-                                : undefined}
-                        </div>
-                        <div className="column six wide right aligned">
+                        {showSave ? <div className="column four wide">
+                            <EditorToolbarButton icon='save' className={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='tablet' />
+                        </div> : undefined}
+                        <div className={`column ${showSave ? 'six' : 'ten'} wide right aligned`}>
                             {showUndoRedo ?
                                 <div className="ui icon small buttons">
                                     <EditorToolbarButton icon='xicon undo' className={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} title={lf("Undo")} onButtonClick={this.undo} view='tablet' />
@@ -248,6 +252,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 <div className="ui icon small buttons">
                                     <EditorToolbarButton icon='plus circle' className="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onButtonClick={this.zoomIn} view='tablet' />
                                     <EditorToolbarButton icon='minus circle' className="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onButtonClick={this.zoomOut} view='tablet' />
+                                </div> : undefined}
+                            {targetTheme.bigRunButton ?
+                                <div className="big-play-button-wrapper">
+                                    <EditorToolbarButton role="menuitem" tooltip={bigRunButtonTooltip} tooltipId="startbtn-tablet" tooltipDelayShow={500} tooltipPlace={"top"} className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='tablet' />
                                 </div> : undefined}
                         </div>
                     </div>
@@ -360,6 +368,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                             <div className="ui icon small buttons">
                                 <EditorToolbarButton icon='plus circle' className="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onButtonClick={this.zoomIn} view='computer' />
                                 <EditorToolbarButton icon='minus circle' className="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onButtonClick={this.zoomOut} view='computer' />
+                            </div> : undefined}
+                        {targetTheme.bigRunButton ?
+                            <div className="big-play-button-wrapper">
+                                <EditorToolbarButton role="menuitem" tooltip={bigRunButtonTooltip} tooltipId="startbtn-computer" tooltipDelayShow={500} tooltipPlace={"top"} className={`big-play-button play-button ${running ? "stop" : "play"}`} key='runmenubtn' icon={running ? "stop" : "play"} title={bigRunButtonTooltip} onButtonClick={this.startStopSimulator} view='computer' />
                             </div> : undefined}
                     </div>
                 </div>


### PR DESCRIPTION
Add temporary / internal flags to configure the toolbar to: 
- move the sim collapse view to the settings menu
- hide the project rename input
- show the run button on the right
- show a transparent editor toolbar

Note: these flags might change once we get a chance to cleanup. I've added a comment to note that they're internal.