### PR TITLE
Tablet fullscreen

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -820,10 +820,6 @@ p.ui.font.small {
     .collapsedEditorTools #maineditor {
         left: 0;
     }
-
-    #filelistOverlay {
-        display: block;
-    }
 }
 
 /* <= Small Monitor (Mobile + Tablet + Small Monitor) */
@@ -832,9 +828,6 @@ p.ui.font.small {
     #filelist, #downloadArea {
         min-width:@simulatorWidthSmall;
         max-width:@simulatorWidthSmall;
-    }
-    #filelistOverlay {
-        display: block;
     }
     #maineditor {
         left:@simulatorWidthSmall;

--- a/theme/common.less
+++ b/theme/common.less
@@ -125,6 +125,16 @@ body {
     bottom: 0rem !important;
 }
 
+#filelistOverlay {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    display: none;
+    cursor: pointer;
+}
+
 /* File list / Simulator layout */
 #simulator {
     height: 100%;
@@ -670,6 +680,89 @@ p.ui.font.small {
 }
 
 /*******************************
+        fuyllscreensim
+*******************************/
+.fullscreensim {
+    /* Full screen */
+    #filelist {
+        position: fixed;
+        z-index: @fullscreenZIndex;
+        top:0 !important;
+        left:0 !important;
+        bottom:0 !important;
+        right:0 !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        max-width: 100%;
+        min-width: 100%;
+        height:100% !important;
+    }
+    #filelistOverlay {
+        display: none;
+    }
+    #boardview {
+        position: relative;
+        height:100%;
+        background-color: white;
+        padding: @mainMenuHeight;
+        padding-left: calc(2*@mainMenuHeight);
+        padding-right: calc(2*@mainMenuHeight);
+
+        background-color: @fullscreenBackgroundGradientStart;
+        background: @fullscreenBackgroundGradientStart; /* For browsers that do not support gradients */
+        background: -webkit-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Safari 5.1 to 6.0 */
+        background: -o-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Opera 11.1 to 12.0 */
+        background: -moz-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Firefox 3.6 to 15 */
+        background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
+    }
+    #simulator .hidefullscreen,
+    .menubar .ui.item:not(.logo),
+    #maineditor,
+    #editortools,
+    #serialPreview {
+        display: none !important;
+        z-index: -10 !important;
+    }
+    .sandboxfooter {
+        z-index: @sandboxFooterZIndex;
+        bottom: 1rem;
+    }
+    #mainmenu {
+        background: transparent !important;
+    }
+    #filelist .simtoolbar {
+        position: fixed;
+        bottom: 1rem;
+        left: auto;
+        right: auto;
+        display: block !important;
+    }
+    #simulators {
+        position: relative;
+        padding: 3rem;
+        width: 100%;
+        height: 100%;
+    }
+    div.simframe {
+        position:relative;
+        width: 50%;
+        height: 100%;
+        float: left;
+        padding-bottom: 0 !important;
+    }
+    div.simframe > iframe {
+        position:relative;
+        max-width: 90%;
+    }
+    div.simframe:only-child {
+        width: 100%;
+    }
+    div.simframe:only-child > iframe {
+        max-width: 100%;
+    }
+}
+
+/*******************************
         Media Adjustments
 *******************************/
 
@@ -727,77 +820,8 @@ p.ui.font.small {
         left: 0;
     }
 
-    /* Full screen */
-    .fullscreensim #filelist {
-        position: fixed;
-        z-index: @fullscreenZIndex;
-        top:0;
-        left:0;
-        bottom:0;
-        right:0;
-        padding: 0;
-        max-width: 100%;
-        min-width: 100%;
-        height:100%;
-    }
-    .fullscreensim #boardview {
-        position: relative;
-        height:100%;
-        background-color: white;
-        padding: @mainMenuHeight;
-        padding-left: calc(2*@mainMenuHeight);
-        padding-right: calc(2*@mainMenuHeight);
-
-        background-color: @fullscreenBackgroundGradientStart;
-        background: @fullscreenBackgroundGradientStart; /* For browsers that do not support gradients */
-        background: -webkit-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Safari 5.1 to 6.0 */
-        background: -o-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Opera 11.1 to 12.0 */
-        background: -moz-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Firefox 3.6 to 15 */
-        background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
-    }
-    .fullscreensim #simulator .hidefullscreen,
-        .fullscreensim .menubar .ui.item:not(.logo),
-        .fullscreensim #maineditor,
-        .fullscreensim #editortools,
-        .fullscreensim #serialPreview {
-        display: none !important;
-        z-index: -10 !important;
-    }
-    .fullscreensim .sandboxfooter {
-        z-index: @sandboxFooterZIndex;
-        bottom: 1rem;
-    }
-    .fullscreensim #mainmenu {
-        background: transparent !important;
-    }
-    .fullscreensim #filelist .simtoolbar {
-        position: fixed;
-        bottom: 1rem;
-        left: auto;
-        right: auto;
-    }
-    .fullscreensim #simulators {
-        position: relative;
-        padding: 3rem;
-        width: 100%;
-        height: 100%;
-    }
-    .fullscreensim div.simframe {
-        position:relative;
-        width: 50%;
-        height: 100%;
-        float: left;
-        padding-bottom: 0 !important;
-    }
-    .fullscreensim div.simframe > iframe {
-        position:relative;
-        max-width: 90%;
-    }
-    .fullscreensim div.simframe:only-child {
-        width: 100%;
-    }
-    .fullscreensim div.simframe:only-child > iframe {
-        max-width: 100%;
+    #filelistOverlay {
+        display: block;
     }
 }
 
@@ -807,6 +831,9 @@ p.ui.font.small {
     #filelist, #downloadArea {
         min-width:@simulatorWidthSmall;
         max-width:@simulatorWidthSmall;
+    }
+    #filelistOverlay {
+        display: block;
     }
     #maineditor {
         left:@simulatorWidthSmall;
@@ -848,6 +875,9 @@ p.ui.font.small {
         min-width: inherit;
         max-width: inherit;
         background: transparent !important;
+    }
+    #filelistOverlay {
+        display: block;
     }
     #maineditor {
         left: 0;

--- a/theme/common.less
+++ b/theme/common.less
@@ -704,9 +704,10 @@ p.ui.font.small {
         position: relative;
         height:100%;
         background-color: white;
-        padding: @mainMenuHeight;
-        padding-left: calc(2*@mainMenuHeight);
-        padding-right: calc(2*@mainMenuHeight);
+        padding-top: 2rem;
+        padding-bottom: 6rem;
+        padding-left: 2rem;
+        padding-right: 2rem;
 
         background-color: @fullscreenBackgroundGradientStart;
         background: @fullscreenBackgroundGradientStart; /* For browsers that do not support gradients */

--- a/theme/common.less
+++ b/theme/common.less
@@ -761,6 +761,9 @@ p.ui.font.small {
     div.simframe:only-child > iframe {
         max-width: 100%;
     }
+    .simtoolbar .ui.button {
+        font-size: 1.7rem;
+    }
 }
 
 /*******************************
@@ -985,6 +988,9 @@ p.ui.font.small {
         .ui.logo.organization {
             display: none !important;
         }
+    }
+    .fullscreensim .simtoolbar .ui.button {
+        font-size: 1rem;
     }
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -141,6 +141,7 @@ export class ProjectView
         this.openSimSerial = this.openSimSerial.bind(this);
         this.openDeviceSerial = this.openDeviceSerial.bind(this);
         this.toggleGreenScreen = this.toggleGreenScreen.bind(this);
+        this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
     }
 
     shouldShowHomeScreen() {
@@ -2698,6 +2699,7 @@ export class ProjectView
                                 <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.openDeviceSerial} />
                             </div> : undefined}
                         {sandbox || isBlocks || this.editor == this.serialEditor ? undefined : <filelist.FileList parent={this} />}
+                        <div id="filelistOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.toggleSimulatorFullscreen}></div>
                     </div>
                 </div>
                 <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main" aria-hidden={inHome}>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -127,7 +127,8 @@ export class ProjectView
             showFiles: false,
             home: shouldShowHomeScreen,
             active: document.visibilityState == 'visible' || pxt.BrowserUtils.isElectron() || pxt.winrt.isWinRT() || pxt.appTarget.appTheme.dontSuspendOnVisibility,
-            collapseEditorTools: simcfg.headless || (!isSandbox && pxt.BrowserUtils.isMobile()),
+            // don't start collapsed in mobile since we can go fullscreen now
+            collapseEditorTools: simcfg.headless,
             highContrast: isHighContrast,
             simState: pxt.editor.SimState.Stopped,
             autoRun: true // always start simulator by default

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -110,16 +110,16 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const screenshotTooltip = lf("Download Screenshot")
 
         return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait hide")} role="complementary" aria-label={lf("Simulator toolbar")}>
-            <div className={`ui icon tiny buttons ${isFullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>
+            <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make ? <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} /> : undefined}
                 {run ? <sui.Button disabled={debugging || isStarting} key='runbtn' className={`play-button ${isRunning ? "stop" : "play"}`} icon={isRunning ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
                 {restart ? <sui.Button disabled={debugging || isStarting} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
                 {trace ? <sui.Button key='trace' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={this.toggleTrace} /> : undefined}
             </div>
-            <div className={`ui icon tiny buttons ${isFullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>
+            <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {audio ? <sui.Button key='mutebtn' className={`mute-button ${isMuted ? 'red' : ''}`} icon={`${isMuted ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={this.toggleMute} /> : undefined}
             </div>
-            <div className={`ui icon tiny buttons ${isFullscreen ? 'massive' : ''}`} style={{ padding: "0" }}>
+            <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {screenshot ? <sui.Button key='screenshotbtn' className={`screenshot-button ${screenshotClass}`} icon={`icon camera left`} title={screenshotTooltip} onClick={this.takeScreenshot} /> : undefined}
                 {collapse && !isFullscreen ? <sui.Button key='collapsebtn' className={`collapse-button`} icon={`icon toggle left`} title={collapseTooltip} onClick={this.toggleSimulatorCollapse} /> : undefined}
                 {fullscreen ? <sui.Button key='fullscreenbtn' className={`fullscreen-button`} icon={`xicon ${isFullscreen ? 'fullscreencollapse' : 'fullscreen'}`} title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} /> : undefined}


### PR DESCRIPTION
Support fullscreensim in all views. Toggle happens by clicking simulator in smaller views. Tested Chrome, Edge, IE, FF
![fullscreen](https://user-images.githubusercontent.com/4175913/51272117-13300a80-197e-11e9-8ed4-34fc30f502ab.gif)

https://arcade.makecode.com/app/273004070eb4db74833e3728e03d1939a8e06784-21300a2dc9