### PR TITLE
Fix some accessibility bugs found using Keros

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -152,6 +152,7 @@ namespace pxsim {
 
             const frame = document.createElement('iframe') as HTMLIFrameElement;
             frame.id = 'sim-frame-' + this.nextId()
+            frame.title = pxsim.localization.lf("Simulator")
             frame.allowFullscreen = true;
             frame.setAttribute('allow', 'autoplay');
             frame.setAttribute('sandbox', 'allow-same-origin allow-scripts');

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2523,7 +2523,7 @@ export class ProjectView
         const tutorialOptions = this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const inHome = this.state.home && !sandbox;
-        const inEditor = !!this.state.header;
+        const inEditor = !!this.state.header && !inHome;
         const { lightbox, greenScreen } = this.state;
         const simDebug = !!targetTheme.debugger;
 
@@ -2577,7 +2577,7 @@ export class ProjectView
         return (
             <div id='root' className={rootClasses}>
                 {greenScreen ? <greenscreen.WebCam close={this.toggleGreenScreen} /> : undefined}
-                {hideMenuBar ? undefined :
+                {hideMenuBar || inHome ? undefined :
                     <header className="menubar" role="banner">
                         {inEditor ? <accessibility.EditorAccessibilityMenu parent={this} highContrast={this.state.highContrast} /> : undefined}
                         <notification.NotificationBanner parent={this} />
@@ -2588,9 +2588,8 @@ export class ProjectView
                 </div> : undefined}
                 <div id="simulator">
                     {simDebug ? <debug.DebuggerToolbar parent={this} /> : undefined}
-                    <aside id="filelist" className="ui items">
-                        <label htmlFor="boardview" id="boardviewLabel" className="accessible-hidden" aria-hidden="true">{lf("Simulator")}</label>
-                        <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-labelledby="boardviewLabel">
+                    <div id="filelist" className="ui items">
+                        <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")}>
                         </div>
                         <simtoolbar.SimulatorToolbar parent={this} />
                         <div className="ui item portrait hide hidefullscreen">
@@ -2602,17 +2601,17 @@ export class ProjectView
                                 <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.openDeviceSerial} />
                             </div> : undefined}
                         {sandbox || isBlocks || this.editor == this.serialEditor ? undefined : <filelist.FileList parent={this} />}
-                    </aside>
+                    </div>
                 </div>
-                <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
+                <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main" aria-hidden={inHome}>
                     {this.allEditors.map(e => e.displayOuter())}
                 </div>
-                {inHome ? <div id="homescreen" className="full-abs" role="main">
+                {inHome ? <div id="homescreen" className="full-abs">
                     <div className="ui home projectsdialog">
-                        <div className="menubar" role="banner">
+                        <header className="menubar" role="banner">
                             <accessibility.HomeAccessibilityMenu parent={this} highContrast={this.state.highContrast} />
                             <projects.ProjectsMenu parent={this} />
-                        </div>
+                        </header>
                         <projects.Projects parent={this} ref={this.handleHomeRef} />
                     </div>
                 </div> : undefined}

--- a/webapp/src/carousel.tsx
+++ b/webapp/src/carousel.tsx
@@ -85,7 +85,7 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
         const { rightDisabled, leftDisabled } = this.state;
 
         return <div className="ui carouselouter">
-            <span role="button" className={"carouselarrow left aligned" + (leftDisabled ? " arrowdisabled" : "")}
+            <span role="button" className={"carouselarrow left aligned" + (leftDisabled ? " arrowdisabled" : "")} aria-label={lf("See previous")}
                 tabIndex={leftDisabled ? -1 : 0} onClick={this.onLeftArrowClick} onKeyDown={sui.fireClickOnEnter} ref={this.handleArrowRefs}>
                 <sui.Icon icon="circle angle left" />
             </span>
@@ -99,7 +99,7 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
                     }
                 </div>
             </div>
-            <span role="button" className={"carouselarrow right aligned" + (rightDisabled ? " arrowdisabled" : "")}
+            <span role="button" className={"carouselarrow right aligned" + (rightDisabled ? " arrowdisabled" : "")} aria-label={lf("See more")}
                 tabIndex={rightDisabled ? -1 : 0} onClick={this.onRightArrowClick} onKeyDown={sui.fireClickOnEnter} ref={this.handleArrowRefs}>
                 <sui.Icon icon="circle angle right" />
             </span>

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -95,7 +95,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                 </div> : null}
             {card.label || card.labelIcon || card.blocksXml || card.typeScript || imageUrl || cardType == "file" ? <div className={"ui image"}>
                 {card.label || card.labelIcon ?
-                    <label role={card.onLabelClicked ? 'button' : ''} onClick={card.onLabelClicked}
+                    <label role={card.onLabelClicked ? 'button' : undefined} onClick={card.onLabelClicked}
                         className={`ui ${card.labelClass ? card.labelClass : "orange right ribbon"} label`}>
                     {card.labelIcon ? <sui.Icon icon={card.labelIcon} /> : card.label}</label> : undefined}
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : undefined}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -179,10 +179,10 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             signIn = this.getData("sync:username") || lf("Sign in")
         }
 
-        return <div ref="homeContainer" className={tabClasses}>
+        return <div ref="homeContainer" className={tabClasses} role="main">
             {showHeroBanner ?
                 <div className="ui segment getting-started-segment" style={{ backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` }} /> : undefined}
-            <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment">
+            <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment" role="region" aria-label={lf("My Projects")}>
                 <div className="ui grid equal width padded heading">
                     <div className="column" style={{ zIndex: 1 }}>
                         {targetTheme.scriptManager ? <h2 role="button" className="ui header myproject-header" title={lf("See all projects")} tabIndex={0}
@@ -203,7 +203,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 </div>
             </div>
             {Object.keys(galleries).map(galleryName =>
-                <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment">
+                <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment" role="region" aria-label={pxt.Util.rlf(galleryName)}>
                     <h2 className="ui header heading">{pxt.Util.rlf(galleryName)} </h2>
                     <div className="content">
                         <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`} key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]}


### PR DESCRIPTION
Landmarks:
Only show home landmarks when in home, only show editor landmarks when in editor. 
Added landmarks for each of the carousels on the home screen such that it's made up of: 
-banner
-main
-regions for each carousel
Editor landmarks are: 
-banner
-main
-complementary for editor toolbar, and sim toolbar
-region for the simulator iframe

Added labels for the next / previous buttons in the home screen (See more, and See previous)