### PR TITLE
Upload screenshot with script

### DIFF
--- a/cli/gitfs.ts
+++ b/cli/gitfs.ts
@@ -5,6 +5,7 @@ import * as util from 'util';
 import U = pxt.Util;
 
 export async function uploadRefs(id: string, repoUrl: string): Promise<void> {
+    pxt.log(`uploading refs to ${pxt.Cloud.apiRoot}`);
     let gitCatFile: child_process.ChildProcess
     let gitCatFileBuf = new U.PromiseBuffer<Buffer>()
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -117,6 +117,7 @@ declare namespace pxt {
         workspaces?: boolean;
         packages?: boolean;
         sharing?: boolean; // uses cloud-based anonymous sharing
+        thumbnails?: boolean; // attach screenshots/thumbnail to published scripts
         importing?: boolean; // import url dialog
         embedding?: boolean;
         githubPackages?: boolean; // allow searching github for packages

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -32,8 +32,9 @@ declare namespace pxt {
         id: string; // has to match ^[a-z]+$; used in URLs and domain names
         platformid?: string; // eg "codal"; used when search for gh packages ("for PXT/codal"); defaults to id
         nickname?: string; // friendly id used when generating files, folders, etc... id is used instead if missing
-        name: string;
-        description?: string;
+        name: string; // long name
+        description?: string; // description
+        thumbnailName?: string; // name imprited on thumbnails when using saveAsPNG
         corepkg: string;
         title?: string;
         cloud?: AppCloud;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -185,7 +185,7 @@ namespace pxt.editor {
         completeTutorial(): void;
         showTutorialHint(): void;
 
-        anonymousPublishAsync(): Promise<string>;
+        anonymousPublishAsync(screenshotUri?: string): Promise<string>;
 
         startStopSimulator(clickTrigger?: boolean): void;
         stopSimulator(unload?: boolean): void;
@@ -204,6 +204,7 @@ namespace pxt.editor {
         openInstructions(): void;
         closeFlyout(): void;
         printCode(): void;
+        requestScreenshotAsync(force?: boolean): Promise<string>;
         downloadScreenshotAsync(): Promise<void>;
 
         toggleDebugging(): void;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -136,7 +136,6 @@ namespace pxsim {
 
     export interface SimulatorScreenshotMessage extends SimulatorMessage {
         type: "screenshot";
-        title?: string;
         // force take a new screenshot
         force?: boolean;
         data: string;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1236,51 +1236,65 @@ export class ProjectView
         return this.saveProjectAsPNGAsync(true, false);
     }
 
-    private saveProjectAsPNGAsync(force: boolean, showDialog: boolean): Promise<void> {
-        // in porgress
-        if (this.screenshotHandler) return Promise.resolve();
+    requestScreenshotPromise: Promise<string>;
+    private requestScreenshotAsync(force: boolean): Promise<string> {
+        if (this.requestScreenshotPromise)
+            return this.requestScreenshotPromise;
+
+        // make sure simulator is ready
 
         this.setState({ screenshoting: true });
         simulator.driver.postMessage({ type: "screenshot", title: this.state.header.name, force } as pxsim.SimulatorScreenshotMessage);
-        return new Promise<void>((resolve, reject) => {
-            this.screenshotHandler = (img) => {
-                resolve(this.exportProjectToFileAsync()
-                    .then(blob => screenshot.encodeBlobAsync(img, blob))
-                    .then(img => {
-                        const fn = pkg.genFileName(".png");
-                        pxt.BrowserUtils.browserDownloadDataUri(img, fn);
-
-                        if (showDialog)
-                            return core.dialogAsync({
-                                header: lf("Project Saved!"),
-                                disagreeLbl: lf("Got it!"),
-                                disagreeClass: "green",
-                                hasCloseIcon: false,
-                                jsx: <div className="ui items">
-                                    <div className="item">
-                                        <div className="ui small image">
-                                            <a download={fn} className="ui link" href={img}>
-                                                <img src={img} alt={lf("Project cartridge")} title={lf("Click to download again")} />
-                                            </a>
-                                        </div>
-                                        <div className="content">
-                                            <div className="description">
-                                                <p>
-                                                    {lf("Your project is saved in this image.")}
-                                                    {lf("Import or drag it into the editor to reload it.")}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            });
-                        else return Promise.resolve();
-                    }))
-            }
-        }).finally(() => {
-            this.screenshotHandler = null
-            this.setState({ screenshoting: false });
+        return this.requestScreenshotPromise = new Promise<string>((resolve, reject) => {
+            if (this.screenshotHandler) reject(new Error("screenshot in progress")); // this should not happend
+            this.screenshotHandler = (img) => resolve(img);
         })
+            .timeout(3000) // simulator might be stopped or in bad shape
+            .catch(e => {
+                return undefined;
+            })
+            .finally(() => {
+                this.screenshotHandler = undefined;
+                this.requestScreenshotPromise = undefined;
+                this.setState({ screenshoting: false });
+            });
+    }
+
+    private saveProjectAsPNGAsync(force: boolean, showDialog: boolean): Promise<void> {
+        let img: string;
+        return this.requestScreenshotAsync(force)
+            .then(img_ => {
+                img = img_;
+                return this.exportProjectToFileAsync();
+            }).then(blob => screenshot.encodeBlobAsync(img, blob))
+            .then(img => {
+                const fn = pkg.genFileName(".png");
+                pxt.BrowserUtils.browserDownloadDataUri(img, fn);
+                if (!showDialog) return Promise.resolve();
+                return core.dialogAsync({
+                    header: lf("Project Saved!"),
+                    disagreeLbl: lf("Got it!"),
+                    disagreeClass: "green",
+                    hasCloseIcon: false,
+                    jsx: <div className="ui items">
+                        <div className="item">
+                            <div className="ui small image">
+                                <a download={fn} className="ui link" href={img}>
+                                    <img src={img} alt={lf("Project cartridge")} title={lf("Click to download again")} />
+                                </a>
+                            </div>
+                            <div className="content">
+                                <div className="description">
+                                    <p>
+                                        {lf("Your project is saved in this image.")}
+                                        {lf("Import or drag it into the editor to reload it.")}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                });
+            });
     }
 
     saveProjectToFileAsync(): Promise<void> {
@@ -2139,8 +2153,11 @@ export class ProjectView
         this.setState({ publishing: true })
         const mpkg = pkg.mainPkg
         const epkg = pkg.getEditorPkg(mpkg)
+        let screenshot: string;
         return this.saveProjectNameAsync()
             .then(() => this.saveFileAsync())
+            .then(() => pxt.appTarget.compile.saveAsPNG ? this.requestScreenshotAsync(false) : undefined)
+            .then(img => screenshot = img)
             .then(() => mpkg.filesToBePublishedAsync(true))
             .then(files => {
                 if (epkg.header.pubCurrent)
@@ -2153,7 +2170,7 @@ export class ProjectView
                     meta.blocksHeight = blocksSize.height;
                     meta.blocksWidth = blocksSize.width;
                 }
-                return workspace.anonymousPublishAsync(epkg.header, files, meta)
+                return workspace.anonymousPublishAsync(epkg.header, files, meta, screenshot)
                     .then(inf => inf.id)
             }).finally(() => {
                 this.setState({ publishing: false })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2156,7 +2156,7 @@ export class ProjectView
         let screenshot: string;
         return this.saveProjectNameAsync()
             .then(() => this.saveFileAsync())
-            .then(() => pxt.appTarget.compile.saveAsPNG ? this.requestScreenshotAsync(false) : undefined)
+            .then(() => pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails ? this.requestScreenshotAsync(false) : undefined)
             .then(img => screenshot = img)
             .then(() => mpkg.filesToBePublishedAsync(true))
             .then(files => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1237,7 +1237,7 @@ export class ProjectView
     }
 
     requestScreenshotPromise: Promise<string>;
-    private requestScreenshotAsync(force: boolean): Promise<string> {
+    requestScreenshotAsync(force?: boolean): Promise<string> {
         if (this.requestScreenshotPromise)
             return this.requestScreenshotPromise;
 
@@ -2147,16 +2147,13 @@ export class ProjectView
             });
     }
 
-    anonymousPublishAsync(): Promise<string> {
+    anonymousPublishAsync(screenshotUri?: string): Promise<string> {
         pxt.tickEvent("publish");
         this.setState({ publishing: true })
         const mpkg = pkg.mainPkg
         const epkg = pkg.getEditorPkg(mpkg)
-        let screenshot: string;
         return this.saveProjectNameAsync()
             .then(() => this.saveFileAsync())
-            .then(() => pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails ? this.requestScreenshotAsync(false) : undefined)
-            .then(img => screenshot = img)
             .then(() => mpkg.filesToBePublishedAsync(true))
             .then(files => {
                 if (epkg.header.pubCurrent)
@@ -2169,7 +2166,7 @@ export class ProjectView
                     meta.blocksHeight = blocksSize.height;
                     meta.blocksWidth = blocksSize.width;
                 }
-                return workspace.anonymousPublishAsync(epkg.header, files, meta, screenshot)
+                return workspace.anonymousPublishAsync(epkg.header, files, meta, screenshotUri)
                     .then(inf => inf.id)
             }).finally(() => {
                 this.setState({ publishing: false })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1243,7 +1243,7 @@ export class ProjectView
 
         // make sure simulator is ready
         this.setState({ screenshoting: true });
-        simulator.driver.postMessage({ type: "screenshot", title: this.state.header.name, force } as pxsim.SimulatorScreenshotMessage);
+        simulator.driver.postMessage({ type: "screenshot", force } as pxsim.SimulatorScreenshotMessage);
         return this.requestScreenshotPromise = new Promise<string>((resolve, reject) => {
             if (this.screenshotHandler) reject(new Error("screenshot in progress")); // this should not happend
             this.screenshotHandler = (img) => resolve(img);
@@ -1265,7 +1265,7 @@ export class ProjectView
             .then(img_ => {
                 img = img_;
                 return this.exportProjectToFileAsync();
-            }).then(blob => screenshot.encodeBlobAsync(pkg.mainEditorPkg().header.name, img, blob))
+            }).then(blob => screenshot.encodeBlobAsync(this.state.header.name, img, blob))
             .then(img => {
                 const fn = pkg.genFileName(".png");
                 pxt.BrowserUtils.browserDownloadDataUri(img, fn);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1242,7 +1242,6 @@ export class ProjectView
             return this.requestScreenshotPromise;
 
         // make sure simulator is ready
-
         this.setState({ screenshoting: true });
         simulator.driver.postMessage({ type: "screenshot", title: this.state.header.name, force } as pxsim.SimulatorScreenshotMessage);
         return this.requestScreenshotPromise = new Promise<string>((resolve, reject) => {
@@ -1266,7 +1265,7 @@ export class ProjectView
             .then(img_ => {
                 img = img_;
                 return this.exportProjectToFileAsync();
-            }).then(blob => screenshot.encodeBlobAsync(img, blob))
+            }).then(blob => screenshot.encodeBlobAsync(pkg.mainEditorPkg().header.name, img, blob))
             .then(img => {
                 const fn = pkg.genFileName(".png");
                 pxt.BrowserUtils.browserDownloadDataUri(img, fn);

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -242,10 +242,11 @@ export function encodeBlobAsync(title: string, dataURL: string, blob: Uint8Array
         })
 }
 
+/*
 export function testBlobEncodeAsync(dataURL: string, sz = 10000) {
     let blob = new Uint8Array(sz)
     pxt.Util.getRandomBuf(blob)
-    return encodeBlobAsync(dataURL, blob)
+    return encodeBlobAsync("test", dataURL, blob)
         .then(url => {
             let img = document.createElement("img")
             img.src = url
@@ -259,3 +260,4 @@ export function testBlobEncodeAsync(dataURL: string, sz = 10000) {
             }
         })
 }
+*/

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -102,19 +102,44 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
     const w = canvas.width;
     const h = canvas.height;
     const work = document.createElement("canvas")
-    const border = 16;
+    const vborder = 16;
+    const leftBorder = 16;
+    const rightBorder = 16;
     const bottom = 32;
-    work.width = w + border * 2;
-    work.height = h + border * 2 + bottom;
+    work.width = w + leftBorder + rightBorder;
+    work.height = h + vborder * 2 + bottom;
     const ctx = work.getContext("2d")
     ctx.imageSmoothingEnabled = false
+    // white background
     ctx.fillStyle = 'white'
     ctx.fillRect(0, 0, work.width, work.height)
-    ctx.drawImage(canvas, border, border);
-    const lblTop = 2 * border + h + 4
-    ctx.fillStyle = 'black'
-    ctx.font = '13px sans-serif'
-    ctx.fillText(title, border, lblTop, w);
+
+    // border
+    {
+        ctx.strokeStyle = '2px grey';
+        ctx.rect(0, 0, work.width, work.height);
+    }
+
+    // draw image
+    ctx.drawImage(canvas, leftBorder, vborder);
+
+    // header
+    const header = pxt.appTarget.thumbnailName || pxt.appTarget.name;
+    if (header) {
+        const lblTop = 2 * vborder + h + 4
+        ctx.fillStyle = 'grey'
+        ctx.font = '8px monospace'
+        ctx.fillText(header, leftBorder, lblTop, w);
+    }
+
+    // title
+    if (title) {
+        const lblTop = 2 * vborder + h + 4
+        ctx.fillStyle = 'black'
+        ctx.font = '13px monospace'
+        ctx.fillText(title, leftBorder, lblTop, w);
+    }
+
     return work;
 }
 

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -102,12 +102,13 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
     const w = canvas.width;
     const h = canvas.height;
     const work = document.createElement("canvas")
-    const vborder = 16;
+    const topBorder = 16;
+    const bottomBorder = 16;
     const leftBorder = 16;
     const rightBorder = 16;
     const bottom = 32;
     work.width = w + leftBorder + rightBorder;
-    work.height = h + vborder * 2 + bottom;
+    work.height = h + topBorder + bottomBorder + bottom;
     const ctx = work.getContext("2d")
     ctx.imageSmoothingEnabled = false
     // white background
@@ -121,23 +122,34 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
     }
 
     // draw image
-    ctx.drawImage(canvas, leftBorder, vborder);
+    ctx.drawImage(canvas, leftBorder, topBorder);
 
     // header
     const header = pxt.appTarget.thumbnailName || pxt.appTarget.name;
     if (header) {
-        const lblTop = 2 * vborder + h + 4
-        ctx.fillStyle = 'grey'
-        ctx.font = '8px monospace'
-        ctx.fillText(header, leftBorder, lblTop, w);
+        const lblTop = 12
+        ctx.fillStyle = 'black'
+        ctx.font = '10px monospace'
+        ctx.fillText(header, leftBorder, lblTop, w - leftBorder);
     }
 
     // title
     if (title) {
-        const lblTop = 2 * vborder + h + 4
+        const lblTop = topBorder + bottomBorder + h + 4;
         ctx.fillStyle = 'black'
         ctx.font = '13px monospace'
-        ctx.fillText(title, leftBorder, lblTop, w);
+        ctx.fillText(title, leftBorder, lblTop, w - leftBorder);
+    }
+
+    // domain
+    {
+        const lblTop = topBorder + bottomBorder + h + 4 + 16
+        ctx.fillStyle = '#444'
+        ctx.font = '10px monospace'
+        const url = pxt.appTarget.appTheme.homeUrl
+            .replace(/^https:\/\//, '')
+            .replace(/\/$/, '');
+        ctx.fillText(url, leftBorder, lblTop, w);
     }
 
     return work;

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -98,8 +98,29 @@ export function decodeBlobAsync(dataURL: string) {
         })
 }
 
-export function encodeBlobAsync(dataURL: string, blob: Uint8Array) {
+function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElement {
+    const w = canvas.width;
+    const h = canvas.height;
+    const work = document.createElement("canvas")
+    const border = 16;
+    const bottom = 32;
+    work.width = w + border * 2;
+    work.height = h + border * 2 + bottom;
+    const ctx = work.getContext("2d")
+    ctx.imageSmoothingEnabled = false
+    ctx.fillStyle = 'white'
+    ctx.fillRect(0, 0, work.width, work.height)
+    ctx.drawImage(canvas, border, border);
+    const lblTop = 2 * border + h + 4
+    ctx.fillStyle = 'black'
+    ctx.font = '13px sans-serif'
+    ctx.fillText(title, border, lblTop, w);
+    return work;
+}
+
+export function encodeBlobAsync(title: string, dataURL: string, blob: Uint8Array) {
     return pxt.BrowserUtils.loadCanvasAsync(dataURL)
+        .then(cvs => chromifyAsync(cvs, title))
         .then(canvas => {
             const neededBytes = imageHeaderSize + blob.length
             const usableBytes = (canvas.width * canvas.height - 1) * 3

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -219,7 +219,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                                 <p className="ui message info">{
                                     lf("You need to publish your project to share it or embed it in other web pages.") + " " +
                                     lf("You acknowledge having consent to publish this project.")}
-                                    {screenshotUri ? lf("The screenshot will be published with your project.") : undefined}
+                                    {screenshotUri ? " " + lf("The screenshot will be published with your project.") : undefined}
                                 </p>
                                 {this.state.sharingError ?
                                     <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -25,6 +25,7 @@ export interface ShareEditorState {
     sharingError?: boolean;
     loading?: boolean;
     projectName?: string;
+    screenshotUri?: string;
 }
 
 export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorState> {
@@ -34,7 +35,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             currentPubId: undefined,
             pubCurrent: false,
             visible: false,
-            advancedMenu: false
+            advancedMenu: false,
+            screenshotUri: undefined
         }
 
         this.hide = this.hide.bind(this);
@@ -44,11 +46,23 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
     }
 
     hide() {
-        this.setState({ visible: false });
+        this.setState({ visible: false, screenshotUri: undefined });
     }
 
     show(header: pxt.workspace.Header) {
-        this.setState({ visible: true, mode: ShareMode.Code, pubCurrent: header.pubCurrent, sharingError: false });
+        this.setState({
+            visible: true,
+            mode: ShareMode.Code,
+            pubCurrent: header.pubCurrent,
+            sharingError: false,
+            screenshotUri: undefined
+        }, () => this.refreshScreenshot());
+    }
+
+    refreshScreenshot() {
+        if (pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails)
+            this.props.parent.requestScreenshotAsync(false)
+                .done(img => this.setState({ screenshotUri: img }));
     }
 
     componentWillReceiveProps(newProps: ShareEditorProps) {
@@ -72,7 +86,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             || this.state.currentPubId != nextState.currentPubId
             || this.state.sharingError != nextState.sharingError
             || this.state.projectName != nextState.projectName
-            || this.state.loading != nextState.loading;
+            || this.state.loading != nextState.loading
+            || this.state.screenshotUri != nextState.screenshotUri;
     }
 
     private toggleAdvancedMenu() {
@@ -89,7 +104,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
     }
 
     renderCore() {
-        const { visible, projectName: newProjectName, loading } = this.state;
+        const { visible, projectName: newProjectName, loading, screenshotUri } = this.state;
         const { projectName } = this.props.parent.state;
         const targetTheme = pxt.appTarget.appTheme;
         const header = this.props.parent.state.header;
@@ -143,7 +158,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 // save project name if we've made a change change
                 p = this.props.parent.updateHeaderNameAsync(newProjectName);
             }
-            p.then(() => this.props.parent.anonymousPublishAsync())
+            p.then(() => this.props.parent.anonymousPublishAsync(screenshotUri))
                 .catch((e) => {
                     this.setState({ sharingError: true });
                 })
@@ -188,6 +203,9 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 <div className={`ui form`}>
                     {action ?
                         <div>
+                            {screenshotUri ? <div className="ui">
+                                <img className="ui small image" src={screenshotUri} alt={lf("Screenshot")} />
+                            </div> : undefined}
                             {shouldNameProject ?
                                 <div>
                                     <p>{lf("Give your project a name before sharing.")}</p>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -202,25 +202,30 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 closeOnEscape>
                 <div className={`ui form`}>
                     {action ?
-                        <div>
-                            {screenshotUri ? <div className="ui">
-                                <img className="ui small image" src={screenshotUri} alt={lf("Screenshot")} />
-                            </div> : undefined}
-                            {shouldNameProject ?
-                                <div>
-                                    <p>{lf("Give your project a name before sharing.")}</p>
-                                    <div>
-                                        <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
-                                            ariaLabel={lf("Type a name for your project")} autoComplete={false}
-                                            value={newProjectName || ''} onChange={this.handleProjectNameChange} />
-                                    </div>
-                                </div> : undefined}
-                            <p className="ui message info">{lf("You need to publish your project to share it or embed it in other web pages.") + " " +
-                                lf("You acknowledge having consent to publish this project.")}</p>
-                            {this.state.sharingError ?
-                                <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>
+                        <div className="ui items"><div className="item">
+                            {screenshotUri
+                                ? <img className="ui small image" src={screenshotUri} alt={lf("Screenshot")} />
                                 : undefined}
-                        </div>
+                            <div className="content">
+                                {shouldNameProject ?
+                                    <div>
+                                        <p>{lf("Give your project a name before sharing.")}</p>
+                                        <div>
+                                            <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
+                                                ariaLabel={lf("Type a name for your project")} autoComplete={false}
+                                                value={newProjectName || ''} onChange={this.handleProjectNameChange} />
+                                        </div>
+                                    </div> : undefined}
+                                <p className="ui message info">{
+                                    lf("You need to publish your project to share it or embed it in other web pages.") + " " +
+                                    lf("You acknowledge having consent to publish this project.")}
+                                    {screenshotUri ? lf("The screenshot will be published with your project.") : undefined}
+                                </p>
+                                {this.state.sharingError ?
+                                    <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>
+                                    : undefined}
+                            </div>
+                        </div></div>
                         : undefined}
                     {url && ready ? <div>
                         <p>{lf("Your project is ready! Use the address below to share your projects.")}</p>

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -202,9 +202,18 @@ export interface ScriptMeta {
 }
 
 // https://github.com/Microsoft/pxt-backend/blob/master/docs/sharing.md#anonymous-publishing
-export function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptMeta) {
+export function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptMeta, screenshotUri?: string) {
     const saveId = {}
     h.saveId = saveId
+    let thumbnailBuffer: string;
+    let thumbnailMimeType: string;
+    if (screenshotUri) {
+        const m = /^data:(image\/(png|gif));base64,([a-zA-Z0-9]+)$/.exec(screenshotUri);
+        if (m) {
+            thumbnailBuffer = m[3];
+            thumbnailMimeType = m[1];
+        }
+    }
     const stext = JSON.stringify(text, null, 2) + "\n"
     const scrReq = {
         name: h.name,
@@ -217,7 +226,9 @@ export function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptM
             versions: pxt.appTarget.versions,
             blocksHeight: meta.blocksHeight,
             blocksWidth: meta.blocksWidth
-        }
+        },
+        thumbnailBuffer,
+        thumbnailMimeType
     }
     pxt.debug(`publishing script; ${stext.length} bytes`)
     return Cloud.privatePostAsync("scripts", scrReq, /* forceLiveEndpoint */ true)

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -208,7 +208,7 @@ export function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptM
     let thumbnailBuffer: string;
     let thumbnailMimeType: string;
     if (screenshotUri) {
-        const m = /^data:(image\/(png|gif));base64,([a-zA-Z0-9]+)$/.exec(screenshotUri);
+        const m = /^data:(image\/(png|gif));base64,([a-zA-Z0-9+/]+=*)$/.exec(screenshotUri);
         if (m) {
             thumbnailBuffer = m[3];
             thumbnailMimeType = m[1];


### PR DESCRIPTION
* new option in cloud to enable uploading screenshots along with published script.
* renders chrome around screenshot if saveAsPNG enabled. Chrome is rendered on the fly based on pxtarget info, no customization.
* share dialog display published screenshot

Note that there is still a few issues around having the simulator stopped and not having a screenshot to save into but it will be part of a different PR.

![image](https://user-images.githubusercontent.com/4175913/50999834-248d9880-14e0-11e9-8310-2d60e60eb111.png)
