### PR TITLE
Add local variables to the variable dropdown

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -2167,7 +2167,7 @@ namespace pxt.blocks {
             });
 
             if (hasStatementInput(block)) {
-                let draggableParams = false;
+                let draggableParams = block.type === "function_definition";
                 let stdFunc = e.stdCallTable[block.type];
                 if (stdFunc && stdFunc.comp.handlerArgs.length && stdFunc.attrs.draggableParameters === "reporter") {
                     draggableParams = true;
@@ -2287,6 +2287,10 @@ namespace pxt.blocks {
         let stdFunc = e.stdCallTable[block.type];
         if (stdFunc && stdFunc.comp.handlerArgs.length) {
             return getCBParameters(block, stdFunc);
+        }
+
+        if (block.type === "function_definition") {
+            return (block as Blockly.FunctionDefinitionBlock).getArguments().map(arg => [arg.name, ground(arg.type)] as [string, Point])
         }
 
         return [];


### PR DESCRIPTION
The new function/event blocks in Arcade use draggable function reporters for their arguments. The downside is that those blocks are not "true" Blockly variables so they don't show up in the dropdowns of variable fields. It quickly gets annoying in Arcade, because all of the Sprite related blocks have variable_get blocks as shadows and to use any local variables you need to drag them on top.

This PR adds those local variables to the dropdown, but only in the function scope where they are visible. I only added that for "get" blocks, because function arguments should really be considered readonly. When the user selects a local variable from the dropdown, it gets promoted to a global variable (and thus will also show up in the flyout).

Here's a demo:

![local_variable_dropdown](https://user-images.githubusercontent.com/13754588/52888019-df880200-312e-11e9-9b9c-befad9ac5ed7.gif)


In that GIF, "sprite" and "otherSprite" are local, while the other variables are global.