### PR TITLE
Reload simulator on changes

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -348,10 +348,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private markIncomplete = false;
     isIncomplete() {
-        const incomplete = this.editor ?
-            ((this.editor as any).currentGesture_ != null && (this.editor as any).currentGesture_.isDraggingBlock_)
-            || (Blockly as any).WidgetDiv.isVisible()
-            || (Blockly as any).DropDownDiv.isVisible() : false;
+        const incomplete = this.editor && ((this.editor as any).currentGesture_ && (this.editor as any).currentGesture_.isDraggingBlock_);
         if (incomplete) this.markIncomplete = true;
         return incomplete;
     }


### PR DESCRIPTION
The following situation was fairly common when testing arcade

![code not working :(](https://user-images.githubusercontent.com/5615930/49778331-8d071100-fcb9-11e8-8659-587b5aeef5c3.gif)

This was very confusing, because it looks like nothing is happening after they input - there is no indication that you have to click outside of the editor or press enter for the code to 'count' and be reflected on the screen.

This makes it so the simulator is reloaded when values are changed.

![Code is changing!](https://user-images.githubusercontent.com/5615930/49778426-fe46c400-fcb9-11e8-8331-f40873ad932e.gif)

