### PR TITLE
Re-write dropdown menu component

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -272,29 +272,29 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             && greenscreen.isSupported();
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
-            <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} tabIndex={-1} />
-            {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} tabIndex={-1} /> : undefined}
-            {boards ? <sui.Item role="menuitem" icon="microchip" text={lf("Change Board")} onClick={this.showBoardDialog} tabIndex={-1} /> : undefined}
-            {targetTheme.print ? <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} tabIndex={-1} /> : undefined}
-            {showSave ? <sui.Item role="menuitem" icon="save" text={lf("Save Project")} onClick={this.saveProject} tabIndex={-1} /> : undefined}
-            {!isController ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={this.removeProject} tabIndex={-1} /> : undefined}
-            {showSimCollapse ? <sui.Item role="menuitem" icon='toggle right' text={lf("Toggle the simulator")} onClick={this.toggleCollapse} tabIndex={-1} /> : undefined}
-            {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} tabIndex={-1} /> : undefined}
+            <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} />
+            {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} /> : undefined}
+            {boards ? <sui.Item role="menuitem" icon="microchip" text={lf("Change Board")} onClick={this.showBoardDialog} /> : undefined}
+            {targetTheme.print ? <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} /> : undefined}
+            {showSave ? <sui.Item role="menuitem" icon="save" text={lf("Save Project")} onClick={this.saveProject} /> : undefined}
+            {!isController ? <sui.Item role="menuitem" icon="trash" text={lf("Delete Project")} onClick={this.removeProject} /> : undefined}
+            {showSimCollapse ? <sui.Item role="menuitem" icon='toggle right' text={lf("Toggle the simulator")} onClick={this.toggleCollapse} /> : undefined}
+            {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             <div className="ui divider"></div>
-            {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} tabIndex={-1} /> : undefined}
-            {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} tabIndex={-1} /> : undefined}
-            {showGreenScreen ? <sui.Item role="menuitem" text={greenScreen ? lf("Green Screen Off") : lf("Green Screen On")} onClick={this.toggleGreenScreen} tabIndex={-1} /> : undefined}
+            {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
+            {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
+            {showGreenScreen ? <sui.Item role="menuitem" text={greenScreen ? lf("Green Screen Off") : lf("Green Screen On")} onClick={this.toggleGreenScreen} /> : undefined}
             {
                 // we always need a way to clear local storage, regardless if signed in or not
             }
-            {!isController ? <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} tabIndex={-1} /> : undefined}
-            {pxt.usb.isEnabled ? <sui.Item role="menuitem" icon='usb' text={lf("Pair device")} onClick={this.pair} tabIndex={-1} /> : undefined}
-            {pxt.webBluetooth.isAvailable() ? <sui.Item role="menuitem" icon='bluetooth' text={lf("Pair Bluetooth")} onClick={this.pairBluetooth} tabIndex={-1} /> : undefined}
+            {!isController ? <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} /> : undefined}
+            {pxt.usb.isEnabled ? <sui.Item role="menuitem" icon='usb' text={lf("Pair device")} onClick={this.pair} /> : undefined}
+            {pxt.webBluetooth.isAvailable() ? <sui.Item role="menuitem" icon='bluetooth' text={lf("Pair Bluetooth")} onClick={this.pairBluetooth} /> : undefined}
             <div className="ui mobile only divider"></div>
             {renderDocItems(this.props.parent, "mobile only")}
             <div className="ui divider"></div>
-            <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} tabIndex={-1} />
-            {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback")} target="_blank" rel="noopener noreferrer" tabIndex={-1}>{lf("Give Feedback")}</a> : undefined}
+            <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />
+            {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback")} target="_blank" rel="noopener noreferrer" >{lf("Give Feedback")}</a> : undefined}
         </sui.DropdownMenu>;
     }
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -80,17 +80,17 @@ export interface DropdownProps extends UiProps {
     title?: string;
     onChange?: (v: string) => void;
 
-    openOnMouseOver?: boolean;
 }
 
 export interface DropdownState {
     open?: boolean;
+    focus?: boolean;
 }
 
 export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
 
     show() {
-        this.setState({ open: true });
+        this.setState({ open: true, focus: true });
     }
 
     hide() {
@@ -98,7 +98,11 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
     }
 
     toggle() {
-        this.setState({ open: !this.state.open });
+        if (this.state.open) {
+            this.hide();
+        } else {
+            this.show();
+        }
     }
 
     private focus(el: HTMLElement) {
@@ -122,59 +126,9 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
         return el && el.classList.contains("active");
     }
 
-    private selectFirstElementOnDown(e: KeyboardEvent, first: HTMLElement) {
-        // When the dropdown menu item is selected, an Enter Space or Down arrow opens the menu
-        const charCode = core.keyCodeFromEvent(e);
-        if (charCode === core.SPACE_KEY || charCode === core.ENTER_KEY) {
-            e.preventDefault();
-            this.toggle();
-        } else if (charCode === core.ESC_KEY) {
-            e.preventDefault();
-            this.hide();
-        } else if (charCode === 40 /* Down arrow key */) {
-            e.preventDefault();
-            if (!this.state.open) this.show();
-            if (first) this.focus(first);
-        } else if (charCode === core.TAB_KEY) {
-            this.hide();
-        }
-    }
-
-    private navigateToNextElement(e: KeyboardEvent, prev: HTMLElement, next: HTMLElement) {
-        const charCode = core.keyCodeFromEvent(e);
-        const current = e.currentTarget as HTMLElement;
-        if (charCode === 40 /* Down arrow */
-            || (!e.shiftKey && charCode === core.TAB_KEY)) {
-            e.preventDefault();
-            if (next) {
-                //this.blur(current);
-                this.focus(next);
-            }
-        } else if (charCode === 38 /* Up arrow */
-            || (e.shiftKey && charCode === core.TAB_KEY)) {
-            e.preventDefault();
-            if (prev) {
-                //this.blur(current);
-                this.focus(prev);
-            }
-        } else if (charCode === core.ESC_KEY) {
-            e.preventDefault();
-            const dropdown = this.refs["dropdown"] as HTMLElement;
-            this.hide();
-            dropdown.focus();
-        } else if (charCode === core.SPACE_KEY || charCode === core.ENTER_KEY) {
-            // Trigger click
-            e.preventDefault();
-            current.click();
-        }
-    }
-
-    componentDidMount() {
-        const { openOnMouseOver } = this.props;
-        const dropdown = this.refs["dropdown"] as HTMLElement;
-
+    getChildren() {
         const menu = this.refs["menu"] as HTMLElement;
-        let children = [];
+        const children = [];
         for (let i = 0; i < menu.childNodes.length; i++) {
             const child = menu.childNodes[i] as HTMLElement;
             // Remove separators
@@ -183,58 +137,86 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
             if (child.classList.contains("mobile") && !pxt.BrowserUtils.isMobile()) continue;
             children.push(child);
         }
-        for (let i = 0; i < children.length; i++) {
-            const prev = i > 0 ? children[i - 1] as HTMLElement : dropdown;
-            const child = children[i] as HTMLElement;
-            const next = i < children.length ? children[i + 1] as HTMLElement : undefined;
-            child.addEventListener('keydown', (e) => {
-                this.navigateToNextElement(e, prev, next);
-                e.stopPropagation();
-            })
-            child.addEventListener('focus', (e) => {
-                this.setActive(child);
-            })
-            child.addEventListener('blur', (e) => {
-                this.blur(child);
-                setTimeout(() => {
-                    if (menu.querySelectorAll('.item.active').length == 0) {
-                        this.hide();
-                    }
-                }, 10);
-            })
-        }
-        const first = children.length > 0 ? children[0] as HTMLElement : undefined;
-        dropdown.addEventListener('keydown', (e) => {
-            this.selectFirstElementOnDown(e, first)
-        });
-        dropdown.addEventListener('blur', (e) => {
-            setTimeout(() => {
-                if (menu.querySelectorAll('.item.active').length == 0) {
-                    this.hide();
-                }
-            }, 1);
-        });
-        if (openOnMouseOver) {
-            dropdown.addEventListener('mouseover', (e) => {
-                dropdown.focus();
-                this.show();
-            });
-        }
-        dropdown.addEventListener('click', (e) => {
-            this.toggle();
-        })
+        return children;
     }
 
-    componentDidUpdate(nextProps: DropdownProps, nextState: DropdownState) {
+    isChildFocused() {
+        const children = this.getChildren();
+        for (let i = 0; i < children.length; i++) {
+            if (document.activeElement === children[i]) return true;
+        }
+        return false;
+    }
+
+    private navigateToNextElement = (e: KeyboardEvent, prev: HTMLElement, next: HTMLElement) => {
+        const dropdown = this.refs["dropdown"] as HTMLElement;
+        const charCode = core.keyCodeFromEvent(e);
+        const current = e.currentTarget as HTMLElement;
+        if (charCode === 40 /* Down arrow */) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (next) {
+                this.focus(next);
+            }
+        } else if (charCode === 38 /* Up arrow */) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (prev) {
+                this.focus(prev);
+            } else {
+                // Prev is undefined, go to dropdown
+                dropdown.focus();
+                this.setState({ open: false });
+            }
+        } else if (charCode === core.SPACE_KEY || charCode === core.ENTER_KEY) {
+            // Trigger click
+            e.preventDefault();
+            e.stopPropagation();
+            current.click();
+        }
+    }
+
+    componentDidMount() {
+        const children = this.getChildren();
+        for (let i = 0; i < children.length; i++) {
+            const prev = i > 0 ? children[i - 1] as HTMLElement : undefined;
+            const child = children[i] as HTMLElement;
+            const next = i < children.length ? children[i + 1] as HTMLElement : undefined;
+
+            child.addEventListener('keydown', (e) => {
+                this.navigateToNextElement(e, prev, next);
+            })
+
+            child.addEventListener('focus', (e: FocusEvent) => {
+                this.setActive(child);
+            })
+            child.addEventListener('blur', (e: FocusEvent) => {
+                this.blur(child);
+            })
+
+            if (i == children.length - 1) {
+                // set tab on last child to clear focus
+                child.addEventListener('keydown', (e) => {
+                    const charCode = core.keyCodeFromEvent(e);
+                    if (!e.shiftKey && charCode === core.TAB_KEY) {
+                        this.hide();
+                    }
+                })
+            }
+        }
+    }
+
+    componentDidUpdate(prevProps: DropdownProps, prevState: DropdownState) {
         // Remove active from all menu items on any update
-        const menu = this.refs["menu"] as HTMLElement;
-        for (let i = 0; i < menu.childNodes.length; i++) {
-            const child = menu.childNodes[i] as HTMLElement;
-            this.blur(child);
+        const children = this.getChildren();
+        for (let i = 0; i < children.length; i++) {
+            const child = children[i] as HTMLElement;
+            // On allow tabbing to valid child nodes (ie: no separators or mobile only items)
+            child.tabIndex = this.state.open ? 0 : -1;
         }
 
         // Check if dropdown width exceeds the bounds, add the left class to the menu
-        if (nextState.open != this.state.open && this.state.open) {
+        if (prevState.open != this.state.open && this.state.open) {
             const dropdown = this.refs["dropdown"] as HTMLElement;
             const menu = this.refs["menu"] as HTMLElement;
             if (dropdown.offsetLeft + menu.offsetWidth > window.innerWidth) {
@@ -242,10 +224,97 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
                 pxsim.U.addClass(menu, 'left');
             }
         }
+
+        if (!prevState.focus && this.state.focus) {
+            // Dropdown focused
+        } else if (prevState.focus && !this.state.focus) {
+            // Dropdown blurred
+            if (!this.isMouseDown) {
+                this.hide()
+            }
+        }
+
+        if (!prevState.open && this.state.open) {
+            // Dropdown opened
+            document.addEventListener('keydown', this.closeOnEscape);
+        } else if (prevState.open && !this.state.open) {
+            // Dropdown closed
+            document.removeEventListener('keydown', this.closeOnEscape);
+            this.handleClose()
+        }
+        if (this.focusFirst && children.length > 0) {
+            // Focus the first child
+            this.focus(children[0]);
+            this.focusFirst = false;
+        }
+    }
+
+    private closeOnEscape = (e: KeyboardEvent) => {
+        const charCode = core.keyCodeFromEvent(e);
+        if (charCode === core.ESC_KEY) {
+            e.preventDefault();
+            const dropdown = this.refs["dropdown"] as HTMLElement;
+            dropdown.focus();
+            // Reset the focus handlers
+            this.isMouseDown = true;
+            this.hide();
+        }
+    }
+
+    private handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        this.toggle();
+        e.stopPropagation()
+    }
+
+    private handleClose = () => {
+        this.isMouseDown = false
+        const hasFocus = document.activeElement === this.refs['dropdown'];
+        this.setState({ focus: hasFocus })
+    }
+
+    private isMouseDown: boolean;
+    private handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+        this.isMouseDown = true
+        document.addEventListener(pxsim.pointerEvents.up, this.handleDocumentMouseUp)
+    }
+
+    private handleDocumentMouseUp = (e: MouseEvent) => {
+        this.isMouseDown = false
+        document.removeEventListener(pxsim.pointerEvents.up, this.handleDocumentMouseUp)
+    }
+
+    private handleFocus = (e: React.FocusEvent<HTMLDivElement>) => {
+        const { focus } = this.state;
+        if (focus) return;
+
+        this.setState({ focus: true });
+    }
+
+    private handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+        if (this.isMouseDown) return;
+        // Use timeout to delay examination of activeElement until after blur/focus 
+        // events have been processed.
+        setTimeout(() => {
+            let open = this.isChildFocused();
+            this.setState({ focus: open });
+        }, 1);
+    }
+
+    private focusFirst: boolean;
+    private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        const charCode = core.keyCodeFromEvent(e);
+        if (charCode === 40 /* Down arrow key */) {
+            e.preventDefault();
+            this.focusFirst = true;
+            this.show();
+        } else if (charCode === core.SPACE_KEY || charCode === core.ENTER_KEY) {
+            e.preventDefault();
+            this.toggle();
+        }
     }
 
     renderCore() {
-        const { disabled, title, role, icon, className, children } = this.props;
+        const { disabled, title, role, icon, className, children, avatarImage, avatarInitials } = this.props;
         const { open } = this.state;
 
         const aria = {
@@ -264,15 +333,20 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
             open ? 'active visible' : '',
             'dropdown',
             icon ? 'icon' : '',
-            className,
+            className || '',
         ]);
         const menuClasses = cx([
             'menu',
             open ? 'visible transition' : ''
         ])
         return (
-            <div ref="dropdown" title={title} {...aria}
+            <div role="listbox" ref="dropdown" title={title} {...aria}
                 className={classes}
+                onMouseDown={this.handleMouseDown}
+                onClick={this.handleClick}
+                onKeyDown={this.handleKeyDown}
+                onFocus={this.handleFocus}
+                onBlur={this.handleBlur}
                 tabIndex={0}
             >
                 {genericContent(this.props)}
@@ -538,7 +612,7 @@ export class Input extends data.Component<InputProps, { value: string }> {
                         autoComplete={p.autoComplete ? "" : "off"}
                         autoCorrect={p.autoComplete ? "" : "off"}
                         autoCapitalize={p.autoComplete ? "" : "off"}
-                        spellCheck={p.autoComplete}/>
+                        spellCheck={p.autoComplete} />
                         : <textarea
                             id={p.id}
                             className={"ui input " + (p.class || "") + (p.inputLabel ? " labelled" : "")}
@@ -1012,7 +1086,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             style={customStyles}
             aria={aria} {...rest}>
             {header || showBack || helpUrl ? <div id={this.id + 'title'} className={"header " + (headerClass || "")}>
-                <span className="header-title" style={{margin: `0 ${helpUrl ? '-20rem' : '0'} 0 ${showBack ? '-20rem' : '0'}`}}>{header}</span>
+                <span className="header-title" style={{ margin: `0 ${helpUrl ? '-20rem' : '0'} 0 ${showBack ? '-20rem' : '0'}` }}>{header}</span>
                 {showBack ? <div className="header-close">
                     <Button className="back-button large" title={lf("Go back")} onClick={onClose} tabIndex={0} onKeyDown={fireClickOnEnter}>
                         <Icon icon="arrow left" />

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -314,7 +314,7 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
     }
 
     renderCore() {
-        const { disabled, title, role, icon, className, children, avatarImage, avatarInitials } = this.props;
+        const { disabled, title, role, icon, className, children } = this.props;
         const { open } = this.state;
 
         const aria = {


### PR DESCRIPTION
Re-write dropdown menu sui component with better handling of blur and focus events in a more “React” way.

The dropdown component had a bunch of hangover code from a more Jquery approach to writing components, this introduces a race with blur / focus events that would sometimes block the a click on a menu item. 

I've re-written the component in a more react friendly way using the state to handle focus of the dropdown. 
The component now handles tabIndex internally so no need to set that on any child components. It will set the tabindex to it's children when it opens.

This also improves the accessibility of the dropdown menu allowing you to both use the up / down keys to navigate but also use tab navigation. 
It compiles with approach 2 in https://www.w3.org/WAI/tutorials/menus/flyout/#flyoutnavmousefixed


Tested on Chrome, Edge, IE, Firefox, Safari, and IOS. 