### PR TITLE
Fixing arrray inference bug

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -207,7 +207,7 @@ namespace pxt.blocks {
                     if (parentType.childType) {
                         return parentType.childType;
                     }
-                    const p = isArrayType(parentType.type) ? mkPoint(parentType.type.substr(-2)) : mkPoint(null);
+                    const p = isArrayType(parentType.type) ? mkPoint(parentType.type.substr(0, parentType.type.length - 2)) : mkPoint(null);
                     genericLink(parentType, p);
                     return p;
                 }
@@ -467,14 +467,14 @@ namespace pxt.blocks {
         if (p.childType) {
             union(p.childType, c);
         }
-        else {
+        else if (!p.type) {
             p.childType = c;
         }
 
         if (c.parentType) {
             union(c.parentType, p);
         }
-        else {
+        else if (!c.type) {
             c.parentType = p;
         }
     }


### PR DESCRIPTION
Thanks to @RoboErikG for finally nailing down a repro for this bug!

To reproduce the bug in arcade.makecode.com:

1. Drag out the `set list to number[]` block from the arrays category
1. Drag out the `for value of list` block from the loops category
1. Drag out the `set sprite list to array of sprites of kind` block from the arrays category
1. Change the list variable in the for-of block to the `sprite list`
1. Observe as we try to turn everything into a number array

That's one way to do it, but the bug was actually that we were leaking type information between block compiles so I have a feeling it showed up in other places as well.