### PR TITLE
Add the plus input to expandable blocks to fix flyout

### DIFF
--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -130,6 +130,8 @@ namespace pxt.blocks {
 
         Blockly.Extensions.apply('inline-svgs', b, false);
 
+        addPlusButton();
+
         appendMutation(b, {
             mutationToDom: (el: Element) => {
                 // The reason we store the inputsInitialized variable separately from visibleOptions


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/496
Fixes https://github.com/Microsoft/pxt-arcade/issues/496

Blockly doesn't apply mutations before the flyout size is calculated, so we need to add the button in the init function (even though it might get removed once the mutation is applied).