### PR TITLE
don't allow props to override name if local changes

### DIFF
--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -59,8 +59,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             this.loanedSimulator = undefined;
             this.props.parent.popScreenshotHandler();
         }
-        this.setState({ 
-            visible: false, 
+        this.setState({
+            visible: false,
             screenshotUri: undefined,
             projectName: undefined,
             projectNameChanged: false
@@ -81,7 +81,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             mode: ShareMode.Code,
             pubCurrent: header.pubCurrent,
             sharingError: false,
-            screenshotUri: undefined            
+            screenshotUri: undefined
         }, () => this.props.parent.startSimulator());
     }
 

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -26,6 +26,7 @@ export interface ShareEditorState {
     sharingError?: boolean;
     loading?: boolean;
     projectName?: string;
+    projectNameChanged?: boolean;
     thumbnails?: boolean;
     takingScreenshot?: boolean;
     screenshotUri?: string;
@@ -58,7 +59,12 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             this.loanedSimulator = undefined;
             this.props.parent.popScreenshotHandler();
         }
-        this.setState({ visible: false, screenshotUri: undefined });
+        this.setState({ 
+            visible: false, 
+            screenshotUri: undefined,
+            projectName: undefined,
+            projectNameChanged: false
+        });
     }
 
     show(header: pxt.workspace.Header) {
@@ -75,7 +81,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             mode: ShareMode.Code,
             pubCurrent: header.pubCurrent,
             sharingError: false,
-            screenshotUri: undefined
+            screenshotUri: undefined            
         }, () => this.props.parent.startSimulator());
     }
 
@@ -86,7 +92,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
 
     componentWillReceiveProps(newProps: ShareEditorProps) {
         const newState: ShareEditorState = {}
-        if (newProps.parent.state.projectName != this.state.projectName) {
+        if (!this.state.projectNameChanged &&
+            newProps.parent.state.projectName != this.state.projectName) {
             newState.projectName = newProps.parent.state.projectName;
         }
         if (newProps.loading != this.state.loading) {
@@ -105,6 +112,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             || this.state.currentPubId != nextState.currentPubId
             || this.state.sharingError != nextState.sharingError
             || this.state.projectName != nextState.projectName
+            || this.state.projectNameChanged != nextState.projectNameChanged
             || this.state.loading != nextState.loading
             || this.state.takingScreenshot != nextState.takingScreenshot
             || this.state.screenshotUri != nextState.screenshotUri;
@@ -120,7 +128,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
     }
 
     handleProjectNameChange(name: string) {
-        this.setState({ projectName: name });
+        this.setState({ projectName: name, projectNameChanged: true });
     }
 
     restartSimulator() {


### PR DESCRIPTION
Screenshot triggers a props update which overrides the local name. Keep a flag to track if the project name has been changed locally.
Fix for https://github.com/Microsoft/pxt-arcade/issues/641