### PR TITLE
normalize user language + normalize en-US -> en

### DIFF
--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -49,8 +49,8 @@ namespace ts.pxtc.Util {
     let _localizeLang: string = "en";
     let _localizeStrings: pxt.Map<string> = {};
     let _translationsCache: pxt.Map<pxt.Map<string>> = {};
-    let _didSetlocalizations = false;
-    let _didReportLocalizationsNotSet = false;
+    //let _didSetlocalizations = false;
+    //let _didReportLocalizationsNotSet = false;
     export let localizeLive = false;
 
     /**
@@ -65,8 +65,18 @@ namespace ts.pxtc.Util {
     export function userLanguage(): string {
         return _localizeLang;
     }
+
+    export function normalizeLanguageCode(code: string): string[] {
+        const langParts = /^(\w{2})-(\w{2}$)/i.exec(code);
+        if (langParts && langParts[1] && langParts[2]) {
+            return [`${langParts[1].toLowerCase()}-${langParts[2].toUpperCase()}`, langParts[1].toLowerCase()];
+        } else {
+            return [(code || "en").toLowerCase()];
+        }
+    }
+
     export function setUserLanguage(localizeLang: string) {
-        _localizeLang = localizeLang;
+        _localizeLang = normalizeLanguageCode(localizeLang)[0];
     }
 
     export function isUserLanguageRtl(): boolean {
@@ -90,7 +100,7 @@ namespace ts.pxtc.Util {
     }
 
     export function setLocalizedStrings(strs: pxt.Map<string>) {
-        _didSetlocalizations = true;
+        //_didSetlocalizations = true;
         _localizeStrings = strs;
     }
 

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -876,15 +876,6 @@ namespace ts.pxtc.Util {
 
     }
 
-    export function normalizeLanguageCode(code: string): string[] {
-        const langParts = /^(\w{2})-(\w{2}$)/i.exec(code);
-        if (langParts && langParts[1] && langParts[2]) {
-            return [`${langParts[1].toLowerCase()}-${langParts[2].toUpperCase()}`, langParts[1].toLowerCase()];
-        } else {
-            return [code.toLowerCase()];
-        }
-    }
-
     export function isLocaleEnabled(code: string): boolean {
         let [lang, baseLang] = normalizeLanguageCode(code);
         let appTheme = pxt.appTarget.appTheme;
@@ -902,9 +893,14 @@ namespace ts.pxtc.Util {
 
     export function updateLocalizationAsync(targetId: string, baseUrl: string, code: string, pxtBranch: string, targetBranch: string, live?: boolean, force?: boolean): Promise<void> {
         code = normalizeLanguageCode(code)[0];
-        if (code === userLanguage() || (!isLocaleEnabled(code) && !force))
+        if (code === "en-US") 
+            code = "en"; // special case for built-in language
+        if (code === userLanguage() || (!isLocaleEnabled(code) && !force)) {
+            pxt.debug(`loc: ${code} (using built-in)`)
             return Promise.resolve();
+        }
 
+        pxt.debug(`loc: ${code}`);
         return downloadTranslationsAsync(targetId, baseUrl, code, pxtBranch, targetBranch, live)
             .then((translations) => {
                 if (translations) {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -893,7 +893,7 @@ namespace ts.pxtc.Util {
 
     export function updateLocalizationAsync(targetId: string, baseUrl: string, code: string, pxtBranch: string, targetBranch: string, live?: boolean, force?: boolean): Promise<void> {
         code = normalizeLanguageCode(code)[0];
-        if (code === "en-US") 
+        if (code === "en-US")
             code = "en"; // special case for built-in language
         if (code === userLanguage() || (!isLocaleEnabled(code) && !force)) {
             pxt.debug(`loc: ${code} (using built-in)`)


### PR DESCRIPTION
Fix for https://github.com/Microsoft/pxt-arcade/issues/883

Normalize "en-US" to "en" which is the neutral language of makecode (en skips all localization work).