### PR TITLE
Remove requestIdleCallback from home screen load

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3165,14 +3165,7 @@ document.addEventListener("DOMContentLoaded", () => {
             pxsim.U.remove(document.getElementById('loading'));
             return workspace.loadedAsync();
         })
-        .done(() => {
-            // preload delay loaded resources
-            if ((window as any).requestIdleCallback) {
-                (window as any).requestIdleCallback(() => {
-                    if (theEditor) theEditor.loadBlocklyAsync().done();
-                })
-            }
-        })
+        .done()
 
     document.addEventListener("visibilitychange", ev => {
         if (theEditor)


### PR DESCRIPTION
This change removes the requestIdleCallback in the home screen that was intended to load blockly when the editor had a chance to do so. 
In theory I agree with the incentive for this change, but it's not properly implemented. 

First of all, requestIdleCallback sends a deadline / time remaining parameter which is max 50ms, and you must complete your subtask within that deadline. The browser won't prevent you from exceeding it. In our case we always were, so it was the equivalent of adding loading Blockly into the critical path of the home screen (almost).

requestIdleCallback is meant to be used to complete subtasks, and there's no real way to chunk out loading of Blockly and injecting the Blockly workspace into < 50ms chunks, so I'm voting to remove this optimization attempt all together. 

To read up more about requestIdleCallback, see the FAQ here: https://developers.google.com/web/updates/2015/08/using-requestidlecallback
