### PR TITLE
Update 'Defining blocks' page a bit

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -300,7 +300,7 @@ export function showNumber(value: number, interval: number = 150): void
 value is used as the shadow value.
 * An optional `help` attribute can be used to point to an specific documentation path.
 * If the parameter has a default value (``interval`` in this case), it is **not** exposed in blocks.
-* If you want to include minimum and maximum value range for a numeric parameter, you can use square brackets with the range [min-max] after the parameter name in the `@param` annotation. It is important to include the shadow value if you are using range
+* If you want to include minimum and maximum value range for a numeric parameter, you can use square brackets with the range [min-max] after the parameter name in the `@param` annotation. It is important to include the shadow value if you are using a range.
      - `@param` power [0-7] a value in the range 0..7, where 0 is the lowest power and 7 is the highest. `eg:` 7
 
 ## Objects and Instance methods

--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -554,7 +554,7 @@ class Foo {
 
 Field editors let you control how a parameter value is entered or selected. A field editor is a [shadow](#shadow-block) block that invokes the render of a selection UI element, dropdown list of items, or some other extended input method.
 
-A field editor is attached to a parameter using the `shadow` attribute with the field editor name. In this example, a function to turn and LED on or off uses the `toggleOnOff` field editor to show a switch element as a block paramter.
+A field editor is attached to a parameter using the `shadow` attribute with the field editor name. In this example, a function to turn an LED on or off uses the `toggleOnOff` field editor to show a switch element as a block paramter.
 
 ```typescript-ignore
 /**


### PR DESCRIPTION
Some updates to the 'Defining blocks' page.

- [x] Add sections for block defined enums, inline input, and field editors.
- [x] Link to related playground examples.
- [x] A few format edits.