### PR TITLE
disabling HID from CLi

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -583,16 +583,18 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
     }
 
     let p = Promise.resolve();
-    if (pxt.appTarget.compile
+    // TODO renable when HID/webusb fixed deployment
+/*    if (pxt.appTarget.compile
         && pxt.appTarget.compile.useUF2
         && !pxt.appTarget.serial.noDeploy
-        && hid.isInstalled(true)) {
+        && hid.isInstalled(true) {
         // try hid or simply bail out
         p = p.then(() => hidDeployAsync())
             .catch(e => copyDeployAsync());
     } else {
+        */
         p = p.then(() => copyDeployAsync())
-    }
+  //  }
     return p;
 }
 

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -584,17 +584,16 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
 
     let p = Promise.resolve();
     // TODO renable when HID/webusb fixed deployment
-/*    if (pxt.appTarget.compile
+    if (pxt.appTarget.compile
         && pxt.appTarget.compile.useUF2
         && !pxt.appTarget.serial.noDeploy
-        && hid.isInstalled(true) {
+        && hid.isInstalled(true)) {
         // try hid or simply bail out
         p = p.then(() => hidDeployAsync())
             .catch(e => copyDeployAsync());
     } else {
-        */
         p = p.then(() => copyDeployAsync())
-  //  }
+    }
     return p;
 }
 

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -583,7 +583,6 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
     }
 
     let p = Promise.resolve();
-    // TODO renable when HID/webusb fixed deployment
     if (pxt.appTarget.compile
         && pxt.appTarget.compile.useUF2
         && !pxt.appTarget.serial.noDeploy

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5502,6 +5502,7 @@ PXT_NODOCKER     - don't use Docker image, and instead use host's
 PXT_RUNTIME_DEV  - always rebuild the C++ runtime, allowing for modification
                    in the lower level runtime if any
 PXT_ASMDEBUG     - embed additional information in generated binary.asm file
+PXT_USE_HID      - use webusb or hid to flash device
 `)
         return Promise.resolve();
     }, "[all|command]");

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5493,6 +5493,7 @@ The following environment variables modify the behavior of the CLI when set to
 non-empty string:
 
 PXT_DEBUG        - display extensive logging info
+PXT_USE_HID      - use webusb or hid to flash device
 
 These apply to the C++ runtime builds:
 
@@ -5502,7 +5503,6 @@ PXT_NODOCKER     - don't use Docker image, and instead use host's
 PXT_RUNTIME_DEV  - always rebuild the C++ runtime, allowing for modification
                    in the lower level runtime if any
 PXT_ASMDEBUG     - embed additional information in generated binary.asm file
-PXT_USE_HID      - use webusb or hid to flash device
 `)
         return Promise.resolve();
     }, "[all|command]");

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -2,12 +2,15 @@ import HF2 = pxt.HF2
 import U = pxt.U
 import * as nodeutil from './nodeutil';
 
+const PXT_USE_HID = !!process.env["PXT_USE_HID"];
+
 function useWebUSB() {
     return !!pxt.appTarget.compile.webUSB
 }
 
 let HID: any = undefined;
 function requireHID(install?: boolean): boolean {
+    if (!PXT_USE_HID) return false;
     if (useWebUSB()) {
         // in node.js, we need "webusb" package
         if (pxt.Util.isNodeJS)
@@ -37,7 +40,7 @@ export interface HidDevice {
 }
 
 export function listAsync() {
-    if (!requireHID(true))
+    if (!isInstalled(true))
         return Promise.resolve();
     return getHF2DevicesAsync()
         .then(devices => {
@@ -47,7 +50,7 @@ export function listAsync() {
 }
 
 export function serialAsync() {
-    if (!requireHID(true))
+    if (!isInstalled(true))
         return Promise.resolve();
     return initAsync()
         .then(d => {
@@ -75,7 +78,7 @@ export function deviceInfo(h: HidDevice) {
 }
 
 function getHF2Devices(): HidDevice[] {
-    if (!requireHID(false))
+    if (!isInstalled(false))
         return [];
     let devices = HID.devices() as HidDevice[]
     for (let d of devices) {
@@ -130,7 +133,7 @@ export function hf2ConnectAsync(path: string, raw = false) {
     }
 
 
-    if (!requireHID(true)) return Promise.resolve(undefined);
+    if (!isInstalled(true)) return Promise.resolve(undefined);
     // in .then() to make sure we catch errors
     let h = new HF2.Wrapper(new HidIO(path))
     h.rawMode = raw
@@ -188,7 +191,7 @@ export class HidIO implements HF2.PacketIO {
     }
 
     private connect() {
-        U.assert(requireHID(false))
+        U.assert(isInstalled(false))
         if (this.requestedPath == null) {
             let devs = getHF2Devices()
             if (devs.length == 0)


### PR DESCRIPTION
The WebUSB / HID deployment has issues. It mostly does not work on arcade. This flag disables it by default and default to MSD deployment. can be turned off once we get webusb back on its feet.