### PR TITLE
Numbertostringblock

### DIFF
--- a/common-docs/reference/math/to-string.md
+++ b/common-docs/reference/math/to-string.md
@@ -1,0 +1,7 @@
+# to string
+
+Converts a number into its text representation
+
+```sig
+(123).toString()
+```

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -352,7 +352,7 @@ declare interface Number {
      */
     //% help=math/to-string
     //% blockId=numberToString 
-    //% block="convert %number| to string"
+    //% block="convert %n| to string"
     //% blockNamespace="Math"
     //% weight=1
     //% shim=numops::toString

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -350,6 +350,10 @@ declare interface Number {
     /**
      * Returns a string representation of a number.
      */
+    //% help=math/to-string
+    //% blockId=numberToString block="convert $value to string"
+    //% blockNamespace=Math
+    //% weight=1
     //% shim=numops::toString
     toString(): string;
 }

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -351,8 +351,9 @@ declare interface Number {
      * Returns a string representation of a number.
      */
     //% help=math/to-string
-    //% blockId=numberToString block="convert $value to string"
-    //% blockNamespace=Math
+    //% blockId=numberToString 
+    //% block="convert %number| to string"
+    //% blockNamespace="Math"
     //% weight=1
     //% shim=numops::toString
     toString(): string;

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -352,7 +352,7 @@ declare interface Number {
      */
     //% help=math/to-string
     //% blockId=numberToString 
-    //% block="convert %number| to string"
+    //% block="convert %n| to string"
     //% blockNamespace="Math"
     //% weight=1
     //% shim=numops::toString

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -350,6 +350,10 @@ declare interface Number {
     /**
      * Returns a string representation of a number.
      */
+    //% help=math/to-string
+    //% blockId=numberToString block="convert %this to string"
+    //% blockNamespace="Math"
+    //% weight=-1
     //% shim=numops::toString
     toString(): string;
 }

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -351,9 +351,10 @@ declare interface Number {
      * Returns a string representation of a number.
      */
     //% help=math/to-string
-    //% blockId=numberToString block="convert %this to string"
+    //% blockId=numberToString 
+    //% block="convert %number| to string"
     //% blockNamespace="Math"
-    //% weight=-1
+    //% weight=1
     //% shim=numops::toString
     toString(): string;
 }


### PR DESCRIPTION
Block to convert number to string, should we expose "Object.toString" ?
![image](https://user-images.githubusercontent.com/4175913/54775639-a62e3080-4bcb-11e9-8bd6-223642ed7dcb.png)

Fix for https://github.com/Microsoft/pxt-microbit/issues/1637