### PR TITLE
bail out to copy strategy of hid fails

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -560,9 +560,9 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
                     return Promise.resolve(0);
                 }
                 pxt.log(`copying ${firmwareName} to ` + drives.join(", "));
-                const writeHexFile = (filename: string) => {
-                    return writeFileAsync(path.join(filename, firmwareName), firmware, encoding)
-                        .then(() => pxt.debug("   wrote hex file to " + filename));
+                const writeHexFile = (drivename: string) => {
+                    return writeFileAsync(path.join(drivename, firmwareName), firmware, encoding)
+                        .then(() => pxt.debug("   wrote hex file to " + drivename));
                 };
                 return Promise.map(drives, d => writeHexFile(d))
                     .then(() => drives.length);

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -575,6 +575,7 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
             }).then(() => { });
     }
 
+    /* TODO reenable when webusb node.js caching issue is fixed
     function hidDeployAsync() {
         const f = firmware
         const blocks = pxtc.UF2.parseFile(U.stringToUint8Array(atob(f)))
@@ -582,7 +583,6 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
             .then(dev => dev.flashAsync(blocks))
     }
 
-    /* TODO reenable when webusb node.js caching issue is fixed
     let p = Promise.resolve();
     if (pxt.appTarget.compile
         && pxt.appTarget.compile.useUF2

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -582,6 +582,7 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
             .then(dev => dev.flashAsync(blocks))
     }
 
+    /* TODO reenable when webusb node.js caching issue is fixed
     let p = Promise.resolve();
     if (pxt.appTarget.compile
         && pxt.appTarget.compile.useUF2
@@ -593,8 +594,10 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
     } else {
         p = p.then(() => copyDeployAsync())
     }
-
     return p;
+    */
+
+    return copyDeployAsync();
 }
 
 function getBoardDrivesAsync(): Promise<string[]> {

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -575,7 +575,6 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
             }).then(() => { });
     }
 
-    /* TODO reenable when webusb node.js caching issue is fixed
     function hidDeployAsync() {
         const f = firmware
         const blocks = pxtc.UF2.parseFile(U.stringToUint8Array(atob(f)))
@@ -595,9 +594,6 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
         p = p.then(() => copyDeployAsync())
     }
     return p;
-    */
-
-    return copyDeployAsync();
 }
 
 function getBoardDrivesAsync(): Promise<string[]> {

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -562,7 +562,8 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
                 pxt.log(`copying ${firmwareName} to ` + drives.join(", "));
                 const writeHexFile = (drivename: string) => {
                     return writeFileAsync(path.join(drivename, firmwareName), firmware, encoding)
-                        .then(() => pxt.debug("   wrote hex file to " + drivename));
+                        .then(() => pxt.debug("   wrote to " + drivename))
+                        .catch(() => pxt.log(`   failed writing to ${drivename}`));
                 };
                 return Promise.map(drives, d => writeHexFile(d))
                     .then(() => drives.length);

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -551,6 +551,11 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
     const encoding = pxt.isOutputText() ? "utf8" : "base64";
     const firmware = res.outfiles[firmwareName];
 
+    if (!firmware) { // something went wrong heres
+        pxt.reportError("compile", `${firmwareName} missing from built files (${Object.keys(res.outfiles).join(', ')})`)
+        return Promise.resolve();
+    }
+
     function copyDeployAsync() {
         return getBoardDrivesAsync()
             .then(drives => filterDrives(drives))

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2103,10 +2103,10 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         let hexFile = path.join(hexCachePath, sha + ".hex");
 
                         if (fs.existsSync(hexFile)) {
-                            pxt.log(`native image already in offline cache for project ${dirname}: ${hexFile}`);
+                            pxt.debug(`native image already in offline cache for project ${dirname}: ${hexFile}`);
                         } else {
                             nodeutil.writeFileSync(hexFile, hex.join(os.EOL));
-                            pxt.log(`created native image in offline cache for project ${dirname}: ${hexFile}`);
+                            pxt.debug(`created native image in offline cache for project ${dirname}: ${hexFile}`);
                         }
                     }
                 })

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "keytar": "4.2.1",
     "node-hid": "^0.7.2",
     "serialport": "^6.2.0",
-    "webusb": "^1.0.14"
+    "webusb": "^1.1.1"
   },
   "devDependencies": {
     "monaco-editor": "0.10.0",

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -198,7 +198,7 @@ function winrtDeployCoreAsync(r: pxtc.CompileResult, d: pxt.commands.DeployOptio
 
 function localhostDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     pxt.debug('local deployment...');
-    core.infoNotification(lf("Uploading .hex file..."));
+    core.infoNotification(lf("Uploading..."));
     let deploy = () => pxt.Util.requestAsync({
         url: "/api/deploy",
         headers: { "Authorization": Cloud.localToken },


### PR DESCRIPTION
Since webusb fails on the second flash (internal caching issue on the node.js webusb module), disable and just do file copy for now for deployments.
