### PR TITLE
Tutorials for JavaScript/Python

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4982,11 +4982,12 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
                         case "tutorial":
                             {
                                 const tutorialMd = nodeutil.resolveMd(docsRoot, card.url);
+                                const tutorial = pxt.tutorial.parseTutorial(tutorialMd);
                                 const pkgs: pxt.Map<string> = { "blocksprj": "*" };
                                 pxt.Util.jsonMergeFrom(pkgs, pxt.gallery.parsePackagesFromMarkdown(tutorialMd) || {});
                                 addSnippet(<CodeSnippet>{
                                     name: card.name,
-                                    code: pxt.tutorial.bundleTutorialCode(tutorialMd),
+                                    code: tutorial.code,
                                     type: "blocks",
                                     ext: "ts",
                                     packages: pkgs

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -739,6 +739,12 @@ declare namespace ts.pxtc {
 
 
 declare namespace pxt.tutorial {
+    interface TutorialInfo {
+        editor: string; // preferred editor or blocks by default 
+        steps: TutorialStepInfo[];
+        code: string; // all code
+    }
+
     interface TutorialStepInfo {
         fullscreen?: boolean;
         // no coding

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -762,6 +762,7 @@ declare namespace pxt.tutorial {
         tutorialStep?: number; // current tutorial page
         tutorialReady?: boolean; // current tutorial page
         tutorialMd?: string; // full tutorial markdown
+        tutorialCode?: string; // all tutorial code bundled
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -838,7 +838,6 @@ namespace pxt.blocks {
      */
     export function initialize(blockInfo: pxtc.BlocksInfo) {
         init();
-        initTooltip(blockInfo);
         initJresIcons(blockInfo);
     }
 
@@ -866,6 +865,7 @@ namespace pxt.blocks {
         initDrag();
         initDebugger();
         initComments();
+        initTooltip();
 
         // PXT is in charge of disabling, don't record undo for disabled events
         (Blockly.Block as any).prototype.setDisabled = function (disabled: any) {
@@ -2453,7 +2453,7 @@ namespace pxt.blocks {
         Blockly.Msg.WORKSPACE_COMMENT_DEFAULT_TEXT = '';
     }
 
-    function initTooltip(blockInfo: pxtc.BlocksInfo) {
+    function initTooltip() {
 
         const renderTip = (el: any) => {
             if (el.disabled)

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -97,6 +97,7 @@ namespace pxt.editor {
         tutorial?: pxt.tutorial.TutorialOptions;
         dependencies?: pxt.Map<string>;
         tsOnly?: boolean;
+        preferredEditor?: string; // preferred editor to open, pxt.BLOCKS_PROJECT_NAME, ...
     }
 
     export interface ExampleImportOptions {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -238,7 +238,8 @@ namespace pxt.editor {
         loadBlocklyAsync(): Promise<void>;
         isBlocksEditor(): boolean;
         isTextEditor(): boolean;
-        renderBlocksAsync(req: EditorMessageRenderBlocksRequest): Promise<any>;
+        renderBlocksAsync(req: EditorMessageRenderBlocksRequest): Promise<EditorMessageRenderBlocksResponse>;
+        renderPythonAsync(req: EditorMessageRenderPythonRequest): Promise<EditorMessageRenderPythonResponse>;
 
         toggleHighContrast(): void;
         toggleGreenScreen(): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -47,6 +47,7 @@ namespace pxt.editor {
         | "undo"
         | "redo"
         | "renderblocks"
+        | "renderpython"
         | "setscale"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
@@ -171,8 +172,18 @@ namespace pxt.editor {
     }
 
     export interface EditorMessageRenderBlocksResponse {
-        mime: "application/svg+xml";
-        data: string;
+        svg: SVGSVGElement;
+        xml: Promise<any>;
+    }
+
+    export interface EditorMessageRenderPythonRequest extends EditorMessageRequest {
+        action: "renderpython";
+        // typescript code to render
+        ts: string;
+    }
+
+    export interface EditorMessageRenderPythonResponse {
+        python: string;
     }
 
     export interface EditorSimulatorEvent extends EditorMessageRequest {
@@ -328,7 +339,7 @@ namespace pxt.editor {
                                     const rendermsg = data as EditorMessageRenderBlocksRequest;
                                     return Promise.resolve()
                                         .then(() => projectView.renderBlocksAsync(rendermsg))
-                                        .then((r: any) => {
+                                        .then(r => {
                                             return r.xml.then((svg: any) => {
                                                 resp = svg.xml;
                                             })

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -345,6 +345,14 @@ namespace pxt.editor {
                                             })
                                         });
                                 }
+                                case "renderpython": {
+                                    const rendermsg = data as EditorMessageRenderPythonRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.renderPythonAsync(rendermsg))
+                                        .then(r => {
+                                            resp = r.python;
+                                        });
+                                }
                                 case "toggletrace": {
                                     const togglemsg = data as EditorMessageToggleTraceRequest;
                                     return Promise.resolve()

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -24,7 +24,6 @@ namespace pxt.tutorial {
         });
 
         if (steps.length < 1) return undefined; // Promise.resolve();
-        let options = steps[0];
         steps = steps.slice(1, steps.length); // Remove tutorial title
 
         for (let i = 0; i < steps.length; i++) {
@@ -40,7 +39,7 @@ namespace pxt.tutorial {
     export function bundleTutorialCode(tutorialmd: string): string {
         tutorialmd = tutorialmd.replace(/((?!.)\s)+/g, "\n");
 
-        const regex = /```(sim|block|blocks|filterblocks)\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /```(sim|block|blocks|filterblocks|spy|typescript)\s*\n([\s\S]*?)\n```/gmi;
         let code = '';
         // Concatenate all blocks in separate code blocks and decompile so we can detect what blocks are used (for the toolbox)
         tutorialmd.replace(regex, function(m0,m1,m2) {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -47,8 +47,8 @@ namespace pxt.tutorial {
                 return false;
             } else {
                 editor = expected;
+                return true;
             }
-            return true;
         }
     }
 

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -88,4 +88,28 @@ namespace pxt.tutorial {
         }
         return stepInfo;
     }
+
+    export function highlight(pre: HTMLPreElement): void {
+        const text = pre.textContent;
+        if (!/@highlight/.test(text)) // shortcut, nothing to do
+            return;
+
+        pre.textContent = ""; // clear up and rebuild
+        const lines = text.split('\n');
+        for (let i = 0; i < lines.length; ++i) {
+            let line = lines[i];
+            if (/@highlight/.test(line)) {
+                // highlight next line
+                line = lines[++i];
+                if (line !== undefined) {
+                    const span = document.createElement("span");
+                    span.className = "highlight-line";
+                    span.textContent = line;
+                    pre.appendChild(span);
+                }
+            } else {
+                pre.appendChild(document.createTextNode(line + '\n'));
+            }
+        }
+    }
 }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -104,6 +104,15 @@ namespace pxt.tutorial {
                 if (line !== undefined) {
                     const span = document.createElement("span");
                     span.className = "highlight-line";
+                    if (/\"{3}$/.test(line)) { // python literal
+                        for (; i < lines.length; ++i) {
+                            line += '\n' + lines[i + 1];
+                            if (/\"{3}/.test(lines[i + 1])) {
+                                i++;
+                                break;
+                            }
+                        }
+                    }
                     span.textContent = line;
                     pre.appendChild(span);
                 }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -90,10 +90,15 @@ namespace pxt.tutorial {
     }
 
     export function highlight(pre: HTMLPreElement): void {
-        const text = pre.textContent;
+        let text = pre.textContent;
         if (!/@highlight/.test(text)) // shortcut, nothing to do
             return;
 
+        // collapse image python/js literales
+        text = text.replace(/img\s*\(\s*"{3}(.|\n)*"{3}\s*\)/g, `""" """`);
+        text = text.replace(/img\s*\(\s*`(.|\n)*`\s*\)/g, "img` `");
+
+        // render lines
         pre.textContent = ""; // clear up and rebuild
         const lines = text.split('\n');
         for (let i = 0; i < lines.length; ++i) {
@@ -104,15 +109,6 @@ namespace pxt.tutorial {
                 if (line !== undefined) {
                     const span = document.createElement("span");
                     span.className = "highlight-line";
-                    if (/\"{3}$/.test(line)) { // python literal
-                        for (; i < lines.length; ++i) {
-                            line += '\n' + lines[i + 1];
-                            if (/\"{3}/.test(lines[i + 1])) {
-                                i++;
-                                break;
-                            }
-                        }
-                    }
                     span.textContent = line;
                     pre.appendChild(span);
                 }

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -6,6 +6,7 @@
 @import (reference) "semantic.less";
 
 @inlineBlockColor: #D83B01;
+@highlightLineColor: #fcfc90;
 
 /*******************************
       Tutorial mode
@@ -232,6 +233,10 @@ code.lang-filterblocks {
 
 span.highlight-line {
     font-weight: bold;
+    white-space: pre-wrap;
+    background: @highlightLineColor;
+    display: block;
+    padding: 0.5rem;
 }
 
 /*******************************

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -230,6 +230,10 @@ code.lang-filterblocks {
     display: none;
 }
 
+span.highlight-line {
+    font-weight: bold;
+}
+
 /*******************************
         Tutorial Hint
 *******************************/

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1107,7 +1107,7 @@ export class ProjectView
         if (!header || !header.tutorial || !header.tutorial.tutorialMd) return Promise.resolve();
 
         const t = header.tutorial;
-        return tutorial.getUsedBlocksAsync(t.tutorial, t.tutorialMd)
+        return tutorial.getUsedBlocksAsync(t.tutorialCode)
             .then((usedBlocks) => {
                 let editorState: pxt.editor.EditorState = {
                     searchBar: false
@@ -1663,11 +1663,13 @@ export class ProjectView
             cfg.files = cfg.files.filter(f => f != "main.blocks")
             delete files["main.blocks"]
         }
+        if (options.preferredEditor)
+            cfg.preferredEditor = options.preferredEditor;
         files["pxt.json"] = JSON.stringify(cfg, null, 4) + "\n";
         return workspace.installAsync({
             name: cfg.name,
             meta: {},
-            editor: options.prj.id,
+            editor: options.preferredEditor || options.prj.id,
             pubId: "",
             pubCurrent: false,
             target: pxt.appTarget.id,
@@ -2719,11 +2721,13 @@ export class ProjectView
                 tutorialStep: 0,
                 tutorialReady: true,
                 tutorialStepInfo: tutorialInfo.steps,
-                tutorialMd: md
+                tutorialMd: md,
+                tutorialCode: tutorialInfo.code
             };
             return this.createProjectAsync({
                 name: title,
                 tutorial: tutorialOptions,
+                preferredEditor: tutorialInfo.editor,
                 dependencies
             }).then(() => autoChooseBoard ? this.autoChooseBoardAsync(features) : Promise.resolve());
         })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2386,7 +2386,7 @@ export class ProjectView
 
     renderBlocksAsync(req: pxt.editor.EditorMessageRenderBlocksRequest): Promise<pxt.editor.EditorMessageRenderBlocksResponse> {
         return compiler.getBlocksAsync()
-            .then(blocksInfo => compiler.decompileSnippetAsync(req.ts, blocksInfo))
+            .then(blocksInfo => compiler.decompileBlocksSnippetAsync(req.ts, blocksInfo))
             .then(resp => {
                 const svg = pxt.blocks.render(resp, {
                     snippetMode: true,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2379,9 +2379,10 @@ export class ProjectView
     }
 
     renderPythonAsync(req: pxt.editor.EditorMessageRenderPythonRequest): Promise<pxt.editor.EditorMessageRenderPythonResponse> {
-        return Promise.resolve({
-            python: req.ts
-        })
+        return compiler.decompilePythonSnippetAsync(req.ts)
+            .then(resp => {
+                return { python: resp };
+            });
     }
 
     renderBlocksAsync(req: pxt.editor.EditorMessageRenderBlocksRequest): Promise<pxt.editor.EditorMessageRenderBlocksResponse> {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1108,7 +1108,8 @@ export class ProjectView
 
     private loadTutorialFiltersAsync(): Promise<void> {
         const header = pkg.mainEditorPkg().header;
-        if (!header || !header.tutorial || !header.tutorial.tutorialMd) return Promise.resolve();
+        if (!header || !header.tutorial || !header.tutorial.tutorialMd)
+            return Promise.resolve();
 
         const t = header.tutorial;
         return this.loadBlocklyAsync()
@@ -2747,12 +2748,11 @@ export class ProjectView
                 tutorial: tutorialOptions,
                 preferredEditor: tutorialInfo.editor,
                 dependencies
-            }).then(() => autoChooseBoard ? this.autoChooseBoardAsync(features) : Promise.resolve());
-        })
-            .then(() => this.loadTutorialFiltersAsync())
-            .catch((e) => {
-                core.handleNetworkError(e);
-            }).finally(() => core.hideLoading("tutorial"));
+            });
+        }).then(() => autoChooseBoard ? this.autoChooseBoardAsync(features) : Promise.resolve()
+        ).catch((e) => {
+            core.handleNetworkError(e);
+        }).finally(() => core.hideLoading("tutorial"));
     }
 
     completeTutorial() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -913,7 +913,7 @@ export class ProjectView
                                     filters: { blocks: tt.toolboxSubset, defaultState: pxt.editor.FilterState.Hidden }
                                 }
                             });
-                            this.editor.filterToolbox(tt.toolboxSubset, tt.showCategories);
+                            this.editor.filterToolbox(tt.showCategories);
                         }
                         let tutorialOptions = this.state.tutorialOptions;
                         tutorialOptions.tutorialReady = true;
@@ -1121,7 +1121,7 @@ export class ProjectView
                     }
                 }
                 this.setState({ editorState: editorState });
-                this.editor.filterToolbox(usedBlocks, true);
+                this.editor.filterToolbox(true);
                 const stepInfo = t.tutorialStepInfo;
                 const fullscreen = stepInfo[0].fullscreen;
                 if (fullscreen) this.showTutorialHint();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1019,8 +1019,11 @@ export class ProjectView
                 return compiler.newProjectAsync();
             }).then(() => compiler.applyUpgradesAsync())
             .then(() => {
-                let e = this.settings.fileHistory.filter(e => e.id == h.id)[0]
-                let main = pkg.getEditorPkg(pkg.mainPkg)
+                const e = this.settings.fileHistory.filter(e => e.id == h.id)[0]
+                const main = pkg.getEditorPkg(pkg.mainPkg)
+                // override preferred editor if specified
+                if (pkg.mainPkg.config.preferredEditor)
+                    h.editor = pkg.mainPkg.config.preferredEditor
                 let file = main.getMainFile();
                 if (e)
                     file = main.lookupFile(e.name) || file
@@ -1036,8 +1039,6 @@ export class ProjectView
                 if (file.name === "main.ts") {
                     this.shouldTryDecompile = true;
                 }
-                if (pkg.mainPkg.config.preferredEditor)
-                    h.editor = pkg.mainPkg.config.preferredEditor
                 this.setState({
                     home: false,
                     showFiles: h.githubId ? true : false,
@@ -1665,6 +1666,12 @@ export class ProjectView
         }
         if (options.preferredEditor)
             cfg.preferredEditor = options.preferredEditor;
+        // ensure a main.py is ready if this is the desired project
+        if (cfg.preferredEditor == pxt.PYTHON_PROJECT_NAME
+            && cfg.files.indexOf("main.py") < 0) {
+            cfg.files.push("main.py");
+            files["main.py"] = "\n";
+        }
         files["pxt.json"] = JSON.stringify(cfg, null, 4) + "\n";
         return workspace.installAsync({
             name: cfg.name,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2707,14 +2707,18 @@ export class ProjectView
 
         return p.then(md => {
             if (!md)
-                throw new Error("tutorial not found");
-            const tutorialOptions = {
+                throw new Error(lf("Tutorial not found"));
+            const tutorialInfo = pxt.tutorial.parseTutorial(md);
+            if (!tutorialInfo)
+                throw new Error(lf("Invalid tutorial format"));
+
+            const tutorialOptions: pxt.tutorial.TutorialOptions = {
                 tutorial: tutorialId,
                 tutorialName: title,
                 tutorialReportId: reportId,
                 tutorialStep: 0,
                 tutorialReady: true,
-                tutorialStepInfo: pxt.tutorial.parseTutorialSteps(tutorialId, md),
+                tutorialStepInfo: tutorialInfo.steps,
                 tutorialMd: md
             };
             return this.createProjectAsync({

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -910,7 +910,10 @@ export class ProjectView
                             this.setState({
                                 editorState: {
                                     searchBar: false,
-                                    filters: { blocks: tt.toolboxSubset, defaultState: pxt.editor.FilterState.Hidden }
+                                    filters: {
+                                        blocks: tt.toolboxSubset,
+                                        defaultState: pxt.editor.FilterState.Hidden
+                                    }
                                 }
                             });
                             this.editor.filterToolbox(tt.showCategories);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2378,7 +2378,13 @@ export class ProjectView
         this.importDialog.show();
     }
 
-    renderBlocksAsync(req: pxt.editor.EditorMessageRenderBlocksRequest): Promise<any> {
+    renderPythonAsync(req: pxt.editor.EditorMessageRenderPythonRequest): Promise<pxt.editor.EditorMessageRenderPythonResponse> {
+        return Promise.resolve({
+            python: req.ts
+        })
+    }
+
+    renderBlocksAsync(req: pxt.editor.EditorMessageRenderBlocksRequest): Promise<pxt.editor.EditorMessageRenderBlocksResponse> {
         return compiler.getBlocksAsync()
             .then(blocksInfo => compiler.decompileSnippetAsync(req.ts, blocksInfo))
             .then(resp => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1108,7 +1108,8 @@ export class ProjectView
         if (!header || !header.tutorial || !header.tutorial.tutorialMd) return Promise.resolve();
 
         const t = header.tutorial;
-        return tutorial.getUsedBlocksAsync(t.tutorialCode)
+        return this.loadBlocklyAsync()
+            .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode))
             .then((usedBlocks) => {
                 let editorState: pxt.editor.EditorState = {
                     searchBar: false

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -27,7 +27,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     functionsDialog: CreateFunctionDialog = null;
 
     showCategories: boolean = true;
-    showSearch: boolean;
     breakpointsByBlock: pxt.Map<number>; // Map block id --> breakpoint ID
     breakpointsSet: number[]; // the IDs of the breakpoints set.
     debuggerToolboxDiv: JSX.Element;
@@ -689,11 +688,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.closeFlyout();
 
                 this.filterToolbox();
-                if (this.parent.state.editorState && this.parent.state.editorState.searchBar != undefined) {
-                    this.showSearch = this.parent.state.editorState.searchBar;
-                } else {
-                    this.showSearch = true;
-                }
                 if (this.parent.state.editorState && this.parent.state.editorState.hasCategories != undefined) {
                     this.showCategories = this.parent.state.editorState.hasCategories;
                 } else {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -27,7 +27,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     functionsDialog: CreateFunctionDialog = null;
 
     showCategories: boolean = true;
-    filters: pxt.editor.ProjectFilters;
     showSearch: boolean;
     breakpointsByBlock: pxt.Map<number>; // Map block id --> breakpoint ID
     breakpointsSet: number[]; // the IDs of the breakpoints set.
@@ -689,14 +688,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 pxt.blocks.clearWithoutEvents(this.editor);
                 this.closeFlyout();
 
-                if (this.currFile && this.currFile != file) {
-                    this.filterToolbox(null);
-                }
-                if (this.parent.state.editorState && this.parent.state.editorState.filters) {
-                    this.filterToolbox(this.parent.state.editorState.filters);
-                } else {
-                    this.filters = null;
-                }
+                this.filterToolbox();
                 if (this.parent.state.editorState && this.parent.state.editorState.searchBar != undefined) {
                     this.showSearch = this.parent.state.editorState.searchBar;
                 } else {
@@ -976,8 +968,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
-    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories?: boolean) {
-        this.filters = filters;
+    filterToolbox(showCategories?: boolean) {
         this.showCategories = showCategories;
         this.refreshToolbox();
     }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -198,7 +198,7 @@ export function decompileAsync(fileName: string, blockInfo?: ts.pxtc.BlocksInfo,
         })
 }
 
-export function decompileSnippetAsync(code: string, blockInfo?: ts.pxtc.BlocksInfo): Promise<string> {
+export function decompileBlocksSnippetAsync(code: string, blockInfo?: ts.pxtc.BlocksInfo): Promise<string> {
     const snippetTs = "main.ts";
     const snippetBlocks = "main.blocks";
     let trg = pkg.mainPkg.getTargetOptions()
@@ -213,7 +213,6 @@ export function decompileSnippetAsync(code: string, blockInfo?: ts.pxtc.BlocksIn
             if (opts.sourceFiles.indexOf(snippetBlocks) === -1) {
                 opts.sourceFiles.push(snippetBlocks);
             }
-
             opts.ast = true;
             return decompileCoreAsync(opts, snippetTs)
         }).then(resp => {

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -240,6 +240,28 @@ export function pyDecompileAsync(fileName: string): Promise<pxtc.CompileResult> 
         })
 }
 
+export function decompilePythonSnippetAsync(code: string): Promise<string> {
+    const snippetTs = "main.ts";
+    const snippetPy = "main.py";
+    let trg = pkg.mainPkg.getTargetOptions()
+    return pkg.mainPkg.getCompileOptionsAsync(trg)
+        .then(opts => {
+            opts.fileSystem[snippetTs] = code;
+            opts.fileSystem[snippetPy] = "";
+
+            if (opts.sourceFiles.indexOf(snippetTs) === -1) {
+                opts.sourceFiles.push(snippetTs);
+            }
+            if (opts.sourceFiles.indexOf(snippetPy) === -1) {
+                opts.sourceFiles.push(snippetPy);
+            }
+            opts.ast = true;
+            return pyDecompileCoreAsync(opts, snippetTs)
+        }).then(resp => {
+            return resp.outfiles[snippetPy]
+        })
+}
+
 function pyDecompileCoreAsync(opts: pxtc.CompileOptions, fileName: string): Promise<pxtc.CompileResult> {
     return workerOpAsync("pydecompile", { options: opts, fileName: fileName })
 }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -42,6 +42,18 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     private renderSnippets(content: HTMLElement) {
         const { parent } = this.props;
 
+        pxt.Util.toArray(content.querySelectorAll(`.lang-typescript`))
+            .forEach((langBlock: HTMLElement) => {
+                const code = langBlock.textContent;
+                const wrapperDiv = document.createElement('div');
+                pxsim.U.clear(langBlock);
+                langBlock.appendChild(wrapperDiv);
+                wrapperDiv.className = 'ui segment raised';
+                const preDiv = document.createElement('pre');
+                preDiv.textContent = code;
+                wrapperDiv.appendChild(preDiv);
+            });
+
         pxt.Util.toArray(content.querySelectorAll(`.lang-spy`))
             .forEach((langBlock: HTMLElement) => {
                 const code = langBlock.textContent;

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -42,6 +42,24 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     private renderSnippets(content: HTMLElement) {
         const { parent } = this.props;
 
+        pxt.Util.toArray(content.querySelectorAll(`.lang-spy`))
+            .forEach((langBlock: HTMLElement) => {
+                const code = langBlock.textContent;
+                const wrapperDiv = document.createElement('div');
+                pxsim.U.clear(langBlock);
+                langBlock.appendChild(wrapperDiv);
+                wrapperDiv.className = 'ui segment raised loading';
+                parent.renderPythonAsync({
+                    type: "pxteditor",
+                    action: "renderpython", ts: code
+                }).done(resp => {
+                    const preDiv = document.createElement('pre');
+                    preDiv.textContent = resp.python;
+                    wrapperDiv.appendChild(preDiv);
+                    pxsim.U.removeClass(wrapperDiv, 'loading');
+                });
+            });
+
         pxt.Util.toArray(content.querySelectorAll(`.lang-blocks`))
             .forEach((langBlock: HTMLElement) => {
                 // Can't use innerHTML here because it escapes certain characters (e.g. < and >)
@@ -60,9 +78,10 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                     pxsim.U.removeClass(wrapperDiv, 'loading');
                 } else {
                     parent.renderBlocksAsync({
+                        type: "pxteditor",
                         action: "renderblocks", ts: code
-                    } as pxt.editor.EditorMessageRenderBlocksRequest)
-                        .done((resp: any) => {
+                    })
+                        .done(resp => {
                             const svg = resp.svg;
                             if (svg) {
                                 svg.setAttribute('height', `${svg.getAttribute('viewBox').split(' ')[3]}px`);

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -49,15 +49,22 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 pxsim.U.clear(langBlock);
                 langBlock.appendChild(wrapperDiv);
                 wrapperDiv.className = 'ui segment raised loading';
-                parent.renderPythonAsync({
-                    type: "pxteditor",
-                    action: "renderpython", ts: code
-                }).done(resp => {
+                if (MarkedContent.blockSnippetCache[code]) {
                     const preDiv = document.createElement('pre');
-                    preDiv.textContent = resp.python;
+                    preDiv.textContent = MarkedContent.blockSnippetCache[code];
                     wrapperDiv.appendChild(preDiv);
                     pxsim.U.removeClass(wrapperDiv, 'loading');
-                });
+                } else {
+                    parent.renderPythonAsync({
+                        type: "pxteditor",
+                        action: "renderpython", ts: code
+                    }).done(resp => {
+                        const preDiv = document.createElement('pre');
+                        preDiv.textContent = resp.python;
+                        wrapperDiv.appendChild(preDiv);
+                        pxsim.U.removeClass(wrapperDiv, 'loading');
+                    });
+                }
             });
 
         pxt.Util.toArray(content.querySelectorAll(`.lang-blocks`))

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -42,19 +42,20 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     private renderSnippets(content: HTMLElement) {
         const { parent } = this.props;
 
-        pxt.Util.toArray(content.querySelectorAll(`.lang-typescript`))
+        pxt.Util.toArray(content.querySelectorAll(`code.lang-typescript`))
             .forEach((langBlock: HTMLElement) => {
                 const code = langBlock.textContent;
                 const wrapperDiv = document.createElement('div');
                 pxsim.U.clear(langBlock);
                 langBlock.appendChild(wrapperDiv);
                 wrapperDiv.className = 'ui segment raised';
-                const preDiv = document.createElement('pre');
+                const preDiv = document.createElement('pre') as HTMLPreElement;
                 preDiv.textContent = code;
+                pxt.tutorial.highlight(preDiv);
                 wrapperDiv.appendChild(preDiv);
             });
 
-        pxt.Util.toArray(content.querySelectorAll(`.lang-spy`))
+        pxt.Util.toArray(content.querySelectorAll(`code.lang-spy`))
             .forEach((langBlock: HTMLElement) => {
                 const code = langBlock.textContent;
                 const wrapperDiv = document.createElement('div');
@@ -62,8 +63,9 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 langBlock.appendChild(wrapperDiv);
                 wrapperDiv.className = 'ui segment raised loading';
                 if (MarkedContent.blockSnippetCache[code]) {
-                    const preDiv = document.createElement('pre');
+                    const preDiv = document.createElement('pre') as HTMLPreElement;
                     preDiv.textContent = MarkedContent.blockSnippetCache[code];
+                    pxt.tutorial.highlight(preDiv);
                     wrapperDiv.appendChild(preDiv);
                     pxsim.U.removeClass(wrapperDiv, 'loading');
                 } else {
@@ -71,15 +73,16 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         type: "pxteditor",
                         action: "renderpython", ts: code
                     }).done(resp => {
-                        const preDiv = document.createElement('pre');
+                        const preDiv = document.createElement('pre') as HTMLPreElement;
                         preDiv.textContent = resp.python;
+                        pxt.tutorial.highlight(preDiv);
                         wrapperDiv.appendChild(preDiv);
                         pxsim.U.removeClass(wrapperDiv, 'loading');
                     });
                 }
             });
 
-        pxt.Util.toArray(content.querySelectorAll(`.lang-blocks`))
+        pxt.Util.toArray(content.querySelectorAll(`code.lang-blocks`))
             .forEach((langBlock: HTMLElement) => {
                 // Can't use innerHTML here because it escapes certain characters (e.g. < and >)
                 // Also can't use innerText because IE strips out the newlines from the code

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1501,12 +1501,18 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             const w1 = (f1.attributes.weight || 50) + (f1.attributes.advanced ? 0 : 1000);
             return w2 > w1 ? 1 : -1;
         }).map(fn => {
-            let monacoBlockDisabled = false;
-            const fnState = filters ? (filters.fns && filters.fns[fn.name] != undefined ? filters.fns[fn.name] : (categoryState != undefined ? categoryState : filters.defaultState)) : undefined;
-            monacoBlockDisabled = fnState == pxt.editor.FilterState.Disabled;
+            let fnState = filters.defaultState;
+            if (filters && filters.fns && filters.fns[fn.name] !== undefined) {
+                fnState = filters.fns[fn.name];
+            } else if (filters && filters.blocks && fn.attributes.blockId && filters.blocks[fn.attributes.blockId] !== undefined) {
+                fnState = filters.blocks[fn.attributes.blockId];
+            } else if (categoryState !== undefined) {
+                fnState = categoryState;
+            }
             if (fnState == pxt.editor.FilterState.Hidden) return undefined;
 
-            return monacoEditor.getMonacoBlock(fn, ns, color, monacoBlockDisabled); // try this
+            const monacoBlockDisabled = fnState == pxt.editor.FilterState.Disabled;
+            return monacoEditor.getMonacoBlock(fn, ns, color, monacoBlockDisabled);
         })
         monacoEditor.attachMonacoBlockAccessibility(monacoBlocks);
     }

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -97,6 +97,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     name: "var_let",
                     snippetName: "let",
                     snippet: `let item: number`,
+                    pySnippet: `item = 0`,
                     snippetOnly: true,
                     attributes: {
                         blockId: 'variables_set',

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -119,7 +119,7 @@ export class Editor implements pxt.editor.IEditor {
         return true
     }
 
-    filterToolbox(filters?: pxt.editor.ProjectFilters, showCategories?: boolean) {
+    filterToolbox(showCategories?: boolean) {
     }
 
     insertBreakpoint() {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -18,8 +18,7 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
     const usedBlocks: pxt.Map<number> = {};
-    return pxt.BrowserUtils.loadBlocklyAsync()
-        .then(() => compiler.getBlocksAsync())
+    return compiler.getBlocksAsync()
         .then(blocksInfo => compiler.decompileBlocksSnippetAsync(code, blocksInfo))
         .then(blocksXml => {
             if (blocksXml) {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -20,7 +20,7 @@ export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
     const usedBlocks: pxt.Map<number> = {};
     return compiler.getBlocksAsync()
         .then(blocksInfo => {
-            pxt.blocks.initialize(blocksInfo);
+            pxt.blocks.initializeAndInject(blocksInfo);
             return compiler.decompileBlocksSnippetAsync(code, blocksInfo);
         }).then(blocksXml => {
             if (blocksXml) {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -17,29 +17,25 @@ type ISettingsProps = pxt.editor.ISettingsProps;
  */
 export function getUsedBlocksAsync(tutorialId: string, tutorialmd: string): Promise<pxt.Map<number>> {
     const code = pxt.tutorial.bundleTutorialCode(tutorialmd);
-    return Promise.resolve()
-        .then(() => {
-            if (code == '') return Promise.resolve({});
-
-            const usedBlocks: pxt.Map<number> = {};
-            return compiler.getBlocksAsync()
-                .then(blocksInfo => compiler.decompileSnippetAsync(code, blocksInfo))
-                .then(blocksXml => {
-                    if (blocksXml) {
-                        const headless = pxt.blocks.loadWorkspaceXml(blocksXml);
-                        const allblocks = headless.getAllBlocks();
-                        for (let bi = 0; bi < allblocks.length; ++bi) {
-                            const blk = allblocks[bi];
-                            usedBlocks[blk.type] = 1;
-                        }
-                        return usedBlocks;
-                    } else {
-                        throw new Error("Empty blocksXml, failed to decompile");
-                    }
-                }).catch(() => {
-                    pxt.log(`Failed to decompile tutorial: ${tutorialId}`);
-                    throw new Error(`Failed to decompile tutorial: ${tutorialId}`);
-                })
+    if (!code) return Promise.resolve({});
+    const usedBlocks: pxt.Map<number> = {};
+    return compiler.getBlocksAsync()
+        .then(blocksInfo => compiler.decompileSnippetAsync(code, blocksInfo))
+        .then(blocksXml => {
+            if (blocksXml) {
+                const headless = pxt.blocks.loadWorkspaceXml(blocksXml);
+                const allblocks = headless.getAllBlocks();
+                for (let bi = 0; bi < allblocks.length; ++bi) {
+                    const blk = allblocks[bi];
+                    usedBlocks[blk.type] = 1;
+                }
+                return usedBlocks;
+            } else {
+                throw new Error("Empty blocksXml, failed to decompile");
+            }
+        }).catch(() => {
+            pxt.log(`Failed to decompile tutorial: ${tutorialId}`);
+            throw new Error(`Failed to decompile tutorial: ${tutorialId}`);
         });
 }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -15,8 +15,7 @@ type ISettingsProps = pxt.editor.ISettingsProps;
  * We'll run this step when we first start the tutorial to figure out what blocks are used so we can
  * filter the toolbox. 
  */
-export function getUsedBlocksAsync(tutorialId: string, tutorialmd: string): Promise<pxt.Map<number>> {
-    const code = pxt.tutorial.bundleTutorialCode(tutorialmd);
+export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
     const usedBlocks: pxt.Map<number> = {};
     return compiler.getBlocksAsync()
@@ -34,8 +33,8 @@ export function getUsedBlocksAsync(tutorialId: string, tutorialmd: string): Prom
                 throw new Error("Empty blocksXml, failed to decompile");
             }
         }).catch(() => {
-            pxt.log(`Failed to decompile tutorial: ${tutorialId}`);
-            throw new Error(`Failed to decompile tutorial: ${tutorialId}`);
+            pxt.debug(`failed to decompile tutorial`);
+            throw new Error(`Failed to decompile tutorial`);
         });
 }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -18,7 +18,8 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
     const usedBlocks: pxt.Map<number> = {};
-    return compiler.getBlocksAsync()
+    return pxt.BrowserUtils.loadBlocklyAsync()
+        .then(() => compiler.getBlocksAsync())
         .then(blocksInfo => compiler.decompileSnippetAsync(code, blocksInfo))
         .then(blocksXml => {
             if (blocksXml) {
@@ -32,8 +33,8 @@ export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
             } else {
                 throw new Error("Empty blocksXml, failed to decompile");
             }
-        }).catch(() => {
-            pxt.debug(`failed to decompile tutorial`);
+        }).catch((e) => {
+            pxt.reportException(e);
             throw new Error(`Failed to decompile tutorial`);
         });
 }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -19,10 +19,16 @@ export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
     const usedBlocks: pxt.Map<number> = {};
     return compiler.getBlocksAsync()
-        .then(blocksInfo => compiler.decompileBlocksSnippetAsync(code, blocksInfo))
-        .then(blocksXml => {
+        .then(blocksInfo => {
+            pxt.blocks.initialize(blocksInfo);
+            return compiler.decompileBlocksSnippetAsync(code, blocksInfo);
+        }).then(blocksXml => {
             if (blocksXml) {
                 const headless = pxt.blocks.loadWorkspaceXml(blocksXml);
+                if (!headless) {
+                    pxt.debug(`used blocks xml failed to load\n${blocksXml}`);
+                    throw new Error("blocksXml failed to load");
+                }
                 const allblocks = headless.getAllBlocks();
                 for (let bi = 0; bi < allblocks.length; ++bi) {
                     const blk = allblocks[bi];

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -20,7 +20,7 @@ export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
     const usedBlocks: pxt.Map<number> = {};
     return pxt.BrowserUtils.loadBlocklyAsync()
         .then(() => compiler.getBlocksAsync())
-        .then(blocksInfo => compiler.decompileSnippetAsync(code, blocksInfo))
+        .then(blocksInfo => compiler.decompileBlocksSnippetAsync(code, blocksInfo))
         .then(blocksXml => {
             if (blocksXml) {
                 const headless = pxt.blocks.loadWorkspaceXml(blocksXml);


### PR DESCRIPTION
Extends the tutorial engine to extract typescript/python code snippets and open the corresponding editor.

![image](https://user-images.githubusercontent.com/4175913/56145840-e928bd00-5f59-11e9-80fb-ae2fe5cf7814.png)


- [x] desired editor is inferred from the language of the snippets (only 1 kind per tutorial)
- [x] filters are computed using the same logic as blocks -- so the code is decompiled as well
- [x] cleaned up the tutorial parsing a bit.
- [x] added "renderPythonAsync" to editor interface