### PR TITLE
Tutorial mobile / iOS

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -306,7 +306,10 @@ namespace pxt.blocks.layout {
 
         const images = xsg.getElementsByTagName("image") as NodeListOf<Element>;
         const p = pxt.Util.toArray(images)
-            .filter(image => !/^data:/.test(image.getAttributeNS(XLINK_NAMESPACE, "href")))
+            .filter(image => {
+                const href = image.getAttributeNS(XLINK_NAMESPACE, "href");
+                return href && !/^data:/.test(href);
+            })
             .map((image: HTMLImageElement) => {
                 const href = image.getAttributeNS(XLINK_NAMESPACE, "href");
                 let dataUri = imageXLinkCache[href];

--- a/pxtlib/svgUtil.ts
+++ b/pxtlib/svgUtil.ts
@@ -22,6 +22,8 @@ namespace pxt.svgUtil {
         percent
     }
 
+    const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
+
     export class BaseElement<T extends SVGElement> {
         el: T;
         protected titleElement: SVGTitleElement;
@@ -37,6 +39,11 @@ namespace pxt.svgUtil {
 
         setAttribute(name: string, value: string | number | boolean): this {
             this.el.setAttribute(name, value.toString());
+            return this;
+        }
+
+        setAttributeNS(ns: string, name: string, value: string | number | boolean): this {
+            this.el.setAttributeNS(ns, name, value.toString());
             return this;
         }
 
@@ -470,7 +477,7 @@ namespace pxt.svgUtil {
         constructor() { super("image") }
 
         src(url: string) {
-            return this.setAttribute("href", url);
+            return this.setAttributeNS(XLINK_NAMESPACE, "href", url);
         }
 
         width(width: number, unit = LengthUnit.px): this {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -62,6 +62,16 @@ export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
         const currentStep = tutorialStep;
         if (!tutorialReady) return <div />;
 
+        function intermediateClassName(index: number) {
+            if (tutorialStepInfo.length < 8 // always show first 8
+                || index == 0 // always show first
+                || index == tutorialStepInfo.length - 1 // always show last
+                || Math.abs(index - currentStep) < 2 // 1 around current step
+            ) return "";
+
+            return "mobile hide";
+        }
+
         return <div className="ui item">
             <div className="ui item tutorial-menuitem" role="menubar">
                 {tutorialStepInfo.map((step, index) =>
@@ -72,7 +82,7 @@ export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
                                 ariaLabel={lf("Tutorial step {0}. This is the current step", index + 1)}
                                 onClick={this.openTutorialStep}>{index + 1}</TutorialMenuItemLink>
                         </span> :
-                        <span className="step-label" key={'tutorialStep' + index} data-tooltip={`${index + 1}`} data-inverted="" data-position="bottom center">
+                        <span className={`ui step-label ${intermediateClassName(index)}`} key={'tutorialStep' + index} data-tooltip={`${index + 1}`} data-inverted="" data-position="bottom center">
                             <TutorialMenuItemLink index={index}
                                 className={`ui empty circular label ${!tutorialReady ? 'disabled' : ''} clear`}
                                 ariaLabel={lf("Tutorial step {0}", index + 1)}


### PR DESCRIPTION
- [x] don't show too many dots in tutorials on mobile as it bleeds out the screen

![image](https://user-images.githubusercontent.com/4175913/50859389-14db4c00-1348-11e9-9a43-4195ec73e578.png)

- [x] specify xlink namespace for svg:image href so that the image shows in Safari iOS.
