### PR TITLE
Handle pointer events in sprite editor more appropriately

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -917,21 +917,21 @@ namespace pxt.BrowserUtils {
     }
 
     export const pointerEvents: IPointerEvents = (() => {
-        if (isTouchEnabled()) {
-            return {
-                up: "mouseup",
-                down: ["mousedown", "touchstart"],
-                move: "touchmove",
-                enter: "touchenter",
-                leave: "touchend"
-            }
-        } else if (hasPointerEvents()) {
+        if (hasPointerEvents()) {
             return {
                 up: "pointerup",
                 down: ["pointerdown"],
                 move: "pointermove",
                 enter: "pointerenter",
                 leave: "pointerleave"
+            }
+        } else if (isTouchEnabled()) {
+            return {
+                up: "mouseup",
+                down: ["mousedown", "touchstart"],
+                move: "touchmove",
+                enter: "touchenter",
+                leave: "touchend"
             }
         } else {
             return {

--- a/theme/spriteeditor.less
+++ b/theme/spriteeditor.less
@@ -24,6 +24,7 @@
 .sprite-editor-canvas {
     cursor: crosshair;
     z-index: 1001;
+    touch-action: none;
 }
 
 .sprite-editor-canvas.sprite-editor-eyedropper {


### PR DESCRIPTION
Fixes sprite editor mouse interactions on some machines, while still allowing touchscreen input