### PR TITLE
Don't show the cookie banner when noCookieBanner=1 is passed

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -277,8 +277,15 @@ namespace pxt {
      */
     function shouldHideCookieBanner(): boolean {
         //We don't want a cookie notification when embedded in editor controllers, we'll use the url to determine that
-        const noCookieBanner = /nocookiebanner=1/i.test(window.location.href)
+        const noCookieBanner = isIFrame() && /nocookiebanner=1/i.test(window.location.href)
         return noCookieBanner;
+    }
+    function isIFrame(): boolean {
+        try {
+            return window && window.self !== window.top;
+        } catch (e) {
+            return true;
+        }
     }
     /**
      * checks for sandbox

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -71,7 +71,7 @@ namespace pxt {
     let exceptionLogger: TelemetryQueue<any, string, Map<string>>;
 
     export function initAnalyticsAsync() {
-        if (isNativeApp()) {
+        if (isNativeApp() || shouldHideCookieBanner()) {
             initializeAppInsightsInternal(true);
             return;
         }
@@ -271,6 +271,14 @@ namespace pxt {
         const isPxtElectron = hasWindow && !!(window as any).pxtElectron;
         const isCC = hasWindow && !!(window as any).ipcRenderer || /ipc=1/.test(location.hash) || /ipc=1/.test(location.search); // In WKWebview, ipcRenderer is injected later, so use the URL query
         return isUwp || isPxtElectron || isCC;
+    }
+    /**
+     * Checks whether we should hide the cookie banner
+     */
+    function shouldHideCookieBanner(): boolean {
+        //We don't want a cookie notification when embedded in editor controllers, we'll use the url to determine that
+        const noCookieBanner = /nocookiebanner=1/i.test(window.location.href)
+        return noCookieBanner;
     }
     /**
      * checks for sandbox


### PR DESCRIPTION
Don't show the cookie banner when noCookieBanner=1 is passed.

Note: this still drops a cookie but it's used for editor controllers to not show the cookie banner when we're embedded in an iframe.

Tested locally.