### PR TITLE
Fix some typos found by translators

### DIFF
--- a/common-docs/reference/arrays/remove-at.md
+++ b/common-docs/reference/arrays/remove-at.md
@@ -7,7 +7,7 @@ Remove an element from an array at some position.
 ```
 
 The size of the array shrinks by one. The element is removed from the array at the position you want. All the other elements after it are moved (shifted) to down to the next lower position. So, an array that has the numbers
-`4, 5, 9, 3, 2` will be `4, 5, 2, 3` if `9` is removed at position 2. It looks like this in blocks:
+`4, 5, 9, 3, 2` will be `4, 5, 3, 2` if `9` is removed at position 2. It looks like this in blocks:
 
 ```block
 let myNumbers = [4, 5, 9, 3, 2];

--- a/common-docs/reference/arrays/reverse.md
+++ b/common-docs/reference/arrays/reverse.md
@@ -8,7 +8,7 @@ Reverse all the elements in an array.
 
 All the elements in the array change their position. The elements going from the lowest to the highest
 position will end up having new order. The element with the highest position is now in the lowest position
-and so on. The array `9, 8, 3, 5, 9, 8, 7, 2` looks like `2, 7, 8, 9, 5, 8, 9` after it is reversed.
+and so on. The array `9, 8, 3, 5, 9, 8, 7, 2` looks like `2, 7, 8, 9, 5, 3, 8, 9` after it is reversed.
 
 You might notice that if your array has an odd number of elements, the element in the very middle gets to
 keep is old position when the array is reversed.
@@ -19,7 +19,7 @@ keep is old position when the array is reversed.
 
 # Example
 
-Reverse the colors of the rainbow. You could call a reversed rainbow a "wobnair".
+Reverse the colors of the rainbow. You could call a reversed rainbow a "wobniar".
 
 ```blocks
 let rainbow = ["red", "orange", "yellow", "green", "blue", "indigo", "violet"];

--- a/common-docs/reference/arrays/set.md
+++ b/common-docs/reference/arrays/set.md
@@ -6,7 +6,7 @@ Store a value in an array at some index.
 [""][0] = "item";
 ```
 
-When an item exists in the array at the index you've chosen, it is replaced with a new value. If you use and index that is past the length of the array, the array is expanded to put the value at the location you want. All locations between the previous last item and the new last item have values of `0`.
+When an item exists in the array at the index you've chosen, it is replaced with a new value. If you use an index that is past the length of the array, the array is expanded to put the value at the location you want. All locations between the previous last item and the new last item have values of `0`.
 
 ## Parameters
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -699,7 +699,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                             icon="cloud download"
                             iconColor="secondary"
                             name={lf("Import URL...")}
-                            description={lf("Open a shared project URL or GithHub repo")}
+                            description={lf("Open a shared project URL or GitHub repo")}
                             onClick={this.importUrl}
                         /> : undefined}
 


### PR DESCRIPTION
Fixing typos noted in Crowdin comments:

* https://crowdin.com/translate/kindscript/32/en-da#151872
* https://crowdin.com/translate/kindscript/1938/en-fr#71831
* https://crowdin.com/translate/kindscript/1938/en-fr#71836
* https://crowdin.com/translate/kindscript/1937/en-fr#71812
* https://crowdin.com/translate/kindscript/1939/en-fr#72919
