### PR TITLE
report count of diagnostic errors

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -32,7 +32,25 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[]) {
 
     let f = mainPkg.outputPkg.setFile("output.txt", output)
     // display total number of errors on the output file
-    f.numDiagnosticsOverride = diagnostics.filter(d => d.category == ts.pxtc.DiagnosticCategory.Error).length
+    const errors = diagnostics.filter(d => d.category == ts.pxtc.DiagnosticCategory.Error);
+    f.numDiagnosticsOverride = errors.length
+    reportDiagnosticErrors(errors);
+}
+
+let lastErrorCounts: string = "";
+function reportDiagnosticErrors(errors: pxtc.KsDiagnostic[]) {
+    // report to analytics;
+    if (errors) {
+        const counts: pxt.Map<number> = {};
+        errors.filter(err => err.code).forEach(err => counts[err.code] = (counts[err.code] || 0) + 1);
+        const errorCounts = JSON.stringify(errors);
+        if (errorCounts !== lastErrorCounts) {
+            pxt.tickEvent("dianostics", counts);
+            lastErrorCounts = errorCounts;
+        }
+    } else {
+        lastErrorCounts = "";
+    }
 }
 
 let noOpAsync = new Promise<any>(() => { })

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -40,7 +40,7 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[]) {
 let lastErrorCounts: string = "";
 function reportDiagnosticErrors(errors: pxtc.KsDiagnostic[]) {
     // report to analytics;
-    if (errors) {
+    if (errors && errors.length) {
         const counts: pxt.Map<number> = {};
         errors.filter(err => err.code).forEach(err => counts[err.code] = (counts[err.code] || 0) + 1);
         const errorCounts = JSON.stringify(errors);


### PR DESCRIPTION
Data will allow us to determine which errors are common.

- [x] pushes a map error code -> count to a single key "diagnostics"
- [x] only upload when errors have changed

