### PR TITLE
Request a versioned targetconfig rather than latest

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -281,7 +281,7 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
         // innerpath start with targetid
         return Promise.resolve(readMd(innerPath.slice(pxt.appTarget.id.length + 1)))
     }
-    else if (cmd == "GET config" && pxt.appTarget.id + "/targetconfig" == innerPath) {
+    else if (cmd == "GET config" && new RegExp(`${pxt.appTarget.id}\/targetconfig(\/v[0-9.]+)?$`).test(innerPath)) {
         // target config
         return readFileAsync("targetconfig.json").then(buf => JSON.parse(buf.toString("utf8")));
     }

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -61,7 +61,9 @@ namespace pxt.Cloud {
         if (!Cloud.isOnline()) // offline
             return Promise.resolve(undefined);
 
-        const url = pxt.webConfig && pxt.webConfig.isStatic ? `targetconfig.json` : `config/${pxt.appTarget.id}/targetconfig`;
+        const targetVersion = pxt.appTarget.versions && pxt.appTarget.versions.target;
+        const url = pxt.webConfig && pxt.webConfig.isStatic ? `targetconfig.json` : `config/${pxt.appTarget.id}/targetconfig${targetVersion ? `/v${targetVersion}` : ''}`;
+
         if (Cloud.isLocalHost())
             return Util.requestAsync({
                 url: "/api/" + url,


### PR DESCRIPTION
We are currently requesting the lastest targetconfig for our v0 editors, which means it's fetching the targetconfig that's in master. 
This makes it request the version in the target and if it's v0, it will go to the v0 branch to fetch that targetconfig.

Fixes https://github.com/Microsoft/pxt-microbit/issues/1525