### PR TITLE
server deploy for correct app variant

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -554,7 +554,7 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
     }
 
     const firmware = res.outfiles[firmwareName];
-    const encoding = firmwareName == pxtc.BINARY_HEX 
+    const encoding = firmwareName == pxtc.BINARY_HEX
         ? "utf8" : "base64";
 
 

--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -547,14 +547,16 @@ function getCSharpCommand() {
 }
 
 function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
-    const firmwareName = pxt.outputName()
-    const encoding = pxt.isOutputText() ? "utf8" : "base64";
-    const firmware = res.outfiles[firmwareName];
-
-    if (!firmware) { // something went wrong heres
-        pxt.reportError("compile", `${firmwareName} missing from built files (${Object.keys(res.outfiles).join(', ')})`)
+    const firmwareName = [pxtc.BINARY_UF2, pxtc.BINARY_HEX, pxtc.BINARY_HEX].filter(f => !!res.outfiles[f])[0];
+    if (!firmwareName) { // something went wrong heres
+        pxt.reportError("compile", `firmware missing from built files (${Object.keys(res.outfiles).join(', ')})`)
         return Promise.resolve();
     }
+
+    const firmware = res.outfiles[firmwareName];
+    const encoding = firmwareName == pxtc.BINARY_HEX 
+        ? "utf8" : "base64";
+
 
     function copyDeployAsync() {
         return getBoardDrivesAsync()


### PR DESCRIPTION
When the local server deploys a compiled file, don't rely on the current target config which might have the wrong variant.
Fix for https://github.com/microsoft/pxt-maker/issues/229