### PR TITLE
Trims description for fixed height cards

### DIFF
--- a/theme/scriptsearch.less
+++ b/theme/scriptsearch.less
@@ -3,7 +3,6 @@
 /*******************************
     Script search dialog
 *******************************/
-
 .ui.searchdialog {
     .cards {
         overflow-y: auto;
@@ -14,6 +13,20 @@
         height: 20rem;
         .ui.cardimage {
             height: 11rem;
+        }
+        .content:not(.extra) {
+            .header {
+                white-space: nowrap;
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
+            .description {
+                height: 2.8em;
+                overflow: hidden;
+            }
+            .description.long  {
+                height: 14em;
+            }
         }
     }
     /* Search input */

--- a/theme/scriptsearch.less
+++ b/theme/scriptsearch.less
@@ -3,6 +3,7 @@
 /*******************************
     Script search dialog
 *******************************/
+
 .ui.searchdialog {
     .cards {
         overflow-y: auto;

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -113,7 +113,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             {card.shortName || card.name || card.description ?
                 <div className="content">
                     {card.shortName || card.name ? <div className="header">{card.shortName || card.name}</div> : null}
-                    {card.description ? <div className="description tall">{renderMd(card.description)}</div> : null}
+                    {card.description ? <div className={`description tall ${card.icon || card.iconContent || card.imageUrl ? "" : "long"}`}>{renderMd(card.description)}</div> : null}
                 </div> : undefined}
             {card.time ? <div className="meta">
                 {card.time ? <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span> : null}


### PR DESCRIPTION
There are a few cards that we fix the height for: extensions, experiments, and the board selection in maker. This sets the title to be 1 line and uses an ellipsis to show that the title is longer, but couldn't be displayed. This sets a fixed height for the description of each card do that they don't bleed outside of the card. The description height is either set to 2 lines or 10 lines depending on whether or not there is an image present in the card. 

Fixes Microsoft/pxt-microbit#1835

Here is what it looks like before and after:

## Desktop Before
![desktop-before](https://user-images.githubusercontent.com/13285164/55584311-c3d5bc80-56d8-11e9-8e45-21113b9ef1f9.png)

## Desktop After
![desktop-after](https://user-images.githubusercontent.com/13285164/55584325-ca643400-56d8-11e9-8102-3f2c055ad1d9.png)

## Tablet Before
![tablet-before](https://user-images.githubusercontent.com/13285164/55584340-d4863280-56d8-11e9-8d30-90141dfa97ce.gif)

## Tablet After
![tablet-after](https://user-images.githubusercontent.com/13285164/55584352-dbad4080-56d8-11e9-93f2-f5b00956bcf4.gif)

## Phone Before
![phone-before](https://user-images.githubusercontent.com/13285164/55584370-e5cf3f00-56d8-11e9-95a6-0c2f52264253.gif)

## Phone After
![phone-after](https://user-images.githubusercontent.com/13285164/55584382-ec5db680-56d8-11e9-868e-e299bf5d8af8.gif)



