### PR TITLE
Fix group help callback identifier

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1143,9 +1143,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     protected showFlyoutGroupLabel(group: string, groupicon: string, labelLineWidth: string, helpCallback: string) {
         let groupLabel = pxt.blocks.createFlyoutGroupLabel(pxt.Util.rlf(`{id:group}${group}`),
-            groupicon, labelLineWidth, helpCallback ? `GROUP_HELP_${helpCallback}` : undefined);
+            groupicon, labelLineWidth, helpCallback ? `GROUP_HELP_${group}` : undefined);
         if (helpCallback) {
-            this.editor.registerButtonCallback(`GROUP_HELP_${helpCallback}`, (/*btn*/) => {
+            this.editor.registerButtonCallback(`GROUP_HELP_${group}`, (/*btn*/) => {
                 this.helpButtonCallback(group);
             })
         }


### PR DESCRIPTION
Use the group id as an identifier instead of the help callback content. 

Fixes issue run into when using the helpcallback authoring of "true" as described in this sample: 
https://github.com/playi/pxt-wonder/pull/351

Related https://github.com/playi/pxt-wonder/pull/355

Note: this is going into stable4.5 and will cherry-pick to master.