### PR TITLE
Semver star

### DIFF
--- a/pxtlib/semver.ts
+++ b/pxtlib/semver.ts
@@ -59,6 +59,15 @@ namespace pxt.semver {
     }
 
     export function tryParse(v: string): Version {
+        if (/\*/.test(v)) {
+            return {
+                major: Number.MAX_SAFE_INTEGER,
+                minor: Number.MAX_SAFE_INTEGER,
+                patch: Number.MAX_SAFE_INTEGER,
+                pre: [],
+                build: []
+            };
+        }
         if (/^v\d/i.test(v)) v = v.slice(1)
         let m = /^(\d+)\.(\d+)\.(\d+)(-([0-9a-zA-Z\-\.]+))?(\+([0-9a-zA-Z\-\.]+))?$/.exec(v)
         if (m)

--- a/pxtlib/semver.ts
+++ b/pxtlib/semver.ts
@@ -59,7 +59,7 @@ namespace pxt.semver {
     }
 
     export function tryParse(v: string): Version {
-        if (/\*/.test(v)) {
+        if ("*" === v) {
             return {
                 major: Number.MAX_SAFE_INTEGER,
                 minor: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
Support parsing "*" as the maximum sermver version. Used to create patches that don't expire: "0.0.0 - *"