### PR TITLE
Fix crashing when GitHub extension doesn't exist

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -556,7 +556,7 @@ namespace pxt.github {
                     tag: rid.tag,
                     status
                 };
-            })
+            }).catch(err => undefined);
     }
 
     export function searchAsync(query: string, config: pxt.PackagesConfig): Promise<GitRepo[]> {
@@ -565,7 +565,7 @@ namespace pxt.github {
         let repos = query.split('|').map(parseRepoUrl).filter(repo => !!repo);
         if (repos.length > 0)
             return Promise.all(repos.map(id => repoAsync(id.path, config)))
-                .then(rs => rs.filter(r => r.status != GitRepoStatus.Banned)); // allow deep links to github repos
+                .then(rs => rs.filter(r => r && r.status != GitRepoStatus.Banned)); // allow deep links to github repos
 
         let fetch = () => useProxy()
             ? U.httpGetJsonAsync(`${pxt.Cloud.apiRoot}ghsearch/${appTarget.id}/${appTarget.platformid || appTarget.id}?q=`

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -556,7 +556,10 @@ namespace pxt.github {
                     tag: rid.tag,
                     status
                 };
-            }).catch(err => undefined);
+            }).catch(err => {
+                pxt.reportException(err);
+                return undefined;
+            });
     }
 
     export function searchAsync(query: string, config: pxt.PackagesConfig): Promise<GitRepo[]> {


### PR DESCRIPTION
Add checks to see if the GitHub extension exists before processing it as an extension.

Fixes Microsoft/pxt-arcade#777