### PR TITLE
Transform old functions on import

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -151,13 +151,13 @@ namespace pxt.blocks {
      * Patch to transform old function blocks to new ones, and rename child nodes
      */
     function patchFunctionBlocks(dom: Element, info: pxtc.BlocksInfo) {
-        var functionNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_defnoreturn]"));
+        let functionNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_defnoreturn]"));
         functionNodes.forEach(node => {
             node.setAttribute("type", "function_definition");
             node.querySelector("field[name=NAME]").setAttribute("name", "function_name");
         })
 
-        var functionCallNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_callnoreturn]"));
+        let functionCallNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_callnoreturn]"));
         functionCallNodes.forEach(node => {
             node.setAttribute("type", "function_call");
             node.querySelector("field[name=NAME]").setAttribute("name", "function_name");

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -148,6 +148,23 @@ namespace pxt.blocks {
     }
 
     /**
+     * Patch to transform old function blocks to new ones, and rename child nodes
+     */
+    function patchFunctionBlocks(dom: Element, info: pxtc.BlocksInfo) {
+        var functionNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_defnoreturn]"));
+        functionNodes.forEach(node => {
+            node.setAttribute("type", "function_definition");
+            node.querySelector("field[name=NAME]").setAttribute("name", "function_name");
+        })
+
+        var functionCallNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_callnoreturn]"));
+        functionCallNodes.forEach(node => {
+            node.setAttribute("type", "function_call");
+            node.querySelector("field[name=NAME]").setAttribute("name", "function_name");
+        })
+    }
+
+    /**
      * This callback is populated from the editor extension result.
      * Allows a target to provide version specific blockly updates
      */
@@ -205,6 +222,9 @@ namespace pxt.blocks {
 
             // patch floating blocks
             patchFloatingBlocks(doc.documentElement, info);
+
+            // patch function blocks
+            patchFunctionBlocks(doc.documentElement, info)
 
             // apply extension patches
             if (pxt.blocks.extensionBlocklyPatch)

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2032,7 +2032,6 @@ namespace pxt.blocks {
         Blockly.Blocks['procedures_callnoreturn'] = {
             init: function () {
                 let nameField = new pxtblockly.FieldProcedure('');
-                nameField.setSourceBlock(this);
                 this.appendDummyInput('TOPROW')
                     .appendField(proceduresCallDef.block['PROCEDURES_CALLNORETURN_TITLE'])
                     .appendField(nameField, 'NAME');


### PR DESCRIPTION
Transform old functions on import (bug: Microsoft/pxt-microbit/issues/1987), remove extra call to setSourceBlock (source already set in appendField)