### PR TITLE
Dutch Translation of comment is commentaar

### DIFF
--- a/webapp/public/locales/nl/strings.json
+++ b/webapp/public/locales/nl/strings.json
@@ -151,7 +151,7 @@
   "Quit": "Sluit af",
   "Redo": "Opnieuw uitvoeren",
   "Reference, lessons, ...": "Referentie, lessen...",
-  "Remove Comment": "Reactie Verwijderen",
+  "Remove Comment": "Commentaar Verwijderen",
   "Remove all the blocks from the {0} package and try again.": "Verwijder alle blokken uit pakket {0} en probeer het opnieuw.",
   "Remove it": "Verwijderen",
   "Remove package(s) and add {0}": "Verwijder pakket(ten) en voeg {0} toe",

--- a/webapp/public/locales/nl/strings.json
+++ b/webapp/public/locales/nl/strings.json
@@ -10,7 +10,7 @@
   "A new version of {0} is ready to download and install. The app will restart during the update. Update now?": "Een nieuwe versie van {0} is klaar om te downloaden en te installeren. De app wordt opnieuw gestart tijdens de update. Nu bijwerken?",
   "About {0}": "Over {0}",
   "About...": "Over...",
-  "Add Comment": "Reactie toevoegen",
+  "Add Comment": "Commentaar toevoegen",
   "Add Package...": "Pakket toevoegen...",
   "Alert": "Waarschuwing",
   "All synced": "Alle gesynchroniseerd",


### PR DESCRIPTION
The Dutch translation used for the word 'comment' is strange. It's translated as 'reactie', which is a comment in the sense of a reaction (as in a reply to something).

While this might technically be a correct translation for 'comment', it would be better to use the 'commentaar' translation, which is 'comment' as in a note or remark.

It really bother me, because I'm writing a Dutch course and it's very strange.

Closes #5542 