### PR TITLE
Add ability to ramp frequencies of sounds

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -431,6 +431,7 @@ namespace pxsim {
                 const duration = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 4)
                 const startVol = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 6)
                 const endVol = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 8)
+                const endFreq = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 10)
 
                 if (!ctx || prevStop != instrStopId)
                     return Promise.delay(duration)
@@ -454,12 +455,24 @@ namespace pxsim {
                     ch.gain = ctx.createGain()
                     ch.gain.gain.value = scaleVol(startVol)
 
+                    if (endFreq != freq) {
+                        if ((ch.generator as any).frequency != undefined) {
+                            // If generator is an OscillatorNode
+                            const param = (ch.generator as any).frequency as AudioParam;
+                            param.linearRampToValueAtTime(endFreq, ctx.currentTime + ((timeOff + duration) / 1000));
+                        } else if ((ch.generator as any).playbackRate != undefined) {
+                            // If generator is an AudioBufferSourceNode
+                            const param = (ch.generator as any).playbackRate as AudioParam;
+                            param.linearRampToValueAtTime(endFreq / (context().sampleRate / 1024), ctx.currentTime + ((timeOff + duration) / 1000));
+                        }
+                    }
+
                     ch.generator.connect(ch.gain)
                     ch.gain.connect(ctx.destination);
                     ch.generator.start();
                 }
 
-                idx += 10
+                idx += 12
 
                 ch.gain.gain.setValueAtTime(scaleVol(startVol), ctx.currentTime + (timeOff / 1000))
                 timeOff += duration


### PR DESCRIPTION
This is the simulator implementation of ramping the frequencies of sounds. Needs to be merged in conjunction with microsoft/pxt-common-packages#841