### PR TITLE
guard sourcemap with envrionment variable

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -12,10 +12,10 @@ function tscIn(task, dir, builtDir) {
     let command = 'node ' + path.relative(dir, './node_modules/typescript/bin/tsc')
     if (process.env.sourceMaps === 'true') {
         command += ' --sourceMap --mapRoot file:///' + path.resolve(builtDir)
-    }
-    if (process.env.PXT_ENV != 'production') {
-        // In development, dump the sources inline
-        command += ' --inlineSourceMap --inlineSources'
+        if (process.env.PXT_ENV != 'production') {
+            // In development, dump the sources inline
+            command += ' --inlineSourceMap --inlineSources'
+        }
     }
     cmdIn(task, dir, command)
 }


### PR DESCRIPTION
Guard source map generation with the environment flag. They are producing invalid maps on my box.