### PR TITLE
urldata may come back as object instead of array

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -108,18 +108,20 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             data: [],
             status: data.FetchStatus.Complete
         };
-        if (!this.state.searchFor || this.state.mode != ScriptSearchMode.Extensions) return emptyResult;
+        if (!this.state.searchFor || this.state.mode != ScriptSearchMode.Extensions) 
+            return emptyResult;
 
-        let scriptid = pxt.Cloud.parseScriptId(this.state.searchFor)
-
+        const scriptid = pxt.Cloud.parseScriptId(this.state.searchFor)
         if (!scriptid) {
             return emptyResult;
         }
 
         const res = this.getDataWithStatus(`cloud-search:${scriptid}`);
-
         if (!res.data || (res.data && res.data.statusCode === 404))
             res.data = []; // No shared project with that URL exists
+        // cloud may return single result, wrapping in array
+        if (!Array.isArray(res.data))
+            res.data = [res.data];
         return res;
     }
 

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -118,9 +118,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
         const res = this.getDataWithStatus(`cloud-search:${scriptid}`);
 
-        if (res.data && res.data.statusCode === 404)
+        if (!res.data || (res.data && res.data.statusCode === 404))
             res.data = []; // No shared project with that URL exists
-
         return res;
     }
 

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -108,7 +108,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             data: [],
             status: data.FetchStatus.Complete
         };
-        if (!this.state.searchFor || this.state.mode != ScriptSearchMode.Extensions) 
+        if (!this.state.searchFor || this.state.mode != ScriptSearchMode.Extensions)
             return emptyResult;
 
         const scriptid = pxt.Cloud.parseScriptId(this.state.searchFor)


### PR DESCRIPTION
Wrap in array as needed.

Fix for https://github.com/Microsoft/pxt-arcade/issues/342