### PR TITLE
Fix transparent background Zindex issue with the flyout

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -110,7 +110,7 @@ body {
 
 .transparentEditorTools #editortools {
     background-color: transparent;
-    z-index: (@blocklyToolboxZIndex)-1;
+    z-index: (@blocklyFlyoutZIndex)-1;
 }
 
 #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #filelist {


### PR DESCRIPTION
Fix subtle Minecraft bug with z-index clash between Blockly flyout and transparent toolbar.