### PR TITLE
Add base reference page for 'to-string'

### DIFF
--- a/common-docs/reference/text.md
+++ b/common-docs/reference/text.md
@@ -8,10 +8,11 @@ Functions to combine, split, and search text strings.
 "".substr(0, 0);
 parseFloat("");
 parseInt("");
+toString(0);
 ```
 
 ## See also
 
 [char at](/reference/text/char-at), [compare](/reference/text/compare),
 [substr](/reference/text/substr), [parse int](/reference/text/parse-int), 
-[parse float](/reference/text/parse-float)
+[parse float](/reference/text/parse-float), [to string](/reference/text/to-string)

--- a/common-docs/reference/text/to-string.md
+++ b/common-docs/reference/text/to-string.md
@@ -1,0 +1,34 @@
+# to String
+
+Change a [number](/types/number) or a [boolean](/types/boolean) value into a text [string](/types/string).
+
+```sig
+toString(123)
+```
+
+## Parameters
+
+* **value**: a [number](/types/number) or [boolean](/types/boolean) value to convert to a [string](/types/string).
+
+## Returns
+
+* a [string](/types/string) that is a text representation of **value**.
+
+## Example #example
+
+Convert a boolean and a number value to strings and join them in a sentence.
+
+```blocks
+let myBoolean = false
+let myNumber = 0
+
+myBoolean = true
+myNumber = 123
+
+let myString = "It is " + toString(myBoolean) + " that " + toString(myNumber) + " is now a string!"
+```
+
+## Sea also #seealso
+
+[parse int](/reference/text/parse-int), 
+[parse float](/reference/text/parse-float)

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -327,6 +327,7 @@ declare interface Boolean {
      * Returns a string representation of an object.
      */
     //% shim=numops::toString
+    //% help=text/to-string
     toString(): string;
 }
 
@@ -350,6 +351,7 @@ declare interface Number {
      * Returns a string representation of a number.
      */
     //% shim=numops::toString
+    //% help=text/to-string
     toString(): string;
 }
 


### PR DESCRIPTION
- [x] Put in a base reference page for **toString()**.
- [x] Add help paths for number.toString() and boolean.toString().
- [x] Add 'toString()' to card page.
