### PR TITLE
Languages

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -148,6 +148,23 @@ namespace pxt.blocks {
     }
 
     /**
+     * Patch to transform old function blocks to new ones, and rename child nodes
+     */
+    function patchFunctionBlocks(dom: Element, info: pxtc.BlocksInfo) {
+        let functionNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_defnoreturn]"));
+        functionNodes.forEach(node => {
+            node.setAttribute("type", "function_definition");
+            node.querySelector("field[name=NAME]").setAttribute("name", "function_name");
+        })
+
+        let functionCallNodes = pxt.U.toArray(dom.querySelectorAll("block[type=procedures_callnoreturn]"));
+        functionCallNodes.forEach(node => {
+            node.setAttribute("type", "function_call");
+            node.querySelector("field[name=NAME]").setAttribute("name", "function_name");
+        })
+    }
+
+    /**
      * This callback is populated from the editor extension result.
      * Allows a target to provide version specific blockly updates
      */
@@ -205,6 +222,9 @@ namespace pxt.blocks {
 
             // patch floating blocks
             patchFloatingBlocks(doc.documentElement, info);
+
+            // patch function blocks
+            patchFunctionBlocks(doc.documentElement, info)
 
             // apply extension patches
             if (pxt.blocks.extensionBlocklyPatch)

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2032,7 +2032,6 @@ namespace pxt.blocks {
         Blockly.Blocks['procedures_callnoreturn'] = {
             init: function () {
                 let nameField = new pxtblockly.FieldProcedure('');
-                nameField.setSourceBlock(this);
                 this.appendDummyInput('TOPROW')
                     .appendField(proceduresCallDef.block['PROCEDURES_CALLNORETURN_TITLE'])
                     .appendField(nameField, 'NAME');

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -876,6 +876,59 @@ namespace ts.pxtc.Util {
 
     }
 
+    export const pxtLangCookieId = "PXT_LANG";
+    export const langCookieExpirationDays = 30;
+
+    export interface Language {
+        englishName: string;
+        localizedName: string;
+    }
+
+    export const allLanguages: pxt.Map<Language> = {
+        "af": { englishName: "Afrikaans", localizedName: "Afrikaans" },
+        "ar": { englishName: "Arabic", localizedName: "العربية" },
+        "bg": { englishName: "Bulgarian", localizedName: "български" },
+        "ca": { englishName: "Catalan", localizedName: "Català" },
+        "cs": { englishName: "Czech", localizedName: "Čeština" },
+        "da": { englishName: "Danish", localizedName: "Dansk" },
+        "de": { englishName: "German", localizedName: "Deutsch" },
+        "el": { englishName: "Greek", localizedName: "Ελληνικά" },
+        "en": { englishName: "English", localizedName: "English" },
+        "es-ES": { englishName: "Spanish (Spain)", localizedName: "Español (España)" },
+        "es-MX": { englishName: "Spanish (Mexico)", localizedName: "Español (México)" },
+        "fi": { englishName: "Finnish", localizedName: "Suomi" },
+        "fr": { englishName: "French", localizedName: "Français" },
+        "fr-CA": { englishName: "French (Canada)", localizedName: "Français (Canada)" },
+        "he": { englishName: "Hebrew", localizedName: "עברית" },
+        "hr": { englishName: "Croatian", localizedName: "Hrvatski" },
+        "hu": { englishName: "Hungarian", localizedName: "Magyar" },
+        "hy-AM": { englishName: "Armenian (Armenia)", localizedName: "Հայերէն (Հայաստան)" },
+        "id": { englishName: "Indonesian", localizedName: "Bahasa Indonesia" },
+        "is": { englishName: "Icelandic", localizedName: "Íslenska" },
+        "it": { englishName: "Italian", localizedName: "Italiano" },
+        "ja": { englishName: "Japanese", localizedName: "日本語" },
+        "ko": { englishName: "Korean", localizedName: "한국어" },
+        "lt": { englishName: "Lithuanian", localizedName: "Lietuvių" },
+        "nl": { englishName: "Dutch", localizedName: "Nederlands" },
+        "no": { englishName: "Norwegian", localizedName: "Norsk" },
+        "pl": { englishName: "Polish", localizedName: "Polski" },
+        "pt-BR": { englishName: "Portuguese (Brazil)", localizedName: "Português (Brasil)" },
+        "pt-PT": { englishName: "Portuguese (Portugal)", localizedName: "Português (Portugal)" },
+        "ro": { englishName: "Romanian", localizedName: "Română" },
+        "ru": { englishName: "Russian", localizedName: "Русский" },
+        "si-LK": { englishName: "Sinhala (Sri Lanka)", localizedName: "සිංහල (ශ්රී ලංකා)" },
+        "sk": { englishName: "Slovak", localizedName: "Slovenčina" },
+        "sl": { englishName: "Slovenian", localizedName: "Slovenski" },
+        "sr": { englishName: "Serbian", localizedName: "Srpski" },
+        "sv-SE": { englishName: "Swedish (Sweden)", localizedName: "Svenska (Sverige)" },
+        "ta": { englishName: "Tamil", localizedName: "தமிழ்" },
+        "tr": { englishName: "Turkish", localizedName: "Türkçe" },
+        "uk": { englishName: "Ukrainian", localizedName: "Українська" },
+        "vi": { englishName: "Vietnamese", localizedName: "Tiếng việt" },
+        "zh-CN": { englishName: "Chinese (Simplified)", localizedName: "简体中文" },
+        "zh-TW": { englishName: "Chinese (Traditional)", localizedName: "繁体中文" },
+    };
+
     export function isLocaleEnabled(code: string): boolean {
         let [lang, baseLang] = normalizeLanguageCode(code);
         let appTheme = pxt.appTarget.appTheme;


### PR DESCRIPTION
The purpose of this PR is to refactor the list of all languages currently available in pxt/webapp/src/lang.pxt

In this way we can use this list of languages and cookie info in the docs language picker.