### PR TITLE
Making debugger resume properly after breakpoint

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -358,7 +358,7 @@ namespace pxsim {
                 })
             }).then(() => {
                 // if some events arrived while processing above then keep processing
-                if (this.events.length > 0 && !runtime.pausedOnBreakpoint) {
+                if (this.events.length > 0) {
                     return this.poke()
                 } else {
                     this.lock = false


### PR DESCRIPTION
Fixing https://github.com/Microsoft/pxt-arcade/issues/846.
This was introduced in https://github.com/Microsoft/pxt/pull/5411 trying to make sure all fibers were being paused on breakpoint.