### PR TITLE
Early semantic init

### DIFF
--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -53,6 +53,15 @@ function searchSubmit(form) {
     if (pxt && pxt.tickEvent) pxt.tickEvent("docs.search", { 'source': form.id }, { interactiveConsent: true })
 }
 
+function scrollActiveHeaderIntoView() {
+    var activeHeaders = document.getElementsByClassName("header active");
+    for (var i = 0; i < activeHeaders.length; ++i) {
+        var activeHeader = activeHeaders.item(i);
+        if (activeHeader.scrollIntoView)
+            activeHeader.scrollIntoView()
+    }
+}
+
 function setupSidebar() {
     $('#togglesidebar').on('keydown', handleEnterKey);
 
@@ -62,6 +71,7 @@ function setupSidebar() {
             onShow: function () {
                 togglesidebar.setAttribute("aria-expanded", "true");
                 document.getElementsByClassName("sidebar").item(0).getElementsByClassName("focused").item(0).focus();
+                scrollActiveHeaderIntoView();
             },
             onHidden: function () {
                 togglesidebar.setAttribute("aria-expanded", "false");
@@ -112,6 +122,8 @@ function setupSidebar() {
     for (var i = 0; i < searchIcons.length; i++) {
         searchIcons.item(i).onkeydown = handleEnterKey;
     }
+
+    scrollActiveHeaderIntoView();
 }
 
 function setupSemantic() {

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -63,8 +63,8 @@ function scrollActiveHeaderIntoView() {
 }
 
 function setupSidebar() {
+    // do not use pxt.appTarget in this function
     $('#togglesidebar').on('keydown', handleEnterKey);
-
     $('.ui.sidebar')
         .sidebar({
             dimPage: false,
@@ -127,6 +127,7 @@ function setupSidebar() {
 }
 
 function setupSemantic() {
+    // do not use pxt.appTarget in this function
     // don't show related videos
     $.fn.embed.settings.sources.youtube.url = '//www.youtube.com/embed/{id}?rel=0'
 
@@ -234,8 +235,6 @@ function setupBlocklyAsync() {
 function renderSnippets() {
     var path = window.location.href.split('/').pop().split(/[?#]/)[0];
     ksRunnerReady(function () {
-        setupSidebar();
-        setupSemantic();
         setupBlocklyAsync()
             .then(function () {
                 return pxt.runner.renderAsync({
@@ -259,5 +258,7 @@ function renderSnippets() {
 }
 
 $(document).ready(function () {
+    setupSidebar();
+    setupSemantic();
     renderSnippets();
 });

--- a/docfiles/head.html
+++ b/docfiles/head.html
@@ -7,11 +7,11 @@
 <link rel="stylesheet" href="/docfiles/vs.css" />
 <link rel="stylesheet" href="/docfiles/target.css" />
 
-<script src="/doccdn/jquery.js"></script>
-
+<script src="/doccdn/jquery.js" type="text/javascript"></script>
+<script src="/doccdn/semantic.js" type="text/javascript"></script>
+<script src="/blb/target.js" type="text/javascript"></script>
 <script src="/--embed" type="text/javascript"></script>
 <script src="/docfiles/docs.js" type="text/javascript"></script>
-<script src="/docfiles/target.js" type="text/javascript"></script>
 
 <style>
     @targetstyle@

--- a/webapp/public/embed.js
+++ b/webapp/public/embed.js
@@ -7,14 +7,16 @@
     var scripts = [
         "/blb/highlight.js/highlight.pack.js",
         "/blb/bluebird.min.js",
-        "/blb/semantic.js",
         "/blb/marked/marked.min.js",
-        "/blb/target.js",
-        "/blb/pxtembed.js"
     ]
 
     if (typeof jQuery == "undefined")
-        scripts.unshift("/blb/jquery.js")
+        scripts.unshift("/doccdn/jquery.js")
+    if (typeof jQuery == "undefined" || !jQuery.prototype.sidebar)
+        scripts.push("/doccdn/semantic.js")
+    if (!window.pxtTargetBundle)
+        scripts.push("/blb/target.js");
+    scripts.push("/blb/pxtembed.js");
 
     var pxtCallbacks = []
 


### PR DESCRIPTION
* [x] move semantic init before loading PXT compilers. In Arcade, compilation takes a ton of time and the page is in limbo for 10seconds.
* [x] always scroll active header into view
* [x] consistently use /doccdn/ for semantic, /blb/ for other resources