### PR TITLE
Include `String.charCodeAt` in toolbox

### DIFF
--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -333,16 +333,15 @@ declare interface Boolean {
 /**
  * Combine, split, and search text strings.
 */
-//% blockNamespace="Text"
+//% blockNamespace="text"
 declare namespace String {
 
     /**
      * Make a string from the given ASCII character code.
      */
     //% help=math/from-char-code
-    //% shim=String_::fromCharCode
-    //% weight=0
-    //% blockNamespace="Text" blockId="stringFromCharCode" block="text from char code %code" weight=1
+    //% shim=String_::fromCharCode weight=1
+    //% blockNamespace="text" blockId="stringFromCharCode" block="text from char code %code"
     function fromCharCode(code: number): string;
 }
 

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -333,16 +333,15 @@ declare interface Boolean {
 /**
  * Combine, split, and search text strings.
 */
-//% blockNamespace="Text"
+//% blockNamespace="text"
 declare namespace String {
 
     /**
      * Make a string from the given ASCII character code.
      */
     //% help=math/from-char-code
-    //% shim=String_::fromCharCode
-    //% weight=0
-    //% blockNamespace="Text" blockId="stringFromCharCode" block="text from char code %code" weight=1
+    //% shim=String_::fromCharCode weight=1
+    //% blockNamespace="text" blockId="stringFromCharCode" block="text from char code %code"
     function fromCharCode(code: number): string;
 }
 


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-microbit/issues/1725
fixes the last part of https://github.com/Microsoft/pxt-microbit/issues/1940 (still outstanding issues there though)

<img width="393" alt="Screen Shot 2019-04-01 at 9 54 56 AM" src="https://user-images.githubusercontent.com/5615930/55345233-40ac3080-5464-11e9-868e-7fe1f67f0c32.png">

^^

For consistency, this should probably switch to `text` to match the string interface methods declared just above which fixes the issue, but it's probably worth making `blockNamespace` ignore case as well.