### PR TITLE
Fix typo in OR condition description

### DIFF
--- a/common-docs/blocks/logic/boolean.md
+++ b/common-docs/blocks/logic/boolean.md
@@ -29,15 +29,15 @@ let greaterOrEqualThan = 42 >= 0;
 
 Boolean values and operators are often used with an [if](/blocks/logic/if) or [while](/blocks/loops/while) statement to determine which code will execute next. For example:
 
-### Functions that return a Boolean
+## Functions that return a Boolean
 
 Some functions return a Boolean value, which you can store in a Boolean variable. For example, the following code gets the on/off state of `point (1, 2)` and stores this in the Boolean variable named `on`. Then the code clears the screen if `on` is `true`:
 
-### Boolean operators
+## Boolean operators
 
 Boolean operators take Boolean inputs and evaluate to a Boolean output:
 
-### Conjunction: `A and B`
+## Conjunction: `A and B`
 
 `A and B` evaluates to `true` if-and-only-if both A and B are true:
 
@@ -48,18 +48,18 @@ let off3 = true && false;
 let on = true && true;
 ```
 
-### Disjunction: `A or B`
+## Disjunction: `A or B`
 
-`A or B` evaluates to `true` if-and-only-if either A is true or B is true:
+`A or B` evaluates to `true` if either `A` is true or `B` is true, or if both `A` and `B` are true:
 
 ```block
 let off = false || false;
 let on = false || true;
-let on2 =true || false;
+let on2 = true || false;
 let on3 = true || true;
 ```
 
-### Negation: `not A`
+## Negation: `not A`
 
 `not A` evaluates to the opposite (negation) of A:
 


### PR DESCRIPTION
- [x] The OR description was really for XOR. Changed to describe the 3 cases where the eval is true.
- [x] Fix heading levels.

RE: https://crowdin.com/translate/kindscript/748/en-nl#36528