### PR TITLE
specify a flag to hide package from the extension dialog

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -64,6 +64,7 @@ declare namespace pxt {
             excludePrefix?: string[];
         };
         features?: string[];
+        hidden?: boolean; // hide package from package selection dialog
     }
 
     interface PackageExtension {

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -172,6 +172,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const features = this.state.features;
         return Object.keys(bundled).filter(k => !/prj$/.test(k))
             .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig)
+            .filter(pk => !pk.hidden)
             .filter(pk => !query || pk.name.toLowerCase().indexOf(query.toLowerCase()) > -1) // search filter
             .filter(pk => boards || !pkg.mainPkg.deps[pk.name] || pkg.mainPkg.deps[pk.name].cppOnly) // don't show package already referenced in extensions
             .filter(pk => !/---/.test(pk.name)) //filter any package with ---, these are part of common-packages such as core---linux or music---pwm


### PR DESCRIPTION
Some package should not be shown to users as they are used purely to support the hardware build.
![image](https://user-images.githubusercontent.com/4175913/54393126-a4fa8200-4666-11e9-836b-1ecbc70716d5.png)


The "hidden" flag in pxt.json allows to hide them.