### PR TITLE
Save png when no png

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -74,6 +74,10 @@ namespace pxsim {
         constructor(public container: HTMLElement, public options: SimulatorDriverOptions = {}) {
         }
 
+        isDebug() {
+            return this.runOptions && !!this.runOptions.debug;
+        }
+
         setDirty() {
             // We suspend the simulator here to stop it from running without
             // interfering with the user's stopped state. We're not doing this check
@@ -392,11 +396,18 @@ namespace pxsim {
             this.start();
         }
 
+        public restart() {
+            this.stop();
+            this.start();
+        }
+
         private start() {
             this.clearDebugger();
             this.addEventListeners();
             this.applyAspectRatio();
             this.scheduleFrameCleanup();
+
+            if (!this.currentRuntime) return; // nothing to do
 
             // first frame
             let frame = this.simFrames()[0];

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1251,8 +1251,9 @@ export class ProjectView
             if (this.screenshotHandler) reject(new Error("screenshot in progress")); // this should not happend
             this.screenshotHandler = (img) => resolve(img);
         })
-            .timeout(3000) // simulator might be stopped or in bad shape
+            .timeout(1000) // simulator might be stopped or in bad shape
             .catch(e => {
+                pxt.tickEvent('screenshot.timeout');
                 return undefined;
             })
             .finally(() => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1960,8 +1960,12 @@ export class ProjectView
     }
 
     restartSimulator(debug?: boolean) {
-        this.stopSimulator();
-        return this.startSimulator(debug);
+        if (this.state.simState == pxt.editor.SimState.Stopped
+            || simulator.driver.isDebug() != !!debug)
+            this.startSimulator(debug);
+        else {
+            simulator.driver.restart(); // fast restart
+        }
     }
 
     startSimulator(debug?: boolean, clickTrigger?: boolean) {

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -117,8 +117,10 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
 
     // border
     {
-        ctx.strokeStyle = '2px grey';
-        ctx.rect(0, 0, work.width, work.height);
+        ctx.strokeStyle = 'grey';
+        ctx.lineWidth = 2;
+        ctx.shadowBlur = 2;
+        ctx.strokeRect(1, 1, work.width - 1, work.height - 1);
     }
 
     // draw image
@@ -155,8 +157,22 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
     return work;
 }
 
+function defaultCanvasAsync(): Promise<HTMLCanvasElement> {
+    const cvs = document.createElement("canvas");
+    cvs.width = 160;
+    cvs.height = 120;
+    const ctx = cvs.getContext("2d");
+    ctx.fillStyle = '#33b';
+    ctx.fillRect(0, 0, 160, 120);
+    ctx.font = '30px monospace';
+    ctx.fillStyle = '#fff';
+    ctx.fillText(':(', 60, 70);
+    return Promise.resolve(cvs);
+}
+
 export function encodeBlobAsync(title: string, dataURL: string, blob: Uint8Array) {
-    return pxt.BrowserUtils.loadCanvasAsync(dataURL)
+    // if screenshot failed, dataURL is empty
+    return (dataURL ? pxt.BrowserUtils.loadCanvasAsync(dataURL) : defaultCanvasAsync())
         .then(cvs => chromifyAsync(cvs, title))
         .then(canvas => {
             const neededBytes = imageHeaderSize + blob.length

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -115,12 +115,6 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
     ctx.fillStyle = 'white'
     ctx.fillRect(0, 0, work.width, work.height)
 
-    // border
-    {
-        ctx.strokeStyle = 'black';
-        ctx.strokeRect(1, 1, work.width - 1, work.height - 1);
-    }
-
     // draw image
     ctx.drawImage(canvas, leftBorder, topBorder);
 

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -117,9 +117,7 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
 
     // border
     {
-        ctx.strokeStyle = 'grey';
-        ctx.lineWidth = 2;
-        ctx.shadowBlur = 2;
+        ctx.strokeStyle = 'black';
         ctx.strokeRect(1, 1, work.width - 1, work.height - 1);
     }
 


### PR DESCRIPTION
If the simulator is still loading, no PNG is available. Yet, we should still save something.

- [x] generate an image on the fly if screenshot ismissing
- [x] extra: speeded up resetting process (skips compilation phase so instantenaous)

https://github.com/Microsoft/pxt-arcade/issues/578