### PR TITLE
Don't allow invalid bitmaps in image editor

### DIFF
--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -179,7 +179,12 @@ namespace pxtblockly {
         }
 
         private parseBitmap(newText: string) {
-            this.state = pxtsprite.imageLiteralToBitmap(newText);
+            const bmp = pxtsprite.imageLiteralToBitmap(newText);
+
+            // Ignore invalid bitmaps
+            if (bmp && bmp.width && bmp.height) {
+                this.state = bmp;
+            }
         }
 
         /**


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/451

I must have refactored some code and broken this with the Monaco field editor.