### PR TITLE
enable analytics in docs / send error reports in docs

### DIFF
--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -9,6 +9,7 @@ namespace pxt {
 namespace pxt.analytics {
     const defaultProps: Map<string> = {};
     const defaultMeasures: Map<number> = {};
+    let enabled = false;
 
     export function addDefaultProperties(props: Map<string | number>) {
         Object.keys(props).forEach(k => {
@@ -21,8 +22,9 @@ namespace pxt.analytics {
     }
 
     export function enable() {
-        if (!pxt.aiTrackException || !pxt.aiTrackEvent) return;
+        if (!pxt.aiTrackException || !pxt.aiTrackEvent || enabled) return;
 
+        enabled = true;
         pxt.debug('setting up app insights')
 
         const te = pxt.tickEvent;

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -158,22 +158,24 @@ namespace pxt.runner {
         el: JQuery;
         source: string;
         options: blocks.BlocksRenderOptions;
-        cls: string;
         render: (container: JQuery, r: pxt.runner.DecompileResult) => void;
     }[] = [];
     function consumeRenderQueueAsync(): Promise<void> {
         const job = renderQueue.shift();
         if (!job) return Promise.resolve(); // done
 
-        const { el, options, render, cls } = job;
+        const { el, options, render } = job;
         return pxt.runner.decompileToBlocksAsync(el.text(), options)
             .then((r) => {
-                try {
-                    render(el, r);
-                } catch (e) {
-                    console.error('error while rendering ' + el.html())
-                    el.append($('<div/>').addClass("ui segment warning").text(e.message));
-                }
+                const errors = r.compileJS && r.compileJS.diagnostics && r.compileJS.diagnostics.filter(d => d.category == pxtc.DiagnosticCategory.Error);
+                if (errors && errors.length)
+                    errors.forEach(diag => pxt.reportError("docs.decompile", "" + diag.messageText, { "code": diag.code + "" }));
+                render(el, r);
+                el.removeClass("lang-shadow");
+                return consumeRenderQueueAsync();
+            }, e => {
+                pxt.reportException(e);
+                el.append($('<div/>').addClass("ui segment warning").text(e.message));
                 el.removeClass("lang-shadow");
                 return consumeRenderQueueAsync();
             });
@@ -191,7 +193,7 @@ namespace pxt.runner {
         if (!options.layout) options.layout = pxt.blocks.BlockLayout.Align;
         options.splitSvg = true;
 
-        renderQueue.push({ el: $el, source: $el.text(), options, render, cls });
+        renderQueue.push({ el: $el, source: $el.text(), options, render });
         $el.addClass("lang-shadow");
         $el.removeClass(cls);
         return renderNextSnippetAsync(cls, render, options);
@@ -287,7 +289,7 @@ namespace pxt.runner {
                     try {
                         render($el, r);
                     } catch (e) {
-                        console.error('error while rendering ' + $el.html())
+                        pxt.reportException(e)
                         $el.append($('<div/>').addClass("ui segment warning").text(e.message));
                     }
                     $el.removeClass(cls);
@@ -602,6 +604,7 @@ namespace pxt.runner {
                             })
                             .catch(e => {
                                 // swallow
+                                pxt.reportException(e);
                                 pxt.debug(`failed to load repo ${card.url}`)
                             })
                     }
@@ -626,7 +629,7 @@ namespace pxt.runner {
             if (!Array.isArray(js)) js = [js];
             cards = js as pxt.CodeCard[];
         } catch (e) {
-            console.error('error while rendering ' + $el.html())
+            pxt.reportException(e);
             $el.append($('<div/>').addClass("ui segment warning").text(e.messageText));
         }
 
@@ -711,6 +714,7 @@ namespace pxt.runner {
     }
 
     export function renderAsync(options?: ClientRenderOptions): Promise<void> {
+        pxt.analytics.enable();
         if (!options) options = {}
         if (options.pxtUrl) options.pxtUrl = options.pxtUrl.replace(/\/$/, '');
         if (options.showEdit) options.showEdit = !pxt.BrowserUtils.isIFrame();

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -173,7 +173,7 @@ namespace pxt.runner {
                 render(el, r);
                 el.removeClass("lang-shadow");
                 return consumeRenderQueueAsync();
-            }, e => {
+            }).catch(e => {
                 pxt.reportException(e);
                 el.append($('<div/>').addClass("ui segment warning").text(e.message));
                 el.removeClass("lang-shadow");


### PR DESCRIPTION
I've noticed that we do not get reports when our documentation pages fail to render snippets. In fact, we don't get any analytics at all because AI is not properly initialized.

- [x] properly initialize AI in docs pages
- [x] report all errors through AI

@abchatra i don't think this will mess up your stats but please double check.