### PR TITLE
Make debugging pxt-blockly in PXT easier.

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -307,6 +307,7 @@ file("built/web/pxtlib.js", [
 
     jake.cpR("built/pxtlib.js", "built/web/")
     jake.cpR("built/pxtcompiler.js", "built/web/")
+    jake.cpR("built/pxtblocks.js", "built/web/")
     jake.cpR("built/pxtblockly.js", "built/web/")
     jake.cpR("built/pxtsim.js", "built/web/")
     jake.cpR("built/pxtrunner.js", "built/web/")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+# Scripts for PXT
+
+## pxt-blockly
+In order to debug pxt-blockly in PXT, run the ``scripts/link-pxtblockly.sh`` which will link pxt-blockly under ``built/web/`` and then instead of using index.html to debug, using blockly.html which will using the blockly uncompressed files instead of the bundled files in PXT.
+
+To remove the link, there's a helper script that you can use as well ``scripts/unlink-pxtblockly.sh``

--- a/scripts/link-pxtblockly.sh
+++ b/scripts/link-pxtblockly.sh
@@ -1,0 +1,4 @@
+cd ../built/web/
+ln -s ../../../pxt-blockly
+ln -s ../../../closure-library
+

--- a/scripts/unlink-pxtblockly.sh
+++ b/scripts/unlink-pxtblockly.sh
@@ -1,0 +1,3 @@
+cd ../built/web/
+unlink pxt-blockly
+unlink closure-library

--- a/webapp/public/blockly.html
+++ b/webapp/public/blockly.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="@locale@" data-manifest="" data-framework="typescript">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0">
+
+    <!-- @include appmeta.html -->
+
+    <link rel="stylesheet" data-rtl="/blb/rtlsemantic.css" href="/blb/semantic.css" type="text/css">
+</head>
+
+<body class="main">
+    <div id='loading' class="ui active dimmer">
+        <div class="ui large main loader"></div>
+    </div>
+
+    <div id='custom-content'>
+    </div>
+
+    <div id="allcontent">
+        <div id="cookiebanner"></div>
+        <div id="editorcontent">
+            <div id='content' class="ui dimmable full-abs">
+            </div>
+        </div>
+    </div>
+
+    <div id='msg' aria-live="polite">
+        <div id='errmsg' class="ui red inverted segment"></div>
+        <div id='warnmsg' class="ui orange inverted segment"></div>
+        <div id='infomsg' class="ui teal inverted segment"></div>
+        <div id='compilemsg' class="ui ignored info message"></div>
+    </div>
+
+    <script>
+        // This line gets patched up by the cloud
+        var pxtConfig = null;
+    </script>
+    <!-- @include apptrackingweb.html -->
+    <!-- @include apptracking.html -->
+    <script src="/blb/pxt-blockly/blockly_uncompressed.js"></script>
+    <script src="/blb/pxt-blockly/msg/messages.js"></script>
+    <script src="/blb/pxt-blockly/blocks/extensions.js"></script>
+    <script src="/blb/pxt-blockly/blocks/logic.js"></script>
+    <script src="/blb/pxt-blockly/blocks/loops.js"></script>
+    <script src="/blb/pxt-blockly/blocks/math.js"></script>
+    <script src="/blb/pxt-blockly/blocks/text.js"></script>
+    <script src="/blb/pxt-blockly/blocks/lists.js"></script>
+    <script src="/blb/pxt-blockly/blocks/colour.js"></script>
+    <script src="/blb/pxt-blockly/blocks/variables.js"></script>
+    <script src="/blb/pxt-blockly/blocks/variables_dynamic.js"></script>
+    <script src="/blb/pxt-blockly/blocks/procedures.js"></script>
+
+    <script type="text/javascript" src="/blb/pxtapp.js"></script>
+    <script type="text/javascript" src="/blb/pxtblocks.js"></script>
+
+    <script type="text/javascript" src="/blb/target.js"></script>
+    <script id="mainscript" type="text/javascript" src="/blb/main.js"></script>
+    <xml id="blocklyToolboxDefinitionCategory" style="display: none">
+        <!-- An empty category is required so that Blockly launches in category mode -->
+        <category name="">
+        </category>
+    </xml>
+    <xml id="blocklyToolboxDefinitionFlyout" style="display: none">
+    </xml>
+    <script>
+        // Before loading vs/editor/editor.main, define a global MonacoEnvironment that overwrites
+        // the default worker url location (used when creating WebWorkers). The problem here is that
+        // HTML5 does not (yet) allow cross-domain web workers, so we need to proxy the instantion of
+        // a web worker through a same-domain script
+        window.MonacoEnvironment = {
+            getWorkerUrl: function(workerId, label) {
+                return pxt.webConfig.monacoworkerjs;
+            }
+        };
+
+        // this get rewritten to blob URLs with SHAs while uploading to the cloud
+        // keep in sync with release.manifest
+        window.MonacoPaths = {
+            "vs/loader": "/blb/vs/loader.js",
+            "vs/base/worker/workerMain": "/blb/vs/base/worker/workerMain.js",
+            "vs/basic-languages/src/bat": "/blb/vs/basic-languages/src/bat.js",
+            "vs/basic-languages/src/cpp": "/blb/vs/basic-languages/src/cpp.js",
+            "vs/editor/editor.main.css": "/blb/vs/editor/editor.main.css",
+            "vs/editor/editor.main": "/blb/vs/editor/editor.main.js",
+            "vs/editor/editor.main.nls": "/blb/vs/editor/editor.main.nls.js",
+            "vs/language/json/jsonMode": "/blb/vs/language/json/jsonMode.js",
+            "vs/language/json/jsonWorker": "/blb/vs/language/json/jsonWorker.js",
+            "vs/language/typescript/lib/typescriptServices": "/blb/vs/language/typescript/lib/typescriptServices.js",
+            "vs/language/typescript/src/mode": "/blb/vs/language/typescript/src/mode.js",
+            "vs/language/typescript/src/worker": "/blb/vs/language/typescript/src/worker.js",
+            "lzma/lzma_worker-min.js": "/blb/lzma/lzma_worker-min.js",
+            "smoothie/smoothie_compressed.js": "/blb/smoothie/smoothie_compressed.js",
+            "blockly.css": "/blb/blockly.css",
+            "rtlblockly.css": "/blb/rtlblockly.css"
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
I've added a couple of scripts that link pxt-blockly and closure-library under built/web. 
Once blockly is linked, I've created blockly.html which uses the uncompressed blockly files instead of our version that is both compressed and built into pxtblockly.js. 

This means we can debug Blockly in the same way that we do using the Blockly playground but in PXT. 

@riknoll @guillaumejenkins @pelikhan FYI (I know you guys have asked for this over and over again, so thought I'd finally do it ha). 

@pelikhan is there any issue with hosting that blockly.html file, or should I place it somewhere else. This is only for local debugging.
