### PR TITLE
use 3px stroke-width in high contrast on blocks

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -127,6 +127,9 @@
         background: @HCblocklyToolboxColor !important;
         border-right: 0px !important;
     }
+    .blocklyPath {
+        stroke-width: 3px;
+    }
 
     /* Menu bar */
     .menubar .menu > .item:focus > i,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4175913/49899398-78895c80-fe10-11e8-870d-869a7f16dc27.png)

vs

![image](https://user-images.githubusercontent.com/4175913/49899424-8939d280-fe10-11e8-8d97-a6a6d44ecf4a.png)
