### PR TITLE
Suspend simulator

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -182,7 +182,8 @@ namespace pxsim {
             }
         }
 
-        private suspend() {
+        public suspend() {
+            this.postMessage({ type: 'stop' });
             this.setState(SimulatorState.Suspended);
 
             let frames = this.container.getElementsByTagName("iframe");

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -94,7 +94,7 @@ namespace pxsim {
         private setState(state: SimulatorState) {
             if (this.state != state) {
                 this.state = state;
-                this.freeze(this.state == SimulatorState.Paused || this.state == SimulatorState.Suspended); // don't allow interaction when pause
+                this.freeze(this.state == SimulatorState.Paused); // don't allow interaction when pause
                 if (this.options.onStateChanged)
                     this.options.onStateChanged(this.state);
             }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -156,8 +156,8 @@ export class ProjectView
         pxt.debug(`page visibility: ${active}`)
         this.setState({ active: active })
         if (!active && (pxt.appTarget.simulator && pxt.appTarget.simulator.autoRun)) {
-            if (this.state.running) {
-                this.stopSimulator();
+            if (simulator.driver.state == pxsim.SimulatorState.Running) {
+                this.suspendSimulator();
                 this.setState({ resumeOnVisibility: true });
             }
             this.saveFileAsync().done();
@@ -167,7 +167,7 @@ export class ProjectView
                 let id = this.state.header ? this.state.header.id : '';
                 workspace.initAsync()
                     .done(() => !this.state.home && id ? this.loadHeaderAsync(workspace.getHeader(id), this.state.editorState) : Promise.resolve());
-            } else if (this.state.resumeOnVisibility && !this.state.running) {
+            } else if (this.state.resumeOnVisibility) {
                 this.setState({ resumeOnVisibility: false });
                 this.runSimulator();
             }
@@ -1728,6 +1728,11 @@ export class ProjectView
         pxt.tickEvent('simulator.stop')
         simulator.stop(unload)
         this.setState({ running: false })
+    }
+
+    suspendSimulator() {
+        pxt.tickEvent('simulator.suspend')
+        simulator.suspend()
     }
 
     proxySimulatorMessage(content: string) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -478,6 +478,7 @@ export class ProjectView
                         if (output && !output.numDiagnosticsOverride
                             && (simulator.driver.state == pxsim.SimulatorState.Running
                                 || simulator.driver.state == pxsim.SimulatorState.Paused
+                                || simulator.driver.state == pxsim.SimulatorState.Suspended
                                 || simulator.driver.state == pxsim.SimulatorState.Unloaded)) {
                             if (this.editor == this.blocksEditor) this.autoRunBlocksSimulator();
                             else this.autoRunSimulator();

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -27,8 +27,6 @@ let displayedModals: pxt.Map<boolean> = {};
 export let simTranslations: pxt.Map<string>;
 let dirty = false;
 
-let debuggerDOM: HTMLElement;
-
 export function setTranslations(translations: pxt.Map<string>) {
     simTranslations = translations;
 }
@@ -45,7 +43,6 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
     debuggerDiv.className = 'ui item landscape only';
     root.appendChild(debuggerDiv);
 
-    debuggerDOM = document.getElementById('debugger')
     let options: pxsim.SimulatorDriverOptions = {
         revealElement: (el) => {
             if (pxt.options.light) return;
@@ -236,6 +233,9 @@ export function setState(editor: string, tutMode?: boolean) {
 export function makeDirty() { // running outdated code
     pxsim.U.addClass(driver.container, getInvalidatedClass());
     dirty = true;
+
+    // No need to continue running if we're dirty
+    driver.suspend();
 }
 
 export function isDirty(): boolean { // in need of a restart?
@@ -276,7 +276,6 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
 
 export function mute(mute: boolean) {
     driver.mute(mute);
-    pxsim.U.removeChildren(debuggerDOM);
 }
 
 export function stop(unload?: boolean) {
@@ -284,7 +283,13 @@ export function stop(unload?: boolean) {
 
     makeClean();
     driver.stop(unload);
-    pxsim.U.removeChildren(debuggerDOM);
+}
+
+export function suspend() {
+    if (!driver) return;
+
+    makeClean();
+    driver.suspend();
 }
 
 export function hide(completeHandler?: () => void) {
@@ -292,7 +297,6 @@ export function hide(completeHandler?: () => void) {
         makeDirty();
     }
     driver.hide(completeHandler);
-    pxsim.U.removeChildren(debuggerDOM);
 }
 
 export function unhide() {
@@ -307,7 +311,6 @@ export function proxy(message: pxsim.SimulatorCustomMessage) {
     if (!driver) return;
 
     driver.postMessage(message);
-    pxsim.U.removeChildren(debuggerDOM);
 }
 
 export function dbgPauseResume() {
@@ -354,74 +357,3 @@ function getStoppedClass() {
     }
     return undefined;
 }
-
-/*
-function updateDebuggerButtonsInternal(brk: pxsim.DebuggerBreakpointMessage = null) {
-    function btn(icon: string, name: string, label: string, click: () => void) {
-        let b = document.createElement('button');
-        b.className = `ui mini button teal ${icon ? 'icon' : ''}`;
-        b.title = pxt.Util.htmlEscape(label);
-        if (icon) {
-            let i = document.createElement('i');
-            i.className = `${icon} icon`;
-            b.appendChild(i);
-        }
-        if (name) b.appendChild(document.createTextNode(pxt.Util.htmlEscape(name)));
-        b.addEventListener('click', click);
-        return b;
-    }
-
-    pxsim.U.removeChildren(debuggerDOM);
-    if (!driver.runOptions.debug) return;
-    let advanced = config.editor == 'tsprj';
-
-    if (driver.state == pxsim.SimulatorState.Paused) {
-        let $resume = btn("play", lf("Resume"), lf("Resume execution"), () => driver.resume(pxsim.SimulatorDebuggerCommand.Resume));
-        let $stepOver = btn("xicon stepover", lf("Step over"), lf("Step over next function call"), () => driver.resume(pxsim.SimulatorDebuggerCommand.StepOver));
-        let $stepInto = btn("xicon stepinto", lf("Step into"), lf("Step into next function call"), () => driver.resume(pxsim.SimulatorDebuggerCommand.StepInto));
-        debuggerDOM.appendChild($resume).appendChild($stepOver)
-        if (advanced)
-            debuggerDOM.appendChild($stepInto);
-    } else if (driver.state == pxsim.SimulatorState.Running) {
-        let $pause = btn("pause", lf("Pause"), lf("Pause execution on the next instruction"), () => driver.resume(pxsim.SimulatorDebuggerCommand.Pause));
-        debuggerDOM.appendChild($pause);
-    }
-
-    if (!brk || !advanced) return;
-
-    function vars(hd: string, frame: pxsim.Variables) {
-        let frameView = document.createElement('div');
-        let heading = document.createElement('h4');
-        heading.appendChild(document.createTextNode(hd));
-        frameView.appendChild(heading);
-        for (let k of Object.keys(frame)) {
-            let v = frame[k]
-            let sv = ""
-            switch (typeof (v)) {
-                case "number": sv = v + ""; break;
-                case "boolean": sv = v + ""; break;
-                case "string": sv = JSON.stringify(v); break;
-                case "object":
-                    if (v == null) sv = "null";
-                    else if (v.id !== undefined) sv = "(object)"
-                    else if (v.text) sv = v.text;
-                    else sv = "(unknown)"
-                    break;
-                default: U.oops()
-            }
-            let n = k.replace(/___\d+$/, "")
-            frameView.appendChild(document.createElement('div').appendChild(document.createTextNode(`${n}: ${sv}`)));
-        }
-        return frameView
-    }
-
-    let dbgView = document.createElement('div');
-    dbgView.className = "ui segment debuggerview";
-    dbgView.appendChild(vars(U.lf("globals"), brk.globals))
-    brk.stackframes.forEach(sf => {
-        let info = sf.funcInfo as pxtc.FunctionLocationInfo
-        dbgView.appendChild(vars(info.functionName, sf.locals))
-    })
-    debuggerDOM.appendChild(dbgView);
-}
-*/


### PR DESCRIPTION
This PR does three things: 
- Stop the simulator when we invalidate (no need to run code that is invalidated) @pelikhan FYI
- Adds another state for the simulator called suspended, suspended is more or less the same as stop except it differentiates between a user action stop and a code (compiler / runtime error) stop. ie: if we fix the code, we will run again if the simulator is in the suspended state. Unlike if the user hits the stop button, we will continue to be stopped regardless of what changes.

Explanation:
When we hit an exception, we stop the simulator (which is equivalent to a user hitting the stop button) this means that we don't restart the simulator when a change is made and the "exception" is fixed. 

This change creates a new simulator state "Suspended" which means that the simulator appears as stopped "grayscale class" but is actually in a unique state where it will restart if a change is made. 

Another case that this tries to address is when the page is invisible it stops the simulator and restarts it when we are active again. If there is a compiler error, it won't run, but it also will set the state as "stopped" which is problematic as the user never explicitly stopped the simulator. 

Tested: 
Running -> Compiler error -> Fix error -> Running
Running -> Runtime error -> Fix error -> Running
Running -> Switch page -> Running
Running -> Compiler error -> Switch page -> Running
Running -> Runtime error -> Switch page -> Running
Stopped -> Any change -> Stopped
Stopped -> Switch page -> Stopped



Runtime error test: 
```
let array: number[] = null
array[0]
```

Compiler error test: 
```
let x = 0
x = ""
```