### PR TITLE
Fixed centering for all closing icons

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -218,22 +218,21 @@
             z-index: 1;
         }
         >.close .remove.icon {
-            font-size: 34px;
+            font-size: 2.15rem;
+            line-height: 2.15rem;
             cursor: pointer;
-            width: 2.0rem;
+            width: 2.15rem;
             color: @homeDetailCloseColor;
-            height: 2.0rem;
+            height: 2.15rem;
             transition: all 0.15s ease-out;
             opacity: 0.9;
             border-radius: 50%;
-            padding-top: 0.3rem;
-            outline: none;
             background-color: @homeDetailCloseBackground;
         }
         > .close .remove.icon:hover, > .close .remove.icon:focus {
             opacity: 1;
             transform: scale(1.1, 1.1);
-            box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.35);
+            box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.35);
         }
     }
 }

--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -206,7 +206,8 @@
     right: @innerCloseRight;
     color: @innerCloseColor;
     border-radius: 50%;
-    font-size: 34px;
+    font-size: 2.15rem;
+    line-height: 2.15rem;
     transition: all .15s ease-out;
     height: 2.15rem;
     width: 2.15rem;
@@ -214,7 +215,7 @@
 }
 .ui.modal > .closeIcon:focus .close,
 .ui.modal > .closeIcon:hover  .close {
-    box-shadow: 0 0 0 4px rgba(0,0,0,.35);
+    box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.35);
     outline: none;
     transform: scale(1.1);
 }


### PR DESCRIPTION
Does the same fix as Microsoft/pxt#5102, but for all closing icons.

Also makes the three icons, (home page, modal, and sprite editor) more consistent with each other with the same heights/widths and border-shadows.