### PR TITLE
faster maker build

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2054,6 +2054,9 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         cfg.bundledpkgs[path.basename(dirname)] = res
                     }
                     if (isHw) isPrj = true
+                    if (isCore && pxt.appTarget.simulator &&
+                        pxt.appTarget.simulator.dynamicBoardDefinition)
+                        isPrj = true
                 })
                 .then(() => options.quick ? null : testForBuildTargetAsync(isPrj || (!options.skipCore && isCore)))
                 .then((compileOpts) => {
@@ -2573,7 +2576,7 @@ class Host
             nodeutil.writeFileSync(p, contents, { encoding: "utf8" })
     }
 
-    getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<any> {
+    getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo> {
         if (process.env["PXT_LOCAL_DOCKER_TEST"] === "yes") {
             const compileReq = JSON.parse(new Buffer(extInfo.compileData, "base64").toString("utf8"))
             const mappedFiles =
@@ -2599,6 +2602,30 @@ class Host
             const fn = "built/dockerreq.json"
             nodeutil.writeFileSync(fn, JSON.stringify(dockerReq, null, 4))
         }
+
+        if (pxt.options.debug) {
+            const compileReq = JSON.parse(new Buffer(extInfo.compileData, "base64").toString("utf8"))
+            const replLong = (m: any) => {
+                for (let k of Object.keys(m)) {
+                    let v = m[k]
+                    if (typeof v == "string" && v.length > 200) {
+                        m[k] = v.slice(0, 100) + " ... " + U.sha256(v).slice(0, 10)
+                    } else if (v && typeof v == "object") {
+                        replLong(v)
+                    }
+                }
+            }
+            replLong(compileReq)
+            nodeutil.writeFileSync("built/cpp.json", JSON.stringify(compileReq, null, 4))
+        }
+
+        const cachedPath = path.resolve(nodeutil.targetDir, "built", "hexcache", extInfo.sha + ".hex");
+        pxt.debug("trying " + cachedPath)
+        try {
+            const lines = fs.readFileSync(cachedPath, "utf8").split(/\r?\n/)
+            pxt.log(`Using hexcache: ${extInfo.sha}`)
+            return Promise.resolve({ hex: lines })
+        } catch (e) { }
 
         if (!forceLocalBuild && (extInfo.onlyPublic || forceCloudBuild))
             return pxt.hex.getHexInfoAsync(this, extInfo)

--- a/docs/extensions/pxt-json.md
+++ b/docs/extensions/pxt-json.md
@@ -35,8 +35,10 @@ interface PackageConfig {
     targetVersions?: TargetVersions; // versions of the target/pxt the extension was compiled against
 
     testFiles?: string[];
-    testDependencies?: string[];
+    testDependencies?: Map<string>;
     simFiles?: string[];
+
+    cppDependencies?: Map<string>;
 
     binaryonly?: boolean;
     platformio?: PlatformIOConfig;
@@ -93,6 +95,27 @@ with respect to the `pxt.json` in `additionalFilePath`.
 
 The `additionalFilePath` is recursive or multi-level - the `pxt.json` in the referenced directory
 might have another `additionalFilePath` and it will work as expected.
+
+## Test files
+
+The files listed under `testFiles` are only included when the extension is compiled
+as the top-level program and not just imported into some other program.
+Typically this happens when you run `pxt` from command line in the
+extension directory, or when you hit **Download** when editing extension itself in
+the online editor.
+They usually contain unit tests for extension.
+
+Similarly, dependencies from `testDependencies` are only included when compiled
+as top-level.
+
+## C++ dependencies
+
+Dependencies under `cppDependencies` are only considered when generating
+code for the C++ compiler.
+Usually, one would list all optional packages which contain
+C++ code in `cppDependencies` of your core package.
+Then, when user actually adds any of these optional packages, the
+C++ code doesn't change and re-compilation (and thus cloud round-trip) is not required.
 
 [adafruit]: https://github.com/Microsoft/pxt-adafruit
 [common-packages]: https://github.com/Microsoft/pxt-common-packages

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -41,6 +41,7 @@ declare namespace pxt {
         simFiles?: string[];
         testFiles?: string[];
         testDependencies?: pxt.Map<string>;
+        cppDependencies?: pxt.Map<string>;
         public?: boolean;
         binaryonly?: boolean;
         platformio?: PlatformIOConfig;

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1287,7 +1287,7 @@ namespace pxt.hex {
         if (pxtc.hex.isSetupFor(extInfo))
             return Promise.resolve(pxtc.hex.currentHexInfo)
 
-        pxt.log("get hex info: " + extInfo.sha)
+        pxt.debug("get hex info: " + extInfo.sha)
 
         let key = "hex-" + extInfo.sha
         return host.cacheGetAsync(key)

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -146,7 +146,9 @@ namespace pxt.cpp {
         let constsName = "dal.d.ts"
         let sourcePath = "/source/"
 
-        for (let pkg of mainPkg.sortedDeps()) {
+        let mainDeps = mainPkg.sortedDeps(true)
+
+        for (let pkg of mainDeps) {
             pkg.addSnapshot(pkgSnapshot, [constsName, ".h", ".cpp"])
         }
 
@@ -213,7 +215,7 @@ namespace pxt.cpp {
 
         let makefile = ""
 
-        for (const pkg of mainPkg.sortedDeps()) {
+        for (const pkg of mainDeps) {
             if (pkg.getFiles().indexOf(constsName) >= 0) {
                 const src = pkg.host().readFile(pkg, constsName)
                 Util.assert(!!src, `${constsName} not found in ${pkg.id}`)
@@ -763,8 +765,7 @@ namespace pxt.cpp {
         if (mainPkg) {
             let seenMain = false
 
-            // TODO computeReachableNodes(pkg, true)
-            for (let pkg of mainPkg.sortedDeps()) {
+            for (let pkg of mainDeps) {
                 thisErrors = ""
                 parseJson(pkg)
                 if (pkg == mainPkg) {
@@ -1286,7 +1287,7 @@ namespace pxt.hex {
         if (pxtc.hex.isSetupFor(extInfo))
             return Promise.resolve(pxtc.hex.currentHexInfo)
 
-        pxt.debug("get hex info: " + extInfo.sha)
+        pxt.log("get hex info: " + extInfo.sha)
 
         let key = "hex-" + extInfo.sha
         return host.cacheGetAsync(key)

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -520,8 +520,8 @@ namespace pxt {
                 .then<any>(() => {
                     if (this.level != 0)
                         return Promise.resolve()
-                    return Promise.map(U.values(this.parent.deps), pkg =>
-                        loadDepsRecursive(null, pkg, true))
+                    return Promise.all(U.values(this.parent.deps).map(pkg =>
+                        loadDepsRecursive(null, pkg, true)))
                 })
                 .then(() => null);
         }

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -34,6 +34,7 @@ namespace pxt {
         public isLoaded = false;
         private resolvedVersion: string;
         public ignoreTests = false;
+        public cppOnly = false;
 
         constructor(public id: string, public _verspec: string, public parent: MainPackage, addedBy: Package) {
             if (addedBy) {
@@ -378,13 +379,16 @@ namespace pxt {
             }
         }
 
-        dependencies(): pxt.Map<string> {
+        dependencies(includeCpp = false): pxt.Map<string> {
             if (!this.config) return {};
 
             const dependencies = Util.clone(this.config.dependencies || {});
             // add test dependencies if nedeed
             if (this.level == 0 && this.config.testDependencies) {
                 Util.jsonMergeFrom(dependencies, this.config.testDependencies);
+            }
+            if (includeCpp && this.config.cppDependencies) {
+                Util.jsonMergeFrom(dependencies, this.config.cppDependencies);
             }
             return dependencies;
         }
@@ -439,30 +443,35 @@ namespace pxt {
                 })
             }
 
-            const loadDepsRecursive = (deps: Map<string>) => {
-                return U.mapStringMapAsync(deps, (id, ver) => {
+
+            const loadDepsRecursive = (deps: pxt.Map<string>, from: Package, isCpp = false) => {
+                return U.mapStringMapAsync(deps || from.dependencies(isCpp), (id, ver) => {
                     if (id == "hw" && pxt.hwVariant)
                         id = "hw---" + pxt.hwVariant
-                    let mod = this.resolveDep(id)
+                    let mod = from.resolveDep(id)
                     ver = ver || "*"
                     if (mod) {
                         if (mod._verspec != ver && !/^file:/.test(mod._verspec) && !/^file:/.test(ver))
                             U.userError("Version spec mismatch on " + id)
-                        mod.level = Math.min(mod.level, this.level + 1)
-                        mod.addedBy.push(this)
+                        if (!isCpp) {
+                            mod.level = Math.min(mod.level, from.level + 1)
+                            mod.addedBy.push(from)
+                        }
                         return Promise.resolve()
                     } else {
-                        mod = new Package(id, ver, this.parent, this)
-                        this.parent.deps[id] = mod
+                        let mod = new Package(id, ver, from.parent, from)
+                        if (isCpp)
+                            mod.cppOnly = true
+                        from.parent.deps[id] = mod
                         // we can have "core---nrf52" to be used instead of "core" in other packages
-                        this.parent.deps[id.replace(/---.*/, "")] = mod
+                        from.parent.deps[id.replace(/---.*/, "")] = mod
                         return mod.loadAsync(isInstall)
                     }
                 })
             }
 
             return initPromise
-                .then(() => loadDepsRecursive(this.dependencies()))
+                .then(() => loadDepsRecursive(null, this))
                 .then(() => {
                     // get paletter config loading deps, so the more higher level packages take precedence
                     if (this.config.palette && appTarget.runtime)
@@ -494,7 +503,7 @@ namespace pxt {
                                         this.config.dependencies[missing] = "*"
                                         const addDependency: Map<string> = {};
                                         addDependency[missing] = missingPackages[missing];
-                                        return loadDepsRecursive(addDependency);
+                                        return loadDepsRecursive(addDependency, this);
                                     }
                                 });
                         }, Promise.resolve(null))
@@ -507,6 +516,12 @@ namespace pxt {
                             });
                     }
                     return Promise.resolve(null);
+                })
+                .then<any>(() => {
+                    if (this.level != 0)
+                        return Promise.resolve()
+                    return Promise.map(U.values(this.parent.deps), pkg =>
+                        loadDepsRecursive(null, pkg, true))
                 })
                 .then(() => null);
         }
@@ -597,17 +612,20 @@ namespace pxt {
             return this.loadAsync(true, targetVersion);
         }
 
-        sortedDeps() {
+        sortedDeps(includeCpp = false) {
             let visited: Map<boolean> = {}
             let ids: string[] = []
-            let rec = (p: Package) => {
+            const weight = (p: Package) =>
+                p.config ? Object.keys(p.config.cppDependencies || {}).length : 0
+            const rec = (p: Package) => {
                 if (!p || U.lookup(visited, p.id)) return;
                 visited[p.id] = true;
 
-                const dependencies = p.dependencies();
-                const deps = Object.keys(dependencies);
-                deps.sort((a, b) => U.strcmp(a, b))
-                deps.forEach(id => rec(this.resolveDep(id)))
+                const depNames = Object.keys(p.dependencies(includeCpp))
+                const deps = depNames.map(id => this.resolveDep(id))
+                // packages with more cppDependencies (core---* most likely) come first
+                deps.sort((a, b) => weight(b) - weight(a) || U.strcmp(a.id, b.id))
+                deps.forEach(rec)
                 ids.push(p.id)
             }
             rec(this)

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -331,6 +331,7 @@ export class EditorPackage {
         let res: EditorPackage[] = []
         for (let k of depkeys) {
             if (/---/.test(k)) continue
+            if (deps[k].cppOnly) continue
             res.push(getEditorPkg(deps[k]))
         }
         if (this.assetsPkg)

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -173,7 +173,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         return Object.keys(bundled).filter(k => !/prj$/.test(k))
             .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig)
             .filter(pk => !query || pk.name.toLowerCase().indexOf(query.toLowerCase()) > -1) // search filter
-            .filter(pk => boards || !pkg.mainPkg.deps[pk.name]) // don't show package already referenced in extensions
+            .filter(pk => boards || !pkg.mainPkg.deps[pk.name] || pkg.mainPkg.deps[pk.name].cppOnly) // don't show package already referenced in extensions
             .filter(pk => !/---/.test(pk.name)) //filter any package with ---, these are part of common-packages such as core---linux or music---pwm
             .filter(pk => boards == !!pk.core) // show core in "boards" mode
             .filter(pk => !features || features.every(f => pk.features && pk.features.indexOf(f) > -1)); // ensure features are supported


### PR DESCRIPTION
This brings down maker build time down to earth (5x probably).

This works by reusing the same C++ image for all boards with the same MCU (by including a bit more C++ than strictly needed). From docs:

> Dependencies under `cppDependencies` are only considered when generating code for the C++ compiler. Usually, one would list all optional packages which contain C++ code in `cppDependencies` of your core package. Then, when user actually adds any of these optional packages, the C++ code doesn't change and re-compilation (and thus cloud round-trip) is not required.

@abchatra this should not affect Arcade, but I guess can wait until after release