### PR TITLE
Shift actions for rectangle, circle tools

### DIFF
--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -126,7 +126,7 @@ namespace pxtsprite {
             this.paintSurface.leave(() => {
                 if (this.edit) {
                     this.rePaint();
-                    if (this.edit.isStarted && this.activeTool === PaintTool.Normal) {
+                    if (this.edit.isStarted && !this.shiftDown) {
                         this.commit();
                     }
                 }
@@ -558,15 +558,26 @@ namespace pxtsprite {
             if (!this.shiftDown || this.altDown)
                 return;
 
-            if (this.activeTool === PaintTool.Line) {
-                this.setCell(this.paintSurface.mouseCol, this.paintSurface.mouseRow, this.color, false);
+            switch (this.activeTool) {
+                case PaintTool.Line:
+                case PaintTool.Rectangle:
+                case PaintTool.Circle:
+                    this.setCell(this.paintSurface.mouseCol, this.paintSurface.mouseRow, this.color, false);
+                    break;
             }
         }
 
         private clearShiftAction() {
-            if (this.activeTool === PaintTool.Line && !this.mouseDown) {
-                this.updateEdit();
-                this.paintSurface.restore(this.state, true);
+            if (this.mouseDown)
+                return;
+
+            switch (this.activeTool) {
+                case PaintTool.Line:
+                case PaintTool.Rectangle:
+                case PaintTool.Circle:
+                    this.updateEdit();
+                    this.paintSurface.restore(this.state, true);
+                    break;
             }
         }
 


### PR DESCRIPTION
Adds alternate behavior while holding shift for the rectangle and circle tools, that matches the behavior of the line tool. These ones are likely a bit lesson common to use than the line tool, but can be fun to use

![2019-05-17 21 04 31](https://user-images.githubusercontent.com/5615930/57964325-714b0b00-78e8-11e9-8767-3ac68cd5b292.gif)
![2019-05-17 21 04 02](https://user-images.githubusercontent.com/5615930/57964327-714b0b00-78e8-11e9-97d1-afea0cadf810.gif)

