### PR TITLE
pxt-core@latest now points to latest master

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -518,7 +518,7 @@ function travisAsync() {
 
     function npmPublishAsync() {
         if (!npmPublish) return Promise.resolve();
-        return nodeutil.runNpmAsync("publish", "--tag=dev");
+        return nodeutil.runNpmAsync("publish");
     }
 
     let pkg = readJson("package.json")


### PR DESCRIPTION
Fix 2 of 2 for Microsoft/pxt-microbit#1558

(Other fix here: https://github.com/Microsoft/pxt/pull/4951)

We've decided that:
- v0 will take tag `_v0` (a tag can't start with "v" or a number)
- master will take default tag `latest`