### PR TITLE
Only count blocks, not other pieces of the XML, towards MAX_BLOCKS

### DIFF
--- a/tests/decompile-test/baselines/almost_too_large.blocks
+++ b/tests/decompile-test/baselines/almost_too_large.blocks
@@ -1,4994 +1,9639 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
-    <block type="pxt-on-start">
-    <statement name="HANDLER">
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    <next>
-    <block type="variables_set">
-    <field name="VAR">x</field>
-    <value name="VALUE">
-    <shadow type="math_number">
-    <field name="NUM">1</field>
-    </shadow>
-    </value>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </next>
-    </block>
-    </statement>
-    </block>
-    </xml>
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">x</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">42</field>
+</shadow>
+</value>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+<comment pinned="false">&#47; &#60;reference path&#61;&#34;.&#47;testBlocks&#47;mb.ts&#34; &#47;&#62;</comment>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/almost_too_large.ts
+++ b/tests/decompile-test/cases/almost_too_large.ts
@@ -1,500 +1,321 @@
-let x = 0;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
-x = 1;
+/// <reference path="./testBlocks/mb.ts" />
+
+let x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+x = 1
+basic.showNumber(x)
+basic.showNumber(x)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)
+basic.showNumber(x + x + 42)


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-arcade/issues/915 (there seems to be a blockly related issue in the last one linked there still, but that seems unrelated)

Ties the block count to the number of ``<blocks>`` created, so that it maps directly to the number of blocks listed in the ``Delete all {num} blocks`` dialogue:

![Screen Shot 2019-04-24 at 9 21 56 PM](https://user-images.githubusercontent.com/5615930/56709611-0e929500-66d7-11e9-9d8c-83f68d3e4b9f.png)

For example, ``Delete all blocks`` on Falling Duck says it has 77 blocks, but currently ends up with ``emittedBlocks`` at 150; from the users perspective there is no real way to tell what they're at until it gives the error.

(Also arbitrarily bumped ``MAX_BLOCKS`` to just more than the largest arcade game I've seen that was built in blocks, but can revert that if preferred)

Making this a draft PR as I'll have to add a test still, but the one in https://github.com/Microsoft/pxt/pull/2925/files is a bit... long... so I'll add it tomorrow