### PR TITLE
Include release date for mbit Summer Beta

### DIFF
--- a/docs/blog/microbit/2019-beta.md
+++ b/docs/blog/microbit/2019-beta.md
@@ -6,6 +6,14 @@ Believe it or not, we are getting ready to ship the **Summer 2019 release** of *
 
 If you are the type of person who puts in pre-orders, goes to the opening night of a movie, or tries out brand new restaurants, then please start using the beta and tell us what you think!
 
+## ~reminder
+
+### Update!
+
+We have a date! We plan to release this Beta live on **Friday June 14th**!
+
+## ~
+
 **https://makecode.microbit.org/beta**
 
 ## Finding bugs or suggesting inprovements


### PR DESCRIPTION
Added it using the new ``reminder`` block. I can move it to the very top of the post for more immediate effect if you like that.

Also, I've changed "into production" to "live" as the general reader base my not be as familiar with that terminology.

Closes #5439
