### PR TITLE
Fix ios image editor offset

### DIFF
--- a/pxtlib/sprite-editor/canvasGrid.ts
+++ b/pxtlib/sprite-editor/canvasGrid.ts
@@ -300,8 +300,8 @@ namespace pxtsprite {
         protected clientToCell(coord: ClientCoordinates) {
             const bounds = this.paintLayer.getBoundingClientRect();
 
-            const left = bounds.left + window.scrollX;
-            const top = bounds.top + window.scrollY;
+            const left = bounds.left + (window.scrollX !== null ? window.scrollX : window.pageXOffset);
+            const top = bounds.top + (window.scrollY !== null ? window.scrollY : window.pageYOffset);
             this.mouseCol = Math.floor((coord.clientX - left) / this.cellWidth);
             this.mouseRow = Math.floor((coord.clientY - top) / this.cellHeight);
 

--- a/pxtlib/sprite-editor/canvasGrid.ts
+++ b/pxtlib/sprite-editor/canvasGrid.ts
@@ -299,9 +299,9 @@ namespace pxtsprite {
          */
         protected clientToCell(coord: ClientCoordinates) {
             const bounds = this.paintLayer.getBoundingClientRect();
-
             const left = bounds.left + (window.scrollX !== null ? window.scrollX : window.pageXOffset);
             const top = bounds.top + (window.scrollY !== null ? window.scrollY : window.pageYOffset);
+
             this.mouseCol = Math.floor((coord.clientX - left) / this.cellWidth);
             this.mouseRow = Math.floor((coord.clientY - top) / this.cellHeight);
 

--- a/pxtlib/sprite-editor/canvasGrid.ts
+++ b/pxtlib/sprite-editor/canvasGrid.ts
@@ -299,8 +299,12 @@ namespace pxtsprite {
          */
         protected clientToCell(coord: ClientCoordinates) {
             const bounds = this.paintLayer.getBoundingClientRect();
-            this.mouseCol = Math.floor((coord.clientX - bounds.left) / this.cellWidth);
-            this.mouseRow = Math.floor((coord.clientY - bounds.top) / this.cellHeight);
+
+            const left = bounds.left + window.scrollX;
+            const top = bounds.top + window.scrollY;
+            this.mouseCol = Math.floor((coord.clientX - left) / this.cellWidth);
+            this.mouseRow = Math.floor((coord.clientY - top) / this.cellHeight);
+
             return [
                 this.mouseCol,
                 this.mouseRow

--- a/pxtlib/sprite-editor/canvasGrid.ts
+++ b/pxtlib/sprite-editor/canvasGrid.ts
@@ -297,7 +297,8 @@ namespace pxtsprite {
         /**
          * This calls getBoundingClientRect() so don't call it in a loop!
          */
-        protected clientToCell(coord: ClientCoordinates) {
+        protected clientEventToCell(ev: MouseEvent) {
+            const coord = clientCoord(ev);
             const bounds = this.paintLayer.getBoundingClientRect();
             const left = bounds.left + (window.scrollX !== null ? window.scrollX : window.pageXOffset);
             const top = bounds.top + (window.scrollY !== null ? window.scrollY : window.pageYOffset);
@@ -318,13 +319,13 @@ namespace pxtsprite {
                 pxt.BrowserUtils.pointerEvents.down.forEach(evId => {
                     this.paintLayer.addEventListener(evId, (ev: MouseEvent) => {
                         this.startDrag();
-                        const [col, row] = this.clientToCell(clientCoord(ev));
+                        const [col, row] = this.clientEventToCell(ev);
                         this.gesture.handle(InputEvent.Down, col, row);
                     });
                 })
 
                 this.paintLayer.addEventListener("click", (ev: MouseEvent) => {
-                    const [col, row] = this.clientToCell(clientCoord(ev));
+                    const [col, row] = this.clientEventToCell(ev);
                     this.gesture.handle(InputEvent.Down, col, row);
                     this.gesture.handle(InputEvent.Up, col, row);
                 });
@@ -335,7 +336,7 @@ namespace pxtsprite {
 
         private upHandler = (ev: MouseEvent) => {
             this.endDrag();
-            const [col, row] = this.clientToCell(clientCoord(ev));
+            const [col, row] = this.clientEventToCell(ev);
             this.gesture.handle(InputEvent.Up, col, row);
 
             ev.stopPropagation();
@@ -344,7 +345,7 @@ namespace pxtsprite {
 
         private leaveHandler = (ev: MouseEvent) => {
             this.endDrag();
-            const [col, row] = this.clientToCell(clientCoord(ev));
+            const [col, row] = this.clientEventToCell(ev);
             this.gesture.handle(InputEvent.Leave, col, row);
 
             ev.stopPropagation();
@@ -352,7 +353,7 @@ namespace pxtsprite {
         };
 
         private moveHandler = (ev: MouseEvent) => {
-            const [col, row] = this.clientToCell(clientCoord(ev));
+            const [col, row] = this.clientEventToCell(ev);
             if (col >= 0 && row >= 0 && col < this.image.width && row < this.image.height) {
                 if (ev.buttons & 1) {
                     this.gesture.handle(InputEvent.Down, col, row);
@@ -365,7 +366,7 @@ namespace pxtsprite {
         }
 
         private hoverHandler = (ev: MouseEvent) => {
-            const [col, row] = this.clientToCell(clientCoord(ev));
+            const [col, row] = this.clientEventToCell(ev);
             if (col >= 0 && row >= 0 && col < this.image.width && row < this.image.height) {
                 this.gesture.handle(InputEvent.Move, col, row);
                 this.gesture.isHover = true;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/671

Apparently iOS takes a downward motion to inherently be a scroll (even if nothing moves), so the bounding rect top was changing position as you dragged down. This takes into account the scroll offset so that it behaves nicely

broken:

![2019-05-15 13 30 09](https://user-images.githubusercontent.com/5615930/57816787-74e86180-7731-11e9-9e40-6e838bc2c32d.gif)

new:

![2019-05-15 16 49 04](https://user-images.githubusercontent.com/5615930/57816776-6b5ef980-7731-11e9-8e4a-fc4d1e92045c.gif)
