### PR TITLE
Sent target id to package extensions

### DIFF
--- a/pxteditor/extension.ts
+++ b/pxteditor/extension.ts
@@ -42,6 +42,7 @@ namespace pxt.editor {
      */
     export interface ExtensionEvent extends ExtensionMessage {
         event: string;
+        target: string;
     }
 
     /**

--- a/pxteditor/extension.ts
+++ b/pxteditor/extension.ts
@@ -46,6 +46,13 @@ namespace pxt.editor {
     }
 
     /**
+     * Event fired when the extension is loaded.
+     */
+    export interface LoadedEvent extends ExtensionEvent {
+        event: "extloaded";
+    }
+
+    /**
      * Event fired when the extension becomes visible.
      */
     export interface ShownEvent extends ExtensionEvent {

--- a/webapp/src/extensionManager.ts
+++ b/webapp/src/extensionManager.ts
@@ -303,6 +303,7 @@ function handleWriteCodeRequestAsync(name: string, resp: e.ExtensionResponse, fi
 
 function mkEvent(event: string): e.ExtensionEvent {
     return {
+        target: pxt.appTarget.id,
         type: "pxtpkgext",
         event
     };

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -100,6 +100,9 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
         frame.style.display = 'block';
         if (!frame.src) {
             frame.src = this.state.url + "#" + this.manager.getExtId(this.state.extension);
+            frame.onload = () => {
+                this.send(this.state.extension, { target: pxt.appTarget.id, type: "pxtpkgext", event: "extloaded" } as pxt.editor.LoadedEvent);
+            }
         }
     }
 

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -55,6 +55,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
         // called by app when a serial entry is read
         exts.forEach(n => {
             this.send(n, {
+                target: pxt.appTarget.id,
                 type: "pxtpkgext",
                 event: "extconsole",
                 body: {
@@ -76,7 +77,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
         core.showLoading("reloadproject", lf("loading..."));
         this.props.parent.reloadHeaderAsync()
             .done(() => {
-                this.send(this.state.extension, { type: "pxtpkgext", event: "exthidden" } as pxt.editor.HiddenEvent);
+                this.send(this.state.extension, { target: pxt.appTarget.id, type: "pxtpkgext", event: "exthidden" } as pxt.editor.HiddenEvent);
                 core.hideLoading("reloadproject");
             });
     }
@@ -84,7 +85,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
     showExtension(extension: string, url: string, consentRequired: boolean) {
         let consent = consentRequired ? this.manager.hasConsent(this.manager.getExtId(extension)) : true;
         this.setState({ visible: true, extension: extension, url: url, consent: consent }, () => {
-            this.send(extension, { type: "pxtpkgext", event: "extshown" } as pxt.editor.ShownEvent);
+            this.send(extension, { target: pxt.appTarget.id, type: "pxtpkgext", event: "extshown" } as pxt.editor.ShownEvent);
         })
     }
 


### PR DESCRIPTION
Send the target id with every package extension event.

Also send a loaded event when the frame is loaded.