### PR TITLE
Debugger improvements

### DIFF
--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -20,17 +20,14 @@ namespace pxsim {
         }
 
         toDebugString(): string {
-            return "[" + this.data.join(", ") + "]";
-        }
-        toDebugStringTruncating(): string {
             let s = "[";
             for (let i = 0; i < this.data.length; ++i) {
                 if (i > 0)
                     s += ",";
                 let newElem = RefObject.toDebugString(this.data[i]);
-                if (s.length + newElem.length > 20) {
+                if (s.length + newElem.length > 100) {
                     if (i == 0) {
-                        s += newElem.substr(0, 20);
+                        s += newElem.substr(0, 100);
                     }
                     s += "..."
                     break;

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -20,6 +20,9 @@ namespace pxsim {
         }
 
         toDebugString(): string {
+            return "[" + this.data.join(", ") + "]";
+        }
+        toDebugStringTruncating(): string {
             let s = "[";
             for (let i = 0; i < this.data.length; ++i) {
                 if (i > 0)
@@ -27,7 +30,7 @@ namespace pxsim {
                 let newElem = RefObject.toDebugString(this.data[i]);
                 if (s.length + newElem.length > 20) {
                     if (i == 0) {
-                        s += newElem.substr(0,20);
+                        s += newElem.substr(0, 20);
                     }
                     s += "..."
                     break;

--- a/theme/common.less
+++ b/theme/common.less
@@ -374,6 +374,7 @@ div.simframe > iframe {
 }
 
 /* Icon and text */
+.ui.item.link > .icon-and-text.icon ~ .ui.text,
 .ui.item.icon > .icon-and-text.icon ~ .ui.text,
 .ui.button.icon > .icon-and-text.icon ~ .ui.text {
     margin-left: 0.5em !important;

--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -21,14 +21,18 @@
 .debugtoolbar {
     width: 100%;
     z-index: @debuggerToolsZIndex;
+    display: flex;
     .ui.menu {
         border-radius: 0 !important;
-        border: 0 !important;
+        border-left: none;
         display: flex;
+        width: 100%;
         .item {
             padding-left: 10px;
             padding-right: 10px;
-            border-radius: 0 !important;
+        }
+        .separator-after {
+            border-right: 1px solid #dddddd;
         }
     }
 }
@@ -43,11 +47,15 @@
 }
 
 /* Debugger toolbar buttons */
-.ui.button.dbg-btn .icon.blue {
-    color: #72BDFF !important;
+
+.ui.item.dbg-btn {
+    white-space: pre;
+}
+.ui.item.dbg-btn .icon.blue {
+    color: #0078D7!important;
 }
 
-.ui.button.dbg-btn .icon.red {
+.ui.item.dbg-btn .icon.red {
     color: #F6876D !important;
 }
 
@@ -64,9 +72,8 @@
 .ui.segment.debugvariables {
     table-layout: auto;
     width: 100%;
-    background: @debuggerVariableExplorerBackground;
     display: none;
-    
+
     .ui.middle.aligned.list {
         overflow-y: auto;
         max-height: 25rem;
@@ -128,20 +135,6 @@ div.simframe div.pause-overlay {
     height: 100%;
     position: absolute;
     z-index: 100;    
-}
-
-.debugger .grid.equal.width {
-    background: @DebuggerBackgroundPrimaryColor;
-}
-
-.debugger #downloadArea {
-    background: @DebuggerBackgroundPrimaryColor;
-    //background-color: lightgreen
-}
-
-.debugger #filelist {
-    background: @DebuggerBackgroundPrimaryColor;
-    background-color: @DebuggerBackgroundSecondaryColor
 }
 
 /* Old debugger view */

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -38,7 +38,6 @@
 
 .debugger .blocklyToolboxDiv {
     width: 20%;
-    background: @debuggerVariableExplorerBackground!important;
 }
 
 .debugger .blocklyToolbox, .debuggerToolbox {

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -60,7 +60,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                 else sv = "(unknown)"
                 break;
         }
-        return DebuggerVariables.capLength(sv);
+        return sv;
     }
 
     static capLength(varstr: string) {
@@ -134,6 +134,18 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
         }
     }
 
+    private shouldShowValueOnHover(type: string): boolean {
+        switch (type) {
+            case "string":
+            case "number":
+            case "boolean":
+            case "array":
+                return true;
+            default:
+                return false;
+        }
+    }
+
     toggleDebugging(): void {
         this.props.parent.toggleDebugging();
     }
@@ -158,14 +170,14 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             const onClick = v.value && v.value.id ? () => this.toggle(v) : undefined;
 
             r.push(<tr key={(parent || "") + variable} className="item" onClick={onClick} onMouseOver={this.onMouseOverVariable}>
-                <td className={`variable varname ${v.prevValue !== undefined ? "changed" : ""}`}>
+                <td className={`variable varname ${v.prevValue !== undefined ? "changed" : ""}`} title={variable}>
                     <i className={`${(v.children ? "down triangle icon" : "right triangle icon") + ((v.value && v.value.hasFields) ? "" : " transparent")}`} style={{ marginLeft: margin }} ></i>
                     <span>{variable + ':'}</span>
                 </td>
-                <td style={{ padding: 0.2 }}>
+                <td style={{ padding: 0.2 }} title={this.shouldShowValueOnHover(type) ? newValue : ""}>
                     <div className="variable detail">
-                        <span className={`varval ${type}`}>{DebuggerVariables.renderValue(v.value)}</span>
-                        <span className="previousval">{(oldValue !== "undefined" && oldValue !== newValue) ? `${oldValue}` : ''}</span>
+                        <span className={`varval ${type}`}>{DebuggerVariables.capLength(newValue)}</span>
+                        <span className="previousval">{(oldValue !== "undefined" && oldValue !== newValue) ? `${DebuggerVariables.capLength(oldValue)}` : ''}</span>
                     </div>
                 </td>
             </tr>
@@ -181,7 +193,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
         const variableTableHeader = lf("Variable");
         const valueTableHeader = lf("Type/Value");
 
-        return <table className={`ui segment debugvariables ${frozen ? "frozen" : ""} ui collapsing basic table`}>
+        return <table className={`ui segment debugvariables ${frozen ? "frozen" : ""} ui collapsing basic striped table`}>
             <thead>
                 <tr>
                     <th>{variableTableHeader}</th>
@@ -274,17 +286,29 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
         const dbgStepOutTooltip = lf("Step out");
         const dbgExitTooltip = lf("Exit Debug Mode");
 
-        return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")}>
-            {!isDebugging ? undefined :
+        if (!isDebugging) {
+            return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")} />
+        } else if (advancedDebugging) {
+            // Debugger Toolbar for the monaco editor.
+            return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")}>
+                {!isDebugging ? undefined :
+                    <div className={`ui compact menu icon`}>
+                        <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
+                        <sui.Item key='dbgstepover' className={`dbg-btn dbg-step-over`} icon={`xicon stepover ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepOverTooltip} onClick={this.dbgStepOver} />
+                        <sui.Item key='dbgstepinto' className={`dbg-btn dbg-step-into`} icon={`xicon stepinto ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} />
+                        <sui.Item key='dbgstepout' className={`dbg-btn dbg-step-out`} icon={`xicon stepout ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepOutTooltip} onClick={this.dbgStepOut} />
+                        <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart right`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
+                    </div>}
+            </div>;
+        } else {
+            // Debugger Toolbar for the blocks editor.
+            return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")}>
                 <div className={`ui compact borderless menu icon`}>
-                    <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "step forward green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
-                    {!advancedDebugging ? <sui.Item key='dbgstep' className={`dbg-btn dbg-step`} icon={`arrow right ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} /> : undefined}
-                    {advancedDebugging ? <sui.Item key='dbgstepover' className={`dbg-btn dbg-step-over`} icon={`xicon stepover ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepOverTooltip} onClick={this.dbgStepOver} /> : undefined}
-                    {advancedDebugging ? <sui.Item key='dbgstepinto' className={`dbg-btn dbg-step-into`} icon={`xicon stepinto ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} /> : undefined}
-                    {advancedDebugging ? <sui.Item key='dbgstepout' className={`dbg-btn dbg-step-out`} icon={`xicon stepout ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepOutTooltip} onClick={this.dbgStepOut} /> : undefined}
-                    <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart right`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
-                    <sui.Item key='dbgexit' className={`dbg-btn dbg-exit`} icon={`stop`} title={dbgExitTooltip} onClick={this.exitDebugging} />
-                </div>}
-        </div>;
+                    <sui.Item key='dbgstep' className={`dbg-btn dbg-step separator-after`} icon={`arrow right ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} text={"Step"} />
+                    <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
+                    <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
+                </div>
+            </div>;
+        }
     }
 }

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -114,9 +114,9 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait hide")} role="complementary" aria-label={lf("Simulator toolbar")}>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make ? <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} /> : undefined}
-                {run ? <sui.Button disabled={debugging || isStarting} key='runbtn' className={`play-button ${isRunning ? "stop" : "play"}`} icon={isRunning ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
-                {restart ? <sui.Button disabled={isStarting} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
-                {run ? <sui.Button disabled={false} key='debugbtn' className={`debug-button ${debugging ? "red" : "orange"}`} icon="xicon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
+                {run ? <sui.Button disabled={debugging || isStarting} key='runbtn' className={`play-button ${isRunning || debugging ? "stop" : "play"}`} icon={isRunning ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
+                {restart ? <sui.Button disabled={debugging || isStarting} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
+                {run ? <sui.Button disabled={false} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="xicon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
                 {trace ? <sui.Button key='trace' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={this.toggleTrace} /> : undefined}
             </div>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -91,6 +91,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const run = true; // !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
         const restart = run && !simOpts.hideRestart;
         const trace = !!targetTheme.enableTrace;
+        const debug = targetTheme.debugger;
         const tracing = this.props.parent.state.tracing;
         const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debugging = parentState.debugging;
@@ -116,7 +117,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
                 {make ? <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} /> : undefined}
                 {run ? <sui.Button disabled={debugging || isStarting} key='runbtn' className={`play-button ${isRunning || debugging ? "stop" : "play"}`} icon={isRunning ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
                 {restart ? <sui.Button disabled={debugging || isStarting} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
-                {run ? <sui.Button disabled={false} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="xicon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
+                {run && debug ? <sui.Button disabled={false} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="xicon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
                 {trace ? <sui.Button key='trace' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={this.toggleTrace} /> : undefined}
             </div>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>


### PR DESCRIPTION
Rearranging controls toolbar in the toolbox.
Variable explorer:
- Show variables name on hover. Show variables value on hover for
{string, bool, number, array}
- Zebra decoration.
- Background change.

Reduced the amount of green.
Changed color of debug button in the simulator toolbar to be gray/orange for off/on.

![Variable Explorer v2 2 1](https://user-images.githubusercontent.com/5607882/54398694-59e96a80-4678-11e9-8acc-01dfbd01a4a4.PNG)
