### PR TITLE
Speed up toolbox opening by 4X for monaco blocks

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1426,8 +1426,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private getMonacoBlock(fn: toolbox.BlockDefinition, ns: string, color: string, isDisabled?: boolean): HTMLDivElement {
-        // TODO(dz):
-        console.log(`getMonacoBlock(ns: ${ns})`)
         // Check if the block is built in, ignore it as it's already defined in snippets
         if (fn.attributes.blockBuiltin) {
             pxt.log("ignoring built in block: " + fn.attributes.blockId);

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1426,6 +1426,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private getMonacoBlock(fn: toolbox.BlockDefinition, ns: string, color: string, isDisabled?: boolean) {
+        // TODO(dz):
+        console.log(`getMonacoBlock(ns: ${ns})`)
         // Check if the block is built in, ignore it as it's already defined in snippets
         if (fn.attributes.blockBuiltin) {
             pxt.log("ignoring built in block: " + fn.attributes.blockId);
@@ -1482,15 +1484,17 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     let exactInstances = fixedInstances.filter(value =>
                         value.retType == nsInfo.qName)
                         .sort((v1, v2) => v1.name.localeCompare(v2.name));
-                    // second choice: use fixed instances whose retType extends type of nsInfo.name
-                    // e.g., nsInfo.name == AnalogPin and instance retType == PwmPin
-                    let extendedInstances = fixedInstances.filter(value =>
-                        getExtendsTypesFor(nsInfo.qName).indexOf(value.retType) !== -1)
-                        .sort((v1, v2) => v1.name.localeCompare(v2.name));
                     if (exactInstances.length) {
                         snippetPrefix = `${exactInstances[0].name}`
-                    } else if (extendedInstances.length) {
-                        snippetPrefix = `${extendedInstances[0].name}`
+                    } else {
+                        // second choice: use fixed instances whose retType extends type of nsInfo.name
+                        // e.g., nsInfo.name == AnalogPin and instance retType == PwmPin
+                        let extendedInstances = fixedInstances.filter(value =>
+                            getExtendsTypesFor(nsInfo.qName).indexOf(value.retType) !== -1)
+                            .sort((v1, v2) => v1.name.localeCompare(v2.name));
+                        if (extendedInstances.length) {
+                            snippetPrefix = `${extendedInstances[0].name}`
+                        }
                     }
                     isInstance = true;
                     addNamespace = true;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1425,7 +1425,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         workspace.fireEvent({ type: 'ui', editor: 'ts', action: 'groupHelpClicked', data: { group } } as pxt.editor.events.UIEvent);
     }
 
-    private getMonacoBlock(fn: toolbox.BlockDefinition, ns: string, color: string, isDisabled?: boolean) {
+    private getMonacoBlock(fn: toolbox.BlockDefinition, ns: string, color: string, isDisabled?: boolean): HTMLDivElement {
         // TODO(dz):
         console.log(`getMonacoBlock(ns: ${ns})`)
         // Check if the block is built in, ignore it as it's already defined in snippets


### PR DESCRIPTION
I've speed up the toolbox opening / switching by rearranging some of the frequently run code.
We only need to compute extended types on blocks if an exact match isn't found.

Before: 1.33s to open toolbox 
![speed-up-toolbox-before](https://user-images.githubusercontent.com/6453828/53972483-3023c700-40ff-11e9-81be-feb220f3cd2a.gif)

After: 0.34s to open toolbox (still too slow IMO)
![speed-up-toolbox-after](https://user-images.githubusercontent.com/6453828/53972496-34e87b00-40ff-11e9-9487-f78b131377cd.gif)

Perf numbers are from Chrome's profiler with "6x CPU throttle" enabled. Once I get my ChromeBook I'll get some "real world" slow device numbers :)

