### PR TITLE
Share dialog fixes for Edge

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -249,6 +249,9 @@ namespace pxsim {
             i.style.display = "none";
             wrapper.appendChild(l);
 
+            if (this.runOptions)
+                this.applyAspectRatioToFrame(frame);
+
             return wrapper;
         }
 
@@ -322,10 +325,12 @@ namespace pxsim {
 
         private applyAspectRatio() {
             const frames = this.simFrames();
-            frames.forEach(frame => {
-                frame.parentElement.style.paddingBottom =
-                    (100 / this.runOptions.aspectRatio) + "%";
-            });
+            frames.forEach(frame => this.applyAspectRatioToFrame(frame));
+        }
+
+        private applyAspectRatioToFrame(frame: HTMLIFrameElement) {
+            frame.parentElement.style.paddingBottom =
+            (100 / this.runOptions.aspectRatio) + "%";
         }
 
         private cleanupFrames() {

--- a/theme/common.less
+++ b/theme/common.less
@@ -1107,3 +1107,9 @@ p.ui.font.small {
         margin-bottom: 1em !important;
     }
 }
+
+img.pixelart {
+    image-rendering: auto;
+    image-rendering: crisp-edges;
+    image-rendering: pixelated;    
+}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -949,8 +949,7 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
                                 ariaLabel={card.name}
                                 description={card.description}
                                 imageUrl={card.imageUrl}
-                                learnMoreUrl={card.learnMoreUrl}
-                                buyUrl={card.buyUrl}
+                                learnMoreUrl={card.url}
                                 onClick={card.onClick}
                             />
                         )}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -233,7 +233,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             lf("You acknowledge having consent to publish this project.");
 
         return (
-            <sui.Modal isOpen={visible} className="sharedialog" 
+            <sui.Modal isOpen={visible} className="sharedialog"
                 size={thumbnails ? "" : "small"}
                 onClose={this.hide}
                 dimmer={true} header={lf("Share Project")}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -55,15 +55,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             simulator.driver.unloanSimulator();
             this.loanedSimulator = undefined;
         }
-        this.setState({ visible: false, screenshotUri: undefined },
-            () => {
-                // Edge has a rendering bug after closing this dialog
-                if (pxt.BrowserUtils.isEdge()) {
-                    const el = document.body;
-                    el.style.display = 'none';
-                    el.style.display = '';                    
-                }
-            });
+        this.setState({ visible: false, screenshotUri: undefined });
     }
 
     show(header: pxt.workspace.Header) {
@@ -232,10 +224,10 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         }
 
         const disclaimer = lf("You need to publish your project to share it or embed it in other web pages.") + " " +
-        lf("You acknowledge having consent to publish this project.");
+            lf("You acknowledge having consent to publish this project.");
 
         return (
-            <sui.Modal isOpen={visible} className="sharedialog" size={this.loanedSimulator ? "" : "small"}
+            <sui.Modal isOpen={visible} className="sharedialog" size={pxt.appTarget.cloud && pxt.appTarget.cloud.thumbnails ? "" : "small"}
                 onClose={this.hide}
                 dimmer={true} header={lf("Share Project")}
                 closeIcon={true} buttons={actions}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -235,7 +235,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         lf("You acknowledge having consent to publish this project.");
 
         return (
-            <sui.Modal isOpen={visible} className="sharedialog" size={this.loanedSimulator ? "large" : "small"}
+            <sui.Modal isOpen={visible} className="sharedialog" size={this.loanedSimulator ? "" : "small"}
                 onClose={this.hide}
                 dimmer={true} header={lf("Share Project")}
                 closeIcon={true} buttons={actions}
@@ -252,8 +252,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         </div>
                     </div> : undefined}
                     {action && this.loanedSimulator ? <div className="ui fields">
-                        <div id="shareLoanedSimulator" className="ui seven wide field landscape only"></div>
-                        <div className="ui seven wide field">
+                        <div id="shareLoanedSimulator" className="ui six wide field landscape only"></div>
+                        <div className="ui ten wide field">
                             <label>{lf("Name")}</label>
                             <div>
                                 <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
@@ -261,16 +261,15 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                                     value={newProjectName || ''} onChange={this.handleProjectNameChange} />
                             </div>
                             <div className="ui segment landscape only">{screenshotUri
-                                ? <img className="ui fluid image pixelart" src={screenshotUri} alt={lf("Screenshot")} />
+                                ? <img className="ui centered image pixelart" src={screenshotUri} alt={lf("Screenshot")} />
                                 : <p>{lf("No screenshot!")}</p>}</div>
                             <div className="ui buttons landscape only">
                                 <sui.Button icon="refresh" title={lf("Restart")} ariaLabel={lf("Restart")} onClick={this.restartSimulator} loading={takingScreenshot} />
                                 <sui.Button icon="camera" title={lf("Take screenshot")} ariaLabel={lf("Take screenshot")} onClick={this.takeScreenshot} loading={takingScreenshot} />
                             </div>
-                            <p className="ui tiny message info">{disclaimer}</p>
                         </div>
                     </div> : undefined}
-                    {action && !this.loanedSimulator ? <p className="ui tiny message info">{disclaimer}</p> : undefined}
+                    {action ? <p className="ui tiny message info">{disclaimer}</p> : undefined}
                     {this.state.sharingError ?
                         <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>
                         : undefined}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -223,6 +223,9 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             })
         }
 
+        const disclaimer = lf("You need to publish your project to share it or embed it in other web pages.") + " " +
+        lf("You acknowledge having consent to publish this project.");
+
         return (
             <sui.Modal isOpen={visible} className="sharedialog" size={this.loanedSimulator ? "large" : "small"}
                 onClose={this.hide}
@@ -241,8 +244,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         </div>
                     </div> : undefined}
                     {action && this.loanedSimulator ? <div className="ui fields">
-                        <div id="shareLoanedSimulator" className="ui eight wide field landscape only"></div>
-                        <div className="ui seven wide field">
+                        <div id="shareLoanedSimulator" className="ui seven wide field landscape only"></div>
+                        <div className="ui eight wide field">
                             <label>{lf("Name")}</label>
                             <div>
                                 <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
@@ -250,18 +253,16 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                                     value={newProjectName || ''} onChange={this.handleProjectNameChange} />
                             </div>
                             <div className="ui segment landscape only">{screenshotUri
-                                ? <img className="ui fluid image" src={screenshotUri} alt={lf("Screenshot")} />
+                                ? <img className="ui fluid image pixelart" src={screenshotUri} alt={lf("Screenshot")} />
                                 : <p>{lf("No screenshot!")}</p>}</div>
                             <div className="ui buttons landscape only">
                                 <sui.Button icon="refresh" title={lf("Restart")} ariaLabel={lf("Restart")} onClick={this.restartSimulator} loading={takingScreenshot} />
                                 <sui.Button icon="camera" title={lf("Take screenshot")} ariaLabel={lf("Take screenshot")} onClick={this.takeScreenshot} loading={takingScreenshot} />
                             </div>
+                            <p className="ui tiny message info">{disclaimer}</p>
                         </div>
                     </div> : undefined}
-                    {action ? <p className="ui tiny message info">{
-                        lf("You need to publish your project to share it or embed it in other web pages.") + " " +
-                        lf("You acknowledge having consent to publish this project.")}
-                    </p> : undefined}
+                    {action && !this.loanedSimulator ? <p className="ui tiny message info">{disclaimer}</p> : undefined}
                     {this.state.sharingError ?
                         <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>
                         : undefined}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -245,7 +245,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                     </div> : undefined}
                     {action && this.loanedSimulator ? <div className="ui fields">
                         <div id="shareLoanedSimulator" className="ui seven wide field landscape only"></div>
-                        <div className="ui eight wide field">
+                        <div className="ui seven wide field">
                             <label>{lf("Name")}</label>
                             <div>
                                 <sui.Input ref="filenameinput" autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -55,7 +55,15 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             simulator.driver.unloanSimulator();
             this.loanedSimulator = undefined;
         }
-        this.setState({ visible: false, screenshotUri: undefined });
+        this.setState({ visible: false, screenshotUri: undefined },
+            () => {
+                // Edge has a rendering bug after closing this dialog
+                if (pxt.BrowserUtils.isEdge()) {
+                    const el = document.body;
+                    el.style.display = 'none';
+                    el.style.display = '';                    
+                }
+            });
     }
 
     show(header: pxt.workspace.Header) {

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -926,7 +926,7 @@ export interface ModalProps extends ReactModal.Props {
     defaultOpen?: boolean;
     closeIcon?: boolean | string;
 
-    size?: 'fullscreen' | 'large' | 'mini' | 'small' | 'tiny';
+    size?: '' | 'fullscreen' | 'large' | 'mini' | 'small' | 'tiny';
     className?: string;
     basic?: boolean;
     longer?: boolean;


### PR DESCRIPTION
- [x] disable screenshot generation for Edge. Browser rendering engine bugs leaves the screen unusable.
- [x] larger dialog
![image](https://user-images.githubusercontent.com/4175913/51218637-3ad19500-18e2-11e9-9c9e-d887aebf1ca3.png)
