### PR TITLE
Fix translate note names

### DIFF
--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -74,57 +74,57 @@ namespace pxtblockly {
     }
 
     const Notes: {[key: number]: NoteData} = {
-        28: {name: "C", prefixedName: "Low C", freq: 131},
-        29: {name: "C#", prefixedName: "Low C#", freq: 139},
-        30: {name: "D", prefixedName: "Low D", freq: 147},
-        31: {name: "D#", prefixedName: "Low D#", freq: 156},
-        32: {name: "E", prefixedName: "Low E", freq: 165},
-        33: {name: "F", prefixedName: "Low F", freq: 175},
-        34: {name: "F#", prefixedName: "Low F#", freq: 185},
-        35: {name: "G", prefixedName: "Low G", freq: 196},
-        36: {name: "G#", prefixedName: "Low G#", freq: 208},
-        37: {name: "A", prefixedName: "Low A", freq: 220},
-        38: {name: "A#", prefixedName: "Low A#", freq: 233},
-        39: {name: "B", prefixedName: "Low B", freq: 247},
+        28: {name: lf("C"), prefixedName: lf("Low C"), freq: 131},
+        29: {name: lf("C#"), prefixedName: lf("Low C#"), freq: 139},
+        30: {name: lf("D"), prefixedName: lf("Low D"), freq: 147},
+        31: {name: lf("D#"), prefixedName: lf("Low D#"), freq: 156},
+        32: {name: lf("E"), prefixedName: lf("Low E"), freq: 165},
+        33: {name: lf("F"), prefixedName: lf("Low F"), freq: 175},
+        34: {name: lf("F#"), prefixedName: lf("Low F#"), freq: 185},
+        35: {name: lf("G"), prefixedName: lf("Low G"), freq: 196},
+        36: {name: lf("G#"), prefixedName: lf("Low G#"), freq: 208},
+        37: {name: lf("A"), prefixedName: lf("Low A"), freq: 220},
+        38: {name: lf("A#"), prefixedName: lf("Low A#"), freq: 233},
+        39: {name: lf("B"), prefixedName: lf("Low B"), freq: 247},
 
-        40: {name: "C", prefixedName: "Middle C", freq: 262},
-        41: {name: "C#", prefixedName: "Middle C#", freq: 277},
-        42: {name: "D", prefixedName: "Middle D", freq: 294},
-        43: {name: "D#", prefixedName: "Middle D#", freq: 311},
-        44: {name: "E", prefixedName: "Middle E", freq: 330},
-        45: {name: "F", prefixedName: "Middle F", freq: 349},
-        46: {name: "F#", prefixedName: "Middle F#", freq: 370},
-        47: {name: "G", prefixedName: "Middle G", freq: 392},
-        48: {name: "G#", prefixedName: "Middle G#", freq: 415},
-        49: {name: "A", prefixedName: "Middle A", freq: 440},
-        50: {name: "A#", prefixedName: "Middle A#", freq: 466},
-        51: {name: "B", prefixedName: "Middle B", freq: 494},
+        40: {name: lf("C"), prefixedName: lf("Middle C"), freq: 262},
+        41: {name: lf("C#"), prefixedName: lf("Middle C#"), freq: 277},
+        42: {name: lf("D"), prefixedName: lf("Middle D"), freq: 294},
+        43: {name: lf("D#"), prefixedName: lf("Middle D#"), freq: 311},
+        44: {name: lf("E"), prefixedName: lf("Middle E"), freq: 330},
+        45: {name: lf("F"), prefixedName: lf("Middle F"), freq: 349},
+        46: {name: lf("F#"), prefixedName: lf("Middle F#"), freq: 370},
+        47: {name: lf("G"), prefixedName: lf("Middle G"), freq: 392},
+        48: {name: lf("G#"), prefixedName: lf("Middle G#"), freq: 415},
+        49: {name: lf("A"), prefixedName: lf("Middle A"), freq: 440},
+        50: {name: lf("A#"), prefixedName: lf("Middle A#"), freq: 466},
+        51: {name: lf("B"), prefixedName: lf("Middle B"), freq: 494},
 
-        52: {name: "C", prefixedName: "Tenor C", altPrefixedName: "High C", freq: 523},
-        53: {name: "C#", prefixedName: "Tenor C#", altPrefixedName: "High C#", freq: 554},
-        54: {name: "D", prefixedName: "Tenor D", altPrefixedName: "High D", freq: 587},
-        55: {name: "D#", prefixedName: "Tenor D#", altPrefixedName: "High D#", freq: 622},
-        56: {name: "E", prefixedName: "Tenor E", altPrefixedName: "High E", freq: 659},
-        57: {name: "F", prefixedName: "Tenor F", altPrefixedName: "High F", freq: 698},
-        58: {name: "F#", prefixedName: "Tenor F#", altPrefixedName: "High F#", freq: 740},
-        59: {name: "G", prefixedName: "Tenor G", altPrefixedName: "High G", freq: 784},
-        60: {name: "G#", prefixedName: "Tenor G#", altPrefixedName: "High G#", freq: 831},
-        61: {name: "A", prefixedName: "Tenor A", altPrefixedName: "High A", freq: 880},
-        62: {name: "A#", prefixedName: "Tenor A#", altPrefixedName: "High A#", freq: 932},
-        63: {name: "B", prefixedName: "Tenor B", altPrefixedName: "High B", freq: 988},
+        52: {name: lf("C"), prefixedName: lf("Tenor C"), altPrefixedName: lf("High C"), freq: 523},
+        53: {name: lf("C#"), prefixedName: lf("Tenor C#"), altPrefixedName: lf("High C#"), freq: 554},
+        54: {name: lf("D"), prefixedName: lf("Tenor D"), altPrefixedName: lf("High D"), freq: 587},
+        55: {name: lf("D#"), prefixedName: lf("Tenor D#"), altPrefixedName: lf("High D#"), freq: 622},
+        56: {name: lf("E"), prefixedName: lf("Tenor E"), altPrefixedName: lf("High E"), freq: 659},
+        57: {name: lf("F"), prefixedName: lf("Tenor F"), altPrefixedName: lf("High F"), freq: 698},
+        58: {name: lf("F#"), prefixedName: lf("Tenor F#"), altPrefixedName: lf("High F#"), freq: 740},
+        59: {name: lf("G"), prefixedName: lf("Tenor G"), altPrefixedName: lf("High G"), freq: 784},
+        60: {name: lf("G#"), prefixedName: lf("Tenor G#"), altPrefixedName: lf("High G#"), freq: 831},
+        61: {name: lf("A"), prefixedName: lf("Tenor A"), altPrefixedName: lf("High A"), freq: 880},
+        62: {name: lf("A#"), prefixedName: lf("Tenor A#"), altPrefixedName: lf("High A#"), freq: 932},
+        63: {name: lf("B"), prefixedName: lf("Tenor B"), altPrefixedName: lf("High B"), freq: 988},
 
-        64: {name: "C", prefixedName: "High C", freq: 1046},
-        65: {name: "C#", prefixedName: "High C#", freq: 1109},
-        66: {name: "D", prefixedName: "High D", freq: 1175},
-        67: {name: "D#", prefixedName: "High D#", freq: 1245},
-        68: {name: "E", prefixedName: "High E", freq: 1319},
-        69: {name: "F", prefixedName: "High F", freq: 1397},
-        70: {name: "F#", prefixedName: "High F#", freq: 1478},
-        71: {name: "G", prefixedName: "High G", freq: 1568},
-        72: {name: "G#", prefixedName: "High G#", freq: 1661},
-        73: {name: "A", prefixedName: "High A", freq: 1760},
-        74: {name: "A#", prefixedName: "High A#", freq: 1865},
-        75: {name: "B", prefixedName: "High B", freq: 1976}
+        64: {name: lf("C"), prefixedName: lf("High C"), freq: 1046},
+        65: {name: lf("C#"), prefixedName: lf("High C#"), freq: 1109},
+        66: {name: lf("D"), prefixedName: lf("High D"), freq: 1175},
+        67: {name: lf("D#"), prefixedName: lf("High D#"), freq: 1245},
+        68: {name: lf("E"), prefixedName: lf("High E"), freq: 1319},
+        69: {name: lf("F"), prefixedName: lf("High F"), freq: 1397},
+        70: {name: lf("F#"), prefixedName: lf("High F#"), freq: 1478},
+        71: {name: lf("G"), prefixedName: lf("High G"), freq: 1568},
+        72: {name: lf("G#"), prefixedName: lf("High G#"), freq: 1661},
+        73: {name: lf("A"), prefixedName: lf("High A"), freq: 1760},
+        74: {name: lf("A#"), prefixedName: lf("High A#"), freq: 1865},
+        75: {name: lf("B"), prefixedName: lf("High B"), freq: 1976}
     }
 
     let regex: RegExp = /^Note\.(.+)$/;
@@ -245,80 +245,6 @@ namespace pxtblockly {
                     thisField.noteName_.push(name);
                     thisField.noteFreq_.push(Notes[i].freq);
                 }
-
-                // Do not remove this comment.
-                // lf("C")
-                // lf("C#")
-                // lf("D")
-                // lf("D#")
-                // lf("E")
-                // lf("F")
-                // lf("F#")
-                // lf("G")
-                // lf("G#")
-                // lf("A")
-                // lf("A#")
-                // lf("B")
-                // lf("Deep C")
-                // lf("Deep C#")
-                // lf("Deep D")
-                // lf("Deep D#")
-                // lf("Deep E")
-                // lf("Deep F")
-                // lf("Deep F#")
-                // lf("Deep G")
-                // lf("Deep G#")
-                // lf("Deep A")
-                // lf("Deep A#")
-                // lf("Deep B")
-                // lf("Low C")
-                // lf("Low C#")
-                // lf("Low D")
-                // lf("Low D#")
-                // lf("Low E")
-                // lf("Low F")
-                // lf("Low F#")
-                // lf("Low G")
-                // lf("Low G#")
-                // lf("Low A")
-                // lf("Low A#")
-                // lf("Low B")
-                // lf("Middle C")
-                // lf("Middle C#")
-                // lf("Middle D")
-                // lf("Middle D#")
-                // lf("Middle E")
-                // lf("Middle F")
-                // lf("Middle F#")
-                // lf("Middle G")
-                // lf("Middle G#")
-                // lf("Middle A")
-                // lf("Middle A#")
-                // lf("Middle B")
-                // lf("Tenor C")
-                // lf("Tenor C#")
-                // lf("Tenor D")
-                // lf("Tenor D#")
-                // lf("Tenor E")
-                // lf("Tenor F")
-                // lf("Tenor F#")
-                // lf("Tenor G")
-                // lf("Tenor G#")
-                // lf("Tenor A")
-                // lf("Tenor A#")
-                // lf("Tenor B")
-                // lf("High C")
-                // lf("High C#")
-                // lf("High D")
-                // lf("High D#")
-                // lf("High E")
-                // lf("High F")
-                // lf("High F#")
-                // lf("High G")
-                // lf("High G#")
-                // lf("High A")
-                // lf("High A#")
-                // lf("High B")
             }
         }
         /**


### PR DESCRIPTION
After upgrading from v0 to v1, the note names do not translate. This change is to fix this and shows translated note names as it is in v0.

v1 (before this change):
![image](https://user-images.githubusercontent.com/485416/47960242-3152c380-e03b-11e8-84d9-072a03991536.png)

v0:
![image](https://user-images.githubusercontent.com/485416/47960257-81ca2100-e03b-11e8-8a09-92a58a2329dc.png)
