### PR TITLE
Fix tickEvent props when an object is passed in

### DIFF
--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -41,7 +41,7 @@ namespace pxt.analytics {
                 Object.keys(data).forEach(k => {
                     if (typeof data[k] == "string") props[k] = <string>data[k];
                     else if (typeof data[k] == "number") measures[k] = <number>data[k];
-                    else props[k] = JSON.stringify(data[k]) || '';
+                    else props[k] = JSON.stringify(data[k] || '');
                 });
                 pxt.aiTrackEvent(id, props, measures);
             }

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -41,7 +41,7 @@ namespace pxt.analytics {
                 Object.keys(data).forEach(k => {
                     if (typeof data[k] == "string") props[k] = <string>data[k];
                     else if (typeof data[k] == "number") measures[k] = <number>data[k];
-                    else props[k] = JSON.stringify(data[k]);
+                    else props[k] = JSON.stringify(data[k]) || '';
                 });
                 pxt.aiTrackEvent(id, props, measures);
             }

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -40,7 +40,8 @@ namespace pxt.analytics {
                 const measures: Map<number> = defaultMeasures || {};
                 Object.keys(data).forEach(k => {
                     if (typeof data[k] == "string") props[k] = <string>data[k];
-                    else measures[k] = <number>data[k];
+                    else if (typeof data[k] == "number") measures[k] = <number>data[k];
+                    else props[k] = JSON.stringify(data[k]);
                 });
                 pxt.aiTrackEvent(id, props, measures);
             }


### PR DESCRIPTION
Currently passing tickEvent props that are not string or numbers causes issues where it tries to send it as a measure, and app insights only accepts measures of type number, which makes it drop the event. 

This PR makes it so that we pass any string as a property. Any number as a measure.
And anything else get's stringifed and passed in as a property. 

