### PR TITLE
Fixed inline blocks coloring to reflect updated/overwritten colors

### DIFF
--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -3,7 +3,6 @@ namespace pxt.toolbox {
         loops: '#107c10',
         logic: '#006970',
         math: '#712672',
-        images: '#5C2D91',
         variables: '#A80000',
         functions: '#005a9e',
         text: '#996600',

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -334,7 +334,7 @@ namespace pxt.runner {
             })
             .then((nsStyleBuffer) => {
                 Object.keys(pxt.toolbox.blockColors).forEach((ns) => {
-                    const color = pxt.toolbox.blockColors[ns] as string;
+                    const color = pxt.toolbox.getNamespaceColor(ns);
                     nsStyleBuffer += `
                         span.docs.${ns.toLowerCase()} {
                             background-color: ${color} !important;


### PR DESCRIPTION
Fixes Microsoft/pxt-arcade#355

This removes images color from the toolbox colors. From what I can tell, it shouldn't be there since it isn't a default category, doesn't even have an icon, and is always defined elsewhere if used (micro:bit and arcade). Also, having it in here and defining it elsewhere was creating 2 conflicting css classes for inline blocks

This also changes the default category blocks to check what color they should be instead of just setting their value to their default color.