### PR TITLE
Script manager duplication fixes

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -841,6 +841,9 @@ namespace ts.pxtc.service {
             }
             const fns = lastProjectFuse.search(search.term);
             return fns;
+        },
+        projectSearchClear: () => {
+            lastProjectFuse = undefined;
         }
     }
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -215,6 +215,13 @@ export function projectSearchAsync(searchFor: pxtc.service.ProjectSearchOptions)
         });
 }
 
+export function projectSearchClear() {
+    return ensureApisInfoAsync()
+        .then(() => {
+            return workerOpAsync("projectSearchClear", { });
+        });
+}
+
 export function formatAsync(input: string, pos: number) {
     return workerOpAsync("format", { format: { input: input, pos: pos } });
 }

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -250,6 +250,7 @@ export interface VirtualApi {
     isSync?: boolean;
     expirationTime?(path: string): number; // in milliseconds
     isOffline?: () => boolean;
+    onInvalidated?: () => void;
 }
 
 export function mountVirtualApi(protocol: string, handler: VirtualApi) {
@@ -273,6 +274,8 @@ export function invalidate(prefix: string) {
             ce.lastRefresh = 0;
             if (ce.components.length > 0)
                 queue(lookup(ce.path))
+            if (ce.api.onInvalidated)
+                ce.api.onInvalidated();
         }
     })
 }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -794,6 +794,9 @@ data.mountVirtualApi("headers", {
             });
     },
     expirationTime: p => 5 * 1000,
+    onInvalidated: () => {
+        compiler.projectSearchClear();
+    }
 })
 
 /*

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -356,11 +356,11 @@ export function duplicateAsync(h: Header, text: ScriptText, rename?: boolean): P
     delete h._rev
     delete (h as any)._id
     return importAsync(h, text)
-        .then(() => h2)
+        .then(() => h)
 }
 
 export function createDuplicateName(h: Header) {
-    let names = U.toDictionary(allScripts, e => e.header.name)
+    let names = U.toDictionary(allScripts.filter(e => !e.header.isDeleted), e => e.header.name)
     let n = 2
     while (names.hasOwnProperty(h.name + " #" + n))
         n++

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -360,11 +360,13 @@ export function duplicateAsync(h: Header, text: ScriptText, rename?: boolean): P
 }
 
 export function createDuplicateName(h: Header) {
+    let reducedName = h.name.indexOf("#") > -1 ?
+        h.name.substring(0, h.name.lastIndexOf('#')).trim() : h.name;
     let names = U.toDictionary(allScripts.filter(e => !e.header.isDeleted), e => e.header.name)
     let n = 2
-    while (names.hasOwnProperty(h.name + " #" + n))
+    while (names.hasOwnProperty(reducedName + " #" + n))
         n++
-    return h.name + " #" + n;
+    return reducedName + " #" + n;
 }
 
 export function saveScreenshotAsync(h: Header, data: string, icon: string) {


### PR DESCRIPTION
Fix issues reported with project duplicates. Found that we were returning the old header instead of the new header when duplicating which created some unexpected behaviour when deleting a duplicated project. 

Fixed issue where the sort order wasn't accounted for in the internal model which meant that we were interacting with a different order of scripts for deleting / duplication / editing.

Better duplication algorithm that uses the pound sign as an indicator of a project number and increments that number. 

Invalidate search header scripts when headers are invalidated, such that duplicating / deleting a project refreshes the search set.