### PR TITLE
Stop the simulator if running when code is invalidated (autorun: false)

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -482,6 +482,9 @@ export class ProjectView
                             if (this.editor == this.blocksEditor) this.autoRunBlocksSimulator();
                             else this.autoRunSimulator();
                         }
+                    } else if (this.state.running) {
+                        // Stop the simulator if it's running, since the code has been invalidated
+                        this.stopSimulator();
                     }
 
                     this.maybeShowPackageErrors();


### PR DESCRIPTION
Reason for this change: 
(Most of our targets have autoRun = true).
If the simulator is running and autoRun is false, then if a user makes a change to their code (invalidates the code running), we should stop the simulator. 
@pelikhan do you agree with this behavior or should I have it behind a flag?

This also affects Wonder workshop so we should chat to them about this change.