### PR TITLE
Improvements to the Debug Mode UI.

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -11,6 +11,19 @@
         Debugger
 *******************************/
 
+/* Top bar menu */
+.menubar .debugger-menu-item.centered {
+    position: fixed;
+    place-content: center;
+    right: 0;
+    left: 0;
+    margin-right: auto;
+    margin-left: auto;
+    min-height: inherit;
+    width: 33%;
+}
+
+/* Debugger toolbox */
 .debuggerToolbox.elements {
     height: 100%;
     display: flex;

--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -73,6 +73,10 @@
     color: rgb(255, 21, 0);
 }
 
+.ui.item.link.dbg-btn.disabled {
+    color: rgba(40, 40, 40, .3);
+}
+
 /* Debugger variables view */
 .ui.segment.debugvariables {
     table-layout: auto;

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -77,3 +77,14 @@
 .debugger .ui.inverted.menu {
     background: @DebuggerBackgroundPrimaryColor !important;
 }
+
+/* Debug mode */
+.menubar .debugger-menu-item.centered {
+    position: fixed;
+    place-content: center;
+    right: 0;
+    left: 0;
+    margin-right: auto;
+    margin-left: auto;
+    min-height: inherit;
+}

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -77,14 +77,3 @@
 .debugger .ui.inverted.menu {
     background: @DebuggerBackgroundPrimaryColor !important;
 }
-
-/* Debug mode */
-.menubar .debugger-menu-item.centered {
-    position: fixed;
-    place-content: center;
-    right: 0;
-    left: 0;
-    margin-right: auto;
-    margin-left: auto;
-    min-height: inherit;
-}

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -300,7 +300,7 @@
 @debugArrayVariable: #663905;
 @debugSpriteVariable: blue;
 
-@DebuggerBackgroundPrimaryColor: @green;
+@DebuggerBackgroundPrimaryColor: #e67e22;
 @DebuggerBackgroundSecondaryColor: lightgreen;
 
 @debuggerVariableExplorerBackground: white;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -428,7 +428,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                         <img className="ui mini image" src={rightLogo} tabIndex={0} onClick={this.launchFullEditor} onKeyDown={sui.fireClickOnEnter} alt={`${targetTheme.boardName} Logo`} />
                     </span>
                 </div>}
-            {!inTutorial && !targetTheme.blocksOnly ? <div className="ui item link editor-menuitem">
+            {!inTutorial && !targetTheme.blocksOnly && !debugging ? <div className="ui item link editor-menuitem">
                 <div className="ui grid padded">
                     {sandbox ? <sui.Item className="sim-menuitem" role="menuitem" textClass="landscape only" text={lf("Simulator")} icon={simActive && isRunning ? "stop" : "play"} active={simActive} onClick={this.openSimView} title={!simActive ? lf("Show Simulator") : runTooltip} /> : undefined}
                     <sui.Item className="blocks-menuitem" role="menuitem" textClass="landscape only" text={lf("Blocks")} icon="xicon blocks" active={blockActive} onClick={this.openBlocks} title={lf("Convert code to Blocks")} />
@@ -437,6 +437,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 </div>
             </div> : undefined}
             {inTutorial ? <tutorial.TutorialMenuItem parent={this.props.parent} /> : undefined}
+            {debugging && !inTutorial ? <sui.MenuItem className="debugger-menu-item centered" icon="large bug" name="Debug Mode" /> : undefined}
             <div className="right menu">
                 {debugging ? <sui.ButtonMenuItem className="exit-debugmode-btn" role="menuitem" icon="external" text={lf("Exit Debug Mode")} textClass="landscape only" onClick={this.toggleDebug} /> : undefined}
                 {docMenu ? <container.DocsMenu parent={this.props.parent} /> : undefined}

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -301,6 +301,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
         if (!isValidDebugFile) return <div />;
 
         const dbgStepDisabled = isDebuggerRunning || isStarting;
+        const dbgStepDisabledClass = dbgStepDisabled ? "disabled" : ""
 
         const restartTooltip = lf("Restart debugging");
         const dbgPauseResumeTooltip = isRunning ? lf("Pause execution") : lf("Continue execution");
@@ -316,10 +317,10 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
             return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")}>
                 {!isDebugging ? undefined :
                     <div className={`ui compact menu icon`}>
-                        <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${dbgStepDisabled ? "disabled" : ""} ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
-                        <sui.Item key='dbgstepover' className={`dbg-btn dbg-step-over ${dbgStepDisabled ? "disabled" : ""}`} icon={`xicon stepover ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepOverTooltip} onClick={this.dbgStepOver} />
-                        <sui.Item key='dbgstepinto' className={`dbg-btn dbg-step-into ${dbgStepDisabled ? "disabled" : ""}`} icon={`xicon stepinto ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} />
-                        <sui.Item key='dbgstepout' className={`dbg-btn dbg-step-out ${dbgStepDisabled ? "disabled" : ""}`} icon={`xicon stepout ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepOutTooltip} onClick={this.dbgStepOut} />
+                        <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${dbgStepDisabledClass} ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
+                        <sui.Item key='dbgstepover' className={`dbg-btn dbg-step-over ${dbgStepDisabledClass}`} icon={`xicon stepover ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepOverTooltip} onClick={this.dbgStepOver} />
+                        <sui.Item key='dbgstepinto' className={`dbg-btn dbg-step-into ${dbgStepDisabledClass}`} icon={`xicon stepinto ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} />
+                        <sui.Item key='dbgstepout' className={`dbg-btn dbg-step-out ${dbgStepDisabledClass}`} icon={`xicon stepout ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepOutTooltip} onClick={this.dbgStepOut} />
                         <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart right`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
                     </div>}
             </div>;
@@ -327,7 +328,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
             // Debugger Toolbar for the blocks editor.
             return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")}>
                 <div className={`ui compact borderless menu icon`}>
-                    <sui.Item key='dbgstep' className={`dbg-btn dbg-step separator-after ${dbgStepDisabled ? "disabled" : ""}`} icon={`arrow right ${dbgStepDisabled ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} text={"Step"} />
+                    <sui.Item key='dbgstep' className={`dbg-btn dbg-step separator-after ${dbgStepDisabledClass}`} icon={`arrow right ${dbgStepDisabled ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} text={"Step"} />
                     <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
                     <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
                 </div>

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -290,6 +290,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
 
         const simState = parentState.simState;
         const isRunning = simState == pxt.editor.SimState.Running;
+        const isStarting = simState == pxt.editor.SimState.Starting;
         const isDebugging = parentState.debugging;
         if (!isDebugging) return <div />;
 
@@ -298,6 +299,8 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
 
         const isValidDebugFile = advancedDebugging || this.props.parent.isBlocksActive();
         if (!isValidDebugFile) return <div />;
+
+        const dbgStepDisabled = isDebuggerRunning || isStarting;
 
         const restartTooltip = lf("Restart debugging");
         const dbgPauseResumeTooltip = isRunning ? lf("Pause execution") : lf("Continue execution");
@@ -313,10 +316,10 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
             return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")}>
                 {!isDebugging ? undefined :
                     <div className={`ui compact menu icon`}>
-                        <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
-                        <sui.Item key='dbgstepover' className={`dbg-btn dbg-step-over`} icon={`xicon stepover ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepOverTooltip} onClick={this.dbgStepOver} />
-                        <sui.Item key='dbgstepinto' className={`dbg-btn dbg-step-into`} icon={`xicon stepinto ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} />
-                        <sui.Item key='dbgstepout' className={`dbg-btn dbg-step-out`} icon={`xicon stepout ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepOutTooltip} onClick={this.dbgStepOut} />
+                        <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${dbgStepDisabled ? "disabled" : ""} ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
+                        <sui.Item key='dbgstepover' className={`dbg-btn dbg-step-over ${dbgStepDisabled ? "disabled" : ""}`} icon={`xicon stepover ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepOverTooltip} onClick={this.dbgStepOver} />
+                        <sui.Item key='dbgstepinto' className={`dbg-btn dbg-step-into ${dbgStepDisabled ? "disabled" : ""}`} icon={`xicon stepinto ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} />
+                        <sui.Item key='dbgstepout' className={`dbg-btn dbg-step-out ${dbgStepDisabled ? "disabled" : ""}`} icon={`xicon stepout ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepOutTooltip} onClick={this.dbgStepOut} />
                         <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart right`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
                     </div>}
             </div>;
@@ -324,7 +327,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
             // Debugger Toolbar for the blocks editor.
             return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")}>
                 <div className={`ui compact borderless menu icon`}>
-                    <sui.Item key='dbgstep' className={`dbg-btn dbg-step separator-after`} icon={`arrow right ${isDebuggerRunning ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} text={"Step"} />
+                    <sui.Item key='dbgstep' className={`dbg-btn dbg-step separator-after ${dbgStepDisabled ? "disabled" : ""}`} icon={`arrow right ${dbgStepDisabled ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} text={"Step"} />
                     <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
                     <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
                 </div>

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -84,6 +84,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const simState = parentState.simState;
         const isRunning = simState == pxt.editor.SimState.Running;
         const isStarting = simState == pxt.editor.SimState.Starting;
+        const isSimulatorPending = simState == pxt.editor.SimState.Pending;
         const isFullscreen = parentState.fullscreen;
         const isMuted = parentState.mute;
         const inTutorial = !!parentState.tutorialOptions && !!parentState.tutorialOptions.tutorial;
@@ -102,6 +103,8 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const screenshot = !!targetTheme.simScreenshot;
         const screenshotClass = !!parentState.screenshoting ? "loading" : "";
         if (isHeadless) return <div />;
+        const debugBtnEnabled = isRunning || (debugging && !isStarting);
+        const runControlsEnabled = !debugging && !isStarting && !isSimulatorPending;
 
         const runTooltip = [lf("Start the simulator"), lf("Starting the simulator"), lf("Stop the simulator")][simState];
         const makeTooltip = lf("Open assembly instructions");
@@ -115,9 +118,9 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait hide")} role="complementary" aria-label={lf("Simulator toolbar")}>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make ? <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} /> : undefined}
-                {run ? <sui.Button disabled={debugging || isStarting} key='runbtn' className={`play-button ${isRunning || debugging ? "stop" : "play"}`} icon={isRunning ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
-                {restart ? <sui.Button disabled={isStarting} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
-                {run && debug ? <sui.Button disabled={false} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
+                {run ? <sui.Button disabled={!runControlsEnabled} key='runbtn' className={`play-button ${(isRunning || debugging) ? "stop" : "play"}`} icon={(isRunning || debugging) ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
+                {restart ? <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} /> : undefined}
+                {run && debug ? <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
                 {trace ? <sui.Button key='trace' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={this.toggleTrace} /> : undefined}
             </div>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>


### PR DESCRIPTION
Removed Blocks/Javascript toggle and added a title instead, centered and
not clickable.
Changed debugMode color to Orange (matching tutorial one).
Disabled Step buttons when simulator not paused on breakpoint.

Disabled Run/Restart button when simulator is loading, and in debug mode.

![topBar](https://user-images.githubusercontent.com/5607882/54789747-c45a5780-4bf0-11e9-888e-89ba3ffefe53.PNG)
