### PR TITLE
Wait till transition is over before changing editor again

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -300,6 +300,8 @@ export class ProjectView
     }
 
     openJavaScript(giveFocusOnLoading = true) {
+        if (this.updatingEditorFile) return; // already transitioning
+
         if (this.isJavaScriptActive()) {
             if (this.state.embedSimView) {
                 this.setState({ embedSimView: false });
@@ -319,6 +321,8 @@ export class ProjectView
     }
 
     openBlocks() {
+        if (this.updatingEditorFile) return; // already transitioning
+
         if (this.isBlocksActive()) {
             if (this.state.embedSimView) this.setState({ embedSimView: false });
             return;
@@ -598,6 +602,8 @@ export class ProjectView
         if (this.updatingEditorFile)
             return undefined;
         this.updatingEditorFile = true;
+        const simRunning = !!this.state.running;
+        this.stopSimulator();
         this.saveSettings();
 
         const hc = this.state.highContrast;
@@ -631,6 +637,8 @@ export class ProjectView
             }).finally(() => {
                 this.forceUpdate();
                 this.updatingEditorFile = false;
+                if (simRunning)
+                    this.startSimulator();
             })
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -7,7 +7,6 @@ import * as core from "./core";
 import * as toolboxeditor from "./toolboxeditor"
 import * as compiler from "./compiler"
 import * as sui from "./sui";
-import * as data from "./data";
 import * as snippets from "./monacoSnippets"
 import * as toolbox from "./toolbox";
 import * as workspace from "./workspace";


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-arcade/issues/359

This is a race that is exposed in Arcade because the editor significantly slower there. The repro is very easy: you just need to button-smash "javascript" in the toggle to loose the code. This happens because both editor are trying to transition and the code hasn't been migrated yet.

There was a flag that track that we were transitioning but it wasn't used. So that fixed it. Also turning off simulator during transition to speed it up.

Overall, state management in the editor is scatered and could use a cleanup.
