### PR TITLE
Fix type checks for events that use the reporter draggable parameters

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -457,7 +457,7 @@ namespace pxt.blocks {
                 comp.handlerArgs.filter(a => !a.inBlockDef).forEach(arg => {
                     const i = block.appendValueInput("HANDLER_DRAG_PARAM_" + arg.name);
                     if (fn.attributes.draggableParameters == "reporter") {
-                        i.setCheck(arg.type);
+                        i.setCheck(getBlocklyCheckForType(arg.type, info));
                     } else {
                         i.setCheck("Variable");
                     }
@@ -571,7 +571,7 @@ namespace pxt.blocks {
 
                         if (isHandlerArg(pr)) {
                             inputName = "HANDLER_DRAG_PARAM_" + pr.name;
-                            inputCheck = fn.attributes.draggableParameters === "reporter" ? pr.type : "Variable";
+                            inputCheck = fn.attributes.draggableParameters === "reporter" ? getBlocklyCheckForType(pr.type, info) : "Variable";
                             return;
                         }
 
@@ -812,28 +812,50 @@ namespace pxt.blocks {
         };
     }
 
-    function setOutputCheck(block: Blockly.Block, retType: string, info: pxtc.BlocksInfo) {
-        switch (retType) {
-            case "number": block.setOutput(true, "Number"); break;
-            case "string": block.setOutput(true, "String"); break;
-            case "boolean": block.setOutput(true, "Boolean"); break;
-            case "void": break; // do nothing
-            //TODO
+    /**
+     * Converts a TypeScript type into an array of type checks for Blockly inputs/outputs. Use
+     * with block.setOutput() and input.setCheck().
+     *
+     * @returns An array of checks if the type is valid, undefined if there are no valid checks
+     *      (e.g. type is void), and null if all checks should be accepted (e.g. type is generic)
+     */
+    function getBlocklyCheckForType(type: string, info: pxtc.BlocksInfo) {
+        switch (type) {
+            // Blockly capitalizes primitive types for its builtin math/string/logic blocks
+            case "number": return ["Number"];
+            case "string": return ["String"];
+            case "boolean": return ["Boolean"];
+            case "void": return undefined
             default:
-                if (retType !== "T") {
-                    const opt_check = isArrayType(retType) ? ["Array"] : [];
+                if (type !== "T") {
+                    // We add "Array" to the front for array types so that they can be connected
+                    // to the blocks that accept any array (e.g. length, push, pop, etc)
+                    const opt_check = isArrayType(type) ? ["Array"] : [];
 
-                    const si_r = info.apis.byQName[retType];
+                    // Blockly has no concept of inheritance, so we need to add all
+                    // super classes to the check array
+                    const si_r = info.apis.byQName[type];
                     if (si_r && si_r.extendsTypes && 0 < si_r.extendsTypes.length) {
                         opt_check.push(...si_r.extendsTypes);
                     } else {
-                        opt_check.push(retType);
+                        opt_check.push(type);
                     }
 
-                    block.setOutput(true, opt_check);
+                    return opt_check;
                 } else {
-                    block.setOutput(true);
+                    // The type is generic, so accept any checks. This is mostly used with functions that
+                    // get values from arrays. This could be improved if we ever add proper type
+                    // inference for generic types
+                    return null;
                 }
+        }
+    }
+
+    function setOutputCheck(block: Blockly.Block, retType: string, info: pxtc.BlocksInfo) {
+        const check = getBlocklyCheckForType(retType, info);
+
+        if (check || check === null) {
+            block.setOutput(true, check);
         }
     }
 

--- a/tests/blocklycompiler-test/baselines/draggable_primitive_reporter.ts
+++ b/tests/blocklycompiler-test/baselines/draggable_primitive_reporter.ts
@@ -1,0 +1,6 @@
+radio.onReceivedNumber(function (receivedNumber) {
+  basic.showNumber(receivedNumber)
+})
+radio.onReceivedString(function (receivedString) {
+  basic.showString(receivedString)
+})

--- a/tests/blocklycompiler-test/cases/draggable_primitive_reporter.blocks
+++ b/tests/blocklycompiler-test/cases/draggable_primitive_reporter.blocks
@@ -1,0 +1,43 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables>
+    <variable type="" id="kp;iJ:a}WgI=?D+za9b#">asdfsadf</variable>
+  </variables>
+  <block type="radio_on_number_2" x="0" y="0">
+    <value name="HANDLER_DRAG_PARAM_receivedNumber">
+      <shadow type="argument_reporter_number">
+        <field name="VALUE">receivedNumber</field>
+      </shadow>
+    </value>
+    <statement name="HANDLER">
+      <block type="device_show_number">
+        <value name="number">
+          <shadow type="math_number" id="()(l(2Af$zIB[dmq}du[">
+            <field name="NUM">0</field>
+          </shadow>
+          <block type="argument_reporter_number">
+            <field name="VALUE">receivedNumber</field>
+          </block>
+        </value>
+      </block>
+    </statement>
+  </block>
+  <block type="radio_on_string_2" x="3" y="158">
+    <value name="HANDLER_DRAG_PARAM_receivedString">
+      <shadow type="argument_reporter_string">
+        <field name="VALUE">receivedString</field>
+      </shadow>
+    </value>
+    <statement name="HANDLER">
+      <block type="device_print_message">
+        <value name="text">
+          <shadow type="text" id="k^a@`@4?MJU,L73Sc#2]">
+            <field name="TEXT">Hello!</field>
+          </shadow>
+          <block type="argument_reporter_string">
+            <field name="VALUE">receivedString</field>
+          </block>
+        </value>
+      </block>
+    </statement>
+  </block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/mbit.ts
+++ b/tests/blocklycompiler-test/test-library/mbit.ts
@@ -10,4 +10,42 @@ namespace basic {
     //% parts="ledmatrix" interval.defl=150
     export function showNumber(value: number, interval?: number) {
     }
+
+    /**
+     * Display text on the display, one character at a time. If the string fits on the screen (i.e. is one letter), does not scroll.
+     * @param text the text to scroll on the screen, eg: "Hello!"
+     * @param interval how fast to shift characters; eg: 150, 100, 200, -100
+     */
+    //% help=basic/show-string
+    //% weight=87 blockGap=16
+    //% block="show|string %text"
+    //% blockId=device_print_message
+    //% parts="ledmatrix"
+    //% text.shadowOptions.toString=true interval.defl=150
+    export function showString(text: string, interval?: number): void {
+
+    }
+}
+
+
+namespace radio {
+    /**
+     * Registers code to run when the radio receives a number.
+     */
+    //% help=radio/on-received-number blockHandlerKey="radioreceived"
+    //% blockId=radio_on_number_2 block="on radio received" blockGap=16 draggableParameters="reporter"
+    //% useLoc="radio.onDataPacketReceived"
+    export function onReceivedNumber(cb: (receivedNumber: number) => void) {
+
+    }
+
+    /**
+     * Registers code to run when the radio receives a string.
+     */
+    //% help=radio/on-received-string
+    //% blockId=radio_on_string_2 block="on radio received" blockGap=16 draggableParameters="reporter"
+    //% useLoc="radio.onDataPacketReceived"
+    export function onReceivedString(cb: (receivedString: string) => void) {
+
+    }
 }

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -421,6 +421,10 @@ describe("blockly compiler", function () {
         it("should convert handler parameters to draggable variables", done => {
             blockTestAsync("draggable_parameters").then(done, done);
         });
+
+        it("should set the right check for primitive draggable parameters in blockly loader", done => {
+            blockTestAsync("draggable_primitive_reporter").then(done, done);
+        });
     });
 
     describe("compiling expandable blocks", () => {


### PR DESCRIPTION
Fixing the type checks for APIs where `draggableParameters=reporter`. I think only Arcade uses that feature, but this bug doesn't affect those APIs because they use "custom" types (like `Sprite`). The logic was broken for primitive types, arrays, and types that extend other types (like the pins in mbit and cpx).

I also added some comments explaining the logic behind the checks we set.