### PR TITLE
Use metaColor instead of color for inverted toolboxes

### DIFF
--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -645,7 +645,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
 
     renderCore() {
         const { selected, onClick, onKeyDown, isRtl } = this.props;
-        const { nameid, subns, name, icon, color } = this.props.treeRow;
+        const { nameid, subns, name, icon } = this.props.treeRow;
         const appTheme = pxt.appTarget.appTheme;
         const metaColor = this.getMetaColor();
 
@@ -678,7 +678,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
         if (selected) {
             treeRowClass += ' blocklyTreeSelected';
             if (appTheme.invertedToolbox) {
-                treeRowStyle.backgroundColor = `${pxt.toolbox.fadeColor(color, invertedMultipler, false)}`;
+                treeRowStyle.backgroundColor = `${pxt.toolbox.fadeColor(metaColor, invertedMultipler, false)}`;
             } else {
                 treeRowStyle.backgroundColor = (metaColor || '#ddd');
             }


### PR DESCRIPTION
Fix null color issue when no namespace color is set in an inverted toolbox setting.

Fixes https://github.com/samelhusseini/pxt-holidays/issues/7