### PR TITLE
Fix svg cursorPoints for safari in iOS

### DIFF
--- a/pxtsim/svg.ts
+++ b/pxtsim/svg.ts
@@ -9,8 +9,9 @@ namespace pxsim.svg {
 
     let pt: SVGPoint;
     export function cursorPoint(pt: SVGPoint, svg: SVGSVGElement, evt: MouseEvent): SVGPoint {
-        pt.x = evt.clientX;
-        pt.y = evt.clientY;
+        // clientX and clientY are not defined in iOS safari
+        pt.x = evt.clientX || evt.pageX;
+        pt.y = evt.clientY || evt.pageY;
         return pt.matrixTransform(svg.getScreenCTM().inverse());
     }
 

--- a/pxtsim/svg.ts
+++ b/pxtsim/svg.ts
@@ -10,8 +10,8 @@ namespace pxsim.svg {
     let pt: SVGPoint;
     export function cursorPoint(pt: SVGPoint, svg: SVGSVGElement, evt: MouseEvent): SVGPoint {
         // clientX and clientY are not defined in iOS safari
-        pt.x = evt.clientX || evt.pageX;
-        pt.y = evt.clientY || evt.pageY;
+        pt.x = evt.clientX != null ? evt.clientX : evt.pageX;
+        pt.y = evt.clientY != null ? evt.clientY : evt.pageY;
         return pt.matrixTransform(svg.getScreenCTM().inverse());
     }
 


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-microbit/issues/1382 (this behavior also applied to the compass heading and light level at a glance; looks like any svg simulator buttons that required x/y positions)

it looks like the accelerometer is also broken on iOS safari, though; it's probably the same type thing as this, will give it a look tomorrow morning

## xcode simulator view

![2019-04-04 17 26 23](https://user-images.githubusercontent.com/5615930/55596729-e8dd2600-56fe-11e9-8378-c78ca280f14b.gif)