### PR TITLE
Don't mark the workspace as incomplete if the workspace is being dragged

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -348,7 +348,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private markIncomplete = false;
     isIncomplete() {
-        const incomplete = this.editor ? this.editor.isDragging()
+        const incomplete = this.editor ?
+            ((this.editor as any).currentGesture_ != null && (this.editor as any).currentGesture_.isDraggingBlock_)
             || (Blockly as any).WidgetDiv.isVisible()
             || (Blockly as any).DropDownDiv.isVisible() : false;
         if (incomplete) this.markIncomplete = true;


### PR DESCRIPTION
WW pointed out that if a user drags a block onto the workspace from the flyout and then immediately drags the workspace, we don't save. 

This is because we're marking the blocks editor as incomplete when a user is dragging, but that should only be the case if the user is dragging a block not the workspace. 
This adds a check for that instead. 

The code is a little ugly, I can add helper methods to check for is block dragging on the workspace in blockly later, but for now this works :)

https://github.com/playi/pxt-wonder/issues/359
note: Needs to be integrated to master.