### PR TITLE
Don't consider "null" and "undefined" different appTargetVariants

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -162,7 +162,7 @@ namespace pxt {
     // this is set by compileServiceVariant in pxt.json
     export function setAppTargetVariant(variant: string): void {
         pxt.debug(`app variant: ${variant}`);
-        if (appTargetVariant === variant) return;
+        if (!!appTargetVariant === !!variant) return;
         appTargetVariant = variant
         appTarget = U.clone(savedAppTarget)
         if (variant) {
@@ -173,7 +173,7 @@ namespace pxt {
                 U.userError(lf("Variant '{0}' not defined in pxtarget.json", variant))
         }
         patchAppTarget();
-        if (onAppTargetChanged && variant)
+        if (onAppTargetChanged)
             onAppTargetChanged();
     }
 

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -173,7 +173,7 @@ namespace pxt {
                 U.userError(lf("Variant '{0}' not defined in pxtarget.json", variant))
         }
         patchAppTarget();
-        if (onAppTargetChanged)
+        if (onAppTargetChanged && variant)
             onAppTargetChanged();
     }
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -30,7 +30,7 @@ namespace pxt {
 
         public addedBy: Package[];
         public config: PackageConfig;
-        public level = -1;
+        public level = -1; // main package = 0, first children = 1, etc
         public isLoaded = false;
         private resolvedVersion: string;
         public ignoreTests = false;

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -164,7 +164,6 @@ export class Editor extends srceditor.Editor {
         this.appendRawData(data);
         const niceSource = this.mapSource(source);
 
-        // TODO(dz) parsing has to happen after chunking
         // packet payload as json
         if (/^\s*\{[^}]+\}\s*$/.test(data)) {
             try {

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -164,6 +164,7 @@ export class Editor extends srceditor.Editor {
         this.appendRawData(data);
         const niceSource = this.mapSource(source);
 
+        // TODO(dz) parsing has to happen after chunking
         // packet payload as json
         if (/^\s*\{[^}]+\}\s*$/.test(data)) {
             try {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1875
Partially rolls back behavior in introduced with: #5234 

This PR changes the behavior in setAppTargetVariant so that we don't consider "null" and "undefined" different appTargetVariants

Before this fix, pxt-microbit start up looked like:
call cmds.ts init() which sets the target-agnostic deploy behavior
call initExtensionsAsync() in pxt-microbit which sets the target-specific deploy behavior
call setAppTargetVariant(null) which triggers \/
call cmds.ts init() which **overwrites** the target-specific deploy behavior, which caused the bug
