### PR TITLE
allow blocks with 'any' inputs to accept any block

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -512,7 +512,7 @@ namespace pxt.blocks {
         const body = fn.parameters ? fn.parameters.filter(pr => pr.type == "() => void" || pr.type == "Action")[0] : undefined;
         if (body || hasHandler) {
             block.appendStatementInput("HANDLER")
-                .setCheck("null");
+                .setCheck(null);
             block.setInputsInline(true);
         }
 
@@ -689,6 +689,8 @@ namespace pxt.blocks {
                                 else {
                                     inputCheck = "String"
                                 }
+                            } else if (pr.type == "any") {
+                                inputCheck = null;
                             } else {
                                 inputCheck = pr.type == "T" ? undefined : (isArrayType(pr.type) ? ["Array", pr.type] : pr.type);
                             }
@@ -825,6 +827,7 @@ namespace pxt.blocks {
             case "number": return ["Number"];
             case "string": return ["String"];
             case "boolean": return ["Boolean"];
+            case "any": return null;
             case "void": return undefined
             default:
                 if (type !== "T") {


### PR DESCRIPTION
Allow parameters of type ``any`` to accept any reporters as valid input, rather than bouncing away everything besides variable reporters

![2019-04-02 16 55 48](https://user-images.githubusercontent.com/5615930/55443651-5efb5480-5568-11e9-977e-9636482bbd96.gif)
