### PR TITLE
Sprite markee fixes

### DIFF
--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -432,7 +432,8 @@ namespace pxtsprite {
                 PaintTool.Rectangle,
                 PaintTool.Erase,
                 PaintTool.Circle,
-                PaintTool.Line
+                PaintTool.Line,
+                PaintTool.Marquee
             ]
 
             tools.forEach(tool => {

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -328,7 +328,9 @@ namespace pxtsprite {
 
         closeEditor() {
             if (this.closeHandler) {
-                this.closeHandler();
+                const ch = this.closeHandler;
+                this.closeHandler = undefined;
+                ch();
                 if (this.state.floatingLayer) {
                     this.state.mergeFloatingLayer();
                     this.pushState(true);

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -26,6 +26,8 @@ namespace pxtsprite {
                 return "l";
             case PaintTool.Erase:
                 return "e";
+            case PaintTool.Marquee:
+                return "m";
             default:
                 return undefined;
         }

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -27,7 +27,7 @@ namespace pxtsprite {
             case PaintTool.Erase:
                 return "e";
             case PaintTool.Marquee:
-                return "m";
+                return "s";
             default:
                 return undefined;
         }


### PR DESCRIPTION
- "m" shortcut
- don't stack overflow on close