### PR TITLE
Add builtin 'string compare' block

### DIFF
--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -155,11 +155,30 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     </value>
                 </block>`
                 }, {
+                    name: "logic_compare_strings",
+                    attributes: {
+                        blockId: "logic_compare",
+                        group: lf("Comparison"),
+                        weight: 45
+                    },
+                    blockXml: `<block type="logic_compare" gap="8">
+                    <value name="A">
+                        <shadow type="text">
+                            <field name="TEXT"></field>
+                        </shadow>
+                    </value>
+                    <value name="B">
+                        <shadow type="text">
+                            <field name="TEXT"></field>
+                        </shadow>
+                    </value>
+                </block>`
+                }, {
                     name: "logic_operation_and",
                     attributes: {
                         blockId: "logic_operation",
                         group: lf("Boolean"),
-                        weight: 45
+                        weight: 44
                     },
                     blockXml: `<block type="logic_operation" gap="8">
                     <field name="OP">AND</field>
@@ -169,7 +188,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     attributes: {
                         blockId: "logic_operation",
                         group: lf("Boolean"),
-                        weight: 44
+                        weight: 43
                     },
                     blockXml: `<block type="logic_operation" gap="8">
                     <field name="OP">OR</field>
@@ -179,7 +198,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     attributes: {
                         blockId: "logic_negate",
                         group: lf("Boolean"),
-                        weight: 43
+                        weight: 42
                     },
                     blockXml: `<block type="logic_negate"></block>`
                 }, {
@@ -187,7 +206,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     attributes: {
                         blockId: "logic_boolean",
                         group: lf("Boolean"),
-                        weight: 42
+                        weight: 41
                     },
                     blockXml: `<block type="logic_boolean" gap="8">
                     <field name="BOOL">TRUE</field>
@@ -197,7 +216,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     attributes: {
                         blockId: "logic_boolean",
                         group: lf("Boolean"),
-                        weight: 41
+                        weight: 40
                     },
                     blockXml: `<block type="logic_boolean">
                     <field name="BOOL">FALSE</field>


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-microbit/issues/1050

Adds a new builtin block that is the same as normal comparison, but contains strings by default instead of numbers

![Screen Shot 2019-04-08 at 11 35 49 AM](https://user-images.githubusercontent.com/5615930/55748510-c2b3d080-59f3-11e9-83dc-dc5ca0954b54.png)
