### PR TITLE
Show 'open in editor' button for blocks

### DIFF
--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -250,6 +250,7 @@ function renderSnippets() {
                     projectClass: 'lang-project',
                     snippetReplaceParent: true,
                     simulator: true,
+                    showEdit: true,
                     hex: true,
                     hexName: path
                 });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -63,7 +63,7 @@ namespace pxt.runner {
         let $menu = $h.find('.right.menu');
 
         const theme = pxt.appTarget.appTheme || {};
-        if (woptions.showEdit && !theme.hideDocsEdit) { // edit button
+        if (woptions.showEdit && !theme.hideDocsEdit && decompileResult) { // edit button
             const $editBtn = $(`<a class="item" role="button" tabindex="0" aria-label="${lf("edit")}"><i role="presentation" aria-hidden="true" class="edit icon"></i></a>`).click(() => {
                 decompileResult.package.compressToFileAsync(options.showJavaScript ? pxt.JAVASCRIPT_PROJECT_NAME : pxt.BLOCKS_PROJECT_NAME)
                     .done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'))
@@ -663,7 +663,7 @@ namespace pxt.runner {
                 opts.run = false;
                 opts.showEdit = false;
             }
-            fillWithWidget(options, $(e).parent(), $(e), undefined, undefined, opts);
+            fillWithWidget(options, $(e).parent(), $(e), /* JQuery */ undefined, /* decompileResult */ undefined, opts);
         }
 
         $('code.lang-typescript').each((i, e) => {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -784,6 +784,7 @@ ${linkString}
             projectClass: 'lang-project',
             snippetReplaceParent: true,
             simulator: true,
+            showEdit: true,
             hex: true,
             tutorial: !!options.tutorial,
             showJavaScript: editorLanguageMode == LanguageMode.TypeScript,
@@ -793,6 +794,7 @@ ${linkString}
             renderOptions.showEdit = false;
             renderOptions.simulator = false;
         }
+
         return pxt.runner.renderAsync(renderOptions).then(() => {
             // patch a elements
             $(content).find('a[href^="/"]').removeAttr('target').each((i, a) => {


### PR DESCRIPTION
These were just behind a flag that got turned off or missed at some point, as it previously existed in microbit v0:  https://makecode.microbit.org/v0/examples/turtle-square

Two issues with the current implementation:

* All projects seem to open in typescript, even if set to always send it as a blocks project
* Typescript snippets don't have a decompileResult, so they don't get the edit button. I would imagine that's readily available from the `$js` parameter with the js code in it, but I didn't want to spend too long searching for something that's probably readily known by someone more familiar with this section of the code :)

<img width="1071" alt="Screen Shot 2019-03-21 at 1 35 15 PM" src="https://user-images.githubusercontent.com/5615930/54783272-31b0bd00-4bde-11e9-9816-500e333a7542.png">

As a side note, if you test this out locally they won't load in the standard view, as something seems to have changed since that version of pxt; need to explicitly change to /beta or localhost and then it will load properly. Also, it does properly load extensions: [example link](https://arcade.makecode.com/beta#project:XQAAgAA1BwAAAAAAAAA9goAXHC4MqgeNHgoIMpsTCTurzyZquKQOb1TCv3qwmPyG+YAK6z7nP4WLOdVfWC6WyAOfkE0nQj0EIuV/Oh92a4AqbfSodD0CClzV1IiHNbyjFnSkGfCoWvZR2ybB3NrYme/sDcCQY6nPy2LGQgjYEE/5FdyuI15VnzQ5/C7H9mBgEm/mJ+uWrHJ5qtlABhNE3KgFHyG1f3h3EJ7OU1gfEIi3SgFaubLlP8kGeQPz00toGvzJ7mVgxSUl9a0GvjCvseNeNmSYF85EM1qMiu9shacIi4oGgDVAe8R2EYo29I952hCQ0mEyit/EXxfdCI0yuJvAsDljIKxOP9JNIKv3DYRdd0ga0ub15kkx/VeB+oamsoGlTbeQY74Xh0/4jVycUoBJWvdxZgSXeo07txcC0wl1cfLpV4Bj0K/sVHmlbEwYvD+poZJS+P6ctDCje0ROSwgnLQNYX6NqX2CymAb92De6YqY4ItKkWOMl5j/Q0rMXCc9vJqZWEYywhJzeYQ3SUynUnsHY0EvBcoP6429+sAK8MG3hJIuh3N3goKZIJqq7pULKTzBO8aDyWZCL19ROs4yZm8NU4xKxS9DmYAHLrxe651SYJQ9k5tUiF5iisSToVzmpNk9ZyxW6l1zevJCEyVpXUrehVbH9G+nhC9Ss5MiSluwHw8Lk/kUzRpHKMHk2yHYm34gWVrrwJfcxBqZhJns0//TdBPI=)

fixes https://github.com/Microsoft/pxt-arcade/issues/202