### PR TITLE
Better centering of closing icon for sprite editor

### DIFF
--- a/theme/spriteeditor.less
+++ b/theme/spriteeditor.less
@@ -173,12 +173,12 @@
     right: 1rem;
     color: white;
     border-radius: 50%;
-    font-size: 34px;
+    font-size: 2.15rem;
     transition: all .15s ease-out;
     height: 2.15rem;
     width: 2.15rem;
     padding: 0;
-    line-height: 34px;
+    line-height: 2.15rem;
 }
 
 .sprite-editor-glyph {


### PR DESCRIPTION
I realize this is very minor, but it was really bugging me.

In the closing icon for the sprite editor, the icon is currently set to a different size then the icon tag it is in causing the center of the icon and the center of the outer circle to not line up. If you look at the bottom, you can see there is more space (about 50% more) between the icon and the outer circle than the top.

![center-icon](https://user-images.githubusercontent.com/13285164/49984038-094c5f00-ff1b-11e8-902e-13e4074e1102.gif)
