### PR TITLE
guard from missing runtime

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -457,8 +457,6 @@ namespace pxsim {
                 case 'ready':
                     let frameid = (msg as pxsim.SimulatorReadyMessage).frameid;
                     let frame = document.getElementById(frameid) as HTMLIFrameElement;
-                    // simulator might be gone
-                    // or the compiler might not have sent a compiled program yet
                     if (frame) {
                         this.startFrame(frame);
                         if (this.options.revealElement)

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -60,7 +60,7 @@ namespace pxsim {
         private runId = '';
         private nextFrameId = 0;
         private frameCounter = 0;
-        private currentRuntime: pxsim.SimulatorRunMessage;
+        private _currentRuntime: pxsim.SimulatorRunMessage;
         private listener: (ev: MessageEvent) => void;
         private traceInterval = 0;
         public runOptions: SimulatorRunOptions = {};
@@ -283,7 +283,7 @@ namespace pxsim {
             pxsim.U.removeChildren(this.container);
             this.setState(SimulatorState.Unloaded);
             this.runOptions = undefined; // forget about program
-            this.currentRuntime = undefined;
+            this._currentRuntime = undefined;
             this.runId = undefined;
         }
 
@@ -389,7 +389,7 @@ namespace pxsim {
             this.runOptions = opts;
             this.runId = this.nextId();
             // store information
-            this.currentRuntime = {
+            this._currentRuntime = {
                 type: "run",
                 boardDefinition: opts.boardDefinition,
                 parts: opts.parts,
@@ -419,7 +419,7 @@ namespace pxsim {
             this.applyAspectRatio();
             this.scheduleFrameCleanup();
 
-            if (!this.currentRuntime) return; // nothing to do
+            if (!this._currentRuntime) return; // nothing to do
 
             // first frame
             let frame = this.simFrames()[0];
@@ -435,7 +435,7 @@ namespace pxsim {
         }
 
         private startFrame(frame: HTMLIFrameElement) {
-            let msg = JSON.parse(JSON.stringify(this.currentRuntime)) as pxsim.SimulatorRunMessage;
+            let msg = JSON.parse(JSON.stringify(this._currentRuntime)) as pxsim.SimulatorRunMessage;
             let mc = '';
             let m = /player=([A-Za-z0-9]+)/i.exec(window.location.href); if (m) mc = m[1];
             msg.frameCounter = ++this.frameCounter;
@@ -454,7 +454,9 @@ namespace pxsim {
                 case 'ready':
                     let frameid = (msg as pxsim.SimulatorReadyMessage).frameid;
                     let frame = document.getElementById(frameid) as HTMLIFrameElement;
-                    if (frame) {
+                    // simulator might be gone
+                    // or the compiler might not have sent a compiled program yet
+                    if (frame && this._currentRuntime) {
                         this.startFrame(frame);
                         if (this.options.revealElement)
                             this.options.revealElement(frame);

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -199,8 +199,7 @@ namespace pxsim {
                     this.container.appendChild(this.createFrame());
                     frames = this.simFrames();
                 } else if (frames[1].dataset['runid'] != this.runId) {
-                    if (this._currentRuntime)
-                        this.startFrame(frames[1]);
+                    this.startFrame(frames[1]);
                 }
             }
 
@@ -436,7 +435,8 @@ namespace pxsim {
         }
 
         // ensure _currentRuntime is ready
-        private startFrame(frame: HTMLIFrameElement) {
+        private startFrame(frame: HTMLIFrameElement): boolean {
+            if (!this._currentRuntime) return false;
             let msg = JSON.parse(JSON.stringify(this._currentRuntime)) as pxsim.SimulatorRunMessage;
             let mc = '';
             let m = /player=([A-Za-z0-9]+)/i.exec(window.location.href); if (m) mc = m[1];
@@ -449,6 +449,7 @@ namespace pxsim {
             frame.dataset['runid'] = this.runId;
             frame.contentWindow.postMessage(msg, "*");
             this.setFrameState(frame);
+            return true;
         }
 
         private handleMessage(msg: pxsim.SimulatorMessage, source?: Window) {
@@ -458,7 +459,7 @@ namespace pxsim {
                     let frame = document.getElementById(frameid) as HTMLIFrameElement;
                     // simulator might be gone
                     // or the compiler might not have sent a compiled program yet
-                    if (frame && this._currentRuntime) {
+                    if (frame) {
                         this.startFrame(frame);
                         if (this.options.revealElement)
                             this.options.revealElement(frame);

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -199,7 +199,8 @@ namespace pxsim {
                     this.container.appendChild(this.createFrame());
                     frames = this.simFrames();
                 } else if (frames[1].dataset['runid'] != this.runId) {
-                    this.startFrame(frames[1]);
+                    if (this._currentRuntime)
+                        this.startFrame(frames[1]);
                 }
             }
 
@@ -434,6 +435,7 @@ namespace pxsim {
             this.setTraceInterval(this.traceInterval);
         }
 
+        // ensure _currentRuntime is ready
         private startFrame(frame: HTMLIFrameElement) {
             let msg = JSON.parse(JSON.stringify(this._currentRuntime)) as pxsim.SimulatorRunMessage;
             let mc = '';


### PR DESCRIPTION
Make sure _currentRuntime is ready before starting a frame, as it may have started faster than the compiler. The fix guards the startFrame function against missing runtime.
Fix for https://github.com/Microsoft/pxt-arcade/pull/656#issuecomment-455402398

Fix verified.
![image](https://user-images.githubusercontent.com/4175913/51361793-04347f80-1a86-11e9-9606-bd599841e449.png)
