### PR TITLE
 Adding ability to run getters in the debugger.

### DIFF
--- a/localtypings/pxtparts.d.ts
+++ b/localtypings/pxtparts.d.ts
@@ -209,6 +209,7 @@ declare namespace pxsim {
 
     export interface VariablesRequestMessage extends DebuggerMessage {
         variablesReference: string;
+        fields?: string[]
     }
 
     export interface VariablesMessage extends DebuggerMessage {

--- a/localtypings/vscode-debug-protocol.d.ts
+++ b/localtypings/vscode-debug-protocol.d.ts
@@ -519,7 +519,7 @@ declare namespace DebugProtocol {
         start?: number;
         /** The number of variables to return. If count is missing or 0, all variables are returned. */
         count?: number;
-        /** The variable's fields to get. If missing, all variables returned. */
+        /** The variable's fields to get. */
         fields?: string[];
     }
     /** Response to 'variables' request. */

--- a/localtypings/vscode-debug-protocol.d.ts
+++ b/localtypings/vscode-debug-protocol.d.ts
@@ -519,6 +519,8 @@ declare namespace DebugProtocol {
         start?: number;
         /** The number of variables to return. If count is missing or 0, all variables are returned. */
         count?: number;
+        /** The variable's fields to get. If missing, all variables returned. */
+        fields?: string[];
     }
     /** Response to 'variables' request. */
     export interface VariablesResponse extends Response {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -158,6 +158,7 @@ namespace ts.pxtc {
         advanced?: boolean;
         deprecated?: boolean;
         useEnumVal?: boolean; // for conversion from typescript to blocks with enumVal
+        callInDebugger?: boolean; // for getters, they will be invoked by the debugger.
         // On block
         subcategory?: string;
         group?: string;
@@ -717,7 +718,8 @@ namespace ts.pxtc {
         "enumIsBitMask",
         "enumIsHash",
         "decompileIndirectFixedInstances",
-        "topblock"
+        "topblock",
+        "callInDebugger",
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {

--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -156,21 +156,24 @@ namespace pxsim {
     }
 
     function evalGetter(fn: LabelFn, target: RefObject) {
-        let p: any = {
+        // This function evaluates a getter, and we assume it doesn't have any side effects.
+        let parentFrame: any = {
         };
 
-        let s: any = {
+        // We create a dummy stack frame
+        let stackFrame: any = {
             pc: 0,
             arg0: target,
             fn,
-            parent: p
+            parent: parentFrame
         };
 
-        while (s.fn) {
-            s = s.fn(s as any);
+        // And we evaluate the getter
+        while (stackFrame.fn) {
+            stackFrame = stackFrame.fn(stackFrame as any);
         }
 
-        return s.retval;
+        return stackFrame.retval;
     }
 
     export function getBreakpointMsg(s: pxsim.StackFrame, brkId: number): { msg: DebuggerBreakpointMessage, heap: Map<any> } {

--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -135,8 +135,7 @@ namespace pxsim {
             if (frame.fields && fields) {
                 // Fields of an object.
                 for (let k of fields) {
-                    k = k.substring(k.lastIndexOf(".") + 1)
-                    r[k] = valToJSON(evalGetter(frame.vtable.iface[k], frame));
+                    r[k] = valToJSON(evalGetter(frame.vtable.iface[k.substring(k.lastIndexOf(".") + 1)], frame));
                 }
             } else if (frame.fields) {
                 for (let k of Object.keys(frame.fields)) {

--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -135,10 +135,12 @@ namespace pxsim {
             if (frame.fields && fields) {
                 // Fields of an object.
                 for (let k of fields) {
-                    r[k] = valToJSON(evalGetter(frame.vtable.iface[k.substring(k.lastIndexOf(".") + 1)], frame));
+                    k = k.substring(k.lastIndexOf(".") + 1);
+                    r[k] = valToJSON(evalGetter(frame.vtable.iface[k], frame));
                 }
-            } else if (frame.fields) {
-                for (let k of Object.keys(frame.fields)) {
+            }
+            if (frame.fields) {
+                for (let k of Object.keys(frame.fields).filter(field => !field.startsWith('_'))) {
                     r[k.replace(/___\d+$/, '')] = valToJSON(frame.fields[k])
                 }
             } else if (Array.isArray(frame.data)) {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -319,7 +319,7 @@ namespace pxsim {
         private awaiters: ((v?: any) => void)[] = [];
         private lock: boolean;
         private _handlers: RefAction[] = [];
-        private _addRemoveLog: { act: RefAction, log: LogType}[] = [];
+        private _addRemoveLog: { act: RefAction, log: LogType }[] = [];
 
         constructor(public runtime: Runtime, private valueToArgs?: EventValueToActionArgs<T>) { }
 
@@ -384,9 +384,9 @@ namespace pxsim {
                 this._handlers = [a];
                 pxtcore.incr(a)
             } else {
-                this._addRemoveLog.push({act: a, log: LogType.UserSet});
+                this._addRemoveLog.push({ act: a, log: LogType.UserSet });
             }
-    }
+        }
 
         addHandler(a: RefAction) {
             if (!this.lock) {
@@ -397,7 +397,7 @@ namespace pxsim {
                     pxtcore.incr(a)
                 }
             } else {
-                this._addRemoveLog.push({act: a, log: LogType.BackAdd});
+                this._addRemoveLog.push({ act: a, log: LogType.BackAdd });
             }
         }
 
@@ -405,11 +405,11 @@ namespace pxsim {
             if (!this.lock) {
                 let index = this._handlers.indexOf(a)
                 if (index != -1) {
-                    this._handlers.splice(index,1)
+                    this._handlers.splice(index, 1)
                     pxtcore.decr(a)
                 }
             } else {
-                this._addRemoveLog.push({act: a, log: LogType.BackRemove});
+                this._addRemoveLog.push({ act: a, log: LogType.BackRemove });
             }
         }
 
@@ -818,7 +818,7 @@ namespace pxsim {
                         if (dbgHeap) {
                             const v = dbgHeap[vmsg.variablesReference];
                             if (v !== undefined)
-                                vars = dumpHeap(v, dbgHeap);
+                                vars = dumpHeap(v, dbgHeap, vmsg.fields);
                         }
                         Runtime.postMessage(<pxsim.VariablesMessage>{
                             type: "debugger",

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -557,8 +557,8 @@ namespace pxsim {
             this.postDebuggerMessage("traceConfig", { interval: intervalMs });
         }
 
-        public variablesAsync(id: number): Promise<VariablesMessage> {
-            return this.postDebuggerMessageAsync("variables", { variablesReference: id } as DebugProtocol.VariablesArguments)
+        public variablesAsync(id: number, fields?: string[]): Promise<VariablesMessage> {
+            return this.postDebuggerMessageAsync("variables", { variablesReference: id, fields: fields } as DebugProtocol.VariablesArguments)
                 .then(msg => msg as VariablesMessage, e => undefined)
         }
 

--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -19,6 +19,11 @@
 
 /* Debugger toolbar */
 .debugtoolbar {
+    // don't show the toolbar unless we're debugging.
+    display: none;
+}
+
+.debugging .debugtoolbar {
     width: 100%;
     z-index: @debuggerToolsZIndex;
     display: flex;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1436,7 +1436,7 @@ export class ProjectView
         if (this.editor) this.editor.unloadFileAsync();
         // clear the hash
         pxt.BrowserUtils.changeHash("", true);
-        this.setState({ home: true, tracing: undefined, fullscreen: undefined, tutorialOptions: undefined, editorState: undefined });
+        this.setState({ home: true, tracing: undefined, fullscreen: undefined, tutorialOptions: undefined, editorState: undefined, debugging: undefined });
         this.allEditors.forEach(e => e.setVisible(false));
         this.homeLoaded();
         this.showPackageErrorsOnNextTypecheck();

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -582,7 +582,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     updateToolbox(debugging: boolean) {
         let debuggerToolbox = debugging ? <div>
             <debug.DebuggerToolbar parent={this.parent} />
-            <debug.DebuggerVariables ref={this.handleDebuggerVariablesRef} parent={this.parent} />
+            <debug.DebuggerVariables ref={this.handleDebuggerVariablesRef} parent={this.parent} apisByQName={this.blockInfo.apis.byQName} />
         </div> : <div />;
         Util.assert(!!this.debuggerToolboxDiv)
         if (debugging) {

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -108,7 +108,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             let fieldsToGet: string[] = [];
             potentialKeys.forEach(key => {
                 let commentAttrs = allApis[key];
-                if (!key.endsWith("@set") && commentAttrs && commentAttrs.attributes.dbgDisplayName) {
+                if (!key.endsWith("@set") && commentAttrs && commentAttrs.attributes.callInDebugger) {
                     fieldsToGet.push(key);
                 }
             });
@@ -125,8 +125,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                         } else {
                             let children: pxt.Map<Variable> = {};
                             Object.keys(msg.variables).forEach(variableName => {
-                                let variableDisplayName = (allApis[variableName] && allApis[variableName].attributes.dbgDisplayName) ? allApis[variableName].attributes.dbgDisplayName : variableName
-                                children[variableDisplayName] = { value: msg.variables[variableName] }
+                                children[variableName] = { value: msg.variables[variableName] }
                             })
                             v.children = children;
                         }

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -18,6 +18,7 @@ interface Variable {
 }
 
 interface DebuggerVariablesProps extends ISettingsProps {
+    apisByQName: pxt.Map<pxtc.SymbolInfo>;
 }
 
 export class DebuggerVariables extends data.Component<DebuggerVariablesProps, DebuggerVariablesState> {
@@ -100,15 +101,34 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             this.setState({ variables: this.state.variables })
         } else {
             if (!v.value.id) return;
-            simulator.driver.variablesAsync(v.value.id)
+            // We filter the getters we want to call for this variable.
+            let allApis = this.props.apisByQName;
+            let matcher = new RegExp("^((.+\.)?" + v.value.type + ")\.");
+            let potentialKeys = Object.keys(allApis).filter(key => matcher.test(key));
+            let fieldsToGet: string[] = [];
+            potentialKeys.forEach(key => {
+                let commentAttrs = allApis[key];
+                if (!key.endsWith("@set") && commentAttrs && commentAttrs.attributes.dbgDisplayName) {
+                    fieldsToGet.push(key);
+                }
+            });
+            simulator.driver.variablesAsync(v.value.id, fieldsToGet)
                 .then((msg: pxsim.VariablesMessage) => {
                     if (msg) {
-                        v.children = pxt.Util.mapMap(msg.variables || {},
-                            (k, v) => {
-                                return {
-                                    value: msg.variables[k]
-                                }
-                            });
+                        if (v.value.type == "array") {
+                            v.children = pxt.Util.mapMap(msg.variables || {},
+                                (k, v) => {
+                                    return {
+                                        value: msg.variables[k]
+                                    }
+                                });
+                        } else {
+                            let children: pxt.Map<Variable> = {};
+                            Object.keys(msg.variables).forEach(variableName => {
+                                children[variableName] = { value: msg.variables[variableName] }
+                            })
+                            v.children = children;
+                        }
                         this.setState({ variables: this.state.variables })
                     }
                 })
@@ -161,7 +181,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             })
         }
         depth = depth || 0;
-        let margin = depth * 1.5 + 'em';
+        let margin = depth * 0.75 + 'em';
         varNames.forEach(variable => {
             const v = variables[variable];
             const oldValue = DebuggerVariables.renderValue(v.prevValue);

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -125,7 +125,8 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                         } else {
                             let children: pxt.Map<Variable> = {};
                             Object.keys(msg.variables).forEach(variableName => {
-                                children[variableName] = { value: msg.variables[variableName] }
+                                let variableDisplayName = (allApis[variableName] && allApis[variableName].attributes.dbgDisplayName) ? allApis[variableName].attributes.dbgDisplayName : variableName
+                                children[variableDisplayName] = { value: msg.variables[variableName] }
                             })
                             v.children = children;
                         }


### PR DESCRIPTION
We add the ability to run getters in the debugger. 
When sending a variable's children request, now we can specify which ones of the class getters we should call to obtain values.

On the webapp side, we use this api to get getters marked to be displayed in their comment attributes.