### PR TITLE
5v breadboarding support

### DIFF
--- a/docs/targets/board.md
+++ b/docs/targets/board.md
@@ -10,6 +10,7 @@ It is important to store all the state within the board instance as PXT will reu
         gpioPinMap: { [pin: string]: string },
         groundPins: string[],
         threeVoltPins: string[],
+        fiveVoltPins: string[],
         attachPowerOnRight?: boolean,
         onboardComponents?: string[]
         marginWhenBreadboarding?: [number, number, number, number],

--- a/localtypings/pxtparts.d.ts
+++ b/localtypings/pxtparts.d.ts
@@ -44,7 +44,8 @@ declare namespace pxsim {
         gpioPinBlocks?: string[][], // not used
         gpioPinMap: { [pin: string]: string },
         groundPins: string[],
-        threeVoltPins: string[],
+        threeVoltPins?: string[],
+        fiveVoltPins?: string[],
         attachPowerOnRight?: boolean,
         onboardComponents?: string[],
         pinStyles?: { [pin: string]: PinStyle },

--- a/pxtsim/allocator.ts
+++ b/pxtsim/allocator.ts
@@ -1,7 +1,7 @@
 namespace pxsim {
     const GROUND_COLOR = "blue";
     const POWER_COLOR = "red";
-    const POWER5V_COLOR = "red";
+    const POWER5V_COLOR = "orange";
 
     export interface AllocatorOpts {
         boardDef: BoardDefinition,
@@ -612,7 +612,7 @@ namespace pxsim {
                 fiveVoltWires.push({
                     start: this.allocLocation("fiveVolt", { referenceBBPin: top }),
                     end: this.allocLocation("fiveVolt", { referenceBBPin: bot }),
-                    color: POWER_COLOR,
+                    color: POWER5V_COLOR,
                 });
             }
 
@@ -628,7 +628,7 @@ namespace pxsim {
                 threeVoltWires.push({
                     start: this.allocLocation("threeVolt", { referenceBBPin: bot }),
                     end: { type: "dalboard", pin: threeVoltPin },
-                    color: POWER_COLOR,
+                    color: POWER5V_COLOR,
                 });
             }
 
@@ -644,7 +644,7 @@ namespace pxsim {
                 fiveVoltWires.push({
                     start: this.allocLocation("fiveVolt", { referenceBBPin: bot }),
                     end: { type: "dalboard", pin: fiveVoltPin },
-                    color: POWER_COLOR,
+                    color: POWER5V_COLOR,
                 });
             }
 

--- a/pxtsim/allocator.ts
+++ b/pxtsim/allocator.ts
@@ -82,10 +82,13 @@ namespace pxsim {
     interface PowerUsage {
         topGround: boolean,
         topThreeVolt: boolean,
+        topFiveVolt: boolean,
         bottomGround: boolean,
         bottomThreeVolt: boolean,
+        bottomFiveVolt: boolean,
         singleGround: boolean,
         singleThreeVolt: boolean,
+        singleFiveVolt: boolean
     }
     interface AllocLocOpts {
         referenceBBPin?: BBLoc,
@@ -110,39 +113,52 @@ namespace pxsim {
         let ends = [wire.start, wire.end];
         let endIsGround = ends.map(e => e === "ground");
         let endIsThreeVolt = ends.map(e => e === "threeVolt");
+        let endIsFiveVolt = ends.map(e => e === "fiveVolt");
         let endIsBot = ends.map(e => isOnBreadboardBottom(e));
         let hasGround = arrAny(endIsGround);
         let hasThreeVolt = arrAny(endIsThreeVolt);
+        let hasFiveVolt = arrAny(endIsFiveVolt);
         let hasBot = arrAny(endIsBot);
         return {
             topGround: hasGround && !hasBot,
             topThreeVolt: hasThreeVolt && !hasBot,
+            topFiveVolt: hasFiveVolt && !hasBot,
             bottomGround: hasGround && hasBot,
             bottomThreeVolt: hasThreeVolt && hasBot,
+            bottomFiveVolt: hasFiveVolt && hasBot,
             singleGround: hasGround,
-            singleThreeVolt: hasThreeVolt
+            singleThreeVolt: hasThreeVolt,
+            singleFiveVolt: hasFiveVolt
         };
     }
-    function mergePowerUsage(powerUsages: PowerUsage[]) {
-        let finalPowerUsage = powerUsages.reduce((p, n) => ({
+    function mergePowerUsage(powerUsages: PowerUsage[]): PowerUsage {
+        const finalPowerUsage = powerUsages.reduce((p, n) => ({
             topGround: p.topGround || n.topGround,
             topThreeVolt: p.topThreeVolt || n.topThreeVolt,
+            topFiveVolt: p.topFiveVolt || n.topFiveVolt,
             bottomGround: p.bottomGround || n.bottomGround,
             bottomThreeVolt: p.bottomThreeVolt || n.bottomThreeVolt,
+            bottomFiveVolt: p.bottomFiveVolt || n.bottomFiveVolt,
             singleGround: n.singleGround ? p.singleGround === null : p.singleGround,
             singleThreeVolt: n.singleThreeVolt ? p.singleThreeVolt === null : p.singleThreeVolt,
+            singleFiveVolt: n.singleFiveVolt ? p.singleFiveVolt === null : p.singleFiveVolt,
         }), {
                 topGround: false,
                 topThreeVolt: false,
+                topFiveVolt: false,
                 bottomGround: false,
                 bottomThreeVolt: false,
+                bottomFiveVolt: false,
                 singleGround: null,
                 singleThreeVolt: null,
+                singleFiveVolt: null
             });
         if (finalPowerUsage.singleGround)
             finalPowerUsage.topGround = finalPowerUsage.bottomGround = false;
         if (finalPowerUsage.singleThreeVolt)
             finalPowerUsage.topThreeVolt = finalPowerUsage.bottomThreeVolt = false;
+        if (finalPowerUsage.singleFiveVolt)
+            finalPowerUsage.topFiveVolt = finalPowerUsage.bottomFiveVolt = false;
         return finalPowerUsage;
     }
     function copyDoubleArray(a: string[][]) {
@@ -430,7 +446,7 @@ namespace pxsim {
             return merge2(part, { wires: wires });
         }
         private allocLocation(location: WireIRLoc, opts: AllocLocOpts): Loc {
-            if (location === "ground" || location === "threeVolt") {
+            if (location === "ground" || location === "threeVolt" || location == "fiveVolt") {
                 //special case if there is only a single ground or three volt pin in the whole build
                 if (location === "ground" && this.powerUsage.singleGround) {
                     let boardGroundPin = this.getBoardGroundPin();
@@ -438,6 +454,9 @@ namespace pxsim {
                 } else if (location === "threeVolt" && this.powerUsage.singleThreeVolt) {
                     let boardThreeVoltPin = this.getBoardThreeVoltPin();
                     return { type: "dalboard", pin: boardThreeVoltPin };
+                } else if (location === "fiveVolt" && this.powerUsage.singleFiveVolt) {
+                    let boardFiveVoltPin = this.getBoardFiveVoltPin();
+                    return { type: "dalboard", pin: boardFiveVoltPin };
                 }
 
                 U.assert(!!opts.referenceBBPin);
@@ -505,24 +524,34 @@ namespace pxsim {
             }
         }
         private getBoardGroundPin(): string {
-            let boardGround = this.opts.boardDef.groundPins[0] || null;
-            if (!boardGround) {
+            let pin = this.opts.boardDef.groundPins && this.opts.boardDef.groundPins[0] || null;
+            if (!pin) {
                 console.log("No available ground pin on board!");
                 //TODO
             }
-            return boardGround;
+            return pin;
         }
         private getBoardThreeVoltPin(): string {
-            let threeVoltPin = this.opts.boardDef.threeVoltPins[0] || null;
-            if (!threeVoltPin) {
+            let pin = this.opts.boardDef.threeVoltPins && this.opts.boardDef.threeVoltPins[0] || null;
+            if (!pin) {
                 console.log("No available 3.3V pin on board!");
                 //TODO
             }
-            return threeVoltPin;
+            return pin;
         }
+        private getBoardFiveVoltPin(): string {
+            let pin = this.opts.boardDef.fiveVoltPins && this.opts.boardDef.fiveVoltPins[0] || null;
+            if (!pin) {
+                console.log("No available 5V pin on board!");
+                //TODO
+            }
+            return pin;
+        }
+
         private allocPowerWires(powerUsage: PowerUsage): PartAndWiresInst {
             let boardGroundPin = this.getBoardGroundPin();
             let threeVoltPin = this.getBoardThreeVoltPin();
+            let fiveVoltPin = this.getBoardFiveVoltPin();
             const topLeft: BBLoc = { type: "breadboard", row: "-", col: "26" };
             const botLeft: BBLoc = { type: "breadboard", row: "-", col: "1" };
             const topRight: BBLoc = { type: "breadboard", row: "-", col: "50" };
@@ -537,6 +566,7 @@ namespace pxsim {
             }
             let groundWires: WireInst[] = [];
             let threeVoltWires: WireInst[] = [];
+            let fiveVoltWires: WireInst[] = [];
             if (powerUsage.bottomGround && powerUsage.topGround) {
                 //bb top - <==> bb bot -
                 groundWires.push({
@@ -560,6 +590,7 @@ namespace pxsim {
                     color: GROUND_COLOR,
                 });
             }
+
             if (powerUsage.bottomThreeVolt && powerUsage.bottomGround) {
                 //bb top + <==> bb bot +
                 threeVoltWires.push({
@@ -567,7 +598,15 @@ namespace pxsim {
                     end: this.allocLocation("threeVolt", { referenceBBPin: bot }),
                     color: POWER_COLOR,
                 });
+            } else if (powerUsage.bottomFiveVolt && powerUsage.bottomGround) {
+                //bb top + <==> bb bot +
+                fiveVoltWires.push({
+                    start: this.allocLocation("fiveVolt", { referenceBBPin: top }),
+                    end: this.allocLocation("fiveVolt", { referenceBBPin: bot }),
+                    color: POWER_COLOR,
+                });
             }
+
             if (powerUsage.topThreeVolt) {
                 //board + <==> bb top +
                 threeVoltWires.push({
@@ -583,14 +622,37 @@ namespace pxsim {
                     color: POWER_COLOR,
                 });
             }
+
+            if (powerUsage.topFiveVolt && !powerUsage.topThreeVolt) {
+                //board + <==> bb top +
+                fiveVoltWires.push({
+                    start: this.allocLocation("fiveVolt", { referenceBBPin: top }),
+                    end: { type: "dalboard", pin: fiveVoltPin },
+                    color: POWER_COLOR,
+                });
+            } else if (powerUsage.bottomFiveVolt && !powerUsage.bottomThreeVolt) {
+                //board + <==> bb bot +
+                fiveVoltWires.push({
+                    start: this.allocLocation("fiveVolt", { referenceBBPin: bot }),
+                    end: { type: "dalboard", pin: fiveVoltPin },
+                    color: POWER_COLOR,
+                });
+            }
+
             let assembly: AssemblyStep[] = [];
             if (groundWires.length > 0)
                 assembly.push({ wireIndices: groundWires.map((w, i) => i) });
             let numGroundWires = groundWires.length;
             if (threeVoltWires.length > 0)
-                assembly.push({ wireIndices: threeVoltWires.map((w, i) => i + numGroundWires) });
+                assembly.push({
+                    wireIndices: threeVoltWires.map((w, i) => i + numGroundWires)
+                });
+            if (fiveVoltWires.length > 0)
+                assembly.push({
+                    wireIndices: threeVoltWires.map((w, i) => i + numGroundWires + threeVoltWires.length)
+                });
             return {
-                wires: groundWires.concat(threeVoltWires),
+                wires: groundWires.concat(threeVoltWires).concat(fiveVoltWires),
                 assembly: assembly
             };
         }


### PR DESCRIPTION
Adding support for routing 5V and 3V power lines on breadboard.
![image](https://user-images.githubusercontent.com/4175913/54064516-e0f69880-41c9-11e9-9d7e-a035f514eba6.png)
