### PR TITLE
Fix decompilation of numbers with sliders.

### DIFF
--- a/tests/decompile-test/baselines/custom_field_editors.blocks
+++ b/tests/decompile-test/baselines/custom_field_editors.blocks
@@ -1,34 +1,44 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
-<block type="pxt-on-start">
-<statement name="HANDLER">
-<block type="test_customFieldEditor">
-<value name="value">
-<shadow type="test_customShadowField">
-<field name="value">100</field>
-</shadow>
-</value>
-<next>
-<block type="test_customFieldEditorWithMutation">
-<value name="value">
-<shadow type="test_customShadowField">
-<mutation customfield="&#123;&#34;test&#34;&#58;&#34;0&#34;&#125;" />
-<field name="value">100</field>
-</shadow>
-</value>
-<next>
-<block type="test_customFieldEditorOnParentBlock">
-<field name="value">100</field>
-<next>
-<block type="test_customTextFieldEditorOnParentBlock">
-<field name="text">text</field>
-</block>
-</next>
-</block>
-</next>
-</block>
-</next>
-<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
-</block>
-</statement>
-</block>
-</xml>
+    <block type="pxt-on-start">
+    <statement name="HANDLER">
+    <block type="test_sliderFieldEditor">
+    <value name="value">
+    <shadow type="math_number_minmax">
+    <mutation min="0" max="500" />
+    <field name="SLIDER">10</field>
+    </shadow>
+    </value>
+    <next>
+    <block type="test_customFieldEditor">
+    <value name="value">
+    <shadow type="test_customShadowField">
+    <field name="value">100</field>
+    </shadow>
+    </value>
+    <next>
+    <block type="test_customFieldEditorWithMutation">
+    <value name="value">
+    <shadow type="test_customShadowField">
+    <mutation customfield="&#123;&#34;test&#34;&#58;&#34;0&#34;&#125;" />
+    <field name="value">100</field>
+    </shadow>
+    </value>
+    <next>
+    <block type="test_customFieldEditorOnParentBlock">
+    <field name="value">100</field>
+    <next>
+    <block type="test_customTextFieldEditorOnParentBlock">
+    <field name="text">text</field>
+    </block>
+    </next>
+    </block>
+    </next>
+    </block>
+    </next>
+    </block>
+    </next>
+    <comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;basic.ts&#34; &#47;&#62;</comment>
+    </block>
+    </statement>
+    </block>
+    </xml>

--- a/tests/decompile-test/cases/custom_field_editors.ts
+++ b/tests/decompile-test/cases/custom_field_editors.ts
@@ -1,5 +1,7 @@
 /// <reference path="./testBlocks/basic.ts" />
 
+testNamespace.sliderFieldEditor(10);
+
 testNamespace.customFieldEditor(100);
 
 testNamespace.customFieldEditorWithMutation(100);

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -169,6 +169,10 @@ namespace testNamespace {
      * Field Editors
      */
 
+    //% blockId=test_sliderFieldEditor block="%value"
+    //% value.min=0 value.max=500
+    export function sliderFieldEditor(value: number): void {  }
+
     //% blockId=test_customFieldEditor block="%value=test_customShadowField"
     export function customFieldEditor(value: number): void {  }
 


### PR DESCRIPTION
Not sure how we haven't noticed this but we never did the work to decompile a number parameter that has min and max defined into a math_number_minmax (ie: a block with a slider field). 

If you try out any shared script that has a block with a slider, it won't work. You'll decompile to number without the slider field. 
Same for typescript to block conversion with any slider field. 

This fixes that, decompiles a number parameter where min and max are defined into a math_number_minmax and sets the correct mutation on that shadow. 

Also added / fixed decompile tests.
Ran decompilation tests and they're all passing. Verified locally with Typescript to Blocks conversion.