### PR TITLE
tweak green color in green screen

### DIFF
--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -49,8 +49,8 @@
         stroke-width: 2px;
     }
 
-    .blocklyBlockBackground[fill=@{greenScreenBlockColor}] {
-        fill: @greenScreenGreen;
+    .blocklyBlockBackground[fill="@{greenScreenBlockColor}"] {
+        fill: @greenScreenGreen !important;
     }
 
     .pxtToolbox:not(.invertedToolbox) {

--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -47,10 +47,9 @@
 
     .blocklyBlockBackground {
         stroke-width: 2px;
-        stroke: #fff;
     }
 
-    .blockBackground[fill=@{greenScreenBlockColor}] {
+    .blocklyBlockBackground[fill=@{greenScreenBlockColor}] {
         fill: @greenScreenGreen;
     }
 

--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -45,6 +45,10 @@
         box-shadow: 1px 1px #000;
     }
 
+    .blocklyBlockBackground {
+        stroke-width: 2px;
+    }
+
     .pxtToolbox:not(.invertedToolbox) {
         .blocklyTreeRow:not(.blocklyTreeSelected) {
             background: white;

--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -50,8 +50,8 @@
         stroke: #fff;
     }
 
-    .blockBackground[fill=@greenScreenBlockColor] {
-        fill: @greenScreenGreen;        
+    .blockBackground[fill=@{greenScreenBlockColor}] {
+        fill: @greenScreenGreen;
     }
 
     .pxtToolbox:not(.invertedToolbox) {

--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -47,6 +47,11 @@
 
     .blocklyBlockBackground {
         stroke-width: 2px;
+        stroke: #fff;
+    }
+
+    .blockBackground[fill=@greenScreenBlockColor] {
+        fill: @greenScreenGreen;        
     }
 
     .pxtToolbox:not(.invertedToolbox) {

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -284,3 +284,6 @@
     Greenscreen
 -------------------*/
 @greenScreenColor: #00ff00;
+@greenScreenBlockColor: #107c10; // loops category typically uses green
+                                   // keep in sync with pxtarget blocks color changes
+@greenScreenGreen: #4f5d00; // a green that does not get erased by chromekey 


### PR DESCRIPTION
Loops get erased as they are "too green". Adds a green replacement in greenscreen mode. Needs LESS overrides in target than change the loops color.