### PR TITLE
Add ability to use extensions in docs

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -331,7 +331,7 @@ namespace pxt {
     export interface Host {
         readFile(pkg: Package, filename: string, skipAdditionalFiles?: boolean): string;
         writeFile(pkg: Package, filename: string, contents: string, force?: boolean): void;
-        downloadPackageAsync(pkg: Package, deps?: string[]): Promise<void>;
+        downloadPackageAsync(pkg: Package): Promise<void>;
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo>;
         cacheStoreAsync(id: string, val: string): Promise<void>;
         cacheGetAsync(id: string): Promise<string>; // null if not found

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -331,7 +331,7 @@ namespace pxt {
     export interface Host {
         readFile(pkg: Package, filename: string, skipAdditionalFiles?: boolean): string;
         writeFile(pkg: Package, filename: string, contents: string, force?: boolean): void;
-        downloadPackageAsync(pkg: Package, deps: string[]): Promise<void>;
+        downloadPackageAsync(pkg: Package, deps?: string[]): Promise<void>;
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo>;
         cacheStoreAsync(id: string, val: string): Promise<void>;
         cacheGetAsync(id: string): Promise<string>; // null if not found

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -331,7 +331,7 @@ namespace pxt {
     export interface Host {
         readFile(pkg: Package, filename: string, skipAdditionalFiles?: boolean): string;
         writeFile(pkg: Package, filename: string, contents: string, force?: boolean): void;
-        downloadPackageAsync(pkg: Package): Promise<void>;
+        downloadPackageAsync(pkg: Package, deps?: string[]): Promise<void>;
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo>;
         cacheStoreAsync(id: string, val: string): Promise<void>;
         cacheGetAsync(id: string): Promise<string>; // null if not found

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -331,7 +331,7 @@ namespace pxt {
     export interface Host {
         readFile(pkg: Package, filename: string, skipAdditionalFiles?: boolean): string;
         writeFile(pkg: Package, filename: string, contents: string, force?: boolean): void;
-        downloadPackageAsync(pkg: Package): Promise<void>;
+        downloadPackageAsync(pkg: Package, deps: string[]): Promise<void>;
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo>;
         cacheStoreAsync(id: string, val: string): Promise<void>;
         cacheGetAsync(id: string): Promise<string>; // null if not found

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -35,7 +35,7 @@ namespace pxt {
         private resolvedVersion: string;
         public ignoreTests = false;
         public cppOnly = false;
-        public depends: string[];
+        public dependLinks: string[];
 
         constructor(public id: string, public _verspec: string, public parent: MainPackage, addedBy: Package) {
             if (addedBy) {
@@ -156,7 +156,7 @@ namespace pxt {
             return Promise.resolve(v)
         }
 
-        private downloadAsync(deps: string[]) {
+        private downloadAsync() {
             return this.resolveVersionAsync()
                 .then(verNo => {
                     if (this.invalid()) {
@@ -167,7 +167,7 @@ namespace pxt {
                         this.config && this.config.installedVersion == verNo)
                         return undefined;
                     pxt.debug('downloading ' + verNo)
-                    return this.host().downloadPackageAsync(this, this.depends)
+                    return this.host().downloadPackageAsync(this)
                         .then(() => {
                             const confStr = this.readFile(pxt.CONFIG_NAME)
                             if (!confStr)
@@ -422,7 +422,7 @@ namespace pxt {
             return dependencies;
         }
 
-        loadAsync(isInstall = false, targetVersion?: string, deps?: string[]): Promise<void> {
+        loadAsync(isInstall = false, targetVersion?: string): Promise<void> {
             if (this.isLoaded) return Promise.resolve();
 
             let initPromise = Promise.resolve()
@@ -440,7 +440,7 @@ namespace pxt {
             }
 
             if (isInstall)
-                initPromise = initPromise.then(() => this.downloadAsync(deps))
+                initPromise = initPromise.then(() => this.downloadAsync())
 
             if (appTarget.simulator && appTarget.simulator.dynamicBoardDefinition) {
                 if (this.level == 0)
@@ -647,8 +647,8 @@ namespace pxt {
         }
 
         installAllAsync(targetVersion?: string, deps?: string[]) {
-            this.depends = deps;
-            return this.loadAsync(true, targetVersion, deps);
+            this.dependLinks = deps;
+            return this.loadAsync(true, targetVersion);
         }
 
         sortedDeps(includeCpp = false) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -4,7 +4,6 @@
 /// <reference path="util.ts"/>
 
 namespace pxt {
-
     export class Package {
         static getConfigAsync(pkgTargetVersion: string, id: string, fullVers: string): Promise<pxt.PackageConfig> {
             return Promise.resolve().then(() => {
@@ -439,9 +438,8 @@ namespace pxt {
                 initPromise = initPromise.then(() => this.parseConfig(str))
             }
 
-            if (isInstall) {
+            if (isInstall)
                 initPromise = initPromise.then(() => this.downloadAsync())
-            }
 
             if (appTarget.simulator && appTarget.simulator.dynamicBoardDefinition) {
                 if (this.level == 0)
@@ -506,6 +504,7 @@ namespace pxt {
                     }
                 })
             }
+
             return initPromise
                 .then(() => loadDepsRecursive(null, this))
                 .then(() => {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -4,6 +4,35 @@
 /// <reference path="util.ts"/>
 
 namespace pxt {
+
+    export class EditorPackage {
+        files: Map<string> = {};
+        id: string;
+
+        constructor(private ksPkg: pxt.Package, public topPkg: EditorPackage) {
+        }
+
+        getKsPkg() {
+            return this.ksPkg;
+        }
+
+        getPkgId() {
+            return this.ksPkg ? this.ksPkg.id : this.id;
+        }
+
+        isTopLevel() {
+            return this.ksPkg && this.ksPkg.level == 0;
+        }
+
+        setFiles(files: Map<string>) {
+            this.files = files;
+        }
+
+        getAllFiles() {
+            return Util.mapMap(this.files, (k, f) => f)
+        }
+    }
+
     export class Package {
         static getConfigAsync(pkgTargetVersion: string, id: string, fullVers: string): Promise<pxt.PackageConfig> {
             return Promise.resolve().then(() => {
@@ -35,6 +64,7 @@ namespace pxt {
         private resolvedVersion: string;
         public ignoreTests = false;
         public cppOnly = false;
+        public _editorPkg: EditorPackage;
 
         constructor(public id: string, public _verspec: string, public parent: MainPackage, addedBy: Package) {
             if (addedBy) {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -115,7 +115,7 @@ namespace pxt.runner {
                 else {
                     let padding = '81.97%';
                     if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
-                    let deps = options.package ? "&deps=" + options.package : "";
+                    let deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
                     let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($js.text())}${deps}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
                     $c.append($embed);
                 }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -716,7 +716,7 @@ namespace pxt.runner {
                     </div>
                     </div></div>`)
                 let deps = options.package;
-                $sim.find("iframe").attr("src", getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($c.text().trim()) + (deps ? "&deps=" + deps: ""));
+                $sim.find("iframe").attr("src", getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($c.text().trim()) + (deps ? "&deps=" + deps : ""));
                 if (options.snippetReplaceParent) $c = $c.parent();
                 $c.replaceWith($sim);
             });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -115,7 +115,8 @@ namespace pxt.runner {
                 else {
                     let padding = '81.97%';
                     if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
-                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($js.text())}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
+                    let deps = options.package ? "&deps=" + options.package : "";
+                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($js.text())}${deps}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
                     $c.append($embed);
                 }
             })
@@ -714,7 +715,8 @@ namespace pxt.runner {
                     <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" allowfullscreen="allowfullscreen" frameborder="0" sandbox="allow-popups allow-forms allow-scripts allow-same-origin"></iframe>
                     </div>
                     </div></div>`)
-                $sim.find("iframe").attr("src", getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($c.text().trim()));
+                let deps = options.package;
+                $sim.find("iframe").attr("src", getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($c.text().trim()) + (deps ? "&deps=" + deps: ""));
                 if (options.snippetReplaceParent) $c = $c.parent();
                 $c.replaceWith($sim);
             });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -115,8 +115,9 @@ namespace pxt.runner {
                 else {
                     let padding = '81.97%';
                     if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
-                    let deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
-                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($js.text())}${deps}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
+                    const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
+                    const url = getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($js.text()) + deps;
+                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
                     $c.append($embed);
                 }
             })
@@ -715,8 +716,9 @@ namespace pxt.runner {
                     <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" allowfullscreen="allowfullscreen" frameborder="0" sandbox="allow-popups allow-forms allow-scripts allow-same-origin"></iframe>
                     </div>
                     </div></div>`)
-                let deps = options.package;
-                $sim.find("iframe").attr("src", getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($c.text().trim()) + (deps ? "&deps=" + deps : ""));
+                const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
+                const url = getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($c.text().trim()) + deps;
+                $sim.find("iframe").attr("src", url);
                 if (options.snippetReplaceParent) $c = $c.parent();
                 $c.replaceWith($sim);
             });

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -14,7 +14,7 @@ namespace pxt.runner {
         highContrast?: boolean;
         light?: boolean;
         fullScreen?: boolean;
-        deps?: string[]
+        dependencies?: string[]
     }
 
     class EditorPackage {
@@ -92,7 +92,7 @@ namespace pxt.runner {
         }
 
         private githubPackageCache: pxt.Map<Map<string>> = {};
-        downloadPackageAsync(pkg: pxt.Package, deps?: string[]) {
+        downloadPackageAsync(pkg: pxt.Package, dependencies?: string[]) {
             let proto = pkg.verProtocol()
             let cached: pxt.Map<string> = undefined;
             // cache resolve github packages
@@ -111,10 +111,10 @@ namespace pxt.runner {
                         if (Object.keys(epkg.files).length == 0) {
                             epkg.setFiles(emptyPrjFiles())
                         }
-                        if (deps) {
+                        if (dependencies) {
                             let files = getEditorPkg(pkg).files;
                                 let cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-                                deps.forEach((dep: string) => {
+                                dependencies.forEach((dep: string) => {
                                     if (dep.indexOf("=") > 0) {
                                         let ids = /(\S+)=(\S+:\S+)/.exec(dep);
                                         let id = ids[1];
@@ -231,7 +231,7 @@ namespace pxt.runner {
     }
 
     let previousMainPackage: pxt.MainPackage = undefined;
-    function loadPackageAsync(id: string, code?: string, deps?: string[]) {
+    function loadPackageAsync(id: string, code?: string, dependencies?: string[]) {
         const verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj";
         let host: pxt.Host;
         let downloadPackagePromise: Promise<void>;
@@ -245,7 +245,7 @@ namespace pxt.runner {
             host = mainPkg.host();
             mainPkg = new pxt.MainPackage(host)
             mainPkg._verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj"
-            downloadPackagePromise = host.downloadPackageAsync(mainPkg, deps);
+            downloadPackagePromise = host.downloadPackageAsync(mainPkg, dependencies);
             installPromise = mainPkg.installAllAsync();
             // cache previous package
             previousMainPackage = mainPkg;
@@ -313,7 +313,7 @@ namespace pxt.runner {
     }
 
     export function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
-        return loadPackageAsync(simOptions.id, simOptions.code, simOptions.deps)
+        return loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies)
             .then(() => compileAsync(false, opts => {
                 if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
             }))

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -112,19 +112,19 @@ namespace pxt.runner {
                             epkg.setFiles(emptyPrjFiles())
                         }
                         if (dependencies) {
-                            let files = getEditorPkg(pkg).files;
-                                let cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-                                dependencies.forEach((dep: string) => {
-                                    if (dep.indexOf("=") > 0) {
-                                        let ids = /(\S+)=(\S+:\S+)/.exec(dep);
-                                        let id = ids[1];
-                                        let ver = ids[2];
-                                        cfg.dependencies[id] = ver;
-                                    } else {
-                                        cfg.dependencies[dep] = "*";
-                                    }
-                                });
-                                files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
+                            const files = getEditorPkg(pkg).files;
+                            const cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
+                            dependencies.forEach((dep: string) => {
+                                if (dep.indexOf("=") > 0) {
+                                    const ids = /(\S+)=(\S+:\S+)/.exec(dep);
+                                    const id = ids[1];
+                                    const ver = ids[2];
+                                    cfg.dependencies[id] = ver;
+                                } else {
+                                    cfg.dependencies[dep] = "*";
+                                }
+                            });
+                            files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
                         }
                         return Promise.resolve()
                     } else if (proto == "docs") {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -99,8 +99,8 @@ namespace pxt.runner {
             // cache resolve github packages
             if (proto == "github")
                 cached = this.githubPackageCache[pkg._verspec];
-
             let epkg = getEditorPkg(pkg)
+
             return (cached ? Promise.resolve(cached) : pkg.commonDownloadAsync())
                 .then(resp => {
                     if (resp) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -264,11 +264,11 @@ namespace pxt.runner {
     }
 
     function loadDependencies(pkg: pxt.Package) {
-        if (pkg.depends) {
+        if (pkg.dependLinks) {
             console.log("loading dependencices")
             let epkg = getEditorPkg(pkg)
             let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-            pkg.depends.forEach((dep: string) => {
+            pkg.dependLinks.forEach((dep: string) => {
                 if (dep.indexOf("=") > 0) {
                     let ids =/(\S+)=(\S+:\S+)/.exec(dep);
                     let id = ids[1];

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -270,7 +270,7 @@ namespace pxt.runner {
             let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
             pkg.dependLinks.forEach((dep: string) => {
                 if (dep.indexOf("=") > 0) {
-                    let ids =/(\S+)=(\S+:\S+)/.exec(dep);
+                    let ids = /(\S+)=(\S+:\S+)/.exec(dep);
                     let id = ids[1];
                     let ver = ids[2];
                     cfg.dependencies[id] = ver;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -17,34 +17,6 @@ namespace pxt.runner {
         deps?: string[]
     }
 
-    class EditorPackage {
-        files: Map<string> = {};
-        id: string;
-
-        constructor(private ksPkg: pxt.Package, public topPkg: EditorPackage) {
-        }
-
-        getKsPkg() {
-            return this.ksPkg;
-        }
-
-        getPkgId() {
-            return this.ksPkg ? this.ksPkg.id : this.id;
-        }
-
-        isTopLevel() {
-            return this.ksPkg && this.ksPkg.level == 0;
-        }
-
-        setFiles(files: Map<string>) {
-            this.files = files;
-        }
-
-        getAllFiles() {
-            return Util.mapMap(this.files, (k, f) => f)
-        }
-    }
-
     class Host
         implements pxt.Host {
 
@@ -142,15 +114,15 @@ namespace pxt.runner {
     export let mainPkg: pxt.MainPackage;
 
     function getEditorPkg(p: pxt.Package) {
-        let r: EditorPackage = (p as any)._editorPkg
+        let r: pxt.EditorPackage = p._editorPkg
         if (r) return r
-        let top: EditorPackage = null
+        let top: pxt.EditorPackage = null
         if (p != mainPkg)
             top = getEditorPkg(mainPkg)
-        let newOne = new EditorPackage(p, top)
+        let newOne = new pxt.EditorPackage(p, top)
         if (p == mainPkg)
             newOne.topPkg = newOne;
-        (p as any)._editorPkg = newOne
+        p._editorPkg = newOne
         return newOne
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -110,7 +110,6 @@ namespace pxt.runner {
                     }
                     if (proto == "empty") {
                         epkg.setFiles(emptyPrjFiles())
-                        loadDependencies(pkg);
                         return Promise.resolve()
                     } else if (proto == "docs") {
                         let files = emptyPrjFiles();
@@ -231,7 +230,7 @@ namespace pxt.runner {
             mainPkg = new pxt.MainPackage(host)
             mainPkg._verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj"
             downloadPackagePromise = host.downloadPackageAsync(mainPkg);
-            installPromise = mainPkg.installAllAsync("",deps)
+            installPromise = mainPkg.installAllAsync("", deps);
             // cache previous package
             previousMainPackage = mainPkg;
         }
@@ -261,25 +260,6 @@ namespace pxt.runner {
                     showError(lf("Cannot load extension: {0}", e.message))
                 })
             });
-    }
-
-    function loadDependencies(pkg: pxt.Package) {
-        if (pkg.dependLinks) {
-            console.log("loading dependencices")
-            let epkg = getEditorPkg(pkg)
-            let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-            pkg.dependLinks.forEach((dep: string) => {
-                if (dep.indexOf("=") > 0) {
-                    let ids = /(\S+)=(\S+:\S+)/.exec(dep);
-                    let id = ids[1];
-                    let ver = ids[2];
-                    cfg.dependencies[id] = ver;
-                } else {
-                    cfg.dependencies[dep] = "*";
-                }
-            });
-            epkg.files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
-        }
     }
 
     function getCompileOptionsAsync(hex?: boolean) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -93,32 +93,19 @@ namespace pxt.runner {
         }
 
         private githubPackageCache: pxt.Map<Map<string>> = {};
-        downloadPackageAsync(pkg: pxt.Package, deps?: string[]) {
+        downloadPackageAsync(pkg: pxt.Package) {
             let proto = pkg.verProtocol()
             let cached: pxt.Map<string> = undefined;
             // cache resolve github packages
             if (proto == "github")
                 cached = this.githubPackageCache[pkg._verspec];
             let epkg = getEditorPkg(pkg)
-
-            if (pkg.depends) {
-                loadDependencies(pkg);
-            }
-            if (deps) {
-                loadDependencies(pkg, deps);
-            }
             return (cached ? Promise.resolve(cached) : pkg.commonDownloadAsync())
                 .then(resp => {
                     if (resp) {
                         if (proto == "github" && !cached)
                             this.githubPackageCache[pkg._verspec] = Util.clone(resp);
                         epkg.setFiles(resp)
-                        //if (pkg.depends) {
-                        //    loadDependencies(pkg);
-                        //}
-                        //let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-                        //cfg.dependencies["pxt-stats"] = "github:chasemor/pxt-stats#f4df403898b26a2cac020417b84d32dd15db6841"
-                        //epkg.files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
                         return Promise.resolve()
                     }
                     if (proto == "empty") {
@@ -138,14 +125,10 @@ namespace pxt.runner {
                             } else
                                 console.warn(`unknown package syntax ${d}`)
                         });
-                        //cfg.dependencies["pxt-stats"] = "github:chasemor/pxt-stats#f4df403898b26a2cac020417b84d32dd15db6841"
                         if (!cfg.yotta) cfg.yotta = {};
                         cfg.yotta.ignoreConflicts = true;
                         files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
                         epkg.setFiles(files);
-                        //if (pkg.depends) {
-                        //    loadDependencies(pkg);
-                        //}
                         return Promise.resolve();
                     } else if (proto == "invalid") {
                         pxt.log(`skipping invalid pkg ${pkg.id}`);
@@ -233,8 +216,8 @@ namespace pxt.runner {
     }
 
     let previousMainPackage: pxt.MainPackage = undefined;
-    function loadPackageAsync(simOptions: SimulateOptions | string, code?: string) {
-        const id = typeof simOptions == "string" ? simOptions : simOptions.id;
+    function loadPackageAsync(simOptions: string, code?: string, deps?: string[]) {
+        const id = simOptions;
         const verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj";
         let host: pxt.Host;
         let downloadPackagePromise: Promise<void>;
@@ -249,12 +232,7 @@ namespace pxt.runner {
             mainPkg = new pxt.MainPackage(host)
             mainPkg._verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj"
             downloadPackagePromise = host.downloadPackageAsync(mainPkg);
-            if (typeof simOptions == "object" && simOptions.deps) {
-                //loadDependencies(mainPkg, simOptions.deps);
-                installPromise = mainPkg.installAllAsync("",simOptions.deps)
-            } else {
-                installPromise = mainPkg.installAllAsync()
-            }
+            installPromise = mainPkg.installAllAsync("",deps)
             // cache previous package
             previousMainPackage = mainPkg;
         }
@@ -286,29 +264,22 @@ namespace pxt.runner {
             });
     }
 
-    function loadDependencies(pkg: pxt.Package, deps?: string[]) {
-        deps = pkg.depends;
-        if (deps) {
+    function loadDependencies(pkg: pxt.Package) {
+        if (pkg.depends) {
             console.log("loading dependencices")
             let epkg = getEditorPkg(pkg)
             let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-            deps.forEach((dep: string) => {
+            pkg.depends.forEach((dep: string) => {
                 if (dep.indexOf("=") > 0) {
                     let ids =/(\S+)=(\S+:\S+)/.exec(dep);
                     let id = ids[1];
                     let ver = ids[2];
-                    //cfg.dependencies["pxt-stats"] = "github:chasemor/pxt-stats#f4df403898b26a2cac020417b84d32dd15db6841"
                     cfg.dependencies[id] = ver;
-                    //mainPkg.deps[id] = new Package(id, ver, mainPkg, mainPkg)
                 } else {
                     cfg.dependencies[dep] = "*";
                 }
-                //cfg.dependencies["pxt-stats"] = "github:chasemor/pxt-stats#f4df403898b26a2cac020417b84d32dd15db6841"
-                //mainPkg.deps[id] = new Package(id, ver, mainPkg, mainPkg)
             });
             epkg.files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
-        } else {
-            console.log("No dependencies given");
         }
     }
 
@@ -347,7 +318,7 @@ namespace pxt.runner {
     }
 
     export function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
-        return loadPackageAsync(simOptions)
+        return loadPackageAsync(simOptions.id, simOptions.code, simOptions.deps)
             .then(() => compileAsync(false, opts => {
                 if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
             }))

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -44,6 +44,7 @@ namespace pxt.runner {
             return Util.mapMap(this.files, (k, f) => f)
         }
     }
+
     class Host
         implements pxt.Host {
 
@@ -98,6 +99,7 @@ namespace pxt.runner {
             // cache resolve github packages
             if (proto == "github")
                 cached = this.githubPackageCache[pkg._verspec];
+
             let epkg = getEditorPkg(pkg)
             return (cached ? Promise.resolve(cached) : pkg.commonDownloadAsync())
                 .then(resp => {
@@ -129,6 +131,7 @@ namespace pxt.runner {
                                 return;
                             }
                         });
+
                         if (!cfg.yotta) cfg.yotta = {};
                         cfg.yotta.ignoreConflicts = true;
                         files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
@@ -158,7 +161,7 @@ namespace pxt.runner {
     }
 
     function getEditorPkg(p: pxt.Package) {
-        let r: EditorPackage = (p as any)._editorPkg;
+        let r: EditorPackage = (p as any)._editorPkg
         if (r) return r
         let top: EditorPackage = null
         if (p != mainPkg)
@@ -246,7 +249,7 @@ namespace pxt.runner {
             mainPkg = new pxt.MainPackage(host)
             mainPkg._verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj"
             downloadPackagePromise = host.downloadPackageAsync(mainPkg, dependencies);
-            installPromise = mainPkg.installAllAsync();
+            installPromise = mainPkg.installAllAsync()
             // cache previous package
             previousMainPackage = mainPkg;
         }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -216,8 +216,7 @@ namespace pxt.runner {
     }
 
     let previousMainPackage: pxt.MainPackage = undefined;
-    function loadPackageAsync(simOptions: string, code?: string, deps?: string[]) {
-        const id = simOptions;
+    function loadPackageAsync(id: string, code?: string, deps?: string[]) {
         const verspec = id ? /\w+:\w+/.test(id) ? id : "pub:" + id : "empty:tsprj";
         let host: pxt.Host;
         let downloadPackagePromise: Promise<void>;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -113,7 +113,7 @@ namespace pxt.runner {
                         if (Object.keys(epkg.files).length == 0) {
                             epkg.setFiles(emptyPrjFiles())
                         }
-                        if (dependencies) {
+                        if (dependencies && dependencies.length) {
                             const files = getEditorPkg(pkg).files;
                             const cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
                             dependencies.forEach((d: string) => {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -167,7 +167,7 @@
                     highContrast: highContrast,
                     light: light,
                     fullScreen: fullScreen,
-                    deps: deps ? deps[1].split(",") : undefined
+                    dependencies: deps ? deps[1].split(",") : undefined
                 };
                 console.log('simulating script')
                 pxt.runner.simulateAsync(sims, options).done(function() {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -167,7 +167,7 @@
                     highContrast: highContrast,
                     light: light,
                     fullScreen: fullScreen,
-                    deps: deps ? deps[1].split(",") : undefined,
+                    deps: deps ? deps[1].split(",") : undefined
                 };
                 console.log('simulating script')
                 pxt.runner.simulateAsync(sims, options).done(function() {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -112,6 +112,7 @@
         var highContrast = !!/hc(?:[:=])1/i.exec(window.location.href);
         var light = !!/light(?:[:=])1/i.exec(window.location.href);
         var fullScreen = !!/fullscreen(?:[:=])1/i.exec(window.location.href);
+        var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
 
         if (!id && !code && !debugSim) {
             console.error("missing id or code");
@@ -165,7 +166,8 @@
                     code: code ? decodeURIComponent(code[1]) : undefined,
                     highContrast: highContrast,
                     light: light,
-                    fullScreen: fullScreen
+                    fullScreen: fullScreen,
+                    deps: deps ? deps[1].split(",") : undefined,
                 };
                 console.log('simulating script')
                 pxt.runner.simulateAsync(sims, options).done(function() {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -167,7 +167,7 @@
                     highContrast: highContrast,
                     light: light,
                     fullScreen: fullScreen,
-                    dependencies: deps ? deps[1].split(",") : undefined
+                    dependencies: deps ? decodeURIComponent(deps[1]).split(",") : undefined
                 };
                 console.log('simulating script')
                 pxt.runner.simulateAsync(sims, options).done(function() {


### PR DESCRIPTION
At the moment, simulators in the docs cannot use extensions as noted in Microsoft/pxt-arcade#242.

However, there is a way to include external packages for blocks rendering using the \```package macro.

This uses those packages and sends them to the embedded simulator through the url like the code is sent.

Once received, when generating the initial files for the project, this adds those dependencies to the pxt.json so it loads them just like a normal project.

fixes Microsoft/pxt-arcade#242