### PR TITLE
Fix editor controller async message passing

### DIFF
--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -271,73 +271,78 @@ namespace pxt.editor {
                         p = p.then(() => req.resolve(data as EditorMessageResponse));
                     }
                 } else if (data.type == "pxteditor") { // request from the editor
-                    getEditorAsync().then(projectView => {
-                        const req = data as EditorMessageRequest;
-                        pxt.debug(`pxteditor: ${req.action}`);
-                        switch (req.action.toLowerCase()) {
-                            case "switchjavascript": p = p.then(() => projectView.openJavaScript()); break;
-                            case "switchblocks": p = p.then(() => projectView.openBlocks()); break;
-                            case "startsimulator": p = p.then(() => projectView.startSimulator()); break;
-                            case "restartsimulator": p = p.then(() => projectView.restartSimulator()); break;
-                            case "hidesimulator": p = p.then(() => projectView.collapseSimulator()); break;
-                            case "showsimulator": p = p.then(() => projectView.expandSimulator()); break;
-                            case "closeflyout": p = p.then(() => projectView.closeFlyout()); break;
-                            case "redo": p = p.then(() => {
-                                const editor = projectView.editor;
-                                if (editor && editor.hasRedo())
-                                    editor.redo();
-                            }); break;
-                            case "undo": p = p.then(() => {
-                                const editor = projectView.editor;
-                                if (editor && editor.hasUndo())
-                                    editor.undo();
-                            }); break;
-                            case "setscale": {
-                                const zoommsg = data as EditorMessageSetScaleRequest;
-                                p = p.then(() => projectView.editor.setScale(zoommsg.scale));
-                                break;
+                    p = p.then(() => {
+                        return getEditorAsync().then(projectView => {
+                            const req = data as EditorMessageRequest;
+                            pxt.debug(`pxteditor: ${req.action}`);
+                            switch (req.action.toLowerCase()) {
+                                case "switchjavascript": return Promise.resolve().then(() => projectView.openJavaScript());
+                                case "switchblocks": return Promise.resolve().then(() => projectView.openBlocks());
+                                case "startsimulator": return Promise.resolve().then(() => projectView.startSimulator());
+                                case "restartsimulator": return Promise.resolve().then(() => projectView.restartSimulator());
+                                case "hidesimulator": return Promise.resolve().then(() => projectView.collapseSimulator());
+                                case "showsimulator": return Promise.resolve().then(() => projectView.expandSimulator());
+                                case "closeflyout": return Promise.resolve().then(() => projectView.closeFlyout());
+                                case "redo": return Promise.resolve()
+                                    .then(() => {
+                                        const editor = projectView.editor;
+                                        if (editor && editor.hasRedo())
+                                            editor.redo();
+                                    });
+                                case "undo": return Promise.resolve()
+                                    .then(() => {
+                                        const editor = projectView.editor;
+                                        if (editor && editor.hasUndo())
+                                            editor.undo();
+                                    });
+                                case "setscale": {
+                                    const zoommsg = data as EditorMessageSetScaleRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.editor.setScale(zoommsg.scale));
+                                }
+                                case "stopsimulator": {
+                                    const stop = data as EditorMessageStopRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.stopSimulator(stop.unload));
+                                }
+                                case "newproject": {
+                                    const create = data as EditorMessageNewProjectRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.newProject(create.options));
+                                }
+                                case "importproject": {
+                                    const load = data as EditorMessageImportProjectRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.importProjectAsync(load.project, {
+                                            filters: load.filters,
+                                            searchBar: load.searchBar
+                                        }));
+                                }
+                                case "proxytosim": {
+                                    const simmsg = data as EditorMessageSimulatorMessageProxyRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.proxySimulatorMessage(simmsg.content));
+                                }
+                                case "renderblocks": {
+                                    const rendermsg = data as EditorMessageRenderBlocksRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.renderBlocksAsync(rendermsg))
+                                        .then((r: any) => { resp = r.xml; });
+                                }
+                                case "toggletrace": {
+                                    const togglemsg = data as EditorMessageToggleTraceRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.toggleTrace(togglemsg.intervalSpeed));
+                                }
+                                case "settracestate": {
+                                    const trcmsg = data as EditorMessageSetTraceStateRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.setTrace(trcmsg.enabled, trcmsg.intervalSpeed));
+                                }
                             }
-                            case "stopsimulator": {
-                                const stop = data as EditorMessageStopRequest;
-                                p = p.then(() => projectView.stopSimulator(stop.unload));
-                                break;
-                            }
-                            case "newproject": {
-                                const create = data as EditorMessageNewProjectRequest;
-                                p = p.then(() => projectView.newProject(create.options));
-                                break;
-                            }
-                            case "importproject": {
-                                const load = data as EditorMessageImportProjectRequest;
-                                p = p.then(() => projectView.importProjectAsync(load.project, {
-                                    filters: load.filters,
-                                    searchBar: load.searchBar
-                                }));
-                                break;
-                            }
-                            case "proxytosim": {
-                                const simmsg = data as EditorMessageSimulatorMessageProxyRequest;
-                                p = p.then(() => projectView.proxySimulatorMessage(simmsg.content));
-                                break;
-                            }
-                            case "renderblocks": {
-                                const rendermsg = data as EditorMessageRenderBlocksRequest;
-                                p = p.then(() => projectView.renderBlocksAsync(rendermsg))
-                                    .then((r: any) => { resp = r.xml; });
-                                break;
-                            }
-                            case "toggletrace": {
-                                const togglemsg = data as EditorMessageToggleTraceRequest;
-                                p = p.then(() => projectView.toggleTrace(togglemsg.intervalSpeed));
-                                break;
-                            }
-                            case "settracestate": {
-                                const trcmsg = data as EditorMessageSetTraceStateRequest;
-                                p = p.then(() => projectView.setTrace(trcmsg.enabled, trcmsg.intervalSpeed));
-                                break;
-                            }
-                        }
-                    });
+                            return Promise.resolve();
+                        });
+                    })
                 }
                 p.done(() => sendResponse(data, resp, true, undefined),
                     (err) => sendResponse(data, resp, false, err))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1991,10 +1991,13 @@ export class ProjectView
                 }) as SVGSVGElement;
                 // TODO: what if svg is undefined? handle that scenario
                 const viewBox = svg.getAttribute("viewBox").split(/\s+/).map(d => parseInt(d));
-                return {
-                    svg: svg,
-                    xml: pxt.blocks.layout.blocklyToSvgAsync(svg, viewBox[0], viewBox[1], viewBox[2], viewBox[3])
-                }
+                return pxt.blocks.layout.blocklyToSvgAsync(svg, viewBox[0], viewBox[1], viewBox[2], viewBox[3])
+                    .then(resp => {
+                        return {
+                            svg: resp.svg,
+                            xml: resp.xml
+                        }
+                    })
             });
     }
 


### PR DESCRIPTION
https://github.com/Microsoft/pxt/pull/4614 introduced a regression in async message passing when we're hosted in an iframe. The promise resolves (done) before it's had a chance to complete its async functionality.

This fixes up the promise chain. 

I've also fixed the editor controller "renderblocks" message which was returning the promise xml rather than completing the promise and returning the xml. 

note: this is going into stable4.5 (WW branch), will integrate into master once the PR is in.