### PR TITLE
Share modal fixes

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2626,7 +2626,7 @@ export class ProjectView
                 {inHome && targetTheme.scriptManager ? <scriptmanager.ScriptManagerDialog parent={this} ref={this.handleScriptManagerDialogRef} onClose={this.handleScriptManagerDialogClose} /> : undefined}
                 {sandbox ? undefined : <projects.ExitAndSaveDialog parent={this} ref={this.handleExitAndSaveDialogRef} />}
                 <projects.ChooseHwDialog parent={this} ref={this.handleChooseHwDialogRef} />
-                {sandbox || !sharingEnabled ? undefined : <share.ShareEditor parent={this} ref={this.handleShareEditorRef} />}
+                {sandbox || !sharingEnabled ? undefined : <share.ShareEditor parent={this} ref={this.handleShareEditorRef} loading={this.state.publishing} />}
                 {selectLanguage ? <lang.LanguagePicker parent={this} ref={this.handleLanguagePickerRef} /> : undefined}
                 {sandbox ? <container.SandboxFooter parent={this} /> : undefined}
                 {hideMenuBar ? <div id="editorlogo"><a className="poweredbylogo"></a></div> : undefined}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -53,11 +53,15 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
 
     componentWillReceiveProps(newProps: ShareEditorProps) {
         const newState: ShareEditorState = {}
-        newState.projectName = newProps.parent.state.projectName;
+        if (newProps.parent.state.projectName != this.state.projectName) {
+            newState.projectName = newProps.parent.state.projectName;
+        }
         if (newProps.loading != this.state.loading) {
             newState.loading = newProps.loading;
         }
-        this.setState(newState);
+        if (Object.keys(newState).length > 0) {
+            this.setState(newState);
+        }
     }
 
     shouldComponentUpdate(nextProps: ShareEditorProps, nextState: ShareEditorState, nextContext: any): boolean {

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -52,10 +52,12 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
     }
 
     componentWillReceiveProps(newProps: ShareEditorProps) {
-        this.handleProjectNameChange(newProps.parent.state.projectName);
+        const newState: ShareEditorState = {}
+        newState.projectName = newProps.parent.state.projectName;
         if (newProps.loading != this.state.loading) {
-            this.setState({ loading: newProps.loading });
+            newState.loading = newProps.loading;
         }
+        this.setState(newState);
     }
 
     shouldComponentUpdate(nextProps: ShareEditorProps, nextState: ShareEditorState, nextContext: any): boolean {


### PR DESCRIPTION
Fix project name loading when the editor is publishing.
Only commit project new name when we hit publish.

Fixes https://github.com/Microsoft/pxt-arcade/issues/507