### PR TITLE
Prefer touch events to pointer events (fix android image editor)

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -916,27 +916,34 @@ namespace pxt.BrowserUtils {
         leave: string
     }
 
-    export const pointerEvents: IPointerEvents = hasPointerEvents() ? {
-        up: "pointerup",
-        down: ["pointerdown"],
-        move: "pointermove",
-        enter: "pointerenter",
-        leave: "pointerleave"
-    } : isTouchEnabled() ?
-            {
+    export const pointerEvents: IPointerEvents = (() => {
+        if (isTouchEnabled()) {
+            return {
                 up: "mouseup",
                 down: ["mousedown", "touchstart"],
                 move: "touchmove",
                 enter: "touchenter",
                 leave: "touchend"
-            } :
-            {
+            }
+        } else if (hasPointerEvents()) {
+            return {
+                up: "pointerup",
+                down: ["pointerdown"],
+                move: "pointermove",
+                enter: "pointerenter",
+                leave: "pointerleave"
+            }
+        } else {
+            return {
                 up: "mouseup",
                 down: ["mousedown"],
                 move: "mousemove",
                 enter: "mouseenter",
                 leave: "mouseleave"
-            };
+            }
+        }
+    })();
+
     export function popupWindow(url: string, title: string, popUpWidth: number, popUpHeight: number) {
         try {
             const winLeft = window.screenLeft ? window.screenLeft : window.screenX;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/379

Would be good to test on chromebook and physical android device / windows with touchscreen with a target build of arcade

Issue is that the browsers were using the pointer events when they should have been using touch events.

Broken / current:

![2019-05-17 10 44 01](https://user-images.githubusercontent.com/5615930/57946281-cbb87d00-7890-11e9-9985-a28a9b425dab.gif)

Fixed:

![2019-05-17 10 43 11](https://user-images.githubusercontent.com/5615930/57946644-b1cb6a00-7891-11e9-9fcd-becf991f9bbb.gif)

testing:

* [x] chrome - mac, no touch screen
* [x] chrome - android emulator
* [x] firefox - mac
* [x] safari - mac
* [x] safari - ipad simulator
* [x] chrome - android hardware
* ~[ ] chrome - touchscreen on chromebook~ don't have a touchscreen chromebook but should match android?
* [x] chrome - touchscreen on windows
* [ ] edge - touchscreen on windows
* [x] firefox - touchscreen on windows