### PR TITLE
use choose hw variant dialog when applicable

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1617,7 +1617,7 @@ export class ProjectView
     checkForHwVariant() {
         if (pxt.hwVariant)
             return false // already set
-        let variants = pxt.getHwVariants()
+        const variants = pxt.getHwVariants()
         if (variants.length == 0)
             return false
         let pairAsync = () => cmds.showWebUSBPairingInstructionsAsync(null)

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -177,7 +177,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     showBoardDialog() {
         pxt.tickEvent("menu.changeboard", undefined, { interactiveConsent: true });
         const variants = pxt.getHwVariants();
-        if (variants.length)
+        if (variants.length > 1)
             this.props.parent.showChooseHwDialog();
         else
             this.props.parent.showBoardDialogAsync(undefined, true).done();

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -176,7 +176,11 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     showBoardDialog() {
         pxt.tickEvent("menu.changeboard", undefined, { interactiveConsent: true });
-        this.props.parent.showBoardDialogAsync(undefined, true).done();
+        const variants = pxt.getHwVariants();
+        if (variants.length)
+            this.props.parent.showChooseHwDialog();
+        else
+            this.props.parent.showBoardDialogAsync(undefined, true).done();
     }
 
     saveProject() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -931,18 +931,6 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
             >
                 <div className="group">
                     <div className="ui cards centered" role="listbox">
-                        {cards.map(card =>
-                            <codecard.CodeCardView
-                                key={'card' + card.name}
-                                name={card.name}
-                                ariaLabel={card.name}
-                                description={card.description}
-                                imageUrl={card.imageUrl}
-                                //learnMoreUrl={card.learnMoreUrl}
-                                buyUrl={card.buyUrl}
-                                onClick={card.onClick}
-                            />
-                        )}
                         {variants.map(cfg =>
                             <codecard.CodeCardView
                                 key={'variant' + cfg.name}
@@ -953,6 +941,18 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                                 //learnMoreUrl={cfg.card.learnMoreUrl}
                                 //buyUrl={cfg.card.buyUrl}
                                 onClick={cfg.card.onClick}
+                            />
+                        )}
+                        {cards.map(card =>
+                            <codecard.CodeCardView
+                                key={'card' + card.name}
+                                name={card.name}
+                                ariaLabel={card.name}
+                                description={card.description}
+                                imageUrl={card.imageUrl}
+                                //learnMoreUrl={card.learnMoreUrl}
+                                buyUrl={card.buyUrl}
+                                onClick={card.onClick}
                             />
                         )}
                     </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -902,7 +902,7 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
         const { visible } = this.state;
         if (!visible) return <div />;
 
-        const variants = visible ? pxt.getHwVariants() : [];
+        const variants = pxt.getHwVariants();
         for (const v of variants) {
             if (!v.card)
                 v.card = {


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-arcade/issues/539, move variants atop dialog.