### PR TITLE
Faster sharing

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1944,6 +1944,11 @@ export class ProjectView
     }
 
     shouldStartSimulator(): boolean {
+        switch (this.state.simState) {
+            case pxt.editor.SimState.Starting:
+            case pxt.editor.SimState.Running:
+                return false; // already reunning
+        }
         const hasHome = !pxt.shell.isControllerMode();
         if (!hasHome) return true;
         return !this.state.home;

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -224,7 +224,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         }
 
         return (
-            <sui.Modal isOpen={visible} className="sharedialog" size={pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails ? "large" : "small"}
+            <sui.Modal isOpen={visible} className="sharedialog" size={this.loanedSimulator ? "large" : "small"}
                 onClose={this.hide}
                 dimmer={true} header={lf("Share Project")}
                 closeIcon={true} buttons={actions}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -224,7 +224,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         }
 
         return (
-            <sui.Modal isOpen={visible} className="sharedialog" size="small"
+            <sui.Modal isOpen={visible} className="sharedialog" size={pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails ? "large" : "small"}
                 onClose={this.hide}
                 dimmer={true} header={lf("Share Project")}
                 closeIcon={true} buttons={actions}


### PR DESCRIPTION
Don't restart simulator when hosting in sharing dialog.
Fixing "shouldstartsimulator" to avoid starting simulator when already running or starting.