### PR TITLE
Allow for empty simulator run at page load

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -140,6 +140,7 @@ declare namespace pxt {
         autoRun?: boolean; // enable autoRun in regular mode, not light mode
         autoRunLight?: boolean; // force autorun in light mode
         stopOnChange?: boolean;
+        emptyRunCode?: string; // when non-empty and autoRun is disabled, this code is run upon simulator first start
         hideRestart?: boolean;
         // moved to theme
         // enableTrace?: boolean;
@@ -299,7 +300,7 @@ declare namespace pxt {
         pairingButton?: boolean; // display a pairing button
         tagColors?: pxt.Map<string>; // optional colors for tags
         dontSuspendOnVisibility?: boolean; // we're inside an app, don't suspend the editor
-        disableFileAccessinMaciOs?:boolean; //Disable save & import of files in Mac and iOS, mainly used as embed webkit doesn't support these
+        disableFileAccessinMaciOs?: boolean; //Disable save & import of files in Mac and iOS, mainly used as embed webkit doesn't support these
         baseTheme?: string; // Use this to determine whether to show a light or dark theme, default is 'light', options are 'light', 'dark', or 'hc'
         scriptManager?: boolean; // Whether or not to enable the script manager. default: false
         monacoFieldEditors?: string[]; // A list of field editors to show in monaco. Currently only "image-editor" is supported

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -492,6 +492,10 @@ namespace pxsim {
                             this.options.revealElement(frame);
                     }
                     break;
+                case 'status':
+                    if ((msg as SimulatorStateMessage).state == "killed")
+                        this.setState(SimulatorState.Stopped)
+                    break;
                 case 'simulator': this.handleSimulatorCommand(msg as pxsim.SimulatorCommandMessage); break; //handled elsewhere
                 case 'serial':
                 case 'pxteditor':

--- a/theme/themes/pxt/modules/embed.variables
+++ b/theme/themes/pxt/modules/embed.variables
@@ -1,0 +1,6 @@
+/*******************************
+         Site Overrides
+*******************************/
+
+@placeholderBackground: rgba(0, 0, 0, 0.1);
+@hoverPlaceholderBackground: rgba(0, 0, 0, 0.1);

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -59,6 +59,30 @@ export interface CompileOptions {
     clickTrigger?: boolean;
 }
 
+export let emptyProgram =
+    `'use strict';
+__this.setupPerfCounters([]);
+entryPoint = function (s) {
+    // START
+    __this.kill()
+    return leave(s, s.r0)
+}
+setupDebugger(1)
+`
+
+export function emptyCompileResult(): pxtc.CompileResult {
+    return {
+        success: true,
+        diagnostics: [],
+        times: {},
+        breakpoints: [],
+        outfiles: {
+            "binary.js": emptyProgram
+                .replace("// START", pxt.appTarget.simulator.emptyRunCode || "")
+        },
+    }
+}
+
 export function compileAsync(options: CompileOptions = {}): Promise<pxtc.CompileResult> {
     let trg = pkg.mainPkg.getTargetOptions()
     trg.isNative = options.native


### PR DESCRIPTION
This prevents invocation of the compiler on the first sim run when autoRun is disabled. The simulator runs "empty" program (in arcade this just sets up the screen, otherwise we get mangled controls), and stops. Simulator still takes time to load, but it doesn't trash the CPU so badly anymore. Subsequent run of the program seems quite fast.

Test build here https://arcade.makecode.com/app/86b397e243ccf34dbbaa4956057a22c7242eaf90-f2e951a619

+ removed radial-gradient from embed placeholder