### PR TITLE
ability to set keys in simulator

### DIFF
--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -36,6 +36,10 @@ namespace pxsim {
         return Object.keys(cfgKey)
     }
 
+    export function setConfigKey(key: string, id: number) {
+        cfgKey[key] = id;
+    }
+
     export function setConfig(id: number, val: number) {
         cfg[id] = val
     }


### PR DESCRIPTION
Support for edge connector in arcade. Allows to set a key dyanmically in the simulator (those keys mostly would exist in the bootloader but not in the code)