### PR TITLE
generate projects.md/summary from targetconfig

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1758,8 +1758,8 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
                     }))
             });
 
-            nodeutil.writeFileSync(path.join(docsRoot, "projects/SUMMARY.md"), tocmd, { encoding: "utf8" });
-            nodeutil.writeFileSync(path.join(docsRoot, "projects.md"),
+            nodeutil.writeFileSync(path.join(docsRoot, "docs/projects/SUMMARY.md"), tocmd, { encoding: "utf8" });
+            nodeutil.writeFileSync(path.join(docsRoot, "docs/projects.md"),
                 `# Projects
 
 \`\`\`codecard

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1727,17 +1727,28 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
     if (nodeutil.fileExistsSync("targetconfig.json")) {
         const targetConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
         if (targetConfig && targetConfig.galleries) {
+            let md: string =
+                `# Projects
+
+`;
             Object.keys(targetConfig.galleries).forEach(k => {
                 targetStrings[k] = k;
                 const docsRoot = nodeutil.targetDir;
                 const gallerymd = nodeutil.resolveMd(docsRoot, targetConfig.galleries[k]);
                 const gallery = pxt.gallery.parseGalleryMardown(gallerymd);
+                md +=
+                    `* [${k}](${targetConfig.galleries[k]})
+`;
                 gallery.forEach(cards => cards.cards
-                    .filter(card => card.tags)
-                    .forEach(card => card.tags.forEach(tag => {
-                        targetStrings[tag] = tag;
-                    })))
+                    .forEach(card => {
+                        md += `  * [${card.name || card.title}](${card.url})
+`;
+                        if (card.tags)
+                            card.tags.forEach(tag => targetStrings[tag] = tag);
+                    }))
             });
+
+            nodeutil.writeFileSync("docs/projects/SUMMARY.md", md, { encoding: "utf8" });
         }
     }
     // extract strings from editor

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1727,6 +1727,7 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
     if (nodeutil.fileExistsSync("targetconfig.json")) {
         const targetConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
         if (targetConfig && targetConfig.galleries) {
+            const docsRoot = nodeutil.targetDir;
             let gcards: pxt.CodeCard[] = [];
             let tocmd: string =
                 `# Projects
@@ -1734,7 +1735,6 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
 `;
             Object.keys(targetConfig.galleries).forEach(k => {
                 targetStrings[k] = k;
-                const docsRoot = nodeutil.targetDir;
                 const gallerymd = nodeutil.resolveMd(docsRoot, targetConfig.galleries[k]);
                 const gallery = pxt.gallery.parseGalleryMardown(gallerymd);
                 tocmd +=
@@ -1758,8 +1758,8 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
                     }))
             });
 
-            nodeutil.writeFileSync("docs/projects/SUMMARY.md", tocmd, { encoding: "utf8" });
-            nodeutil.writeFileSync("docs/projects.md",
+            nodeutil.writeFileSync(path.join(docsRoot, "projects/SUMMARY.md"), tocmd, { encoding: "utf8" });
+            nodeutil.writeFileSync(path.join(docsRoot, "projects.md"),
                 `# Projects
 
 \`\`\`codecard


### PR DESCRIPTION
Keeps in sync the markdown (crawlable) and targetconfig.json by generating the required projects.md and projects/SUMMARY.md.