### PR TITLE
Grouping serial messages from sim to improve performance

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -78,6 +78,12 @@ namespace pxsim {
         sim?: boolean;
         receivedTime?: number;
     }
+    export interface SimulatorBulkSerialMessage extends SimulatorMessage {
+        type: "bulkserial";
+        id: string;
+        data: { data: string, time: number }[];
+        sim?: boolean;
+    }
     export interface SimulatorCommandMessage extends SimulatorMessage {
         type: "simulator",
         command: "modal" | "restart" | "reload"

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1,6 +1,7 @@
 /// <reference path="../localtypings/pxtparts.d.ts"/>
 
 namespace pxsim {
+    const MIN_MESSAGE_WAIT_MS = 200;
     export namespace U {
         export function addClass(element: HTMLElement, classes: string) {
             if (!element) return;
@@ -108,6 +109,11 @@ namespace pxsim {
         finalCallback?: ResumeFn;
     }
 
+    interface SerialMessage {
+        data: string;
+        time: number;
+    }
+
     export let runtime: Runtime;
     export function getResume() { return runtime.getResume() }
 
@@ -124,18 +130,38 @@ namespace pxsim {
         public kill() { }
 
         protected serialOutBuffer: string = '';
-        public writeSerial(s: string) {
-            if (!s) return
 
+        private messages: SerialMessage[] = [];
+        private serialTimeout: number;
+        private lastSerialTime = 0;
+
+        public writeSerial(s: string) {
             this.serialOutBuffer += s;
             if (/\n/.test(this.serialOutBuffer) || this.serialOutBuffer.length > SERIAL_BUFFER_LENGTH) {
-                Runtime.postMessage(<SimulatorSerialMessage>{
-                    type: 'serial',
-                    data: this.serialOutBuffer,
+                this.messages.push({
+                    time: Date.now(),
+                    data: this.serialOutBuffer
+                });
+                this.debouncedPostAll();
+                this.serialOutBuffer = '';
+            }
+        }
+
+        private debouncedPostAll = () => {
+            const nowtime = Date.now();
+            if (this.messages.length && nowtime - this.lastSerialTime > MIN_MESSAGE_WAIT_MS) {
+                clearTimeout(this.serialTimeout);
+                Runtime.postMessage(<any>{
+                    type: 'bulkserial',
+                    data: this.messages,
                     id: runtime.id,
                     sim: true
                 })
-                this.serialOutBuffer = '';
+                this.messages = [];
+                this.lastSerialTime = nowtime;
+            }
+            else {
+                this.serialTimeout = setTimeout(this.debouncedPostAll, 50);
             }
         }
     }
@@ -251,7 +277,7 @@ namespace pxsim {
                     return Promise.resolve()
                 }
             })
-            // all events will be processed by above code, so 
+            // all events will be processed by above code, so
             // start afresh
             this.events = []
             return ret

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -120,9 +120,23 @@ export class Editor extends srceditor.Editor {
 
     processEvent(ev: MessageEvent) {
         let msg = ev.data
-        if (msg.type !== "serial") return;
-        const smsg = msg as pxsim.SimulatorSerialMessage
+        if (msg.type === "serial") {
+            this.processEventCore(msg);
+        }
+        else if (msg.type === "bulkserial") {
+            (msg as pxsim.SimulatorBulkSerialMessage).data.forEach(datum => {
+                this.processEventCore({
+                    type: "serial",
+                    data: datum.data,
+                    receivedTime: datum.time,
+                    sim: msg.sim,
+                    id: msg.id
+                } as pxsim.SimulatorSerialMessage);
+            })
+        }
+    }
 
+    processEventCore(smsg: pxsim.SimulatorSerialMessage) {
         smsg.receivedTime = smsg.receivedTime || Util.now();
         if (!this.active) {
             this.saveMessageForLater(smsg);

--- a/webapp/src/serialindicator.tsx
+++ b/webapp/src/serialindicator.tsx
@@ -30,7 +30,7 @@ export class SerialIndicator extends data.Component<SerialIndicatorProps, Serial
 
     setActive(ev: MessageEvent) {
         let msg = ev.data
-        if (!this.state.active && msg.type === "serial") {
+        if (!this.state.active && (msg.type === "serial" || msg.type === "bulkserial")) {
             const sim = !!msg.sim
             if (sim === this.props.isSim) {
                 this.setState({ active: true })


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1518

Currently this program will hang our editor:

![image](https://user-images.githubusercontent.com/13754588/47685036-53a79580-db92-11e8-8a3f-1ef9dd6169af.png)

The issue seems to be that we are overloading the UI thread by posting way too many serial messages. I've added some logic to group these messages before sending them and it makes a big improvement.
