### PR TITLE
disable events while loading blockly DOMs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,15 @@
         "@types/react": "16.0.25"
       }
     },
+    "@types/react-tooltip": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/react-tooltip/-/react-tooltip-3.3.6.tgz",
+      "integrity": "sha512-zgWlNrRGqhHotsqwQSIXeBxLI01OXp5dq1hxpzjnjHE4XwqY6r8KGWAO+HvMxKercqhrGG5nW1VJY70mQ5jL3Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "16.0.25"
+      }
+    },
     "@types/request": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.0.8.tgz",
@@ -1119,6 +1128,12 @@
         "chalk": "1.1.3"
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -1760,10 +1775,53 @@
         "void-elements": "2.0.1"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.2"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
     },
     "double-ended-queue": {
       "version": "2.0.0-0",
@@ -1897,6 +1955,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
     "envify": {
@@ -3464,6 +3528,42 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
+    },
+    "htmlparser2": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+      "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.2",
+        "domutils": "1.7.0",
+        "entities": "1.1.2",
+        "inherits": "2.0.3",
+        "readable-stream": "3.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "http-errors": {
       "version": "1.6.3",
@@ -7309,6 +7409,17 @@
         "warning": "3.0.0"
       }
     },
+    "react-tooltip": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.9.0.tgz",
+      "integrity": "sha512-vpn738FVv2oe2LzdwUchped3WqLgZSQwrBow+ceChS1+lFEJBPjOa9KD3JH/L/s0Aorxawi3A20qBcHX7vqaag==",
+      "dev": true,
+      "requires": {
+        "classnames": "2.2.6",
+        "prop-types": "15.6.1",
+        "sanitize-html-react": "1.13.0"
+      }
+    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -7448,6 +7559,12 @@
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
+    },
+    "regexp-quote": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
+      "integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI=",
+      "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -7599,6 +7716,17 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sanitize-html-react": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html-react/-/sanitize-html-react-1.13.0.tgz",
+      "integrity": "sha1-51e5rbryyKdi89Lf9wE4g44FQgo=",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "3.10.0",
+        "regexp-quote": "0.0.0",
+        "xtend": "4.0.1"
+      }
     },
     "sax": {
       "version": "1.2.4",

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -2,6 +2,22 @@
 /// <reference path="../built/pxtlib.d.ts" />
 
 namespace pxt.blocks {
+
+    /**
+     * Converts a DOM into workspace without triggering any Blockly event
+     * @param dom 
+     * @param workspace 
+     */
+    export function domToWorkspaceNoEvents(dom: Element, workspace: Blockly.Workspace): string[] {
+        pxt.tickEvent(`blocks.domtow`)
+        try {
+            Blockly.Events.disable();
+            return Blockly.Xml.domToWorkspace(dom, workspace);
+        } finally {
+            Blockly.Events.enable();
+        }
+    }
+
     export function saveWorkspaceXml(ws: Blockly.Workspace): string {
         let xml = Blockly.Xml.workspaceToDom(ws, true);
         let text = Blockly.Xml.domToPrettyText(xml);
@@ -39,7 +55,7 @@ namespace pxt.blocks {
         const workspace = new Blockly.Workspace();
         try {
             const dom = Blockly.Xml.textToDom(xml);
-            Blockly.Xml.domToWorkspace(dom, workspace);
+            pxt.blocks.domToWorkspaceNoEvents(dom, workspace);
             return workspace;
         } catch (e) {
             if (!skipReport)

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -18,6 +18,18 @@ namespace pxt.blocks {
         }
     }
 
+    export function clearWithoutEvents(workspace: Blockly.Workspace) {
+        pxt.tickEvent(`blocks.clear`)
+        if (!workspace) return;
+        try {
+            Blockly.Events.disable();
+            workspace.clear();
+            workspace.clearUndo();
+        } finally {
+            Blockly.Events.enable();
+        }
+    }
+
     export function saveWorkspaceXml(ws: Blockly.Workspace): string {
         let xml = Blockly.Xml.workspaceToDom(ws, true);
         let text = Blockly.Xml.domToPrettyText(xml);

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -446,21 +446,6 @@ namespace pxt.blocks {
         return block;
     }
 
-    function createCategoryElement(name: string, nameid: string, weight: number, colour?: string, iconClass?: string): Element {
-        const result = document.createElement("category");
-        result.setAttribute("name", name);
-        result.setAttribute("nameid", nameid.toLowerCase());
-        result.setAttribute("weight", weight.toString());
-        if (colour) {
-            result.setAttribute("colour", colour);
-        }
-        if (iconClass) {
-            result.setAttribute("iconclass", iconClass);
-            result.setAttribute("expandedclass", iconClass);
-        }
-        return result;
-    }
-
     export function injectBlocks(blockInfo: pxtc.BlocksInfo): pxtc.SymbolInfo[] {
         // inject Blockly with all block definitions
         return blockInfo.blocks
@@ -2251,7 +2236,7 @@ namespace pxt.blocks {
                         field.appendChild(document.createTextNode(this.getProcedureCall()));
                         block.appendChild(field);
                         xml.appendChild(block);
-                        Blockly.Xml.domToWorkspace(xml, this.workspace);
+                        pxt.blocks.domToWorkspaceNoEvents(xml, this.workspace);
                         Blockly.Events.setGroup(false);
                     }
                 } else if (event.type == Blockly.Events.DELETE) {
@@ -2342,7 +2327,7 @@ namespace pxt.blocks {
                 field.appendChild(document.createTextNode(name));
                 block.appendChild(field);
                 xml.appendChild(block);
-                let newBlockIds = Blockly.Xml.domToWorkspace(xml, workspace);
+                let newBlockIds = pxt.blocks.domToWorkspaceNoEvents(xml, workspace);
                 // Close flyout and highlight block
                 Blockly.hideChaff();
                 let newBlock = workspace.getBlockById(newBlockIds[0]);

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -46,10 +46,7 @@ namespace pxt.blocks {
         try {
             let text = blocksXml || `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`;
             let xml = Blockly.Xml.textToDom(text);
-            Blockly.Events.disable();
-            Blockly.Xml.domToWorkspace(xml, workspace);
-            Blockly.Events.enable();
-
+            pxt.blocks.domToWorkspaceNoEvents(xml, workspace);
             const layout = options.splitSvg ? BlockLayout.Align : options.layout;
             switch (layout) {
                 case BlockLayout.Align:

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -42,7 +42,7 @@ namespace pxt.blocks {
             });
         }
 
-        workspace.clear();
+        pxt.blocks.clearWithoutEvents(workspace);
         try {
             let text = blocksXml || `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`;
             let xml = Blockly.Xml.textToDom(text);

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -210,8 +210,7 @@ function blockTestAsync(name: string) {
             const workspace = new Blockly.Workspace();
             (Blockly as any).mainWorkspace = workspace;
             const xml = Blockly.Xml.textToDom(blocksFile);
-            Blockly.Xml.domToWorkspace(xml, workspace);
-
+            pxt.blocks.domToWorkspaceNoEvents(xml, workspace);
             return pxt.blocks.compileAsync(workspace, blocksInfo)
         }, err => fail(`Unable to get block info: ` + JSON.stringify(err)))
         .then((res: pxt.blocks.BlockCompilationResult) => {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -138,7 +138,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
 
         this.typeScriptSaveable = false;
-        this.editor.clear();
+        pxt.blocks.clearWithoutEvents(this.editor);
         try {
             const text = s || `<block type="${ts.pxtc.ON_START_TYPE}"></block>`;
             const xml = Blockly.Xml.textToDom(text);
@@ -151,7 +151,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.typeScriptSaveable = true;
         } catch (e) {
             pxt.log(e);
-            this.editor.clear();
+            pxt.blocks.clearWithoutEvents(this.editor);
             this.switchToTypeScript();
             this.changeCallback();
             return false;
@@ -623,8 +623,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.typeScriptSaveable = false;
                 this.setDiagnostics(file)
                 this.delayLoadXml = file.content;
-                this.editor.clear();
-                this.editor.clearUndo();
+                pxt.blocks.clearWithoutEvents(this.editor);
                 this.closeFlyout();
 
                 if (this.currFile && this.currFile != file) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -142,7 +142,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         try {
             const text = s || `<block type="${ts.pxtc.ON_START_TYPE}"></block>`;
             const xml = Blockly.Xml.textToDom(text);
-            Blockly.Xml.domToWorkspace(xml, this.editor);
+            pxt.blocks.domToWorkspaceNoEvents(xml, this.editor);
 
             this.initLayout();
             this.editor.clearUndo();

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -313,7 +313,7 @@ function upgradeFromBlocksAsync(): Promise<UpgradeResult> {
             const text = pxt.blocks.importXml(targetVersion, fileText, info, true);
 
             const xml = Blockly.Xml.textToDom(text);
-            Blockly.Xml.domToWorkspace(xml, ws);
+            pxt.blocks.domToWorkspaceNoEvents(xml, ws);
             patchedFiles["main.blocks"] = text;
             return pxt.blocks.compileAsync(ws, info)
         })


### PR DESCRIPTION
Disable events while converting DOM into blockly workspace to avoid polluting data with "automatically" generated events.
* disable during load (generate create events)
* disable during clear (generates delete events)
* Tested that `create` event