### PR TITLE
fix parameter hints in python intellisense

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1665,8 +1665,15 @@ namespace pxt.py {
                 syntaxInfo.auxResult = 0
                 // foo, bar
                 for (let i = 0; i < orderedArgs.length; ++i) {
-                    if (orderedArgs[i] && syntaxInfo.position <= orderedArgs[i].endPos) {
-                        syntaxInfo.auxResult = i
+                    syntaxInfo.auxResult = i
+                    let arg = orderedArgs[i]
+                    if (!arg) {
+                        // if we can't parse this next argument, but the cursor is beyond the 
+                        // previous arguments, assume it's here
+                        break
+                    }
+                    if (arg.startPos <= syntaxInfo.position && syntaxInfo.position <= arg.endPos) {
+                        break
                     }
                 }
             }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -124,14 +124,16 @@ class SignatureHelper implements monaco.languages.SignatureHelpProvider {
                 let sym = r.symbols ? r.symbols[0] : null
                 if (!sym || !sym.parameters) return null;
                 const documentation = pxt.Util.rlf(sym.attributes.jsDoc);
+                let paramInfo: monaco.languages.ParameterInformation[] =
+                    sym.parameters.map(p => ({
+                        label: `${p.name}: ${p.type}`,
+                        documentation: pxt.Util.rlf(p.description)
+                    }))
                 const res: monaco.languages.SignatureHelp = {
                     signatures: [{
-                        label: sym.name,
+                        label: `${sym.name}(${paramInfo.map(p => p.label).join(", ")})`,
                         documentation,
-                        parameters: sym.parameters.map(p => ({
-                            label: `${p.name}: ${p.type}`,
-                            documentation: pxt.Util.rlf(p.description)
-                        }))
+                        parameters: paramInfo
                     }],
                     activeSignature: 0,
                     activeParameter: r.auxResult


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6453828/56809478-3fd4a780-6834-11e9-9726-1b57d86394f7.png)

After:
![image](https://user-images.githubusercontent.com/6453828/56809766-ede05180-6834-11e9-90bb-2fddc7737698.png)


