### PR TITLE
Hiding toolbox flyout when in debug mode

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -30,6 +30,15 @@
     flex-direction: column;
 }
 
+/* Debugger toolbox flyout */
+.debugging .blocklyFlyout {
+    display: none!important;
+}
+
+.debugging .blocklyFlyoutScrollbar {
+    display: none!important;
+}
+
 /* Debugger toolbar */
 .debugtoolbar {
     // don't show the toolbar unless we're debugging.


### PR DESCRIPTION
When toggling debug mode, we should hide the toolbox flyout if it's open.