### PR TITLE
(image editor ) add current image dimensions to preset if non-standard

### DIFF
--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -99,7 +99,7 @@ namespace pxtblockly {
             });
 
             this.editor.setActiveColor(this.params.initColor, true);
-            if (!this.params.sizes.some(s => s[0] == this.state.width && s[1] == this.state.height)) {
+            if (!this.params.sizes.some(s => s[0] === this.state.width && s[1] === this.state.height)) {
                 this.params.sizes.push([this.state.width, this.state.height]);
             }
             this.editor.setSizePresets(this.params.sizes);

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -99,6 +99,9 @@ namespace pxtblockly {
             });
 
             this.editor.setActiveColor(this.params.initColor, true);
+            if (!this.params.sizes.some(s => s[0] == this.state.width && s[1] == this.state.height)) {
+                this.params.sizes.push([this.state.width, this.state.height]);
+            }
             this.editor.setSizePresets(this.params.sizes);
 
             goog.style.setHeight(contentDiv, this.editor.outerHeight() + 1);


### PR DESCRIPTION
If an image has dimensions that were not found by default (e.g. made a different sized sprite in typescript and decompiled), add those dimension to the possible resize options so that the user can cycle back to the same size with the resize button. 

![2018-12-21 16 24 12](https://user-images.githubusercontent.com/5615930/50368416-4b8a2780-053d-11e9-859a-9faa676c7748.gif)

(also serves as a temporary patch for microsoft/pxt-arcade#488, as then they can cycle back to 64x64 or whatever size they had instead of just losing a portion of their sprite)

(thanks @ikeras for pointing out issue)

(and excuse the wonky css in the gif, I hadn't rebuilt css since the monaco field editor update)