### PR TITLE
Allow for specifying hash arguments and language

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -187,7 +187,7 @@ export class ProjectView
         // (e.g. from the URL hash or from WinRT activation arguments)
         const skipStartScreen = pxt.appTarget.appTheme.allowParentController
             || pxt.shell.isControllerMode()
-            || window.location.hash == "#editor";
+            || /^#editor/.test(window.location.hash);
         return !isSandbox && !skipStartScreen && !isProjectRelatedHash(hash);
     }
 
@@ -3016,7 +3016,7 @@ let myexports: any = {
 export let ksVersion: string;
 
 function parseHash(): { cmd: string; arg: string } {
-    let hashM = /^#(\w+)(:([:\.\/\-\+\=\w]+))?$/.exec(window.location.hash)
+    let hashM = /^#(\w+)(:([:\.\/\-\+\=\w]+))?/.exec(window.location.hash)
     if (hashM) {
         return { cmd: hashM[1], arg: hashM[3] || '' };
     }


### PR DESCRIPTION
This makes it so you can specify the hash argument and any other arguments passed through the URL.

This is mostly used for linking to a tutorial or the editor in another language as shown:
[http://makecode.microbit.org/#tutorial:/tutorials/getting-started&lang=fr](http://makecode.microbit.org/#tutorial:/tutorials/getting-started&lang=fr)

Fixes Microsoft/pxt-microbit#1536