### PR TITLE
Fix enum errors in py2ts

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1083,7 +1083,7 @@ namespace pxt.py {
                     return B.mkGroup(res)
                 } else 
                 */
-                if (currIteration < 2) {
+                if (currIteration == 0) {
                     return B.mkText("/* skip for now */")
                 }
                 unifyTypeOf(n.targets[0], fd.pyRetType)


### PR DESCRIPTION
This used to fail:
```python
class SpriteKind(Enum):
    Player = 0
    Projectile = 1
    Enemy = 2
    Food = 3

ship = sprites.create(sprites.space.space_red_ship, SpriteKind.Player)
#ship.set_flag(SpriteFlag.STAY_IN_SCREEN, True)
```

and it would work with the last line uncommented.
