### PR TITLE
Match regular JavaScript for Array.join

### DIFF
--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -81,7 +81,7 @@ interface Array<T> {
       * @param sep the string separator
       */
     //% helper=arrayJoin weight=40
-    join(sep: string): string;
+    join(sep?: string): string;
     
     /**
       * Tests whether at least one element in the array passes the test implemented by the provided function.

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -65,13 +65,14 @@ namespace helpers {
         return arr.removeAt(0);
     }
 
-    export function arrayJoin<T>(arr: T[], sep: string): string {
+    export function arrayJoin<T>(arr: T[], sep?: string): string {
+        sep = sep || ",";
         let r = "";
         let len = arr.length // caching this seems to match V8
         for (let i = 0; i < len; ++i) {
             if (i > 0 && sep)
                 r += sep;
-            r += arr[i] || "";
+            r += (arr[i] === undefined || arr[i] === null) ? "" : arr[i];
         }
         return r;
     }

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -66,7 +66,10 @@ namespace helpers {
     }
 
     export function arrayJoin<T>(arr: T[], sep?: string): string {
-        sep = sep || ",";
+        if (sep === undefined || sep === null) {
+            sep = ",";
+        }
+
         let r = "";
         let len = arr.length // caching this seems to match V8
         for (let i = 0; i < len; ++i) {

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -81,7 +81,7 @@ interface Array<T> {
       * @param sep the string separator
       */
     //% helper=arrayJoin weight=40
-    join(sep: string): string;
+    join(sep?: string): string;
     
     /**
       * Tests whether at least one element in the array passes the test implemented by the provided function.

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -65,13 +65,14 @@ namespace helpers {
         return arr.removeAt(0);
     }
 
-    export function arrayJoin<T>(arr: T[], sep: string): string {
+    export function arrayJoin<T>(arr: T[], sep?: string): string {
+        sep = sep || ",";
         let r = "";
         let len = arr.length // caching this seems to match V8
         for (let i = 0; i < len; ++i) {
             if (i > 0 && sep)
                 r += sep;
-            r += arr[i] || "";
+            r += (arr[i] === undefined || arr[i] === null) ? "" : arr[i];
         }
         return r;
     }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -66,7 +66,10 @@ namespace helpers {
     }
 
     export function arrayJoin<T>(arr: T[], sep?: string): string {
-        sep = sep || ",";
+        if (sep === undefined || sep === null) {
+            sep = ",";
+        }
+
         let r = "";
         let len = arr.length // caching this seems to match V8
         for (let i = 0; i < len; ++i) {


### PR DESCRIPTION
split off from #5408 

fixes https://github.com/Microsoft/pxt-arcade/issues/784
fixes https://github.com/Microsoft/pxt/issues/5396

This matches https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join behavior for ``Array.join`` -- separator defaults to ``,``, and only ``undefined`` and ``null`` are replaced with the empty string, not all falsey values. Note that the second part of this won't behave nicely in the simulator without #5408, as 
all values default to 0. That is, 

```typescript
let mySprites: Sprite[] = [];
mySprites[5] = undefined;
console.log(mySprites.join());
```

results in ``0,0,0,0,0,0`` in the simulator and ``,,,,,`` on hardware