### PR TITLE
show fullscren button in tutorial mode

### DIFF
--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -97,7 +97,8 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const tracing = this.props.parent.state.tracing;
         const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debugging = parentState.debugging;
-        const fullscreen = run && !inTutorial && !simOpts.hideFullscreen && !sandbox;
+        // we need to escape full screen from a tutorial!
+        const fullscreen = run && !simOpts.hideFullscreen && !sandbox;
         const audio = run && targetTheme.hasAudio;
         const isHeadless = simOpts.headless;
         const collapse = !!targetTheme.pairingButton;


### PR DESCRIPTION
In tablet mode, clicking on the simulator, acts as going to full screen. We need to be able to escape that mode in a tutorial. Currently, we're stuck.