### PR TITLE
Made lesson code cards link to external pages

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -1,4 +1,7 @@
 declare namespace pxt {
+
+    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw";
+
     interface Map<T> {
         [index: string]: T;
     }
@@ -119,7 +122,7 @@ declare namespace pxt {
         buyUrl?: string;
         feedbackUrl?: string;
         responsive?: boolean;
-        cardType?: "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw";
+        cardType?: CodeCardType;
 
         header?: string;
         any?: number;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -567,7 +567,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             className: 'huge positive'
         }]
 
-        const isLink = !cardType && (youTubeId || url);
+        const isLink = (!cardType || cardType == "lesson") && (youTubeId || url);
         const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
             ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -523,7 +523,7 @@ export interface ProjectsDetailProps extends ISettingsProps {
     url?: string;
     scr?: any;
     onClick: (scr: any) => void;
-    cardType: string;
+    cardType: pxt.CodeCardType;
     tags?: string[];
 }
 
@@ -567,7 +567,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             className: 'huge positive'
         }]
 
-        const isLink = (!cardType || cardType == "lesson") && (youTubeId || url);
+        const isLink = !cardType && (youTubeId || url);
         const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
             ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
 


### PR DESCRIPTION
The lesson code cards on the Arcade Homepage don't open as links because they have a cardType set to "lesson". This makes it so that if a code card has this specific cardType, it will open as a link just like those without cardTypes set.

Fixes Microsoft/pxt-arcade#374

An alternative would also be to remove the cardType from these lessons. 

The way this commit does it however allows for more flexibility in the future since it allows for being more descriptive about the cards and distinguish between lessons from links.