### PR TITLE
Stop sound when user restarts or stops sim

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -31,6 +31,10 @@ namespace pxsim {
         mute: boolean;
     }
 
+    export interface SimulatorStopSoundMessage extends SimulatorMessage {
+        type: "stopsound";
+    }
+
     export interface SimulatorDocMessage extends SimulatorMessage {
         type: "localtoken" | "docfailed";
         docType?: string;
@@ -243,6 +247,7 @@ namespace pxsim {
                 case "instructions": pxsim.instructions.renderInstructions(<SimulatorInstructionsMessage>data); break;
                 case "stop": stop(); break;
                 case "mute": mute((<SimulatorMuteMessage>data).mute); break;
+                case "stopsound": stopSound(); break;
                 case "print": print(); break;
                 case 'recorder': recorder(<SimulatorRecorderMessage>data); break;
                 case "screenshot": Runtime.postScreenshotAsync(<SimulatorScreenshotMessage>data).done(); break;
@@ -292,6 +297,10 @@ namespace pxsim {
 
         function mute(mute: boolean) {
             AudioContextManager.mute(mute);
+        }
+
+        function stopSound() {
+            AudioContextManager.stopAll();
         }
 
         function queue(msg: SimulatorMessage) {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -322,6 +322,10 @@ namespace pxsim {
             this.postMessage({ type: 'mute', mute: mute } as pxsim.SimulatorMuteMessage);
         }
 
+        public stopSound() {
+            this.postMessage({ type: 'stopsound' } as pxsim.SimulatorStopSoundMessage)
+        }
+
         public isLoanedSimulator(el: HTMLElement) {
             return !!this.loanedSimulator && this.loanedIFrame() == el;
         }
@@ -529,7 +533,7 @@ namespace pxsim {
             if (!this.listener) {
                 this.listener = (ev: MessageEvent) => {
                     if (this.hwdbg) return
-                    this.handleMessage(ev.data, ev.source)
+                    this.handleMessage(ev.data, ev.source as Window)
                 }
                 window.addEventListener('message', this.listener, false);
             }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2248,9 +2248,10 @@ export class ProjectView
     restartSimulator() {
         const isDebug = this.state.tracing || this.state.debugging;
         if (this.state.simState == pxt.editor.SimState.Stopped
-            || simulator.driver.isDebug() != !!isDebug)
+            || simulator.driver.isDebug() != !!isDebug) {
             this.startSimulator();
-        else {
+        } else {
+            simulator.driver.stopSound();
             simulator.driver.restart(); // fast restart
         }
         // TODO: typescript breakpoints

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -280,6 +280,7 @@ export function mute(mute: boolean) {
 
 export function stop(unload?: boolean, starting?: boolean) {
     if (!driver) return;
+    driver.stopSound();
     driver.stop(unload, starting);
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/256

Sends a 'stop sound' message whenever the user ends an instance of the sim running, so that the sound doesn't continue for a few moments into the next game / with no game running. (I think for it to work fully with tones it needs the recent common packages changes to mixer, but I'm not certain / didn't see a reason to roll back the common packages bump to check)

For an example of what this fixes, try stopping or restarting [this game](https://makecode.com/_McfaJVTafC8m) after the sound starts - it will continue momentarily after you press the button. A bit worse when playing with a version with a working ringTone as well