### PR TITLE
force csv, txt, hex to download

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -477,9 +477,10 @@ namespace pxt.docs {
         renderer.link = function (href: string, title: string, text: string) {
             const relative = href.indexOf('/') == 0;
             const target = !relative ? '_blank' : '';
+            const download = /\.(hex|csv|txt)$/.test(href); // some known file extension need the download attribute
             if (relative && d.versionPath) href = `/${d.versionPath}${href}`;
             const html = linkRenderer.call(renderer, href, title, text);
-            return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} rel="nofollow noopener" `);
+            return html.replace(/^<a /, `<a ${target ? `target="${target}"` : ''} ${download ? "download" : ""} rel="nofollow noopener" `);
         };
         markedInstance.setOptions({
             renderer: renderer,


### PR DESCRIPTION
we need to add a "download" attribute to force .hex file direct downloads. This needs to go in the backend asap.