### PR TITLE
Don't watch the simulator's built folder when serving

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2047,7 +2047,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
             dirsToWatch = dirsToWatch.concat(
                 fs.readdirSync(simDir())
                     .map(p => path.join(simDir(), p))
-                    .filter(p => fs.statSync(p).isDirectory()));
+                    .filter(p => path.basename(p) !== "built" && fs.statSync(p).isDirectory()));
         }
     }
 


### PR DESCRIPTION
Fixes the issue where serving pxt-arcade causes a neverending build loop. 