### PR TITLE
Remove duplicate scroll bar in vs editor

### DIFF
--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -49,7 +49,7 @@
 
 /* The view lines in the monaco editor sometimes ignore the editor width and cause a scrollbar to appear */
 .monaco-editor.vs {
-    overflow-x: hidden;
+    overflow: hidden;
 }
 
 /* Monaco Editor Main tokens */


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2050

There's a separate `monaco-scrollable-element` to make the scroll bar nicer - this div having any 'scrolling' makes the scroll bar show up on top of the one we actually use

![2019-05-20 09 30 56](https://user-images.githubusercontent.com/5615930/58037733-ec781100-7ae2-11e9-836f-fb086f1eb153.gif)
