### PR TITLE
Get build working on Node 6 for WW

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -168,7 +168,7 @@ interface KeyTar {
 }
 
 function requireKeyTar(install = false): Promise<KeyTar> {
-    return Promise.resolve(nodeutil.lazyRequire("keytar", install) as KeyTar);
+    return Promise.resolve(undefined); //resolve(nodeutil.lazyRequire("keytar", install) as KeyTar);
 }
 
 function passwordGetAsync(account: string): Promise<string> {


### PR DESCRIPTION
@pelikhan Just removing the require for keytar on stable4.5 so that it builds for WW.

This is a hack, and we should go through the CLI and remove keytar properly, but this gets the build working on Node 6.