### PR TITLE
Add redirect note for github auth blog

### DIFF
--- a/docs/blog/github-packages.md
+++ b/docs/blog/github-packages.md
@@ -2,6 +2,12 @@
 
 **Posted on August 1, 2018 by [mmoskal](https://github.com/mmoskal)**
 
+## ~ hint
+
+**Update**: This feature is now documented in [GitHub extension authoring](/extensions/github-authoring).
+
+## ~
+
 MakeCode is a platform with an easy level of entry, even for middle-schoolers, but allowing nearly unlimited creativity and complexity available to advanced users for writing programs in [TypeScript](https://www.typescriptlang.org/). Our [subset of TypeScript](https://makecode.com/language) supports most of the regular language features of TypeScript, but can be efficiently compiled to run on extremely resource constrained devices like the micro:bit (your phone literally has a _million times_ more available memory than a micro:bit!). In fact, most of the runtime libraries in our editors are implemented in Static TypeScript including all of the defined blocks. We also pack a [full-featured Monaco text editor](https://makecode.com/js/editor) into our web app.
 
 From the very beginning, we allowed extensions to our editor with [user-provided packages](/extensions/getting-started) hosted on GitHub. These packages can even introduce [their own user interface](/extensions/extensions) in the editor. Packages first need [approval](/extensions/approval) to surface in search but, unless they are banned, can be loaded without approval by providing an exact URL.

--- a/docs/extensions/github-authoring.md
+++ b/docs/extensions/github-authoring.md
@@ -32,13 +32,13 @@ When describing changes, you are also given an option to bump the version number
 
 ![Repo commit dialog](/static/extensions/repo-commit.png)
 
-There's really distinguishing between a commit, push, and pull - it all happens at once in the sync operation.
+There's really no distinguishing between a commit, push, and pull - it all happens at once in the sync operation.
 
 You can view a history of changes by following the version number link on the **Project Settings** page.
 
 ![Repo view link in project settings](/static/extensions/repo-view.png)
 
-There is also another button next to the GitHub sync - you can use it to add new files to the project. This is mostly to help keep the project organized. For the TypeScript compiler it doesn't matter if you use one big file or a bunch of smaller ones.
+There's also another button next to the GitHub sync - you can use it to add new files to the project. This is mostly to help keep the project organized. For the TypeScript compiler it doesn't matter if you use one big file or a bunch of smaller ones.
 
 ### Conflicts
 


### PR DESCRIPTION
- [x] Note added to the GitHub package authoring blog post as a hint to direct to the extension docs.
- [x] Couple of tiny edits to the migrated doc.

RE: https://github.com/Microsoft/pxt/pull/5032#issuecomment-440902158
