### PR TITLE
Exit tutorial cleanup

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1578,18 +1578,20 @@ export class ProjectView
         if (this.editor) this.editor.unloadFileAsync();
         // clear the hash
         pxt.BrowserUtils.changeHash("", true);
-        this.setState({
+        this.setStateAsync({
             home: true,
             tracing: undefined,
             fullscreen: undefined,
             tutorialOptions: undefined,
             editorState: undefined,
-            debugging: undefined
-        });
-        this.allEditors.forEach(e => e.setVisible(false));
-        this.homeLoaded();
-        this.showPackageErrorsOnNextTypecheck();
-        workspace.syncAsync().done();
+            debugging: undefined,
+            header: undefined
+        }).then(() => {
+            this.allEditors.forEach(e => e.setVisible(false));
+            this.homeLoaded();
+            this.showPackageErrorsOnNextTypecheck();
+            return workspace.syncAsync();
+        }).done();
     }
 
     private homeLoaded() {


### PR DESCRIPTION
- [x] cleanup header state when going to home
- [x] use "setStateAsync" in various places to avoid races

Seems to be fixed reload of autoRun tutorial https://github.com/Microsoft/pxt-adafruit/issues/1002. I could not trace the exact root cause of the bug but with these fixes I could not reproduce the race anymore. @riknoll maybe you can take a second peek.

