### PR TITLE
Use encodeURIComponent for converting strings to UTF8 buffer

### DIFF
--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -705,6 +705,18 @@ namespace pxsim {
 
 namespace pxsim.control {
     export function createBufferFromUTF8(str: string) {
-        return new pxsim.RefBuffer(U.stringToUint8Array(U.toUTF8(str)));
+        let bytes: number[] = [];
+
+        for (let i = 0; i < str.length; i++) {
+            if (str.charCodeAt(i) > 128) {
+                let char = encodeURIComponent(str[i]);
+                char.split("%").forEach(val => val && bytes.push(parseInt(val, 16)));
+            }
+            else {
+                bytes.push(str.charCodeAt(i));
+            }
+        }
+
+        return new pxsim.RefBuffer(new Uint8Array(bytes));
     }
 }


### PR DESCRIPTION
I've been testing this along as part of the radio overhaul and the implementation we were using sometimes produces junk encodings. Here's an example string that failed:

퐵�漍莆䇃铡

Here's our encoding:

```
%ed%90%b5%ed%b8%9a%e6%bc%8d%e8%8e%86%e4%87%83%e9%93%a1
```

and here's the correct encoding (using `encodeURIComponent()`):

```
%ED%90%B5%EF%BF%BD%E6%BC%8D%E8%8E%86%E4%87%83%E9%93%A1
```

The `toUTF8` function might need to be fixed as well