### PR TITLE
Make breakpoints pause countdown and fibers running in the background.

### DIFF
--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -568,7 +568,7 @@ namespace pxsim {
 
         export function pause(ms: number) {
             let cb = getResume();
-            setTimeout(() => { cb() }, ms)
+            runtime.schedule(() => { cb() }, ms)
         }
 
         export function runInBackground(a: RefAction) {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -440,7 +440,7 @@ namespace pxsim {
     }
 
     export class PausedTimeout {
-        constructor(public fn: any, public timeRemaining: number) { }
+        constructor(public fn: Function, public timeRemaining: number) { }
     }
 
 
@@ -756,7 +756,7 @@ namespace pxsim {
                 Runtime.postMessage(msg)
                 breakAlways = false;
                 breakFrame = null;
-                runtime.pauseScheduled();
+                __this.pauseScheduled();
                 dbgResume = (m: DebuggerMessage) => {
                     dbgResume = null;
                     dbgHeap = null;
@@ -1075,7 +1075,7 @@ namespace pxsim {
         }
 
         // Wrapper for the setTimeout
-        schedule(fn: () => void, timeout: number): number {
+        schedule(fn: Function, timeout: number): number {
             // We call the timeout function and add its id to the timeouts scheduled.
             if (timeout <= 0) return -1;
             let id = setTimeout(fn, timeout);
@@ -1111,8 +1111,9 @@ namespace pxsim {
 
         // Removes from the timeouts scheduled list all the ones that had been fulfilled.
         cleanScheduledExpired() {
+            let now = U.now();
             this.timeoutsScheduled = this.timeoutsScheduled.filter(ts => {
-                let elapsed = U.now() - ts.timestampCall;
+                let elapsed = now - ts.timestampCall;
                 return ts.totalRuntime > elapsed;
             })
         }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1079,7 +1079,7 @@ namespace pxsim {
             // We call the timeout function and add its id to the timeouts scheduled.
             if (timeout <= 0) return -1;
             let id = setTimeout(fn, timeout);
-            this.timeoutsScheduled.push(new TimeoutScheduled(id, fn, timeout, Date.now()));
+            this.timeoutsScheduled.push(new TimeoutScheduled(id, fn, timeout, U.now()));
             return id;
         }
 
@@ -1087,12 +1087,12 @@ namespace pxsim {
         pauseScheduled() {
             this.timeoutsScheduled.forEach(ts => {
                 clearTimeout(ts.id);
-                let elapsed = Date.now() - ts.timestampCall;
+                let elapsed = U.now() - ts.timestampCall;
                 let timeRemaining = ts.totalRuntime - elapsed;
                 if (timeRemaining < 0) timeRemaining = 0;
                 this.timeoutsPausedOnBreakpoint.push(new PausedTimeout(ts.fn, timeRemaining))
             });
-            this.lastPauseTimestamp = Date.now();
+            this.lastPauseTimestamp = U.now();
             this.timeoutsScheduled = [];
         }
 
@@ -1103,7 +1103,7 @@ namespace pxsim {
                 this.schedule(pt.fn, pt.timeRemaining);
             });
             if (this.lastPauseTimestamp) {
-                this.pausedTime += Date.now() - this.lastPauseTimestamp;
+                this.pausedTime += U.now() - this.lastPauseTimestamp;
                 this.lastPauseTimestamp = 0;
             }
             this.timeoutsPausedOnBreakpoint = [];
@@ -1112,7 +1112,7 @@ namespace pxsim {
         // Removes from the timeouts scheduled list all the ones that had been fulfilled.
         cleanScheduledExpired() {
             this.timeoutsScheduled = this.timeoutsScheduled.filter(ts => {
-                let elapsed = Date.now() - ts.timestampCall;
+                let elapsed = U.now() - ts.timestampCall;
                 return ts.totalRuntime > elapsed;
             })
         }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -621,7 +621,7 @@ namespace pxsim {
                             let fi = s.funcInfo
                             stackTrace += `   at ${fi.functionName} (${fi.fileName}:${fi.line + 1}:${fi.column + 1})\n`
                         }
-                        console.error(stackTrace)
+                        if (brk.exceptionMessage) console.error(stackTrace);
                     } else {
                         console.error("debugger: trying to pause from " + this.state);
                     }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -79,6 +79,7 @@ namespace pxsim {
         }
 
         queue(id: number | string, evid: number | string, value: T = null) {
+            if (runtime.pausedOnBreakpoint) return;
             // special handling for notify one
             const notifyOne = this.notifyID && this.notifyOneID && id == this.notifyOneID;
             if (notifyOne)

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -124,7 +124,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                                 });
                         } else {
                             let children: pxt.Map<Variable> = {};
-                            Object.keys(msg.variables).forEach(variableName => {
+                            Object.keys(msg.variables || {}).forEach(variableName => {
                                 children[variableName] = { value: msg.variables[variableName] }
                             })
                             v.children = children;

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -114,9 +114,9 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             });
             simulator.driver.variablesAsync(v.value.id, fieldsToGet)
                 .then((msg: pxsim.VariablesMessage) => {
-                    if (msg) {
+                    if (msg && msg.variables) {
                         if (v.value.type == "array") {
-                            v.children = pxt.Util.mapMap(msg.variables || {},
+                            v.children = pxt.Util.mapMap(msg.variables,
                                 (k, v) => {
                                     return {
                                         value: msg.variables[k]
@@ -124,7 +124,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                                 });
                         } else {
                             let children: pxt.Map<Variable> = {};
-                            Object.keys(msg.variables || {}).forEach(variableName => {
+                            Object.keys(msg.variables).forEach(variableName => {
                                 children[variableName] = { value: msg.variables[variableName] }
                             })
                             v.children = children;


### PR DESCRIPTION
When hitting a breakpoint, pause all fibers running in the background. After resuming via step or continue, restore all fibers.