### PR TITLE
Import extension as file

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -325,6 +325,7 @@ declare namespace pxt {
         simGifWidth?: number; // with in pixels for gif frames
         autoWebUSBDownload?: boolean; // automatically prompt user for webusb download
         qrCode?: boolean; // generate QR code for shared urls
+        importExtensionFiles?: boolean; // import extensions from files
     }
 
     interface SocialOptions {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -141,6 +141,10 @@ namespace pxt.editor {
         clickTrigger?: boolean;
     }
 
+    export interface ImportFileOptions {
+        extension?: boolean;
+    }
+
     export interface IProjectView {
         state: IAppState;
         setState(st: IAppState): void;
@@ -266,7 +270,7 @@ namespace pxt.editor {
         showAboutDialog(): void;
 
         showImportUrlDialog(): void;
-        showImportFileDialog(): void;
+        showImportFileDialog(options?: ImportFileOptions): void;
         showImportGithubDialog(): void;
 
         showResetDialog(): void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -143,6 +143,7 @@ namespace pxt.editor {
 
     export interface ImportFileOptions {
         extension?: boolean;
+        openHomeIfFailed?: boolean;
     }
 
     export interface IProjectView {

--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -101,6 +101,11 @@ namespace pxt.editor.experiments {
                 name: lf("Shared QR Code"),
                 description: lf("Generate a QR Code form the shared project url"),
                 feedbackUrl: "https://github.com/Microsoft/pxt/issues/5456"
+            },
+            {
+                id: "importExtensionFiles",
+                name: lf("Import Extension Files"),
+                description: lf("Import Extensions from compiled project files")
             }
         ].filter(experiment => ids.indexOf(experiment.id) > -1);
     }

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -73,7 +73,7 @@ namespace pxt {
         }
 
         commonDownloadAsync(): Promise<Map<string>> {
-            let proto = this.verProtocol()
+            const proto = this.verProtocol()
             if (proto == "pub") {
                 return Cloud.downloadScriptFilesAsync(this.verArgument())
             } else if (proto == "github") {
@@ -81,10 +81,16 @@ namespace pxt {
                     .then(config => pxt.github.downloadPackageAsync(this.verArgument(), config))
                     .then(resp => resp.files)
             } else if (proto == "embed") {
-                let resp = pxt.getEmbeddedScript(this.verArgument())
+                const resp = pxt.getEmbeddedScript(this.verArgument())
                 return Promise.resolve(resp)
-            } else
-                return Promise.resolve(null as Map<string>)
+            } else if (proto == "pkg") {
+                // the package source is serialized in a file in the package itself
+                const pkgFilesSrc = this.readFile(this.verArgument());
+                const pkgFilesJson = ts.pxtc.Util.jsonTryParse(pkgFilesSrc) as Map<string>;
+                if (!pkgFilesJson)
+                    pxt.log(`unable to find ${this.verArgument()}`)
+                return Promise.resolve(pkgFilesJson)
+            } else return Promise.resolve(null as Map<string>)
         }
 
         host() { return this.parent._host }

--- a/pxtwinrt/winrt.ts
+++ b/pxtwinrt/winrt.ts
@@ -28,7 +28,7 @@ namespace pxt.winrt {
         return typeof Windows !== "undefined";
     }
 
-    export function initAsync(importHexImpl?: (hex: pxt.cpp.HexFile, createNewIfFailed?: boolean) => void) {
+    export function initAsync(importHexImpl?: (hex: pxt.cpp.HexFile, options?: pxt.editor.ImportFileOptions) => void) {
         if (!isWinRT() || pxt.BrowserUtils.isIFrame()) return Promise.resolve();
 
         const uiCore = Windows.UI.Core;
@@ -67,7 +67,7 @@ namespace pxt.winrt {
 
     export function loadActivationProject() {
         return initialActivationDeferred.promise
-            .then((args) => fileActivationHandler(args, /* createNewIfFailed */ true));
+            .then((args) => fileActivationHandler(args, /* openHomeIfFailed */ true));
     }
 
     export function hasActivationProjectAsync() {
@@ -138,9 +138,9 @@ namespace pxt.winrt {
     }
 
     let initialActivationDeferred: Promise.Resolver<ActivationArgs>;
-    let importHex: (hex: pxt.cpp.HexFile, createNewIfFailed?: boolean) => void;
+    let importHex: (hex: pxt.cpp.HexFile, options?: pxt.editor.ImportFileOptions) => void;
 
-    function fileActivationHandler(args: ActivationArgs, createNewIfFailed = false) {
+    function fileActivationHandler(args: ActivationArgs, openHomeIfFailed = false) {
         if (args.kind === Windows.ApplicationModel.Activation.ActivationKind.file) {
             let info = args as Windows.UI.WebUI.WebUIFileActivatedEventArgs;
             let file: Windows.Storage.IStorageItem = info.files.getAt(0);
@@ -156,7 +156,7 @@ namespace pxt.winrt {
                         dataReader.close();
                         return pxt.cpp.unpackSourceFromHexAsync(new Uint8Array(ar));
                     })
-                    .then((hex) => importHex(hex, createNewIfFailed));
+                    .then((hex) => importHex(hex, { openHomeIfFailed }));
             }
         }
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1268,7 +1268,7 @@ export class ProjectView
     importProjectFile(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file) return;
         ts.pxtc.Util.fileReadAsBufferAsync(file)
-            .then(buf => this.importProjectCoreAsync(buf))
+            .then(buf => this.importProjectCoreAsync(buf, options))
     }
 
     importPNGFile(file: File, options?: pxt.editor.ImportFileOptions) {
@@ -1276,7 +1276,7 @@ export class ProjectView
         ts.pxtc.Util.fileReadAsBufferAsync(file)
             .then(buf => screenshot.decodeBlobAsync("data:image/png;base64," +
                 btoa(pxt.Util.uint8ArrayToString(buf))))
-            .then(buf => this.importProjectCoreAsync(buf))
+            .then(buf => this.importProjectCoreAsync(buf, options))
     }
 
     importAssetFile(file: File) {
@@ -1331,7 +1331,7 @@ export class ProjectView
                         if (!cfg.dependencies)
                             cfg.dependencies = {};
                         cfg.dependencies[n] = `pkg:./${fn}`;
-                    })
+                    }).then(() => mpkg.savePkgAsync())
                     .done(() => this.reloadHeaderAsync());
                 }
             }
@@ -2616,7 +2616,7 @@ export class ProjectView
         dialogs.showImportFileDialogAsync(options).done(res => {
             if (res) {
                 pxt.tickEvent("app.open.file");
-                this.importFile(res);
+                this.importFile(res, options);
             }
         });
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1220,30 +1220,30 @@ export class ProjectView
         return false
     }
 
-    importProjectCoreAsync(buf: Uint8Array) {
+    importProjectCoreAsync(buf: Uint8Array, options?: pxt.editor.ImportFileOptions) {
         return (buf[0] == '{'.charCodeAt(0) ?
             Promise.resolve(pxt.U.uint8ArrayToString(buf)) :
             pxt.lzmaDecompressAsync(buf))
             .then(contents => {
                 let data = JSON.parse(contents) as pxt.cpp.HexFile;
-                this.importHex(data);
+                this.importHex(data, options);
             }).catch(e => {
                 core.warningNotification(lf("Sorry, we could not import this project."))
                 this.openHome();
             });
     }
 
-    importHexFile(file: File) {
+    importHexFile(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file) return;
         pxt.cpp.unpackSourceFromHexFileAsync(file)
-            .then(data => this.importHex(data))
+            .then(data => this.importHex(data, options))
             .catch(e => {
                 pxt.reportException(e);
                 core.warningNotification(lf("Sorry, we could not recognize this file."))
             });
     }
 
-    importBlocksFiles(file: File) {
+    importBlocksFiles(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file) return;
         ts.pxtc.Util.fileReadAsTextAsync(file)
             .done(contents => {
@@ -1254,7 +1254,7 @@ export class ProjectView
             })
     }
 
-    importTypescriptFile(file: File) {
+    importTypescriptFile(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file) return;
         ts.pxtc.Util.fileReadAsTextAsync(file)
             .done(contents => {
@@ -1265,13 +1265,13 @@ export class ProjectView
             })
     }
 
-    importProjectFile(file: File) {
+    importProjectFile(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file) return;
         ts.pxtc.Util.fileReadAsBufferAsync(file)
             .then(buf => this.importProjectCoreAsync(buf))
     }
 
-    importPNGFile(file: File) {
+    importPNGFile(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file) return;
         ts.pxtc.Util.fileReadAsBufferAsync(file)
             .then(buf => screenshot.decodeBlobAsync("data:image/png;base64," +
@@ -1288,14 +1288,13 @@ export class ProjectView
             .done()
     }
 
-    importHex(data: pxt.cpp.HexFile, createNewIfFailed: boolean = false) {
-        const targetId = pxt.appTarget.id;
+    importHex(data: pxt.cpp.HexFile, options?: pxt.editor.ImportFileOptions) {
         if (!data || !data.meta) {
             if (data && (data as any)[pxt.CONFIG_NAME]) {
                 data = cloudsync.reconstructMeta(data as any)
             } else {
                 core.warningNotification(lf("Sorry, we could not recognize this file."))
-                if (createNewIfFailed) this.openHome();
+                if (options && options.openHomeIfFailed) this.openHome();
                 return;
             }
         }
@@ -1309,7 +1308,7 @@ export class ProjectView
             const checkAsync = this.tryCheckTargetVersionAsync(data.meta.targetVersions && data.meta.targetVersions.target);
             if (checkAsync) {
                 checkAsync.done(() => {
-                    if (createNewIfFailed) this.newProject();
+                    if (options && options.openHomeIfFailed) this.newProject();
                 });
                 return;
             }
@@ -1326,13 +1325,13 @@ export class ProjectView
                         pxt.reportException(e, { importer: importer.id });
                         core.hideLoading("importhex");
                         core.errorNotification(lf("Oops, something went wrong when importing your project"));
-                        if (createNewIfFailed) this.openHome();
+                        if (options && options.openHomeIfFailed) this.openHome();
                     }));
         }
         else {
             core.warningNotification(lf("Sorry, we could not import this project."))
             pxt.tickEvent("warning.importfailed");
-            if (createNewIfFailed) this.openHome();
+            if (options && options.openHomeIfFailed) this.openHome();
         }
     }
 
@@ -1365,21 +1364,21 @@ export class ProjectView
         );
     }
 
-    importFile(file: File) {
+    importFile(file: File, options?: pxt.editor.ImportFileOptions) {
         if (!file || pxt.shell.isReadOnly()) return;
         if (this.isHexFile(file.name)) {
-            this.importHexFile(file)
+            this.importHexFile(file, options)
         } else if (this.isBlocksFile(file.name)) {
-            this.importBlocksFiles(file)
+            this.importBlocksFiles(file, options)
         } else if (this.isTypescriptFile(file.name)) {
-            this.importTypescriptFile(file);
+            this.importTypescriptFile(file, options);
         } else if (this.isProjectFile(file.name)) {
-            this.importProjectFile(file);
+            this.importProjectFile(file, options);
         } else if (this.isAssetFile(file.name)) {
             // assets need to go before PNG source import below, since target might want PNG assets
-            this.importAssetFile(file)
+            this.importAssetFile(file, options)
         } else if (this.isPNGFile(file.name)) {
-            this.importPNGFile(file);
+            this.importPNGFile(file, options);
         } else {
             const importer = this.resourceImporters.filter(fi => fi.canImport(file))[0];
             if (importer) {
@@ -1390,11 +1389,11 @@ export class ProjectView
         }
     }
 
-    importProjectFromFileAsync(buf: Uint8Array): Promise<void> {
+    importProjectFromFileAsync(buf: Uint8Array, options?: pxt.editor.ImportFileOptions): Promise<void> {
         return pxt.lzmaDecompressAsync(buf)
             .then((project) => {
                 let hexFile = JSON.parse(project) as pxt.cpp.HexFile;
-                return this.importHex(hexFile);
+                return this.importHex(hexFile, options);
             }).catch(() => {
                 return this.newProject();
             })
@@ -2589,8 +2588,8 @@ export class ProjectView
         });
     }
 
-    showImportFileDialog() {
-        dialogs.showImportFileDialogAsync().done(res => {
+    showImportFileDialog(options?: pxt.editor.ImportFileOptions) {
+        dialogs.showImportFileDialogAsync(options).done(res => {
             if (res) {
                 pxt.tickEvent("app.open.file");
                 this.importFile(res);
@@ -3468,7 +3467,7 @@ document.addEventListener("DOMContentLoaded", () => {
     pxt.hex.showLoading = (msg) => core.showLoading("hexcloudcompiler", msg);
     pxt.hex.hideLoading = () => core.hideLoading("hexcloudcompiler");
     pxt.docs.requireMarked = () => require("marked");
-    const importHex = (hex: pxt.cpp.HexFile, createNewIfFailed = false) => theEditor.importHex(hex, createNewIfFailed);
+    const importHex = (hex: pxt.cpp.HexFile, options?: pxt.editor.ImportFileOptions) => theEditor.importHex(hex, options);
 
     const hm = /^(https:\/\/[^/]+)/.exec(window.location.href)
     if (hm) Cloud.apiRoot = hm[1] + "/api/"

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1325,14 +1325,14 @@ export class ProjectView
                 if (mpkg) {
                     pxt.debug(`adding ${fn} to package`);
                     // save file
-                    mpkg.setFile(fn, data.source);
-                    // patch dependencies
-                    const pxtjson = mpkg.updateConfigAsync(cfg => {
-                        if (!cfg.dependencies)
-                            cfg.dependencies = {};
-                        cfg.dependencies[n] = `pkg:./${fn}`;
-                    }).then(() => mpkg.savePkgAsync())
-                    .done(() => this.reloadHeaderAsync());
+                    mpkg.setContentAsync(fn, data.source)
+                        .then(() => mpkg.updateConfigAsync(cfg => {
+                            if (!cfg.dependencies)
+                                cfg.dependencies = {};
+                            cfg.dependencies[n] = `pkg:${fn}`;
+                        }))
+                        .then(() => mpkg.savePkgAsync())
+                        .done(() => this.reloadHeaderAsync());
                 }
             }
             return;

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -670,7 +670,7 @@ export function showImportGithubDialogAsync() {
         })).then(() => res)
 }
 
-export function showImportFileDialogAsync() {
+export function showImportFileDialogAsync(options?: pxt.editor.ImportFileOptions) {
     let input: HTMLInputElement;
     let exts = [pxt.appTarget.compile.saveAsPNG ? ".png" : ".mkcd"];
     if (pxt.appTarget.compile.hasHex) {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -437,6 +437,10 @@ class Host
             epkg.setFiles(pxt.getEmbeddedScript(pkg.verArgument()))
             return Promise.resolve()
         } else if (proto == "pkg") {
+            // TODO don't take dependency on mainPkg!
+            const filesSrc = mainPkg.readFile(pkg.verArgument().replace(/^\.\//, ''));
+            const files = ts.pxtc.Util.jsonTryParse(filesSrc);
+            epkg.setFiles(files);
             return Promise.resolve();
         } else if (proto == "invalid") {
             pxt.log(`skipping invalid pkg ${pkg.id}`);

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -436,6 +436,8 @@ class Host
         } else if (proto == "embed") {
             epkg.setFiles(pxt.getEmbeddedScript(pkg.verArgument()))
             return Promise.resolve()
+        } else if (proto == "pkg") {
+            return Promise.resolve();
         } else if (proto == "invalid") {
             pxt.log(`skipping invalid pkg ${pkg.id}`);
             return Promise.resolve();

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -437,7 +437,6 @@ class Host
             epkg.setFiles(pxt.getEmbeddedScript(pkg.verArgument()))
             return Promise.resolve()
         } else if (proto == "pkg") {
-            // TODO don't take dependency on mainPkg!
             const filesSrc = mainPkg.readFile(pkg.verArgument().replace(/^\.\//, ''));
             const files = ts.pxtc.Util.jsonTryParse(filesSrc);
             if (files)

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -265,7 +265,7 @@ export class EditorPackage {
         if (!f) {
             f = this.setFile(n, v);
             p = p.then(() => this.updateConfigAsync(cfg => cfg.files.indexOf(n) < 0 ? cfg.files.push(n) : 0))
-                p.then(() => this.savePkgAsync())
+            p.then(() => this.savePkgAsync())
         }
         return p.then(() => f.setContentAsync(v));
     }
@@ -440,7 +440,9 @@ class Host
             // TODO don't take dependency on mainPkg!
             const filesSrc = mainPkg.readFile(pkg.verArgument().replace(/^\.\//, ''));
             const files = ts.pxtc.Util.jsonTryParse(filesSrc);
-            epkg.setFiles(files);
+            if (files)
+                epkg.setFiles(files);
+            else pxt.log(`failed to resolve ${pkg.version()}`);
             return Promise.resolve();
         } else if (proto == "invalid") {
             pxt.log(`skipping invalid pkg ${pkg.id}`);

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -50,6 +50,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         this.installGh = this.installGh.bind(this);
         this.addLocal = this.addLocal.bind(this);
         this.toggleExperiment = this.toggleExperiment.bind(this);
+        this.importExtensionFile = this.importExtensionFile.bind(this);
     }
 
     private hide() {
@@ -336,6 +337,11 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         this.forceUpdate();
     }
 
+    importExtensionFile() {
+        pxt.tickEvent("extensions.import", undefined, { interactiveConsent: true });
+        this.props.parent.showImportFileDialog({ extension: true });
+    }
+
     renderCore() {
         const { mode, closeIcon, visible, searchFor, experimentsState } = this.state;
 
@@ -346,6 +352,10 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const local = this.fetchLocal();
         const experiments = this.fetchExperiments();
         const isSearching = searchFor && (ghdata.status === data.FetchStatus.Pending || urldata.status === data.FetchStatus.Pending);
+        const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
+        const showImportFile = mode == ScriptSearchMode.Extensions
+            && pxt.appTarget.appTheme.importExtensionFiles
+            && !disableFileAccessinMaciOs;
 
         const compareConfig = (a: pxt.PackageConfig, b: pxt.PackageConfig) => {
             // core first
@@ -492,6 +502,16 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                     feedbackUrl={experiment.feedbackUrl}
                                 />
                             )}
+                            {showImportFile ? <codecard.CodeCardView
+                                ariaLabel={lf("Open files from your computer")}
+                                role="button"
+                                key={'import'}
+                                icon="upload"
+                                iconColor="secondary"
+                                name={lf("Import File...")}
+                                description={lf("Open files from your computer")}
+                                onClick={this.importExtensionFile}
+                            /> : undefined}
                         </div>
                     }
                     {isEmpty() ?

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -339,6 +339,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
     importExtensionFile() {
         pxt.tickEvent("extensions.import", undefined, { interactiveConsent: true });
+        this.hide();
         this.props.parent.showImportFileDialog({ extension: true });
     }
 

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -356,7 +356,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const showImportFile = mode == ScriptSearchMode.Extensions
             && pxt.appTarget.appTheme.importExtensionFiles
-            && !disableFileAccessinMaciOs;
+            && !disableFileAccessinMaciOs
+            && !searchFor;
 
         const compareConfig = (a: pxt.PackageConfig, b: pxt.PackageConfig) => {
             // core first
@@ -507,7 +508,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                 ariaLabel={lf("Open files from your computer")}
                                 role="button"
                                 key={'import'}
-                                icon="upload"
+                                icon="upload ui cardimage"
                                 iconColor="secondary"
                                 name={lf("Import File...")}
                                 description={lf("Open files from your computer")}


### PR DESCRIPTION
To better support offline scenario, this change allows to import project **files** (.hex, .uf2, .png) as extension in a project.

The full source of the project is stored in a file in the project (say ``donut.json`` for the ``donut`` extension file) and the dependecies has a new protocol ``pkg:donut.json``.

This solves the problem of supporting 3rd party extensions in the web and/or offline app. Also shared scripts will correctly load or reload etc...

In the extension dialog, we have a new card:
![image](https://user-images.githubusercontent.com/4175913/56603259-3d641a80-65b4-11e9-8313-2d5e88080932.png)
