### PR TITLE
Making variables with spaces in their name show properly in the variable explorer.

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -792,9 +792,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (this.debugVariables) this.debugVariables.update();
 
         function getValueOfVariable(name: string): pxsim.Variables {
+            // Variable names could have spaces.
+            let correctedName = name.replace(/\s/g, '_');
             for (let k of Object.keys(globals)) {
                 let n = k.replace(/___\d+$/, "");
-                if (name === n) {
+                if (correctedName === n) {
                     let v = globals[k]
                     return v;
                 }


### PR DESCRIPTION
Variables with spaces in their name (such as "Text list", which is the default for a block) aren't showing their value in the variable explorer in Debug Mode. This fixes that.