### PR TITLE
[gh-integration] make 'Auto-initialized' contain all necessary files

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -478,7 +478,6 @@ export async function bumpAsync(hd: Header) {
 }
 
 export async function commitAsync(hd: Header, msg: string, tag = "", filenames: string[] = null) {
-    // call this
     let files = await getTextAsync(hd.id)
     let gitjsontext = files[GIT_JSON]
     if (!gitjsontext)

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -478,6 +478,7 @@ export async function bumpAsync(hd: Header) {
 }
 
 export async function commitAsync(hd: Header, msg: string, tag = "", filenames: string[] = null) {
+    // call this
     let files = await getTextAsync(hd.id)
     let gitjsontext = files[GIT_JSON]
     if (!gitjsontext)
@@ -625,14 +626,21 @@ export async function recomputeHeaderFlagsAsync(h: Header, files: ScriptText) {
     h.githubCurrent = true
 }
 
-export async function initializeGithubRepoAsync(hd: Header, repoid: string) {
+export async function initializeGithubRepoAsync(hd: Header, repoid: string, addDefaultFiles?: boolean) {
     let parsed = pxt.github.parseRepoId(repoid)
     let name = parsed.fullName.replace(/.*\//, "")
-    let files = pxt.packageFiles(name)
+    let files = pxt.packageFiles(name);
     pxt.packageFilesFixup(files, true)
 
-    let currFiles = await getTextAsync(hd.id)
-    U.jsonMergeFrom(currFiles, files)
+    let currFiles = await getTextAsync(hd.id);
+
+    if (addDefaultFiles) {
+        const initFiles = pxt.packageFiles(parsed.fullName.replace('/', '-'));
+        pxt.packageFilesFixup(initFiles);
+        U.jsonMergeFrom(currFiles, initFiles);
+    }
+
+    U.jsonMergeFrom(currFiles, files);
 
     await saveAsync(hd, currFiles)
     await commitAsync(hd, "Auto-initialized.", "", Object.keys(currFiles))
@@ -663,12 +671,7 @@ export async function importGithubAsync(id: string) {
         if (e.statusCode == 409) {
             // this means repo is completely empty; 
             // put all default files in there
-            const files = pxt.packageFiles(parsed.fullName.replace('/', '-'));
-            pxt.packageFilesFixup(files)
-            for (const f in files) {
-                const c = files[f];
-                await pxt.github.putFileAsync(parsed.fullName, f, c)
-            };
+            await pxt.github.putFileAsync(parsed.fullName, ".gitignore", "# Initial\n");
             isEmpty = true
             sha = await pxt.github.getRefAsync(parsed.fullName, parsed.tag)
         }
@@ -678,7 +681,7 @@ export async function importGithubAsync(id: string) {
     return await githubUpdateToAsync(null, repoid, sha, {})
         .then(hd => {
             if (isEmpty)
-                return initializeGithubRepoAsync(hd, repoid)
+                return initializeGithubRepoAsync(hd, repoid, true);
             return hd
         })
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1011

Package all the files into the second 'Auto-initialized' commit instead of separating each one out as 10 separate commits

current behavior: https://github.com/jwunderl/pxt-buncha-commits-test/commits/master
this change: https://github.com/jwunderl/pxt-test-fixes/commits/master
