### PR TITLE
Disable ok button when no text is entered in prompt

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2231,7 +2231,7 @@ export class ProjectView
             header: lf("Rename your project"),
             agreeLbl: lf("Save"),
             agreeClass: "green",
-            defaultValue: lf("Enter your project name here")
+            placeholder: lf("Enter your project name here")
         };
         return core.promptAsync(opts).then(res => {
             if (res === null) return Promise.resolve(false); // null means cancelled, empty string means ok (but no value entered)

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -266,7 +266,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         Blockly.prompt = function (message, defaultValue, callback) {
             return core.promptAsync({
                 header: message,
-                defaultValue: defaultValue,
+                initialValue: defaultValue,
                 agreeLbl: lf("Ok"),
                 disagreeLbl: lf("Cancel"),
                 size: "tiny"

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -138,7 +138,9 @@ export interface ConfirmOptions extends DialogOptions {
 }
 
 export interface PromptOptions extends ConfirmOptions {
-    defaultValue: string;
+    initialValue?: string;
+    placeholder?: string;
+    onInputChanged?: (newValue?: string) => void;
 }
 
 export interface DialogOptions {
@@ -190,6 +192,7 @@ export function confirmAsync(options: ConfirmOptions): Promise<number> {
             label: options.agreeLbl || lf("Go ahead!"),
             className: options.agreeClass,
             icon: options.agreeIcon || "checkmark",
+            approveButton: true,
             onclick: () => {
                 result = 1;
             }
@@ -229,18 +232,17 @@ export function promptAsync(options: PromptOptions): Promise<string> {
     options.type = 'prompt';
     if (!options.buttons) options.buttons = []
 
-    let result = "";
+    let result = options.initialValue || "";
     let cancelled: boolean = false;
+
+    options.onInputChanged = (v: string) => { result = v };
 
     if (!options.hideAgree) {
         options.buttons.push({
             label: options.agreeLbl || lf("Go ahead!"),
             className: options.agreeClass,
             icon: options.agreeIcon || "checkmark",
-            onclick: () => {
-                let dialogInput = document.getElementById('promptDialogInput') as HTMLInputElement;
-                result = dialogInput.value;
-            }
+            approveButton: true
         })
     }
 
@@ -256,21 +258,6 @@ export function promptAsync(options: PromptOptions): Promise<string> {
         });
         options.hideCancel = true;
     }
-
-    options.onLoaded = (ref: HTMLElement) => {
-        let dialogInput = document.getElementById('promptDialogInput') as HTMLInputElement;
-        if (dialogInput) {
-            dialogInput.setSelectionRange(0, 9999);
-            dialogInput.onkeyup = (e: KeyboardEvent) => {
-                const charCode = keyCodeFromEvent(e);
-                if (charCode === ENTER_KEY) {
-                    e.preventDefault();
-                    const firstButton = ref.getElementsByClassName("approve positive").item(0) as HTMLElement;
-                    if (firstButton) firstButton.click();
-                }
-            }
-        }
-    };
 
     return dialogAsync(options)
         .then(() => cancelled ? null : result);

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -3,20 +3,29 @@ import * as ReactDOM from "react-dom";
 import * as sui from "./sui";
 import * as core from "./core";
 
-export class CoreDialog extends React.Component<core.PromptOptions, {}> {
+interface CoreDialogState {
+    visible?: boolean;
+    inputValue?: string;
+}
+
+export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogState> {
 
     public promise: Promise<any>;
 
     private resolve: any;
     private reject: any;
 
+    private okButton: sui.ModalButton;
+
     constructor(props: core.PromptOptions) {
         super(props);
         this.state = {
+            inputValue: props.initialValue
         }
 
         this.hide = this.hide.bind(this);
         this.modalDidOpen = this.modalDidOpen.bind(this);
+        this.handleInputChange = this.handleInputChange.bind(this);
     }
 
     hide() {
@@ -54,13 +63,34 @@ export class CoreDialog extends React.Component<core.PromptOptions, {}> {
 
     modalDidOpen(ref: HTMLElement) {
         const options = this.props;
+        const dialogInput = this.refs['promptInput'] as HTMLInputElement;
+        if (dialogInput) {
+            dialogInput.setSelectionRange(0, 9999);
+            const that = this;
+            dialogInput.onkeydown = (e: KeyboardEvent) => {
+                const charCode = core.keyCodeFromEvent(e);
+                if (charCode === core.ENTER_KEY && that.okButton && dialogInput.value) {
+                    that.okButton.onclick();
+                    e.preventDefault();
+                }
+            }
+        }
         if (options.onLoaded) {
             options.onLoaded(ref);
         }
     }
 
+    handleInputChange(v: React.ChangeEvent<any>) {
+        const options = this.props;
+        if (options.onInputChanged) {
+            options.onInputChanged(v.target.value);
+        }
+        this.setState({ inputValue: v.target.value });
+    }
+
     render() {
         const options = this.props;
+        const { inputValue } = this.state;
         const size: any = options.size || 'small';
 
         const buttons = options.buttons ? options.buttons.filter(b => !!b) : [];
@@ -71,7 +101,9 @@ export class CoreDialog extends React.Component<core.PromptOptions, {}> {
                 this.close(onclick ? onclick() : 0);
             }
             if (!btn.className) btn.className = "approve positive";
+            if (btn.approveButton) this.okButton = btn;
         })
+        if (options.type == 'prompt' && this.okButton) this.okButton.disabled = !inputValue;
 
         const classes = sui.cx([
             'coredialog',
@@ -91,7 +123,7 @@ export class CoreDialog extends React.Component<core.PromptOptions, {}> {
                 modalDidOpen={this.modalDidOpen}
             >
                 {options.type == 'prompt' ? <div className="ui fluid icon input">
-                    <input autoFocus type="text" id="promptDialogInput" placeholder={options.defaultValue} />
+                    <input autoFocus type="text" ref="promptInput" onChange={this.handleInputChange} value={inputValue} placeholder={options.placeholder} />
                 </div> : undefined}
                 {options.jsx}
                 {options.body ? <p>{options.body}</p> : undefined}
@@ -131,7 +163,7 @@ export function renderConfirmDialogAsync(options: core.PromptOptions): Promise<v
 }
 
 export function hideDialog() {
-    if (currentDialog)  {
+    if (currentDialog) {
         currentDialog.hide();
         currentDialog = undefined;
     }

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -156,8 +156,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
     private addTypeScriptFile() {
         core.promptAsync({
             header: lf("Add new file?"),
-            body: lf("Please provide a name for your new file. The .ts extension will be added automatically. Don't use spaces or special characters."),
-            defaultValue: ""
+            body: lf("Please provide a name for your new file. The .ts extension will be added automatically. Don't use spaces or special characters.")
         }).then(str => {
             str = str || ""
             str = str.trim()

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -840,6 +840,8 @@ export interface ModalButton {
     url?: string;
     fileName?: string;
     loading?: boolean;
+    disabled?: boolean;
+    approveButton?: boolean;
 }
 
 export interface ModalProps extends ReactModal.Props {
@@ -1036,7 +1038,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
                                 key={`action_${action.label}`}
                                 icon={action.icon}
                                 text={action.label}
-                                className={`ui button approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""}`}
+                                className={`ui button approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""} ${action.disabled ? "disabled" : ""}`}
                                 href={action.url}
                                 target={!action.fileName ? '_blank' : undefined}
                                 download={action.fileName ? pxt.Util.htmlEscape(action.fileName) : undefined}
@@ -1064,7 +1066,8 @@ class ModalButtonElement extends data.PureComponent<ModalButton, {}> {
     }
 
     handleClick() {
-        this.props.onclick();
+        if (!this.props.disabled)
+            this.props.onclick();
     }
 
     renderCore() {
@@ -1072,7 +1075,7 @@ class ModalButtonElement extends data.PureComponent<ModalButton, {}> {
         return <Button
             icon={action.icon}
             text={action.label}
-            className={`approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""}`}
+            className={`approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""} ${action.disabled ? "disabled" : ""}`}
             onClick={this.handleClick}
             onKeyDown={fireClickOnEnter} />
     }


### PR DESCRIPTION
This applies to prompt such as "Make a Variable" and "Make a Function".

Refactor coretsx to handle it's own input and call handlers for when the input is changed. (more React like). 

- When in a prompt, disable the ok button if no input is entered. 
- In Blockly prompts use the default value as the initial value rather than a placeholder. see: https://github.com/Microsoft/pxt-adafruit/issues/869

@Jaqster as requested.