### PR TITLE
Disabling debug mode in JavaScript

### DIFF
--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -92,7 +92,8 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const run = true; // !compileBtn || !pxt.appTarget.simulator.autoRun || !isBlocks;
         const restart = run && !simOpts.hideRestart;
         const trace = !!targetTheme.enableTrace;
-        const debug = targetTheme.debugger && !inTutorial;
+        // We hide debug button in Monaco because it's not implemented yet.
+        const debug = targetTheme.debugger && !inTutorial && !pxt.BrowserUtils.isIE() && this.props.parent.isBlocksEditor;
         const tracing = this.props.parent.state.tracing;
         const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debugging = parentState.debugging;

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -93,7 +93,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const restart = run && !simOpts.hideRestart;
         const trace = !!targetTheme.enableTrace;
         // We hide debug button in Monaco because it's not implemented yet.
-        const debug = targetTheme.debugger && !inTutorial && !pxt.BrowserUtils.isIE() && this.props.parent.isBlocksEditor;
+        const debug = targetTheme.debugger && !inTutorial && !pxt.BrowserUtils.isIE() && this.props.parent.isBlocksEditor();
         const tracing = this.props.parent.state.tracing;
         const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debugging = parentState.debugging;


### PR DESCRIPTION
We hide debug mode button in JavaScript until it's implemented.
We also disable it for IE.