### PR TITLE
Showing Object description in debugger for some objects.

### DIFF
--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -104,7 +104,7 @@ namespace pxsim {
                         }
                     }
                     if (v._width && v._height) {
-                        return { text: "Image " + v._width + 'x' + v._height }
+                        return { text: v._width + 'x' + v._height }
                     }
                     return { text: "(object)" }
                 default:

--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -103,6 +103,9 @@ namespace pxsim {
                             preview: RefObject.toDebugString(v)
                         }
                     }
+                    if (v._width && v._height) {
+                        return { text: "Image " + v._width + 'x' + v._height }
+                    }
                     return { text: "(object)" }
                 default:
                     throw new Error();

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -90,6 +90,7 @@ namespace pxsim {
         static toDebugString(o: any): string {
             if (o === null) return "null";
             if (o === undefined) return "undefined;"
+            if (o.vtable && o.vtable.name) return o.vtable.name;
             if (o.toDebugString) return o.toDebugString();
             if (typeof o == "string") return JSON.stringify(o);
             return o.toString();


### PR DESCRIPTION
For user-created objects, debugger will no longer show "object object". For Sprites it will show "Sprite", for Images "Image width x height"