### PR TITLE
Open forum from home

### DIFF
--- a/webapp/src/discourse.ts
+++ b/webapp/src/discourse.ts
@@ -1,0 +1,33 @@
+interface DiscoursePostResponse {
+    featured_link?: string;
+    post_stream?: DiscoursePostStream;
+}
+interface DiscoursePostStream {
+    posts?: DiscoursePost[];
+}
+interface DiscoursePost {
+    link_counts?: DiscourseLinkCount[];
+}
+interface DiscourseLinkCount {
+    url?: string;
+}
+
+export function extractSharedIdFromPostUrl(url: string): Promise<string> {
+    // https://docs.discourse.org/#tag/Posts%2Fpaths%2F~1posts~1%7Bid%7D.json%2Fget
+    return pxt.Util.httpGetJsonAsync(url + ".json")
+        .then((json: DiscoursePostResponse) => {
+            // try featured_link
+            let projectId = pxt.Cloud.parseScriptId(json.featured_link as string);
+            if (!projectId) {
+                // extract from post_stream
+                projectId = json.post_stream
+                    && json.post_stream.posts
+                    && json.post_stream.posts[0]
+                    && json.post_stream.posts[0].link_counts
+                        .map(link => pxt.Cloud.parseScriptId(link.url))
+                        .filter(id => !!id)
+                    [0];
+            }
+            return projectId;
+        });
+}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -5,7 +5,7 @@ import * as ReactDOM from "react-dom";
 import * as data from "./data";
 import * as sui from "./sui";
 import * as core from "./core";
-
+import * as discourse from "./discourse";
 import * as codecard from "./codecard"
 import * as carousel from "./carousel";
 import { showAboutDialogAsync, showCloudSignInDialog } from "./dialogs";
@@ -539,8 +539,8 @@ export interface ProjectsDetailProps extends ISettingsProps {
 }
 
 export interface ProjectsDetailState {
-
 }
+
 
 export class ProjectsDetail extends data.Component<ProjectsDetailProps, ProjectsDetailState> {
 
@@ -550,11 +550,26 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
         }
 
         this.handleDetailClick = this.handleDetailClick.bind(this);
+        this.handleOpenForumUrlInEditor = this.handleOpenForumUrlInEditor.bind(this);
     }
 
     handleDetailClick() {
         const { scr, onClick } = this.props;
         onClick(scr);
+    }
+
+    handleOpenForumUrlInEditor() {
+        const { url } = this.props;
+        discourse.extractSharedIdFromPostUrl(url)
+            .then(projectId => {
+                // if we have a projectid, load it
+                if (projectId)
+                    window.location.hash = "pub:" + projectId; // triggers reload
+                else {
+                    core.warningNotification(lf("Oops, we could not find the program in the forum."));
+                }
+            })
+            .catch(core.handleNetworkError)
     }
 
     renderCore() {
@@ -579,6 +594,8 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             className: 'huge positive'
         }]
 
+        // featured link: featured_link
+        const isForum = cardType == "forumUrl" && url;
         const isLink = (!isCodeCardType(cardType) || cardType === "forumUrl") && (youTubeId || url);
         const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
             ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
@@ -614,6 +631,13 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                                     onClick={action.onClick}
                                     onKeyDown={sui.fireClickOnEnter} />
                         )}
+                        {isForum && <sui.Button
+                            key="action_open"
+                            text={lf("Open in Editor")}
+                            className={`ui button approve`}
+                            onClick={this.handleOpenForumUrlInEditor}
+                            onKeyDown={sui.fireClickOnEnter}
+                        />}
                     </div>
                 </div>
             </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -619,7 +619,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                                     href={linkHref} target={'_blank'}
                                     icon={action.icon}
                                     text={action.label}
-                                    className={`ui button approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''}`}
+                                    className={`approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''}`}
                                     onClick={action.onClick}
                                     onKeyDown={sui.fireClickOnEnter}
                                 />
@@ -634,7 +634,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                         {isForum && <sui.Button
                             key="action_open"
                             text={lf("Open in Editor")}
-                            className={`ui button approve`}
+                            className={`approve huge`}
                             onClick={this.handleOpenForumUrlInEditor}
                             onKeyDown={sui.fireClickOnEnter}
                         />}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -596,7 +596,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         // featured link: featured_link
         const isForum = cardType == "forumUrl" && url;
-        const isLink = (!isCodeCardType(cardType) || cardType === "forumUrl") && (youTubeId || url);
+         const isLink = isForum || (!isCodeCardType(cardType) && (youTubeId || url));
         const linkHref = (youTubeId && !url) ? `https://youtu.be/${youTubeId}` :
             ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
 


### PR DESCRIPTION
It is quite dreadful to open a community project at the moment: go to forum, open shared link (wait), click Open Code (wait) click "Edit" (wait).

This change sniffs the project url using the Discourse API and display a "Open In Editor" option.

**requires to deploy support for "forumUrl" card types*

![image](https://user-images.githubusercontent.com/4175913/57538212-c4c3c480-72fc-11e9-8dbb-7c16ee8f4f0e.png)
