### PR TITLE
Debugger: enter & exit debug mode and variable explorer to toolbox.

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -11,15 +11,20 @@
         Debugger
 *******************************/
 
+.debuggerToolbox.elements {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
 /* Debugger toolbar */
 .debugtoolbar {
-    position: absolute;
-    top: @mainMenuHeight;
+    width: 100%;
     z-index: @debuggerToolsZIndex;
     .ui.menu {
-        box-shadow: 0 2px 8px #a8a8a8;
         border-radius: 0 !important;
         border: 0 !important;
+        display: flex;
         .item {
             padding-left: 10px;
             padding-right: 10px;
@@ -50,12 +55,17 @@
     color: #87D282 !important;
 }
 
+.ui.item.link.dbg-btn.dbg-exit {
+    background-color: #cccccc;
+    color: rgb(255, 21, 0);
+}
+
 /* Debugger variables view */
 .ui.segment.debugvariables {
-    position: absolute;
-    right: 1rem;
-    top: 3.5rem;
-    margin-top: 0rem;
+    table-layout: auto;
+    width: 100%;
+    background: @debuggerVariableExplorerBackground;
+    display: none;
     
     .ui.middle.aligned.list {
         overflow-y: auto;
@@ -68,8 +78,11 @@
     .variable {
         padding: 0.15rem;
     }
-    .variable .varname {
-        font-weight: bold;
+    .variable.varname {
+        text-overflow: ellipsis;
+        max-width: 1rem;
+        overflow: hidden;
+        white-space: nowrap;
     }
     .variable.detail {
         text-align: right;
@@ -94,6 +107,12 @@
         font-size: 90%;
         margin-left: 0.5rem;
     }
+}
+
+.debugging .ui.segment.debugvariables {
+    display: table;
+    margin: 0;
+    border: none;
 }
 
 .ui.segment.debugvariables.frozen {
@@ -128,11 +147,4 @@ div.simframe div.pause-overlay {
 /* Old debugger view */
 #root .debuggerview h4 {
     margin: 0.9em 0 0 0;
-}
-
-/* <= Tablet (Mobile + Tablet) */
-@media only screen and (max-width: @largestTabletScreen) {
-    .debugtoolbar {
-        top: @mobileMenuHeight;
-    }
 }

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -302,3 +302,5 @@
 
 @DebuggerBackgroundPrimaryColor: @green;
 @DebuggerBackgroundSecondaryColor: lightgreen;
+
+@debuggerVariableExplorerBackground: white;

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -36,6 +36,15 @@
     display: none !important;
 }
 
+.debugger .blocklyToolboxDiv {
+    width: 20%;
+    background: @debuggerVariableExplorerBackground!important;
+}
+
+.debugger .blocklyToolbox, .debuggerToolbox {
+    height: 100%;
+}
+
 /*******************************
         Toolbox root
 *******************************/

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -278,6 +278,9 @@ export class ProjectView
         if (this.editor && this.editor.isReady) {
             this.updateEditorFile();
         }
+        if (this.state.debugging) {
+            this.blocksEditor.updateToolbox(true);
+        }
     }
 
     fireResize() {
@@ -2008,6 +2011,7 @@ export class ProjectView
         else {
             simulator.driver.restart(); // fast restart
         }
+        this.blocksEditor.setBreakpointsFromBlocks();
     }
 
     startSimulator(debug?: boolean, clickTrigger?: boolean) {
@@ -2132,7 +2136,9 @@ export class ProjectView
     toggleDebugging() {
         const state = !this.state.debugging;
         pxt.log("turning debugging mode to " + state);
-        this.setState({ debugging: state, tracing: false });
+        this.setState({ debugging: state, tracing: false }, () => {
+            this.renderCore()
+        });
         let blocks = this.blocksEditor.editor.getAllBlocks();
         blocks.forEach(block => {
             if (block.nextConnection && block.previousConnection) {
@@ -2140,8 +2146,8 @@ export class ProjectView
             }
         });
 
+        this.blocksEditor.updateToolbox(state)
         this.restartSimulator(state);
-        this.renderCore()
     }
 
     dbgPauseResume() {
@@ -2384,6 +2390,7 @@ export class ProjectView
     }
 
     showExitAndSaveDialog() {
+        this.setState({ debugging: false })
         if (this.state.projectName !== lf("Untitled")) {
             this.openHome();
         }
@@ -2729,7 +2736,7 @@ export class ProjectView
         const inHome = this.state.home && !sandbox;
         const inEditor = !!this.state.header && !inHome;
         const { lightbox, greenScreen } = this.state;
-        const simDebug = !!targetTheme.debugger;
+        const simDebug = !!targetTheme.debugger || inDebugMode;
 
         const { hideMenuBar, hideEditorToolbar, transparentEditorToolbar } = targetTheme;
         const isHeadless = simOpts && simOpts.headless;
@@ -2793,7 +2800,6 @@ export class ProjectView
                     <tutorial.TutorialCard ref="tutorialcard" parent={this} />
                 </div> : undefined}
                 <div id="simulator">
-                    {simDebug ? <debug.DebuggerToolbar parent={this} /> : undefined}
                     <div id="filelist" className="ui items">
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")}>
                         </div>
@@ -2810,7 +2816,7 @@ export class ProjectView
                         <div id="filelistOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.toggleSimulatorFullscreen}></div>
                     </div>
                 </div>
-                <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main" aria-hidden={inHome}>
+                <div id="maineditor" className={(sandbox ? "sandbox" : "") + (inDebugMode ? "debugging" : "")} role="main" aria-hidden={inHome}>
                     {this.allEditors.map(e => e.displayOuter())}
                 </div>
                 {inHome ? <div id="homescreen" className="full-abs">

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -585,7 +585,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             <debug.DebuggerVariables ref={this.handleDebuggerVariablesRef} parent={this.parent} />
         </div> : <div />;
         Util.assert(!!this.debuggerToolboxDiv)
-        debugging ? this.toolbox.hide() : this.toolbox.show();
+        if (debugging) {
+            this.toolbox.hide();
+        } else {
+            this.toolbox.show();
+        }
         ReactDOM.render(debuggerToolbox, document.getElementById('debuggerToolbox'));
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -31,7 +31,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     showSearch: boolean;
     breakpointsByBlock: pxt.Map<number>; // Map block id --> breakpoint ID
     breakpointsSet: number[]; // the IDs of the breakpoints set.
-    debuggerToolboxDiv: any;
+    debuggerToolboxDiv: JSX.Element;
 
     public nsMap: pxt.Map<toolbox.BlockDefinition[]>;
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -31,6 +31,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     showSearch: boolean;
     breakpointsByBlock: pxt.Map<number>; // Map block id --> breakpoint ID
     breakpointsSet: number[]; // the IDs of the breakpoints set.
+    debuggerToolboxDiv: any;
 
     public nsMap: pxt.Map<toolbox.BlockDefinition[]>;
 
@@ -70,6 +71,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let breakpointId = this.breakpointsByBlock[blockId];
         this.breakpointsSet.filter(breakpoint => breakpoint != breakpointId);
         simulator.driver.setBreakpoints(this.breakpointsSet);
+    }
+
+    clearBreakpoints(): void {
+        simulator.driver.setBreakpoints([]);
     }
 
     setVisible(v: boolean) {
@@ -537,8 +542,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             <div>
                 <div id="blocksEditor"></div>
                 <toolbox.ToolboxTrashIcon />
-                {this.parent.state.debugging ?
-                    <debug.DebuggerVariables ref={this.handleDebuggerVariablesRef} parent={this.parent} /> : undefined}
             </div>
         )
     }
@@ -564,12 +567,26 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     renderToolbox(immediate?: boolean) {
         if (pxt.shell.isReadOnly()) return;
         const blocklyToolboxDiv = this.getBlocklyToolboxDiv();
-        const blocklyToolbox = <toolbox.Toolbox ref={this.handleToolboxRef} editorname="blocks" parent={this} />;
-
+        const debuggerToolboxDiv = <div id="debuggerToolbox"></div>;
+        const blocklyToolbox = <div className="blocklyToolbox">
+            <toolbox.Toolbox ref={this.handleToolboxRef} editorname="blocks" parent={this} />
+            {debuggerToolboxDiv}
+        </div>;
+        this.debuggerToolboxDiv = debuggerToolboxDiv;
         Util.assert(!!blocklyToolboxDiv);
         ReactDOM.render(blocklyToolbox, blocklyToolboxDiv);
 
         if (!immediate) this.toolbox.showLoading();
+    }
+
+    updateToolbox(debugging: boolean) {
+        let debuggerToolbox = debugging ? <div>
+            <debug.DebuggerToolbar parent={this.parent} />
+            <debug.DebuggerVariables ref={this.handleDebuggerVariablesRef} parent={this.parent} />
+        </div> : <div />;
+        Util.assert(!!this.debuggerToolboxDiv)
+        debugging ? this.toolbox.hide() : this.toolbox.show();
+        ReactDOM.render(debuggerToolbox, document.getElementById('debuggerToolbox'));
     }
 
     showPackageDialog() {
@@ -770,6 +787,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
             }
         })
+        this.setBreakpointsFromBlocks();
     }
 
     highlightStatement(stmt: pxtc.LocationInfo, brk?: pxsim.DebuggerBreakpointMessage): boolean {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -321,6 +321,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         this.openJavaScript = this.openJavaScript.bind(this);
         this.exitTutorial = this.exitTutorial.bind(this);
         this.showReportAbuse = this.showReportAbuse.bind(this);
+        this.toggleDebug = this.toggleDebug.bind(this);
     }
 
     brandIconClick() {
@@ -375,21 +376,25 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         this.props.parent.showReportAbuse();
     }
 
+    toggleDebug() {
+        pxt.tickEvent("simulator.debug", undefined, { interactiveConsent: true });
+        this.props.parent.toggleDebugging();
+    }
+
     renderCore() {
-        const { home, header, highContrast, greenScreen, simState } = this.props.parent.state;
+        const { debugging, home, header, highContrast, greenScreen, simState, tutorialOptions } = this.props.parent.state;
         if (home) return <div />; // Don't render if we're on the home screen
 
         const targetTheme = pxt.appTarget.appTheme;
         const isController = pxt.shell.isControllerMode();
         const homeEnabled = !isController;
         const sandbox = pxt.shell.isSandboxMode();
-        const tutorialOptions = this.props.parent.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const tutorialReportId = tutorialOptions && tutorialOptions.tutorialReportId;
-        const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial;
+        const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial && !debugging;
         const isRunning = simState == pxt.editor.SimState.Running;
         const hc = !!this.props.parent.state.highContrast;
-        const showShare = !inTutorial && header && pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && !isController;
+        const showShare = !inTutorial && header && pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && !isController && !debugging;
 
         const logo = (hc ? targetTheme.highContrastLogo : undefined) || targetTheme.logo;
         const portraitLogo = (hc ? targetTheme.highContrastPortraitLogo : undefined) || targetTheme.portraitLogo;
@@ -433,8 +438,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
             </div> : undefined}
             {inTutorial ? <tutorial.TutorialMenuItem parent={this.props.parent} /> : undefined}
             <div className="right menu">
+                {debugging ? <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit Debug Mode")} textClass="landscape only" onClick={this.toggleDebug} /> : undefined}
                 {docMenu ? <container.DocsMenu parent={this.props.parent} /> : undefined}
-                {sandbox || inTutorial ? undefined : <container.SettingsMenu parent={this.props.parent} highContrast={highContrast} greenScreen={greenScreen} />}
+                {sandbox || inTutorial || debugging ? undefined : <container.SettingsMenu parent={this.props.parent} highContrast={highContrast} greenScreen={greenScreen} />}
 
                 {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} /> : undefined}
                 {inTutorial && tutorialReportId ? <sui.ButtonMenuItem className="report-tutorial-btn" role="menuitem" icon="warning circle" text={lf("Report Abuse")} textClass="landscape only" onClick={this.showReportAbuse} /> : undefined}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -377,6 +377,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
     }
 
     toggleDebug() {
+        // This function will get called when the user clicks the "Exit Debug Mode" button in the menu bar.
         pxt.tickEvent("simulator.debug", undefined, { interactiveConsent: true });
         this.props.parent.toggleDebugging();
     }

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -439,7 +439,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
             </div> : undefined}
             {inTutorial ? <tutorial.TutorialMenuItem parent={this.props.parent} /> : undefined}
             <div className="right menu">
-                {debugging ? <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit Debug Mode")} textClass="landscape only" onClick={this.toggleDebug} /> : undefined}
+                {debugging ? <sui.ButtonMenuItem className="exit-debugmode-btn" role="menuitem" icon="external" text={lf("Exit Debug Mode")} textClass="landscape only" onClick={this.toggleDebug} /> : undefined}
                 {docMenu ? <container.DocsMenu parent={this.props.parent} /> : undefined}
                 {sandbox || inTutorial || debugging ? undefined : <container.SettingsMenu parent={this.props.parent} highContrast={highContrast} greenScreen={greenScreen} />}
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -93,7 +93,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     }
 
     renderCore() {
-        const { home, tutorialOptions, hideEditorFloats, collapseEditorTools, projectName, compiling, isSaving, simState } = this.props.parent.state;
+        const { home, tutorialOptions, hideEditorFloats, collapseEditorTools, projectName, compiling, isSaving, simState, debugging } = this.props.parent.state;
 
         if (home) return <div />; // Don't render if we're in the home screen
 
@@ -109,7 +109,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         if (!isEditor) return <div />;
 
         const disableFileAccessinMaciOs = targetTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
-        const showSave = !readOnly && !isController && !targetTheme.saveInMenu && !tutorial && !disableFileAccessinMaciOs;
+        const showSave = !readOnly && !isController && !targetTheme.saveInMenu && !tutorial && !debugging && !disableFileAccessinMaciOs;
         const compile = pxt.appTarget.compile;
         const compileBtn = compile.hasHex || compile.saveAsPNG || compile.useUF2;
         const compileTooltip = lf("Download your code to the {0}", targetTheme.boardName);
@@ -125,8 +125,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const hasRedo = this.props.parent.editor.hasRedo();
 
         const showCollapsed = !tutorial && !sandbox && !targetTheme.simCollapseInMenu;
-        const showProjectRename = !tutorial && !readOnly && !isController && !targetTheme.hideProjectRename;
-        const showUndoRedo = !tutorial && !readOnly;
+        const showProjectRename = !tutorial && !readOnly && !isController && !targetTheme.hideProjectRename && !debugging;
+        const showUndoRedo = !tutorial && !readOnly && !debugging;
         const showZoomControls = true;
 
         const run = !targetTheme.bigRunButton;
@@ -135,12 +135,11 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const tracing = this.props.parent.state.tracing;
         const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debug = !!targetTheme.debugger && !readOnly;
-        const debugging = this.props.parent.state.debugging;
         const debugTooltip = debugging ? lf("Disable Debugging") : lf("Debugging")
         const downloadIcon = pxt.appTarget.appTheme.downloadIcon || "download";
         const downloadText = pxt.appTarget.appTheme.useUploadMessage ? lf("Upload") : lf("Download");
 
-        const bigRunButtonTooltip = [lf("Stop"),lf("Starting"), lf("Run Code in Game")][simState || 0];
+        const bigRunButtonTooltip = [lf("Stop"), lf("Starting"), lf("Run Code in Game")][simState || 0];
 
         let downloadButtonClasses = "";
         let saveButtonClasses = "";

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -24,6 +24,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
         this.toggleSimulatorCollapse = this.toggleSimulatorCollapse.bind(this);
         this.takeScreenshot = this.takeScreenshot.bind(this);
+        this.toggleDebug = this.toggleDebug.bind(this);
     }
 
     openInstructions() {
@@ -104,6 +105,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const runTooltip = [lf("Start the simulator"), lf("Starting the simulator"), lf("Stop the simulator")][simState];
         const makeTooltip = lf("Open assembly instructions");
         const restartTooltip = lf("Restart the simulator");
+        const debugTooltip = lf("Toggle debug mode");
         const fullscreenTooltip = isFullscreen ? lf("Exit fullscreen mode") : lf("Launch in fullscreen");
         const muteTooltip = isMuted ? lf("Unmute audio") : lf("Mute audio");
         const collapseTooltip = lf("Hide the simulator");
@@ -113,7 +115,8 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make ? <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} /> : undefined}
                 {run ? <sui.Button disabled={debugging || isStarting} key='runbtn' className={`play-button ${isRunning ? "stop" : "play"}`} icon={isRunning ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
-                {restart ? <sui.Button disabled={debugging || isStarting} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
+                {restart ? <sui.Button disabled={isStarting} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
+                {run ? <sui.Button disabled={false} key='debugbtn' className={`debug-button ${debugging ? "red" : "orange"}`} icon="xicon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
                 {trace ? <sui.Button key='trace' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={this.toggleTrace} /> : undefined}
             </div>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>


### PR DESCRIPTION
Moved the button to enter/exit debug mode to the simulator toolbar.
Added some options to exit debug mode:
a) Button in the debugger toolbar.
b) Button in top bar (similar to tutorials one).

Moved variable explorer and debugger toolbar to toolbox. They will
replace the usual toolbox when in debug mode.
Removed unnecessary elements in debug mode: Share, help and more in top bar, save, undo, redo in bottom bar.

![Debugger v2 0](https://user-images.githubusercontent.com/5607882/54299624-85852b80-4578-11e9-905e-94667970959f.PNG)
