### PR TITLE
fixes for large classes and static fields

### DIFF
--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -592,7 +592,7 @@ ${baseLabel}_nochk:
                 let off = info.idx * 4 + 4
                 let xoff = "#" + off
                 if (off > 124) {
-                    this.t.emit_int(off, "r3")
+                    this.write(this.t.emit_int(off, "r3"))
                     xoff = "r3"
                 }
                 if (store)
@@ -606,7 +606,7 @@ ${baseLabel}_nochk:
                 let off = info.idx * 4 + 4
                 let xoff = "#" + off
                 if (off > 124) {
-                    this.t.emit_int(off, "r3")
+                    this.write(this.t.emit_int(off, "r3"))
                     xoff = "r3"
                 }
 
@@ -618,7 +618,7 @@ ${baseLabel}_nochk:
                     this.write(`bl _pxt_decr`)
                     this.write(`pop {r0, r1}`)
                     if (off > 124)
-                        this.t.emit_int(off, "r3")
+                        this.write(this.t.emit_int(off, "r3"))
                     this.write(`str r1, [r0, ${xoff}]`)
                     if (info.needsCheck)
                         this.write(`ldrh r2, [r0, #0]`)

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1431,7 +1431,8 @@ namespace ts.pxtc {
                 for (let mem of decl.members) {
                     if (mem.kind == SK.PropertyDeclaration) {
                         let pdecl = <PropertyDeclaration>mem
-                        info.allfields.push(pdecl)
+                        if (!isStatic(pdecl))
+                            info.allfields.push(pdecl)
                     } else if (mem.kind == SK.Constructor) {
                         for (let p of (mem as FunctionLikeDeclaration).parameters) {
                             if (isCtorField(p))
@@ -2918,9 +2919,14 @@ ${lbl}: .short 0xffff
         }
 
         function fieldIndexCore(info: ClassInfo, fld: FieldWithAddInfo, needsCheck = true): FieldAccessInfo {
+            if (isStatic(fld))
+                U.oops("fieldIndex on static field: " + getName(fld))
             let attrs = parseComments(fld)
+            let idx = info.allfields.indexOf(fld) 
+            if (idx < 0 && bin.finalPass)
+                U.oops("missing field")
             return {
-                idx: info.allfields.indexOf(fld),
+                idx,
                 name: getName(fld),
                 isRef: true,
                 shimName: attrs.shim,

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2922,7 +2922,7 @@ ${lbl}: .short 0xffff
             if (isStatic(fld))
                 U.oops("fieldIndex on static field: " + getName(fld))
             let attrs = parseComments(fld)
-            let idx = info.allfields.indexOf(fld) 
+            let idx = info.allfields.indexOf(fld)
             if (idx < 0 && bin.finalPass)
                 U.oops("missing field")
             return {


### PR DESCRIPTION
* we had a bug where field access in classes over 127 bytes wouldn't be emitted correctly
* static fields used to be included in every instance of a class

@abchatra  After some testing on `dev` you may want this on `master`.