### PR TITLE
Slight update to 'loops' docs

### DIFF
--- a/common-docs/SUMMARY.md
+++ b/common-docs/SUMMARY.md
@@ -22,6 +22,7 @@
         * [repeat](/blocks/loops/repeat)
         * [for](/blocks/loops/for)
         * [while](/blocks/loops/while)
+        * [for](/blocks/loops/for-of)
     * [Logic](/blocks/logic)
         * [if](/blocks/logic/if)
         * [Boolean](/blocks/logic/boolean)

--- a/common-docs/SUMMARY.md
+++ b/common-docs/SUMMARY.md
@@ -22,7 +22,7 @@
         * [repeat](/blocks/loops/repeat)
         * [for](/blocks/loops/for)
         * [while](/blocks/loops/while)
-        * [for](/blocks/loops/for-of)
+        * [for of](/blocks/loops/for-of)
     * [Logic](/blocks/logic)
         * [if](/blocks/logic/if)
         * [Boolean](/blocks/logic/boolean)

--- a/common-docs/blocks/loops.md
+++ b/common-docs/blocks/loops.md
@@ -11,4 +11,4 @@ for(let value of [""]) {}
 
 ## See also #seealso
 
-[for](/blocks/loops/for), [while](/blocks/loops/while), [repeat](/blocks/loops/repeat)
+[for](/blocks/loops/for), [while](/blocks/loops/while), [repeat](/blocks/loops/repeat), [for of](/blocks/for-of)

--- a/common-docs/blocks/loops/for.md
+++ b/common-docs/blocks/loops/for.md
@@ -1,6 +1,6 @@
 # For
  
-Run part of the program the number of times you say.
+Run part of the program the number of times you say using an index variable.
 
 ```block
 for(let i = 0; i <= 4; ++i) {


### PR DESCRIPTION
Fix some loops links and one description.

Had thought about adding some text with a general discussion on index usage but that would break translations for 4 topics in all targets.