### PR TITLE
Collapsed toolbar view for headless tutorial mode

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -102,20 +102,20 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const isController = pxt.shell.isControllerMode();
         const readOnly = pxt.shell.isReadOnly();
         const tutorial = tutorialOptions ? tutorialOptions.tutorial : false;
-        const collapsed = (hideEditorFloats || collapseEditorTools) && !tutorial;
+        const simOpts = pxt.appTarget.simulator;
+        const headless = simOpts.headless;
+        const collapsed = (hideEditorFloats || collapseEditorTools) && (!tutorial || headless);
         const isEditor = this.props.parent.isBlocksEditor() || this.props.parent.isTextEditor();
         if (!isEditor) return <div />;
 
-        const showSave = !readOnly && !isController && !targetTheme.saveInMenu;
+        const showSave = !readOnly && !isController && !targetTheme.saveInMenu && !tutorial;
         const compile = pxt.appTarget.compile;
         const compileBtn = compile.hasHex || compile.saveAsPNG;
-        const simOpts = pxt.appTarget.simulator;
         const compileTooltip = lf("Download your code to the {0}", targetTheme.boardName);
         const compileLoading = !!compiling;
         const runTooltip = running ? lf("Stop the simulator") : lf("Start the simulator");
         const restartTooltip = lf("Restart the simulator");
         const collapseTooltip = collapsed ? lf("Show the simulator") : lf("Hide the simulator");
-        const headless = simOpts.headless;
         const pairingButton = !!targetTheme.pairingButton;
 
         const hasUndo = this.props.parent.editor.hasUndo();


### PR DESCRIPTION
Show collapsed toolbar view for headless mode in tutorial.

We always show the non-collapsed view in tutorial mode, but in the case of headless mode, collapsed view is the default and so we should show that in tutorial mode. 

Fixes https://github.com/Microsoft/pxt-minecraft/issues/746
