### PR TITLE
preload simulaor iframe to avoid blank hole for long

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -223,7 +223,7 @@ namespace pxsim {
             frame.setAttribute('sandbox', 'allow-same-origin allow-scripts');
             let simUrl = this.options.simUrl || ((window as any).pxtConfig || {}).simUrl || "/sim/simulator.html"
             frame.className = 'no-select'
-            if (this.runOptions.aspectRatio)
+            if (this.runOptions && this.runOptions.aspectRatio)
                 wrapper.style.paddingBottom = (100 / this.runOptions.aspectRatio) + "%";
             frame.src = simUrl + '#' + frame.id;
             frame.frameBorder = "0";
@@ -271,7 +271,10 @@ namespace pxsim {
             this.clearDebugger();
             this.postMessage({ type: 'stop' });
             this.setState(starting ? SimulatorState.Starting : SimulatorState.Stopped);
-            if (unload) this.unload();
+            if (unload) {
+                this.unload();
+                this.runOptions = undefined; // forget about program
+            }
         }
 
         public suspend() {
@@ -336,6 +339,7 @@ namespace pxsim {
         }
 
         private applyAspectRatio(ratio?: number) {
+            if (!ratio && !this.runOptions) return;
             const frames = this.simFrames();
             frames.forEach(frame => this.applyAspectRatioToFrame(frame, ratio));
         }
@@ -421,7 +425,7 @@ namespace pxsim {
             // first frame
             let frame = this.simFrames()[0];
             if (!frame) {
-                let wrapper = this.createFrame(this.runOptions.light);
+                let wrapper = this.createFrame(this.runOptions && this.runOptions.light);
                 this.container.appendChild(wrapper);
                 frame = wrapper.firstElementChild as HTMLIFrameElement;
             } else // reuse simulator

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -259,6 +259,14 @@ namespace pxsim {
             return wrapper;
         }
 
+        public preload(aspectRatio: number) {
+            if (!this.simFrames().length) {
+                this.container.appendChild(this.createFrame());
+                this.applyAspectRatio(aspectRatio);
+                this.setStarting();
+            }
+        }
+
         public stop(unload = false, starting = false) {
             this.clearDebugger();
             this.postMessage({ type: 'stop' });
@@ -327,14 +335,15 @@ namespace pxsim {
             }, 5000);
         }
 
-        private applyAspectRatio() {
+        private applyAspectRatio(ratio?: number) {
             const frames = this.simFrames();
-            frames.forEach(frame => this.applyAspectRatioToFrame(frame));
+            frames.forEach(frame => this.applyAspectRatioToFrame(frame, ratio));
         }
 
-        private applyAspectRatioToFrame(frame: HTMLIFrameElement) {
+        private applyAspectRatioToFrame(frame: HTMLIFrameElement, ratio?: number) {
+            const r = ratio || this.runOptions.aspectRatio;
             frame.parentElement.style.paddingBottom =
-            (100 / this.runOptions.aspectRatio) + "%";
+                (100 / r) + "%";
         }
 
         private cleanupFrames() {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -223,8 +223,6 @@ namespace pxsim {
             frame.setAttribute('sandbox', 'allow-same-origin allow-scripts');
             let simUrl = this.options.simUrl || ((window as any).pxtConfig || {}).simUrl || "/sim/simulator.html"
             frame.className = 'no-select'
-            if (this.runOptions && this.runOptions.aspectRatio)
-                wrapper.style.paddingBottom = (100 / this.runOptions.aspectRatio) + "%";
             frame.src = simUrl + '#' + frame.id;
             frame.frameBorder = "0";
             frame.dataset['runid'] = this.runId;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1387,7 +1387,7 @@ export class ProjectView
         const hasHome = !pxt.shell.isControllerMode();
         if (!hasHome) return;
 
-        this.stopSimulator();
+        this.stopSimulator(true); // don't keep simulator around
         if (this.editor) this.editor.unloadFileAsync();
         // clear the hash
         pxt.BrowserUtils.changeHash("", true);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -618,6 +618,10 @@ export class ProjectView
         this.updatingEditorFile = true;
         const simRunning = this.state.simState != pxt.editor.SimState.Stopped;
         this.stopSimulator();
+        if (simRunning || this.state.autoRun) {
+            simulator.driver.setStarting();
+            this.setState({ simState: pxt.editor.SimState.Starting });
+        }
         this.saveSettings();
 
         const hc = this.state.highContrast;
@@ -1990,7 +1994,7 @@ export class ProjectView
         }
         simulator.stop(unload);
         const autoRun = this.state.autoRun && !clickTrigger; // if user pressed stop, don't restart
-        this.setState({ simState: pxt.editor.SimState.Stopped, autoRun: autoRun })
+        this.setState({ simState: pxt.editor.SimState.Stopped, autoRun: autoRun });
     }
 
     suspendSimulator() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -875,6 +875,8 @@ export class ProjectView
 
         pxt.debug(`loading ${h.id} (pxt v${h.targetVersion})`);
         this.stopSimulator(true);
+        if (pxt.appTarget.simulator && pxt.appTarget.simulator.aspectRatio)
+            simulator.driver.preload(pxt.appTarget.simulator.aspectRatio);
         this.clearSerial()
         this.setState({ autoRun: true }); // always start simulator once at least
 
@@ -3196,8 +3198,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const isSandbox = pxt.shell.isSandboxMode() || pxt.shell.isReadOnly();
     const isController = pxt.shell.isControllerMode();
+    const theme = pxt.appTarget.appTheme;
     if (query["ws"]) workspace.setupWorkspace(query["ws"]);
-    else if ((pxt.appTarget.appTheme.allowParentController || isController) && pxt.BrowserUtils.isIFrame()) workspace.setupWorkspace("iframe");
+    else if ((theme.allowParentController || isController) && pxt.BrowserUtils.isIFrame()) workspace.setupWorkspace("iframe");
     else if (isSandbox) workspace.setupWorkspace("mem");
     else if (pxt.winrt.isWinRT()) workspace.setupWorkspace("uwp");
     else if (pxt.BrowserUtils.isIpcRenderer() && pxt.BrowserUtils.isSafari()) workspace.setupWorkspace("idb");
@@ -3208,8 +3211,8 @@ document.addEventListener("DOMContentLoaded", () => {
             if (mlang && window.location.hash.indexOf(mlang[0]) >= 0) {
                 pxt.BrowserUtils.changeHash(window.location.hash.replace(mlang[0], ""));
             }
-            const useLang = mlang ? mlang[3] : (lang.getCookieLang() || pxt.appTarget.appTheme.defaultLocale || (navigator as any).userLanguage || navigator.language);
-            const live = !pxt.appTarget.appTheme.disableLiveTranslations || (mlang && !!mlang[1]);
+            const useLang = mlang ? mlang[3] : (lang.getCookieLang() || theme.defaultLocale || (navigator as any).userLanguage || navigator.language);
+            const live = !theme.disableLiveTranslations || (mlang && !!mlang[1]);
             const force = !!mlang && !!mlang[2];
             return Util.updateLocalizationAsync(
                 pxt.appTarget.id,
@@ -3248,9 +3251,9 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(() => cmds.initCommandsAsync())
         .then(() => {
             // editor messages need to be enabled early, in case workspace provider is IFrame
-            if (pxt.appTarget.appTheme.allowParentController
-                || pxt.appTarget.appTheme.allowPackageExtensions
-                || pxt.appTarget.appTheme.allowSimulatorTelemetry
+            if (theme.allowParentController
+                || theme.allowPackageExtensions
+                || theme.allowSimulatorTelemetry
                 || pxt.shell.isControllerMode())
                 pxt.editor.bindEditorMessages(getEditorAsync);
 


### PR DESCRIPTION
Since our load time is pretty bad, we end having a simulator pane empty for 10sec. This change "preloads" an empty simulator that will be spinning until the first compile arrives. Also fix the box resize in arcade (see other PR)

- [x] preload simulator with load spinner
- [x] properly cleanout simulator when leaving to home page
Tested on Chrome, IE, Edge, FF,
![preload](https://user-images.githubusercontent.com/4175913/51265693-2e931980-196e-11e9-8fb1-105cf2437394.gif)
https://arcade.makecode.com/app/e23b69695f19549a992c4a2c85930b495c5cf64f-7dd67bf480