### PR TITLE
Allow for ![](/docs/static/foo.png) in markdown

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2272,6 +2272,8 @@ function renderDocs(builtPackaged: string, localDir: string) {
                 let str = buf.toString("utf8")
                 if (/\.md$/.test(f)) {
                     str = nodeutil.resolveMd(".", f.substr(5, f.length - 8));
+                    // patch any /static/... url to /docs/static/...
+                    str = str.replace(/\"\/static\//g, `"/docs/static/`);
                     nodeutil.writeFileSync(dd, str, { encoding: "utf8" });
                 }
                 let html = ""

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -241,7 +241,7 @@ namespace pxt.docs {
             breadcrumbHtml = `
             <nav class="ui breadcrumb" aria-label="${lf("Breadcrumb")}">
                 ${breadcrumb.map((b, i) =>
-                    `<a class="${i == breadcrumb.length - 1 ? "active" : ""} section"
+                `<a class="${i == breadcrumb.length - 1 ? "active" : ""} section"
                         href="${html2Quote(b.href)}" aria-current="${i == breadcrumb.length - 1 ? "page" : ""}">${html2Quote(b.name)}</a>`)
                     .join('<i class="right chevron icon divider"></i>')}
             </nav>`;
@@ -514,6 +514,11 @@ ${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}#${opts.repo.
 
         // support for breaks which somehow don't work out of the box
         html = html.replace(/&lt;br\s*\/&gt;/ig, "<br/>");
+
+        // github will render images if referenced as ![](/docs/static/foo.png)
+        // we require /static/foo.png
+        html = html.replace(/(<img [^>]* src=")\/docs\/static\/([^">]+)"/g,
+            (f, pref, addr) => pref + '/static/' + addr + '"')
 
         let endBox = ""
 


### PR DESCRIPTION
This replaces `/docs/static` with `/static` in image URLs. This lets them be rendered by github as well as our backend. It doesn't touch existing syntax, but going forward we can use `/docs/static/...` to allow rendering both in our websites and on github.

For example see here https://github.com/Microsoft/pxt-arcade/blob/dbgconn/docs/hardware/dbg.md
