### PR TITLE
don't run test docs concurrently as project may change app target

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3616,7 +3616,7 @@ function testSnippetsAsync(snippets: CodeSnippet[], re?: string): Promise<void> 
                     }
                 ])
             }))
-    }, { concurrency: 8 }).then((a: any) => {
+    }, { concurrency: 1 }).then((a: any) => {
         pxt.log(`${successes.length}/${successes.length + failures.length} snippets compiled to blocks, ${failures.length} failed`)
         if (ignoreCount > 0) {
             pxt.log(`Skipped ${ignoreCount} snippets`)


### PR DESCRIPTION
In Maker, project change the global app target based on the compile target. As a result, running tests concurrently leads interference between projects.