### PR TITLE
Refactor shared buttons in editor toolbar

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -913,16 +913,57 @@ p.ui.font.small {
         position:absolute;
         padding: 0;
         margin: 1em;
-        bottom:0rem !important;
-        left:4rem !important;
-        top:auto;
-        width:auto;
+        bottom: 4rem !important;
+        top: auto;
+        width: auto;
         min-width: inherit;
         max-width: inherit;
         background: transparent !important;
+        overflow: visible;
+    }
+    .collapsedEditorTools #filelist {
+        display: none;
     }
     #filelistOverlay {
         display: block;
+        top: auto;
+        left: 4rem; /* match left pos of #boardview */
+        bottom: -3rem;
+        width: 10rem; /* match width of div.simframe */
+        height: 9rem;
+    }
+    #root:not(.fullscreensim) {
+        #boardview {
+            position: absolute;
+            left: 4rem;
+        }
+        #filelist .simtoolbar {
+            margin: 0.5em 0;
+        }
+        #filelist .simtoolbar > div:not(:first-child),
+        #filelist .simtoolbar > .buttons > .button {
+            display: none;
+        }
+        #filelist .simtoolbar > .buttons > .play-button,
+        #filelist .simtoolbar > .buttons > .restart-button {
+            display: block;
+        }
+        #filelist .simtoolbar > div:first-child {
+            flex-direction: column;
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        #filelist .simtoolbar > div:first-child > button {
+            border-radius: 0;
+            font-size: .92857143rem;
+        }
+        #editortools .left .buttons:first-child {
+            position: absolute;
+            bottom: 0;
+        }
+    }
+    #root.collapsedEditorTools #editortools .left .buttons:first-child {
+        bottom: auto; // undo bottom positioning for collapsed toolbar
     }
     #maineditor {
         left: 0;

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -121,7 +121,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const collapseTooltip = lf("Hide the simulator");
         const screenshotTooltip = targetTheme.simScreenshotKey ? lf("Take Screenshot (shortcut {0})", targetTheme.simScreenshotKey) : lf("Take Screenshot");
 
-        return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait hide")} role="complementary" aria-label={lf("Simulator toolbar")}>
+        return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait ")} role="complementary" aria-label={lf("Simulator toolbar")}>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make ? <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} /> : undefined}
                 {run ? <sui.Button disabled={!runControlsEnabled} key='runbtn' className={`play-button ${(isRunning || debugging) ? "stop" : "play"}`} icon={(isRunning || debugging) ? "stop" : "play green"} title={runTooltip} onClick={this.startStopSimulator} /> : undefined}
@@ -129,10 +129,10 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
                 {run && debug ? <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} /> : undefined}
                 {trace ? <sui.Button key='trace' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={this.toggleTrace} /> : undefined}
             </div>
-            <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
+            <div className={`ui icon tiny buttons computer only`} style={{ padding: "0" }}>
                 {audio ? <sui.Button key='mutebtn' className={`mute-button ${isMuted ? 'red' : ''}`} icon={`${isMuted ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={this.toggleMute} /> : undefined}
             </div>
-            <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
+            <div className={`ui icon tiny buttons computer only`} style={{ padding: "0" }}>
                 {screenshot ? <sui.Button disabled={!isRunning} key='screenshotbtn' className={`screenshot-button ${screenshotClass}`} icon={`icon camera left`} title={screenshotTooltip} onClick={this.takeScreenshot} /> : undefined}
                 {collapse && !isFullscreen ? <sui.Button key='collapsebtn' className={`collapse-button`} icon={`icon toggle left`} title={collapseTooltip} onClick={this.toggleSimulatorCollapse} /> : undefined}
                 {fullscreen ? <sui.Button key='fullscreenbtn' className={`fullscreen-button`} icon={`xicon ${isFullscreen ? 'fullscreencollapse' : 'fullscreen'}`} title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} /> : undefined}


### PR DESCRIPTION
Move undo/redo, zoom, collapse, and save buttons into shared functions for the editor toolbar. Remove the simulator toolbar buttons (play, refresh) except in headless rendering.