### PR TITLE
Use hrefs for youtube and external links

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -114,12 +114,12 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 if (m) this.props.parent.startTutorial(m[1]);
                 else {
                     if (scr.youTubeId && !scr.url) // Youtube video
-                        window.open('https://youtu.be/' + scr.youTubeId, 'yt');
+                        return; // Handled by href
                     else if (/^https:\/\//i.test(scr.url)) // External video
-                        window.open(scr.url, '_blank');
+                        return; // Handled by href
                     else if (scr.url) // Docs url, open in new tab
                         if (/^\//i.test(scr.url))
-                            window.open(scr.url, '_blank');
+                            return; // Handled by href
                         else
                             core.errorNotification(lf("Sorry, the project url looks invalid."));
                     else
@@ -515,7 +515,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     }
 
     renderCore() {
-        const { name, description, imageUrl, largeImageUrl, youTubeId, cardType, tags } = this.props;
+        const { name, description, imageUrl, largeImageUrl, youTubeId, url, cardType, tags } = this.props;
 
         const image = largeImageUrl || imageUrl || (youTubeId ? `https://img.youtube.com/vi/${youTubeId}/0.jpg` : undefined);
         const tagColors: pxt.Map<string> = pxt.appTarget.appTheme.tagColors || {};
@@ -535,6 +535,10 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             className: 'huge positive'
         }]
 
+        const isLink = (youTubeId || url);
+        const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
+            ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
+
         return <div className="ui grid stackable padded">
             {image ? <div className="imagewrapper"><div className="image" style={{ backgroundImage: `url("${image}")` }} /></div> : undefined}
             <div className="column eight wide">
@@ -548,13 +552,23 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                     </p>
                     <div className="actions">
                         {actions.map(action =>
-                            <sui.Button
-                                key={`action_${action.label}`}
-                                icon={action.icon}
-                                text={action.label}
-                                className={`approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''}`}
-                                onClick={action.onClick}
-                                onKeyDown={sui.fireClickOnEnter} />
+                            isLink && linkHref ?
+                                <sui.Link
+                                    key={`action_${action.label}`}
+                                    href={linkHref} target={'_blank'}
+                                    icon={action.icon}
+                                    text={action.label}
+                                    className={`ui button approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''}`}
+                                    onClick={action.onClick}
+                                    onKeyDown={sui.fireClickOnEnter}
+                                />
+                                : <sui.Button
+                                    key={`action_${action.label}`}
+                                    icon={action.icon}
+                                    text={action.label}
+                                    className={`approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''}`}
+                                    onClick={action.onClick}
+                                    onKeyDown={sui.fireClickOnEnter} />
                         )}
                     </div>
                 </div>


### PR DESCRIPTION
Use hrefs for youtube and external links, instead of a button with window.open.
No reason to use window.open in this case, we know that it's a youtube or external link when we create the button. 

This also resolves part of this issue: https://github.com/Microsoft/pxt-minecraft/issues/753