### PR TITLE
Making the editor extension dialog a little less annoying

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -400,10 +400,16 @@ export class ProjectView
     }
 
     private maybeShowPackageErrors(force = false) {
+        // Only show in blocks or main.ts
+        if (this.state.currFile) {
+            const fn = this.state.currFile.name;
+            if (!pkg.File.blocksFileNameRx.test(fn) && fn !== "main.ts") return false;
+        }
+
         if (!this.state.suppressPackageWarning || force) {
+            this.setState({ suppressPackageWarning: true });
             const badPackages = compiler.getPackagesWithErrors();
             if (badPackages.length) {
-                this.setState({ suppressPackageWarning: true });
 
                 const h = this.state.header;
                 const currentVersion = pxt.semver.parse(pxt.appTarget.versions.target);
@@ -421,7 +427,7 @@ export class ProjectView
                         if (projectOpen) {
                             this.reloadHeaderAsync()
                         }
-                        else {
+                        else if (!force) {
                             this.openHome();
                         }
                     });


### PR DESCRIPTION
A few tweaks based on feedback from @pelikhan, @jwunderl, and @ChaseMor 

1. Fixes a bug where the dialog opens if you are editing a file and accidentally create an error. It now only opens on load, simulator start, and compilation.
2. Changed the (x) behavior so that it only takes you to the home screen if you are coming from the home screen. It was very annoying to click the (x) after downloading and have it close the project
3. The dialog should now only show in a blocks file or `main.ts`, so Github package authors won't have it constantly showing up

This should probably go to stable 4.1 once we start merging things again.