### PR TITLE
Fix set declarations where the expression type is generic in blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1073,13 +1073,29 @@ namespace pxt.blocks {
             }, true);
         }
 
-        if (isDef) binding.alreadyDeclared = true;
-        else if (!binding.firstReference) binding.firstReference = b;
-
         let expr = compileExpression(e, bExpr, comments);
+
+        let bindString = binding.escapedName + " = ";
+
+        if (isDef) {
+            binding.alreadyDeclared = true;
+            const declaredType = getConcreteType(binding.type);
+
+            bindString = `let ${binding.escapedName} = `;
+
+            if (declaredType) {
+                const expressionType = getConcreteType(returnType(e, bExpr));
+                if (declaredType.type !== expressionType.type) {
+                    bindString = `let ${binding.escapedName}: ${declaredType.type} = `;
+                }
+            }
+        }
+        else if (!binding.firstReference) {
+            binding.firstReference = b;
+        }
+
         return mkStmt(
-            mkText(isDef ? "let " : ""),
-            mkText(binding.escapedName + " = "),
+            mkText(bindString),
             expr)
     }
 

--- a/tests/blocklycompiler-test/baselines/array_type_declaration_in_set.ts
+++ b/tests/blocklycompiler-test/baselines/array_type_declaration_in_set.ts
@@ -1,0 +1,3 @@
+let arr: string[] = []
+let item = arr[0]
+arr.push("asdf")

--- a/tests/blocklycompiler-test/cases/array_type_declaration_in_set.blocks
+++ b/tests/blocklycompiler-test/cases/array_type_declaration_in_set.blocks
@@ -1,0 +1,57 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable type="" id="bqCo*cmZ~-nKBj?U-w)9">arr</variable>
+    <variable type="" id="Ucz{c2aa%n4%7w7(fFS#">item</variable>
+  </variables>
+  <block type="pxt-on-start" x="0" y="0">
+    <statement name="HANDLER">
+      <block type="variables_set">
+        <field name="VAR" id="bqCo*cmZ~-nKBj?U-w)9" variabletype="">arr</field>
+        <value name="VALUE">
+          <shadow type="math_number" id="M4[cqL9z3yXldMu,!.Mz">
+            <field name="NUM">0</field>
+          </shadow>
+          <block type="lists_create_with">
+            <mutation items="0"></mutation>
+          </block>
+        </value>
+        <next>
+          <block type="variables_set">
+            <field name="VAR" id="Ucz{c2aa%n4%7w7(fFS#" variabletype="">item</field>
+            <value name="VALUE">
+              <shadow type="math_number" id="^*5-(B8W!XITV9LLYzLI">
+                <field name="NUM">0</field>
+              </shadow>
+              <block type="lists_index_get">
+                <value name="LIST">
+                  <block type="variables_get">
+                    <field name="VAR" id="bqCo*cmZ~-nKBj?U-w)9" variabletype="">arr</field>
+                  </block>
+                </value>
+                <value name="INDEX">
+                  <shadow type="math_number">
+                    <field name="NUM">0</field>
+                  </shadow>
+                </value>
+              </block>
+            </value>
+            <next>
+              <block type="array_push">
+                <value name="list">
+                  <block type="variables_get">
+                    <field name="VAR" id="bqCo*cmZ~-nKBj?U-w)9" variabletype="">arr</field>
+                  </block>
+                </value>
+                <value name="value">
+                  <block type="text">
+                    <field name="TEXT">asdf</field>
+                  </block>
+                </value>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -381,6 +381,10 @@ describe("blockly compiler", function () {
         it("should allow variables declared in a for-loop at the top of on-start", (done: () => void) => {
             blockTestAsync("on_start_with_for_loop").then(done, done);
         });
+
+        it("should declare variable types when the initializer expression has a generic type", (done: () => void) => {
+            blockTestAsync("array_type_declaration_in_set").then(done, done);
+        });
     });
 
     describe("compiling functions", () => {


### PR DESCRIPTION
Fixes the crashy bird block errors described in https://github.com/Microsoft/pxt-microbit/issues/1866

The new variable declaration logic doesn't emit type declarations when compiling a "set" block, which is usually fine because our Blocks code is pretty strongly typed. However, you can confuse the TypeScript type checker by assigning an empty array in the first reference without a type declaration. Sometimes the language service figures it out using inference, but it's safer to not rely on that behavior.