### PR TITLE
Use the triple-toggle view in all sandbox embeds

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -619,6 +619,26 @@ p.ui.font.small {
 
 /* Mobile + Tablet */
 @media only screen and (max-width: @largestTabletScreen) {
+    #root.sandbox .active.item.sim-menuitem ~ .toggle {
+        margin-left: 0 !important;
+        box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
+        background: @editorToggleColor !important;
+    }
+    #root.sandbox .active.item.blocks-menuitem ~ .toggle {
+        margin-left: 40px !important;
+        box-shadow: 2px 0px 0px rgba(0,0,0,0.1), -2px 0px 0px rgba(0,0,0,0.1) !important;
+        background: @editorToggleColor !important;
+    }
+    #root.sandbox .active.item.javascript-menuitem ~ .toggle {
+        margin-left: 80px !important;
+        box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
+        background: @editorToggleColor !important;
+    }
+
+    .simView #boardview {
+        padding-top: @sandboxMobileMenuHeight;
+    }
+
     .ui.portrait.only {
         display:inherit !important;
     }
@@ -944,118 +964,128 @@ p.ui.font.small {
     }
 }
 
-/* Mobile, Tablet AND thin screen */
-@media only screen and (max-width: @largestTabletScreen) and (max-height: @thinEditorBreakpoint) {
-    /* Mobile embedded view */
-    .sandbox #simulators{
-        display: none;
-    }
-    .sandbox #maineditor {
-        overflow: hidden;
-    }
-    .sandbox #blocksArea,
-        .sandbox #monacoEditor,
-        .sandbox #pxtJsonEditor,
-        .sandbox #serialEditor,
-        .sandbox #editortools,
-        .sandbox #msg {
-        bottom: 1.5rem !important;
-    }
-    .sandbox #editortools {
-        display: none;
-    }
-    .simView #simulators {
-        display: inherit;
-    }
-    .simView #filelist {
-        position: fixed;
-        z-index: @fullscreenZIndex;
-        top:0 !important;
-        left:0 !important;
-        bottom:0 !important;
-        right:0 !important;
-        padding: 0;
-        margin: 0;
-        max-width: 100%;
-        min-width: 100%;
-        height:100%;
-    }
-    .simView #boardview {
-        position: relative;
-        height:100%;
-        background-color: white;
-        padding-top: @sandboxMobileMenuHeight;
-        padding-left: 2em;
-        padding-right: 2em;
-        padding-bottom: 2em;
-
-        background-color: @fullscreenBackgroundGradientStart;
-        background: @fullscreenBackgroundGradientStart; /* For browsers that do not support gradients */
-        background: -webkit-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Safari 5.1 to 6.0 */
-        background: -o-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Opera 11.1 to 12.0 */
-        background: -moz-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Firefox 3.6 to 15 */
-        background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
-    }
-    .simView #simulator .ui.item,
-        .simView #maineditor {
-        display: none !important;
-        z-index: -10 !important;
-    }
-    .sandboxfooter {
-        left: 0.5em !important;
-        right: 0.5em !important;
-        margin: 0rem !important;
-        right: auto;
-        text-align: center;
-    }
-    .sandboxfooter .item{
-        font-size: 0.7rem !important;
-    }
-    .simView .sandboxfooter {
-        z-index: @sandboxFooterZIndex;
-    }
-    .simView .ui.menu {
-        background: transparent !important;
-    }
-    .simView #simulators {
-        position: relative;
-        width: 100%;
-        height: 100%;
-    }
-    .simView div.simframe {
-        position:relative;
-        width: 50%;
-        height: 100%;
-        float: left;
-        padding-bottom: 0 !important;
-    }
-    .simView div.simframe > iframe {
-        position:relative;
-        max-width: 90%;
-    }
-    .simView div.simframe:only-child {
-        width: 100%;
-    }
-    .simView div.simframe:only-child > iframe {
-        max-width: 100%;
-    }
+.simView #filelist {
+    position: fixed;
+    z-index: @fullscreenZIndex;
+    top:0 !important;
+    left:0 !important;
+    bottom:0 !important;
+    right:0 !important;
+    padding: 0;
+    margin: 0;
+    max-width: 100%;
+    min-width: 100%;
+    height:100%;
 }
 
-@media only screen and (max-height: @thinEditorBreakpoint) and (max-width: @computerBreakpoint){
-    /* sim-menuitem visible in this view (in sandbox mode), adjust toggle margins */
-    #root.sandbox .active.item.sim-menuitem ~ .toggle {
+.simView #boardview {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow-y: hidden;
+
+    background-color: white;
+    padding-left: 2em;
+    padding-right: 2em;
+    padding-bottom: 2em;
+    padding-top: @mainMenuHeight;
+
+    background-color: @fullscreenBackgroundGradientStart;
+    background: @fullscreenBackgroundGradientStart; /* For browsers that do not support gradients */
+    background: -webkit-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Safari 5.1 to 6.0 */
+    background: -o-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Opera 11.1 to 12.0 */
+    background: -moz-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Firefox 3.6 to 15 */
+    background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
+}
+
+.simView #simulator .ui.item,
+    .simView #maineditor {
+    display: none !important;
+    z-index: -10 !important;
+}
+
+.sandboxfooter {
+    left: 0.5em !important;
+    right: 0.5em !important;
+    margin: 0rem !important;
+    right: auto;
+    text-align: center;
+}
+
+.sandboxfooter .item{
+    font-size: 0.7rem !important;
+}
+
+.simView .sandboxfooter {
+    z-index: @sandboxFooterZIndex;
+}
+
+.simView .ui.menu {
+    background: transparent !important;
+}
+
+.simView #simulators {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.simView div.simframe {
+    position:relative;
+    width: 50%;
+    height: 100%;
+    float: left;
+    padding-bottom: 0 !important;
+}
+
+.simView div.simframe > iframe {
+    position:relative;
+    max-width: 90%;
+}
+
+.simView div.simframe:only-child {
+    width: 100%;
+}
+
+.simView div.simframe:only-child > iframe {
+    max-width: 100%;
+}
+
+.sandbox {
+    #simulators, #simulator, #editortools {
+        display: none;
+    }
+
+    #maineditor {
+        overflow: hidden;
+        left: 0;
+    }
+
+    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #editortools, #msg {
+        bottom: 1.5rem !important;
+    }
+
+    .active.item.sim-menuitem ~ .toggle {
         margin-left: 0 !important;
         box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;
     }
-    #root.sandbox .active.item.blocks-menuitem ~ .toggle {
-        margin-left: 40px !important;
-        box-shadow: 2px 0px 0px rgba(0,0,0,0.1), -2px 0px 0px rgba(0,0,0,0.1) !important;
+    .active.item.blocks-menuitem ~ .toggle {
+        margin-left: 140px !important;
+        box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;
     }
-    #root.sandbox .active.item.javascript-menuitem ~ .toggle {
-        margin-left: 80px !important;
+    .active.item.javascript-menuitem ~ .toggle {
+        margin-left: 280px !important;
         box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;
+    }
+}
+
+.sandbox.simView {
+    #simulators, #simulator, #editortools {
+        display: inherit;
     }
 }

--- a/theme/common.less
+++ b/theme/common.less
@@ -1000,8 +1000,7 @@ p.ui.font.small {
     background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
 }
 
-.simView #simulator .ui.item,
-    .simView #maineditor {
+.simView #maineditor {
     display: none !important;
     z-index: -10 !important;
 }
@@ -1027,9 +1026,11 @@ p.ui.font.small {
 }
 
 .simView #simulators {
-    position: relative;
-    width: 100%;
-    height: 100%;
+    position: absolute;
+    top: @mainMenuHeight;
+    bottom: 4rem;
+    left: 0;
+    right: 0;
 }
 
 .simView div.simframe {
@@ -1087,5 +1088,15 @@ p.ui.font.small {
 .sandbox.simView {
     #simulators, #simulator, #editortools {
         display: inherit;
+    }
+
+    #filelist .simtoolbar {
+        position: fixed;
+        bottom: 0.25em;
+        left: auto;
+        right: auto;
+
+        flex-direction: row !important;
+        margin-bottom: 1em !important;
     }
 }

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -413,7 +413,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 </div>}
             {!inTutorial && !targetTheme.blocksOnly ? <div className="ui item link editor-menuitem">
                 <div className="ui grid padded">
-                    {sandbox ? <sui.Item className="sim-menuitem thin portrait only" role="menuitem" textClass="landscape only" text={lf("Simulator")} icon={simActive && isRunning ? "stop" : "play"} active={simActive} onClick={this.openSimView} title={!simActive ? lf("Show Simulator") : runTooltip} /> : undefined}
+                    {sandbox ? <sui.Item className="sim-menuitem" role="menuitem" textClass="landscape only" text={lf("Simulator")} icon={simActive && isRunning ? "stop" : "play"} active={simActive} onClick={this.openSimView} title={!simActive ? lf("Show Simulator") : runTooltip} /> : undefined}
                     <sui.Item className="blocks-menuitem" role="menuitem" textClass="landscape only" text={lf("Blocks")} icon="xicon blocks" active={blockActive} onClick={this.openBlocks} title={lf("Convert code to Blocks")} />
                     <sui.Item className="javascript-menuitem" role="menuitem" textClass="landscape only" text={lf("JavaScript")} icon="xicon js" active={javascriptActive} onClick={this.openJavaScript} title={lf("Convert code to JavaScript")} />
                     <div className="ui item toggle"></div>

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -87,7 +87,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const tracing = this.props.parent.state.tracing;
         const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debugging = parentState.debugging;
-        const fullscreen = run && !inTutorial && !simOpts.hideFullscreen
+        const fullscreen = run && !inTutorial && !simOpts.hideFullscreen && !sandbox;
         const audio = run && !inTutorial && targetTheme.hasAudio;
         const isHeadless = simOpts.headless;
         const collapse = !!targetTheme.pairingButton;
@@ -100,7 +100,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const muteTooltip = isMuted ? lf("Unmute audio") : lf("Mute audio");
         const collapseTooltip = lf("Hide the simulator");
 
-        return <aside className="ui item grid centered portrait hide simtoolbar" role="complementary" aria-label={lf("Simulator toolbar")}>
+        return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait hide")} role="complementary" aria-label={lf("Simulator toolbar")}>
             <div className={`ui icon tiny buttons ${isFullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>
                 {make ? <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} /> : undefined}
                 {run ? <sui.Button disabled={debugging || isStarting} key='runbtn' className={`play-button ${isRunning ? "stop" : "play"}`} icon={isRunning ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}


### PR DESCRIPTION
![triple_embed](https://user-images.githubusercontent.com/13754588/50108021-0e463280-01e9-11e9-828a-a39db26a78fe.gif)

I know that GIF shows the full screen button in the sim toolbar, but after I recorded it I removed that button and was too lazy to redo it. It's redundant in the triple-toggle mode.

Tested in Chrome, Edge, IE, and Firefox.

All of the tests were done with arcade, not sure if that matters.