### PR TITLE
test webusb support

### DIFF
--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -15,9 +15,11 @@ function requireHID(install?: boolean): boolean {
         // in the browser, check that USB is defined
         return pxt.usb.isAvailable();
     }
-    if (HID) return HID;
-    HID = nodeutil.lazyRequire("node-hid", install);
-    return !!HID;
+    else {
+        if (!HID)
+            HID = nodeutil.lazyRequire("node-hid", install);
+        return !!HID;
+    }
 }
 
 export function isInstalled(install?: boolean): boolean {

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -8,8 +8,13 @@ function useWebUSB() {
 
 let HID: any = undefined;
 function requireHID(install?: boolean): any {
-    if (useWebUSB())
-        return true
+    if (useWebUSB()) {
+        // in node.js, we need "webusb" package
+        if (pxt.Util.isNodeJS)
+            return nodeutil.lazyRequire("webusb", install);
+        // in the browser, check that USB is defined
+        return !!window.navigator && !!(window.navigator as any).usb;
+    }
     if (HID) return HID;
     return HID = nodeutil.lazyRequire("node-hid", install);
 }

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -7,20 +7,21 @@ function useWebUSB() {
 }
 
 let HID: any = undefined;
-function requireHID(install?: boolean): any {
+function requireHID(install?: boolean): boolean {
     if (useWebUSB()) {
         // in node.js, we need "webusb" package
         if (pxt.Util.isNodeJS)
-            return nodeutil.lazyRequire("webusb", install);
+            return !!nodeutil.lazyRequire("webusb", install);
         // in the browser, check that USB is defined
-        return !!window.navigator && !!(window.navigator as any).usb;
+        return pxt.usb.isAvailable();
     }
     if (HID) return HID;
-    return HID = nodeutil.lazyRequire("node-hid", install);
+    HID = nodeutil.lazyRequire("node-hid", install);
+    return !!HID;
 }
 
 export function isInstalled(install?: boolean): boolean {
-    return !!requireHID(!!install);
+    return requireHID(!!install);
 }
 
 export interface HidDevice {

--- a/docs/cli/deploy.md
+++ b/docs/cli/deploy.md
@@ -5,14 +5,12 @@
 Builds and deploys the current project
 
 ```
-pxt deploy [--serial]
+pxt deploy
 ```
 
 ## Options
 
-### --serial
-
-Launches the serial port monitor after deployment.
+Run ``pxt help deploy``
 
 ## Description
 


### PR DESCRIPTION
- [x] WebUSB requires "webusb" in node.js or a browser that supports it. If "webusb" is not installed, defaults back to file copying.
- [x] add "--force" flag to skip cache lookups