### PR TITLE
Fix decompilation for microbit game of life example

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1397,8 +1397,6 @@ ${output}</xml>`;
                     case SK.LessThanEqualsToken:
                     case SK.GreaterThanToken:
                     case SK.GreaterThanEqualsToken:
-                    // TODO: &&, ||, ! should check against non boolean l / r (e.g. not `1 || 2`)
-                    // https://github.com/Microsoft/pxt-arcade/issues/946
                     case SK.AmpersandAmpersandToken:
                     case SK.BarBarToken:
                         return undefined;

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1409,10 +1409,12 @@ ${output}</xml>`;
 
             function checkBooleanCallExpression(n: CallExpression) {
                 const callInfo: pxtc.CallInfo = (n.expression as any).callInfo;
-                const type = callInfo.decl.type;
+                if (callInfo) {
+                    const type = callInfo.decl.type;
 
-                if (type && type.kind === SK.BooleanKeyword) {
-                    return undefined;
+                    if (type && type.kind === SK.BooleanKeyword) {
+                        return undefined;
+                    }
                 }
                 return Util.lf("Only functions that return booleans are allowed as conditions");
             }

--- a/tests/decompile-test/baselines/ts_block_as_conditional.blocks
+++ b/tests/decompile-test/baselines/ts_block_as_conditional.blocks
@@ -1,0 +1,22 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="typescript_statement">
+<mutation numlines="3" error="Function with return value not supported in blocks" line0="function getBool&#40;&#41; &#123;" line1="    return true&#59;" line2="&#125;" />
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">getBool&#40;&#41;</field>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/ts_block_as_conditional.ts
+++ b/tests/decompile-test/cases/ts_block_as_conditional.ts
@@ -1,0 +1,7 @@
+function getBool() {
+    return true;
+}
+
+if (getBool()) {
+
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2079

Issue was having a user function in a gray block return a boolean; in this case, the CallExpression itself had a ``.callInfo`` property because it was already a gray block, rather than having it on the expression itself

![microbit-screenshot (4)](https://user-images.githubusercontent.com/5615930/58588048-a1ad7600-8213-11e9-93b1-72900eb9c08f.png)
