### PR TITLE
always redirect /blog to https://makecode.com/blog

### DIFF
--- a/common-docs/blog-ref.json
+++ b/common-docs/blog-ref.json
@@ -1,0 +1,3 @@
+{
+    "redirect": "https://makecode.com/blog"
+}


### PR DESCRIPTION
I keep try to go to https://arcade.makecode.com/blog