### PR TITLE
Adding typeof to sim

### DIFF
--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -531,7 +531,6 @@ namespace pxsim {
         export let dumpDmesg: any;
         export let getVTable: any;
         export let valType: any;
-        export let typeOf: any;
         export let lookupPin: any;
         export let deleteRefObject: any;
         export let popThreadContext: any;
@@ -550,6 +549,10 @@ namespace pxsim {
         export let string_inline_utf8_vt: any;
         export let string_cons_vt: any;
         export let string_skiplist16_vt: any;
+
+        export function typeOf(obj: any) {
+            return typeof obj;
+        }
     }
 
     // these can only be used from assembly - silence warnings


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-microbit/issues/1915

I definitely thought this was going to be more complicated. @mmoskal can you confirm I'm not overlooking anything here?

Here's the code I used for testing:

```typescript
function test(x?: any) {
    basic.showString(typeof x);
}
test(() => true);
test([]);
test({});
test(1.5);
test("x");
test(true);
test();
```
