### PR TITLE
Update disabled blocks before compilation

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1545,14 +1545,13 @@ namespace pxt.blocks {
                 return eventWeight(a, e) - eventWeight(b, e)
             });
 
+            updateDisabledBlocks(e, w.getAllBlocks(), topblocks);
+
             trackAllVariables(topblocks, e);
 
             infer(e, w);
 
             const stmtsMain: JsNode[] = [];
-
-
-            updateDisabledBlocks(e, w.getAllBlocks(), topblocks);
 
             // compile workspace comments, add them to the top
             const topComments = w.getTopComments(true);


### PR DESCRIPTION
Found this bug while testing. When a block that declares variables (e.g. events, loops, etc.) goes from disabled to not disabled, you get an exception:

![disabled_exception](https://user-images.githubusercontent.com/13754588/54859472-bc6ee600-4cca-11e9-9038-8d43e6fc52ad.gif)

We catch the exception so it's not that big of an issue.