### PR TITLE
External tutorial support

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
     * [Macros](/writing-docs/macros)
     * [Anchors](/writing-docs/anchors)
     * [Tutorials](/writing-docs/tutorials)
+    * [User Tutorials](/writing-docs/tutorials)
     * [Routing](/writing-docs/routing)
     * [Testing](/writing-docs/testing)
 * [Translations](/translate)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,7 +33,7 @@
     * [Macros](/writing-docs/macros)
     * [Anchors](/writing-docs/anchors)
     * [Tutorials](/writing-docs/tutorials)
-    * [User Tutorials](/writing-docs/tutorials)
+    * [User Tutorials](/writing-docs/user-tutorials)
     * [Routing](/writing-docs/routing)
     * [Testing](/writing-docs/testing)
 * [Translations](/translate)

--- a/docs/writing-docs.md
+++ b/docs/writing-docs.md
@@ -16,4 +16,5 @@ This page was written using this documentation system, check it out at https://g
 * [Anchors](/writing-docs/anchors)
 * [Routing](/writing-docs/routing)
 * [Tutorials](/writing-docs/tutorials)
+* [User Tutorials](/writing-docs/user-tutorials)
 * [Testing](/writing-docs/testing)

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -1,0 +1,36 @@
+# User Tutorials
+
+This guide explains how users can publish their own [tutorials](/writing-docs/tutorials) on the MakeCode editor.
+
+There are 2 ways of sharing a tutorial: using a shared script or using a [GitHub](https://github.com) repository.
+
+## Authoring
+
+Author the tutorial content in the **README.md** file in your project. The format is the same as documented in [tutorials](/writing-docs/tutorials). 
+
+The dependencies are used when starting the tutorial project, but code content (``main.blocks``, ``main.ts``) is ignored.
+
+### ~ hint
+
+You can access ``README.md`` through by switching to **JavaScript**, then **Explorer**, then click on **README.md**.
+
+### ~
+
+## Share
+
+The easiest way to share a tutorial is to share the program and use the shared project url as follows
+
+    https://[editor url]/#tutorial:[shared project url]
+
+* where ``editor url`` is the editor dmain, like ``makecode.microbit.org``
+* where ``shared project url`` is the url give to you by MakeCode after sharing, ``https://makecode.com/_somefunnyletters``.
+
+## GitHub repository
+
+If you plan to update your tutorial over time, we recommend to store your project in a GitHub repository. In such case, the URL to open the tutorial directly takes the full GitHub repository URL:
+
+        https://[editor url]/#tutorial:[GitHub repository url]
+
+## Report Abuse and approvals
+
+By default, all tutorials opened from a user shared project or GitHub repository will have a **Report Abuse** button. If you whish to avoid this button, use the GitHub project approach and get the repository approved.

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -115,6 +115,7 @@ namespace pxt.editor {
     export interface TutorialOptions {
         tutorial?: string; // tutorial
         tutorialName?: string; // tutorial title
+        tutorialReportId?: string; // if this tutorial was user generated, the report abuse id
         tutorialStepInfo?: pxt.tutorial.TutorialStepInfo[];
         tutorialStep?: number; // current tutorial page
         tutorialReady?: boolean; // current tutorial page

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -458,7 +458,7 @@ namespace pxsim {
 
         // ensure _currentRuntime is ready
         private startFrame(frame: HTMLIFrameElement): boolean {
-            if (!this._currentRuntime) return false;
+            if (!this._currentRuntime || !frame.contentWindow) return false;
             let msg = JSON.parse(JSON.stringify(this._currentRuntime)) as pxsim.SimulatorRunMessage;
             let mc = '';
             let m = /player=([A-Za-z0-9]+)/i.exec(window.location.href); if (m) mc = m[1];

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2474,12 +2474,7 @@ export class ProjectView
                     return files["README.md"];
                 });
         } else {
-            p = Promise.resolve().then(() => {
-                // unknown format
-                pxt.reportError("tutorial", "start unknown", { tutorialId });
-                core.errorNotification(lf("Unsupported tutorial"));
-                return undefined as string;
-            });
+            p = Promise.resolve(undefined);
         }
 
         return p.then(md => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2301,7 +2301,8 @@ export class ProjectView
     ///////////////////////////////////////////////////////////
 
     showReportAbuse() {
-        const pubId = this.state.header && this.state.header.pubCurrent && this.state.header.pubId;
+        const pubId = (this.state.tutorialOptions && this.state.tutorialOptions.tutorialReportId)
+            || (this.state.header && this.state.header.pubCurrent && this.state.header.pubId);
         dialogs.showReportAbuseAsync(pubId);
     }
 
@@ -2446,6 +2447,7 @@ export class ProjectView
         core.showLoading("tutorial", lf("starting tutorial..."));
         sounds.initTutorial(); // pre load sounds
         let id = pxt.Cloud.parseScriptId(tutorialId);
+        let reportId: string = undefined;
         let tutorialmd: string;
         let title: string;
         let autoChooseBoard: boolean = true;
@@ -2471,6 +2473,7 @@ export class ProjectView
                     dependencies = pxtJson.dependencies || {};
                     title = pxtJson.name || lf("Untitled");
                     autoChooseBoard = false;
+                    reportId = id;
                     return files["README.md"];
                 });
         } else {
@@ -2491,7 +2494,8 @@ export class ProjectView
                 this.setState({
                     tutorialOptions: {
                         tutorial: tutorialId,
-                        tutorialName: title
+                        tutorialName: title,
+                        tutorialReportId: reportId
                     },
                     tracing: undefined
                 });
@@ -2512,6 +2516,7 @@ export class ProjectView
                             tutorialOptions: {
                                 tutorial: tutorialId,
                                 tutorialName: title,
+                                tutorialReportId: reportId,
                                 tutorialStep: 0,
                                 tutorialReady: true,
                                 tutorialStepInfo: stepInfo
@@ -2961,7 +2966,7 @@ let myexports: any = {
 export let ksVersion: string;
 
 function parseHash(): { cmd: string; arg: string } {
-    let hashM = /^#(\w+)(:([\/\-\+\=\w]+))?$/.exec(window.location.hash)
+    let hashM = /^#(\w+)(:([:\.\/\-\+\=\w]+))?$/.exec(window.location.hash)
     if (hashM) {
         return { cmd: hashM[1], arg: hashM[3] || '' };
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1170,6 +1170,7 @@ export class ProjectView
         const importer = this.hexFileImporters.filter(fi => fi.canImport(data))[0];
         if (importer) {
             pxt.tickEvent("import." + importer.id);
+            core.hideDialog();
             core.showLoading("importhex", lf("loading project..."))
             importer.importAsync(this, data)
                 .done(() => core.hideLoading("importhex"), e => {
@@ -2441,6 +2442,7 @@ export class ProjectView
     }
 
     startTutorialAsync(tutorialId: string, tutorialTitle?: string): Promise<void> {
+        core.hideDialog();
         core.showLoading("tutorial", lf("starting tutorial..."));
         sounds.initTutorial(); // pre load sounds
         let id = pxt.Cloud.parseScriptId(tutorialId);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2466,7 +2466,7 @@ export class ProjectView
                     return md;
                 })
         } else if (id) {
-            title = lf("Tutorial");
+            pxt.tickEvent("tutorial.shared");
             p = workspace.downloadFilesByIdAsync(id)
                 .then(files => {
                     const pxtJson = JSON.parse(files["pxt.json"]) as pxt.PackageConfig;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -320,6 +320,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         this.openBlocks = this.openBlocks.bind(this);
         this.openJavaScript = this.openJavaScript.bind(this);
         this.exitTutorial = this.exitTutorial.bind(this);
+        this.showReportAbuse = this.showReportAbuse.bind(this);
     }
 
     brandIconClick() {
@@ -369,6 +370,11 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         this.props.parent.exitTutorial();
     }
 
+    showReportAbuse() {
+        pxt.tickEvent("tutorial.reportabuse", undefined, { interactiveConsent: true });
+        this.props.parent.showReportAbuse();
+    }
+
     renderCore() {
         const { home, header, highContrast, greenScreen, simState } = this.props.parent.state;
         if (home) return <div />; // Don't render if we're on the home screen
@@ -379,6 +385,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const sandbox = pxt.shell.isSandboxMode();
         const tutorialOptions = this.props.parent.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
+        const tutorialReportId = tutorialOptions && tutorialOptions.tutorialReportId;
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial;
         const isRunning = simState == pxt.editor.SimState.Running;
         const hc = !!this.props.parent.state.highContrast;
@@ -430,6 +437,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 {sandbox || inTutorial ? undefined : <container.SettingsMenu parent={this.props.parent} highContrast={highContrast} greenScreen={greenScreen} />}
 
                 {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} /> : undefined}
+                {inTutorial && tutorialReportId ? <sui.ButtonMenuItem className="report-tutorial-btn" role="menuitem" icon="warning circle" text={lf("Report")} textClass="landscape only" onClick={this.showReportAbuse} /> : undefined}
                 {inTutorial ? <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={this.exitTutorial} /> : undefined}
 
                 {!sandbox ? <a href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo organization" onClick={this.orgIconClick}>

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -437,7 +437,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 {sandbox || inTutorial ? undefined : <container.SettingsMenu parent={this.props.parent} highContrast={highContrast} greenScreen={greenScreen} />}
 
                 {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} /> : undefined}
-                {inTutorial && tutorialReportId ? <sui.ButtonMenuItem className="report-tutorial-btn" role="menuitem" icon="warning circle" text={lf("Report")} textClass="landscape only" onClick={this.showReportAbuse} /> : undefined}
+                {inTutorial && tutorialReportId ? <sui.ButtonMenuItem className="report-tutorial-btn" role="menuitem" icon="warning circle" text={lf("Report Abuse")} textClass="landscape only" onClick={this.showReportAbuse} /> : undefined}
                 {inTutorial ? <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={this.exitTutorial} /> : undefined}
 
                 {!sandbox ? <a href={targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo organization" onClick={this.orgIconClick}>

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -30,7 +30,6 @@ export interface DataFetchResult<T> {
 }
 
 const virtualApis: pxt.Map<VirtualApi> = {}
-let targetConfig: pxt.TargetConfig = undefined;
 
 mountVirtualApi("cloud", {
     getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(core.handleNetworkError),

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -690,6 +690,15 @@ export function showImportFileDialogAsync() {
 }
 
 export function showReportAbuseAsync(pubId?: string) {
+    // send users to github directly for unwanted repoes
+    const ghid = /^https:\/\/github.com\//i.test(pubId) && pxt.github.parseRepoUrl(pubId);
+    if (ghid) {
+        pxt.tickEvent("reportabuse.github");
+        window.open("https://github.com/contact/report-content", "_blank");
+        return;
+    }
+
+    // shared script id section
     let urlInput: HTMLInputElement;
     let reasonInput: HTMLTextAreaElement;
     const shareUrl = pxt.appTarget.appTheme.shareUrl || "https://makecode.com/";
@@ -699,7 +708,7 @@ export function showReportAbuseAsync(pubId?: string) {
             urlInput = el.querySelectorAll('input')[0] as HTMLInputElement;
             reasonInput = el.querySelectorAll('textarea')[0] as HTMLTextAreaElement;
             if (pubId)
-                urlInput.value = /^https:\/\//i.test(pubId) ? pubId : (shareUrl + pubId);
+                urlInput.value = shareUrl + pubId;
         },
         agreeLbl: lf("Submit"),
         jsx: <div className="ui form">

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -699,7 +699,7 @@ export function showReportAbuseAsync(pubId?: string) {
             urlInput = el.querySelectorAll('input')[0] as HTMLInputElement;
             reasonInput = el.querySelectorAll('textarea')[0] as HTMLTextAreaElement;
             if (pubId)
-                urlInput.value = (shareUrl + pubId);
+                urlInput.value = /^https:\/\//i.test(pubId) ? pubId : (shareUrl + pubId);
         },
         agreeLbl: lf("Submit"),
         jsx: <div className="ui form">

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -673,6 +673,11 @@ export async function importGithubAsync(id: string) {
         })
 }
 
+export function downloadFilesByIdAsync(id: string): Promise<pxt.Map<string>> {
+    return Cloud.privateGetAsync(id, /* forceLiveEndpoint */ true)
+        .then((scr: Cloud.JsonScript) => getPublishedScriptAsync(scr.id));
+}
+
 export function installByIdAsync(id: string) {
     return Cloud.privateGetAsync(id, /* forceLiveEndpoint */ true)
         .then((scr: Cloud.JsonScript) =>


### PR DESCRIPTION
Support for starting a tutorial from a shared script or a github repo.

* URL routes are ``https://[editor url]/#tutorial:[shared url]`` or ``https://[editor url]/#tutorial:[github repo url]``.
* A report abuse button is added in the tutorial UI unless the github repo is approved.
![image](https://user-images.githubusercontent.com/4175913/52352821-2add3a80-29e2-11e9-8ad2-169f9a653a56.png)
