### PR TITLE
Use https to open pxt-sample

### DIFF
--- a/docs/target-creation.md
+++ b/docs/target-creation.md
@@ -5,7 +5,7 @@ supported by Block-based and JavaScript editing. Examples of targets are:
 
 * https://makecode.adafruit.com (sources at https://github.com/microsoft/pxt-adafruit)
 * https://maker.makecode.com (sources at https://github.com/microsoft/pxt-maker)
-* http://microsoft.github.io/pxt-sample/ (sources at https://github.com/microsoft/pxt-sample)
+* https://microsoft.github.io/pxt-sample/ (sources at https://github.com/microsoft/pxt-sample)
 
 We assume that the reader is familiar with Node.JS, NPM, JavaScript and/or C++. If you haven't done so yet, 
 install Node.JS and the **PXT** command line


### PR DESCRIPTION
pxt-sample uses [`window.applicationCache`](https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache). On chrome window.applicationCache is null when using non-secure url. This prevents the website from loading