### PR TITLE
don't restart sim while compiling

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -447,7 +447,7 @@ export class ProjectView
     private autoRunBlocksSimulator = pxtc.Util.debounce(
         () => {
             if (Util.now() - this.lastChangeTime < 1000) return;
-            if (!this.state.active)
+            if (!this.state.active || this.state.compiling)
                 return;
             this.runSimulator({ debug: !!this.state.debugging, background: true });
         },
@@ -456,7 +456,7 @@ export class ProjectView
     private autoRunSimulator = pxtc.Util.debounce(
         () => {
             if (Util.now() - this.lastChangeTime < 1000) return;
-            if (!this.state.active)
+            if (!this.state.active || this.state.compiling)
                 return;
             this.runSimulator({ debug: !!this.state.debugging, background: true });
         },


### PR DESCRIPTION
In arcade, clicking download might trigger a reload and compilation. Simulator should not be running in the background.