### PR TITLE
support for "idling"

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -309,23 +309,25 @@ namespace pxsim {
         }
     }
 
-    export type EventValueToActionArgs<T> = (value: T) => any[];
+    export type EventValueToActionArgs = (value: EventIDType) => any[];
 
     enum LogType {
         UserSet, BackAdd, BackRemove
     }
 
-    export class EventQueue<T> {
+    export type EventIDType = number | string;
+
+    export class EventQueue {
         max: number = 5;
-        events: T[] = [];
+        events: EventIDType[] = [];
         private awaiters: ((v?: any) => void)[] = [];
         private lock: boolean;
         private _handlers: RefAction[] = [];
         private _addRemoveLog: { act: RefAction, log: LogType }[] = [];
 
-        constructor(public runtime: Runtime, private valueToArgs?: EventValueToActionArgs<T>) { }
+        constructor(public runtime: Runtime, private valueToArgs?: EventValueToActionArgs) { }
 
-        public push(e: T, notifyOne: boolean): Promise<void> {
+        public push(e: EventIDType, notifyOne: boolean): Promise<void> {
             if (this.awaiters.length > 0) {
                 if (notifyOne) {
                     const aw = this.awaiters.shift();
@@ -1105,7 +1107,9 @@ namespace pxsim {
             if (this.idleTimer === undefined) {
                 this.idleTimer = setInterval(() => {
                     if (!this.running || this.pausedOnBreakpoint) return;
-                    this.board.bus.queueIdle();
+                    const bus = this.board.bus;
+                    if (bus)
+                        bus.queueIdle();
                 });
             }
         }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1110,7 +1110,7 @@ namespace pxsim {
                     const bus = this.board.bus;
                     if (bus)
                         bus.queueIdle();
-                });
+                }, 20);
             }
         }
 

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -57,7 +57,7 @@ namespace pxsim {
 
         private start(id: EventIDType, evid: EventIDType, background: boolean, create: boolean = false) {
             let key = (background ? "back" : "fore") + ":" + id + ":" + evid
-            if (!this.queues[key] && create) this.queues[key] = new EventQueue<T>(this.runtime, this.valueToArgs);;
+            if (!this.queues[key] && create) this.queues[key] = new EventQueue(this.runtime, this.valueToArgs);
             return this.queues[key];
         }
 
@@ -78,7 +78,7 @@ namespace pxsim {
         }
 
         // this handles ANY (0) semantics for id and evid
-        private getQueues(id: number | string, evid: number | string, bg: boolean) {
+        private getQueues(id: EventIDType, evid: EventIDType, bg: boolean) {
             let ret = [this.start(0, 0, bg)]
             if (id == 0 && evid == 0)
                 return ret
@@ -91,7 +91,7 @@ namespace pxsim {
             return ret
         }
 
-        queue(id: number | string, evid: number | string, value: T = null) {
+        queue(id: EventIDType, evid: EventIDType, value: EventIDType = null) {
             if (runtime.pausedOnBreakpoint) return;
             // special handle for idle, start the idle timeout
             if (this.schedulerID && id == this.idleEventID)

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -21,8 +21,8 @@ namespace pxsim {
         return res;
     }
 
-    export class EventBusGeneric<T> {
-        private queues: Map<EventQueue<T>> = {};
+    export class EventBus {
+        private queues: Map<EventQueue> = {};
         private notifyID: number;
         private notifyOneID: number;
         private schedulerID: number;
@@ -35,7 +35,7 @@ namespace pxsim {
 
         constructor(
             private runtime: Runtime,
-            private valueToArgs?: EventValueToActionArgs<T>
+            private valueToArgs?: EventValueToActionArgs
         ) {
             this.schedulerID = 15; // DEVICE_ID_SCHEDULER
             this.idleEventID = 2; // DEVICE_SCHEDULER_EVT_IDLE
@@ -55,13 +55,13 @@ namespace pxsim {
             this.idleEventID = idleEventID;
         }
 
-        private start(id: number | string, evid: number | string, background: boolean, create: boolean = false) {
+        private start(id: EventIDType, evid: EventIDType, background: boolean, create: boolean = false) {
             let key = (background ? "back" : "fore") + ":" + id + ":" + evid
             if (!this.queues[key] && create) this.queues[key] = new EventQueue<T>(this.runtime, this.valueToArgs);;
             return this.queues[key];
         }
 
-        listen(id: number | string, evid: number | string, handler: RefAction) {
+        listen(id: EventIDType, evid: EventIDType, handler: RefAction) {
             let q = this.start(id, evid, this.backgroundHandlerFlag, true);
             if (this.backgroundHandlerFlag)
                 q.addHandler(handler);
@@ -127,12 +127,6 @@ namespace pxsim {
         getLastEventTime() {
             return 0xffffffff & (this.lastEventTimestampUs - runtime.startTimeUs);
         }
-    }
-
-    export class EventBus extends EventBusGeneric<number> {
-        // queue(id: number | string, evid: number | string, value: number = 0) {
-        //     super.queue(id, evid, value);
-        // }
     }
 
     export interface AnimationOptions {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -34,12 +34,12 @@ namespace pxsim {
         public nextNotifyEvent = 1024;
 
         constructor(
-            private runtime: Runtime, 
+            private runtime: Runtime,
             private valueToArgs?: EventValueToActionArgs<T>
-            ) {
-                this.schedulerID = 15; // DEVICE_ID_SCHEDULER
-                this.idleEventID = 2; // DEVICE_SCHEDULER_EVT_IDLE
-            }
+        ) {
+            this.schedulerID = 15; // DEVICE_ID_SCHEDULER
+            this.idleEventID = 2; // DEVICE_SCHEDULER_EVT_IDLE
+        }
 
         public setBackgroundHandlerFlag() {
             this.backgroundHandlerFlag = true;


### PR DESCRIPTION
- [x] remove generic EventBus and unify support for bus in runtime/bareboard.
- [x] better integration with CODAL "onIdleCallback" infrastructure to avoid spinning fibers for background tasks. in C++, it listens to the IDLE event generated by CODAL. in javascript, starts an interval timer. integrates with eventContext.

REquires https://github.com/Microsoft/pxt-common-packages/pull/806
