### PR TITLE
Bidirectional builtin function map, override pyQname for special cases

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -9,6 +9,28 @@ namespace ts.pxtc {
 . . . . .
 `
 
+    export interface FunOverride {
+        n: string;
+        t: any;
+        scale?: number;
+    }
+
+    export const ts2PyFunNameMap: pxt.Map<FunOverride> = {
+            "Math.trunc": { n: "int", t: ts.SyntaxKind.NumberKeyword },
+            "Math.min": { n: "min", t: ts.SyntaxKind.NumberKeyword },
+            "Math.max": { n: "max", t: ts.SyntaxKind.NumberKeyword },
+            "Math.randomRange": { n: "randint", t: ts.SyntaxKind.NumberKeyword },
+            "console.log": { n: "print", t: ts.SyntaxKind.VoidKeyword },
+            ".length": { n: "len", t: ts.SyntaxKind.NumberKeyword },
+            ".toLowerCase()": { n: "string.lower", t: ts.SyntaxKind.StringKeyword },
+            ".toUpperCase()": { n: "string.upper", t: ts.SyntaxKind.StringKeyword },
+            ".charCodeAt(0)": { n: "ord", t: ts.SyntaxKind.NumberKeyword },
+            "pins.createBuffer": { n: "bytearray", t: ts.SyntaxKind.Unknown },
+            "pins.createBufferFromArray": { n: "bytes", t: ts.SyntaxKind.Unknown },
+            "!!": { n: "bool", t: ts.SyntaxKind.BooleanKeyword },
+            ".indexOf": { n: "Array.index", t: ts.SyntaxKind.NumberKeyword },
+        }
+
     function renderDefaultVal(apis: pxtc.ApisInfo, p: pxtc.ParameterDesc, imgLit: boolean, cursorMarker: string): string {
         if (p.initializer) return p.initializer
         if (p.default) return p.default
@@ -533,7 +555,10 @@ namespace ts.pxtc {
             }
 
             if (si.pyName) {
-                if (si.namespace) {
+                let override = U.lookup(ts2PyFunNameMap, si.qName);
+                if (override && override.n) {
+                    si.pyQName = override.n;
+                } else if (si.namespace) {
                     let par = res.byQName[si.namespace]
                     if (par) {
                         si.pyQName = par.pyQName + "." + si.pyName

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -902,25 +902,6 @@ namespace pxt.py {
                 // TODO confirm the type is correct!
                 return [`len(${left})`, leftSup]
             }
-            // special casing
-            // TODO make this safer. This is syntactic matching, but we really need semantics
-            if (left === "Math") {
-                let mathFn = ""
-                if (right === "max") {
-                    mathFn = "max"
-                } else if (right === "min") {
-                    mathFn = "min"
-                } else if (right === "randomRange") {
-                    mathFn = "random.randint"
-                } else {
-                    throw Error(`Unsupported math fn: ${left}.${right}`);
-                }
-                return [mathFn, leftSup]
-            } else if (left === "console") {
-                if (right === "log") {
-                    return ["print", leftSup]
-                }
-            }
 
             return [`${left}.${right}`, leftSup];
         }


### PR DESCRIPTION
Fixes microsoft/pxt-minecraft/issues/858, and max/min/randint conversion between Python and TS.