### PR TITLE
Tutorial tracking

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -729,12 +729,13 @@ declare namespace pxt.tutorial {
     }
     
     interface TutorialOptions {
-        tutorial?: string; // tutorial
+        tutorial?: string; // tutorial        
         tutorialName?: string; // tutorial title
         tutorialReportId?: string; // if this tutorial was user generated, the report abuse id
         tutorialStepInfo?: pxt.tutorial.TutorialStepInfo[];
         tutorialStep?: number; // current tutorial page
         tutorialReady?: boolean; // current tutorial page
+        tutorialMd?: string; // full tutorial markdown
     }
 
 }

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -716,3 +716,25 @@ declare namespace ts.pxtc {
         usageId: string;
     }
 }
+
+
+declare namespace pxt.tutorial {
+    interface TutorialStepInfo {
+        fullscreen?: boolean;
+        // no coding
+        unplugged?: boolean;
+        hasHint?: boolean;
+        contentMd?: string;
+        headerContentMd?: string;
+    }
+    
+    interface TutorialOptions {
+        tutorial?: string; // tutorial
+        tutorialName?: string; // tutorial title
+        tutorialReportId?: string; // if this tutorial was user generated, the report abuse id
+        tutorialStepInfo?: pxt.tutorial.TutorialStepInfo[];
+        tutorialStep?: number; // current tutorial page
+        tutorialReady?: boolean; // current tutorial page
+    }
+
+}

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -134,6 +134,9 @@ declare namespace pxt {
         blocks?: number;
         javascript?: number;
 
+        tutorialStep?: number;
+        tutorialLength?: number;
+
         icon?: string;
         iconContent?: string; // Text instead of icon name
         iconColor?: string;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -50,7 +50,7 @@ namespace pxt.editor {
         projectName?: string;
         suppressPackageWarning?: boolean;
 
-        tutorialOptions?: TutorialOptions;
+        tutorialOptions?: pxt.tutorial.TutorialOptions;
         lightbox?: boolean;
 
         simState?: SimState;
@@ -94,7 +94,7 @@ namespace pxt.editor {
         filesOverride?: pxt.Map<string>;
         filters?: ProjectFilters;
         temporary?: boolean;
-        inTutorial?: boolean;
+        tutorial?: pxt.tutorial.TutorialOptions;
         dependencies?: pxt.Map<string>;
         tsOnly?: boolean;
     }
@@ -117,15 +117,6 @@ namespace pxt.editor {
         Hidden = 0,
         Visible = 1,
         Disabled = 2
-    }
-
-    export interface TutorialOptions {
-        tutorial?: string; // tutorial
-        tutorialName?: string; // tutorial title
-        tutorialReportId?: string; // if this tutorial was user generated, the report abuse id
-        tutorialStepInfo?: pxt.tutorial.TutorialStepInfo[];
-        tutorialStep?: number; // current tutorial page
-        tutorialReady?: boolean; // current tutorial page
     }
 
     export interface ModalDialogButton {

--- a/pxteditor/workspace.ts
+++ b/pxteditor/workspace.ts
@@ -16,6 +16,8 @@ namespace pxt.workspace {
         pubCurrent: boolean; // is this exactly pubId, or just based on it
         githubId?: string;
         githubCurrent?: boolean;
+        // in progress tutorial if any
+        tutorial?: pxt.tutorial.TutorialOptions;
     }
 
     export interface Header extends InstallHeader {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -1,12 +1,4 @@
 namespace pxt.tutorial {
-    export interface TutorialStepInfo {
-        fullscreen?: boolean;
-        // no coding
-        unplugged?: boolean;
-        hasHint?: boolean;
-        contentMd?: string;
-        headerContentMd?: string;
-    }
 
     export function parseTutorialSteps(tutorialId: string, tutorialmd: string): TutorialStepInfo[] {
         // Download tutorial markdown

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -116,7 +116,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                     {card.description ? <div className="description tall">{renderMd(card.description)}</div> : null}
                 </div> : undefined}
             {card.time ? <div className="meta">
-                {card.tutorialLength ? <span className="ui tutorial-progress left label">{lf("{0}/{1} steps", card.tutorialStep || 0, card.tutorialLength)}</span> : undefined}
+                {card.tutorialLength ? <span className="ui tutorial-progress left floated label">{lf("{0}/{1} steps", (card.tutorialStep || 0) + 1, card.tutorialLength)}</span> : undefined}
                 {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span> : null}
             </div> : undefined}
             {card.extracontent || card.learnMoreUrl || card.buyUrl || card.feedbackUrl ?

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -82,7 +82,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
         const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`}
             role={card.role} aria-selected={card.role === "option" ? "true" : undefined} aria-label={card.ariaLabel || card.title} title={card.title}
             onClick={clickHandler} tabIndex={card.onClick ? card.tabIndex || 0 : null} onKeyDown={card.onClick ? sui.fireClickOnEnter : null}>
-            {card.header || card.blocks || card.javascript || card.hardware || card.software || card.any ?
+            {card.header || card.blocks || card.javascript || card.hardware || card.software || card.any || card.tutorialLength ?
                 <div key="header" className={"ui content " + (card.responsive ? " tall desktop only" : "")}>
                     <div className="right floated meta">
                         {card.any ? (<sui.Icon key="costany" icon="ui grey circular label tiny">{card.any > 0 ? card.any : null} </sui.Icon>) : null}
@@ -90,6 +90,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                         {repeat(card.javascript, (k) => <sui.Icon key={"costjs" + k} icon="align left blue" />)}
                         {repeat(card.hardware, (k) => <sui.Icon key={"costhardware" + k} icon="certificate black" />)}
                         {repeat(card.software, (k) => <sui.Icon key={"costsoftware" + k} icon="square teal" />)}
+                        {card.tutorialLength ? <span className="ui label">{lf("{0}/{1}", card.tutorialStep || 0, card.tutorialLength)}</span> : undefined}
                     </div>
                     {card.header}
                 </div> : null}

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -116,7 +116,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                     {card.description ? <div className="description tall">{renderMd(card.description)}</div> : null}
                 </div> : undefined}
             {card.time ? <div className="meta">
-                {card.tutorialLength ? <span className="ui tutorial-progress left floated label">{lf("{0}/{1} steps", (card.tutorialStep || 0) + 1, card.tutorialLength)}</span> : undefined}
+                {card.tutorialLength ? <span className="ui tutorial-progress orange left floated label">{lf("{0}/{1} steps", (card.tutorialStep || 0) + 1, card.tutorialLength)}</span> : undefined}
                 {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span> : null}
             </div> : undefined}
             {card.extracontent || card.learnMoreUrl || card.buyUrl || card.feedbackUrl ?

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -82,7 +82,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
         const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`}
             role={card.role} aria-selected={card.role === "option" ? "true" : undefined} aria-label={card.ariaLabel || card.title} title={card.title}
             onClick={clickHandler} tabIndex={card.onClick ? card.tabIndex || 0 : null} onKeyDown={card.onClick ? sui.fireClickOnEnter : null}>
-            {card.header || card.blocks || card.javascript || card.hardware || card.software || card.any || card.tutorialLength ?
+            {card.header || card.blocks || card.javascript || card.hardware || card.software || card.any ?
                 <div key="header" className={"ui content " + (card.responsive ? " tall desktop only" : "")}>
                     <div className="right floated meta">
                         {card.any ? (<sui.Icon key="costany" icon="ui grey circular label tiny">{card.any > 0 ? card.any : null} </sui.Icon>) : null}
@@ -90,7 +90,6 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                         {repeat(card.javascript, (k) => <sui.Icon key={"costjs" + k} icon="align left blue" />)}
                         {repeat(card.hardware, (k) => <sui.Icon key={"costhardware" + k} icon="certificate black" />)}
                         {repeat(card.software, (k) => <sui.Icon key={"costsoftware" + k} icon="square teal" />)}
-                        {card.tutorialLength ? <span className="ui label">{lf("{0}/{1}", card.tutorialStep || 0, card.tutorialLength)}</span> : undefined}
                     </div>
                     {card.header}
                 </div> : null}
@@ -98,7 +97,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                 {card.label || card.labelIcon ?
                     <label role={card.onLabelClicked ? 'button' : undefined} onClick={card.onLabelClicked}
                         className={`ui ${card.labelClass ? card.labelClass : "orange right ribbon"} label`}>
-                    {card.labelIcon ? <sui.Icon icon={card.labelIcon} /> : card.label}</label> : undefined}
+                        {card.labelIcon ? <sui.Icon icon={card.labelIcon} /> : card.label}</label> : undefined}
                 {card.typeScript ? <pre key="promots">{card.typeScript}</pre> : undefined}
                 {card.cardType != "file" && imageUrl ? <div className="ui imagewrapper">
                     <div className={`ui cardimage`} data-src={imageUrl} ref="lazyimage" />
@@ -117,6 +116,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                     {card.description ? <div className="description tall">{renderMd(card.description)}</div> : null}
                 </div> : undefined}
             {card.time ? <div className="meta">
+                {card.tutorialLength ? <span className="ui tutorial-progress left label">{lf("{0}/{1} steps", card.tutorialStep || 0, card.tutorialLength)}</span> : undefined}
                 {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span> : null}
             </div> : undefined}
             {card.extracontent || card.learnMoreUrl || card.buyUrl || card.feedbackUrl ?

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -289,7 +289,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
     private hasFetchErrors = false;
     private latestProject: codecard.CodeCardView;
 
-    private static NUM_PROJECTS_HOMESCREEN = 10;
+    private static NUM_PROJECTS_HOMESCREEN = 8;
 
     constructor(props: ProjectsCarouselProps) {
         super(props)
@@ -417,6 +417,8 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                                 scr={scr} index={index}
                                 onCardClick={this.handleCardClick}
                                 cardType={scr.cardType}
+                                tutorialStep={scr.tutorialStep}
+                                tutorialLength={scr.tutorialLength}
                             />
                         )}
                     </carousel.Carousel>
@@ -468,6 +470,8 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                         url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}
                         scr={scr} index={index}
                         onCardClick={this.handleCardClick}
+                        tutorialStep={scr.tutorial && scr.tutorial.tutorialStep}
+                        tutorialLength={scr.tutorial && scr.tutorial.tutorialStepInfo.length}
                     />;
                 })}
                 {showScriptManagerCard ? <div role="button" className="ui card link buttoncard scriptmanagercard" title={lf("See all projects")}


### PR DESCRIPTION
Store tutorial information in header to allow restarting. This means that "Exit Tutorial" exits the editor but retains the progress, "finish" has the same behavior as today.

- [x] store tutorial info in header
- [x] display progress on card
- [x] allow reload within step
- [x] reload filters

![image](https://user-images.githubusercontent.com/4175913/55235621-37645f00-51eb-11e9-8f1b-7e8a2d9508e0.png)

This fixes the download issue in Aracde.

![fire](https://user-images.githubusercontent.com/4175913/55235906-ee60da80-51eb-11e9-9652-58b507a44b35.gif)
