### PR TITLE
Forcing restart when toggling slow-mo

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -138,6 +138,10 @@ namespace pxt.editor {
         event?: "start" | "stop";
     }
 
+    export interface SimulatorStartOptions {
+        clickTrigger?: boolean;
+    }
+
     export interface IProjectView {
         state: IAppState;
         setState(st: IAppState): void;
@@ -195,10 +199,10 @@ namespace pxt.editor {
 
         anonymousPublishAsync(screenshotUri?: string): Promise<string>;
 
-        startStopSimulator(clickTrigger?: boolean): void;
-        stopSimulator(unload?: boolean): void;
-        restartSimulator(debug?: boolean): void;
-        startSimulator(debug?: boolean, clickTrigger?: boolean): void;
+        startStopSimulator(opts?: SimulatorStartOptions): void;
+        stopSimulator(unload?: boolean, opts?: SimulatorStartOptions): void;
+        restartSimulator(): void;
+        startSimulator(opts?: SimulatorStartOptions): void;
         runSimulator(): void;
         isSimulatorRunning(): boolean;
         expandSimulator(): void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -1,6 +1,8 @@
 namespace pxt.editor {
     export enum SimState {
         Stopped,
+        // waiting to be started
+        Pending,
         Starting,
         Running
     }

--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -365,7 +365,8 @@ namespace pxsim {
                 case SimulatorState.Stopped:
                     this.sendEvent(new protocol.TerminatedEvent())
                     break;
-                case SimulatorState.Unloaded:
+                //case SimulatorState.Unloaded:
+                //case SimulatorState.Pending:
                 default:
             }
         }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -20,6 +20,7 @@ namespace pxsim {
     export enum SimulatorState {
         Unloaded,
         Stopped,
+        Pending,
         Starting,
         Running,
         Paused,
@@ -87,7 +88,11 @@ namespace pxsim {
             if (this.state == pxsim.SimulatorState.Running) this.suspend();
         }
 
-        setStarting() {
+        setPending() {
+            this.setState(SimulatorState.Pending);
+        }
+
+        private setStarting() {
             this.setState(SimulatorState.Starting);
         }
 
@@ -136,6 +141,7 @@ namespace pxsim {
             const loader = icon.nextElementSibling as HTMLElement;
             // apply state
             switch (this.state) {
+                case SimulatorState.Pending:
                 case SimulatorState.Starting:
                     icon.style.display = '';
                     icon.className = '';

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1871,7 +1871,7 @@ export class ProjectView
             simulator.setTraceInterval(intervalSpeed || simulator.SLOW_TRACE_INTERVAL);
         }
         this.setState({ tracing: !tracing, debugging: debugging && !tracing },
-            () => this.startSimulator())
+            () => this.restartSimulator())
     }
 
     setTrace(enabled: boolean, intervalSpeed?: number) {
@@ -2017,20 +2017,25 @@ export class ProjectView
         else {
             simulator.driver.restart(); // fast restart
         }
-        this.blocksEditor.setBreakpointsFromBlocks();
+        // TODO: typescript breakpoints
+        if (isDebug)
+            this.blocksEditor.setBreakpointsFromBlocks();
+        else    
+            this.blocksEditor.clearBreakpoints();
     }
 
     startSimulator(opts?: pxt.editor.SimulatorStartOptions) {
         pxt.tickEvent('simulator.start');
-        const dbg = this.state.debugging || this.state.tracing;
+        const isDebug = this.state.debugging || this.state.tracing;
+        const isDebugMatch = simulator.driver.isDebug() == isDebug;
         const clickTrigger = opts && opts.clickTrigger;
         pxt.debug(`start sim (autorun ${this.state.autoRun})`)
-        if (!this.shouldStartSimulator() && !dbg) {
+        if (!this.shouldStartSimulator() && isDebugMatch) {
             pxt.log("Ignoring call to start simulator, either already running or we shouldn't start.");
             return Promise.resolve();
         }
         return this.saveFileAsync()
-            .then(() => this.runSimulator({ debug: dbg, clickTrigger }))
+            .then(() => this.runSimulator({ debug: isDebug, clickTrigger }))
     }
 
     stopSimulator(unload?: boolean, opts?: pxt.editor.SimulatorStartOptions) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1873,7 +1873,7 @@ export class ProjectView
             simulator.setTraceInterval(intervalSpeed != undefined ? intervalSpeed : simulator.SLOW_TRACE_INTERVAL);
         }
         this.setState({ tracing: !tracing })
-        this.restartSimulatorTrace(!tracing);
+        this.startSimulator(true);
     }
 
     setTrace(enabled: boolean, intervalSpeed?: number) {
@@ -1882,7 +1882,7 @@ export class ProjectView
         }
         else if (this.state.tracing) {
             simulator.setTraceInterval(intervalSpeed != undefined ? intervalSpeed : simulator.SLOW_TRACE_INTERVAL);
-            this.restartSimulatorTrace();
+            this.startSimulator(true);
         }
     }
 
@@ -2019,15 +2019,6 @@ export class ProjectView
             simulator.driver.restart(); // fast restart
         }
         this.blocksEditor.setBreakpointsFromBlocks();
-    }
-
-    restartSimulatorTrace(trace?: boolean) {
-        if (this.state.simState == pxt.editor.SimState.Stopped
-            || this.state.tracing != !!trace)
-            this.startSimulator(true);
-        else {
-            simulator.driver.restart(); // fast restart
-        }
     }
 
     startSimulator(debug?: boolean, clickTrigger?: boolean) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -590,6 +590,7 @@ export class ProjectView
                     case pxsim.SimulatorState.Paused:
                     case pxsim.SimulatorState.Unloaded:
                     case pxsim.SimulatorState.Suspended:
+                    case pxsim.SimulatorState.Pending:
                     case pxsim.SimulatorState.Stopped:
                         this.setState({ simState: pxt.editor.SimState.Stopped });
                         break;
@@ -642,8 +643,8 @@ export class ProjectView
         if (!this.state.currFile.virtual) { // switching to serial should not reset the sim
             this.stopSimulator();
             if (simRunning || this.state.autoRun) {
-                simulator.driver.setStarting();
-                this.setState({ simState: pxt.editor.SimState.Starting });
+                simulator.setPending();
+                this.setState({ simState: pxt.editor.SimState.Pending });
             }
         }
         this.saveSettings();
@@ -1849,6 +1850,7 @@ export class ProjectView
     startStopSimulator(opts?: pxt.editor.SimulatorStartOptions) {
         switch (this.state.simState) {
             case pxt.editor.SimState.Starting:
+            case pxt.editor.SimState.Pending:
                 // button smashing, do nothing
                 break;
             case pxt.editor.SimState.Running:

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1868,11 +1868,10 @@ export class ProjectView
         if (tracing) {
             this.editor.clearHighlightedStatements();
             simulator.setTraceInterval(0);
+        } else {
+            simulator.setTraceInterval(intervalSpeed || simulator.SLOW_TRACE_INTERVAL);
         }
-        else {
-            simulator.setTraceInterval(intervalSpeed != undefined ? intervalSpeed : simulator.SLOW_TRACE_INTERVAL);
-        }
-        this.setState({ tracing: !tracing })
+        this.setState({ tracing: !tracing }, () => this.startSimulator(true))
         this.startSimulator(true);
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1864,15 +1864,16 @@ export class ProjectView
     }
 
     toggleTrace(intervalSpeed?: number) {
-        if (this.state.tracing) {
+        let tracing = this.state.tracing;
+        if (tracing) {
             this.editor.clearHighlightedStatements();
             simulator.setTraceInterval(0);
         }
         else {
             simulator.setTraceInterval(intervalSpeed != undefined ? intervalSpeed : simulator.SLOW_TRACE_INTERVAL);
         }
-        this.setState({ tracing: !this.state.tracing })
-        this.restartSimulator();
+        this.setState({ tracing: !tracing })
+        this.restartSimulatorTrace(!tracing);
     }
 
     setTrace(enabled: boolean, intervalSpeed?: number) {
@@ -1881,7 +1882,7 @@ export class ProjectView
         }
         else if (this.state.tracing) {
             simulator.setTraceInterval(intervalSpeed != undefined ? intervalSpeed : simulator.SLOW_TRACE_INTERVAL);
-            this.restartSimulator();
+            this.restartSimulatorTrace();
         }
     }
 
@@ -2018,6 +2019,15 @@ export class ProjectView
             simulator.driver.restart(); // fast restart
         }
         this.blocksEditor.setBreakpointsFromBlocks();
+    }
+
+    restartSimulatorTrace(trace?: boolean) {
+        if (this.state.simState == pxt.editor.SimState.Stopped
+            || this.state.tracing != !!trace)
+            this.startSimulator(true);
+        else {
+            simulator.driver.restart(); // fast restart
+        }
     }
 
     startSimulator(debug?: boolean, clickTrigger?: boolean) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2022,7 +2022,7 @@ export class ProjectView
         // TODO: typescript breakpoints
         if (isDebug)
             this.blocksEditor.setBreakpointsFromBlocks();
-        else    
+        else
             this.blocksEditor.clearBreakpoints();
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -50,7 +50,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     setBreakpointsFromBlocks(): void {
         let breakpoints: number[] = []
         let map = this.breakpointsByBlock;
-        if (map) {
+        if (map && this.editor) {
             this.editor.getAllBlocks().forEach(block => {
                 if (map[block.id] && block.isBreakpointSet()) {
                     breakpoints.push(this.breakpointsByBlock[block.id]);

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -232,7 +232,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
 
     restartSimulator() {
         pxt.tickEvent('debugger.restart', undefined, { interactiveConsent: true });
-        this.props.parent.restartSimulator(true);
+        this.props.parent.restartSimulator();
     }
 
     exitDebugging() {

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -61,7 +61,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
 
     startStopSimulator(view?: string) {
         pxt.tickEvent("editortools.startStopSimulator", { view: view, collapsed: this.getCollapsedState(), headless: this.getHeadlessState() }, { interactiveConsent: true });
-        this.props.parent.startStopSimulator(true);
+        this.props.parent.startStopSimulator({ clickTrigger: true });
     }
 
     restartSimulator(view?: string) {

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -34,12 +34,12 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
 
     startStopSimulator() {
         pxt.tickEvent('simulator.startstop', undefined, { interactiveConsent: true });
-        this.props.parent.startStopSimulator(true);
+        this.props.parent.startStopSimulator({ clickTrigger: true });
     }
 
     restartSimulator() {
         pxt.tickEvent('simulator.restart', undefined, { interactiveConsent: true });
-        this.props.parent.restartSimulator(this.props.parent.state.debugging);
+        this.props.parent.restartSimulator();
     }
 
     toggleTrace() {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -236,8 +236,8 @@ export function setDirty() { // running outdated code
     driver.setDirty();
 }
 
-export function setStarting() {
-    driver.setStarting();
+export function setPending() {
+    driver.setPending();
 }
 
 export function run(pkg: pxt.MainPackage, debug: boolean,


### PR DESCRIPTION
Fixing https://github.com/Microsoft/pxt-microbit/issues/1869.

- [x] cleaning up startSimulator/stopSimulator/restartSimulator to use the React state to determine if a debug build is necessary
- [x] use options bag in startSimulator to avoid unnoticed breaking changes
- [x] adding a "pending" state in the simulator driver that tells the IDE that an code operation has started (like blocks->js). pre-state before "starting" state.