### PR TITLE
Ensure "builtin" flag is correctly set for search results

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -753,7 +753,7 @@ namespace ts.pxtc.service {
 
             if (!lastFuse || search.subset) {
                 const weights: pxt.Map<number> = {};
-                let builtinSearchSet: SearchInfo[];
+                let builtinSearchSet: SearchInfo[] = [];
 
                 if (search.subset) {
                     tbSubset = search.subset;
@@ -782,6 +782,11 @@ namespace ts.pxtc.service {
                     return mappedSi;
                 });
 
+                // filter out built-ins from the main search set as those 
+                // should come from the built-in search set 
+                let builtinBlockIds: pxt.Map<Boolean> = {}
+                builtinSearchSet.forEach(b => builtinBlockIds[b.id] = true)
+                searchSet = searchSet.filter(b => !(b.id in builtinBlockIds));
 
                 let mw = 0;
                 subset.forEach(b => {


### PR DESCRIPTION
Before when searching for "string" you could see errors like this in the console:

![image](https://user-images.githubusercontent.com/6453828/54541288-e908c200-4999-11e9-9d96-3863edd42223.png)

This caused problems downstream occasionally (e.g. https://github.com/Microsoft/pxt/pull/5362)

This was because the builtin blocks (e.g. text_length) are supposed to have the "builtinBlock" flag set to true in the SearchInfo type, but this wasn't being correctly set because of an issue in how the builtin and non-builtin search sets where combined (the non-builtin search set included some builtins that overwrote the builtin search set).

After this PR, these errors no longer appear in the console.