### PR TITLE
better localization support in completions

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -405,10 +405,10 @@ namespace ts.pxtc {
         if (!symbolKindWeight) {
             symbolKindWeight = {};
             symbolKindWeight[SymbolKind.Variable] = 100;
+            symbolKindWeight[SymbolKind.Module] = 101;
             symbolKindWeight[SymbolKind.Function] = 99;
             symbolKindWeight[SymbolKind.Property] = 98;
             symbolKindWeight[SymbolKind.Method] = 97;
-            symbolKindWeight[SymbolKind.Module] = 90
             symbolKindWeight[SymbolKind.Class] = 89;
             symbolKindWeight[SymbolKind.Enum] = 81;
             symbolKindWeight[SymbolKind.EnumMember] = 80;
@@ -823,7 +823,7 @@ namespace ts.pxtc.service {
                     /^__/.test(si.namespace) || // ignore namespaces starting with _-
                     si.attributes.hidden ||
                     si.attributes.deprecated
-                ) continue; // ignore 
+                ) continue; // ignore
                 entries[si.qName] = si
                 const n = lastApiInfo.decls[si.qName];
                 if (isFunctionLike(n)) {

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -141,6 +141,7 @@ namespace pxt.vs {
             occurrencesHighlight: false,
             quickSuggestionsDelay: 200,
             theme: inverted ? 'vs-dark' : 'vs',
+            renderIndentGuides: true,
             //accessibilitySupport: 'on',
             accessibilityHelpUrl: "" //TODO: Add help url explaining how to use the editor with a screen reader
         });

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -66,13 +66,20 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
         return compiler.completionsAsync(fileName, offset, source)
             .then(completions => {
                 const items = (completions.entries || []).map((si, i) => {
+                    const snippet = this.python ? si.pySnippet : si.snippet;
+                    const label = this.python
+                        ? (completions.isMemberCompletion ? si.pyName : si.pyQName)
+                        : (completions.isMemberCompletion ? si.name : si.qName);
+                    const documentation = pxt.Util.rlf(si.attributes.jsDoc);
+                    const block = pxt.Util.rlf(si.attributes.block);
                     return {
-                        label: this.python ? (completions.isMemberCompletion ? si.pyName : si.pyQName) : (completions.isMemberCompletion ? si.name : si.qName),
+                        label,
                         kind: this.tsKindToMonacoKind(si.kind),
-                        documentation: si.attributes.jsDoc,
+                        documentation,
                         detail: this.python ? si.pySnippet : si.snippet,
                         // force monaco to use our sorting
-                        sortText: `${tosort(i)} ${this.python ? si.pySnippet : si.snippet}`
+                        sortText: `${tosort(i)} ${snippet}`,
+                        filterText: `${label} ${documentation} ${block}`
                     } as monaco.languages.CompletionItem;
                 })
                 return items;
@@ -111,13 +118,14 @@ class SignatureHelper implements monaco.languages.SignatureHelpProvider {
             .then(r => {
                 let sym = r.symbols ? r.symbols[0] : null
                 if (!sym || !sym.parameters) return null;
+                const documentation = pxt.Util.rlf(sym.attributes.jsDoc);
                 const res: monaco.languages.SignatureHelp = {
                     signatures: [{
                         label: sym.name,
-                        documentation: sym.attributes.jsDoc,
+                        documentation,
                         parameters: sym.parameters.map(p => ({
-                            label: p.name,
-                            documentation: p.name + ": " + p.type
+                            label: `${p.name}: ${p.type}`,
+                            documentation: pxt.Util.rlf(p.description)
                         }))
                     }],
                     activeSignature: 0,
@@ -146,8 +154,9 @@ class HoverProvider implements monaco.languages.HoverProvider {
             .then(r => {
                 let sym = r.symbols ? r.symbols[0] : null
                 if (!sym) return null;
+                const documentation = pxt.Util.rlf(sym.attributes.jsDoc);
                 const res: monaco.languages.Hover = {
-                    contents: [sym.pyQName + " " + sym.attributes.jsDoc],
+                    contents: [`**${sym.pyQName}**`, documentation],
                     range: monaco.Range.fromPositions(model.getPositionAt(r.beginPos), model.getPositionAt(r.endPos))
                 }
                 return res


### PR DESCRIPTION
* localize jsdocs before passing to monaco
* use block string in filter as well
* show indent guides
