### PR TITLE
Ability to use arrays as shadow blocks

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -104,7 +104,6 @@ namespace pxt.blocks {
         const value = document.createElement("value");
         value.setAttribute("name", p.definitionName);
 
-
         const isArray = /(.*)\[\]$/.exec(p.type);
 
         const shadow = document.createElement(isVariable || isArray ? "block" : "shadow");
@@ -121,10 +120,10 @@ namespace pxt.blocks {
             mut.setAttribute("items", "3");
             shadow.appendChild(mut);
             for (let i = 0; i < 3; i++) {
-                const v2 = document.createElement("value");
-                v2.setAttribute("name", "ADD" + i);
-                const shadow2 = document.createElement("shadow");
-                shadow2.setAttribute("type", typeInfo.block);
+                const innerValue = document.createElement("value");
+                innerValue.setAttribute("name", "ADD" + i);
+                const innerShadow = document.createElement("shadow");
+                innerShadow.setAttribute("type", typeInfo.block);
                 const field = document.createElement("field");
                 field.setAttribute("name", typeInfo.field);
                 switch (isArray[1]) {
@@ -138,9 +137,9 @@ namespace pxt.blocks {
                         field.appendChild(document.createTextNode("FALSE"));
                         break;
                 }
-                shadow2.appendChild(field);
-                v2.appendChild(shadow2);
-                shadow.appendChild(v2);
+                innerShadow.appendChild(field);
+                innerValue.appendChild(innerShadow);
+                shadow.appendChild(innerValue);
             }
             return value;
         }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -30,11 +30,39 @@ namespace pxt.blocks {
     export const optionalDummyInputPrefix = "0_optional_dummy";
     export const optionalInputWithFieldPrefix = "0_optional_field";
 
-    // Matches arrays and tuple types
-    const arrayTypeRegex = /^(?:Array<.+>)|(?:.+\[\])|(?:\[.+\])$/;
-    export function isArrayType(type: string) {
-        return arrayTypeRegex.test(type);
+    // Matches arrays
+    export function isArrayType(type: string): string {
+        const arrayTypeRegex = /^(?:Array<(.+)>)|(?:(.+)\[\])|(?:\[.+\])$/;
+        let parsed = arrayTypeRegex.exec(type);
+        if (parsed) {
+            // Is an array, returns what type it is an array of
+            if (parsed[1]) {
+                // Is an array with form Array<type>
+                return parsed[1];
+            } else {
+                // Is an array with form type[]
+                return parsed[2];
+            }
+        } else {
+            // Not an array
+            return undefined;
+        }
     }
+
+    // Matches tuples
+    export function isTupleType(type: string): string[] {
+        const tupleTypeRegex = /^\[(.+)\]$/;
+        let parsed = tupleTypeRegex.exec(type);
+        if (parsed) {
+            // Returns an array containing the types of the tuple
+            return parsed[1].split(/,\s*/);
+        } else {
+            // Not a tuple
+            return undefined;
+        }
+    }
+
+    const primitiveTypeRegex = /^(string|number|boolean)$/;
 
     type NamedField = { field: Blockly.Field, name?: string };
 
@@ -104,18 +132,19 @@ namespace pxt.blocks {
         const value = document.createElement("value");
         value.setAttribute("name", p.definitionName);
 
-        const isArray = /(.*)\[\]$/.exec(p.type);
+        const isArray = isArrayType(p.type);
 
         const shadow = document.createElement(isVariable || isArray ? "block" : "shadow");
 
         value.appendChild(shadow);
 
-        const typeInfo = typeDefaults[isArray && isArray[1] || p.type];
+        const typeInfo = typeDefaults[isArray || p.type];
 
-        shadow.setAttribute("type", isArray ? 'lists_create_with' : shadowId || typeInfo && typeInfo.block || p.type);
+        shadow.setAttribute("type", shadowId || (isArray ? 'lists_create_with' : typeInfo && typeInfo.block || p.type));
         shadow.setAttribute("colour", (Blockly as any).Colours.textField);
 
-        if (isArray) {
+        // if an array of booleans, numbers, or strings
+        if (isArray && typeInfo && !shadowId) {
             const mut = document.createElement('mutation');
             mut.setAttribute("items", "3");
             shadow.appendChild(mut);
@@ -126,7 +155,7 @@ namespace pxt.blocks {
                 innerShadow.setAttribute("type", typeInfo.block);
                 const field = document.createElement("field");
                 field.setAttribute("name", typeInfo.field);
-                switch (isArray[1]) {
+                switch (isArray) {
                     case "number":
                         field.appendChild(document.createTextNode("" + (i + 1)));
                         break;
@@ -276,7 +305,10 @@ namespace pxt.blocks {
         }
         if (fn.parameters) {
             comp.parameters.filter(pr => !pr.isOptional &&
-                (/^(string|number|boolean)(\[\])?$/.test(pr.type) || pr.shadowBlockId || pr.defaultValue))
+                (primitiveTypeRegex.test(pr.type)
+                    || primitiveTypeRegex.test(isArrayType(pr.type))
+                    || pr.shadowBlockId
+                    || pr.defaultValue))
                 .forEach(pr => {
                     block.appendChild(createShadowValue(info, pr));
                 })


### PR DESCRIPTION
This adds the ability to use arrays as shadow blocks so that you can author blocks that take arrays of numbers, strings, or booleans, as parameters.

![arrays_as_shadows](https://user-images.githubusercontent.com/13285164/55850898-3399dc00-5b0b-11e9-8cf4-f22f96cbc73e.gif)

Fixes Microsoft/pxt-microbit#1654