### PR TITLE
Fix note picker editing on Android

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -559,7 +559,7 @@ declare namespace Blockly {
         updateEditable(): void;
         dispose(): void;
         render_(): void;
-        showEditor_(): void;
+        showEditor_(e?: Event): void;
         getAbsoluteXY_(): goog.math.Coordinate;
         getScaledBBox_(): {top: number, bottom: number, left: number, right: number};
         setValue(newValue: string | number): void;

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -415,7 +415,7 @@ namespace pxtblockly {
         /**
          * Create a piano under the note field.
          */
-        showEditor_(opt_quietInput?: boolean): void {
+        showEditor_(e: Event): void {
             this.updateColor();
 
             // If there is an existing drop-down someone else owns, hide it immediately and clear it.
@@ -427,7 +427,10 @@ namespace pxtblockly {
             //  change Note name to number frequency
             Blockly.FieldNumber.prototype.setText.call(this, this.getText());
 
-            FieldNote.superClass_.showEditor_.call(this, true);
+            const quietInput = (goog.userAgent.MOBILE || goog.userAgent.ANDROID ||
+                goog.userAgent.IPAD);
+            const readOnly = quietInput;
+            FieldNote.superClass_.showEditor_.call(this, e, false, readOnly);
 
             let pianoWidth: number;
             let pianoHeight: number;
@@ -460,7 +463,6 @@ namespace pxtblockly {
                 pianoHeight = keyHeight + labelHeight + prevNextHeight;
             }
             //  Check if Mobile, pagination -> true
-            let quietInput = opt_quietInput || false;
             if (!quietInput && (goog.userAgent.MOBILE || goog.userAgent.ANDROID)) {
                 pagination = true;
                 mobile = true;


### PR DESCRIPTION
This change makes it so the note picker on touch devices doesn't focus on the text field and instead makes it readonly. ie: we're only able to edit the note picker using the field editor. 
