### PR TITLE
Fix help button callback click on Edge

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -92,7 +92,7 @@ text.blocklyText.blocklyBoldItalicizedText {
 *******************************/
 
 .blocklyFlyoutButton {
-    fill: none !important;
+    fill: transparent !important;
 }
 
 .blocklyFlyoutButton:hover {


### PR DESCRIPTION
There's an issue on Edge where if the blockFlyoutButton image has a fill of none. It doesn't attach clicks to it, so clicking on it doesn't work. Making the fill transparent instead. 

I've tested this on WW and micro:bit.
This doesn't seem to current flyout buttons as they have content inside of them whereas the help button only has an image tag instead of it.

Note: cherry pick to master.