### PR TITLE
Keep variables global if assigned to

### DIFF
--- a/tests/blocklycompiler-test/baselines/functions_names.ts
+++ b/tests/blocklycompiler-test/baselines/functions_names.ts
@@ -1,8 +1,9 @@
 function item() {
-    let item2 = 0
+    item2 = 0
 }
 function _Math()  {
 
 }
+let item2 = 0
 item()
 _Math()

--- a/tests/blocklycompiler-test/baselines/lists_length_with_for_of.ts
+++ b/tests/blocklycompiler-test/baselines/lists_length_with_for_of.ts
@@ -1,4 +1,5 @@
+let item = 0
 let list: number[] = []
 for (let value of list) {
-    let item = list.length
+    item = list.length
 }

--- a/tests/blocklycompiler-test/baselines/loops_local_variables.ts
+++ b/tests/blocklycompiler-test/baselines/loops_local_variables.ts
@@ -1,7 +1,9 @@
+let index = 0
+let i = 0
 for (let i = 0; i < 4; i++) {
-  let i = 0
+  i = 0
   for (let i = 0; i < 4; i++) {
-      let index = 0
+    index = 0
   }
 }
 for (let index = 0; index <= 4; index++) {

--- a/tests/blocklycompiler-test/baselines/mc_chat_blocks.ts
+++ b/tests/blocklycompiler-test/baselines/mc_chat_blocks.ts
@@ -1,9 +1,10 @@
 player.onChat("run", function (num1) {
   num1 = 0
-  let asb = 0
+  asb = 0
 })
 player.onChat("hello", function (asb, num2) {
   asb = 0
   num2 = 0
 })
+let asb = 0
 let num2 = 0

--- a/tests/blocklycompiler-test/baselines/old_radio_mutator.ts
+++ b/tests/blocklycompiler-test/baselines/old_radio_mutator.ts
@@ -1,4 +1,5 @@
 actions.onDataPacketReceived(function ({ receivedString }) {
-    let item = receivedString
+    item = receivedString
 })
+let item = ""
 let receivedString = ""

--- a/tests/blocklycompiler-test/baselines/self_reference_vars.ts
+++ b/tests/blocklycompiler-test/baselines/self_reference_vars.ts
@@ -1,0 +1,6 @@
+let y = 0
+let z = 0
+let x = 0
+x = x
+z = z + 1
+y += y

--- a/tests/blocklycompiler-test/cases/self_reference_vars.blocks
+++ b/tests/blocklycompiler-test/cases/self_reference_vars.blocks
@@ -1,0 +1,63 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable type="" id="xE}3AnFZKBa6kz*}d$%P">item</variable>
+    <variable type="" id="6.eTS{iV13ddF!J77tw$">item2</variable>
+    <variable type="" id="9$a?U~c4LZr7V3sh-{dw">x</variable>
+    <variable type="" id="o3nTy#a@ONXu2FSqq4L2">y</variable>
+    <variable type="" id="5$o:L#=cDCQBhx],Abl-">z</variable>
+  </variables>
+  <block type="pxt-on-start" x="0" y="0">
+    <statement name="HANDLER">
+      <block type="variables_set">
+        <field name="VAR" id="9$a?U~c4LZr7V3sh-{dw" variabletype="">x</field>
+        <value name="VALUE">
+          <shadow type="math_number" id="g{2DqX[g(bvC~@1LE7n9">
+            <field name="NUM">0</field>
+          </shadow>
+          <block type="variables_get">
+            <field name="VAR" id="9$a?U~c4LZr7V3sh-{dw" variabletype="">x</field>
+          </block>
+        </value>
+        <next>
+          <block type="variables_set">
+            <field name="VAR" id="5$o:L#=cDCQBhx],Abl-" variabletype="">z</field>
+            <value name="VALUE">
+              <shadow type="math_number" id="@Tb_WVVw,2k4Z+(*s3}1">
+                <field name="NUM">0</field>
+              </shadow>
+              <block type="math_arithmetic">
+                <field name="OP">ADD</field>
+                <value name="A">
+                  <shadow type="math_number" id="*4x(AKe:V,dikOn,?a*:">
+                    <field name="NUM">0</field>
+                  </shadow>
+                  <block type="variables_get">
+                    <field name="VAR" id="5$o:L#=cDCQBhx],Abl-" variabletype="">z</field>
+                  </block>
+                </value>
+                <value name="B">
+                  <shadow type="math_number">
+                    <field name="NUM">1</field>
+                  </shadow>
+                </value>
+              </block>
+            </value>
+            <next>
+              <block type="variables_change">
+                <field name="VAR" id="o3nTy#a@ONXu2FSqq4L2" variabletype="">y</field>
+                <value name="VALUE">
+                  <shadow type="math_number" id="_d~|C@!8sSw83YEvJQDy">
+                    <field name="NUM">1</field>
+                  </shadow>
+                  <block type="variables_get">
+                    <field name="VAR" id="o3nTy#a@ONXu2FSqq4L2" variabletype="">y</field>
+                  </block>
+                </value>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -373,6 +373,10 @@ describe("blockly compiler", function () {
         it("should handle collisions with variables declared by optional callback arguments", (done: () => void) => {
             blockTestAsync("mc_chat_blocks").then(done, done);
         });
+
+        it("should hoist variable declarations when the first set references the target", (done: () => void) => {
+            blockTestAsync("self_reference_vars").then(done, done);
+        });
     });
 
     describe("compiling functions", () => {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/752
Fixes https://github.com/Microsoft/pxt-arcade/issues/751

Unfortunately, this undoes a lot of the logic I added to declare variables locally (oh well). The other improvements still apply (fewer renames, combined declarations, etc.).