### PR TITLE
Fix annotations when using extensions containing a `main.ts`

### DIFF
--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -20,7 +20,7 @@ namespace ts.pxtc {
         const oldTarget = pxtc.target;
         pxtc.target = compileTarget;
 
-        let src = program.getSourceFiles().filter(f => Util.endsWith(f.fileName, entryPoint))[0];
+        let src = program.getSourceFiles().filter(f => f.fileName === entryPoint)[0];
         let checker = program.getTypeChecker();
 
         recurse(src);


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-arcade/issues/780, fixes part of https://github.com/Microsoft/pxt-arcade/issues/915 (found another case on the forum where it is still broken so I'm still looking into that, but the linked example and a handful more work now that didn't before)

Issue for those was the existence of a ``main.ts`` in an extension, which was being used instead of the actual ``main.ts``. This caused the annotations to be missing for most of the file, resulting in a generic error message with almost every line of code highlighted as errors

(notably, this makes it so the arcade space fight example decompiles properly, so that can be changed to be a blocks game eventually)