### PR TITLE
Handle invalid block XML when creating flyout

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1303,6 +1303,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private blocksToString(xmlList: Element[]): string {
         let xmlSerializer: XMLSerializer = null;
         const serialize = (e: Element) => {
+            if (!e)
+                return "<!-- invalid block here! -->"
             if (e.outerHTML)
                 return e.outerHTML
             // The below code is only needed for IE 11 where outerHTML occassionally returns undefined :/


### PR DESCRIPTION
Before this fix, searching in Arcade would occasionally give you this error due to some invalid blocks xml (separate issue):

![image](https://user-images.githubusercontent.com/6453828/54535561-0dab6c80-498f-11e9-88e8-e9d0339a2a85.png)

When there's a problem with xml block xml, we should still gracefully handle the flyout.