### PR TITLE
Fix decompilation of non-boolean conditions

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1359,7 +1359,7 @@ ${output}</xml>`;
         }
 
         function checkConditionalExpression(n: ts.WhileStatement | ts.IfStatement) {
-            const expr: Expression = n.expression;
+            const expr = unwrapNode(n.expression);
             switch (expr.kind) {
                 case SK.TrueKeyword:
                 case SK.FalseKeyword:

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1360,28 +1360,24 @@ ${output}</xml>`;
 
         function checkConditionalExpression(n: ts.WhileStatement | ts.IfStatement) {
             const expr: Expression = n.expression;
-            return checkExpression(expr);
-
-            function checkExpression(expr: Expression): string {
-                switch (expr.kind) {
-                    case SK.TrueKeyword:
-                    case SK.FalseKeyword:
-                    case SK.Identifier:
+            switch (expr.kind) {
+                case SK.TrueKeyword:
+                case SK.FalseKeyword:
+                case SK.Identifier:
+                    return undefined;
+                case SK.BinaryExpression:
+                    return checkBooleanBinaryExpression(expr as BinaryExpression);
+                case SK.CallExpression:
+                    return checkBooleanCallExpression(expr as CallExpression);
+                case SK.PrefixUnaryExpression:
+                    if ((expr as PrefixUnaryExpression).operator === SK.ExclamationToken) {
                         return undefined;
-                    case SK.BinaryExpression:
-                        return checkBinaryExpression(expr as BinaryExpression);
-                    case SK.CallExpression:
-                        return checkCallExpression(expr as CallExpression);
-                    case SK.PrefixUnaryExpression:
-                        if ((expr as PrefixUnaryExpression).operator === SK.ExclamationToken) {
-                            return undefined;
-                        } // else fall through
-                    default:
-                        return Util.lf("Conditions must evaluate to booleans or identifiers");
-                }
+                    } // else fall through
+                default:
+                    return Util.lf("Conditions must evaluate to booleans or identifiers");
             }
 
-            function checkBinaryExpression(n: BinaryExpression): string {
+            function checkBooleanBinaryExpression(n: BinaryExpression) {
                 switch (n.operatorToken.kind) {
                     case SK.EqualsEqualsToken:
                     case SK.EqualsEqualsEqualsToken:
@@ -1391,7 +1387,7 @@ ${output}</xml>`;
                     case SK.LessThanEqualsToken:
                     case SK.GreaterThanToken:
                     case SK.GreaterThanEqualsToken:
-                    // TODO: && / || should check against non boolean l / r (e.g. not `1 || 2`)
+                    // TODO: &&, ||, ! should check against non boolean l / r (e.g. not `1 || 2`)
                     // https://github.com/Microsoft/pxt-arcade/issues/946
                     case SK.AmpersandAmpersandToken:
                     case SK.BarBarToken:
@@ -1401,10 +1397,15 @@ ${output}</xml>`;
                 }
             }
 
-            function checkCallExpression(n: CallExpression) {
+            function checkBooleanCallExpression(n: CallExpression) {
                 // TODO: need to tag callExpressions in emitter or otherwise identify CEs that evaluate to boolean
-                if (0) return Util.lf("Only functions that return booleans are allowed as conditions");
-                return undefined;
+                if (1) {
+                    return undefined;
+                }
+                // if ((n as any).exprInfo) {  // exprInfo is not currently defined on the call expression properly
+                //     return undefined;
+                // }
+                return Util.lf("Only functions that return booleans are allowed as conditions");
             }
         }
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1366,12 +1366,14 @@ ${output}</xml>`;
                 case SK.Identifier:
                     return undefined;
                 case SK.BinaryExpression:
-                    return checkIsBinaryExpression(expr as BinaryExpression);
+                    return checkBinaryExpression(expr as BinaryExpression);
+                case SK.CallExpression:
+                    return checkCallExpression(expr as CallExpression);
                 default:
-                    return Util.lf("TODO error");
+                    return Util.lf("Conditions must evaluate to booleans or identifiers");
             }
 
-            function checkIsBinaryExpression(n: BinaryExpression) {
+            function checkBinaryExpression(n: BinaryExpression) {
                 switch (n.operatorToken.kind) {
                     case SK.EqualsEqualsToken:
                     case SK.EqualsEqualsEqualsToken:
@@ -1384,10 +1386,16 @@ ${output}</xml>`;
                         return undefined;
                     case SK.AmpersandAmpersandToken:
                     case SK.BarBarToken:
-                        return undefined; // todo check that these evaluate?
+                        return undefined; // todo check that these evaluate to boolean (e.g. not `1 || 2`)
                     default:
-                        return Util.lf("TODO error");
+                        return Util.lf("Binary expressions in conditionals must evaluate to booleans");
                 }
+            }
+
+            function checkCallExpression(n: CallExpression) {
+                // todo: need to tag callExpressions in emitter or otherwise identify CEs that evaluate to boolean
+                if (0) return Util.lf("Only functions that return booleans are allowed as conditions");
+                return undefined;
             }
         }
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1398,7 +1398,7 @@ ${output}</xml>`;
             }
 
             function checkBooleanCallExpression(n: CallExpression) {
-                const callInfo: pxtc.CallInfo  = (n.expression as any).callInfo;
+                const callInfo: pxtc.CallInfo = (n.expression as any).callInfo;
                 const type = callInfo.decl.type;
 
                 if (type && type.kind === SK.BooleanKeyword) {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1398,13 +1398,12 @@ ${output}</xml>`;
             }
 
             function checkBooleanCallExpression(n: CallExpression) {
-                // TODO: need to tag callExpressions in emitter or otherwise identify CEs that evaluate to boolean
-                if (1) {
+                const callInfo: pxtc.CallInfo  = (n.expression as any).callInfo;
+                const type = callInfo.decl.type;
+
+                if (type && type.kind === SK.BooleanKeyword) {
                     return undefined;
                 }
-                // if ((n as any).exprInfo) {  // exprInfo is not currently defined on the call expression properly
-                //     return undefined;
-                // }
                 return Util.lf("Only functions that return booleans are allowed as conditions");
             }
         }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1360,17 +1360,22 @@ ${output}</xml>`;
 
         function checkConditionalExpression(n: ts.WhileStatement | ts.IfStatement) {
             const expr: Expression = n.expression;
-            switch (expr.kind) {
-                case SK.TrueKeyword:
-                case SK.FalseKeyword:
-                case SK.Identifier:
-                    return undefined;
-                case SK.BinaryExpression:
-                    return checkBinaryExpression(expr as BinaryExpression);
-                case SK.CallExpression:
-                    return checkCallExpression(expr as CallExpression);
-                default:
-                    return Util.lf("Conditions must evaluate to booleans or identifiers");
+            checkExpression(expr);
+
+            function checkExpression(expr: Expression) {
+                switch (expr.kind) {
+                    case SK.TrueKeyword:
+                    case SK.FalseKeyword:
+                    case SK.ExclamationToken:
+                    case SK.Identifier:
+                        return undefined;
+                    case SK.BinaryExpression:
+                        return checkBinaryExpression(expr as BinaryExpression);
+                    case SK.CallExpression:
+                        return checkCallExpression(expr as CallExpression);
+                    default:
+                        return Util.lf("Conditions must evaluate to booleans or identifiers");
+                }
             }
 
             function checkBinaryExpression(n: BinaryExpression) {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1362,23 +1362,26 @@ ${output}</xml>`;
             const expr: Expression = n.expression;
             return checkExpression(expr);
 
-            function checkExpression(expr: Expression) {
+            function checkExpression(expr: Expression): string {
                 switch (expr.kind) {
                     case SK.TrueKeyword:
                     case SK.FalseKeyword:
-                    case SK.ExclamationToken:
                     case SK.Identifier:
                         return undefined;
                     case SK.BinaryExpression:
                         return checkBinaryExpression(expr as BinaryExpression);
                     case SK.CallExpression:
                         return checkCallExpression(expr as CallExpression);
+                    case SK.PrefixUnaryExpression:
+                        if ((expr as PrefixUnaryExpression).operator === SK.ExclamationToken) {
+                            return undefined;
+                        } // else fall through
                     default:
                         return Util.lf("Conditions must evaluate to booleans or identifiers");
                 }
             }
 
-            function checkBinaryExpression(n: BinaryExpression) {
+            function checkBinaryExpression(n: BinaryExpression): string {
                 switch (n.operatorToken.kind) {
                     case SK.EqualsEqualsToken:
                     case SK.EqualsEqualsEqualsToken:
@@ -1388,17 +1391,18 @@ ${output}</xml>`;
                     case SK.LessThanEqualsToken:
                     case SK.GreaterThanToken:
                     case SK.GreaterThanEqualsToken:
-                        return undefined;
+                    // TODO: && / || should check against non boolean l / r (e.g. not `1 || 2`)
+                    // https://github.com/Microsoft/pxt-arcade/issues/946
                     case SK.AmpersandAmpersandToken:
                     case SK.BarBarToken:
-                        return undefined; // todo check that these evaluate to boolean (e.g. not `1 || 2`)
+                        return undefined;
                     default:
                         return Util.lf("Binary expressions in conditionals must evaluate to booleans");
                 }
             }
 
             function checkCallExpression(n: CallExpression) {
-                // todo: need to tag callExpressions in emitter or otherwise identify CEs that evaluate to boolean
+                // TODO: need to tag callExpressions in emitter or otherwise identify CEs that evaluate to boolean
                 if (0) return Util.lf("Only functions that return booleans are allowed as conditions");
                 return undefined;
             }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1360,7 +1360,7 @@ ${output}</xml>`;
 
         function checkConditionalExpression(n: ts.WhileStatement | ts.IfStatement) {
             const expr: Expression = n.expression;
-            checkExpression(expr);
+            return checkExpression(expr);
 
             function checkExpression(expr: Expression) {
                 switch (expr.kind) {

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -357,7 +357,7 @@ namespace ts.pxtc {
     }
 
     export interface CallInfo {
-        decl: Declaration;
+        decl: TypedDecl;
         qName: string;
         args: Expression[];
         isExpression: boolean;
@@ -392,10 +392,6 @@ namespace ts.pxtc {
     export interface BinaryExpressionInfo {
         leftType: string;
         rightType: string;
-    }
-
-    export interface CallExpressionInfo {
-        type: string;
     }
 
     let lf = assembler.lf;
@@ -2000,12 +1996,7 @@ ${lbl}: .short 0xffff
 
         function emitCallExpression(node: CallExpression): ir.Expr {
             const sig = checker.getResolvedSignature(node);
-            const callExprType = typeOf(node);
-            if (isBooleanType(callExprType)) {
-                (node as any).exprInfo = { type: checker.typeToString(callExprType) } as CallExpressionInfo;
-            }
-            const ret = emitCallCore(node, node.expression, node.arguments, sig);
-            return ret;
+            return emitCallCore(node, node.expression, node.arguments, sig);
         }
 
         function emitCallCore(
@@ -2020,6 +2011,7 @@ ${lbl}: .short 0xffff
                 decl = getDecl(funcExpr) as EmittableAsCall;
             let isMethod = false
             let isProperty = false
+
             if (decl) {
                 switch (decl.kind) {
                     // we treat properties via calls

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -394,6 +394,10 @@ namespace ts.pxtc {
         rightType: string;
     }
 
+    export interface CallExpressionInfo {
+        type: string;
+    }
+
     let lf = assembler.lf;
     let checker: TypeChecker;
     export let target: CompileTarget;
@@ -1995,8 +1999,13 @@ ${lbl}: .short 0xffff
         }
 
         function emitCallExpression(node: CallExpression): ir.Expr {
-            let sig = checker.getResolvedSignature(node)
-            return emitCallCore(node, node.expression, node.arguments, sig)
+            const sig = checker.getResolvedSignature(node);
+            const callExprType = typeOf(node);
+            if (isBooleanType(callExprType)) {
+                (node as any).exprInfo = { type: checker.typeToString(callExprType) } as CallExpressionInfo;
+            }
+            const ret = emitCallCore(node, node.expression, node.arguments, sig);
+            return ret;
         }
 
         function emitCallCore(

--- a/tests/decompile-test/baselines/non_boolean_conditionals.blocks
+++ b/tests/decompile-test/baselines/non_boolean_conditionals.blocks
@@ -33,6 +33,27 @@
 <statement name="DO0">
 </statement>
 <next>
+<block type="device_while">
+<value name="COND">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">&#40;&#40;&#40;&#40;&#40;&#40;&#40;&#40;1&#41;&#41;&#41;&#41;&#41;&#41;&#41;&#41;</field>
+</block>
+</value>
+<statement name="DO">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">&#40;&#40;&#40;&#40;&#40;&#40;&#40;&#40;testNamespace.stringArgumentOutput&#40;&#34;&#34;&#41;&#41;&#41;&#41;&#41;&#41;&#41;&#41;&#41;</field>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
 <block type="controls_if">
 <mutation elseif="0" else="0" />
 <value name="IF0">
@@ -383,6 +404,21 @@
 </value>
 <statement name="DO0">
 </statement>
+<next>
+<block type="device_while">
+<value name="COND">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+<statement name="DO">
+</statement>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
 </block>
 </next>
 </block>

--- a/tests/decompile-test/baselines/non_boolean_conditionals.blocks
+++ b/tests/decompile-test/baselines/non_boolean_conditionals.blocks
@@ -1,0 +1,423 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">1</field>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="device_while">
+<value name="COND">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">1</field>
+</block>
+</value>
+<statement name="DO">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">testNamespace.stringArgumentOutput&#40;&#34;&#34;&#41;</field>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean">
+<field name="BOOL">FALSE</field>
+</shadow>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="test_boolean_argument_output">
+<value name="arg">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_operation">
+<field name="OP">AND</field>
+<value name="A">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="test_boolean_argument_output">
+<value name="arg">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="test_boolean_argument_output">
+<value name="arg">
+<shadow type="logic_boolean">
+<field name="BOOL">FALSE</field>
+</shadow>
+</value>
+</block>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">LT</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">GT</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">LTE</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">GTE</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_negate">
+<value name="BOOL">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_operation">
+<field name="OP">AND</field>
+<value name="A">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">GTE</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">LT</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+</block>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_operation">
+<field name="OP">AND</field>
+<value name="A">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="logic_boolean">
+<field name="BOOL">FALSE</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_operation">
+<field name="OP">OR</field>
+<value name="A">
+<shadow type="logic_boolean">
+<field name="BOOL">FALSE</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="variables_get">
+<field name="VAR">v</field>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_operation">
+<field name="OP">AND</field>
+<value name="A">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">1 &#124; 2</field>
+</block>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_operation">
+<field name="OP">OR</field>
+<value name="A">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">EQ</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">v</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_operation">
+<field name="OP">AND</field>
+<value name="A">
+<shadow type="logic_boolean">
+<field name="BOOL">TRUE</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="logic_boolean">
+<field name="BOOL">FALSE</field>
+</shadow>
+</value>
+</block>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="logic_compare">
+<field name="OP">EQ</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">1</field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="math_number">
+<field name="NUM">2</field>
+</block>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text">
+<field name="TEXT">12</field>
+</block>
+</value>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/non_boolean_conditionals.ts
+++ b/tests/decompile-test/cases/non_boolean_conditionals.ts
@@ -1,6 +1,8 @@
 if (1) { }
 while (1) { }
 if (testNamespace.stringArgumentOutput("")) { }
+while (((((((((1))))))))) { }
+if (((((((((testNamespace.stringArgumentOutput("")))))))))) { }
 
 let v = 0
 if (true) { }
@@ -18,3 +20,5 @@ if (v) { }
 if (true && 1 | 2) { }
 if (v == 1 || true && false) { }
 if ("1" + 2 == "12") { }
+
+while (((((((((true))))))))) { }

--- a/tests/decompile-test/cases/non_boolean_conditionals.ts
+++ b/tests/decompile-test/cases/non_boolean_conditionals.ts
@@ -1,0 +1,20 @@
+if (1) { }
+while (1) { }
+if (testNamespace.stringArgumentOutput("")) { }
+
+let v = 0
+if (true) { }
+if (false) { }
+if (testNamespace.booleanArgumentOutput(true)) { }
+if (testNamespace.booleanArgumentOutput(true) && testNamespace.booleanArgumentOutput(false)) { }
+if (0 < 1) { }
+if (0 > 1) { }
+if (0 <= 1) { }
+if (0 >= 1) { }
+if (!(0 >= 1 && 5 < 1)) { }
+if (true && false) { }
+if (false || true) { }
+if (v) { }
+if (true && 1 | 2) { }
+if (v == 1 || true && false) { }
+if ("1" + 2 == "12") { }


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-arcade/issues/911

(https://github.com/Microsoft/pxt-arcade/issues/946 is related-ish and still causes failures for some expressions, but not fixed with this change)

Emits gray blocks instead of failing to decompile for non-boolean conditions

decompilation test output:

![arcade-screenshot (9)](https://user-images.githubusercontent.com/5615930/57001737-323e5b00-6b6f-11e9-9b10-420816a0c7dd.png)

