### PR TITLE
Fixing function call type inference and name conflicts

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -409,6 +409,11 @@ namespace pxt.blocks {
                         handleGenericType(b, "LIST");
                         unionParam(e, b, "INDEX", ground(pNumber.type));
                         break;
+                    case 'function_call':
+                        (b as Blockly.FunctionCallBlock).getArguments().forEach(arg => {
+                            unionParam(e, b, arg.id, ground(arg.type));
+                        });
+                        break;
                     case pxtc.PAUSE_UNTIL_TYPE:
                         unionParam(e, b, "PREDICATE", pBoolean);
                         break;
@@ -1469,7 +1474,11 @@ namespace pxt.blocks {
             // so add them to the taken names to avoid collision
             Object.keys(blockInfo.apis.byQName).forEach(name => {
                 const info = blockInfo.apis.byQName[name];
-                if (info.kind === pxtc.SymbolKind.Enum || info.kind === pxtc.SymbolKind.Function || info.kind === pxtc.SymbolKind.Module) {
+                // Note: the check for info.pkg filters out functions defined in the user's project.
+                // Otherwise, after the first compile the function will be renamed because it conflicts
+                // with itself. You can still get collisions if you attempt to define a function with
+                // the same name as a function defined in another file in the user's project (e.g. custom.ts)
+                if (info.pkg && (info.kind === pxtc.SymbolKind.Enum || info.kind === pxtc.SymbolKind.Function || info.kind === pxtc.SymbolKind.Module)) {
                     e.renames.takenNames[info.qName] = true;
                 }
             });

--- a/tests/blocklycompiler-test/baselines/function_call_inference.ts
+++ b/tests/blocklycompiler-test/baselines/function_call_inference.ts
@@ -1,0 +1,8 @@
+function doSomething (mySprite: Sprite, text: string, bool: boolean, num: number) {
+
+}
+let mNum = 0
+let mBool = false
+let mText = ""
+let mSprite: Sprite = null
+doSomething(mSprite, mText, mBool, mNum)

--- a/tests/blocklycompiler-test/baselines/functions_v2.ts
+++ b/tests/blocklycompiler-test/baselines/functions_v2.ts
@@ -1,8 +1,4 @@
 // Describe this function...
-function foo_all (num: number, text: string, bool: boolean) {
-
-}
-// Describe this function...
 function foo_noarg () {
 
 }
@@ -18,8 +14,12 @@ function foo_string (text: string) {
 function foo_bool (bool: boolean) {
 
 }
+// Describe this function...
+function foo_all (num: number, text: string, bool: boolean) {
+
+}
 foo_noarg()
 foo_num(1)
-foo_string("abcd")
+foo_string("abc")
 foo_bool(true)
 foo_all(1, "abc", true)

--- a/tests/blocklycompiler-test/cases/function_call_inference.blocks
+++ b/tests/blocklycompiler-test/cases/function_call_inference.blocks
@@ -1,0 +1,87 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable type="" id="I~jOxQyX!eaQL5[Tn-o#">mySprite</variable>
+    <variable type="" id="-BBx.:2/jXmNae~r3~4n">item</variable>
+    <variable type="" id="K}NbL1wSn3d3GSDkVj$k">mSprite</variable>
+    <variable type="" id="H*n9Yr8$nimIy2KY7uqY">mNum</variable>
+    <variable type="" id="AEOZJFyaCa$JK7^(D+-2">mBool</variable>
+    <variable type="" id="p[I+-x!40b0Cn:.7/Xu/">mText</variable>
+  </variables>
+  <block type="pxt-on-start" x="0" y="0">
+    <statement name="HANDLER">
+      <block type="function_call">
+        <mutation name="doSomething" functionid="30f|XZ~e~KfIJHg~d[@o">
+          <arg name="mySprite" id="DfLmgIfD;[5_TGCiK.yE" type="Sprite"></arg>
+          <arg name="text" id="[tRtk`diuVv6i3M]|]d1" type="string"></arg>
+          <arg name="bool" id="*aslVdQj[DY3s0~1tlBN" type="boolean"></arg>
+          <arg name="num" id="|ZE7|JsA{GZmdVgI;5:*" type="number"></arg>
+        </mutation>
+        <field name="function_title">call</field>
+        <field name="function_name">doSomething</field>
+        <value name="DfLmgIfD;[5_TGCiK.yE">
+          <shadow type="variables_get" id="ay}@kK94RK~9PFz;#SRb">
+            <field name="VAR" id="I~jOxQyX!eaQL5[Tn-o#" variabletype="">mySprite</field>
+          </shadow>
+          <block type="variables_get">
+            <field name="VAR" id="K}NbL1wSn3d3GSDkVj$k" variabletype="">mSprite</field>
+          </block>
+        </value>
+        <value name="[tRtk`diuVv6i3M]|]d1">
+          <shadow type="text" id="Wc/]Tpgt7[$arEVQuJQd">
+            <field name="TEXT">abc</field>
+          </shadow>
+          <block type="variables_get">
+            <field name="VAR" id="p[I+-x!40b0Cn:.7/Xu/" variabletype="">mText</field>
+          </block>
+        </value>
+        <value name="*aslVdQj[DY3s0~1tlBN">
+          <shadow type="logic_boolean" id="FHBr}Z:+P`sO?NF!T;?.">
+            <field name="BOOL">TRUE</field>
+          </shadow>
+          <block type="variables_get">
+            <field name="VAR" id="AEOZJFyaCa$JK7^(D+-2" variabletype="">mBool</field>
+          </block>
+        </value>
+        <value name="|ZE7|JsA{GZmdVgI;5:*">
+          <shadow type="math_number" id="rT$@+AtGNLtAY(-5/V^)">
+            <field name="NUM">1</field>
+          </shadow>
+          <block type="variables_get">
+            <field name="VAR" id="H*n9Yr8$nimIy2KY7uqY" variabletype="">mNum</field>
+          </block>
+        </value>
+      </block>
+    </statement>
+  </block>
+  <block type="function_definition" x="10" y="190">
+    <mutation name="doSomething" functionid="30f|XZ~e~KfIJHg~d[@o">
+      <arg name="mySprite" id="DfLmgIfD;[5_TGCiK.yE" type="Sprite"></arg>
+      <arg name="text" id="[tRtk`diuVv6i3M]|]d1" type="string"></arg>
+      <arg name="bool" id="*aslVdQj[DY3s0~1tlBN" type="boolean"></arg>
+      <arg name="num" id="|ZE7|JsA{GZmdVgI;5:*" type="number"></arg>
+    </mutation>
+    <field name="function_title">function</field>
+    <field name="function_name">doSomething</field>
+    <value name="DfLmgIfD;[5_TGCiK.yE">
+      <shadow type="argument_reporter_custom">
+        <mutation typename="Sprite"></mutation>
+        <field name="VALUE">mySprite</field>
+      </shadow>
+    </value>
+    <value name="[tRtk`diuVv6i3M]|]d1">
+      <shadow type="argument_reporter_string">
+        <field name="VALUE">text</field>
+      </shadow>
+    </value>
+    <value name="*aslVdQj[DY3s0~1tlBN">
+      <shadow type="argument_reporter_boolean">
+        <field name="VALUE">bool</field>
+      </shadow>
+    </value>
+    <value name="|ZE7|JsA{GZmdVgI;5:*">
+      <shadow type="argument_reporter_number">
+        <field name="VALUE">num</field>
+      </shadow>
+    </value>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -383,6 +383,18 @@ describe("blockly compiler", function () {
         it("should handle name collisions", (done: () => void) => {
             blockTestAsync("functions_names").then(done, done);
         });
+
+        it("should handle function declarations", (done: () => void) => {
+            blockTestAsync("functions_v2").then(done, done);
+        });
+
+        it("should handle function reporters", (done: () => void) => {
+            blockTestAsync("functions_v2_reporters").then(done, done);
+        });
+
+        it("should narrow variable types when used as function call arguments", (done: () => void) => {
+            blockTestAsync("function_call_inference").then(done, done);
+        });
     });
 
     describe("compiling special blocks", () => {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/748

In addition to the type inference fix, I also fixed another bug I found while testing where functions were getting renamed for no reason (e.g. `doSomething` ->  `doSomething2`). The API info we use to check for name collisions also includes user functions, so functions will collide with themselves after the first compile. My fix for that creates another bug where you can now have collisions with functions defined in `custom.ts`, but I'm not going to fix it since that feature isn't really used that much. I left a comment.

I also "turned on" two test cases for the new functions that I think Guillaume forgot to add to the list of tests.