### PR TITLE
Add 'Open in Forum' display for forum links

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -1,6 +1,6 @@
 declare namespace pxt {
 
-    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw";
+    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw" | "forumLink";
 
     interface Map<T> {
         [index: string]: T;

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -1,6 +1,6 @@
 declare namespace pxt {
 
-    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw" | "forumLink";
+    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw" | "forumUrl";
 
     interface Map<T> {
         [index: string]: T;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -579,7 +579,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             className: 'huge positive'
         }]
 
-        const isLink = !cardType && (youTubeId || url) || cardType === "forumLink";
+        const isLink = (!isCodeCardType(cardType) || cardType === "forumLink") && (youTubeId || url);
         const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
             ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
 
@@ -618,6 +618,23 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                 </div>
             </div>
         </div>;
+
+        function isCodeCardType(value: string): value is pxt.CodeCardType {
+            switch (value) {
+                case "file":
+                case "example":
+                case "codeExample":
+                case "tutorial":
+                case "side":
+                case "template":
+                case "package":
+                case "hw":
+                case "forumLink":
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -568,6 +568,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             clickLabel = lf("Start Tutorial");
         }
         else if (cardType == "codeExample" || cardType == "example") clickLabel = lf("Open Example");
+        else if (cardType == "forumLink") clickLabel = lf("Open in Forum");
         else if (cardType == "template") clickLabel = lf("New Project");
         else if (youTubeId) clickLabel = lf("Play Video");
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -579,7 +579,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             className: 'huge positive'
         }]
 
-        const isLink = !cardType && (youTubeId || url);
+        const isLink = !cardType && (youTubeId || url) || cardType === "forumLink";
         const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
             ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -629,7 +629,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                 case "template":
                 case "package":
                 case "hw":
-                case "forumLink":
+                case "forumUrl":
                     return true;
                 default:
                     return false;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -568,7 +568,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             clickLabel = lf("Start Tutorial");
         }
         else if (cardType == "codeExample" || cardType == "example") clickLabel = lf("Open Example");
-        else if (cardType == "forumLink") clickLabel = lf("Open in Forum");
+        else if (cardType == "forumUrl") clickLabel = lf("Open in Forum");
         else if (cardType == "template") clickLabel = lf("New Project");
         else if (youTubeId) clickLabel = lf("Play Video");
 
@@ -579,7 +579,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             className: 'huge positive'
         }]
 
-        const isLink = (!isCodeCardType(cardType) || cardType === "forumLink") && (youTubeId || url);
+        const isLink = (!isCodeCardType(cardType) || cardType === "forumUrl") && (youTubeId || url);
         const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
             ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
 


### PR DESCRIPTION
Make forum links say 'Open in Forum' instead of 'Show Instructions'

![Screen Shot 2019-05-01 at 1 45 48 PM](https://user-images.githubusercontent.com/5615930/57041757-db409080-6c17-11e9-9094-e51b03e3ebf5.png)
