### PR TITLE
Send an empty controllerId if it's not set.

### DIFF
--- a/webapp/src/iframeworkspace.ts
+++ b/webapp/src/iframeworkspace.ts
@@ -25,7 +25,7 @@ function listAsync() {
         lastSyncState = msg.editor
 
         // controllerId is a unique identifier of the controller source
-        pxt.tickEvent("pxt.controller", { controllerId: msg.controllerId });
+        pxt.tickEvent("pxt.controller", { controllerId: msg.controllerId || "" });
 
         return mem.provider.listAsync()
     })


### PR DESCRIPTION
This message is currently not being sent because we're sending undefined for one of the properties which adds them as measures instead, and measures can only be of type numbers.