### PR TITLE
Use the new for-of block in the decompiler

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1443,12 +1443,10 @@ ${output}</xml>`;
 
         function getForOfStatement(n: ts.ForOfStatement): StatementNode {
             const initializer = n.initializer as ts.VariableDeclarationList;
-            const indexVar = (initializer.declarations[0].name as ts.Identifier).text;
             const renamed = getVariableName(initializer.declarations[0].name as ts.Identifier);
 
-            const r = mkStmt("controls_for_of");
-            r.inputs = [getValue("LIST", n.expression)];
-            r.fields = [getField("VAR", renamed)];
+            const r = mkStmt("pxt_controls_for_of");
+            r.inputs = [getValue("LIST", n.expression), getDraggableVariableBlock("VAR", renamed)];
             r.handlers = [{ name: "DO", statement: getStatementBlock(n.statement) }];
 
             return r

--- a/tests/decompile-test/baselines/array_for_of.blocks
+++ b/tests/decompile-test/baselines/array_for_of.blocks
@@ -15,12 +15,16 @@
 </block>
 </value>
 <next>
-<block type="controls_for_of">
-<field name="VAR">a</field>
+<block type="pxt_controls_for_of">
 <value name="LIST">
 <block type="variables_get">
 <field name="VAR">x</field>
 </block>
+</value>
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">a</field>
+</shadow>
 </value>
 <statement name="DO">
 <block type="variables_change">
@@ -33,8 +37,7 @@
 </block>
 </statement>
 <next>
-<block type="controls_for_of">
-<field name="VAR">b</field>
+<block type="pxt_controls_for_of">
 <value name="LIST">
 <block type="lists_create_with">
 <mutation items="1" />
@@ -44,6 +47,11 @@
 </shadow>
 </value>
 </block>
+</value>
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">b</field>
+</shadow>
 </value>
 <statement name="DO">
 </statement>


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1749

I'm surprised I never noticed this until now :smile:. I don't even remember how long ago we changed the for of block.