### PR TITLE
Fix z-index issue with transparent editor tools

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -110,6 +110,7 @@ body {
 
 .transparentEditorTools #editortools {
     background-color: transparent;
+    z-index: (@blocklyToolboxZIndex)-1;
 }
 
 #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #filelist {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-minecraft/issues/737

Lower the zindex of the transparent editor tools so that we can get to all toolbox items.