### PR TITLE
pxt-core@v0 now uses npm tag _v0

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -464,9 +464,14 @@ function travisAsync() {
     console.log("uploadLocs:", uploadLocs);
     console.log("latest:", latest);
 
+    function npmPublishAsync() {
+        if (!npmPublish) return Promise.resolve();
+        return nodeutil.runNpmAsync("publish", "--tag=_v0");
+    }
+
     let pkg = readJson("package.json")
     if (pkg["name"] == "pxt-core") {
-        let p = npmPublish ? nodeutil.runNpmAsync("publish", "--tag=_v0") : Promise.resolve();
+        let p = npmPublishAsync();
         if (uploadLocs)
             p = p
                 .then(() => execCrowdinAsync("upload", "built/strings.json"))
@@ -477,7 +482,7 @@ function travisAsync() {
     } else {
         return internalBuildTargetAsync()
             .then(() => internalCheckDocsAsync(true))
-            .then(() => npmPublish ? nodeutil.runNpmAsync("publish") : Promise.resolve())
+            .then(() => npmPublishAsync())
             .then(() => {
                 if (!process.env["PXT_ACCESS_TOKEN"]) {
                     // pull request, don't try to upload target

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -466,7 +466,7 @@ function travisAsync() {
 
     let pkg = readJson("package.json")
     if (pkg["name"] == "pxt-core") {
-        let p = npmPublish ? nodeutil.runNpmAsync("publish") : Promise.resolve();
+        let p = npmPublish ? nodeutil.runNpmAsync("publish", "--tag=_v0") : Promise.resolve();
         if (uploadLocs)
             p = p
                 .then(() => execCrowdinAsync("upload", "built/strings.json"))


### PR DESCRIPTION
Fix 1 of 2 for https://github.com/Microsoft/pxt-microbit/issues/1558

(Other fix here: https://github.com/Microsoft/pxt/pull/4952)

We've decided that:
- v0 will take tag `_v0` (a tag can't start with "v" or a number)
- master will take default tag `latest`