### PR TITLE
Removing redundant compile check for snippets

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -205,7 +205,7 @@ namespace pxt.runner {
             const hexname = `${appTarget.nickname || appTarget.id}-${options.hexName || ''}-${snippetCount++}.hex`;
             fillWithWidget(options, c, js, s, r, {
                 showEdit: options.showEdit,
-                run: options.simulator && compiled,
+                run: options.simulator,
                 hexname: hexname,
                 hex: hex,
             });


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/690

I broke this with https://github.com/Microsoft/pxt/pull/5166

The old logic only added the simulator run button below a snippet if the compile was successful. Now, we don't compile the JS, so we can't check it. I don't think it matters though because we are already checking the snippets at build time.