### PR TITLE
Name the project before sharing

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -744,8 +744,8 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         this.hide = this.hide.bind(this);
         this.modalDidOpen = this.modalDidOpen.bind(this);
         this.handleChange = this.handleChange.bind(this);
-        this.cancel = this.cancel.bind(this);
         this.save = this.save.bind(this);
+        this.skip = this.skip.bind(this);
     }
 
     componentWillReceiveProps(newProps: ISettingsProps) {
@@ -794,9 +794,10 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         }
     }
 
-    cancel() {
-        pxt.tickEvent("exitandsave.cancel", undefined, { interactiveConsent: true });
+    skip() {
+        pxt.tickEvent("exitandsave.skip", undefined, { interactiveConsent: true });
         this.hide();
+        this.props.parent.openHome();
     }
 
     save() {
@@ -817,10 +818,13 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         const { visible, emoji, projectName } = this.state;
 
         const actions: sui.ModalButton[] = [{
-            label: lf("Done"),
+            label: lf("Save"),
             onclick: this.save,
             icon: 'check',
             className: 'approve positive'
+        }, {
+            label: lf("Skip"),
+            onclick: this.skip
         }]
 
         return (
@@ -830,10 +834,13 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 modalDidOpen={this.modalDidOpen}
             >
-                <div className="ui form">
-                    <sui.Input ref="filenameinput" autoFocus id={"projectNameInput"} label={lf("Name")}
-                        ariaLabel={lf("Type a name for your project")} autoComplete={false}
-                        value={projectName || ''} onChange={this.handleChange} />
+                <div className={`ui form`}>
+                    <p>{lf("Give your project a name.")}</p>
+                    <p>
+                        <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
+                            ariaLabel={lf("Type a name for your project")} autoComplete={false}
+                            value={projectName || ''} onChange={this.handleChange} />
+                    </p>
                 </div>
             </sui.Modal>
         )

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -834,13 +834,13 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
                 modalDidOpen={this.modalDidOpen}
             >
-                <div className={`ui form`}>
+                <div>
                     <p>{lf("Give your project a name.")}</p>
-                    <p>
+                    <div className="ui form">
                         <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
                             ariaLabel={lf("Type a name for your project")} autoComplete={false}
                             value={projectName || ''} onChange={this.handleChange} />
-                    </p>
+                    </div>
                 </div>
             </sui.Modal>
         )

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -765,7 +765,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
         // Save on enter typed
         let dialogInput = document.getElementById('projectNameInput') as HTMLInputElement;
         if (dialogInput) {
-            dialogInput.setSelectionRange(0, 9999);
+            if (!pxt.BrowserUtils.isMobile()) dialogInput.setSelectionRange(0, 9999);
             dialogInput.onkeydown = (e: KeyboardEvent) => {
                 const charCode = core.keyCodeFromEvent(e);
                 if (charCode === core.ENTER_KEY) {

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -19,6 +19,7 @@ export interface ShareEditorState {
     pubCurrent?: boolean;
     visible?: boolean;
     sharingError?: boolean;
+    projectName?: string;
 }
 
 export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState> {
@@ -34,6 +35,7 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
         this.hide = this.hide.bind(this);
         this.toggleAdvancedMenu = this.toggleAdvancedMenu.bind(this);
         this.setAdvancedMode = this.setAdvancedMode.bind(this);
+        this.handleProjectNameChange = this.handleProjectNameChange.bind(this);
     }
 
     hide() {
@@ -42,6 +44,10 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
 
     show(header: pxt.workspace.Header) {
         this.setState({ visible: true, mode: ShareMode.Code, pubCurrent: header.pubCurrent, sharingError: false });
+    }
+
+    componentWillReceiveProps(newProps: ISettingsProps) {
+        this.handleProjectNameChange(newProps.parent.state.projectName);
     }
 
     shouldComponentUpdate(nextProps: ISettingsProps, nextState: ShareEditorState, nextContext: any): boolean {
@@ -62,8 +68,12 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
         this.setState({ mode: mode });
     }
 
+    handleProjectNameChange(name: string) {
+        this.setState({ projectName: name });
+    }
+
     renderCore() {
-        const { visible } = this.state;
+        const { visible, projectName } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
         const header = this.props.parent.state.header;
         const advancedMenu = !!this.state.advancedMenu;
@@ -143,6 +153,8 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
             })
         }
 
+        const shouldNameProject = projectName == lf("Untitled");
+
         return (
             <sui.Modal isOpen={visible} className="sharedialog" size="small"
                 onClose={this.hide}
@@ -154,7 +166,16 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
                 <div className={`ui form`}>
                     {action ?
                         <div>
-                            <p>{lf("You need to publish your project to share it or embed it in other web pages.") + " " +
+                            {shouldNameProject ?
+                                <div>
+                                    <p>{lf("Give your project a name before sharing.")}</p>
+                                    <p>
+                                        <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
+                                            ariaLabel={lf("Type a name for your project")} autoComplete={false}
+                                            value={projectName || ''} onChange={this.handleProjectNameChange} />
+                                    </p>
+                                </div> : undefined}
+                            <p className="ui message info">{lf("You need to publish your project to share it or embed it in other web pages.") + " " +
                                 lf("You acknowledge having consent to publish this project.")}</p>
                             {this.state.sharingError ?
                                 <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -70,6 +70,10 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
 
     handleProjectNameChange(name: string) {
         this.setState({ projectName: name });
+        // save project name if valid change
+        if (name && this.props.parent.state.projectName != name) {
+            this.props.parent.updateHeaderNameAsync(name);
+        }
     }
 
     renderCore() {
@@ -169,11 +173,11 @@ export class ShareEditor extends data.Component<ISettingsProps, ShareEditorState
                             {shouldNameProject ?
                                 <div>
                                     <p>{lf("Give your project a name before sharing.")}</p>
-                                    <p>
+                                    <div>
                                         <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
                                             ariaLabel={lf("Type a name for your project")} autoComplete={false}
                                             value={projectName || ''} onChange={this.handleProjectNameChange} />
-                                    </p>
+                                    </div>
                                 </div> : undefined}
                             <p className="ui message info">{lf("You need to publish your project to share it or embed it in other web pages.") + " " +
                                 lf("You acknowledge having consent to publish this project.")}</p>


### PR DESCRIPTION
Share dialog allows you to name the project before sharing: 

![screen shot 2018-12-06 at 9 47 42 am](https://user-images.githubusercontent.com/16690124/49601936-132efa80-f93c-11e8-9554-778bf431df48.png)

and the exit dialog: 

![screen shot 2018-12-06 at 9 48 01 am](https://user-images.githubusercontent.com/16690124/49601943-175b1800-f93c-11e8-8c2a-ffb5942a79e6.png)

Note: this only shows if the user has an untitled project, in both cases.