### PR TITLE
Make sure operator args are not GCed

### DIFF
--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -425,7 +425,7 @@ _cmp_${op}:
                 r += boxedOp(`
                         bl numops::${op}
                         bl numops::toBoolDecr
-                        cmp r0, #0`) 
+                        cmp r0, #0`)
             }
 
             return r

--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -255,9 +255,11 @@ ${lbl}:`
                 if (target.gc)
                     r += `
                     ${this.pushLR()}
+                    push {r0, r1}
                     ${this.saveThreadStack()}
                     ${op}
                     ${this.restoreThreadStack()}
+                    add sp, #8
                     ${this.popPC()}
                 `
                 else
@@ -417,7 +419,13 @@ _cmp_${op}:
     movs r0, #1
     bx lr
 `
-                r += boxedOp(`bl numops::${op}\n    bl numops::toBoolDecr`)
+                // the cmp isn't really needed, given how toBoolDecr() is compiled,
+                // but better not rely on it
+                // Also, cmp isn't needed when ref-counting (it ends with movs r0, r4)
+                r += boxedOp(`
+                        bl numops::${op}
+                        bl numops::toBoolDecr
+                        cmp r0, #0`) 
             }
 
             return r

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3441,13 +3441,9 @@ ${lbl}: .short 0xffff
         function emitCondition(expr: Expression, inner: ir.Expr = null) {
             if (!inner && isThumb() && expr.kind == SK.BinaryExpression) {
                 let be = expr as BinaryExpression
-                let lt = typeOf(be.left)
-                let rt = typeOf(be.right)
-                if ((lt.flags & TypeFlags.NumberLike) && (rt.flags & TypeFlags.NumberLike)) {
-                    let mapped = U.lookup(thumbCmpMap, simpleInstruction(be, be.operatorToken.kind))
-                    if (mapped) {
-                        return ir.rtcall(mapped, [emitExpr(be.left), emitExpr(be.right)])
-                    }
+                let mapped = U.lookup(thumbCmpMap, simpleInstruction(be, be.operatorToken.kind))
+                if (mapped) {
+                    return ir.rtcall(mapped, [emitExpr(be.left), emitExpr(be.right)])
                 }
             }
             if (!inner)


### PR DESCRIPTION
The main fix here is  to push arguments of arithmetic boxed operation on the stack, to make sure they stay alive. Not sure if this was ever a problem, but better safe than sorry.