### PR TITLE
Fix UTF8 literal string generation

### DIFF
--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -103,7 +103,7 @@ namespace ts.pxtc {
             let vt = "pxt::string_inline_ascii_vt"
             let utfLit = target.utf8 ? U.toUTF8(strLit, true) : strLit
             if (utfLit !== strLit) {
-                if (utfLit.length > SKIP_INCR) {
+                if (strLit.length > SKIP_INCR) {
                     vt = "pxt::string_skiplist16_vt"
                     let skipList: number[] = []
                     let off = 0


### PR DESCRIPTION
Without this, this fails to compile for native:
```
mySprite.say("你好世界,让我们来数苹果吧")
```
