### PR TITLE
Don't log Blockly events when converting from XML to DOM

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -38,8 +38,10 @@ namespace pxt.blocks {
     export function loadWorkspaceXml(xml: string, skipReport = false) {
         const workspace = new Blockly.Workspace();
         try {
+            Blockly.Events.disable();
             const dom = Blockly.Xml.textToDom(xml);
             Blockly.Xml.domToWorkspace(dom, workspace);
+            Blockly.Events.enable();
             return workspace;
         } catch (e) {
             if (!skipReport)

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -142,7 +142,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         try {
             const text = s || `<block type="${ts.pxtc.ON_START_TYPE}"></block>`;
             const xml = Blockly.Xml.textToDom(text);
+            Blockly.Events.disable();
             Blockly.Xml.domToWorkspace(xml, this.editor);
+            Blockly.Events.enable();
 
             this.initLayout();
             this.editor.clearUndo();

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -313,7 +313,9 @@ function upgradeFromBlocksAsync(): Promise<UpgradeResult> {
             const text = pxt.blocks.importXml(targetVersion, fileText, info, true);
 
             const xml = Blockly.Xml.textToDom(text);
+            Blockly.Events.disable();
             Blockly.Xml.domToWorkspace(xml, ws);
+            Blockly.Events.enable();
             patchedFiles["main.blocks"] = text;
             return pxt.blocks.compileAsync(ws, info)
         })


### PR DESCRIPTION
Blockly logs a BlockCreate event for Top level blocks only (on start, events, forever, etc) when it's converting from XML to DOM. 
I'm not 100% sure why, I'll ask when I get a chance, but I'm sure they have a good reason for it. 

There's no reason for us to have Blockly events turned on as we are converting from xml to dom. ie: when we're loading a project (whether it's a previous script or a shared script), and when we're converting from our decompiled xml to blocks (ie: converting from TS to Blocks).

I've turned off events here when we're doing that conversion. 