### PR TITLE
always use space for python

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1129,6 +1129,8 @@ namespace ts.pxtc.service {
 \``;
 
     export function getSnippet(apis: pxt.Map<SymbolInfo>, fn: SymbolInfo, n: ts.FunctionLikeDeclaration, python?: boolean): string {
+        const PY_INDENT: string = (pxt as any).py.INDENT;
+
         let findex = 0;
         let preStmt = "";
 
@@ -1309,7 +1311,7 @@ namespace ts.pxtc.service {
                 let n = fnName || "fn";
                 if (functionCount++ > 0) n += functionCount;
                 n = snakify(n).toLowerCase();
-                preStmt += `def ${n}${functionArgument}:\n\t${returnValue || "pass"}\n`;
+                preStmt += `def ${n}${functionArgument}:\n${PY_INDENT}${returnValue || "pass"}\n`;
                 return n;
             } else {
                 let functionArgument = "()";
@@ -1325,7 +1327,7 @@ namespace ts.pxtc.service {
         function emitFn(n: string): string {
             if (python) {
                 if (n) n = snakify(n).toLowerCase();
-                preStmt += `def ${n}():\n\tpass\n`;
+                preStmt += `def ${n}():\n${PY_INDENT}pass\n`;
                 return n;
             } else return `function () {}`;
         }

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -136,6 +136,7 @@ namespace pxt.vs {
                 enabled: false
             },
             autoIndent: true,
+            useTabStops: true,
             dragAndDrop: true,
             matchBrackets: true,
             occurrencesHighlight: false,

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -31,7 +31,7 @@ namespace pxt.py {
     ///
     /// UTILS
     ///
-    const INDENT = "\t"
+    export const INDENT = "    "
     function indent(lvl: number): (s: string) => string {
         return s => `${INDENT.repeat(lvl)}${s}`
     }


### PR DESCRIPTION
Until we figure out how to configure monaco to insert tabs, we need to use spaces.