### PR TITLE
dal.d.ts generation for target

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -371,11 +371,12 @@ function updateCodalBuildAsync() {
 // TODO: DAL specific code should be lifted out
 export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage, rebuild = false,
     create = false) {
-    let constName = "dal.d.ts"
-    const config = mainPkg.config;
-    const corePackage = config.dalDTS && config.dalDTS.corePackage;
+    const constName = "dal.d.ts";
+    let constPath = constName;
+    const config = mainPkg && mainPkg.config;
+    const corePackage = config && config.dalDTS && config.dalDTS.corePackage;
     if (corePackage)
-        constName = path.join(corePackage, constName);
+        constPath = path.join(corePackage, constName);
     let vals: Map<string> = {}
     let done: Map<string> = {}
     let excludeSyms: string[] = []
@@ -465,7 +466,7 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
 
     if (mainPkg && (create ||
         (mainPkg.getFiles().indexOf(constName) >= 0 && (rebuild || !fs.existsSync(constName))))) {
-        pxt.log(`rebuilding ${constName}...`)
+        pxt.log(`rebuilding ${constName} into ${constPath}...`)
         let files: string[] = []
         let foundConfig = false
 
@@ -525,7 +526,7 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
             }
         }
         consts += "}\n"
-        fs.writeFileSync(constName, consts)
+        fs.writeFileSync(constPath, consts)
     }
 }
 

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -372,6 +372,10 @@ function updateCodalBuildAsync() {
 export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage, rebuild = false,
     create = false) {
     let constName = "dal.d.ts"
+    const config = mainPkg.config;
+    const corePackage = config.dalDTS && config.dalDTS.corePackage;
+    if (corePackage)
+        constName = path.join(corePackage, constName);
     let vals: Map<string> = {}
     let done: Map<string> = {}
     let excludeSyms: string[] = []
@@ -394,10 +398,6 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
         let pp = parseCppInt(s)
         if (pp != null) return pp
         return null
-    }
-
-    function isValidInt(v: string) {
-        return /^-?(\d+|0[xX][0-9a-fA-F]+)$/.test(v)
     }
 
     function extractConstants(fileName: string, src: string, dogenerate = false): string {
@@ -471,14 +471,15 @@ export function buildDalConst(buildEngine: BuildEngine, mainPkg: pxt.MainPackage
 
         for (let d of mainPkg.sortedDeps()) {
             if (d.config.dalDTS) {
-                for (let dn of d.config.dalDTS.includeDirs) {
-                    dn = buildEngine.buildPath + "/" + dn
-                    if (U.endsWith(dn, ".h")) files.push(dn)
-                    else {
-                        let here = nodeutil.allFiles(dn, 20).filter(fn => U.endsWith(fn, ".h"))
-                        U.pushRange(files, here)
+                if (d.config.dalDTS.includeDirs)
+                    for (let dn of d.config.dalDTS.includeDirs) {
+                        dn = buildEngine.buildPath + "/" + dn
+                        if (U.endsWith(dn, ".h")) files.push(dn)
+                        else {
+                            let here = nodeutil.allFiles(dn, 20).filter(fn => U.endsWith(fn, ".h"))
+                            U.pushRange(files, here)
+                        }
                     }
-                }
                 excludeSyms = d.config.dalDTS.excludePrefix || excludeSyms
                 foundConfig = true
             }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5664,7 +5664,7 @@ function initCommands() {
 
     p.defineCommand({
         name: "builddaldts",
-        help: "build dal.d.ts in current directory (might need to move)",
+        help: "build dal.d.ts in current directory (might be generated in a separate folder)",
         advanced: true
     }, buildDalDTSAsync);
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5679,7 +5679,8 @@ function initCommands() {
     p.defineCommand({
         name: "builddaldts",
         help: "build dal.d.ts in current directory (might be generated in a separate folder)",
-        advanced: true
+        advanced: true,
+        aliases: ["daldts"]
     }, buildDalDTSAsync);
 
     p.defineCommand({

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -55,7 +55,8 @@ declare namespace pxt {
         gistId?: string;
         extension?: PackageExtension; // describe the associated extension if any
         dalDTS?: {
-            includeDirs: string[];
+            corePackage?: string;
+            includeDirs?: string[];
             excludePrefix?: string[];
         };
         features?: string[];


### PR DESCRIPTION
A project can specify a "corePackage" value in pxt.json so the dal.d.ts file is generate over there. Also pxt builddaldts can be run from the target folder.