### PR TITLE
Use Web USB after pairing

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1838,6 +1838,7 @@ export class ProjectView
             if (res) {
                 return pxt.usb.pairAsync()
                     .then(() => {
+                        cmds.setWebUSBEnabled(true);
                         core.infoNotification(lf("Device paired! Try downloading now."))
                     }, (err: Error) => {
                         core.errorNotification(lf("Failed to pair the device: {0}", err.message))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2022,6 +2022,7 @@ export class ProjectView
         pxt.tickEvent(`compile.devicenotfound`);
         const ext = pxt.outputName().replace(/[^.]*/, "");
         const fn = pkg.genFileName(ext);
+        cmds.setWebUSBPaired(false);
         return core.dialogAsync({
             header: lf("Oops, we couldn't find your {0}", pxt.appTarget.appTheme.boardName),
             body: lf("Please make sure your {0} is connected and try again.", pxt.appTarget.appTheme.boardName),

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1838,7 +1838,7 @@ export class ProjectView
             if (res) {
                 return pxt.usb.pairAsync()
                     .then(() => {
-                        cmds.setWebUSBEnabled(true);
+                        cmds.setWebUSBPaired(true);
                         core.infoNotification(lf("Device paired! Try downloading now."))
                     }, (err: Error) => {
                         core.errorNotification(lf("Failed to pair the device: {0}", err.message))

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -237,7 +237,7 @@ export function init(): void {
 
     if (shouldUseWebUSB && !tryPairedDevice) {
         pxt.usb.isPairedAsync().then(paired => {
-            if (paired) setWebUSBEnabled(true);
+            if (paired) setWebUSBPaired(true);
         });
     }
 
@@ -290,7 +290,7 @@ export function init(): void {
     }
 }
 
-export function setWebUSBEnabled(enabled: boolean) {
+export function setWebUSBPaired(enabled: boolean) {
     if (tryPairedDevice === enabled) return;
     tryPairedDevice = enabled;
     init();

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -103,7 +103,15 @@ function askWebUSBPairAsync(resp: pxtc.CompileResult): Promise<void> {
         header: lf("No device detected..."),
         jsx: <div><p><strong>{lf("Do you want to pair your {0} to the editor?", boardName)}</strong></p>
             <p>{lf("You will get one-click downloads and data logging.")}</p></div>,
-    }).then(r => r ? showWebUSBPairingInstructionsAsync(resp) : cmds.browserDownloadDeployCoreAsync(resp));
+    }).then(clickedYes =>  {
+        if (clickedYes) {
+            return showWebUSBPairingInstructionsAsync(resp)
+        }
+        else {
+            cmds.setWebUSBPaired(false);
+            return cmds.browserDownloadDeployCoreAsync(resp);
+        }
+    });
 }
 
 export function webUsbDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {


### PR DESCRIPTION
The logic was broken when we moved the "Always use web USB" stuff into an experiment. With this change, here's the pairing experience:

1, If you never pair the device, we always download
2. If a paired device is connected, we try to use webUSB
3. If the paired device is disconnected, the user gets an error dialog and we go back to downloading until it gets reconnected

