### PR TITLE
Move simulator collapse button out of editor toolbar, CSS updates

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -414,6 +414,41 @@ div.simframe > iframe {
     padding: 0.3em;
 }
 
+/* Collapse/expand button for simulator, sidedocs */
+#togglesim, #sidedocstoggle {
+    position: absolute;
+    border-top-left-radius: 100px;
+    border-bottom-left-radius: 100px;
+    top: 40%;
+    height: 20%;
+    z-index: @sidedocZIndex;
+    padding: 0;
+    margin: 0;
+    background: grey;
+    box-shadow: none!important;
+    transition: none;
+
+    &:hover,
+    &:focus {
+      background: #5A5A5A;
+    }
+}
+
+// Factor in 4rem height of top bar
+#togglesim {
+    left: -21px;
+    top: calc(~'40% - 2.4rem');
+    height: calc(~'20% + 0.8rem');
+}
+
+.collapsedEditorTools #togglesim {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 100px;
+    border-bottom-right-radius: 100px;
+    left: -21px;
+}
+
 /*******************************
       Notification banner
 *******************************/
@@ -913,13 +948,25 @@ p.ui.font.small {
 
 /* >= Small Monitor (Small Monitor + Large Monitor + Wide Monitor) */
 @media only screen and (min-width: @computerBreakpoint) {
-    .collapsedEditorTools #filelist {
+    .collapsedEditorTools:not(.headless) #filelist {
+        min-width: 21px;
+        width: 21px;
+        padding: 0;
+    }
+
+    .collapsedEditorTools:not(.headless) #filelist > * {
         display: none;
     }
+
     .collapsedEditorTools #downloadArea {
         background: @editorToolsBackground;
     }
-    .collapsedEditorTools #maineditor {
+
+    .collapsedEditorTools:not(.headless) #maineditor {
+        left: 21px;
+    }
+
+    .collapsedEditorTools.headless #maineditor {
         left: 0;
     }
 }
@@ -1021,7 +1068,7 @@ p.ui.font.small {
         }
     }
     #root.collapsedEditorTools #editortools .left .buttons:first-child {
-        bottom: auto; // undo bottom positioning for collapsed toolbar
+        bottom: auto!important; // undo bottom positioning for collapsed toolbar
     }
     #maineditor {
         left: 0;
@@ -1061,6 +1108,21 @@ p.ui.font.small {
     #simulators {
         flex-direction: row;
         display: flex !important;
+    }
+    /* Simulator Toggle Button */
+    #togglesim, .collapsedEditorTools #togglesim {
+        border-top-right-radius: 100px;
+        border-top-left-radius: 100px;
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
+        top: unset;
+        left: 40%;
+        width: 20%;
+        height: unset;
+        bottom: 10rem;
+    }
+    .collapsedEditorTools #togglesim {
+        bottom: 4.7rem;
     }
     /* Hide floating editors */
     .hideEditorFloats .editorFloat {
@@ -1145,6 +1207,9 @@ p.ui.font.small {
     }
     .fullscreensim .simtoolbar .ui.button {
         font-size: 1rem;
+    }
+    .collapsedEditorTools #togglesim {
+        bottom: 3.4rem;
     }
 }
 

--- a/theme/sidedoc.less
+++ b/theme/sidedoc.less
@@ -34,24 +34,8 @@
 
 /* Side docs toggle button */
 #sidedocstoggle {
-  position: absolute;
-  border-top-left-radius: 100px;
-  border-bottom-left-radius: 100px;
   right: 0;
-  top: 40%;
-  bottom: 40%;
-  height: 20%;
-  z-index: @sidedocZIndex;
-  padding: 0;
-  margin: 0;
-  background: grey;
-  box-shadow: none !important;
-  transition: none;
-
-  &:hover,
-  &:focus {
-    background: #5A5A5A;
-  }
+  left: auto;
 }
 
 .sideDocs #sidedocs {
@@ -87,17 +71,6 @@
 .sideDocs #sidedocstoggle {
    right: @sideBarWidth;
    transition: right 0.5s, opacity 0.5s linear;
-}
-
-/* Show chevron icon on hover when collapsed */
-#sidedocstoggle > i.icon.hover {
-    display: none;
-}
-#root:not(.sideDocs) #sidedocstoggle.ui.button:hover > i.icon {
-    display: none !important;
-}
-#root:not(.sideDocs) #sidedocstoggle.ui.button:hover > i.icon.hover {
-    display: inherit !important;
 }
 
 .sideDocs #sidedocsbar {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -144,6 +144,7 @@ export class ProjectView
         this.openDeviceSerial = this.openDeviceSerial.bind(this);
         this.toggleGreenScreen = this.toggleGreenScreen.bind(this);
         this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
+        this.toggleSimulatorCollapse = this.toggleSimulatorCollapse.bind(this);
         this.initScreenshots();
     }
 
@@ -2125,6 +2126,7 @@ export class ProjectView
 
     toggleSimulatorCollapse() {
         const state = this.state;
+        pxt.tickEvent("simulator.toggleCollapse", { view: 'computer', collapsedTo: '' + !state.collapseEditorTools }, { interactiveConsent: true });
         if (state.simState == pxt.editor.SimState.Stopped && state.collapseEditorTools)
             this.startStopSimulator();
 
@@ -2993,10 +2995,13 @@ export class ProjectView
         const useSerialEditor = pxt.appTarget.serial && !!pxt.appTarget.serial.useEditor;
 
         const showSideDoc = sideDocs && this.state.sideDocsLoadUrl && !this.state.sideDocsCollapsed;
+        const showCollapseButton = !inTutorial && !sandbox && !targetTheme.simCollapseInMenu && (!isHeadless || inDebugMode);
         const shouldHideEditorFloats = (this.state.hideEditorFloats || this.state.collapseEditorTools) && (!inTutorial || isHeadless);
         const shouldCollapseEditorTools = this.state.collapseEditorTools && (!inTutorial || isHeadless);
         const logoWide = !!targetTheme.logoWide;
         const hwDialog = !sandbox && pxt.hasHwVariants();
+
+        const collapseTooltip = lf("Hide the simulator");
 
         const isApp = cmds.isNativeHost() || pxt.winrt.isWinRT() || pxt.BrowserUtils.isElectron();
 
@@ -3067,6 +3072,8 @@ export class ProjectView
                     </div>
                 </div>
                 <div id="maineditor" className={(sandbox ? "sandbox" : "") + (inDebugMode ? "debugging" : "")} role="main" aria-hidden={inHome}>
+                    {showCollapseButton && <sui.Button id='togglesim' className={`computer only collapse-button large`} icon={`inverted chevron ${this.state.collapseEditorTools ? 'right' : 'left'}`} title={collapseTooltip} onClick={this.toggleSimulatorCollapse} />}
+                    {showCollapseButton && <sui.Button id='togglesim' className={`mobile tablet only collapse-button large`} icon={`inverted chevron ${this.state.collapseEditorTools ? 'up' : 'down'}`} title={collapseTooltip} onClick={this.toggleSimulatorCollapse} />}
                     {this.allEditors.map(e => e.displayOuter())}
                 </div>
                 {inHome ? <div id="homescreen" className="full-abs">

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -567,10 +567,9 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
 
         /* tslint:disable:react-iframe-missing-sandbox */
         return <div>
-            <button id="sidedocstoggle" role="button" aria-label={sideDocsCollapsed ? lf("Expand the side documentation") : lf("Collapse the side documentation")} className="ui icon button" onClick={this.toggleVisibility}>
-                <sui.Icon icon={`icon large inverted ${sideDocsCollapsed ? 'book' : 'chevron right'}`} />
-                {sideDocsCollapsed ? <sui.Icon icon={`large inverted chevron left hover`} /> : undefined}
-            </button>
+            <button id="sidedocstoggle" role="button" aria-label={sideDocsCollapsed ? lf("Expand the side documentation") : lf("Collapse the side documentation")} className="ui icon button large" onClick={this.toggleVisibility}>
+                <sui.Icon icon={`icon inverted chevron ${sideDocsCollapsed ? 'left' : 'right'}`} />
+             </button>
             <div id="sidedocs">
                 <div id="sidedocsframe-wrapper">
                     <iframe id="sidedocsframe" src={docsUrl} title={lf("Documentation")} aria-atomic="true" aria-live="assertive"

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -26,7 +26,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         this.startStopSimulator = this.startStopSimulator.bind(this);
         this.toggleTrace = this.toggleTrace.bind(this);
         this.toggleDebugging = this.toggleDebugging.bind(this);
-        this.toggleCollapse = this.toggleCollapse.bind(this);
     }
 
     saveProjectName(name: string, view?: string) {
@@ -79,11 +78,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         this.props.parent.toggleDebugging();
     }
 
-    toggleCollapse(view?: string) {
-        pxt.tickEvent("editortools.toggleCollapse", { view: view, collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
-        this.props.parent.toggleSimulatorCollapse();
-    }
-
     private getViewString(view: View): string {
         return view.toString().toLowerCase();
     }
@@ -94,18 +88,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
 
     private getHeadlessState(): string {
         return pxt.appTarget.simulator.headless ? "true" : "false";
-    }
-
-    private getCollapseButton(view: View, collapsed: boolean, hideEditorFloats: boolean): JSX.Element {
-        const isRtl = pxt.Util.isUserLanguageRtl();
-        const collapseTooltip = collapsed ? lf("Show the simulator") : lf("Hide the simulator");
-        switch (view) {
-            case View.Computer:
-                return ( <EditorToolbarButton icon={`${this.props.parent.state.collapseEditorTools ? 'toggle ' + (isRtl ? 'left' : 'right') : 'toggle ' + (isRtl ? 'right' : 'left')}`} className={`large collapse-button ${collapsed ? 'collapsed' : ''}`} title={collapseTooltip} onButtonClick={this.toggleCollapse} view='computer' />)
-            default:
-                return (<EditorToolbarButton icon={`${collapsed ? 'toggle up' : 'toggle down'}`} className={`collapse-button ${collapsed ? 'collapsed' : ''} ${hideEditorFloats ? 'disabled' : ''}`} title={collapseTooltip} ariaLabel={lf("{0}, {1}", collapseTooltip, hideEditorFloats ? lf("Disabled") : "")} onButtonClick={this.toggleCollapse} view={this.getViewString(view)}  />);
-
-        }
     }
 
     private getUndoRedo(view: View): JSX.Element[] {
@@ -170,11 +152,9 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const compileLoading = !!compiling;
         const running = simState == pxt.editor.SimState.Running;
         const starting = simState == pxt.editor.SimState.Starting;
-        const pairingButton = !!targetTheme.pairingButton;
 
         const hasUndo = this.props.parent.editor.hasUndo();
 
-        const showCollapsed = !tutorial && !sandbox && !targetTheme.simCollapseInMenu;
         const showProjectRename = !tutorial && !readOnly && !isController && !targetTheme.hideProjectRename && !debugging;
         const showUndoRedo = !tutorial && !readOnly && !debugging;
         const showZoomControls = true;
@@ -209,7 +189,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     <div className="ui grid">
                         {!targetTheme.bigRunButton && <div className="left aligned column six wide">
                             <div className="ui icon small buttons">
-                                {showCollapsed && this.getCollapseButton(View.Mobile, collapsed, hideEditorFloats)}
                                 {compileBtn && <EditorToolbarButton className={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} ariaLabel={lf("Download your code")} onButtonClick={this.compile} view='mobile' />}
                             </div>
                         </div>}
@@ -227,15 +206,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         </div>
                     </div> :
                     <div className="ui equal width grid">
-                        <div className="left aligned two wide column">
-                            {showCollapsed &&
-                                <div className="row" style={{ paddingTop: "1rem" }}>
-                                    <div className="ui vertical icon small buttons">
-                                        {this.getCollapseButton(View.Mobile, collapsed, hideEditorFloats)}
-                                    </div>
-                                </div>}
-                        </div>
-                        <div className="three wide column">
+                        <div className="left aligned five wide column">
                         </div>
                         <div className="column">
                             <div className="ui grid">
@@ -265,7 +236,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     <div className="ui grid seven column">
                         <div className="left aligned six wide column">
                             <div className="ui icon buttons">
-                                {showCollapsed && this.getCollapseButton(View.Tablet, collapsed, hideEditorFloats)}
                                 {compileBtn && <EditorToolbarButton className={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} text={downloadText} title={compileTooltip} onButtonClick={this.compile} view='tablet' />}
                             </div>
                         </div>
@@ -282,15 +252,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         </div>
                     </div>
                     : <div className="ui grid">
-                        <div className="left aligned two wide column">
-                            {showCollapsed &&
-                                <div className="row" style={{ paddingTop: "1rem" }}>
-                                    <div className="ui vertical icon small buttons">
-                                        {this.getCollapseButton(View.Tablet, collapsed, hideEditorFloats)}
-                                    </div>
-                                </div>}
-                        </div>
-                        <div className="three wide column">
+                        <div className="left aligned five wide column">
                         </div>
                         <div className="five wide column">
                             <div className="ui grid right aligned">
@@ -333,12 +295,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                     <div id="downloadArea" className="ui column items">{headless ?
                         <div className="ui item">
                             <div className="ui icon large buttons">
-                                {showCollapsed && this.getCollapseButton(View.Computer, collapsed, hideEditorFloats)}
                                 {compileBtn && <EditorToolbarButton icon={downloadIcon} className={`primary large download-button ${downloadButtonClasses}`} title={compileTooltip} onButtonClick={this.compile} view='computer' />}
                             </div>
                         </div> :
                         <div className="ui item">
-                            {showCollapsed && !pairingButton && this.getCollapseButton(View.Computer, collapsed, hideEditorFloats)}
                             {compileBtn && <EditorToolbarButton icon={downloadIcon} className={`primary huge fluid download-button ${downloadButtonClasses}`} text={downloadText} title={compileTooltip} onButtonClick={this.compile} view='computer' />}
                         </div>
                     }

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -26,7 +26,6 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         this.openInstructions = this.openInstructions.bind(this);
         this.startStopSimulator = this.startStopSimulator.bind(this);
         this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
-        this.toggleSimulatorCollapse = this.toggleSimulatorCollapse.bind(this);
         this.takeScreenshot = this.takeScreenshot.bind(this);
         this.toggleDebug = this.toggleDebug.bind(this);
     }
@@ -66,11 +65,6 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         this.props.parent.toggleSimulatorFullscreen();
     }
 
-    toggleSimulatorCollapse() {
-        pxt.tickEvent("simulator.toggleCollapse", { view: 'computer', collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
-        this.props.parent.toggleSimulatorCollapse();
-    }
-
     takeScreenshot() {
         pxt.tickEvent("simulator.takescreenshot", { view: 'computer', collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
         this.props.parent.downloadScreenshotAsync().done();
@@ -105,8 +99,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const fullscreen = run && !simOpts.hideFullscreen && !sandbox;
         const audio = run && targetTheme.hasAudio;
         const isHeadless = simOpts.headless;
-        const collapse = !!targetTheme.pairingButton;
-        const screenshot = !!targetTheme.simScreenshot && !inTutorial;
+        const screenshot = !!targetTheme.simScreenshot;
         const screenshotClass = !!parentState.screenshoting ? "loading" : "";
         const debugBtnEnabled = !isStarting && !isSimulatorPending;
         const runControlsEnabled = !debugging && !isStarting && !isSimulatorPending;
@@ -117,7 +110,6 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const debugTooltip = lf("Toggle debug mode");
         const fullscreenTooltip = isFullscreen ? lf("Exit fullscreen mode") : lf("Launch in fullscreen");
         const muteTooltip = isMuted ? lf("Unmute audio") : lf("Mute audio");
-        const collapseTooltip = lf("Hide the simulator");
         const screenshotTooltip = targetTheme.simScreenshotKey ? lf("Take Screenshot (shortcut {0})", targetTheme.simScreenshotKey) : lf("Take Screenshot");
 
         return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait ")} role="complementary" aria-label={lf("Simulator toolbar")}>
@@ -133,7 +125,6 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
             </div>}
             {!isHeadless && <div className={`ui icon tiny buttons computer only`} style={{ padding: "0" }}>
                 {screenshot && <sui.Button disabled={!isRunning} key='screenshotbtn' className={`screenshot-button ${screenshotClass}`} icon={`icon camera left`} title={screenshotTooltip} onClick={this.takeScreenshot} />}
-                {collapse && !isFullscreen && <sui.Button key='collapsebtn' className={`collapse-button`} icon={`icon toggle left`} title={collapseTooltip} onClick={this.toggleSimulatorCollapse} />}
                 {fullscreen && <sui.Button key='fullscreenbtn' className={`fullscreen-button`} icon={`xicon ${isFullscreen ? 'fullscreencollapse' : 'fullscreen'}`} title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
             </div>}
         </aside >;


### PR DESCRIPTION
- Move simulator collapse button (update desktop, tablet, mobile styles)
- Small updates to sidedocs toggle (no "docs" symbol on hover, smaller chevron)
- Update tutorial button styles to match (remove text, move out of tutorial card)

Demo: https://makecode.microbit.org/app/357d62b063de9f7e133ae176f93d541572922dd9-1ffda62afe