### PR TITLE
Move polyfil into pxtlib so it’s part of the runner.

### DIFF
--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1153,3 +1153,20 @@ __flash_checksums:
 
     }
 }
+
+// Inject Math imul polyfill
+if (!Math.imul) {
+    // for explanations see:
+    // http://stackoverflow.com/questions/3428136/javascript-integer-math-incorrect-results (second answer)
+    // (but the code below doesn't come from there; I wrote it myself)
+    // TODO use Math.imul if available
+    Math.imul = function (a: number, b: number): number {
+        const ah = (a >>> 16) & 0xffff;
+        const al = a & 0xffff;
+        const bh = (b >>> 16) & 0xffff;
+        const bl = b & 0xffff;
+        // the shift by 0 fixes the sign on the high part
+        // the final |0 converts the unsigned value into a signed value
+        return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0) | 0);
+    }
+}

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1153,20 +1153,3 @@ __flash_checksums:
 
     }
 }
-
-// Inject Math imul polyfill
-if (!Math.imul) {
-    // for explanations see:
-    // http://stackoverflow.com/questions/3428136/javascript-integer-math-incorrect-results (second answer)
-    // (but the code below doesn't come from there; I wrote it myself)
-    // TODO use Math.imul if available
-    Math.imul = function (a: number, b: number): number {
-        const ah = (a >>> 16) & 0xffff;
-        const al = a & 0xffff;
-        const bh = (b >>> 16) & 0xffff;
-        const bl = b & 0xffff;
-        // the shift by 0 fixes the sign on the high part
-        // the final |0 converts the unsigned value into a signed value
-        return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0) | 0);
-    }
-}

--- a/pxtlib/polyfill.ts
+++ b/pxtlib/polyfill.ts
@@ -1,0 +1,17 @@
+
+// Inject Math imul polyfill
+if (!Math.imul) {
+    // for explanations see:
+    // http://stackoverflow.com/questions/3428136/javascript-integer-math-incorrect-results (second answer)
+    // (but the code below doesn't come from there; I wrote it myself)
+    // TODO use Math.imul if available
+    Math.imul = function (a: number, b: number): number {
+        const ah = (a >>> 16) & 0xffff;
+        const al = a & 0xffff;
+        const bh = (b >>> 16) & 0xffff;
+        const bl = b & 0xffff;
+        // the shift by 0 fixes the sign on the high part
+        // the final |0 converts the unsigned value into a signed value
+        return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0) | 0);
+    }
+}

--- a/webapp/src/worker.ts
+++ b/webapp/src/worker.ts
@@ -8,22 +8,6 @@ importScripts("/blb/pxtworker.js");
 
 let pm: any = postMessage;
 
-if (!Math.imul) {
-    // for explanations see:
-    // http://stackoverflow.com/questions/3428136/javascript-integer-math-incorrect-results (second answer)
-    // (but the code below doesn't come from there; I wrote it myself)
-    // TODO use Math.imul if available
-    Math.imul = function (a: number, b: number): number {
-        const ah = (a >>> 16) & 0xffff;
-        const al = a & 0xffff;
-        const bh = (b >>> 16) & 0xffff;
-        const bl = b & 0xffff;
-        // the shift by 0 fixes the sign on the high part
-        // the final |0 converts the unsigned value into a signed value
-        return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0) | 0);
-    }
-}
-
 // work around safari not providing bta
 if (typeof btoa === "undefined") {
     // http://www.rise4fun.com/Bek/base64encode


### PR DESCRIPTION
We recently had an issue where Math.imul was breaking decompilation of any multiplication on IE. This issue was fixed in the worker by polyfilling Math.imul. 

Unfortunately, that wasn't the entire fix. The runner (for docs / tutorials) also calls decompilation and needs the polyfill. 

I'm moving the polyfill into pxtlib. Currently adding it at the bottom of the hexfile.ts (the file which uses the method). I don't like this, and am open to recommendations of where to place it. I didn't see any other logical place to put it in pxtlib. 

@pelikhan 

Note: this is going into stable5.1 so we can release a patch fix, but will have cherry-picked to master once it's in.

Fixes https://github.com/Microsoft/pxt-adafruit/issues/856

Tested on Chrome and IE.