### PR TITLE
Enum isHash

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1645,6 +1645,9 @@ namespace pxt.blocks {
                             if (shift >= 0 && Math.floor(shift) === shift) {
                                 newNode = H.mkAssign(mkText(name), H.mkSimpleCall("<<", [H.mkNumberLiteral(1), H.mkNumberLiteral(shift)]));
                             }
+                        } else if (info.isHash) {
+                            const hash = ts.pxtc.Util.hash32(name);
+                            newNode = H.mkAssign(mkText(name), H.mkNumberLiteral(hash))
                         }
                         if (!newNode) {
                             if (value === lastValue + 1) {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1646,7 +1646,7 @@ namespace pxt.blocks {
                                 newNode = H.mkAssign(mkText(name), H.mkSimpleCall("<<", [H.mkNumberLiteral(1), H.mkNumberLiteral(shift)]));
                             }
                         } else if (info.isHash) {
-                            const hash = ts.pxtc.Util.hash32(name);
+                            const hash = ts.pxtc.Util.codalHash16(name.toLowerCase());
                             newNode = H.mkAssign(mkText(name), H.mkNumberLiteral(hash))
                         }
                         if (!newNode) {

--- a/pxtblocks/fields/field_userenum.ts
+++ b/pxtblocks/fields/field_userenum.ts
@@ -134,6 +134,8 @@ namespace pxtblockly {
                 }
             }
             return 1 << existing.length;
+        } else if (opts.isHash) {
+            return 0; // overriden when compiled
         }
         else {
             const start = opts.firstValue || 0;

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -262,7 +262,7 @@ namespace ts.pxtc.Util {
         }
     }
 
-    export function hash32(s: string): number {
+    export function codalHash16(s: string): number {
         // same hashing as https://github.com/lancaster-university/codal-core/blob/c1fe7a4c619683a50d47cb0c19d15b8ff3bd16a1/source/drivers/PearsonHash.cpp#L26
         const hashTable = [
             251, 175, 119, 215, 81, 14, 79, 191, 103, 49, 181, 143, 186, 157, 0,
@@ -294,17 +294,17 @@ namespace ts.pxtc.Util {
             return hash;
         }
         function hashN(s: string, byteCount: number): number {
+            // this hash is used by enum.isHash. So any modification should be considered a breaking change.
             let hash;
-            const buffer = new Uint8Array(s.length * 2);
+            const buffer = new Uint8Array(s.length); // TODO unicode
             for (let i = 0; i < s.length; ++i) {
                 const c = s.charCodeAt(i);
-                buffer[2 * i] = c & 0xff;
-                buffer[2 * i + 1] = (c >> 8) & 0xff;
+                buffer[i] = c & 0xff;
             }
             let res = 0;
             for (let i = 0; i < byteCount; ++i) {
                 hash = eightBitHash(buffer);
-                res |= (hash << i);
+                res |= hash << (8 * i);
                 buffer[0] = (buffer[0] + 1) % 255;
             }
             return res;
@@ -312,7 +312,7 @@ namespace ts.pxtc.Util {
 
 
         if (!s) return 0;
-        return hashN(s, 4);
+        return hashN(s, 2);
     }
 }
 

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -261,6 +261,59 @@ namespace ts.pxtc.Util {
             }
         }
     }
+
+    export function hash32(s: string): number {
+        // same hashing as https://github.com/lancaster-university/codal-core/blob/c1fe7a4c619683a50d47cb0c19d15b8ff3bd16a1/source/drivers/PearsonHash.cpp#L26
+        const hashTable = [
+            251, 175, 119, 215, 81, 14, 79, 191, 103, 49, 181, 143, 186, 157, 0,
+            232, 31, 32, 55, 60, 152, 58, 17, 237, 174, 70, 160, 144, 220, 90, 57,
+            223, 59, 3, 18, 140, 111, 166, 203, 196, 134, 243, 124, 95, 222, 179,
+            197, 65, 180, 48, 36, 15, 107, 46, 233, 130, 165, 30, 123, 161, 209, 23,
+            97, 16, 40, 91, 219, 61, 100, 10, 210, 109, 250, 127, 22, 138, 29, 108,
+            244, 67, 207, 9, 178, 204, 74, 98, 126, 249, 167, 116, 34, 77, 193,
+            200, 121, 5, 20, 113, 71, 35, 128, 13, 182, 94, 25, 226, 227, 199, 75,
+            27, 41, 245, 230, 224, 43, 225, 177, 26, 155, 150, 212, 142, 218, 115,
+            241, 73, 88, 105, 39, 114, 62, 255, 192, 201, 145, 214, 168, 158, 221,
+            148, 154, 122, 12, 84, 82, 163, 44, 139, 228, 236, 205, 242, 217, 11,
+            187, 146, 159, 64, 86, 239, 195, 42, 106, 198, 118, 112, 184, 172, 87,
+            2, 173, 117, 176, 229, 247, 253, 137, 185, 99, 164, 102, 147, 45, 66,
+            231, 52, 141, 211, 194, 206, 246, 238, 56, 110, 78, 248, 63, 240, 189,
+            93, 92, 51, 53, 183, 19, 171, 72, 50, 33, 104, 101, 69, 8, 252, 83, 120,
+            76, 135, 85, 54, 202, 125, 188, 213, 96, 235, 136, 208, 162, 129, 190,
+            132, 156, 38, 47, 1, 7, 254, 24, 4, 216, 131, 89, 21, 28, 133, 37, 153,
+            149, 80, 170, 68, 6, 169, 234, 151
+        ]
+
+        // REF: https://en.wikipedia.org/wiki/Pearson_hashing
+        function eightBitHash(s: Uint8Array): number {
+            let hash = 0;
+            for (let i = 0; i < s.length; i++) {
+                let c = s[i];
+                hash = hashTable[hash ^ c];
+            }
+            return hash;
+        }
+        function hashN(s: string, byteCount: number): number {
+            let hash;
+            const buffer = new Uint8Array(s.length * 2);
+            for (let i = 0; i < s.length; ++i) {
+                const c = s.charCodeAt(i);
+                buffer[2 * i] = c & 0xff;
+                buffer[2 * i + 1] = (c >> 8) & 0xff;
+            }
+            let res = 0;
+            for (let i = 0; i < byteCount; ++i) {
+                hash = eightBitHash(buffer);
+                res |= (hash << i);
+                buffer[0] = (buffer[0] + 1) % 255;
+            }
+            return res;
+        }
+
+
+        if (!s) return 0;
+        return hashN(s, 4);
+    }
 }
 
 const lf = ts.pxtc.Util.lf;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -90,6 +90,7 @@ namespace ts.pxtc {
         memberName: string;
         blockId: string;
         isBitMask: boolean;
+        isHash: boolean;
         firstValue?: number;
         initialMembers: string[];
         promptHint: string;
@@ -195,6 +196,7 @@ namespace ts.pxtc {
         enumMemberName?: string; // If the name of the enum was "Colors", this would be "color"
         enumStartValue?: number; // The lowest value to emit when going from blocks to TS
         enumIsBitMask?: boolean; // If true then values will be emitted in the form "1 << n"
+        enumIsHash?: boolean; // if true, the name of the enum is normalized, then hashed to generate the value
         enumPromptHint?: string; // The hint that will be displayed in the member creation prompt
         enumInitialMembers?: string[]; // The initial enum values which will be given the lowest values available
 
@@ -545,6 +547,7 @@ namespace ts.pxtc {
                     memberName: s.attributes.enumMemberName,
                     firstValue: isNaN(firstValue) ? undefined : firstValue,
                     isBitMask: s.attributes.enumIsBitMask,
+                    isHash: s.attributes.enumIsHash,
                     initialMembers: s.attributes.enumInitialMembers,
                     promptHint: s.attributes.enumPromptHint
                 };
@@ -707,6 +710,7 @@ namespace ts.pxtc {
         "constantShim",
         "blockCombine",
         "enumIsBitMask",
+        "enumIsHash",
         "decompileIndirectFixedInstances",
         "draggableParameters",
         "topblock"

--- a/tests/blocklycompiler-test/fieldUserEnum.spec.ts
+++ b/tests/blocklycompiler-test/fieldUserEnum.spec.ts
@@ -49,7 +49,8 @@ function basicEnumTest(existing: number[], expected: number) {
         promptHint: "",
         initialMembers: ["does", "not", "matter"],
         blockId: "",
-        isBitMask: false
+        isBitMask: false,
+        isHash: false,
     }, existing, expected);
 }
 
@@ -60,7 +61,8 @@ function bitmaskEnumTest(existing: number[], expected: number) {
         promptHint: "",
         initialMembers: ["does", "not", "matter"],
         blockId: "",
-        isBitMask: true
+        isBitMask: true,
+        isHash: false,
     }, existing, expected);
 }
 
@@ -72,6 +74,7 @@ function startValueEnumTest(existing: number[], expected: number) {
         initialMembers: ["does", "not", "matter"],
         blockId: "",
         isBitMask: false,
+        isHash: false,
         firstValue: 3
     }, existing, expected);
 }

--- a/tests/blocklycompiler-test/test-library/enums.ts
+++ b/tests/blocklycompiler-test/test-library/enums.ts
@@ -31,4 +31,15 @@ namespace userEnums {
     export function userEnumShimBitMask(arg: number) {
         return arg;
     }
+
+    /**
+     * Test enum define block for a hash
+     */
+    //% shim=ENUM_GET
+    //% blockId=enum_user_shim_hash block="%arg"
+    //% enumName="EnumHash" enumMemberName="whatever" enumPromptHint="whatever"  enumInitialMembers="whatever,dontcare"
+    //% enumIsHash=true
+    export function userEnumShimHash(arg: number) {
+        return arg;
+    }
 }

--- a/tests/decompile-test/cases/testBlocks/enums.ts
+++ b/tests/decompile-test/cases/testBlocks/enums.ts
@@ -67,4 +67,12 @@ namespace enumTest {
     export function userEnumShimBitMask(arg: number) {
         return arg;
     }
+
+    //% shim=ENUM_GET
+    //% blockId=enum_user_shim_hash
+    //% enumName="EnumOfFHash" enumMemberName="whatever" enumPromptHint="whatever" enumInitialMembers="whatever,dontcare"
+    //% enumIsHash=true
+    export function userEnumShimHash(arg: number) {
+        return arg;
+    }
 }


### PR DESCRIPTION
Adds a new enum modifier flag, ``EnumIsHash`` that forces MakeCode to generate the enum values as the hash16 of the name. This is particularly useful for radio-broadcast or any other named based broadcast API where users might want to write different programs talking the same protocol.