### PR TITLE
Make the serial back button a normal button

### DIFF
--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -422,7 +422,7 @@ export class Editor extends srceditor.Editor {
                 <div id="serialHeader" className="ui serialHeader">
                     <div className="leftHeaderWrapper">
                         <div className="leftHeader">
-                            <sui.Button className="back-button" title={lf("Go back")} tabIndex={0} onClick={this.goBack} onKeyDown={sui.fireClickOnEnter}>
+                            <sui.Button title={lf("Go back")} tabIndex={0} onClick={this.goBack} onKeyDown={sui.fireClickOnEnter}>
                                 <sui.Icon icon="arrow left" />
                                 <span className="ui text landscape only">{lf("Go back")}</span>
                             </sui.Button>


### PR DESCRIPTION
Today the serial back button is a custom button that is hard to maintain across targets with light and dark themes. There's not much value in that transparent background, so let's just make it a normal button. 
Here's what it currently looks like, and below is the proposal: 
![screen shot 2018-11-13 at 7 38 40 pm](https://user-images.githubusercontent.com/16690124/48458592-d710db80-e77b-11e8-9d8e-5cf518e62995.png)

This fixes the following issues: 
Fixes https://github.com/Microsoft/pxt-adafruit/issues/843
Fixes https://github.com/Microsoft/pxt-adafruit/issues/724

Here's what it looks like on microbit, adafruit and high contrast: 
![screen shot 2018-11-13 at 7 37 12 pm](https://user-images.githubusercontent.com/16690124/48458517-93b66d00-e77b-11e8-9001-4c29c8d7eaf2.png)
![screen shot 2018-11-13 at 7 35 27 pm](https://user-images.githubusercontent.com/16690124/48458518-93b66d00-e77b-11e8-8546-ada46405ef2f.png)
![screen shot 2018-11-13 at 7 35 22 pm](https://user-images.githubusercontent.com/16690124/48458519-93b66d00-e77b-11e8-87fe-e37e0be88193.png)
