### PR TITLE
Allow simulator to reset buttons after breakpoints.

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -203,6 +203,7 @@ namespace pxsim {
             this.runOptions = msg;
             return Promise.resolve()
         }
+        public onDebuggerResume() { }
         public screenshotAsync(width?: number): Promise<ImageData> {
             return Promise.resolve(undefined);
         }
@@ -775,6 +776,7 @@ namespace pxsim {
                     dbgHeap = null;
                     if (__this.dead) return null;
                     __this.resumeAllPausedScheduled();
+                    __this.board.onDebuggerResume();
                     runtime = __this;
                     U.assert(s.pc == retPC);
 


### PR DESCRIPTION
With https://github.com/Microsoft/pxt-arcade-sim/pull/5, when a breakpoint is hit while a button is pressed, the button will be released after resuming execution.