### PR TITLE
Monaco field editor fixes

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -556,7 +556,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private setupFieldEditors() {
-        if (!this.hasFieldEditors) return;
+        if (!this.hasFieldEditors || pxt.shell.isReadOnly()) return;
         if (!this.fieldEditors) this.fieldEditors = new FieldEditorManager();
 
         pxt.appTarget.appTheme.monacoFieldEditors.forEach(name => {
@@ -882,7 +882,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     protected updateFieldEditors = pxt.Util.debounce(() => {
-        if (!this.hasFieldEditors) return;
+        if (!this.hasFieldEditors || pxt.shell.isReadOnly()) return;
         const model = this.editor.getModel();
         this.fieldEditors.clearRanges(this.editor);
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1644,6 +1644,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             if (index === 0) {
                 return line.trim();
             }
+            else if (index === lines.length - 1) {
+                return createIndent(minIndent) + line.trim();
+            }
             else {
                 return innerIndent + line.trim();
             }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/469
Fixes https://github.com/Microsoft/pxt-arcade/issues/447

Changes the folded sections to two lines instead of one (uglier, but less buggy). Also respect when the editor is read only.