### PR TITLE
Default edit button in v0 will point to live

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -33,11 +33,14 @@
             <div class="ui content">
                 @title@ 
                 <!-- @ifdef editbutton -->
-                <a href="/@versionsuff@#pub:@id@" class="ui primary button">Edit</a>
+                <a href="/#pub:@id@" class="ui primary button">Edit</a>
                 <!-- @endif -->
                 <div class='sub header humantime' data-time="@time@">@humantime@</span>
             </div>
         </h1>
+        <!-- @ifdef editbutton -->
+        <a href="/@versionsuff@#pub:@id@">Edit in the old editor</a>
+        <!-- @endif -->
         <p class="ui content description">
             @description@
         </p>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1445,7 +1445,7 @@ export class ProjectView
         pxt.tickEvent("sandbox.openfulleditor");
         Util.assert(pxt.shell.isSandboxMode());
 
-        let editUrl = pxt.appTarget.appTheme.embedUrl;
+        let editUrl = pxt.appTarget.appTheme.shareUrl;
         if (!/\/$/.test(editUrl)) editUrl += '/';
 
         const mpkg = pkg.mainPkg


### PR DESCRIPTION
Edit button in the share page is pointing to v0. If I have shared a page a while ago, I still would like to go to the latest instead of v0. There is a link to go to the old editor if needed.  I see most of the traffic to v0 is through this edit button. Changing the default behavior. 

