### PR TITLE
Download button in the download dialog

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -82,7 +82,7 @@ function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (opt
         hideCancel: true,
         hideAgree: true,
         buttons: [downloadAgain ? {
-            label: userDownload ? lf("Download") : fn,
+            label: userDownload ? lf("Download") : lf("Click to download again"),
             icon: "download",
             class: `${userDownload ? "primary" : "lightgrey"}`,
             url,


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-arcade/issues/510

With the name on the button, some students were getting confused and thinking they had to press it to download, which ends up with them double-downloading the file. Took the wording from the download screenshot section, which is a bit more clear:

<img width="728" alt="Screen Shot 2019-04-19 at 7 29 34 PM" src="https://user-images.githubusercontent.com/5615930/56450363-7cefe580-62da-11e9-84be-acb48c7bf2f6.png">

Could also just switch it to be a link; a decent number of websites do that and it does make it something you seek out rather than click immediately because it's a big green button:

<img width="1078" alt="Screen Shot 2019-04-19 at 7 39 16 PM" src="https://user-images.githubusercontent.com/5615930/56450412-d9530500-62da-11e9-8aca-d79a7588b958.png">

I personally like the button as is, but can switch if that's preferred