### PR TITLE
Evenly distribute grid picker items

### DIFF
--- a/theme/fieldeditors.less
+++ b/theme/fieldeditors.less
@@ -72,6 +72,10 @@
     box-shadow: 0px 0px 8px 1px rgba(0, 0, 0, .3)
 }
 
+.blocklyWidgetDiv .blocklyGridPickerRow {	
+    display: table-row;
+}
+
 .blocklyWidgetDiv .blocklyGridPickerMenu {
     display: table;
     outline: none;


### PR DESCRIPTION
Bring back change to make each item a table-row to evenly distribute grid picker items

Revert https://github.com/Microsoft/pxt/pull/4899

Otherwise this happens: 
<img width="656" alt="screen shot 2018-10-26 at 12 38 21 pm" src="https://user-images.githubusercontent.com/16690124/47589029-e63eff00-d91c-11e8-818e-fdb020ab6207.png">

