### PR TITLE
Point to versioned docs in side docs (v0)

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -429,4 +429,17 @@ namespace pxt.BrowserUtils {
             }
         }
     }
+
+    /**
+     * Simple utility method to join urls.
+     */
+    export function urlJoin(urlPath1: string, urlPath2: string): string {
+        if (!urlPath1) return urlPath2;
+        if (!urlPath2) return urlPath1;
+        const normalizedUrl1 = (urlPath1.indexOf('/') == urlPath1.length - 1) ?
+            urlPath1.substring(0, urlPath1.length - 1) : urlPath1;
+        const normalizedUrl2 = (urlPath2.indexOf('/') == 0) ?
+            urlPath2.substring(1) : urlPath2;
+        return normalizedUrl1 + "/" + normalizedUrl2;
+    }
 }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -315,11 +315,12 @@ namespace pxt.runner {
                 setEditorContextAsync(/\.ts$/i.test(name) ? LanguageMode.TypeScript : LanguageMode.Blocks, fm.locale).done();
                 break;
             case "popout":
-                let mp = /#(doc|md):([^&?:]+)/i.exec(window.location.href);
+                let mp = /((\/v[0-9+])\/)?[^\/]*#(doc|md):([^&?:]+)/i.exec(window.location.href);
                 if (mp) {
                     const docsUrl = pxt.webConfig.docsUrl || '/--docs';
-                    let url = mp[1] == "doc" ? `${mp[2]}` : `${docsUrl}?md=${mp[2]}`;
-                    window.open(url, "_blank");
+                    let verPrefix = mp[2] || '';
+                    let url = mp[3] == "doc" ? (pxt.webConfig.isStatic ? `/docs${mp[4]}.html` : `${mp[4]}`) : `${docsUrl}?md=${mp[4]}`;
+                    window.open(BrowserUtils.urlJoin(verPrefix, url), "_blank");
                     // notify parent iframe that we have completed the popout
                     if (window.parent)
                         window.parent.postMessage(<pxsim.SimulatorDocsReadyMessage>{


### PR DESCRIPTION
The side docs in v0 don't use the version in the URL to navigate to the correct versioned docs.
Porting over this fix from master. 

This fixes the issue with v0 side docs pointing to the latest docs instead of v0 docs.
Fixes https://github.com/Microsoft/pxt-microbit/issues/1544