### PR TITLE
Fix import project filters

### DIFF
--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -56,7 +56,7 @@
             }
         }
         var lastSaved;
-        var filter = true;
+        var filter = false;
 
         function toggleFilters() {
             filter = !filter;
@@ -78,7 +78,7 @@
             if(action == 'importproject') {
                 var prj = JSON.parse(JSON.stringify(projects[0]));
                 msg.project = prj;
-                if (filter) msg.filters = JSON.parse(JSON.stringify(filters));
+                msg.filters = filter ? JSON.parse(JSON.stringify(filters)) : {};
                 msg.response = true;
             } else if (action == 'renderblocks') {
                 msg.response = true;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -851,7 +851,12 @@ export class ProjectView
         this.stopSimulator(true);
         this.clearSerial()
 
-        Util.jsonMergeFrom(editorState || {}, this.state.editorState || {});
+        let oldEditorState = this.state.editorState;
+        if (oldEditorState) {
+            if (editorState.filters === undefined) editorState.filters = oldEditorState.filters;
+            if (editorState.hasCategories === undefined) editorState.hasCategories = oldEditorState.hasCategories;
+            if (editorState.searchBar === undefined) editorState.searchBar = oldEditorState.searchBar;
+        }
 
         return (h.backupRef ? workspace.restoreFromBackupAsync(h) : Promise.resolve())
             .then(() => pkg.loadPkgAsync(h.id))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -851,6 +851,7 @@ export class ProjectView
         this.stopSimulator(true);
         this.clearSerial()
 
+        // Merge current and new state but only if the new state members are undefined
         let oldEditorState = this.state.editorState;
         if (oldEditorState) {
             if (editorState.filters === undefined) editorState.filters = oldEditorState.filters;


### PR DESCRIPTION
There were issues reported regarding updating filters with our editor controller command "importproject".

We were merging any filters sent through importproject with the current ones set in the state. This isn't quite the desired behaviour here as what we want is any new filters to replace the current onces. 
I've added the logic to do that instead.

I've made a fix to the controller.html to make testing filters easier. 

https://github.com/playi/pxt-wonder/issues/352