### PR TITLE
Don't scroll background when using mouse wheel in gallery

### DIFF
--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -39,6 +39,10 @@ namespace pxtsprite {
                     this.containerDiv.style.display = "none";
                 }
             });
+
+            this.contentDiv.addEventListener('wheel', e => {
+                e.stopPropagation();
+            }, true)
         }
 
         getElement() {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/957

![2019-05-14 11 27 44](https://user-images.githubusercontent.com/5615930/57722655-c6aec000-763b-11e9-9ccd-913de0ec5497.gif)
