### PR TITLE
Add zoom controls and don't hide the editor toolbar in tutorial mode

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -254,10 +254,6 @@ code.lang-filterblocks {
 
 /* > Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) {
-    /* Hide the editor toolbor in tutorial mode */
-    .tutorial #editortools  {
-        background: transparent !important;
-    }
     .tutorial #maineditor > div.full-abs {
         bottom: 0;
     }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -124,7 +124,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const showCollapsed = !tutorial && !sandbox && !targetTheme.simCollapseInMenu;
         const showProjectRename = !tutorial && !readOnly && !isController && !targetTheme.hideProjectRename;
         const showUndoRedo = !tutorial && !readOnly;
-        const showZoomControls = !tutorial;
+        const showZoomControls = true;
 
         const run = !targetTheme.bigRunButton;
         const restart = run && !simOpts.hideRestart;


### PR DESCRIPTION
Always show zoom controls.
Fixes https://github.com/Microsoft/pxt/issues/4885
Don't hide the editor toolbar in tutorial mode. 
Fixes https://github.com/Microsoft/pxt-minecraft/issues/538