### PR TITLE
Ignore tooltips for internal functions

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -589,7 +589,7 @@ namespace pxt.blocks {
         block.setPreviousStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
         block.setNextStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
 
-        block.setTooltip(fn.namespace === "__internal" ? "" : fn.attributes.jsDoc);
+        block.setTooltip( /^__/.test(fn.namespace) ? "" : fn.attributes.jsDoc);
         function buildBlockFromDef(def: pxtc.ParsedBlockDef, expanded = false) {
             let anonIndex = 0;
             let firstParam = !expanded && !!comp.thisParameter;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -589,7 +589,7 @@ namespace pxt.blocks {
         block.setPreviousStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
         block.setNextStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
 
-        block.setTooltip(fn.attributes.jsDoc);
+        block.setTooltip(fn.namespace === "__internal" ? "" : fn.attributes.jsDoc);
         function buildBlockFromDef(def: pxtc.ParsedBlockDef, expanded = false) {
             let anonIndex = 0;
             let firstParam = !expanded && !!comp.thisParameter;


### PR DESCRIPTION
If a block is in the namespace ```__internal```, this ignores it's tooltip.

This goes for all functions defined here: [https://github.com/microsoft/pxt/blob/32b9b2393542819a471d2c6ef13e76fd672a3f75/libs/pxt-common/pxt-helpers.ts#L364](https://github.com/microsoft/pxt/blob/32b9b2393542819a471d2c6ef13e76fd672a3f75/libs/pxt-common/pxt-helpers.ts#L364)

Fixes Microsoft/pxt-arcade#494