### PR TITLE
Only skip build if inside package or extension

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2201,7 +2201,8 @@ function buildFailed(msg: string, e: any) {
 }
 
 function buildAndWatchTargetAsync(includeSourceMaps: boolean, rebundle: boolean) {
-    if (!(fs.existsSync(path.join(simDir(), "tsconfig.json")) || nodeutil.existsDirSync(path.join(simDir(), "public")))) {
+    if (fs.existsSync("pxt.json") &&
+        !(fs.existsSync(path.join(simDir(), "tsconfig.json")) || nodeutil.existsDirSync(path.join(simDir(), "public")))) {
         console.log("No sim/tsconfig.json nor sim/public/; assuming npm installed package")
         return Promise.resolve()
     }


### PR DESCRIPTION
Skip build if the sim is missing **and** there is a pxt.json, meaning we're inside a package or extension.

A missing sim can mean the sim is an optional dependency that couldn't be installed. We still want to build in that case.

Fixes https://github.com/Microsoft/pxt-arcade/issues/698