### PR TITLE
keep menu visible when simulator is up

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1021,10 +1021,6 @@ p.ui.font.small {
     z-index: @sandboxFooterZIndex;
 }
 
-.simView .ui.menu {
-    background: transparent !important;
-}
-
 .simView #simulators {
     position: absolute;
     top: @mainMenuHeight;


### PR DESCRIPTION
When trasitioning between the 3 views, feels weird to have the menu go dark.