### PR TITLE
add option to hide "go back" button

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -388,9 +388,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         return (
             <sui.Modal isOpen={this.state.visible} dimmer={true}
                 className="searchdialog" size="fullscreen"
-                hideGoBack={!!this.state.resolve}
                 onClose={this.hide}
-                closeIcon={true} header={headerText}
+                closeIcon={!this.state.resolve} header={headerText}
                 helpUrl={helpPath}
                 closeOnDimmerClick closeOnEscape
                 description={description}>

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -388,6 +388,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         return (
             <sui.Modal isOpen={this.state.visible} dimmer={true}
                 className="searchdialog" size="fullscreen"
+                hideGoBack={!!this.state.resolve}
                 onClose={this.hide}
                 closeIcon={true} header={headerText}
                 helpUrl={helpPath}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -850,6 +850,7 @@ export interface ModalProps extends ReactModal.Props {
     onClose?: () => void;
     defaultOpen?: boolean;
     closeIcon?: boolean | string;
+    hideGoBack?: boolean;
 
     size?: 'fullscreen' | 'large' | 'mini' | 'small' | 'tiny';
     className?: string;
@@ -966,9 +967,10 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             onClose, closeIcon, children,
             header, headerClass, helpUrl, description,
             closeOnDimmerClick, closeOnDocumentClick, closeOnEscape,
-            shouldCloseOnEsc, shouldCloseOnOverlayClick, shouldFocusAfterRender, ...rest } = this.props;
+            shouldCloseOnEsc, shouldCloseOnOverlayClick, shouldFocusAfterRender, hideGoBack, ...rest } = this.props;
         const { marginTop, scrolling, mountClasses } = this.state;
         const isFullscreen = size == 'fullscreen';
+        const goBack = isFullscreen && !hideGoBack;
 
         const classes = cx([
             'ui',
@@ -1038,7 +1040,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
                 onClick={onClose}
                 onKeyDown={fireClickOnEnter}
             ><Icon icon="close remove circle" /> </div> : undefined}
-            {isFullscreen ?
+            {goBack ?
                 <Button text={lf("Go back")} title={lf("Go back to the editor")} className="icon circular small editorBack left labeled" ariaLabel={lf("Go back")} onClick={onClose} onKeyDown={fireClickOnEnter}>
                     <Icon icon="arrow left" />
                 </Button> : undefined}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -850,7 +850,6 @@ export interface ModalProps extends ReactModal.Props {
     onClose?: () => void;
     defaultOpen?: boolean;
     closeIcon?: boolean | string;
-    hideGoBack?: boolean;
 
     size?: 'fullscreen' | 'large' | 'mini' | 'small' | 'tiny';
     className?: string;
@@ -967,10 +966,10 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             onClose, closeIcon, children,
             header, headerClass, helpUrl, description,
             closeOnDimmerClick, closeOnDocumentClick, closeOnEscape,
-            shouldCloseOnEsc, shouldCloseOnOverlayClick, shouldFocusAfterRender, hideGoBack, ...rest } = this.props;
+            shouldCloseOnEsc, shouldCloseOnOverlayClick, shouldFocusAfterRender, ...rest } = this.props;
         const { marginTop, scrolling, mountClasses } = this.state;
         const isFullscreen = size == 'fullscreen';
-        const goBack = isFullscreen && !hideGoBack;
+        const goBack = isFullscreen && !!closeIcon;
 
         const classes = cx([
             'ui',


### PR DESCRIPTION
Hide the "go back" option in scriptsearch when the dialog is waiting on a promise resolve. This is used when a user picks up a board after opening a script or a tutorial.