### PR TITLE
We don't need to trigger an undo when the editor disables a block

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -975,11 +975,14 @@ namespace pxt.blocks {
         initDebugger();
         initComments();
 
-        // PXT is in charge of disabling, don't trigger events when we disable
-        (Blockly.Block as any).prototype.setDisabled = function(disabled: boolean) {
+        // PXT is in charge of disabling, don't record undo for disabled events
+        (Blockly.Block as any).prototype.setDisabled = function(disabled: any) {
             if (this.disabled != disabled) {
-                // Blockly.Events.fire(new Blockly.Events.BlockChange(
-                //     this, 'disabled', null, this.disabled, disabled));
+                let oldRecordUndo = (Blockly as any).Events.recordUndo;
+                (Blockly as any).Events.recordUndo = false;
+                Blockly.Events.fire(new Blockly.Events.BlockChange(
+                    this, 'disabled', null, this.disabled, disabled));
+                (Blockly as any).Events.recordUndo = oldRecordUndo;
                 this.disabled = disabled;
             }
         };

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -974,6 +974,15 @@ namespace pxt.blocks {
         initDrag();
         initDebugger();
         initComments();
+
+        // PXT is in charge of disabling, don't trigger events when we disable
+        (Blockly.Block as any).prototype.setDisabled = function(disabled: boolean) {
+            if (this.disabled != disabled) {
+                // Blockly.Events.fire(new Blockly.Events.BlockChange(
+                //     this, 'disabled', null, this.disabled, disabled));
+                this.disabled = disabled;
+            }
+        };
     }
 
     function setBuiltinHelpInfo(block: any, id: string) {


### PR DESCRIPTION
PXT is in charge of disabling, we shouldn't trigger record undo when disabling a block. 

PR is into stable, will cherry-pick to master once it's in.