### PR TITLE
Fixes pxt-arcade/#648

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -838,7 +838,7 @@ declare namespace Blockly {
         removeField(name: string): void;
         setAlign(align: number): Input;
         setCheck(check: string | string[]): Input;
-        setVisible(visible: boolean): Block;
+        setVisible(visible: boolean): Block[];
     }
 
     class Connection {

--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -292,9 +292,9 @@ namespace pxt.blocks {
             // If the block isn't rendered, Blockly will crash
             if (b.rendered) {
                 let renderList = input.setVisible(visible);
-                for (let i = 0, block; block = renderList[i]; i++) {
+                renderList.forEach(block => {
                     block.render();
-                }
+                });
             }
         }
     }

--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -291,7 +291,10 @@ namespace pxt.blocks {
         function setInputVisible(input: Blockly.Input, visible: boolean) {
             // If the block isn't rendered, Blockly will crash
             if (b.rendered) {
-                input.setVisible(visible);
+                let renderList = input.setVisible(visible);
+                for (let i = 0, block; block = renderList[i]; i++) {
+                    block.render();
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/648
When re-expanding a block, fields would not react properly to changes.