### PR TITLE
Embedded simulator with screenshots in share dialog + no auto-run

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -315,6 +315,8 @@ declare namespace pxt {
         name: string;
         // needs to have one of `path` or `subitems`
         path?: string;
+        // force opening in separate window
+        popout?: boolean;
         tutorial?: boolean;
         subitems?: DocMenuEntry[];
     }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -204,7 +204,7 @@ namespace pxt.editor {
         openInstructions(): void;
         closeFlyout(): void;
         printCode(): void;
-        requestScreenshotAsync(force?: boolean): Promise<string>;
+        requestScreenshotAsync(): Promise<string>;
         downloadScreenshotAsync(): Promise<void>;
 
         toggleDebugging(): void;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -136,8 +136,6 @@ namespace pxsim {
 
     export interface SimulatorScreenshotMessage extends SimulatorMessage {
         type: "screenshot";
-        // force take a new screenshot
-        force?: boolean;
         data: string;
     }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -1,5 +1,6 @@
 namespace pxsim {
     export interface SimulatorDriverOptions {
+        restart?: () => void; // restart simulator
         revealElement?: (el: HTMLElement) => void;
         removeElement?: (el: HTMLElement, onComplete?: () => void) => void;
         unhideElement?: (el: HTMLElement) => void;
@@ -238,8 +239,13 @@ namespace pxsim {
                 i.style.display = "none";
                 i.onclick = (ev) => {
                     ev.preventDefault();
-                    if (this.state != SimulatorState.Running)
-                        this.start();
+                    if (this.state != SimulatorState.Running) {
+                        // we need to request to restart the simulator
+                        if (this.options.restart)
+                            this.options.restart();
+                        else
+                            this.start();
+                    }
                     return false;
                 }
                 wrapper.appendChild(i);

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -301,6 +301,8 @@ namespace pxsim {
 
         public unloanSimulator() {
             if (this.loanedSimulator) {
+                if (this.loanedSimulator.parentNode)
+                    this.loanedSimulator.parentNode.removeChild(this.loanedSimulator);
                 this.container.insertBefore(this.loanedSimulator, this.container.firstElementChild);
                 delete this.loanedSimulator;
             }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -121,7 +121,7 @@ namespace pxsim {
                         const loader = icon.nextElementSibling as HTMLElement;
                         icon.style.display = '';
                         icon.className = '';
-                        loader.className = 'ui active loader';
+                        loader.style.display = '';
                     }
                     break;
                 case SimulatorState.Stopped:
@@ -133,7 +133,7 @@ namespace pxsim {
                         const loader = icon.nextElementSibling as HTMLElement;
                         icon.style.display = '';
                         icon.className = 'video play icon';
-                        loader.className = 'ui loader';
+                        loader.style.display = 'none';
                     }
                     this.scheduleFrameCleanup();
                     break;
@@ -144,7 +144,7 @@ namespace pxsim {
                         const icon = frame.nextElementSibling as HTMLElement;
                         const loader = icon.nextElementSibling as HTMLElement;
                         icon.style.display = 'none';
-                        loader.className = 'ui loader';
+                        loader.style.display = 'none';
                     }
                     break;
             }
@@ -253,7 +253,8 @@ namespace pxsim {
                 wrapper.appendChild(i);
 
                 const l = document.createElement("div");
-                l.className = "ui loader";
+                l.className = "ui active loader";
+                i.style.display = "none";
                 wrapper.appendChild(l);
             }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -224,6 +224,13 @@ namespace pxsim {
             return this.loanedSimulator;
         }
 
+        public unloan() {
+            if (this.loanedSimulator) {
+                this.container.insertBefore(undefined, this.loanedSimulator);
+                delete this.container;
+            }
+        }
+
         private loanedIFrame(): HTMLIFrameElement {
             return this.loanedSimulator
                 && this.loanedSimulator.parentNode

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -130,7 +130,7 @@ export class ProjectView
             collapseEditorTools: simcfg.headless || (!isSandbox && pxt.BrowserUtils.isMobile()),
             highContrast: isHighContrast,
             simState: pxt.editor.SimState.Stopped,
-            autoRun: !!simcfg.autoRun
+            autoRun: true // always start simulator by default
         };
         if (!this.settings.editorFontSize) this.settings.editorFontSize = /mobile/i.test(navigator.userAgent) ? 15 : 19;
         if (!this.settings.fileHistory) this.settings.fileHistory = [];
@@ -487,7 +487,7 @@ export class ProjectView
                     }
                     this.editor.setDiagnostics(this.editorFile, state);
                     data.invalidate("open-pkg-meta:" + pkg.mainEditorPkg().getPkgId());
-                    if (pxt.appTarget.simulator && pxt.appTarget.simulator.autoRun) {
+                    if (this.state.autoRun) {
                         const output = pkg.mainEditorPkg().outputPkg.files["output.txt"];
                         if (output && !output.numDiagnosticsOverride
                             && this.state.autoRun) {
@@ -875,6 +875,7 @@ export class ProjectView
         pxt.debug(`loading ${h.id} (pxt v${h.targetVersion})`);
         this.stopSimulator(true);
         this.clearSerial()
+        this.setState({ autoRun: true }); // always start simulator once at least
 
         // Merge current and new state but only if the new state members are undefined
         const oldEditorState = this.state.editorState;
@@ -2009,7 +2010,7 @@ export class ProjectView
                 opts.trace = true;
 
             simulator.stop(false, true);
-            const autoRun = this.state.autoRun || !!opts.clickTrigger && !!pxt.appTarget.simulator.autoRun;
+            const autoRun = (this.state.autoRun || !!opts.clickTrigger) && !!pxt.appTarget.simulator.autoRun;
             this.setState({ simState: pxt.editor.SimState.Starting, autoRun: autoRun });
 
             const state = this.editor.snapshotState()

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1233,17 +1233,17 @@ export class ProjectView
     }
 
     downloadScreenshotAsync(): Promise<void> {
-        return this.saveProjectAsPNGAsync(true, false);
+        return this.saveProjectAsPNGAsync(false);
     }
 
     requestScreenshotPromise: Promise<string>;
-    requestScreenshotAsync(force?: boolean): Promise<string> {
+    requestScreenshotAsync(): Promise<string> {
         if (this.requestScreenshotPromise)
             return this.requestScreenshotPromise;
 
         // make sure simulator is ready
         this.setState({ screenshoting: true });
-        simulator.driver.postMessage({ type: "screenshot", force } as pxsim.SimulatorScreenshotMessage);
+        simulator.driver.postMessage({ type: "screenshot" } as pxsim.SimulatorScreenshotMessage);
         return this.requestScreenshotPromise = new Promise<string>((resolve, reject) => {
             if (this.screenshotHandler) reject(new Error("screenshot in progress")); // this should not happend
             this.screenshotHandler = (img) => resolve(img);
@@ -1259,9 +1259,9 @@ export class ProjectView
             });
     }
 
-    private saveProjectAsPNGAsync(force: boolean, showDialog: boolean): Promise<void> {
+    private saveProjectAsPNGAsync(showDialog: boolean): Promise<void> {
         let img: string;
-        return this.requestScreenshotAsync(force)
+        return this.requestScreenshotAsync()
             .then(img_ => {
                 img = img_;
                 return this.exportProjectToFileAsync();
@@ -1307,7 +1307,7 @@ export class ProjectView
             return pkg.mainPkg.saveToJsonAsync(this.getPreferredEditor())
                 .then(project => pxt.commands.saveProjectAsync(project));
         }
-        if (pxt.appTarget.compile.saveAsPNG) return this.saveProjectAsPNGAsync(false, true);
+        if (pxt.appTarget.compile.saveAsPNG) return this.saveProjectAsPNGAsync(true);
         else return this.exportProjectToFileAsync()
             .then((buf: Uint8Array) => {
                 const fn = pkg.genFileName(".mkcd");

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -277,7 +277,7 @@ export class ProjectView
             .then(() => {
                 let txt = this.editor.getCurrentSource()
                 if (txt != this.editorFile.content)
-                    simulator.makeDirty();
+                    simulator.setDirty();
                 if (this.editor.isIncomplete()) return Promise.resolve();
                 return this.editorFile.setContentAsync(txt);
             });
@@ -555,6 +555,7 @@ export class ProjectView
             restartSimulator: () => {
                 if (!restartingSim) { // prevent button smashing
                     restartingSim = true;
+                    simulator.setStarting();
                     core.hideDialog();
                     this.runSimulator()
                         .delay(1000) // 1 second debounce
@@ -889,7 +890,7 @@ export class ProjectView
                 if (!this.state || this.state.header != h) {
                     this.showPackageErrorsOnNextTypecheck();
                 }
-                simulator.makeDirty();
+                simulator.setDirty();
                 return compiler.newProjectAsync();
             }).then(() => compiler.applyUpgradesAsync())
             .then(() => {
@@ -2007,7 +2008,7 @@ export class ProjectView
             if (this.state.tracing)
                 opts.trace = true;
 
-            simulator.stop();
+            simulator.stop(false, true);
             const autoRun = this.state.autoRun || !!opts.clickTrigger && !!pxt.appTarget.simulator.autoRun;
             this.setState({ simState: pxt.editor.SimState.Starting, autoRun: autoRun });
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -63,7 +63,7 @@ export class DocsMenu extends data.PureComponent<ISettingsProps, {}> {
     private doDocEntryAction(parent: pxt.editor.IProjectView, m: pxt.DocMenuEntry) {
         if (m.tutorial) {
             return () => { openTutorial(parent, m.path) };
-        } else if (!/^\//.test(m.path)) {
+        } else if (!/^\//.test(m.path) && !m.popout) {
             return () => { window.open(m.path, "docs"); };
         } else if (m.popout) {
             return () => { window.open(`${pxt.appTarget.appTheme.homeUrl}${m.path}`, "docs"); };

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -65,6 +65,8 @@ export class DocsMenu extends data.PureComponent<ISettingsProps, {}> {
             return () => { openTutorial(parent, m.path) };
         } else if (!/^\//.test(m.path)) {
             return () => { window.open(m.path, "docs"); };
+        } else if (m.popout) {
+            return () => { window.open(`${pxt.appTarget.appTheme.homeUrl}${m.path}`, "docs"); };
         } else {
             return () => { openDocs(parent, m.path) };
         }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -68,7 +68,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             pubCurrent: header.pubCurrent,
             sharingError: false,
             screenshotUri: undefined
-        });
+        }, () => this.props.parent.startSimulator());
     }
 
     componentWillReceiveProps(newProps: ShareEditorProps) {

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -136,7 +136,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
 
     renderCore() {
         const { visible, projectName: newProjectName, loading, screenshoting, screenshotUri } = this.state;
-        const { projectName } = this.props.parent.state;
         const targetTheme = pxt.appTarget.appTheme;
         const header = this.props.parent.state.header;
         const advancedMenu = !!this.state.advancedMenu;
@@ -243,7 +242,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         </div>
                     </div> : undefined}
                     {action && this.loanedSimulator ? <div className="ui fields">
-                        <div id="shareLoanedSimulator" className="ui eight wide field"></div>
+                        <div id="shareLoanedSimulator" className="ui eight wide field landscape only"></div>
                         <div className="ui seven wide field">
                             <label>{lf("Name")}</label>
                             <div>
@@ -251,10 +250,10 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                                     ariaLabel={lf("Type a name for your project")} autoComplete={false}
                                     value={newProjectName || ''} onChange={this.handleProjectNameChange} />
                             </div>
-                            <div className="ui segment">{screenshotUri
+                            <div className="ui segment landscape only">{screenshotUri
                                 ? <img className="ui fluid image" src={screenshotUri} alt={lf("Screenshot")} />
                                 : <p>{lf("No screenshot!")}</p>}</div>
-                            <div className="ui buttons">
+                            <div className="ui buttons landscape only">
                                 <sui.Button icon="refresh" title={lf("Restart")} ariaLabel={lf("Restart")} onClick={this.restartSimulator} loading={screenshoting} />
                                 <sui.Button icon="camera" title={lf("Take screenshot")} ariaLabel={lf("Take screenshot")} onClick={this.takeScreenshot} loading={screenshoting} />
                             </div>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -68,14 +68,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             pubCurrent: header.pubCurrent,
             sharingError: false,
             screenshotUri: undefined
-        }, () => this.refreshScreenshot());
-    }
-
-    refreshScreenshot() {
-        if (pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails) {
-            this.props.parent.requestScreenshotAsync(false)
-                .done(img => this.setState({ screenshotUri: img }));
-        }
+        });
     }
 
     componentWillReceiveProps(newProps: ShareEditorProps) {
@@ -125,9 +118,15 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
     takeScreenshot() {
         pxt.tickEvent("shakre.takescreenshot", { view: 'computer', collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
         if (this.state.screenshoting) return;
+        this.refreshScreenshot();
+    }
+
+    private refreshScreenshot() {
+        if (!pxt.appTarget.cloud || !pxt.appTarget.cloud.thumbnails || this.state.screenshoting)
+            return;
 
         this.setState({ screenshoting: true })
-        this.props.parent.requestScreenshotAsync(true)
+        this.props.parent.requestScreenshotAsync()
             .then(img => {
                 const st: ShareEditorState = { screenshoting: false };
                 if (img) st.screenshotUri = img;

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -26,7 +26,7 @@ export interface ShareEditorState {
     sharingError?: boolean;
     loading?: boolean;
     projectName?: string;
-    screenshoting?: boolean;
+    takingScreenshot?: boolean;
     screenshotUri?: string;
 }
 
@@ -48,7 +48,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         this.handleProjectNameChange = this.handleProjectNameChange.bind(this);
         this.restartSimulator = this.restartSimulator.bind(this);
         this.takeScreenshot = this.takeScreenshot.bind(this);
-        this.loanedSimulator = undefined;
     }
 
     hide() {
@@ -93,7 +92,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             || this.state.sharingError != nextState.sharingError
             || this.state.projectName != nextState.projectName
             || this.state.loading != nextState.loading
-            || this.state.screenshoting != nextState.screenshoting
+            || this.state.takingScreenshot != nextState.takingScreenshot
             || this.state.screenshotUri != nextState.screenshotUri;
     }
 
@@ -117,25 +116,25 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
 
     takeScreenshot() {
         pxt.tickEvent("shakre.takescreenshot", { view: 'computer', collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
-        if (this.state.screenshoting) return;
+        if (this.state.takingScreenshot) return;
         this.refreshScreenshot();
     }
 
     private refreshScreenshot() {
-        if (!pxt.appTarget.cloud || !pxt.appTarget.cloud.thumbnails || this.state.screenshoting)
+        if (!pxt.appTarget.cloud || !pxt.appTarget.cloud.thumbnails || this.state.takingScreenshot)
             return;
 
-        this.setState({ screenshoting: true })
+        this.setState({ takingScreenshot: true })
         this.props.parent.requestScreenshotAsync()
             .then(img => {
-                const st: ShareEditorState = { screenshoting: false };
+                const st: ShareEditorState = { takingScreenshot: false };
                 if (img) st.screenshotUri = img;
                 this.setState(st);
             });
     }
 
     renderCore() {
-        const { visible, projectName: newProjectName, loading, screenshoting, screenshotUri } = this.state;
+        const { visible, projectName: newProjectName, loading, takingScreenshot, screenshotUri } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
         const header = this.props.parent.state.header;
         const advancedMenu = !!this.state.advancedMenu;
@@ -254,8 +253,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                                 ? <img className="ui fluid image" src={screenshotUri} alt={lf("Screenshot")} />
                                 : <p>{lf("No screenshot!")}</p>}</div>
                             <div className="ui buttons landscape only">
-                                <sui.Button icon="refresh" title={lf("Restart")} ariaLabel={lf("Restart")} onClick={this.restartSimulator} loading={screenshoting} />
-                                <sui.Button icon="camera" title={lf("Take screenshot")} ariaLabel={lf("Take screenshot")} onClick={this.takeScreenshot} loading={screenshoting} />
+                                <sui.Button icon="refresh" title={lf("Restart")} ariaLabel={lf("Restart")} onClick={this.restartSimulator} loading={takingScreenshot} />
+                                <sui.Button icon="camera" title={lf("Take screenshot")} ariaLabel={lf("Take screenshot")} onClick={this.takeScreenshot} loading={takingScreenshot} />
                             </div>
                         </div>
                     </div> : undefined}

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -231,14 +231,13 @@ export function setState(editor: string, tutMode?: boolean) {
 }
 
 export function makeDirty() { // running outdated code
-    driver.dirty = true;
+    driver.setDirty();
 }
 
 export function run(pkg: pxt.MainPackage, debug: boolean,
     res: pxtc.CompileResult, mute?: boolean,
     highContrast?: boolean, light?: boolean,
     clickTrigger?: boolean) {
-    driver.dirty = false;
     const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
     const parts = pxtc.computeUsedParts(res, true);

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -230,8 +230,12 @@ export function setState(editor: string, tutMode?: boolean) {
     tutorialMode = tutMode;
 }
 
-export function makeDirty() { // running outdated code
+export function setDirty() { // running outdated code
     driver.setDirty();
+}
+
+export function setStarting() {
+    driver.setStarting();
 }
 
 export function run(pkg: pxt.MainPackage, debug: boolean,
@@ -272,9 +276,9 @@ export function mute(mute: boolean) {
     driver.mute(mute);
 }
 
-export function stop(unload?: boolean) {
+export function stop(unload?: boolean, starting?: boolean) {
     if (!driver) return;
-    driver.stop(unload);
+    driver.stop(unload, starting);
 }
 
 export function suspend() {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -18,11 +18,8 @@ export const FAST_TRACE_INTERVAL = 100;
 export const SLOW_TRACE_INTERVAL = 500;
 
 export let driver: pxsim.SimulatorDriver;
-let nextFrameId: number = 0;
-const themes = ["blue", "red", "green", "yellow"];
 let config: SimulatorConfig;
 let lastCompileResult: pxtc.CompileResult;
-let tutorialMode: boolean;
 let displayedModals: pxt.Map<boolean> = {};
 export let simTranslations: pxt.Map<string>;
 
@@ -43,6 +40,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
     root.appendChild(debuggerDiv);
 
     let options: pxsim.SimulatorDriverOptions = {
+        restart: () => cfg.restartSimulator(),
         revealElement: (el) => {
             if (pxt.options.light || driver.isLoanedSimulator(el)) return;
             // Play enter animation
@@ -222,6 +220,7 @@ function postSimEditorEvent(subtype: string, exception?: string) {
     }
 }
 
+let tutorialMode: boolean = false;
 export function setState(editor: string, tutMode?: boolean) {
     if (config && config.editor != editor) {
         config.editor = editor;

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -204,7 +204,8 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         onTopLevelCodeEnd: () => {
             postSimEditorEvent("toplevelfinished");
         },
-        stoppedClass: getStoppedClass()
+        stoppedClass: getStoppedClass(),
+        embedIcons: pxt.appTarget.simulator && !pxt.appTarget.simulator.autoRun
     };
     driver = new pxsim.SimulatorDriver(document.getElementById('simulators'), options);
     config = cfg

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -45,7 +45,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
 
     let options: pxsim.SimulatorDriverOptions = {
         revealElement: (el) => {
-            if (pxt.options.light) return;
+            if (pxt.options.light || driver.isLoanedSimulator(el)) return;
             // Play enter animation
             const animation = pxt.appTarget.appTheme.simAnimationEnter || 'fly right in';
             el.style.animationDuration = '500ms';

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -431,7 +431,7 @@ export class Button extends StatelessUIElement<ButtonProps> {
         const classes = cx([
             color,
             size,
-            disabled || loading ? 'disabled' : '',
+            (disabled || loading) ? 'disabled' : '',
             loading ? 'loading' : '',
             genericClassName("ui button", this.props)
         ])

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -418,6 +418,7 @@ export interface ButtonProps extends UiProps, TooltipUIProps {
     ariaExpanded?: boolean;
     onClick?: (e: React.MouseEvent<HTMLElement>) => void;
     disabled?: boolean;
+    loading?: boolean;
     onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
     labelPosition?: "left" | "right";
     color?: string;
@@ -426,11 +427,12 @@ export interface ButtonProps extends UiProps, TooltipUIProps {
 
 export class Button extends StatelessUIElement<ButtonProps> {
     renderCore() {
-        const { labelPosition, color, size, disabled } = this.props;
+        const { labelPosition, color, size, disabled, loading } = this.props;
         const classes = cx([
             color,
             size,
-            disabled ? 'disabled' : '',
+            disabled || loading ? 'disabled' : '',
+            loading ? 'loading' : '',
             genericClassName("ui button", this.props)
         ])
         const button = <button className={classes}


### PR DESCRIPTION
2 changes: simulator in share dialog + no-autorun mode with clear icons on simulator.

When an editor supports screenshots for the simulator, host the simulator in the sharing dialog and allow use to snap the right screenshot. It increases the quality of the shared scrips since it has more changes to have a good screenshot. Tested in Chrome, IE, Firefox (Edge untestable right now).

**ps:** we should consider disabling autoRun on slow machines for micro:bit as well.
**pss:** we need a quantitative analysis of compile times in the wild

- [x] Under the hood, the simdriver gives the simulator IFrame on "loan" to the share dialog. As soon as the dialog is done, the IFrame comes back in its original location.

![screenshot](https://user-images.githubusercontent.com/4175913/51097054-06d96100-1776-11e9-9f3d-5eea978bade0.gif)

- [x] no autorun mode

Using the embed lightbox rendering to clearly display what's going on with the simulator.
![autorun](https://user-images.githubusercontent.com/4175913/51101702-92f88200-1790-11e9-818a-76e38056eefb.gif)


Test: https://arcade.makecode.com/app/6947d73e04dfb5a9c38493e483656230cdca3168-7e1ebf74e5
