### PR TITLE
Links that start with '#' appear on the same page instead of a new tab

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -475,7 +475,7 @@ namespace pxt.docs {
         setupRenderer(renderer);
         const linkRenderer = renderer.link;
         renderer.link = function (href: string, title: string, text: string) {
-            const relative = href.indexOf('/') == 0;
+            const relative = href.charAt(0) === '/' || href.charAt(0) === '#';
             const target = !relative ? '_blank' : '';
             if (relative && d.versionPath) href = `/${d.versionPath}${href}`;
             const html = linkRenderer.call(renderer, href, title, text);

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -475,7 +475,7 @@ namespace pxt.docs {
         setupRenderer(renderer);
         const linkRenderer = renderer.link;
         renderer.link = function (href: string, title: string, text: string) {
-            const relative = href.charAt(0) === '/' || href.charAt(0) === '#';
+            const relative = new RegExp('^[/#]').test(href);
             const target = !relative ? '_blank' : '';
             if (relative && d.versionPath) href = `/${d.versionPath}${href}`;
             const html = linkRenderer.call(renderer, href, title, text);


### PR DESCRIPTION
Fixes Microsoft/pxt#4534

This makes it so that if link in the docs starts with a '#', meaning it is an anchor link to the same page, it will open in the same tab instead of a separate tab.