### PR TITLE
 Debugger: Improvements to variable explorer

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -100,14 +100,34 @@
 }
 
 /* Debugger variables view */
+.ui.varExplorer {
+    width: 100%;
+    .ui.variableTableHeader {
+        padding-top: 1rem;
+        padding-bottom: 0.5rem;
+        padding-left: 1rem;
+        border: none;
+        font-family: @pageFont;
+        font-size: larger;
+        color: black;
+    }
+}
 .ui.segment.debugvariables {
-    table-layout: auto;
     width: 100%;
     display: none;
+    max-width: 100%;
 
     .ui.middle.aligned.list {
         overflow-y: auto;
         max-height: 25rem;
+    }
+    .item {
+        max-width: 100%;
+    }
+    .variableAndValue {
+        display: flex;
+        padding-right: 0.4rem;
+        padding-left: 0.4rem;
     }
 
     .transparent{
@@ -118,12 +138,16 @@
     }
     .variable.varname {
         text-overflow: ellipsis;
-        max-width: 1rem;
         overflow: hidden;
         white-space: nowrap;
+        flex-grow: 2;
     }
     .variable.detail {
+        overflow: hidden;
         text-align: right;
+        max-width: 50%;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
     .varval.number {
         color: @debugNumberVariable;
@@ -148,13 +172,20 @@
 }
 
 .debugging .ui.segment.debugvariables {
-    display: table;
+    display: block;
     margin: 0;
     border: none;
 }
 
+.ui.segment.debugvariables:not(.frozen) .item:nth-child(even) {
+    background-color: @debugVariableEven;
+}
+.ui.segment.debugvariables:not(.frozen) .item:nth-child(odd) {
+    background-color: @debugVariableOdd;
+}
+
 .ui.segment.debugvariables.frozen {
-    background: #eee;
+    background: @debugVariableFrozen;
 }
 /* sim overlay */
 div.simframe div.pause-overlay {

--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -14,7 +14,8 @@
 /* Top bar menu */
 .menubar .debugger-menu-item.centered {
     position: fixed;
-    place-content: center;
+    align-content: center;
+    justify-content: center;
     right: 0;
     left: 0;
     margin-right: auto;

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -300,7 +300,9 @@
 @debugArrayVariable: #663905;
 @debugSpriteVariable: blue;
 
+@debugVariableOdd: #fafafa;
+@debugVariableEven: #f0f0f0;
+@debugVariableFrozen: #eee;
+
 @DebuggerBackgroundPrimaryColor: #e67e22;
 @DebuggerBackgroundSecondaryColor: lightgreen;
-
-@debuggerVariableExplorerBackground: white;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2326,7 +2326,6 @@ export class ProjectView
 
     toggleDebugging() {
         const state = !this.state.debugging;
-        pxt.log("turning debugging mode to " + state);
         this.setState({ debugging: state, tracing: false }, () => {
             this.renderCore()
             if (this.editor) {

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -189,18 +189,17 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             let type = this.variableType(v);
             const onClick = v.value && v.value.id ? () => this.toggle(v) : undefined;
 
-            r.push(<tr key={(parent || "") + variable} className="item" onClick={onClick} onMouseOver={this.onMouseOverVariable}>
-                <td className={`variable varname ${v.prevValue !== undefined ? "changed" : ""}`} title={variable}>
-                    <i className={`${(v.children ? "down triangle icon" : "right triangle icon") + ((v.value && v.value.hasFields) ? "" : " transparent")}`} style={{ marginLeft: margin }} ></i>
-                    <span>{variable + ':'}</span>
-                </td>
-                <td style={{ padding: 0.2 }} title={this.shouldShowValueOnHover(type) ? newValue : ""}>
-                    <div className="variable detail">
-                        <span className={`varval ${type}`}>{DebuggerVariables.capLength(newValue)}</span>
-                        <span className="previousval">{(oldValue !== "undefined" && oldValue !== newValue) ? `${DebuggerVariables.capLength(oldValue)}` : ''}</span>
+            r.push(<div key={(parent || "") + variable} className="item" onClick={onClick} onMouseOver={this.onMouseOverVariable}>
+                <div className="variableAndValue">
+                    <div className={`variable varname ${v.prevValue !== undefined ? "changed" : ""}`} title={variable}>
+                        <i className={`${(v.children ? "down triangle icon" : "right triangle icon") + ((v.value && v.value.hasFields) ? "" : " transparent")}`} style={{ marginLeft: margin }} ></i>
+                        <span>{variable + ':'}</span>
                     </div>
-                </td>
-            </tr>
+                    <div className="variable detail" style={{ padding: 0.2 }} title={this.shouldShowValueOnHover(type) ? newValue : ""}>
+                        <span className={`varval ${type}`}>{DebuggerVariables.capLength(newValue)}</span>
+                    </div>
+                </div>
+            </div>
             );
             if (v.children)
                 r = r.concat(this.renderVariables(v.children, variable, depth + 1));
@@ -210,20 +209,17 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
 
     renderCore() {
         const { variables, frozen } = this.state;
-        const variableTableHeader = lf("Variable");
+        const variableTableHeader = lf("Variables");
         const valueTableHeader = lf("Type/Value");
 
-        return <table className={`ui segment debugvariables ${frozen ? "frozen" : ""} ui collapsing basic striped table`}>
-            <thead>
-                <tr>
-                    <th>{variableTableHeader}</th>
-                    <th>{valueTableHeader}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {(Object.keys(variables).length == 0) ? <tr /> : this.renderVariables(variables)}
-            </tbody>
-        </table>;
+        return <div className={`ui varExplorer`}>
+            <div className="ui variableTableHeader">
+                {variableTableHeader}
+            </div>
+            <div className={`ui segment debugvariables ${frozen ? "frozen" : ""} ui collapsing basic striped table`}>
+                {(Object.keys(variables).length == 0) ? <div /> : this.renderVariables(variables)}
+            </div>
+        </div>;
     }
 }
 

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -184,7 +184,6 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
         let margin = depth * 0.75 + 'em';
         varNames.forEach(variable => {
             const v = variables[variable];
-            const oldValue = DebuggerVariables.renderValue(v.prevValue);
             const newValue = DebuggerVariables.renderValue(v.value);
             let type = this.variableType(v);
             const onClick = v.value && v.value.id ? () => this.toggle(v) : undefined;
@@ -210,7 +209,6 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
     renderCore() {
         const { variables, frozen } = this.state;
         const variableTableHeader = lf("Variables");
-        const valueTableHeader = lf("Type/Value");
 
         return <div className={`ui varExplorer`}>
             <div className="ui variableTableHeader">

--- a/webapp/src/debugger.tsx
+++ b/webapp/src/debugger.tsx
@@ -189,7 +189,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             let type = this.variableType(v);
             const onClick = v.value && v.value.id ? () => this.toggle(v) : undefined;
 
-            r.push(<div key={(parent || "") + variable} className="item" onClick={onClick} onMouseOver={this.onMouseOverVariable}>
+            r.push(<div key={(parent || "") + variable} role="listitem" className="item" onClick={onClick} onMouseOver={this.onMouseOverVariable}>
                 <div className="variableAndValue">
                     <div className={`variable varname ${v.prevValue !== undefined ? "changed" : ""}`} title={variable}>
                         <i className={`${(v.children ? "down triangle icon" : "right triangle icon") + ((v.value && v.value.hasFields) ? "" : " transparent")}`} style={{ marginLeft: margin }} ></i>


### PR DESCRIPTION
Rolling back from table. Now every row of variable:value will auto adjust width to accommodate variables with long names and/or values.
Aesthetic changes.
Fixing bug in Edge where "Debug Mode" title was not centered.