### PR TITLE
Don't watch dirs that don't exist during build

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2225,7 +2225,7 @@ function buildAndWatchTargetAsync(includeSourceMaps: boolean, rebundle: boolean)
             if (hasCommonPackages) {
                 toWatch = toWatch.concat(simDirectories);
             }
-            return toWatch;
+            return toWatch.filter(d => fs.existsSync(d));
         }));
 }
 


### PR DESCRIPTION
Now that we only skip target build when serving from packages and extensions, our server is crashing when running `pxt serve` inside the pxt repo, because we hardcoded watching the `node_modules/pxt-core` folder, which doesn't exist. This simply filters out dirs to watch based on their existence.