### PR TITLE
Fix simulator width for tablet+mobile in Edge

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -982,6 +982,7 @@ p.ui.font.small {
         #boardview {
             position: absolute;
             left: 4rem;
+            width: 10rem;
         }
         #filelist .simtoolbar {
             margin: 0.5em 0;


### PR DESCRIPTION
Fix simulator width for tablet+mobile in Edge