### PR TITLE
ios greenscreen (stable4.4)

### DIFF
--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -114,7 +114,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
         // playsInline required for iOS
         const { hasPrompt, devices, userFacing } = this.state;
         return <div className="videoContainer">
-            <video className={userFacing ? "flipx" : ""} playsInline ref={this.handleVideoRef} />
+            <video className={userFacing ? "flipx" : ""} autoPlay playsInline ref={this.handleVideoRef} />
             {hasPrompt ?
                 <sui.Modal isOpen={hasPrompt} onClose={this.handleClose} closeIcon={true}
                     dimmer={true} header={lf("Choose a camera")}>


### PR DESCRIPTION
iOS requires "autoplay" on the video element to allow webcam streaming.