### PR TITLE
Additional file path load issue

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -800,6 +800,8 @@ namespace pxt {
                     })
                     files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4)
                     for (let f of this.getFiles()) {
+                        // already stored
+                        if (f == pxt.CONFIG_NAME) continue;
                         let str = this.readFile(f)
                         if (str == null)
                             U.userError("referenced file missing: " + f)

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -524,7 +524,7 @@ namespace pxt {
                         loadDepsRecursive(null, pkg, true)))
                 })
                 .then(() => {
-                    pxt.log(`  installed ${this.id}`)
+                    pxt.debug(`  installed ${this.id}`)
                 });
         }
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -523,7 +523,9 @@ namespace pxt {
                     return Promise.all(U.values(this.parent.deps).map(pkg =>
                         loadDepsRecursive(null, pkg, true)))
                 })
-                .then(() => null);
+                .then(() => {
+                    pxt.log(`  installed ${this.id}`)
+                });
         }
 
         getFiles() {


### PR DESCRIPTION
I'm not sure why we did not more issues with this one. Basically, we patch the pxt.json payload before packaging it into target.json.
https://github.com/Microsoft/pxt/pull/5242/files#diff-3395275f9da491d407273b5a3d768ea1R803

However, we also cycle through the files, read pxt.json and override it.