### PR TITLE
Note which targets are active for translation

### DIFF
--- a/docs/translate.md
+++ b/docs/translate.md
@@ -26,6 +26,30 @@ When you select a language, you see a folder view of the translation files for b
 
 The source language for all of the files is English and that's the language the files are in when uploaded to Crowdin. During the translation process, Crowdin keeps a database of all the current and suggested translations for each part of a translation file.
 
+## Target folders
+
+Under each language there are top-level folders for all of the editors (including the MakeCode core) supported by the MakeCode team. Some of these are featured on the [MakeCode](https://www.microsoft.com/en-us/makecode) home page. If you are interested in helping translate a particular target, you can focus your efforts in the files under its top-level folder. If you wish to help generally and want to work in more than one target, be aware that not all targets are presently active. To make your help count the most, you probably want to work with an active target. These are active and inactive targets:
+
+### Active targets
+
+- [x] [adafruit](https://crowdin.com/project/kindscript/en#/adafruit)
+- [x] [arcade](https://crowdin.com/project/kindscript/en#/arcade)
+- [x] [brainpad](https://crowdin.com/project/kindscript/en#/brainpad)
+- [x] [core](https://crowdin.com/project/kindscript/en#/core)
+- [x] [chibitronics](https://crowdin.com/project/kindscript/en#/chibitronics)
+- [x] [ev3](https://crowdin.com/project/kindscript/en#/ev3)
+- [x] [grovezero](https://crowdin.com/project/kindscript/en#/grovezero)
+- [x] [maker](https://crowdin.com/project/kindscript/en#/maker)
+- [x] [microbit](https://crowdin.com/project/kindscript/en#/microbit)
+- [x] [minecraft](https://crowdin.com/project/kindscript/en#/minecraft)
+- [x] [stm32iotnode](https://crowdin.com/project/kindscript/en#/stm32iotnode)
+
+### Inactive targets
+
+- [ ] [v0](https://crowdin.com/project/kindscript/en#/v0)
+- [ ] [calliope](https://crowdin.com/project/kindscript/en#/calliope)
+- [ ] [calliopemini](https://crowdin.com/project/kindscript/en#/calliopemini)
+
 ## File types
 
 ### Strings files
@@ -170,7 +194,7 @@ Once a translation is approved by a proofreader it is published to the "live" we
 
 To test your changes "live", use **beta** build and the ``?liveforcelang=CODE`` hash argument where ``CODE`` is your language ISO code. For example, to see the french translations:
 
-* https://pxt.microbit.org/beta?liveforcelang=fr
+* https://makecode.microbit.org/beta?liveforcelang=fr
 
 Note that there may be a delay of up to 24 hours before your changes in Crowdin make it into the "live" view.
 Also, the language will only be available in the editor's language selection if the target has enabled that locale - which is why you need to use the hash mentioned above.


### PR DESCRIPTION
I've noticed that some people are working under ``v0`` in Crowdin. Is this still considered an active target? I added a section to direct translators to work under "active" projects.