### PR TITLE
Added Array Concatenation

### DIFF
--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -17,7 +17,6 @@ interface Array<T> {
     //% blockId="array_push" block="%list| add value %value| to end" blockNamespace="arrays"
     push(item: T): void;
 
-
     /**
       * Concatenates the values with another array.
       * @param arr The other array that is being concatenated with

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -17,6 +17,14 @@ interface Array<T> {
     //% blockId="array_push" block="%list| add value %value| to end" blockNamespace="arrays"
     push(item: T): void;
 
+
+    /**
+      * Concatenates the values with another array.
+      * @param arr The other array that is being concatenated with
+      */
+    //% helper=arrayConcat weight=40
+    concat(arr: T[]): T[];
+
     /**
       * Remove the last element from an array and return it.
       */

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -140,6 +140,17 @@ namespace helpers {
         return initialValue
     }
 
+    export function arrayConcat<T>(arr: T[], otherArr: T[]): T[]{
+        let out: T[] = [];
+        for (let value of arr) {
+            out.push(value);
+        }
+        for (let value of otherArr) {
+            out.push(value);
+        }
+        return out;
+    }
+
     export function arraySlice<T>(arr: T[], start: number, end: number): T[] {
         const res: T[] = [];
         const len = arr.length;

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -17,7 +17,6 @@ interface Array<T> {
     //% blockId="array_push" block="%list| add value %value| to end" blockNamespace="arrays"
     push(item: T): void;
 
-
     /**
       * Concatenates the values with another array.
       * @param arr The other array that is being concatenated with

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -17,6 +17,14 @@ interface Array<T> {
     //% blockId="array_push" block="%list| add value %value| to end" blockNamespace="arrays"
     push(item: T): void;
 
+
+    /**
+      * Concatenates the values with another array.
+      * @param arr The other array that is being concatenated with
+      */
+    //% helper=arrayConcat weight=40
+    concat(arr: T[]): T[];
+
     /**
       * Remove the last element from an array and return it.
       */

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -140,6 +140,17 @@ namespace helpers {
         return initialValue
     }
 
+    export function arrayConcat<T>(arr: T[], otherArr: T[]): T[]{
+        let out: T[] = [];
+        for (let value of arr) {
+            out.push(value);
+        }
+        for (let value of otherArr) {
+            out.push(value);
+        }
+        return out;
+    }
+
     export function arraySlice<T>(arr: T[], start: number, end: number): T[] {
         const res: T[] = [];
         const len = arr.length;


### PR DESCRIPTION
This adds the ability to concatenate arrays. 

Only works with JavaScript as Blocks had issues detecting the type.

Also doesn't use rest parameters like the original JavaScript function. Only supports concatenation of two arrays at a time.