### PR TITLE
Fix SVGs generated by the tutorial engine

### DIFF
--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -327,7 +327,11 @@ namespace pxt.editor {
                                     const rendermsg = data as EditorMessageRenderBlocksRequest;
                                     return Promise.resolve()
                                         .then(() => projectView.renderBlocksAsync(rendermsg))
-                                        .then((r: any) => { resp = r.xml; });
+                                        .then((r: any) => {
+                                            return r.xml.then((svg: any) => {
+                                                resp = svg.xml;
+                                            })
+                                        });
                                 }
                                 case "toggletrace": {
                                     const togglemsg = data as EditorMessageToggleTraceRequest;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2001,13 +2001,10 @@ export class ProjectView
                 }) as SVGSVGElement;
                 // TODO: what if svg is undefined? handle that scenario
                 const viewBox = svg.getAttribute("viewBox").split(/\s+/).map(d => parseInt(d));
-                return pxt.blocks.layout.blocklyToSvgAsync(svg, viewBox[0], viewBox[1], viewBox[2], viewBox[3])
-                    .then(resp => {
-                        return {
-                            svg: resp.svg,
-                            xml: resp.xml
-                        }
-                    })
+                return {
+                    svg: svg,
+                    xml: pxt.blocks.layout.blocklyToSvgAsync(svg, viewBox[0], viewBox[1], viewBox[2], viewBox[3])
+                }
             });
     }
 


### PR DESCRIPTION
https://github.com/Microsoft/pxt/commit/e0648e14e72abf10a380ceb6b4c3079caf061f21 regressed the tutorial SVGs. another code path that renders blocks..