### PR TITLE
Show extra code card content on tablet view and up

### DIFF
--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -119,7 +119,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                 {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span> : null}
             </div> : undefined}
             {card.extracontent || card.learnMoreUrl || card.buyUrl || card.feedbackUrl ?
-                <div className="ui extra content widedesktop only">
+                <div className="ui extra content mobile hide">
                     {card.extracontent}
                     {card.buyUrl ?
                         <a className="learnmore left floated" href={card.buyUrl}


### PR DESCRIPTION
fixes Microsoft/pxt-microbit#1741

Show extra code card content on tablet view and up (rather than only on wide desktops)

![ezgif com-resize (6)](https://user-images.githubusercontent.com/5615930/55521137-4ce6e800-5634-11e9-84b4-6935e430f60a.gif)
