### PR TITLE
Improving the stopped overlay for the simulator

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -153,7 +153,7 @@ namespace pxsim {
                         ? this.stoppedClass : this.invalidatedClass);
                     if (!this.options.autoRun) {
                         icon.style.display = '';
-                        icon.className = 'video play icon';
+                        icon.className = 'videoplay xicon icon';
                     } else
                         icon.style.display = 'none';
                     loader.style.display = 'none';
@@ -259,7 +259,7 @@ namespace pxsim {
             wrapper.appendChild(frame);
 
             const i = document.createElement("i");
-            i.className = "video play icon";
+            i.className = "videoplay xicon icon";
             i.style.display = "none";
             i.onclick = (ev) => {
                 ev.preventDefault();

--- a/svgicons/videoplay.svg
+++ b/svgicons/videoplay.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="90.510178mm"
+   height="90.510178mm"
+   viewBox="0 0 90.510178 90.510178"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="videoplay.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="-215.05428"
+     inkscape:cy="199.57986"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="3240"
+     inkscape:window-height="2035"
+     inkscape:window-x="5107"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-34.130555,-47.834176)">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.29999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 171.04297 0.15039062 A 170.89285 170.89285 0 0 0 0.15039062 171.04297 A 170.89285 170.89285 0 0 0 171.04297 341.93555 A 170.89285 170.89285 0 0 0 341.93555 171.04297 A 170.89285 170.89285 0 0 0 171.04297 0.15039062 z M 171.04297 13.365234 A 157.67858 157.67858 0 0 1 328.7207 171.04297 A 157.67858 157.67858 0 0 1 171.04297 328.7207 A 157.67858 157.67858 0 0 1 13.365234 171.04297 A 157.67858 157.67858 0 0 1 171.04297 13.365234 z M 119.70508 86.246094 C 119.12678 86.269671 118.65574 86.374955 118.30664 86.566406 C 110.85918 90.650696 107.61437 162.31285 107.42773 170.80469 C 107.2411 179.29653 107.33487 251.0319 114.5957 255.43945 C 121.85653 259.847 185.54277 226.82843 192.99023 222.74414 C 200.4377 218.65985 262.51454 182.70864 262.70117 174.2168 C 262.88781 165.72496 202.45028 127.08333 195.18945 122.67578 C 188.26897 118.47484 131.46385 85.766684 119.70508 86.246094 z "
+       transform="matrix(0.26458333,0,0,0.26458333,34.130555,47.834176)"
+       id="path838" />
+  </g>
+</svg>

--- a/theme/common.less
+++ b/theme/common.less
@@ -198,6 +198,24 @@ body {
     text-align: center;
 }
 
+#simulators .ui.embed .icon.xicon::before {
+    transform: translateX(-77%) translateY(-120%);
+    transition: opacity .25s ease,color .25s ease;
+}
+
+#simulators .ui.embed .icon.xicon::after {
+    background: rgba(0,0,0,.3);
+    transition: opacity .25s ease;
+}
+
+#simulators .ui.embed .icon.xicon:hover:before {
+    color: #2ecc71;
+}
+
+#simulators .ui.embed .icon.xicon:hover:after {
+    opacity: 0.6;
+}
+
 /* Simulator */
 div.simframe {
     border:none;

--- a/theme/common.less
+++ b/theme/common.less
@@ -209,7 +209,7 @@ body {
 }
 
 #simulators .ui.embed .icon.xicon:hover:before {
-    color: #2ecc71;
+    color: @green;
 }
 
 #simulators .ui.embed .icon.xicon:hover:after {


### PR DESCRIPTION
Does the following:
1. Adds a new icon for the play button (I made it in Inkscape)
2. Makes the embed overlay slightly more opaque
3. Changes the hover animation so that it's faster and turns the icon green

**PLEASE NOTE:** I will center the icon on the screen in arcade, it's just not shown in the GIF below because that css needs to go in a separate PR

And here it is in action:

![stopped_simulator](https://user-images.githubusercontent.com/13754588/55199559-a56f3e80-5177-11e9-8a6b-50ed46b4cc4c.gif)

Tested in Edge, Chrome, and Firefox. Also tested in IE, but the icon gets weirdly cropped. I'll open an issue once this gets merged.
