### PR TITLE
Fix decompilation of non-block combined fields

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1296,7 +1296,7 @@ ${output}</xml>`;
                         return getVariableSetOrChangeBlock(n.left as ts.Identifier, n.right);
                     }
                     else if (n.left.kind == SK.PropertyAccessExpression) {
-                        return getPropertySetBlock(n.left as ts.PropertyAccessExpression, n.right, "@set@");
+                        return getPropertySetBlock(n, "@set@");
                     }
                     else {
                         return getArraySetBlock(n.left as ts.ElementAccessExpression, n.right);
@@ -1312,7 +1312,7 @@ ${output}</xml>`;
                     }
 
                     if (n.left.kind == SK.PropertyAccessExpression)
-                        return getPropertySetBlock(n.left as ts.PropertyAccessExpression, n.right, "@change@");
+                        return getPropertySetBlock(n, "@change@");
                     else
                         return getVariableSetOrChangeBlock(n.left as ts.Identifier, n.right, true);
                 case SK.MinusEqualsToken:
@@ -1497,9 +1497,14 @@ ${output}</xml>`;
             return r;
         }
 
-
-        function getPropertySetBlock(left: ts.PropertyAccessExpression, right: ts.Expression, tp: string) {
-            return getPropertyBlock(left, right, tp) as StatementNode
+        function getPropertySetBlock(n: ts.BinaryExpression, tp: string) {
+            const info: pxtc.CallInfo = (n.left as any).callInfo;
+            const sym = env.blocks.apis.byQName[info ? info.qName : ""];
+            if (!sym || !sym.attributes.blockCombine) {
+                return getTypeScriptStatementBlock(n);
+            } else {
+                return getPropertyBlock(n.left as ts.PropertyAccessExpression, n.right, tp) as StatementNode;
+            }
         }
 
         function getPropertyGetBlock(left: ts.PropertyAccessExpression) {
@@ -1509,10 +1514,11 @@ ${output}</xml>`;
         function getPropertyBlock(left: ts.PropertyAccessExpression, right: ts.Expression, tp: string): StatementNode | ExpressionNode {
             const info: pxtc.CallInfo = (left as any).callInfo
             const sym = env.blocks.apis.byQName[info ? info.qName : ""]
-            if (!sym || !sym.attributes.blockCombine) {
+            if (!sym) {
                 error(left);
                 return undefined;
             }
+
             const qName = `${sym.namespace}.${sym.retType}.${tp}`;
             const setter = env.blocks.blocks.find(b => b.qName == qName)
             const r = right ? mkStmt(setter.attributes.blockId) : mkExpr(setter.attributes.blockId)

--- a/tests/decompile-test/baselines/non_block_combined_fields.blocks
+++ b/tests/decompile-test/baselines/non_block_combined_fields.blocks
@@ -10,7 +10,7 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="a.data &#61; 5" />
+<mutation numlines="1" error="No call info found" line0="a.data &#61; 5&#59;" />
 <next>
 <block type="device_show_number">
 <value name="number">

--- a/tests/decompile-test/baselines/non_block_combined_fields.blocks
+++ b/tests/decompile-test/baselines/non_block_combined_fields.blocks
@@ -1,0 +1,28 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR">a</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="bc_create_test">
+</block>
+</value>
+<next>
+<block type="typescript_statement">
+<mutation numlines="1" line0="a.data &#61; 5" />
+<next>
+<block type="device_show_number">
+<value name="number">
+<block type="typescript_expression">
+<field name="EXPRESSION">a.data</field>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/non_block_combined_fields.ts
+++ b/tests/decompile-test/cases/non_block_combined_fields.ts
@@ -1,0 +1,4 @@
+let a = bc.createTest();
+
+a.data = 5;
+basic.showNumber(a.data)

--- a/tests/decompile-test/cases/testBlocks/blockCombine.ts
+++ b/tests/decompile-test/cases/testBlocks/blockCombine.ts
@@ -23,6 +23,8 @@ namespace bc {
         get testgetter(): boolean {
             return false;
         }
+
+        data: any;
     }
 
     //% blockId=bc_create_test block="create test"


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/966

```typescript
let a = bc.createTest()
a.data = 5
testNamespace.numberArgument(a.data)
```

goes to

![arcade-screenshot (5)](https://user-images.githubusercontent.com/5615930/57719076-c5799500-7633-11e9-9f7d-cc80caf4304c.png)

(Fixes decompilation of https://forum.makecode.com/t/combo-attack-and-button-combination-extension/169, decompiles successfully to mostly gray blocks)
