### PR TITLE
Adding blocks test runner for targets to pxt.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typings/**",
     "localtypings/**",
     "tests/blocks-test/karma.conf.js",
+    "built/tests/blocksrunner.js",
     "docfiles",
     "theme",
     "common-docs"


### PR DESCRIPTION
Part of fixing the build for https://github.com/Microsoft/pxt-microbit/pull/1798

I left a file out of package.json that's necessary for running the blocks test in pxt-microbit. We didn't hit it until the GC PR because master of micro:bit was on an old version of PXT.

Once this gets merged I'll bump pxt and update the GC PR.