### PR TITLE
Fix vtable emit when methods have shim

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1261,7 +1261,8 @@ namespace ts.pxtc {
             for (let m of inf.methods) {
                 bin.numMethods++
                 let minf = getFunctionInfo(m)
-                if (isToString(m)) {
+                const attrs = parseComments(m)
+                if (isToString(m) && !attrs.shim) {
                     inf.toStringMethod = lookupProc(m)
                     inf.toStringMethod.info.usedAsIface = true
                 }
@@ -1302,6 +1303,9 @@ namespace ts.pxtc {
                 for (let m of curr.methods) {
                     const n = getName(m)
                     if (isIfaceMemberUsed(n) || isUsed(m)) {
+                        const attrs = parseComments(m);
+                        if (attrs.shim) continue;
+
                         const proc = lookupProc(m)
                         const ex = inf.itable.find(e => e.name == n)
                         const isSet = m.kind == SK.SetAccessor


### PR DESCRIPTION
@mmoskal this is the fix I was talking about; the compiler was erroring out when trying to set `usedAsIface` on shim functions inside `getVTable()`, so I'm just checking to see if a shim exists and ignoring those methods.