### PR TITLE
refresh commands on app target load

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -160,22 +160,25 @@ namespace pxt {
     }
 
     // this is set by compileServiceVariant in pxt.json
-    export function setAppTargetVariant(variant: string) {
+    export function setAppTargetVariant(variant: string): void {
         pxt.debug(`app variant: ${variant}`);
+        if (appTargetVariant === variant) return;
         appTargetVariant = variant
         appTarget = U.clone(savedAppTarget)
         if (variant) {
-            if (appTarget.variants) {
-                let v = appTarget.variants[variant]
-                if (v) {
-                    U.jsonMergeFrom(appTarget, v)
-                    return
-                }
-            }
-            U.userError(lf("Variant '{0}' not defined in pxtarget.json", variant))
+            const v = appTarget.variants && appTarget.variants[variant];
+            if (v)
+                U.jsonMergeFrom(appTarget, v)
+            else
+                U.userError(lf("Variant '{0}' not defined in pxtarget.json", variant))
         }
         patchAppTarget();
+        if (onAppTargetChanged)
+            onAppTargetChanged();
     }
+
+    // notify when app target was changed
+    export let onAppTargetChanged: () => void;
 
     // This causes the `hw` package to be replaced with `hw---variant` upon package load
     // the pxt.json of hw---variant would generally specify compileServiceVariant

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3269,17 +3269,16 @@ document.addEventListener("DOMContentLoaded", () => {
                         simulator.setTranslations(simStrings);
                 });
         })
-        .then(() => pxt.BrowserUtils.initTheme())
-        .then(() => pxt.editor.experiments.syncTheme())
-        .then(() => cmds.initCommandsAsync())
         .then(() => {
+            pxt.BrowserUtils.initTheme();
+            pxt.editor.experiments.syncTheme();
+            cmds.init();
             // editor messages need to be enabled early, in case workspace provider is IFrame
             if (theme.allowParentController
                 || theme.allowPackageExtensions
                 || theme.allowSimulatorTelemetry
                 || pxt.shell.isControllerMode())
                 pxt.editor.bindEditorMessages(getEditorAsync);
-
             return workspace.initAsync()
         })
         .then((state) => {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -357,16 +357,21 @@ function localhostDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     return deploy()
 }
 
-export function initCommandsAsync(): Promise<void> {
+export function init(): void {
+    pxt.onAppTargetChanged = init;
     pxt.commands.browserDownloadAsync = browserDownloadAsync;
     pxt.commands.saveOnlyAsync = browserDownloadDeployCoreAsync;
     pxt.commands.showUploadInstructionsAsync = showUploadInstructionsAsync;
     const forceHexDownload = /forceHexDownload/i.test(window.location.href);
 
     if (pxt.usb.isAvailable() && pxt.appTarget.compile.webUSB) {
-        pxt.log(`enabled webusb`);
+        pxt.debug(`enabled webusb`);
         pxt.usb.setEnabled(true);
         pxt.HF2.mkPacketIOAsync = pxt.usb.mkPacketIOAsync;
+    } else {
+        pxt.debug(`disabled webusb`);
+        pxt.usb.setEnabled(false);
+        pxt.HF2.mkPacketIOAsync = undefined;
     }
     if (isNativeHost()) {
         pxt.debug(`deploy/save using webkit host`);
@@ -408,6 +413,4 @@ export function initCommandsAsync(): Promise<void> {
     } else { // in browser
         pxt.commands.deployCoreAsync = browserDownloadDeployCoreAsync;
     }
-
-    return Promise.resolve();
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -881,7 +881,8 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
             if (res instanceof Error) {
                 // ignore
             } else {
-                this.prevGalleries = pxt.Util.concat(res.map(g => g.cards));
+                this.prevGalleries = pxt.Util.concat(res.map(g => g.cards))
+                    .filter(c => !!c.variant);
             }
         }
         return this.prevGalleries || [];


### PR DESCRIPTION
Some variants support WebUSB, some not. We need to re-initialize the command after loading the app target variant to reflect this.

+ filter out cards from "choose hardware dialog" that don't have  a variant.