### PR TITLE
Don't decompile globals

### DIFF
--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -42,14 +42,13 @@ namespace ts.pxtc {
                     case SyntaxKind.BinaryExpression:
                         annotateBinaryExpression(child as ts.BinaryExpression);
                         break;
-                    case SK.Identifier:
-                        const decl = getDecl(child);
-                        if (decl.getSourceFile().fileName !== "main.ts") {
+                    case SyntaxKind.Identifier:
+                        const decl: Declaration = getDecl(child);
+                        if (decl.getSourceFile().fileName !== "main.ts" && decl.kind == SyntaxKind.VariableDeclaration) {
                             const info: IdentifierInfo = {
                                 isGlobal: true
                             };
                             (child as any).identifierInfo = info;
-                            console.log(child.getFullText() + " is global");
                         }
                         break;
 

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -44,7 +44,7 @@ namespace ts.pxtc {
                         break;
                     case SyntaxKind.Identifier:
                         const decl: Declaration = getDecl(child);
-                        if (decl.getSourceFile().fileName !== "main.ts" && decl.kind == SyntaxKind.VariableDeclaration) {
+                        if (decl && decl.getSourceFile().fileName !== "main.ts" && decl.kind == SyntaxKind.VariableDeclaration) {
                             const info: IdentifierInfo = {
                                 isGlobal: true
                             };

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -1,5 +1,9 @@
 namespace ts.pxtc {
 
+    interface IdentifierInfo {
+        isGlobal: boolean;
+    }
+
     /**
      * Traverses the AST and injects information about function calls into the expression
      * nodes. The decompiler consumes this information later
@@ -37,6 +41,16 @@ namespace ts.pxtc {
                         break;
                     case SyntaxKind.BinaryExpression:
                         annotateBinaryExpression(child as ts.BinaryExpression);
+                        break;
+                    case SK.Identifier:
+                        const decl = getDecl(child);
+                        if (decl.getSourceFile().fileName !== "main.ts") {
+                            const info: IdentifierInfo = {
+                                isGlobal: true
+                            };
+                            (child as any).identifierInfo = info;
+                            console.log(child.getFullText() + " is global");
+                        }
                         break;
 
                 }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -230,8 +230,7 @@ namespace ts.pxtc.decompiler {
         const allRenames: RenameLocation[] = [];
         const globals: Node[] = [];
         let names = collectNameCollisions();
-        const renameMap = new RenameMap(allRenames, globals);
-        return [renameMap, names];
+        return [new RenameMap(allRenames, globals), names];
 
         function collectNameCollisions(): NamesSet {
             const takenNames: NamesSet = {};

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1144,6 +1144,9 @@ ${output}</xml>`;
                     case SK.DebuggerStatement:
                         stmt = getDebuggerStatementBlock(node);
                         break;
+                    case SK.EmptyStatement:
+                    stmt = undefined; // don't generate blocks for empty statements
+                    break;
                     case SK.EnumDeclaration:
                         // If the enum declaration made it past the checker then it is emitted elsewhere
                         return getNext();
@@ -2144,6 +2147,7 @@ ${output}</xml>`;
             case SK.EnumDeclaration:
                 return checkEnumDeclaration(node as ts.EnumDeclaration, topLevel);
             case SK.DebuggerStatement:
+            case SK.EmptyStatement:
                 return undefined;
         }
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -227,6 +227,7 @@ namespace ts.pxtc.decompiler {
     export function buildRenameMap(p: Program, s: SourceFile): [RenameMap, NamesSet] {
         let service = ts.createLanguageService(new LSHost(p))
         const allRenames: RenameLocation[] = [];
+
         let names = collectNameCollisions();
 
         return [new RenameMap(allRenames), names];
@@ -325,7 +326,7 @@ namespace ts.pxtc.decompiler {
             attrs: attrs,
             compInfo: compInfo,
             localReporters: [],
-            opts: options || {},
+            opts: options || {}
         };
         const fileText = file.getFullText();
         let output = ""

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1144,8 +1144,8 @@ ${output}</xml>`;
                         stmt = getDebuggerStatementBlock(node);
                         break;
                     case SK.EmptyStatement:
-                    stmt = undefined; // don't generate blocks for empty statements
-                    break;
+                        stmt = undefined; // don't generate blocks for empty statements
+                        break;
                     case SK.EnumDeclaration:
                         // If the enum declaration made it past the checker then it is emitted elsewhere
                         return getNext();

--- a/tests/decompile-test/baselines/global_variables.blocks
+++ b/tests/decompile-test/baselines/global_variables.blocks
@@ -1,0 +1,31 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="test_number_argument">
+<value name="arg">
+<block type="typescript_expression">
+<field name="EXPRESSION">someConstant</field>
+</block>
+</value>
+<next>
+<block type="test_number_argument">
+<value name="arg">
+<block type="typescript_expression">
+<field name="EXPRESSION">someNonConstant</field>
+</block>
+</value>
+<next>
+<block type="test_string_argument">
+<value name="arg">
+<block type="typescript_expression">
+<field name="EXPRESSION">someString</field>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/global_variables.ts
+++ b/tests/decompile-test/cases/global_variables.ts
@@ -1,0 +1,3 @@
+testNamespace.numberArgument(someConstant);
+testNamespace.numberArgument(someNonConstant);
+testNamespace.stringArgument(someString);

--- a/tests/decompile-test/cases/testBlocks/globals.ts
+++ b/tests/decompile-test/cases/testBlocks/globals.ts
@@ -1,0 +1,4 @@
+// These should decompile to gray blocks
+const someConstant = 10;
+const someString = "100";
+let someNonConstant = 15;

--- a/tests/decompile-test/cases/testBlocks/pxt.json
+++ b/tests/decompile-test/cases/testBlocks/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "testBlocks",
-    "description": "Project that defines a variety of blocks to be used in decopmiler test cases",
+    "description": "Project that defines a variety of blocks to be used in decompiler test cases",
     "files": [
         "basic.ts",
         "banned.ts",
@@ -12,7 +12,8 @@
         "constantShim.ts",
         "cp.ts",
         "templateStrings.ts",
-        "classHandlerParameter.ts"
+        "classHandlerParameter.ts",
+        "globals.ts"
     ],
     "public": true,
     "dependencies": {},


### PR DESCRIPTION
 Checks to see if a variable is declared in another file before recompiling it as a block.

If an identifier is defined in another file, it is flagged as a global and will fail decompilation.

Fixes Microsoft/pxt-arcade#554