### PR TITLE
Fixing sprite editor styling, toggle, and scrolling in monaco

### DIFF
--- a/pxtlib/sprite-editor/buttons.ts
+++ b/pxtlib/sprite-editor/buttons.ts
@@ -120,12 +120,14 @@ namespace pxtsprite {
             // Draw the left option
             this.leftElement = this.root.group();
             this.leftText = mkText(this.props.leftText)
+                .appendClass("sprite-editor-text")
                 .fill(this.props.selectedTextColor);
             this.leftElement.appendChild(this.leftText);
 
             // Draw the right option
             this.rightElement = this.root.group();
             this.rightText = mkText(this.props.rightText)
+                .appendClass("sprite-editor-text")
                 .fill(this.props.unselectedTextColor);
             this.rightElement.appendChild(this.rightText);
 
@@ -276,7 +278,9 @@ namespace pxtsprite {
 
     export function mkTextButton(text: string, width: number, height: number) {
         const g = drawSingleButton(width, height);
-        return new TextButton(g.root, g.cx, g.cy, text, "sprite-editor-text");
+        const t = new TextButton(g.root, g.cx, g.cy, text, "sprite-editor-text");
+        t.addClass("sprite-editor-label");
+        return t;
     }
 
     /**

--- a/pxtlib/sprite-editor/header.ts
+++ b/pxtlib/sprite-editor/header.ts
@@ -45,8 +45,7 @@ namespace pxtsprite {
 
         layout() {
             this.toggle.layout();
-            const bounds = this.div.getBoundingClientRect();
-            this.toggle.translate((bounds.width - this.toggle.width()) / 2, (bounds.height - this.toggle.height()) / 2);
+            this.toggle.translate((TOTAL_HEIGHT - this.toggle.width()) / 2, (HEADER_HEIGHT - this.toggle.height()) / 2);
         }
     }
 }

--- a/pxtlib/sprite-editor/reporterBar.ts
+++ b/pxtlib/sprite-editor/reporterBar.ts
@@ -37,6 +37,7 @@ namespace pxtsprite {
 
             this.cursorText = this.root.draw("text")
                 .appendClass("sprite-editor-text")
+                .appendClass("sprite-editor-label")
                 .setAttribute("dominant-baseline", "middle")
                 .setAttribute("dy", 2.5);
         }

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -9,14 +9,14 @@ namespace pxtsprite {
     import svg = pxt.svgUtil;
     import lf = pxt.Util.lf;
 
-    const TOTAL_HEIGHT = 500;
+    export const TOTAL_HEIGHT = 500;
 
     const PADDING = 10;
 
     const DROP_DOWN_PADDING = 4;
 
     // Height of toolbar (the buttons above the canvas)
-    const HEADER_HEIGHT = 50;
+    export const HEADER_HEIGHT = 50;
 
     // Spacing between the toolbar and the canvas
     const HEADER_CANVAS_MARGIN = 10;

--- a/theme/spriteeditor.less
+++ b/theme/spriteeditor.less
@@ -146,6 +146,12 @@
 }
 
 .sprite-editor-text {
+    font-family: @pageFont !important;
+    user-select: none;
+    cursor: auto;
+}
+
+.sprite-editor-label {
     fill: white;
 }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -73,6 +73,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             if (!this.hasBlocks())
                 return undefined;
 
+            if (this.feWidget) {
+                this.feWidget.close();
+                this.activeRangeID = null;
+            }
+
             let blockFile = this.currFile.getVirtualFileName();
             if (!blockFile) {
                 let mainPkg = pkg.mainEditorPkg();
@@ -874,6 +879,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.feWidget.heightInPx = viewZoneHeight;
         this.feWidget.showAsync(this.editor)
             .then(edit => {
+                this.activeRangeID = null;
                 if (edit) {
                     this.editModelAsync(edit.range, edit.replacement)
                         .then(newRange => this.indentRangeAsync(newRange));

--- a/webapp/src/monacoFieldEditorHost.ts
+++ b/webapp/src/monacoFieldEditorHost.ts
@@ -57,7 +57,12 @@ export class ViewZoneEditorHost implements pxt.editor.MonacoFieldEditorHost, mon
                 this.blocks = bi;
                 return this.showViewZoneAsync();
             })
-            .then(() => this.fe.showEditorAsync(this.range, this))
+            .then(() => {
+                this.editor.setScrollPosition({
+                    scrollTop: this.editor.getTopForLineNumber(this.afterLineNumber)
+                });
+                return this.fe.showEditorAsync(this.range, this)
+            })
             .finally(() => {
                 this.close();
             })


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/470

More specifically:
1. Fixes toggle layout when created off-screen
1. Fixes the font, cursor, and select behavior of text when the field editor is in Monaco
1. Fixes the toggle behavior of the gutter decoration in Monaco
1. Fixes a bug where the Field Editor persists if you switch to blocks before closing it
1. Adds a feature so that Monaco scrolls to a field editor when it opens