### PR TITLE
Changing the x in the sprite editor to a done button

### DIFF
--- a/pxtlib/sprite-editor/buttons.ts
+++ b/pxtlib/sprite-editor/buttons.ts
@@ -1,7 +1,7 @@
 namespace pxtsprite {
     import svg = pxt.svgUtil;
 
-    interface ButtonGroup {
+    export interface ButtonGroup {
         root: svg.Group;
         cx: number;
         cy: number;
@@ -238,8 +238,8 @@ namespace pxtsprite {
     export class TextButton extends Button {
         protected textEl: svg.Text;
 
-        constructor(root: svg.Group, cx: number, cy: number, text: string, className: string) {
-            super(root, cx, cy);
+        constructor(button: ButtonGroup, text: string, className: string) {
+            super(button.root, button.cx, button.cy);
 
             this.textEl = mkText(text)
                 .appendClass(className);
@@ -252,6 +252,50 @@ namespace pxtsprite {
         setText(text: string) {
             this.textEl.text(text);
             this.textEl.moveTo(this.cx, this.cy);
+        }
+
+        getComputedTextLength() {
+            try {
+                return this.textEl.el.getComputedTextLength();
+            }
+            catch (e) {
+                // Internet Explorer and Microsoft Edge throw if the element
+                // is not visible. The best we can do is approximate
+                return this.textEl.el.textContent.length * 8;
+            }
+        }
+    }
+
+    export class StandaloneTextButton extends TextButton {
+        protected padding = 30;
+
+        constructor(text: string, readonly height: number) {
+            super(drawSingleButton(65, height), text, "sprite-editor-text");
+            this.addClass("sprite-editor-label");
+        }
+
+        layout() {
+            const newBG = drawSingleButton(this.width(), this.height);
+
+            while (this.root.el.hasChildNodes()) {
+                this.root.el.removeChild(this.root.el.firstChild);
+            }
+
+            while (newBG.root.el.hasChildNodes()) {
+                const el = newBG.root.el.firstChild;
+                newBG.root.el.removeChild(el);
+                this.root.el.appendChild(el);
+            }
+
+            this.cx = newBG.cx;
+            this.cy = newBG.cy;
+
+            this.root.appendChild(this.textEl);
+            this.textEl.moveTo(this.cx, this.cy);
+        }
+
+        width() {
+            return this.getComputedTextLength() + this.padding * 2;
         }
     }
 
@@ -268,17 +312,17 @@ namespace pxtsprite {
 
     export function mkIconButton(icon: string, width: number, height = width + BUTTON_BOTTOM_BORDER_WIDTH - BUTTON_BORDER_WIDTH) {
         const g = drawSingleButton(width, height);
-        return new TextButton(g.root, g.cx, g.cy, icon, "sprite-editor-icon");
+        return new TextButton(g, icon, "sprite-editor-icon");
     }
 
     export function mkXIconButton(icon: string, width: number, height = width + BUTTON_BOTTOM_BORDER_WIDTH - BUTTON_BORDER_WIDTH) {
         const g = drawSingleButton(width, height);
-        return new TextButton(g.root, g.cx, g.cy, icon, "sprite-editor-xicon");
+        return new TextButton(g, icon, "sprite-editor-xicon");
     }
 
     export function mkTextButton(text: string, width: number, height: number) {
         const g = drawSingleButton(width, height);
-        const t = new TextButton(g.root, g.cx, g.cy, text, "sprite-editor-text");
+        const t = new TextButton(g, text, "sprite-editor-text");
         t.addClass("sprite-editor-label");
         return t;
     }
@@ -382,12 +426,12 @@ namespace pxtsprite {
             this.host = host;
             const [undo, redo] = buttonGroup(width, height, 2);
 
-            this.undo = new TextButton(undo.root, undo.cx, undo.cy, "\uf118", "sprite-editor-xicon");
+            this.undo = new TextButton(undo, "\uf118", "sprite-editor-xicon");
             this.undo.onClick(() => this.host.undo());
             this.root.appendChild(this.undo.getElement());
 
 
-            this.redo = new TextButton(redo.root, redo.cx, redo.cy, "\uf111", "sprite-editor-xicon");
+            this.redo = new TextButton(redo, "\uf111", "sprite-editor-xicon");
             this.redo.onClick(() => this.host.redo());
             this.root.appendChild(this.redo.getElement());
         }
@@ -552,6 +596,6 @@ namespace pxtsprite {
         return new svg.Text(text)
             .anchor("middle")
             .setAttribute("dominant-baseline", "middle")
-            .setAttribute("dy", (pxt.BrowserUtils.isIE() || pxt.BrowserUtils.isEdge()) ? "0.3em" : "0")
+            .setAttribute("dy", (pxt.BrowserUtils.isIE() || pxt.BrowserUtils.isEdge()) ? "0.3em" : "0.1em")
     }
 }

--- a/pxtlib/sprite-editor/header.ts
+++ b/pxtlib/sprite-editor/header.ts
@@ -5,7 +5,6 @@ namespace pxtsprite {
     export interface SpriteHeaderHost {
         showGallery(): void;
         hideGallery(): void;
-        closeEditor(): void;
     }
 
     export class SpriteHeader {
@@ -14,8 +13,6 @@ namespace pxtsprite {
         toggle: Toggle;
         undoButton: Button;
         redoButton: Button;
-
-        closeButton: HTMLDivElement;
 
         constructor(protected host: SpriteHeaderHost) {
             this.div = document.createElement("div");
@@ -30,12 +27,6 @@ namespace pxtsprite {
                 else {
                     this.host.showGallery();
                 }
-            });
-
-            this.closeButton = makeCloseButton();
-            this.div.appendChild(this.closeButton);
-            this.closeButton.addEventListener("click", () => {
-                host.closeEditor();
             });
         }
 

--- a/pxtlib/sprite-editor/reporterBar.ts
+++ b/pxtlib/sprite-editor/reporterBar.ts
@@ -8,6 +8,7 @@ namespace pxtsprite {
 
     export interface ReporterHost extends UndoRedoHost {
         resize(width: number, height: number): void;
+        closeEditor(): void;
     }
 
     export class ReporterBar {
@@ -15,6 +16,7 @@ namespace pxtsprite {
         cursorText: svg.Text;
 
         sizeButton: TextButton;
+        doneButton: StandaloneTextButton;
         undoRedo: UndoRedoGroup;
 
         protected sizePresets: [number, number][];
@@ -30,6 +32,12 @@ namespace pxtsprite {
             });
 
             this.root.appendChild(this.sizeButton.getElement());
+
+            this.doneButton = new StandaloneTextButton(lf("Done"), height);
+            this.doneButton.addClass("sprite-editor-confirm-button");
+            this.doneButton.onClick(() => this.host.closeEditor());
+
+            this.root.appendChild(this.doneButton.getElement());
 
             this.sizePresets = [
                 [16, 16]
@@ -60,7 +68,13 @@ namespace pxtsprite {
 
         layout(top: number, left: number, width: number) {
             this.root.translate(left, top);
-            this.undoRedo.translate(width - UNDO_REDO_WIDTH, 0);
+
+            this.doneButton.layout();
+
+            const doneWidth = this.doneButton.width();
+
+            this.undoRedo.translate(width - UNDO_REDO_WIDTH - SIZE_CURSOR_MARGIN - doneWidth, 0);
+            this.doneButton.getElement().translate(width - doneWidth, 0);
             this.cursorText.moveTo(SIZE_BUTTON_WIDTH + SIZE_CURSOR_MARGIN, this.height / 2);
         }
 

--- a/theme/spriteeditor.less
+++ b/theme/spriteeditor.less
@@ -103,6 +103,16 @@
     fill: #7f8c8d;
 }
 
+.sprite-editor-confirm-button {
+    .sprite-editor-button-bg {
+        fill: #294da0;
+    }
+
+    .sprite-editor-button-fg {
+        fill: #4B7BEC;
+    }
+}
+
 .sprite-editor-button.disabled {
     cursor: not-allowed;
 
@@ -165,31 +175,6 @@
     border-radius: 4px;
     padding-top: 4px;
     position: relative;
-}
-
-
-.sprite-editor-dropdown .closeIcon {
-    position: absolute;
-    top: 0;
-    right: 0;
-    height: 0px;
-    width: 4.5rem;
-    outline: none;
-    cursor: pointer;
-}
-
-.sprite-editor-dropdown .closeIcon .close {
-    position: absolute;
-    top: .5rem;
-    right: 1rem;
-    color: white;
-    border-radius: 50%;
-    font-size: 2.15rem;
-    transition: all .15s ease-out;
-    height: 2.15rem;
-    width: 2.15rem;
-    padding: 0;
-    line-height: 2.15rem;
 }
 
 .sprite-editor-glyph {


### PR DESCRIPTION
Pretty self-explanatory; fixes https://github.com/Microsoft/pxt-arcade/issues/761

![done_button](https://user-images.githubusercontent.com/13754588/53195028-98d05700-35c9-11e9-9fdb-5351b19dd3d6.gif)
