### PR TITLE
filter out blocksprj when compiling docs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
 	"version": "0.2.0",
 	"configurations": [
+
 		{
 			"name": "checkdocs",
 			"type": "node",
@@ -10,10 +11,9 @@
 			"args": [
 				"checkdocs",
 				"--re", 
-				"turtle-spiral",
-				"--dbg"
+				"adafruit"
 			],
-			"cwd": "${workspaceRoot}/../pxt-microbit",
+			"cwd": "${workspaceRoot}/../pxt-maker",
 			"runtimeExecutable": null,
 			"runtimeArgs": [
 				"--nolazy"

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -360,7 +360,10 @@ namespace pxt {
 
             // find all core packages in target
             const corePackages = Object.keys(this.config.dependencies)
-                .filter(dep => !!dep && (<pxt.PackageConfig>JSON.parse((pxt.appTarget.bundledpkgs[dep] || {})[pxt.CONFIG_NAME] || "{}").core));
+                .filter(dep => !!dep && (
+                    dep == pxt.BLOCKS_PROJECT_NAME || dep == pxt.JAVASCRIPT_PROJECT_NAME ||
+                    (<pxt.PackageConfig>JSON.parse((pxt.appTarget.bundledpkgs[dep] || {})[pxt.CONFIG_NAME] || "{}").core)
+                ));
             // no core package? add the first one
             if (corePackages.length == 0) {
                 const allCorePkgs = pxt.Package.corePackages();


### PR DESCRIPTION
When building docs in maker, ensure that a single board is referenced for the build.