### PR TITLE
Fix consent screen for third party package extensions

### DIFF
--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -286,7 +286,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
         if (!needsConsent && visible) this.initializeFrame();
         return (
             <sui.Modal isOpen={visible} className={`${needsConsent ? 'extensionconsentdialog' : 'extensiondialog'}`}
-                size="fullscreen" closeIcon={true}
+                size={needsConsent ? 'small' : 'fullscreen'} closeIcon={true}
                 onClose={this.hide} dimmer={true} buttons={actions}
                 modalDidOpen={this.updateDimensions} shouldFocusAfterRender={false}
                 onPositionChanged={this.updateDimensions}


### PR DESCRIPTION
The consent screen for third party package extensions is broken as the full screen size doesn't support actions. (Maybe we should) but I think it's more appropriate that we show a smaller modal for that consent dialog.

<img width="777" alt="screen shot 2018-11-27 at 5 42 34 pm" src="https://user-images.githubusercontent.com/16690124/49123021-dbed8900-f26b-11e8-950f-732d836bb894.png">
