### PR TITLE
add default array.sort behavior for numbers and strings

### DIFF
--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -116,11 +116,17 @@ namespace helpers {
     }
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
-        if (!callbackfn) {
-            //TODO: support native strings and number sorting
-            /* callbackfn = function (value1: string, value2: string) : number {
-                return value1.compare(value2);
-                }*/
+        if (!callbackfn && arr.length > 1) {
+            const firstElement = arr[0];
+            if (typeof(firstElement) == "string") {
+                callbackfn = (a, b) => {
+                    return (a as any as string).compare(b as any as string);
+                }
+            } else if (typeof(firstElement) == "number") {
+                callbackfn = (a, b) => {
+                    return (a as any as number) - (b as any as number);
+                }
+            }
         }
         return sortHelper(arr, callbackfn);
     }

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -103,15 +103,43 @@ namespace helpers {
         if (arr.length <= 0 || !callbackfn) {
             return arr;
         }
-        let len = arr.length;
-        // simple selection sort.
-        for (let i = 0; i < len - 1; ++i) {
-            for (let j = i + 1; j < len; ++j) {
-                if (callbackfn(arr[i], arr[j]) > 0) {
-                    swap(arr, i, j);
-                }
+
+        function buildMaxHeap(a: T[]) {
+            let i = Math.floor(a.length / 2 - 1);
+
+            while (i >= 0) {
+                heapify(a, i, a.length);
+                i -= 1;
             }
         }
+
+        function heapify(heap: T[], i: number, max: number) {
+            while (i < max) {
+                const left = 2 * i + 1;
+                const right = left + 1;
+                let curr = i;
+
+                if (left < max && callbackfn(heap[curr], heap[left])) {
+                    curr = left;
+                }
+
+                if (right < max && callbackfn(heap[curr], heap[right])) {
+                    curr = right;
+                }
+
+                if (curr == i) return;
+
+                swap(heap, i, curr);
+                i = curr;
+            }
+        }
+        buildMaxHeap(arr);
+
+        for (let i = arr.length - 1; i > 0; --i) {
+            swap(arr, 0, i);
+            heapify(arr, 0, i);
+        }
+
         return arr;
     }
 

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -117,14 +117,21 @@ namespace helpers {
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
         if (!callbackfn && arr.length > 1) {
-            if (arr.every(v => typeof(v) == "string")) {
-                callbackfn = (a, b) => {
-                    return (a as any as string).compare(b as any as string);
-                }
-            } else if (arr.every(v => typeof(v) == "number")) {
-                callbackfn = (a, b) => {
-                    return (a as any as number) - (b as any as number);
-                }
+            callbackfn = (a, b) => {
+                // default is sort as if the element were a string, with null < undefined
+                const aIsUndef = a === undefined;
+                const bIsUndef = b === undefined;
+                if (aIsUndef && bIsUndef) return 0;
+                else if (aIsUndef) return 1;
+                else if (bIsUndef) return -1;
+
+                const aIsNull = a === null;
+                const bIsNull = b === null;
+                if (aIsNull && bIsNull) return 0;
+                else if (aIsNull) return 1;
+                else if (bIsNull) return -1;
+
+                return (a + "").compare(b + "");
             }
         }
         return sortHelper(arr, callbackfn);

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -117,12 +117,11 @@ namespace helpers {
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
         if (!callbackfn && arr.length > 1) {
-            const firstElement = arr[0];
-            if (typeof(firstElement) == "string") {
+            if (!arr.some(v => typeof(v) != "string")) {
                 callbackfn = (a, b) => {
                     return (a as any as string).compare(b as any as string);
                 }
-            } else if (typeof(firstElement) == "number") {
+            } else if (!arr.some(v => typeof(v) != "number")) {
                 callbackfn = (a, b) => {
                     return (a as any as number) - (b as any as number);
                 }

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -103,43 +103,15 @@ namespace helpers {
         if (arr.length <= 0 || !callbackfn) {
             return arr;
         }
-
-        function buildMaxHeap(a: T[]) {
-            let i = Math.floor(a.length / 2 - 1);
-
-            while (i >= 0) {
-                heapify(a, i, a.length);
-                i -= 1;
+        let len = arr.length;
+        // simple selection sort.
+        for (let i = 0; i < len - 1; ++i) {
+            for (let j = i + 1; j < len; ++j) {
+                if (callbackfn(arr[i], arr[j]) > 0) {
+                    swap(arr, i, j);
+                }
             }
         }
-
-        function heapify(heap: T[], i: number, max: number) {
-            while (i < max) {
-                const left = 2 * i + 1;
-                const right = left + 1;
-                let curr = i;
-
-                if (left < max && callbackfn(heap[curr], heap[left])) {
-                    curr = left;
-                }
-
-                if (right < max && callbackfn(heap[curr], heap[right])) {
-                    curr = right;
-                }
-
-                if (curr == i) return;
-
-                swap(heap, i, curr);
-                i = curr;
-            }
-        }
-        buildMaxHeap(arr);
-
-        for (let i = arr.length - 1; i > 0; --i) {
-            swap(arr, 0, i);
-            heapify(arr, 0, i);
-        }
-
         return arr;
     }
 

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -117,11 +117,11 @@ namespace helpers {
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
         if (!callbackfn && arr.length > 1) {
-            if (!arr.some(v => typeof(v) != "string")) {
+            if (arr.every(v => typeof(v) == "string")) {
                 callbackfn = (a, b) => {
                     return (a as any as string).compare(b as any as string);
                 }
-            } else if (!arr.some(v => typeof(v) != "number")) {
+            } else if (arr.every(v => typeof(v) == "number")) {
                 callbackfn = (a, b) => {
                     return (a as any as number) - (b as any as number);
                 }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -116,11 +116,17 @@ namespace helpers {
     }
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
-        if (!callbackfn) {
-            //TODO: support native strings and number sorting
-            /* callbackfn = function (value1: string, value2: string) : number {
-                return value1.compare(value2);
-                }*/
+        if (!callbackfn && arr.length > 1) {
+            const firstElement = arr[0];
+            if (typeof(firstElement) == "string") {
+                callbackfn = (a, b) => {
+                    return (a as any as string).compare(b as any as string);
+                }
+            } else if (typeof(firstElement) == "number") {
+                callbackfn = (a, b) => {
+                    return (a as any as number) - (b as any as number);
+                }
+            }
         }
         return sortHelper(arr, callbackfn);
     }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -103,15 +103,43 @@ namespace helpers {
         if (arr.length <= 0 || !callbackfn) {
             return arr;
         }
-        let len = arr.length;
-        // simple selection sort.
-        for (let i = 0; i < len - 1; ++i) {
-            for (let j = i + 1; j < len; ++j) {
-                if (callbackfn(arr[i], arr[j]) > 0) {
-                    swap(arr, i, j);
-                }
+
+        function buildMaxHeap(a: T[]) {
+            let i = Math.floor(a.length / 2 - 1);
+
+            while (i >= 0) {
+                heapify(a, i, a.length);
+                i -= 1;
             }
         }
+
+        function heapify(heap: T[], i: number, max: number) {
+            while (i < max) {
+                const left = 2 * i + 1;
+                const right = left + 1;
+                let curr = i;
+
+                if (left < max && callbackfn(heap[curr], heap[left])) {
+                    curr = left;
+                }
+
+                if (right < max && callbackfn(heap[curr], heap[right])) {
+                    curr = right;
+                }
+
+                if (curr == i) return;
+
+                swap(heap, i, curr);
+                i = curr;
+            }
+        }
+        buildMaxHeap(arr);
+
+        for (let i = arr.length - 1; i > 0; --i) {
+            swap(arr, 0, i);
+            heapify(arr, 0, i);
+        }
+
         return arr;
     }
 

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -117,14 +117,21 @@ namespace helpers {
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
         if (!callbackfn && arr.length > 1) {
-            if (arr.every(v => typeof(v) == "string")) {
-                callbackfn = (a, b) => {
-                    return (a as any as string).compare(b as any as string);
-                }
-            } else if (arr.every(v => typeof(v) == "number")) {
-                callbackfn = (a, b) => {
-                    return (a as any as number) - (b as any as number);
-                }
+            callbackfn = (a, b) => {
+                // default is sort as if the element were a string, with null < undefined
+                const aIsUndef = a === undefined;
+                const bIsUndef = b === undefined;
+                if (aIsUndef && bIsUndef) return 0;
+                else if (aIsUndef) return 1;
+                else if (bIsUndef) return -1;
+
+                const aIsNull = a === null;
+                const bIsNull = b === null;
+                if (aIsNull && bIsNull) return 0;
+                else if (aIsNull) return 1;
+                else if (bIsNull) return -1;
+
+                return (a + "").compare(b + "");
             }
         }
         return sortHelper(arr, callbackfn);

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -117,12 +117,11 @@ namespace helpers {
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
         if (!callbackfn && arr.length > 1) {
-            const firstElement = arr[0];
-            if (typeof(firstElement) == "string") {
+            if (!arr.some(v => typeof(v) != "string")) {
                 callbackfn = (a, b) => {
                     return (a as any as string).compare(b as any as string);
                 }
-            } else if (typeof(firstElement) == "number") {
+            } else if (!arr.some(v => typeof(v) != "number")) {
                 callbackfn = (a, b) => {
                     return (a as any as number) - (b as any as number);
                 }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -103,43 +103,15 @@ namespace helpers {
         if (arr.length <= 0 || !callbackfn) {
             return arr;
         }
-
-        function buildMaxHeap(a: T[]) {
-            let i = Math.floor(a.length / 2 - 1);
-
-            while (i >= 0) {
-                heapify(a, i, a.length);
-                i -= 1;
+        let len = arr.length;
+        // simple selection sort.
+        for (let i = 0; i < len - 1; ++i) {
+            for (let j = i + 1; j < len; ++j) {
+                if (callbackfn(arr[i], arr[j]) > 0) {
+                    swap(arr, i, j);
+                }
             }
         }
-
-        function heapify(heap: T[], i: number, max: number) {
-            while (i < max) {
-                const left = 2 * i + 1;
-                const right = left + 1;
-                let curr = i;
-
-                if (left < max && callbackfn(heap[curr], heap[left])) {
-                    curr = left;
-                }
-
-                if (right < max && callbackfn(heap[curr], heap[right])) {
-                    curr = right;
-                }
-
-                if (curr == i) return;
-
-                swap(heap, i, curr);
-                i = curr;
-            }
-        }
-        buildMaxHeap(arr);
-
-        for (let i = arr.length - 1; i > 0; --i) {
-            swap(arr, 0, i);
-            heapify(arr, 0, i);
-        }
-
         return arr;
     }
 

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -117,11 +117,11 @@ namespace helpers {
 
     export function arraySort<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
         if (!callbackfn && arr.length > 1) {
-            if (!arr.some(v => typeof(v) != "string")) {
+            if (arr.every(v => typeof(v) == "string")) {
                 callbackfn = (a, b) => {
                     return (a as any as string).compare(b as any as string);
                 }
-            } else if (!arr.some(v => typeof(v) != "number")) {
+            } else if (arr.every(v => typeof(v) == "number")) {
                 callbackfn = (a, b) => {
                     return (a as any as number) - (b as any as number);
                 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2072
fixes https://github.com/microsoft/pxt-arcade/issues/782

matches javascript at least? Sorting number arrays isn't generally useful in javascript without adding the callback, but at least it will do something.