### PR TITLE
Fix Math.idiv in the simulator (#5233)

### DIFF
--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -197,7 +197,7 @@ namespace pxsim {
         }
 
         export function idiv(x: number, y: number) {
-            return (x / y) >> 0
+            return ((x | 0) / (y | 0)) | 0
         }
 
         export function round(n: number) { return Math.round(n) }


### PR DESCRIPTION
Cherry picking the fix from https://github.com/Microsoft/pxt/pull/5233

Original issue:
https://github.com/Microsoft/pxt-microbit/issues/1803