### PR TITLE
clip blocks/javascript toggle text for localized languages

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -95,7 +95,7 @@ namespace pxt.runner {
             if (woptions.showJs) {
                 appendJs($c, $js, woptions);
             } else {
-                const $jsBtn = $(`<a class="item js" role="button" tabindex="0" aria-label="${lf("JavaScript")}"><i role="presentation" aria-hidden="true" class="align left icon"></i></a>`).click(() => {
+                const $jsBtn = $(`<a class="item js" role="button" tabindex="0" aria-label="${"JavaScript"}"><i role="presentation" aria-hidden="true" class="align left icon"></i></a>`).click(() => {
                     if ($c.find('.js')[0])
                         $c.find('.js').remove();
                     else {

--- a/theme/common.less
+++ b/theme/common.less
@@ -274,6 +274,15 @@ div.simframe > iframe {
     background: @editorToggleColor !important;
 }
 
+.item.javascript-menuitem span.ui.text,
+.item.blocks-menuitem span.ui.text
+ {
+    word-wrap: break-word;
+    text-overflow: clip;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 /* Help card */
 #helpcard {
     position: absolute;

--- a/theme/common.less
+++ b/theme/common.less
@@ -274,15 +274,6 @@ div.simframe > iframe {
     background: @editorToggleColor !important;
 }
 
-.item.javascript-menuitem span.ui.text,
-.item.blocks-menuitem span.ui.text
- {
-    word-wrap: break-word;
-    text-overflow: clip;
-    overflow: hidden;
-    white-space: nowrap;
-}
-
 /* Help card */
 #helpcard {
     position: absolute;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -15,7 +15,6 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 // lf("Getting started")
 // lf("Buy")
 // lf("Blocks")
-// lf("JavaScript")
 // lf("Examples")
 // lf("Tutorials")
 // lf("Projects")
@@ -433,7 +432,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 <div className="ui grid padded">
                     {sandbox ? <sui.Item className="sim-menuitem" role="menuitem" textClass="landscape only" text={lf("Simulator")} icon={simActive && isRunning ? "stop" : "play"} active={simActive} onClick={this.openSimView} title={!simActive ? lf("Show Simulator") : runTooltip} /> : undefined}
                     <sui.Item className="blocks-menuitem" role="menuitem" textClass="landscape only" text={lf("Blocks")} icon="xicon blocks" active={blockActive} onClick={this.openBlocks} title={lf("Convert code to Blocks")} />
-                    <sui.Item className="javascript-menuitem" role="menuitem" textClass="landscape only" text={lf("JavaScript")} icon="xicon js" active={javascriptActive} onClick={this.openJavaScript} title={lf("Convert code to JavaScript")} />
+                    <sui.Item className="javascript-menuitem" role="menuitem" textClass="landscape only" text={"JavaScript"} icon="xicon js" active={javascriptActive} onClick={this.openJavaScript} title={lf("Convert code to JavaScript")} />
                     <div className="ui item toggle"></div>
                 </div>
             </div> : undefined}


### PR DESCRIPTION
Prevents long translations of "blocks"/"JavaScript" to bleed out of the toggle. We should really fix the sizing of that toggle but this fix prevents out menu bar to be completed destructed.

Also prevents "JavaScript" to be localized.