### PR TITLE
support optional args in .ctor

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2358,10 +2358,12 @@ ${lbl}: .short 0xffff
                 if (ctor) {
                     obj = sharedDef(obj)
                     markUsed(ctor)
-                    let args = node.arguments.slice(0)
+                    // arguments undefined on .ctor with optional args
+                    let args = (node.arguments || []).slice(0)
                     let ctorAttrs = parseComments(ctor)
 
-                    let sig = checker.getResolvedSignature(node)
+                    // unused?
+                    // let sig = checker.getResolvedSignature(node)
                     // TODO: can we have overloeads?
                     addDefaultParametersAndTypeCheck(checker.getResolvedSignature(node), args, ctorAttrs)
                     let compiled = args.map((x) => emitExpr(x))

--- a/tests/compile-test/lang-test0/17classes.ts
+++ b/tests/compile-test/lang-test0/17classes.ts
@@ -40,6 +40,17 @@ function testToString() {
 testToString()
 testClass()
 
+
+class CtorOptional {
+    constructor(opts?: string) {
+    }
+}
+function testCtorOptional() {
+    let co = new CtorOptional();
+    let co2 = new CtorOptional("");
+}
+testCtorOptional();
+
 namespace ClassInit {
     const seven = 7
     class FooInit {


### PR DESCRIPTION
Fix support for optional args in .ctors
```
class C {
  constructor(a? : any) {
  }
}
```