### PR TITLE
Fix simulator audio on iOS

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -214,6 +214,7 @@ namespace pxt.editor {
         toggleTrace(intervalSpeed?: number): void;
         setTrace(enabled: boolean, intervalSpeed?: number): void;
         toggleMute(): void;
+        setMute(on: boolean): void;
         openInstructions(): void;
         closeFlyout(): void;
         printCode(): void;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -236,9 +236,9 @@ namespace pxsim {
             // TODO: test origins
 
             let data: SimulatorMessage = event.data || {};
-            let type = data.type || '';
+            let type = data.type;
             if (!type) return;
-            switch (type || '') {
+            switch (type) {
                 case "run": run(<SimulatorRunMessage>data); break;
                 case "instructions": pxsim.instructions.renderInstructions(<SimulatorInstructionsMessage>data); break;
                 case "stop": stop(); break;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -317,6 +317,8 @@ namespace pxsim {
         }
 
         public mute(mute: boolean) {
+            if (this._currentRuntime)
+                this._currentRuntime.mute = mute;
             this.postMessage({ type: 'mute', mute: mute } as pxsim.SimulatorMuteMessage);
         }
 
@@ -425,6 +427,7 @@ namespace pxsim {
                 fnArgs: opts.fnArgs,
                 code: js,
                 partDefinitions: opts.partDefinitions,
+                mute: opts.mute,
                 highContrast: opts.highContrast,
                 light: opts.light,
                 cdnUrl: opts.cdnUrl,

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -425,7 +425,6 @@ namespace pxsim {
                 fnArgs: opts.fnArgs,
                 code: js,
                 partDefinitions: opts.partDefinitions,
-                mute: opts.mute,
                 highContrast: opts.highContrast,
                 light: opts.light,
                 cdnUrl: opts.cdnUrl,

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -199,7 +199,7 @@ namespace pxsim {
         // for playing WAV
         let audio: HTMLAudioElement;
 
-        function context(): AudioContext {
+        export function context(): AudioContext {
             if (!_context) _context = freshContext();
             return _context;
         }
@@ -219,6 +219,9 @@ namespace pxsim {
         export function mute(mute: boolean) {
             _mute = mute;
             stopAll();
+            const ctx = context();
+            if (!mute && ctx)
+                ctx.resume();
         }
 
         function stopTone() {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -220,7 +220,7 @@ namespace pxsim {
             _mute = mute;
             stopAll();
             const ctx = context();
-            if (!mute && ctx)
+            if (!mute && ctx && ctx.state === "suspended")
                 ctx.resume();
         }
 

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -199,7 +199,7 @@ namespace pxsim {
         // for playing WAV
         let audio: HTMLAudioElement;
 
-        export function context(): AudioContext {
+        function context(): AudioContext {
             if (!_context) _context = freshContext();
             return _context;
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2134,6 +2134,11 @@ export class ProjectView
         this.setState({ mute: !this.state.mute });
     }
 
+    setMute(on: boolean) {
+        simulator.mute(on);
+        this.setState({ mute: on });
+    }
+
     openInstructions() {
         const running = this.state.simState != pxt.editor.SimState.Stopped;
         if (running) this.stopSimulator();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2130,8 +2130,7 @@ export class ProjectView
     }
 
     toggleMute() {
-        simulator.mute(!this.state.mute);
-        this.setState({ mute: !this.state.mute });
+        this.setMute(!this.state.mute);
     }
 
     setMute(on: boolean) {

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -16,6 +16,10 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         this.state = {
         }
 
+        // iOS requires interactive consent to use audio
+        if (pxt.BrowserUtils.isIOS())
+            this.props.parent.setMute(true);
+
         this.toggleTrace = this.toggleTrace.bind(this);
         this.toggleMute = this.toggleMute.bind(this);
         this.restartSimulator = this.restartSimulator.bind(this);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/626, where the audio wouldn't start until the user actively pressed the start / restart icons on iOS

Mute audio on iOS on page load, and require the user to unmute it themselves. This is directly triggered by the user, and enables the audio for the session.

Also fixes a bug that triggers semi - randomly cross browsers (that I hadn't seen before as it's weird and minor). It looks like the change to allow a quick restart caused the simulator to occasionally use old options due to ``SimulatorDriver._currentRuntime`` not getting updated, which would lead to the simulator being in an incorrect state after restarting the game (i.e. ``simtoolbar`` has it muted, but the sim was just unmuted, or vice-versa). I don't have a consistent way to trigger this, besides randomly pressing the mute, start, and restart buttons until it breaks. But it's fixed.