### PR TITLE
allow to specify a default compile variant

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -46,6 +46,7 @@ declare namespace pxt {
         serial?: AppSerial;
         appTheme: AppTheme;
         compileService?: TargetCompileService;
+        defaultCompileServiceVariant?: string;
         ignoreDocsErrors?: boolean;
         variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
         queryVariants?: Map<AppTarget>; // patches on top of the current AppTarget using query url regex

--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -22,7 +22,7 @@ namespace pxt.editor.experiments {
         })
         if (experiments.length && Object.keys(r).length) {
             pxt.tickEvent("experiments.loaded", r);
-            pxt.setAppTargetVariant(null);
+            pxt.setAppTargetVariant(pxt.appTarget.defaultCompileServiceVariant);
         }
     }
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -418,7 +418,9 @@ namespace pxt {
                     initPromise = initPromise.then(() => this.patchCorePackage());
                 initPromise = initPromise.then(() => {
                     if (this.config.compileServiceVariant)
-                        pxt.setAppTargetVariant(this.config.compileServiceVariant)
+                        pxt.setAppTargetVariant(this.config.compileServiceVariant);
+                    else if (pxt.appTarget.defaultCompileServiceVariant)
+                        pxt.setAppTargetVariant(pxt.appTarget.defaultCompileServiceVariant);
                     if (this.config.files.indexOf("board.json") < 0) return
                     const def = appTarget.simulator.boardDefinition = JSON.parse(this.readFile("board.json")) as pxsim.BoardDefinition;
                     def.id = this.config.name;

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -399,7 +399,7 @@ namespace pxt {
             let initPromise = Promise.resolve()
 
             if (this.level == 0)
-                pxt.setAppTargetVariant(null)
+                pxt.setAppTargetVariant(pxt.appTarget.defaultCompileServiceVariant)
 
             this.isLoaded = true;
             const str = this.readFile(pxt.CONFIG_NAME);


### PR DESCRIPTION
Allow to specify the default compile service variant to be used when not specified in the project.