### PR TITLE
Fix toggle icon alignment issue

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -397,7 +397,8 @@ div.simframe > iframe {
 }
 
 /* Icon and text */
-.ui.item.link > .icon-and-text.icon ~ .ui.text,
+.ui.item.link.dbg-btn > .icon-and-text.icon ~ .ui.text,
+.ui.item.link > .icon-and-text.icon ~ .ui.text.exit-debugmode-btn,
 .ui.item.icon > .icon-and-text.icon ~ .ui.text,
 .ui.button.icon > .icon-and-text.icon ~ .ui.text {
     margin-left: 0.5em !important;


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-microbit/issues/1960

Return the top bar back to normal:

<img width="1680" alt="Screen Shot 2019-04-11 at 2 51 13 PM" src="https://user-images.githubusercontent.com/5615930/55996986-0285ec80-5c6e-11e9-8a1e-ebbab54bf3fe.png">

and preserve behavior for debug buttons:

<img width="178" alt="Screen Shot 2019-04-11 at 3 20 55 PM" src="https://user-images.githubusercontent.com/5615930/55996990-0580dd00-5c6e-11e9-8db3-42e3ec9aea21.png">
<img width="70" alt="Screen Shot 2019-04-11 at 3 20 49 PM" src="https://user-images.githubusercontent.com/5615930/55996991-0580dd00-5c6e-11e9-9266-c3d5af36c67d.png">

As mentioned in the issue, the alignment definitely feels a bit weird on the top bar, but it does seem to technically be centered; maybe worth spending a minute at a design meeting to figure out how to make it not feel off.
