### PR TITLE
Send code through data-code attribute instead of src

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -124,8 +124,9 @@ namespace pxt.runner {
                     let padding = '81.97%';
                     if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
                     const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
-                    const url = getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($js.text()) + deps;
-                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
+                    const url = getRunUrl(options) + "#nofooter=1" + deps;
+                    const name = "&code=" + encodeURIComponent($js.text());
+                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" name="${name}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
                     $c.append($embed);
                 }
             })
@@ -795,8 +796,10 @@ namespace pxt.runner {
                     </div>
                     </div></div>`)
                 const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
-                const url = getRunUrl(options) + "#nofooter=1&code=" + encodeURIComponent($c.text().trim()) + deps;
+                const url = getRunUrl(options) + "#nofooter=1" + deps;
+                const name = "&code=" + encodeURIComponent($c.text().trim());
                 $sim.find("iframe").attr("src", url);
+                $sim.find("iframe").attr("name", name);
                 if (options.snippetReplaceParent) $c = $c.parent();
                 $c.replaceWith($sim);
             });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -125,8 +125,8 @@ namespace pxt.runner {
                     if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
                     const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
                     const url = getRunUrl(options) + "#nofooter=1" + deps;
-                    const name = "&code=" + encodeURIComponent($js.text());
-                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" name="${name}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
+                    const data = encodeURIComponent($js.text());
+                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" data-code="${data}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
                     $c.append($embed);
                 }
             })
@@ -797,9 +797,9 @@ namespace pxt.runner {
                     </div></div>`)
                 const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
                 const url = getRunUrl(options) + "#nofooter=1" + deps;
-                const name = "&code=" + encodeURIComponent($c.text().trim());
+                const data = encodeURIComponent($c.text().trim());
                 $sim.find("iframe").attr("src", url);
-                $sim.find("iframe").attr("name", name);
+                $sim.find("iframe").attr("data-code", data);
                 if (options.snippetReplaceParent) $c = $c.parent();
                 $c.replaceWith($sim);
             });

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -103,7 +103,7 @@
         (function () {
         var loading = document.getElementById('loading');
         var id = /id(?:[:=])([^&?]+)/i.exec(window.location.href);
-        var code = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
+        var code = /code(?:[:=])([^&?]+)/i.exec(window.name);
         var localToken = /local_token(?:[:=])([^&?]+)/i.exec(window.location.href);
         var hex = !!/hex(?:[:=])1/i.exec(window.location.href);
         var footer = !/nofooter(?:[:=])1/i.exec(window.location.href);

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -103,7 +103,7 @@
         (function () {
         var loading = document.getElementById('loading');
         var id = /id(?:[:=])([^&?]+)/i.exec(window.location.href);
-        var code = /code(?:[:=])([^&?]+)/i.exec(window.name);
+        var code = window.frameElement.getAttribute('data-code')
         var localToken = /local_token(?:[:=])([^&?]+)/i.exec(window.location.href);
         var hex = !!/hex(?:[:=])1/i.exec(window.location.href);
         var footer = !/nofooter(?:[:=])1/i.exec(window.location.href);
@@ -163,7 +163,7 @@
             else if (!debugSim) {
                 var options = {
                     id: id ? id[1] : undefined,
-                    code: code ? decodeURIComponent(code[1]) : undefined,
+                    code: code ? decodeURIComponent(code) : undefined,
                     highContrast: highContrast,
                     light: light,
                     fullScreen: fullScreen,


### PR DESCRIPTION
The ```src``` attribute has an obtainable character limit when writing large programs. The ~~```name```~~ ```data-code``` attribute doesn't seem to have as strict limitations. 

This switches to send the code of a program to the docs simulator using the ~~```name```~~ ```data-code``` attribute so that larger programs can run on Edge and IE.

Fixes Microsoft/pxt-arcade#943