### PR TITLE
Only starts HID watchers when they aren't activated (Win 10 App)

### DIFF
--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -157,7 +157,9 @@ namespace pxt.winrt {
         if (pxt.appTarget && pxt.appTarget.compile && pxt.appTarget.compile.hidSelectors) {
             pxt.appTarget.compile.hidSelectors.forEach((s) => {
                 const sel = whid.getDeviceSelector(parseInt(s.usagePage), parseInt(s.usageId), parseInt(s.vid), parseInt(s.pid));
-                hidSelectors.push(sel);
+                if (hidSelectors.indexOf(sel) < 0) {
+                    hidSelectors.push(sel);
+                }
             });
         }
         hidSelectors.forEach((s) => {

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -196,6 +196,10 @@ namespace pxt.winrt {
             });
             watchers.push(watcher);
         });
-        watchers.forEach((w) => w.start());
+        watchers.forEach((w) => {
+                if (!w.status) {
+                    w.start();
+                }
+            });
     }
 }

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -198,10 +198,6 @@ namespace pxt.winrt {
             });
             watchers.push(watcher);
         });
-        watchers.forEach((w) => {
-                if (!w.status) {
-                    w.start();
-                }
-            });
+        watchers.filter(w => !w.status).forEach((w) =>  w.start());
     }
 }


### PR DESCRIPTION
This adds a check to see if the HID watchers are activated before starting them.

Starting them while activated causes an error.

Fixes Microsoft/pxt-microbit#1975