### PR TITLE
Support HSV colors

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -327,7 +327,7 @@ namespace pxt.blocks {
     }
 
     export function createFlyoutHeadingLabel(name: string, color?: string, icon?: string, iconClass?: string) {
-        const headingLabel = createFlyoutLabel(name, color, icon, iconClass);
+        const headingLabel = createFlyoutLabel(name, pxt.toolbox.convertColor(color), icon, iconClass);
         headingLabel.setAttribute('web-class', 'blocklyFlyoutHeading');
         return headingLabel;
     }
@@ -349,7 +349,7 @@ namespace pxt.blocks {
         let headingLabel = goog.dom.createDom('label') as HTMLElement;
         headingLabel.setAttribute('text', name);
         if (color) {
-            headingLabel.setAttribute('web-icon-color', color);
+            headingLabel.setAttribute('web-icon-color', pxt.toolbox.convertColor(color));
         }
         if (icon) {
             if (icon.length === 1) {

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -91,8 +91,6 @@ namespace pxt.toolbox {
         const hue = parseInt(colour);
         if (!isNaN(hue)) {
             return hueToRgb(hue);
-        } else {
-            return colour;
         }
         return colour;
     }
@@ -125,36 +123,36 @@ namespace pxt.toolbox {
             let val3 = brightness * (1 - (s * (1 - remainder)));
             switch (sextant) {
                 case 1:
-                red = val2;
-                green = brightness;
-                blue = val1;
-                break;
+                    red = val2;
+                    green = brightness;
+                    blue = val1;
+                    break;
                 case 2:
-                red = val1;
-                green = brightness;
-                blue = val3;
-                break;
+                    red = val1;
+                    green = brightness;
+                    blue = val3;
+                    break;
                 case 3:
-                red = val1;
-                green = val2;
-                blue = brightness;
-                break;
+                    red = val1;
+                    green = val2;
+                    blue = brightness;
+                    break;
                 case 4:
-                red = val3;
-                green = val1;
-                blue = brightness;
-                break;
+                    red = val3;
+                    green = val1;
+                    blue = brightness;
+                    break;
                 case 5:
-                red = brightness;
-                green = val1;
-                blue = val2;
-                break;
+                    red = brightness;
+                    green = val1;
+                    blue = val2;
+                    break;
                 case 6:
                 case 0:
-                red = brightness;
-                green = val3;
-                blue = val1;
-                break;
+                    red = brightness;
+                    green = val3;
+                    blue = val1;
+                    break;
             }
         }
         return [Math.floor(red), Math.floor(green), Math.floor(blue)];

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -90,10 +90,79 @@ namespace pxt.toolbox {
     export function convertColor(colour: string): string {
         const hue = parseInt(colour);
         if (!isNaN(hue)) {
-            console.error('hue style color not supported anymore, use #rrggbb')
+            return hueToRgb(hue);
+        } else {
+            return colour;
         }
-        // TODO: HSV support
         return colour;
+    }
+
+    export function hueToRgb(hue: number) {
+        const HSV_SATURATION = 0.45;
+        const HSV_VALUE = 0.65 * 255;
+        const rgbArray = hsvToRgb(hue, HSV_SATURATION, HSV_VALUE);
+        return `#${componentToHex(rgbArray[0])}${componentToHex(rgbArray[1])}${componentToHex(rgbArray[2])}`;
+    }
+
+    /**
+     * Converts an HSV triplet to an RGB array.  V is brightness because b is
+     *   reserved for blue in RGB.
+     * Closure's HSV to RGB function: https://github.com/google/closure-library/blob/master/closure/goog/color/color.js#L613
+     */
+    function hsvToRgb(h: number, s: number, brightness: number) {
+        let red = 0;
+        let green = 0;
+        let blue = 0;
+        if (s == 0) {
+            red = brightness;
+            green = brightness;
+            blue = brightness;
+        } else {
+            let sextant = Math.floor(h / 60);
+            let remainder = (h / 60) - sextant;
+            let val1 = brightness * (1 - s);
+            let val2 = brightness * (1 - (s * remainder));
+            let val3 = brightness * (1 - (s * (1 - remainder)));
+            switch (sextant) {
+                case 1:
+                red = val2;
+                green = brightness;
+                blue = val1;
+                break;
+                case 2:
+                red = val1;
+                green = brightness;
+                blue = val3;
+                break;
+                case 3:
+                red = val1;
+                green = val2;
+                blue = brightness;
+                break;
+                case 4:
+                red = val3;
+                green = val1;
+                blue = brightness;
+                break;
+                case 5:
+                red = brightness;
+                green = val1;
+                blue = val2;
+                break;
+                case 6:
+                case 0:
+                red = brightness;
+                green = val3;
+                blue = val1;
+                break;
+            }
+        }
+        return [Math.floor(red), Math.floor(green), Math.floor(blue)];
+    }
+
+    function componentToHex(c: number) {
+        const hex = c.toString(16);
+        return hex.length == 1 ? "0" + hex : hex;
     }
 
     export function fadeColor(hex: string, luminosity: number, lighten: boolean): string {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1208,7 +1208,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             labelIcon.className = `monacoFlyoutHeadingIcon blocklyTreeIcon ${iconClass}`;
             labelIcon.setAttribute('role', 'presentation');
             labelIcon.style.display = 'inline-block';
-            labelIcon.style.color = `${iconColor}`;
+            labelIcon.style.color = `${pxt.toolbox.convertColor(iconColor)}`;
             if (icon.length === 1) {
                 labelIcon.textContent = icon;
             }
@@ -1345,6 +1345,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             .replace(/(?:\{\{)|(?:\}\})/g, '');
 
         monacoBlock.title = comment;
+
+        color = pxt.toolbox.convertColor(color);
 
         if (!isDisabled) {
             monacoBlock.draggable = true;


### PR DESCRIPTION
When we did the delay loading work for Blockly https://github.com/Microsoft/pxt/pull/4976/files
we stopped supporting HSV values as a color value for namespace / block colors. 

This brings back that support. 
Fixes https://github.com/Microsoft/pxt-microbit/issues/1604