### PR TITLE
win / lose toggle for game over

### DIFF
--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -411,6 +411,17 @@ namespace __internal {
     }
 
     /**
+     * A shim to render a boolean as a win/lose toggle
+     */
+    //% shim=TD_ID blockHidden=1
+    //% blockId=toggleWinLose block="%win"
+    //% win.fieldEditor=togglewinlose
+    //% win.fieldOptions.decompileLiterals=true
+    export function __winLose(win: boolean): boolean {
+        return win;
+    }
+
+    /**
      * Get the color wheel field editor
      * @param color color, eg: #ff0000
      */

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -411,6 +411,17 @@ namespace __internal {
     }
 
     /**
+     * A shim to render a boolean as a win/lose toggle
+     */
+    //% shim=TD_ID blockHidden=1
+    //% blockId=toggleWinLose block="%win"
+    //% win.fieldEditor=togglewinlose
+    //% win.fieldOptions.decompileLiterals=true
+    export function __winLose(win: boolean): boolean {
+        return win;
+    }
+
+    /**
      * Get the color wheel field editor
      * @param color color, eg: #ff0000
      */

--- a/pxtblocks/blocklycustomeditor.ts
+++ b/pxtblocks/blocklycustomeditor.ts
@@ -37,6 +37,7 @@ namespace pxt.blocks {
         registerFieldEditor('toggleupdown', pxtblockly.FieldToggleUpDown);
         registerFieldEditor('toggledownup', pxtblockly.FieldToggleDownUp);
         registerFieldEditor('togglehighlow', pxtblockly.FieldToggleHighLow);
+        registerFieldEditor('togglewinlose', pxtblockly.FieldToggleWinLose);
         registerFieldEditor('colornumber', pxtblockly.FieldColorNumber);
         registerFieldEditor('images', pxtblockly.FieldImages);
         registerFieldEditor('sprite', pxtblockly.FieldSpriteEditor);

--- a/pxtblocks/fields/field_toggle_winlose.ts
+++ b/pxtblocks/fields/field_toggle_winlose.ts
@@ -1,0 +1,21 @@
+/// <reference path="../../localtypings/blockly.d.ts" />
+/// <reference path="./field_toggle.ts" />
+
+namespace pxtblockly {
+
+    export class FieldToggleWinLose extends FieldToggle implements Blockly.FieldCustom {
+        public isFieldCustom_ = true;
+
+        constructor(state: string, params: Blockly.FieldCustomOptions, opt_validator?: Function) {
+            super(state, params, opt_validator);
+        }
+
+        getTrueText() {
+            return lf("WIN");
+        }
+
+        getFalseText() {
+            return lf("LOSE");
+        }
+    }
+}


### PR DESCRIPTION
![2019-01-11 16 03 20](https://user-images.githubusercontent.com/5615930/51065607-a3ef9a80-15ba-11e9-89de-3883551d39fc.gif)

If this gets merged before https://github.com/Microsoft/pxt-common-packages/pull/634 I'll update that PR to use this, or just add another one later