### PR TITLE
Fix blockly compiler bug when a statement handler is on top of onstart

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -2130,10 +2130,6 @@ namespace pxt.blocks {
                 currentScope.referencedVars.push(info.id);
             }
 
-            forEachChildExpression(block, child => {
-                trackVariables(child, currentScope, e);
-            });
-
             if (hasStatementInput(block)) {
                 const vars: VarInfo[] = getDeclaredVariables(block, e).map(binding => {
                     return {
@@ -2149,7 +2145,7 @@ namespace pxt.blocks {
                     // We need to create a scope for this block, and then a scope
                     // for each statement input (in case there are multiple)
 
-                    parentScope = currentScope.firstStatement === block ? currentScope : {
+                    parentScope = {
                         parent: currentScope,
                         firstStatement: block,
                         declaredVars: {},
@@ -2171,6 +2167,10 @@ namespace pxt.blocks {
                     currentScope.children.push(parentScope);
                 }
 
+                forEachChildExpression(block, child => {
+                    trackVariables(child, parentScope, e);
+                });
+
                 forEachStatementInput(block, connectedBlock => {
                     const newScope: Scope = {
                         parent: parentScope,
@@ -2182,6 +2182,11 @@ namespace pxt.blocks {
                     };
                     parentScope.children.push(newScope);
                     trackVariables(connectedBlock, newScope, e);
+                });
+            }
+            else {
+                forEachChildExpression(block, child => {
+                    trackVariables(child, currentScope, e);
                 });
             }
 
@@ -2300,8 +2305,7 @@ namespace pxt.blocks {
                 // If we can't find a better place to declare the variable, we'll declare
                 // it before the first statement in the code block so we need to keep
                 // track of the blocks ids
-                Util.assert(!e.blockDeclarations[scope.firstStatement.id]);
-                e.blockDeclarations[scope.firstStatement.id] = decls;
+                e.blockDeclarations[scope.firstStatement.id] = decls.concat(e.blockDeclarations[scope.firstStatement.id] || []);
             }
 
             decls.forEach(d => e.allVariables.push(d));

--- a/tests/blocklycompiler-test/baselines/on_start_with_for_loop.ts
+++ b/tests/blocklycompiler-test/baselines/on_start_with_for_loop.ts
@@ -1,0 +1,5 @@
+let x = 0
+for (let i = 0; i <= 4 - 1; i++) {
+    x = 2 ** i
+    basic.showNumber(x)
+}

--- a/tests/blocklycompiler-test/cases/on_start_with_for_loop.blocks
+++ b/tests/blocklycompiler-test/cases/on_start_with_for_loop.blocks
@@ -1,0 +1,70 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable id="w.OIOX?=t$([a.g%Yt79" type="">i</variable>
+    <variable id="%$O(I-okZGi6.rO=`Rdp" type="">x</variable>
+  </variables>
+  <block type="pxt-on-start" x="0" y="0">
+    <statement name="HANDLER">
+      <block type="pxt_controls_for">
+        <value name="VAR">
+          <shadow type="variables_get_reporter">
+            <field id="w.OIOX?=t$([a.g%Yt79" name="VAR" variabletype="">i</field>
+          </shadow>
+        </value>
+        <value name="TO">
+          <shadow type="math_whole_number">
+            <field name="NUM">0</field>
+          </shadow>
+          <block type="math_arithmetic">
+            <field name="OP">MINUS</field>
+            <value name="A">
+              <shadow type="math_number">
+                <field name="NUM">4</field>
+              </shadow>
+            </value>
+            <value name="B">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+          </block>
+        </value>
+        <statement name="DO">
+          <block type="variables_set">
+            <field id="%$O(I-okZGi6.rO=`Rdp" name="VAR" variabletype="">x</field>
+            <value name="VALUE">
+              <shadow type="math_number">
+                <field name="NUM">0</field>
+              </shadow>
+              <block type="math_arithmetic">
+                <field name="OP">POWER</field>
+                <value name="A">
+                  <shadow type="math_number">
+                    <field name="NUM">2</field>
+                  </shadow>
+                </value>
+                <value name="B">
+                  <shadow type="math_number">
+                    <field name="NUM">0</field>
+                  </shadow>
+                  <block type="variables_get">
+                    <field id="w.OIOX?=t$([a.g%Yt79" name="VAR" variabletype="">i</field>
+                  </block>
+                </value>
+              </block>
+            </value>
+            <next>
+              <block type="device_show_number">
+                <value name="number">
+                  <block type="variables_get">
+                    <field id="%$O(I-okZGi6.rO=`Rdp" name="VAR" variabletype="">x</field>
+                  </block>
+                </value>
+              </block>
+            </next>
+          </block>
+        </statement>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/mbit.ts
+++ b/tests/blocklycompiler-test/test-library/mbit.ts
@@ -1,0 +1,13 @@
+namespace basic {
+    /**
+     * Scroll a number on the screen. If the number fits on the screen (i.e. is a single digit), do not scroll.
+     * @param interval speed of scroll; eg: 150, 100, 200, -100
+     */
+    //% help=basic/show-number
+    //% weight=96
+    //% blockId=device_show_number block="show|number %number" blockGap=8
+    //% async
+    //% parts="ledmatrix" interval.defl=150
+    export function showNumber(value: number, interval?: number) {
+    }
+}

--- a/tests/blocklycompiler-test/test-library/pxt.json
+++ b/tests/blocklycompiler-test/test-library/pxt.json
@@ -4,6 +4,7 @@
     "files": [
         "actionEvent.ts",
         "enums.ts",
+        "mbit.ts",
         "expandableBlocks.ts",
         "toStringArgs.ts"
     ],

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -377,6 +377,10 @@ describe("blockly compiler", function () {
         it("should hoist variable declarations when the first set references the target", (done: () => void) => {
             blockTestAsync("self_reference_vars").then(done, done);
         });
+
+        it("should allow variables declared in a for-loop at the top of on-start", (done: () => void) => {
+            blockTestAsync("on_start_with_for_loop").then(done, done);
+        });
     });
 
     describe("compiling functions", () => {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1881