### PR TITLE
Don't assume that the block namespace is the same as the category name.

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1253,7 +1253,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         const comment = fn.attributes.jsDoc;
 
-        let snippetPrefix = fn.noNamespace ? "" : ns;
+        let snippetPrefix = fn.noNamespace ? "" : (fn.attributes.blockNamespace || fn.namespace);
         let isInstance = false;
         let addNamespace = false;
         let namespaceToUse = "";


### PR DESCRIPTION
We were assuming the block namespace is the same as the category name when inserting a snippet. 
This is particularly problematic for the new "Basic" category, but also for any blocks that use blockNamespace to specify a different namespace than the one they're under.

https://github.com/Microsoft/pxt-minecraft/issues/728
