### PR TITLE
Fix color parsing in field_colour

### DIFF
--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -69,7 +69,7 @@ namespace pxtblockly {
         setValue(colour: string) {
             colour = parseColour(colour);
 
-            if (this.valueMode_ === "index") {
+            if (!/^#/.test(colour) && this.valueMode_ === "index") {
                 const allColors = this.getColours_();
                 if (allColors.indexOf(colour) === -1) {
                     // Might be the index and not the color
@@ -112,7 +112,7 @@ namespace pxtblockly {
     function parseColour(colour: string) {
         if (colour) {
             const enumSplit = /Colors\.([a-zA-Z]+)/.exec(colour);
-            const hexSplit = /0x([0-9a-fA-F]+)/.exec(colour);
+            const hexSplit = /[0x|#]([0-9a-fA-F]+)/.exec(colour);
 
             if (enumSplit) {
                 switch (enumSplit[1].toLocaleLowerCase()) {
@@ -142,10 +142,17 @@ namespace pxtblockly {
                     return output;
                 } else if (hexLiteralNumber.length === 6) {
                     return "#" + hexLiteralNumber;
-                } else {
-                    // else return parsed as index
-                    return "" + parseInt(colour);
                 }
+            }
+
+            const parsedAsInt = parseInt(colour);
+            const allColors = this.getColours_();
+
+            // Might be the index and not the color
+            if (!isNaN(parsedAsInt) && allColors[parsedAsInt] != undefined) {
+                return allColors[parsedAsInt];
+            } else {
+                return allColors[0];
             }
         }
         return colour;

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -69,10 +69,7 @@ namespace pxtblockly {
         setValue(colour: string) {
             colour = parseColour(colour);
 
-            if (/^0x/.test(colour)) {
-                colour = `#${colour.substr(2)}`;
-            }
-            else if (this.valueMode_ === "index") {
+            if (this.valueMode_ === "index") {
                 const allColors = this.getColours_();
                 if (allColors.indexOf(colour) === -1) {
                     // Might be the index and not the color
@@ -137,14 +134,14 @@ namespace pxtblockly {
 
                 if (hexLiteralNumber.length === 3) {
                     // if shorthand color, return standard hex triple
-                    let output = "0x";
+                    let output = "#";
                     for (let i = 0; i < hexLiteralNumber.length; i++) {
                         const digit = hexLiteralNumber.charAt(i);
                         output += digit + digit;
                     }
                     return output;
                 } else if (hexLiteralNumber.length === 6) {
-                    return colour;
+                    return "#" + hexLiteralNumber;
                 } else {
                     // else return parsed as index
                     return "" + parseInt(colour);

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -67,21 +67,7 @@ namespace pxtblockly {
          * @param {string} colour The new colour in '#rrggbb' format.
          */
         setValue(colour: string) {
-            colour = parseColour(colour);
-
-            if (!/^#/.test(colour) && this.valueMode_ === "index") {
-                const allColors = this.getColours_();
-                if (allColors.indexOf(colour) === -1) {
-                    // Might be the index and not the color
-                    const i = parseInt(colour);
-                    if (!isNaN(i) && i >= 0 && i < allColors.length) {
-                        colour = allColors[i];
-                    }
-                    else {
-                        colour = allColors[0];
-                    }
-                }
-            }
+            colour = parseColour(colour, this.getColours_());
 
             if (this.sourceBlock_ && Blockly.Events.isEnabled() &&
                 this.colour_ != colour) {
@@ -109,10 +95,10 @@ namespace pxtblockly {
         }
     }
 
-    function parseColour(colour: string) {
+    function parseColour(colour: string, allColours: string[]) {
         if (colour) {
             const enumSplit = /Colors\.([a-zA-Z]+)/.exec(colour);
-            const hexSplit = /[0x|#]([0-9a-fA-F]+)/.exec(colour);
+            const hexSplit = /(0x|#)([0-9a-fA-F]+)/.exec(colour);
 
             if (enumSplit) {
                 switch (enumSplit[1].toLocaleLowerCase()) {
@@ -130,7 +116,7 @@ namespace pxtblockly {
                     default: return colour;
                 }
             } else if (hexSplit) {
-                const hexLiteralNumber = hexSplit[1];
+                const hexLiteralNumber = hexSplit[2];
 
                 if (hexLiteralNumber.length === 3) {
                     // if shorthand color, return standard hex triple
@@ -145,14 +131,15 @@ namespace pxtblockly {
                 }
             }
 
-            const parsedAsInt = parseInt(colour);
-            const allColors = this.getColours_();
+            if (allColours) {
+                const parsedAsInt = parseInt(colour);
 
-            // Might be the index and not the color
-            if (!isNaN(parsedAsInt) && allColors[parsedAsInt] != undefined) {
-                return allColors[parsedAsInt];
-            } else {
-                return allColors[0];
+                // Might be the index and not the color
+                if (!isNaN(parsedAsInt) && allColours[parsedAsInt] != undefined) {
+                    return allColours[parsedAsInt];
+                } else {
+                    return allColours[0];
+                }
             }
         }
         return colour;

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -68,6 +68,7 @@ namespace pxtblockly {
          */
         setValue(colour: string) {
             colour = parseColour(colour);
+
             if (colour.indexOf('0x') > -1) {
                 colour = `#${colour.substr(2)}`;
             }
@@ -90,6 +91,10 @@ namespace pxtblockly {
                 Blockly.Events.fire(new (Blockly as any).Events.BlockChange(
                     this.sourceBlock_, 'field', this.name, this.colour_, colour));
             }
+
+            // if color is not valid, do not apply color
+            if (!/#[0-9a-fA-F]{6}/.exec(colour)) return;
+
             this.colour_ = colour;
             if (this.sourceBlock_) {
                 this.sourceBlock_.setColour(colour, colour, colour);

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -74,14 +74,13 @@ namespace pxtblockly {
         setValue(colour: string) {
             colour = parseColour(colour, this.getColours_());
 
+            if (!colour) return;
+
             if (this.sourceBlock_ && Blockly.Events.isEnabled() &&
                 this.colour_ != colour) {
                 Blockly.Events.fire(new (Blockly as any).Events.BlockChange(
                     this.sourceBlock_, 'field', this.name, this.colour_, colour));
             }
-
-            // if color is not valid, do not apply color
-            if (!/#[0-9a-fA-F]{6}/.test(colour)) return;
 
             this.colour_ = colour;
             if (this.sourceBlock_) {

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -67,7 +67,7 @@ namespace pxtblockly {
          * @param {string} colour The new colour in '#rrggbb' format.
          */
         setValue(colour: string) {
-            colour = fixEnumColor(colour);
+            colour = parseColour(colour);
             if (colour.indexOf('0x') > -1) {
                 colour = `#${colour.substr(2)}`;
             }
@@ -107,7 +107,7 @@ namespace pxtblockly {
         }
     }
 
-    function fixEnumColor(colour: string) {
+    function parseColour(colour: string) {
         if (colour) {
             const match = /Colors\.([a-zA-Z]+)/.exec(colour);
             if (match) {
@@ -127,6 +127,6 @@ namespace pxtblockly {
                 }
             }
         }
-        return colour;
+        return parseInt(colour) + "";
     }
 }

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -109,9 +109,11 @@ namespace pxtblockly {
 
     function parseColour(colour: string) {
         if (colour) {
-            const match = /Colors\.([a-zA-Z]+)/.exec(colour);
-            if (match) {
-                switch (match[1].toLocaleLowerCase()) {
+            const enumSplit = /Colors\.([a-zA-Z]+)/.exec(colour);
+            const hexSplit = /0x([0-9a-fA-F]+)/.exec(colour);
+
+            if (enumSplit) {
+                switch (enumSplit[1].toLocaleLowerCase()) {
                     case "red": return "#FF0000";
                     case "orange": return "#FF7F00";
                     case "yellow": return "#FFFF00";
@@ -125,8 +127,25 @@ namespace pxtblockly {
                     case "black": return "#000000";
                     default: return colour;
                 }
+            } else if (hexSplit) {
+                const hexLiteralNumber = hexSplit[1];
+
+                if (hexLiteralNumber.length === 3) {
+                    // if shorthand color, return standard hex triple
+                    let output = "0x";
+                    for (let i = 0; i < hexLiteralNumber.length; i++) {
+                        const digit = hexLiteralNumber.charAt(i);
+                        output += digit + digit;
+                    }
+                    return output;
+                } else if (hexLiteralNumber.length === 6) {
+                    return colour;
+                } else {
+                    // else return parsed as index
+                    return "" + parseInt(colour);
+                }
             }
         }
-        return parseInt(colour) + "";
+        return colour;
     }
 }

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -69,7 +69,7 @@ namespace pxtblockly {
         setValue(colour: string) {
             colour = parseColour(colour);
 
-            if (colour.indexOf('0x') > -1) {
+            if (/^0x/.test(colour)) {
                 colour = `#${colour.substr(2)}`;
             }
             else if (this.valueMode_ === "index") {
@@ -93,7 +93,7 @@ namespace pxtblockly {
             }
 
             // if color is not valid, do not apply color
-            if (!/#[0-9a-fA-F]{6}/.exec(colour)) return;
+            if (!/#[0-9a-fA-F]{6}/.test(colour)) return;
 
             this.colour_ = colour;
             if (this.sourceBlock_) {

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -57,7 +57,12 @@ namespace pxtblockly {
                         return this.colour_;
                     }
                 case "index":
-                    return this.getColours_().indexOf(this.colour_).toString();
+                    const allColours = this.getColours_();
+                    for (let i = 0; i < allColours.length; i++) {
+                        if (this.colour_.toUpperCase() === allColours[i].toUpperCase()) {
+                            return i + "";
+                        }
+                    }
             }
             return this.colour_;
         }
@@ -91,7 +96,7 @@ namespace pxtblockly {
         }
 
         getColours_(): string[] {
-            return (this as any).colours_;
+            return this.colours_;
         }
     }
 

--- a/pxtblocks/fields/field_colour.ts
+++ b/pxtblocks/fields/field_colour.ts
@@ -57,6 +57,7 @@ namespace pxtblockly {
                         return this.colour_;
                     }
                 case "index":
+                    if (!this.colour_) return "-1";
                     const allColours = this.getColours_();
                     for (let i = 0; i < allColours.length; i++) {
                         if (this.colour_.toUpperCase() === allColours[i].toUpperCase()) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/988 (field editor bug, not decompiler)

Also:

* doesn't fail on invalid indices / super big numbers
* allows shortcut hex codes to decompile as expected when decompiling (e.g. ``0xfff``)

This does have slightly weird behaviors in some cases, though - for example, the ``set background color`` block in arcade will not match the hex inputs, but if you decompile to blocks it will behave as you would normally expect:

https://makecode.com/_UawYdtFWWhsA

The same would apply in adafruit (shortcut syntax doesn't work in typescript but decompiling makes it work). ~Maybe we could add a helper function to parse the input and make the behavior consistent for all the functions that use this field editor?~ I suppose there isn't really too much to do about this, as there isn't anything to disambiguate index vs color with unless you actually have the literal itself - this field editor is just converting typescript that doesn't make sense into blocks that presumably match the intention.