### PR TITLE
Specify simulator by class instead of id for css

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -136,7 +136,7 @@ body {
 }
 
 /* File list / Simulator layout */
-#simulator {
+.simulator {
     height: 100%;
 }
 #filelist, #downloadArea {
@@ -194,25 +194,25 @@ body {
     background: rgba(0,0,0,0.05);
 }
 
-#simulators {
+.simulator {
     text-align: center;
 }
 
-#simulators .ui.embed .icon.xicon::before {
+.simulator .ui.embed .icon.xicon::before {
     transform: translateX(-77%) translateY(-120%);
     transition: opacity .25s ease,color .25s ease;
 }
 
-#simulators .ui.embed .icon.xicon::after {
+.simulator .ui.embed .icon.xicon::after {
     background: rgba(0,0,0,.3);
     transition: opacity .25s ease;
 }
 
-#simulators .ui.embed .icon.xicon:hover:before {
+.simulator .ui.embed .icon.xicon:hover:before {
     color: @green;
 }
 
-#simulators .ui.embed .icon.xicon:hover:after {
+.simulator .ui.embed .icon.xicon:hover:after {
     opacity: 0.6;
 }
 
@@ -761,7 +761,7 @@ p.ui.font.small {
         background: -moz-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Firefox 3.6 to 15 */
         background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
     }
-    #simulator .hidefullscreen,
+    .simulator .hidefullscreen,
     .menubar .ui.item:not(.logo),
     #maineditor,
     #editortools,
@@ -783,7 +783,7 @@ p.ui.font.small {
         right: auto;
         display: block !important;
     }
-    #simulators {
+    .simulator {
         position: relative;
         padding: 3rem 1rem 3rem;
         width: 100%;
@@ -959,7 +959,7 @@ p.ui.font.small {
     div.simframe:not(:first-child) {
         display:none;
     }
-    #simulators {
+    .simulator {
         flex-direction: row;
         display: flex !important;
     }
@@ -1106,7 +1106,7 @@ p.ui.font.small {
     z-index: @sandboxFooterZIndex;
 }
 
-.simView #simulators {
+.simView .simulator {
     position: absolute;
     top: @mainMenuHeight;
     bottom: 4rem;
@@ -1141,7 +1141,7 @@ div.simframe.ui.embed {
 }
 
 .sandbox {
-    #simulators, #simulator, #editortools {
+    .simulator, #editortools {
         display: none;
     }
 
@@ -1155,7 +1155,7 @@ div.simframe.ui.embed {
         display: none;
     }
 
-    #simulators {
+    .simulator {
         flex-direction: row;
         display: flex !important;
     }
@@ -1202,7 +1202,7 @@ div.simframe.ui.embed {
 }
 
 .sandbox.simView {
-    #simulators, #simulator, #editortools {
+    .simulator, #editortools {
         display: inherit;
     }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -1141,7 +1141,7 @@ div.simframe.ui.embed {
 }
 
 .sandbox {
-    #simulators, #simulator #editortools {
+    #simulators, #simulator, #editortools {
         display: none;
     }
 
@@ -1202,7 +1202,7 @@ div.simframe.ui.embed {
 }
 
 .sandbox.simView {
-    .simulator, #editortools {
+    #simulators, #simulator, #editortools {
         display: inherit;
     }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -136,7 +136,7 @@ body {
 }
 
 /* File list / Simulator layout */
-.simulator {
+#simulator {
     height: 100%;
 }
 #filelist, #downloadArea {
@@ -194,7 +194,7 @@ body {
     background: rgba(0,0,0,0.05);
 }
 
-.simulator {
+#simulators {
     text-align: center;
 }
 
@@ -761,7 +761,7 @@ p.ui.font.small {
         background: -moz-linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* For Firefox 3.6 to 15 */
         background: linear-gradient(@fullscreenBackgroundGradientStart 50%, @fullscreenBackgroundGradientEnd); /* Standard syntax */
     }
-    .simulator .hidefullscreen,
+    #simulator .hidefullscreen,
     .menubar .ui.item:not(.logo),
     #maineditor,
     #editortools,
@@ -783,7 +783,7 @@ p.ui.font.small {
         right: auto;
         display: block !important;
     }
-    .simulator {
+    #simulators {
         position: relative;
         padding: 3rem 1rem 3rem;
         width: 100%;
@@ -959,7 +959,7 @@ p.ui.font.small {
     div.simframe:not(:first-child) {
         display:none;
     }
-    #simulator {
+    #simulators {
         flex-direction: row;
         display: flex !important;
     }
@@ -1106,7 +1106,7 @@ p.ui.font.small {
     z-index: @sandboxFooterZIndex;
 }
 
-.simView .simulator {
+.simView #simulators {
     position: absolute;
     top: @mainMenuHeight;
     bottom: 4rem;
@@ -1141,8 +1141,8 @@ div.simframe.ui.embed {
 }
 
 .sandbox {
-    #simulator, #editortools {
-        display: none !important;
+    #simulators, #simulator #editortools {
+        display: none;
     }
 
     #maineditor {
@@ -1155,7 +1155,7 @@ div.simframe.ui.embed {
         display: none;
     }
 
-    .simulator {
+    #simulators {
         flex-direction: row;
         display: flex !important;
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -959,7 +959,7 @@ p.ui.font.small {
     div.simframe:not(:first-child) {
         display:none;
     }
-    .simulator {
+    #simulator {
         flex-direction: row;
         display: flex !important;
     }
@@ -1141,8 +1141,8 @@ div.simframe.ui.embed {
 }
 
 .sandbox {
-    .simulator, #editortools {
-        display: none;
+    #simulator, #editortools {
+        display: none !important;
     }
 
     #maineditor {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -86,7 +86,7 @@
     <div id='loading' style='font-size: 25px; font-family:monospace; margin: 20% auto; width: 200px;'>
         loading...
     </div>
-    <div id="simulators">
+    <div id="simulators" className="simulator">
     </div>
     <footer id="footer" style="display:none;">
     </footer>
@@ -122,7 +122,7 @@
 
         if (fullScreen) {
             document.getElementById("injected-style").textContent =
-                "#simulators {\n"
+                ".simulator {\n"
                 + "    height: 100%;\n"
                 + "}\n"
                 + "div.simframe {\n"

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -122,7 +122,7 @@
 
         if (fullScreen) {
             document.getElementById("injected-style").textContent =
-                ".simulator {\n"
+                "#simulators {\n"
                 + "    height: 100%;\n"
                 + "}\n"
                 + "div.simframe {\n"

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3003,7 +3003,7 @@ export class ProjectView
                 {inTutorial ? <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
                     <tutorial.TutorialCard ref="tutorialcard" parent={this} />
                 </div> : undefined}
-                <div id="simulator">
+                <div id="simulator" className="simulator">
                     <div id="filelist" className="ui items">
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")}>
                         </div>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -431,7 +431,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         </div>
                     </div> : undefined}
                     {action && this.loanedSimulator ? <div className="ui fields">
-                        <div id="shareLoanedSimulator" className={`ui six wide field landscape only ${gifRecordingClass}`}></div>
+                        <div id="shareLoanedSimulator" className={`simulator ui six wide field landscape only ${gifRecordingClass}`}></div>
                         <div className="ui ten wide field">
                             <sui.Input ref="filenameinput" placeholder={lf("Name")} autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
                                 ariaLabel={lf("Type a name for your project")} autoComplete={false}


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/849

CSS wasn't applying appropriately to simulator in the share dialogue as it didn't have the same ID as the normal simulator.

## Current

![2019-04-22 15 55 48](https://user-images.githubusercontent.com/5615930/56540752-7ea9eb00-651e-11e9-89ac-eb0bd6644695.gif)

## This change

![2019-04-22 15 54 17](https://user-images.githubusercontent.com/5615930/56540753-7ea9eb00-651e-11e9-9141-15238a4cfceb.gif)