### PR TITLE
Persist image editor undo/redo in blocks editor

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -543,7 +543,9 @@ namespace pxt.blocks {
                     input.fieldRow.forEach((fieldRow: Blockly.FieldCustom) => {
                         if (fieldRow.isFieldCustom_ && fieldRow.saveOptions) {
                             const getOptions = fieldRow.saveOptions();
-                            el.setAttribute(`customfield`, JSON.stringify(getOptions));
+                            if (getOptions) {
+                                el.setAttribute(`customfield`, JSON.stringify(getOptions));
+                            }
                         }
                     })
                 })
@@ -554,7 +556,9 @@ namespace pxt.blocks {
                     input.fieldRow.forEach((fieldRow: Blockly.FieldCustom) => {
                         if (fieldRow.isFieldCustom_ && fieldRow.restoreOptions) {
                             const options = JSON.parse(saved.getAttribute(`customfield`));
-                            fieldRow.restoreOptions(options);
+                            if (options) {
+                                fieldRow.restoreOptions(options);
+                            }
                         }
                     })
                 })

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -94,13 +94,13 @@ namespace pxtblockly {
 
             this.editor = new pxtsprite.SpriteEditor(this.state, this.blocksInfo, this.lightMode);
             this.editor.initializeUndoRedo(this.undoStack, this.redoStack);
-            this.undoStack = this.editor.getUndoStack();
-            this.redoStack = this.editor.getRedoStack();
 
             this.editor.render(contentDiv);
             this.editor.rePaint();
 
             this.editor.onClose(() => {
+                this.undoStack = this.editor.getUndoStack();
+                this.redoStack = this.editor.getRedoStack();
                 Blockly.DropDownDiv.hideIfOwner(this);
             });
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -94,6 +94,8 @@ namespace pxtblockly {
 
             this.editor = new pxtsprite.SpriteEditor(this.state, this.blocksInfo, this.lightMode);
             this.editor.initializeUndoRedo(this.undoStack, this.redoStack);
+            this.undoStack = this.editor.getUndoStack();
+            this.redoStack = this.editor.getRedoStack();
 
             this.editor.render(contentDiv);
             this.editor.rePaint();
@@ -235,15 +237,6 @@ namespace pxtblockly {
             }
 
             return canvas.toDataURL();
-        }
-
-        saveOptions(): pxt.Map<string> {
-            if (this.editor) {
-                this.undoStack = this.editor.getUndoStack();
-                this.redoStack = this.editor.getRedoStack();
-            }
-
-            return undefined;
         }
     }
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -38,6 +38,8 @@ namespace pxtblockly {
         private editor: pxtsprite.SpriteEditor;
         private state: pxtsprite.Bitmap;
         private lightMode: boolean;
+        private undoStack: pxtsprite.Bitmap[];
+        private redoStack: pxtsprite.Bitmap[];
 
         constructor(text: string, params: any, validator?: Function) {
             super(text, validator);
@@ -91,6 +93,8 @@ namespace pxtblockly {
             let contentDiv = Blockly.DropDownDiv.getContentDiv() as HTMLDivElement;
 
             this.editor = new pxtsprite.SpriteEditor(this.state, this.blocksInfo, this.lightMode);
+            this.editor.initializeUndoRedo(this.undoStack, this.redoStack);
+
             this.editor.render(contentDiv);
             this.editor.rePaint();
 
@@ -234,39 +238,12 @@ namespace pxtblockly {
         }
 
         saveOptions(): pxt.Map<string> {
-            const save: pxt.Map<string> = {};
             if (this.editor) {
-                save["undo"] = serializeBitmapStack(this.editor.undoStack);
-                save["redo"] = serializeBitmapStack(this.editor.undoStack);
+                this.undoStack = this.editor.getUndoStack();
+                this.redoStack = this.editor.getRedoStack();
             }
-            return save;
 
-            function serializeBitmapStack(bmps: pxtsprite.Bitmap[]): string {
-                return JSON.stringify(
-                    bmps.map(bmp => pxtsprite.bitmapToImageLiteral(bmp, pxt.editor.FileType.TypeScript))
-                );
-            }
-        }
-        restoreOptions(map: pxt.Map<string>): void {
-            if (!map || !this.editor) return;
-            if (map["undo"]) {
-                const parsedUndo = unSerializeBitmapStack(map["undo"]);
-                if (parsedUndo) {
-                    this.editor.undoStack = parsedUndo;
-                }
-            }
-            if (map["redo"]) {
-                const parsedRedo = unSerializeBitmapStack(map["redo"]);
-                if (parsedRedo) {
-                    this.editor.redoStack = parsedRedo;
-                }
-            }
-            function unSerializeBitmapStack(input: string): pxtsprite.Bitmap[] {
-                if (!input || input == "undefined") return undefined;
-                const parsed = JSON.parse(input);
-                return parsed.map((str: string) => pxtsprite.imageLiteralToBitmap(str));
-            }
-            this.editor.updateUndoRedo();
+            return undefined;
         }
     }
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -232,6 +232,42 @@ namespace pxtblockly {
 
             return canvas.toDataURL();
         }
+
+        saveOptions(): pxt.Map<string> {
+            const save: pxt.Map<string> = {};
+            if (this.editor) {
+                save["undo"] = serializeBitmapStack(this.editor.undoStack);
+                save["redo"] = serializeBitmapStack(this.editor.undoStack);
+            }
+            return save;
+
+            function serializeBitmapStack(bmps: pxtsprite.Bitmap[]): string {
+                return JSON.stringify(
+                    bmps.map(bmp => pxtsprite.bitmapToImageLiteral(bmp, pxt.editor.FileType.TypeScript))
+                );
+            }
+        }
+        restoreOptions(map: pxt.Map<string>): void {
+            if (!map || !this.editor) return;
+            if (map["undo"]) {
+                const parsedUndo = unSerializeBitmapStack(map["undo"]);
+                if (parsedUndo) {
+                    this.editor.undoStack = parsedUndo;
+                }
+            }
+            if (map["redo"]) {
+                const parsedRedo = unSerializeBitmapStack(map["redo"]);
+                if (parsedRedo) {
+                    this.editor.redoStack = parsedRedo;
+                }
+            }
+            function unSerializeBitmapStack(input: string): pxtsprite.Bitmap[] {
+                if (!input || input == "undefined") return undefined;
+                const parsed = JSON.parse(input);
+                return parsed.map((str: string) => pxtsprite.imageLiteralToBitmap(str));
+            }
+            this.editor.updateUndoRedo();
+        }
     }
 
     function parseFieldOptions(opts: FieldSpriteEditorOptions) {

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -62,8 +62,8 @@ namespace pxtsprite {
         private cursorCol = 0;
         private cursorRow = 0;
 
-        undoStack: Bitmap[] = [];
-        redoStack: Bitmap[] = [];
+        private undoStack: Bitmap[] = [];
+        private redoStack: Bitmap[] = [];
 
         private columns: number = 16;
         private rows: number = 16;
@@ -221,6 +221,24 @@ namespace pxtsprite {
         setToolWidth(width: number) {
             this.toolWidth = width;
             this.edit = this.newEdit(this.color);
+        }
+
+        initializeUndoRedo(undoStack: Bitmap[], redoStack: Bitmap[]) {
+            if (undoStack) {
+                this.undoStack = undoStack;
+            }
+            if (redoStack) {
+                this.redoStack = redoStack;
+            }
+            this.updateUndoRedo();
+        }
+
+        getUndoStack() {
+            return this.undoStack;
+        }
+
+        getRedoStack() {
+            return this.redoStack;
         }
 
         undo() {
@@ -442,7 +460,7 @@ namespace pxtsprite {
             }
         }
 
-        updateUndoRedo() {
+        private updateUndoRedo() {
             this.bottomBar.updateUndoRedo(this.undoStack.length === 0, this.redoStack.length === 0)
         }
 

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -62,8 +62,8 @@ namespace pxtsprite {
         private cursorCol = 0;
         private cursorRow = 0;
 
-        private undoStack: Bitmap[] = [];
-        private redoStack: Bitmap[] = [];
+        undoStack: Bitmap[] = [];
+        redoStack: Bitmap[] = [];
 
         private columns: number = 16;
         private rows: number = 16;
@@ -442,7 +442,7 @@ namespace pxtsprite {
             }
         }
 
-        private updateUndoRedo() {
+        updateUndoRedo() {
             this.bottomBar.updateUndoRedo(this.undoStack.length === 0, this.redoStack.length === 0)
         }
 

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -234,11 +234,11 @@ namespace pxtsprite {
         }
 
         getUndoStack() {
-            return this.undoStack;
+            return this.undoStack.slice();
         }
 
         getRedoStack() {
-            return this.redoStack;
+            return this.redoStack.slice();
         }
 
         undo() {


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-arcade/issues/955

![ezgif com-optimize (5)](https://user-images.githubusercontent.com/5615930/57349184-08a4a700-710e-11e9-8cbe-dcd74816989f.gif)

Not added to monaco editor with this, as it doesn't seem like there's necessarily a place to persist that stacks there