### PR TITLE
Monaco debug part 2

### DIFF
--- a/localtypings/pxtparts.d.ts
+++ b/localtypings/pxtparts.d.ts
@@ -179,13 +179,26 @@ declare namespace pxsim {
     export interface DebuggerBreakpointMessage extends DebuggerMessage {
         breakpointId: number;
         globals: Variables;
-        stackframes: {
-            locals: Variables;
-            funcInfo: any; // pxtc.FunctionLocationInfo
-            breakpointId: number;
-        }[];
+        stackframes: StackFrameInfo[];
         exceptionMessage?: string;
         exceptionStack?: string;
+    }
+
+    export interface StackFrameInfo {
+        locals: Variables;
+        funcInfo: any; // pxtc.FunctionLocationInfo
+        breakpointId: number;
+        arguments?: FunctionArgumentsInfo;
+    }
+
+    export interface FunctionArgumentsInfo {
+        thisParam: any;
+        params: FunctionArgument[];
+    }
+
+    export interface FunctionArgument {
+        name: string;
+        value: any;
     }
 
     // subtype=trace

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -197,6 +197,8 @@ switch (step) {
         writeRaw(`} } }`)
         let info = nodeLocationInfo(proc.action) as FunctionLocationInfo
         info.functionName = proc.getName()
+        info.argumentNames = proc.args && proc.args.map(a => a.getName());
+
         writeRaw(`${proc.label()}.info = ${JSON.stringify(info)}`)
         if (proc.isRoot)
             writeRaw(`${proc.label()}.continuations = [ ${asyncContinuations.join(",")} ]`)

--- a/pxtlib/hwdbg.ts
+++ b/pxtlib/hwdbg.ts
@@ -178,6 +178,7 @@ namespace pxt.HWDBG {
             let bp = findPrevBrkp(currAddr)
             let info = U.clone(bp) as any as pxtc.FunctionLocationInfo
             info.functionName = pi.name
+            info.argumentNames = pi.args && pi.args.map(a => a.name);
             msg.stackframes.push({
                 locals: {},
                 funcInfo: info,

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -66,6 +66,7 @@ namespace ts.pxtc {
 
     export interface FunctionLocationInfo extends LocationInfo {
         functionName: string;
+        argumentNames?: string[];
     }
 
     export interface KsDiagnostic extends LocationInfo {

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -115,6 +115,7 @@ namespace pxsim {
         numFields: number;
         toStringMethod?: LabelFn;
         classNo: number;
+        iface?: Map<any>;
     }
 
     export class RefRecord extends RefObject {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -719,6 +719,10 @@ namespace pxsim {
             }
 
             function maybeYield(s: StackFrame, pc: number, r0: any): boolean {
+                // If code is running on a breakpoint, it's because we are evaluating getters;
+                // no need to yield in that case.
+                if (__this.pausedOnBreakpoint) return false;
+
                 __this.cleanScheduledExpired()
                 yieldSteps = yieldMaxSteps;
                 let now = Date.now()

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -768,7 +768,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     highlightStatement(stmt: pxtc.LocationInfo, brk?: pxsim.DebuggerBreakpointMessage): boolean {
         if (!this.compilationResult || this.delayLoadXml || this.loadingXml)
             return false;
-        this.updateDebuggerVariables(brk ? brk.globals : undefined);
+        this.updateDebuggerVariables(brk);
         if (stmt) {
             let bid = pxt.blocks.findBlockId(this.compilationResult.sourceMap, { start: stmt.line, length: stmt.endLine - stmt.line });
             if (bid) {
@@ -807,12 +807,18 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.debugVariables = c;
     }
 
-    updateDebuggerVariables(globals: pxsim.Variables) {
+    updateDebuggerVariables(brk: pxsim.DebuggerBreakpointMessage) {
         if (!this.parent.state.debugging) return;
 
         if (this.debugVariables) {
             const visibleVars = Blockly.Variables.allUsedVarModels(this.editor).map((variable: any) => variable.name as string);
-            this.debugVariables.updateVariables(globals, visibleVars)
+
+            if (brk) {
+                this.debugVariables.updateVariables(brk.globals, brk.stackframes, visibleVars)
+            }
+            else {
+                this.debugVariables.updateVariables(null, null, visibleVars)
+            }
         }
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1025,7 +1025,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.sendBreakpoints();
             }
 
-            this.fieldEditors.clearRanges(this.editor);
+            this.fieldEditors && this.fieldEditors.clearRanges(this.editor);
             if (this.feWidget) {
                 this.feWidget.close();
             }
@@ -1127,7 +1127,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     protected updateFieldEditors = pxt.Util.debounce(() => {
-        if (!this.hasFieldEditors || pxt.shell.isReadOnly() || this.isDebugging()) return;
+        if (!this.hasFieldEditors || !this.editor || pxt.shell.isReadOnly() || this.isDebugging()) return;
         const model = this.editor.getModel();
         this.fieldEditors.clearRanges(this.editor);
 
@@ -1439,7 +1439,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.sendBreakpoints();
             }
         }
-        else {
+        else if (this.fieldEditors) {
             // Open/close any field editors in range
             const model = this.editor.getModel();
             const decorations = model.getDecorationsInRange(new monaco.Range(line, model.getLineMinColumn(line), line, model.getLineMaxColumn(line)));
@@ -1864,7 +1864,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.editor.setSelection(afterRange);
 
                 // Clear ranges because the model changed
-                this.fieldEditors.clearRanges(this.editor);
+                if (this.fieldEditors) this.fieldEditors.clearRanges(this.editor);
                 resolve(afterRange);
             });
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -377,7 +377,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             <div id="monacoEditorArea" className="full-abs" style={{ direction: 'ltr' }}>
                 <div className={`monacoToolboxDiv ${(this.toolbox && !this.toolbox.state.visible && !this.isDebugging()) ? 'invisible' : ''}`}>
                     <toolbox.Toolbox ref={this.handleToolboxRef} editorname="monaco" parent={this} />
-                    <div id="debuggerToolbox" ref={this.handleDebugToolboxRef}></div>
+                    <div id="monacoDebuggerToolbox" ref={this.handleDebugToolboxRef}></div>
                 </div>
                 <div id='monacoEditorInner' style={{ float: 'right' }} />
             </div>
@@ -828,7 +828,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         } else {
             this.toolbox.show();
         }
-        ReactDOM.render(debuggerToolbox, document.getElementById('debuggerToolbox'));
+        ReactDOM.render(debuggerToolbox, document.getElementById('monacoDebuggerToolbox'));
 
         if (this.toolbox)
             this.toolbox.setState({
@@ -1030,15 +1030,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.feWidget.close();
             }
 
-            this.editor.updateOptions({
-                readOnly: true
-            });
+            if (this.editor) this.editor.updateOptions({ readOnly: true });
         }
         else {
-
-            this.editor.updateOptions({
-                readOnly: pxt.shell.isReadOnly() || (this.currFile && this.currFile.isReadonly())
-            });
+            if (this.editor) {
+                this.editor.updateOptions({
+                    readOnly: pxt.shell.isReadOnly() || (this.currFile && this.currFile.isReadonly())
+                });
+            }
 
             if (this.breakpoints) {
                 this.breakpoints.dispose();
@@ -1217,7 +1216,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             // center on statement
             this.editor.revealPositionInCenter(position);
             if (this.isDebugging() && this.debugVariables) {
-                this.debugVariables.updateVariables(brk.globals);
+                this.debugVariables.updateVariables(brk.globals, brk.stackframes);
                 this.resize();
             }
         }
@@ -1888,7 +1887,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private handleDebugToolboxRef = (ref: HTMLDivElement) => {
-        this.debuggerToolbox = ref;
+        if (ref) {
+            this.debuggerToolbox = ref;
+            if (this.isDebugging()) this.updateToolbox();
+        }
     }
 
     private handleDebuggerVariablesRef = (c: debug.DebuggerVariables) => {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -16,7 +16,7 @@ import * as workspace from "./workspace";
 import { ViewZoneEditorHost, FieldEditorManager } from "./monacoFieldEditorHost";
 
 import Util = pxt.Util;
-import { MonacoBreakpoint, BreakpointCollection } from "./monacoDebugger";
+import { BreakpointCollection } from "./monacoDebugger";
 
 const MIN_EDITOR_FONT_SIZE = 10
 const MAX_EDITOR_FONT_SIZE = 40
@@ -1025,11 +1025,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.sendBreakpoints();
             }
 
-            this.fieldEditors && this.fieldEditors.clearRanges(this.editor);
-            if (this.feWidget) {
-                this.feWidget.close();
-            }
-
+            if (this.fieldEditors) this.fieldEditors.clearRanges(this.editor);
+            if (this.feWidget) this.feWidget.close();
             if (this.editor) this.editor.updateOptions({ readOnly: true });
         }
         else {

--- a/webapp/src/monacoDebugger.ts
+++ b/webapp/src/monacoDebugger.ts
@@ -1,6 +1,8 @@
 /// <reference path="../../localtypings/monaco.d.ts" />
 /// <reference path="../../built/pxteditor.d.ts" />
 
+import * as pkg from "./package";
+
 export class MonacoBreakpoint implements monaco.IDisposable {
     protected active: boolean;
     protected decoration: string;
@@ -19,7 +21,6 @@ export class MonacoBreakpoint implements monaco.IDisposable {
         else {
             this.range = new monaco.Range(start.lineNumber, start.column, start.lineNumber, model.getLineMaxColumn(start.lineNumber));
         }
-
 
         this.updateDecoration();
     }
@@ -68,5 +69,89 @@ export class MonacoBreakpoint implements monaco.IDisposable {
             }
         ]);
         this.decoration = dec[0];
+    }
+}
+
+export class BreakpointCollection implements monaco.IDisposable {
+    protected fileToBreakpoint: pxt.Map<pxtc.Breakpoint[]>;
+    protected loadedBreakpoints: MonacoBreakpoint[];
+    protected activeBreakpoints: number[];
+
+    constructor(allBreakpoints: pxtc.Breakpoint[]) {
+        this.fileToBreakpoint = {};
+        this.activeBreakpoints = [];
+
+        for (const bp of allBreakpoints) {
+            if (!this.fileToBreakpoint[bp.fileName]) this.fileToBreakpoint[bp.fileName] = [];
+            this.fileToBreakpoint[bp.fileName].push(bp);
+        }
+    }
+
+    loadBreakpointsForFile(file: pkg.File, editor: monaco.editor.IStandaloneCodeEditor) {
+        if (this.loadedBreakpoints) this.loadedBreakpoints.forEach(bp => bp.dispose());
+
+        const fileBreakpoints = this.fileToBreakpoint[file.name];
+
+        if (fileBreakpoints) {
+            this.loadedBreakpoints = fileBreakpoints.map(bp => {
+                const mbp = new MonacoBreakpoint(bp, editor);
+                if (this.activeBreakpoints.indexOf(bp.id) != -1) mbp.setActive(true);
+
+                return mbp
+            });
+        }
+    }
+
+    toggleBreakpointAt(lineNo: number) {
+        const bp = this.getBreakpointForLine(lineNo);
+        if (bp) {
+            bp.toggle();
+
+            if (bp.isActive()) {
+                this.activeBreakpoints.push(bp.source.id);
+            }
+            else {
+                this.activeBreakpoints = this.activeBreakpoints.filter(id => id != bp.source.id);
+            }
+        }
+    }
+
+    refreshDecorations() {
+        if (this.loadedBreakpoints) this.loadedBreakpoints.forEach(bp => bp.updateDecoration());
+    }
+
+    clearDecorations() {
+        if (this.loadedBreakpoints) this.loadedBreakpoints.forEach(bp => bp.dispose());
+    }
+
+    getActiveBreakpoints() {
+        return this.activeBreakpoints;
+    }
+
+    dispose() {
+        if (this.loadedBreakpoints) {
+            this.loadedBreakpoints.forEach(bp => bp.dispose());
+            this.loadedBreakpoints = undefined;
+        }
+        this.activeBreakpoints = undefined;
+        this.fileToBreakpoint = undefined;
+    }
+
+    protected getBreakpointForLine(lineNo: number) {
+        if (!this.loadedBreakpoints || !this.loadedBreakpoints.length) return undefined;
+
+        let closestBreakpoint: MonacoBreakpoint;
+        let closestDistance: number;
+
+        for (const bp of this.loadedBreakpoints) {
+            const distance = bp.distanceFromLine(lineNo);
+            if (closestDistance === undefined || distance < closestDistance) {
+                closestBreakpoint = bp;
+                closestDistance = distance;
+            }
+        }
+
+        if (closestDistance < 5) return closestBreakpoint;
+        return undefined;
     }
 }

--- a/webapp/src/monacoDebugger.ts
+++ b/webapp/src/monacoDebugger.ts
@@ -90,6 +90,8 @@ export class BreakpointCollection implements monaco.IDisposable {
     loadBreakpointsForFile(file: pkg.File, editor: monaco.editor.IStandaloneCodeEditor) {
         if (this.loadedBreakpoints) this.loadedBreakpoints.forEach(bp => bp.dispose());
 
+        if (!file) return;
+
         const fileBreakpoints = this.fileToBreakpoint[file.name];
 
         if (fileBreakpoints) {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -362,6 +362,7 @@ export class EditorPackage {
     }
 
     lookupFile(name: string) {
+        if (name.indexOf("pxt_modules/") === 0) name = name.slice(12);
         return this.filterFiles(f => f.getName() == name)[0]
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-adafruit/issues/998

This PR adds support for local variables, function arguments, and "this" in the debugger. It also fixes a few bugs:

1. Fixes a crash when the app receives breakpoints before Monaco is loaded
2. Fixes a crash where the code for evaluating getters was yielding (via `maybeYield`) and causing an exception in the simulator. You can see it if you open/close sprites 6 times in the variable list
3. Fixes the issue where the Monaco debugger is not visible if you have been to Blockly at least once.
4. Fixes a lot of places in debugger.tsx where we were mutating the component state directly instead of treating it as immutable

Also includes a lot of refactoring in the debugger to support multi-file debugging, which I will finish up in a separate PR.

No GIF because there isn't really anything to show off!