### PR TITLE
display version info when running in electron

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -155,7 +155,8 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
 
     pxt.targetConfigAsync()
         .then(config => {
-            const em = pxt.BrowserUtils.isPxtElectron() && config && config.electronManifest;
+            const isElectron = pxt.BrowserUtils.isPxtElectron();
+            const electronManifest = config && config.electronManifest;
             return core.confirmAsync({
                 header: lf("About"),
                 hideCancel: true,
@@ -163,10 +164,12 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
                 agreeClass: "positive",
                 buttons,
                 jsx: <div>
-                    {em ?
-                        pxt.semver.strcmp(pxt.appTarget.versions.target, em.latest) < 0
-                            ? <p>{lf("An update {0} for {1} is available", em.latest, pxt.appTarget.title)}</p>
-                            : <p>{lf("{0} is up to date", pxt.appTarget.title)}</p>
+                    {isElectron ?
+                        (!pxt.Cloud.isOnline() || !electronManifest)
+                            ? <p>{lf("Please connect to internet to check for updates")}</p>
+                            : pxt.semver.strcmp(pxt.appTarget.versions.target, electronManifest.latest) < 0
+                                ? <p>{lf("An update {0} for {1} is available", electronManifest.latest, pxt.appTarget.title)}</p>
+                                : <p>{lf("{0} is up to date", pxt.appTarget.title)}</p>
                         : undefined}
                     {githubUrl && versions ?
                         renderVersionLink(pxt.appTarget.name, versions.target, `${githubUrl}/releases/tag/v${versions.target}`)

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -168,7 +168,7 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
                         (!pxt.Cloud.isOnline() || !electronManifest)
                             ? <p>{lf("Please connect to internet to check for updates")}</p>
                             : pxt.semver.strcmp(pxt.appTarget.versions.target, electronManifest.latest) < 0
-                                ? <p>{lf("An update {0} for {1} is available", electronManifest.latest, pxt.appTarget.title)}</p>
+                                ? <a href="/offline-app">{lf("An update {0} for {1} is available", electronManifest.latest, pxt.appTarget.title)}</a>
                                 : <p>{lf("{0} is up to date", pxt.appTarget.title)}</p>
                         : undefined}
                     {githubUrl && versions ?

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -153,30 +153,39 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
             }
         })
 
-    core.confirmAsync({
-        header: lf("About"),
-        hideCancel: true,
-        agreeLbl: lf("Ok"),
-        agreeClass: "positive",
-        buttons,
-        jsx: <div>
-            {githubUrl && versions ?
-                renderVersionLink(pxt.appTarget.name, versions.target, `${githubUrl}/releases/tag/v${versions.target}`)
-                : undefined}
-            {versions ?
-                renderVersionLink("Microsoft MakeCode", versions.pxt, `https://github.com/Microsoft/pxt/releases/tag/v${versions.pxt}`)
-                : undefined}
-            {showCompile ?
-                renderCompileLink(compileService)
-                : undefined}
-            <p><br /></p>
-            <p>
-                {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
-                &nbsp;&nbsp;&nbsp; {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
-            </p>
-            {targetTheme.copyrightText ? <p> {targetTheme.copyrightText} </p> : undefined}
-        </div>
-    }).done();
+    pxt.targetConfigAsync()
+        .then(config => {
+            const em = pxt.BrowserUtils.isPxtElectron() && config && config.electronManifest;
+            return core.confirmAsync({
+                header: lf("About"),
+                hideCancel: true,
+                agreeLbl: lf("Ok"),
+                agreeClass: "positive",
+                buttons,
+                jsx: <div>
+                    {em ?
+                        pxt.semver.strcmp(pxt.appTarget.versions.target, em.latest) < 0
+                            ? <p>{lf("An update {0} for {1} is available", em.latest, pxt.appTarget.title)}</p>
+                            : <p>{lf("{0} is up to date", pxt.appTarget.title)}</p>
+                        : undefined}
+                    {githubUrl && versions ?
+                        renderVersionLink(pxt.appTarget.name, versions.target, `${githubUrl}/releases/tag/v${versions.target}`)
+                        : undefined}
+                    {versions ?
+                        renderVersionLink("Microsoft MakeCode", versions.pxt, `https://github.com/Microsoft/pxt/releases/tag/v${versions.pxt}`)
+                        : undefined}
+                    {showCompile ?
+                        renderCompileLink(compileService)
+                        : undefined}
+                    <p><br /></p>
+                    <p>
+                        {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
+                        &nbsp;&nbsp;&nbsp; {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
+                    </p>
+                    {targetTheme.copyrightText ? <p> {targetTheme.copyrightText} </p> : undefined}
+                </div>
+            })
+        }).done();
 }
 
 

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -155,7 +155,7 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
 
     pxt.targetConfigAsync()
         .then(config => {
-            const isElectron = pxt.BrowserUtils.isPxtElectron();
+            const isPxtElectron = pxt.BrowserUtils.isPxtElectron();
             const electronManifest = config && config.electronManifest;
             return core.confirmAsync({
                 header: lf("About"),
@@ -164,7 +164,7 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
                 agreeClass: "positive",
                 buttons,
                 jsx: <div>
-                    {isElectron ?
+                    {isPxtElectron ?
                         (!pxt.Cloud.isOnline() || !electronManifest)
                             ? <p>{lf("Please connect to internet to check for updates")}</p>
                             : pxt.semver.strcmp(pxt.appTarget.versions.target, electronManifest.latest) < 0


### PR DESCRIPTION
I find it frustrating that i dont' know if the elecron app is updating or not. Add some info about online version availability in electron.
* not online -> please connect to internet to update
* online, updated -> you're up to date
* online, outdated, an update is avilable
![image](https://user-images.githubusercontent.com/4175913/56434904-6a01f480-628b-11e9-88f9-7ca5a25fd1c4.png)
