### PR TITLE
Monaco toolbox for python

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -615,7 +615,7 @@ declare namespace ts.pxtc {
         EnumMember,
         Class,
         Interface,
-    }    
+    }
 
     interface SymbolInfo {
         attributes: CommentAttrs;

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -462,6 +462,11 @@ namespace ts.pxtc {
         }
         toclose.forEach(closeSi)
 
+        if (legacyOnly) {
+            // conflicts with pins.map()
+            delete res.byQName["Array.map"]
+        }
+
         // fill in snippets
         for (let qName in res.byQName) {
             const si = res.byQName[qName];
@@ -471,11 +476,6 @@ namespace ts.pxtc {
                 if (opts.pySnippets)
                     si.pySnippet = ts.pxtc.service.getSnippet(res.byQName, si, stmt as FunctionLikeDeclaration, si.attributes, true);
             }
-        }
-
-        if (legacyOnly) {
-            // conflicts with pins.map()
-            delete res.byQName["Array.map"]
         }
 
         return res

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1073,6 +1073,9 @@ namespace ts.pxtc.service {
         let insertText = snippetPrefix ? `${snippetPrefix}.${snippet}` : snippet;
         insertText = addNamespace ? `${firstWord(namespaceToUse)}.${insertText}` : insertText;
 
+        if (attrs && attrs.blockSetVariable)
+            insertText = `${python ? "": "let "}${attrs.blockSetVariable} = ${insertText}`; 
+
         return preStmt + insertText;
 
         function firstWord(s: string) {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1074,7 +1074,7 @@ namespace ts.pxtc.service {
         insertText = addNamespace ? `${firstWord(namespaceToUse)}.${insertText}` : insertText;
 
         if (attrs && attrs.blockSetVariable)
-            insertText = `${python ? "": "let "}${attrs.blockSetVariable} = ${insertText}`; 
+            insertText = `${python ? "" : "let "}${attrs.blockSetVariable} = ${insertText}`;
 
         return preStmt + insertText;
 

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -580,8 +580,8 @@ namespace ts.pxtc.service {
     let service: LanguageService;
     let host: Host;
 
-    interface CachedApisInfo { 
-        apis: ApisInfo; 
+    interface CachedApisInfo {
+        apis: ApisInfo;
         decls: pxt.Map<Declaration>;
     }
 

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -468,9 +468,9 @@ namespace ts.pxtc {
             const si = res.byQName[qName];
             const stmt = qNameToNode[qName];
             if (si && stmt && ts.isFunctionLike(stmt)) {
-                si.snippet = ts.pxtc.service.getSnippet(res.byQName, si, stmt as FunctionLikeDeclaration, si.attributes);
+                si.snippet = ts.pxtc.service.getSnippet(res.byQName, si, stmt as FunctionLikeDeclaration);
                 if (opts.pySnippets)
-                    si.pySnippet = ts.pxtc.service.getSnippet(res.byQName, si, stmt as FunctionLikeDeclaration, si.attributes, true);
+                    si.pySnippet = ts.pxtc.service.getSnippet(res.byQName, si, stmt as FunctionLikeDeclaration, true);
             }
         }
 
@@ -940,12 +940,13 @@ namespace ts.pxtc.service {
 . . . . .
 \``;
 
-    export function getSnippet(apis: pxt.Map<SymbolInfo>, fn: SymbolInfo, n: ts.SignatureDeclaration, attrs?: CommentAttrs, python?: boolean): string {
+    export function getSnippet(apis: pxt.Map<SymbolInfo>, fn: SymbolInfo, n: ts.SignatureDeclaration, python?: boolean): string {
         if (!ts.isFunctionLike(n)) {
             return undefined;
         }
         let preStmt = "";
 
+        const attrs = fn.attributes;
         const checker = service && !python ? service.getProgram().getTypeChecker() : undefined;
         const args = n.parameters ? n.parameters.filter(param => !param.initializer && !param.questionToken).map(param => {
             const typeNode = param.type;
@@ -1074,8 +1075,9 @@ namespace ts.pxtc.service {
 
         return preStmt + insertText;
 
-        function firstWord(s: string) {
-            return /[^\.]+/.exec(s)[0]
+        function firstWord(s: string): string {
+            const i = s.indexOf('.');
+            return i < 0 ? s : s.substring(0, i);
         }
 
         function getFunctionString(functionSignature: ts.Signature) {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -328,10 +328,6 @@ namespace ts.pxtc {
             return !!sym.attributes.block && !!sym.attributes.blockId;
         }
 
-        function capitalize(name: string) {
-            return name[0].toUpperCase() + name.slice(1);
-        }
-
         function compareSymbol(l: SymbolInfo, r: SymbolInfo): number {
             let c = -(hasBlock(l) ? 1 : -1) + (hasBlock(r) ? 1 : -1);
             if (c) return c;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1038,7 +1038,7 @@ namespace ts.pxtc {
                 filename = U.fromUTF8(U.uint8ArrayToString(fnbuf))
                 fileSize = wordAt(28)
             }
-            
+
             if (flags & UF2_FLAG_FAMILY_ID_PRESENT) {
                 familyId = wordAt(28)
             }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1308,6 +1308,12 @@ namespace ts.pxtc.service {
         format?: FormatOptions;
         blocks?: BlocksOptions;
         projectSearch?: ProjectSearchOptions;
+        snippet?: SnippetOptions;
+    }
+
+    export interface SnippetOptions {
+        qName: string;
+        python?: boolean;
     }
 
     export interface SearchOptions {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1136,7 +1136,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private getBuiltInBlocks(ns: string, subns: string) {
         let cat = snippets.getBuiltinCategory(ns);
         let blocks: toolbox.BlockDefinition[] = cat.blocks || [];
-        blocks.forEach(b => { b.noNamespace = true })
         if (!cat.custom && this.nsMap[ns]) {
             blocks = this.filterBlocks(subns, blocks.concat(this.nsMap[ns]));
         }
@@ -1158,8 +1157,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     blockId: ts.pxtc.ON_START_TYPE,
                     weight: pxt.appTarget.runtime.onStartWeight || 10
                 },
-                blockXml: `<block type="pxt-on-start"></block>`,
-                noNamespace: true
+                blockXml: `<block type="pxt-on-start"></block>`
             });
         }
         // Inject pause until block

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -656,8 +656,7 @@ export function getPauseUntil() {
                 blockNamespace: opts.category || "loops",
                 weight: opts.weight == null ? 0 : opts.weight
             },
-            blockXml: Blockly.Xml.domToText(pxt.blocks.mkPredicateBlock(pxtc.PAUSE_UNTIL_TYPE)),
-            noNamespace: true
+            blockXml: Blockly.Xml.domToText(pxt.blocks.mkPredicateBlock(pxtc.PAUSE_UNTIL_TYPE))
         };
     }
 
@@ -697,8 +696,7 @@ export function allBuiltinBlocks() {
             blockId: ts.pxtc.ON_START_TYPE,
             weight: pxt.appTarget.runtime.onStartWeight || 10
         },
-        blockXml: `<block type="pxt-on-start"></block>`,
-        noNamespace: true
+        blockXml: `<block type="pxt-on-start"></block>`
     };
     // Add pause until built in block
     const pauseUntil = getPauseUntil();
@@ -770,7 +768,6 @@ function blockFromJson(b: pxt.editor.ToolboxBlockDefinition, currentWeight?: num
             jsDoc: b.jsDoc,
             group: b.group,
         },
-        noNamespace: true,
         retType: b.retType,
         blockXml: b.blockXml
     }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -294,6 +294,10 @@ export function formatAsync(input: string, pos: number) {
     return workerOpAsync("format", { format: { input: input, pos: pos } });
 }
 
+export function snippetAsync(qName: string, python?: boolean) {
+    return workerOpAsync("snippet", { snippet: { qName, python } });
+}
+
 export function typecheckAsync() {
     let p = pkg.mainPkg.getCompileOptionsAsync()
         .then(opts => {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -497,7 +497,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
                 // always insert the text on the next lin
                 insertText += "\n";
-                position.lineNumber++;                
+                position.lineNumber++;
                 position.column = 1;
                 // check existing content
                 if (position.lineNumber < model.getLineCount() && model.getLineContent(position.lineNumber)) // non-empty line
@@ -512,7 +512,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         text: insertText,
                         forceMoveMarkers: true,
                         isAutoWhitespaceEdit: true,
-                        
+
                     }
                 ]);
                 this.beforeCompile();
@@ -1582,7 +1582,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             //    instanceToken.textContent = snippetPrefix + '.';
             //    instanceToken.className = 'sigPrefix';
             //    monacoBlock.appendChild(instanceToken);
-           // }
+            // }
             let methodToken = document.createElement('span');
             methodToken.textContent = snippetName;
             monacoBlock.appendChild(methodToken);

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -495,15 +495,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 if (!position) // IE11 fails to locate the mouse
                     position = currPos;
 
-                insertText = (currPos.column > 1) ? '\n' + insertText :
-                    model.getWordUntilPosition(currPos) != undefined && model.getWordUntilPosition(currPos).word != '' ?
-                        insertText + '\n' : insertText;
-                if (insertText.indexOf('{{}}') > -1) {
-                    cursor += (insertText.indexOf('{{}}'));
-                    insertText = insertText.replace('{{}}', '');
-                } else
-                    cursor += (insertText.length);
+                // always insert the text on the next lin
+                insertText += "\n";
+                position.lineNumber++;                
+                position.column = 1;
+                // check existing content
+                if (position.lineNumber < model.getLineCount() && model.getLineContent(position.lineNumber)) // non-empty line
+                    insertText = "\n" + insertText;
 
+                // update cursor
                 this.editor.pushUndoStop();
                 this.editor.executeEdits("", [
                     {
@@ -511,14 +511,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
                         text: insertText,
                         forceMoveMarkers: true,
-                        isAutoWhitespaceEdit: true
+                        isAutoWhitespaceEdit: true,
+                        
                     }
                 ]);
                 this.beforeCompile();
                 this.editor.pushUndoStop();
-
-                let endPos = model.getPositionAt(cursor);
-                this.editor.setPosition(endPos);
                 this.editor.focus();
             });
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1474,7 +1474,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let monacoFlyout = this.getMonacoFlyout();
 
         const isPython = this.fileType == pxt.editor.FileType.Python;
-        if ((isPython ? fn.pySnippet : fn.snippet) === undefined)
+        if (fn.snippet === undefined)
             return undefined;
         const qName = fn.qName;
         const snippetName = (isPython ? fn.pySnippetName : undefined) || fn.snippetName || fn.name;
@@ -1518,7 +1518,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 });
 
                 const snippet = isPython ? fn.pySnippet : fn.snippet;
-                if (snippet !== undefined)
+                if (!snippet)
                     e.dataTransfer.setData('text', 'qName:' + qName); // IE11 only supports text
                 else
                     e.dataTransfer.setData('text', snippet); // IE11 only supports text

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -579,8 +579,7 @@ export function getPauseUntil() {
                 weight: opts.weight == null ? 0 : opts.weight,
                 jsDoc: lf("Pause execution of code until the given boolean expression is true"),
                 advanced: false
-            },
-            noNamespace: true
+            }
         };
     }
 
@@ -706,7 +705,6 @@ function blockFromJson(b: pxt.editor.ToolboxBlockDefinition, currentWeight?: num
             jsDoc: b.jsDoc,
             group: b.group,
         },
-        noNamespace: true,
         retType: b.retType,
         blockXml: b.blockXml
     }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -21,6 +21,7 @@ export const enum CategoryNameID {
 
 // this is a supertype of pxtc.SymbolInfo (see partitionBlocks)
 export interface BlockDefinition {
+    qName?: string;
     name: string;
     namespace?: string;
     type?: string;

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -44,7 +44,6 @@ export interface BlockDefinition {
         subcategory?: string;
         topblockWeight?: number;
     };
-    noNamespace?: boolean;
     retType?: string;
     blockXml?: string;
     builtinBlock?: boolean;
@@ -60,7 +59,6 @@ export interface ButtonDefinition {
         weight?: number;
     }
     callback?: () => void;
-    noNamespace?: boolean;
 }
 
 export interface BuiltinCategoryDefinition {


### PR DESCRIPTION
The display on the monaco toolbox is more basic but the service is now completely lazy. Signatures are generated on demand when a user drags the block for either JS/Py.

- [x] move snippet generation in service
- [x] fixes/simplifications
- [x] lazy snippet generation