### PR TITLE
Handle double sim for radio in tablet and embed when fullscreen

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -518,7 +518,7 @@ Avatar
 
 .glow > div {
     outline: 3px solid transparent;
-    animation: glow 0.3s infinite alternate;  
+    animation: glow 0.3s infinite alternate;
     transition: outline 0.3s linear;
 }
 
@@ -775,6 +775,9 @@ p.ui.font.small {
     .simtoolbar .ui.button {
         font-size: 1.7rem;
     }
+    div.simframe:not(:first-child) {
+        display: inherit;
+    }
 }
 
 /*******************************
@@ -920,7 +923,11 @@ p.ui.font.small {
         padding-bottom: 81.96% !important;
     }
     div.simframe:not(:first-child) {
-        display:none !important;
+        display:none;
+    }
+    #simulators {
+        flex-direction: row;
+        display: flex !important;
     }
     /* Hide floating editors */
     .hideEditorFloats .editorFloat {
@@ -1106,6 +1113,20 @@ div.simframe.ui.embed {
         left: 0;
     }
 
+    /* Not needed in triple toggle view */
+    #filelistOverlay {
+        display: none;
+    }
+
+    #simulators {
+        flex-direction: row;
+        display: flex !important;
+    }
+
+    div.simframe:not(:first-child) {
+        display: inherit;
+    }
+
     #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #editortools, #msg {
         bottom: 1.5rem !important;
     }
@@ -1157,5 +1178,5 @@ div.simframe.ui.embed {
 img.pixelart {
     image-rendering: auto;
     image-rendering: crisp-edges;
-    image-rendering: pixelated;    
+    image-rendering: pixelated;
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1700

![mbit_radio](https://user-images.githubusercontent.com/13754588/54392769-ac6d5b80-4665-11e9-8879-39f2ccc5a045.gif)

Also takes care of a bug on beta where the filelist overlay was showing up when the sim was in sandbox mode, even though the sim is always full screen there.