### PR TITLE
Py module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "5.17.15",
+  "version": "5.17.16",
   "description": "Microsoft MakeCode, also known as Programming Experience Toolkit (PXT), provides Blocks / JavaScript tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -325,7 +325,6 @@ namespace ts.pxtc {
                     r.pyName = snakify(r.name).toUpperCase()
                     break
                 case SymbolKind.Variable:
-                case SymbolKind.Module:
                 case SymbolKind.Method:
                 case SymbolKind.Property:
                 case SymbolKind.Function:
@@ -334,6 +333,7 @@ namespace ts.pxtc {
                 case SymbolKind.Enum:
                 case SymbolKind.Class:
                 case SymbolKind.Interface:
+                case SymbolKind.Module:
                 default:
                     r.pyName = r.name
                     break

--- a/pxtpy/ast.ts
+++ b/pxtpy/ast.ts
@@ -179,6 +179,7 @@ namespace pxt.py {
         decorator_list: Expr[];
         baseClass?: ClassDef;
         isEnum?: boolean;
+        isNamespace?: boolean;
     }
     export interface Return extends Stmt {
         kind: "Return";

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1294,7 +1294,8 @@ namespace pxt.py {
             pref = "export "
         if (nm && ctx.currClass && !ctx.currFun) {
             // class fields can't be const
-            isConstCall = isConstCall && !ctx.currClass.isNamespace;
+            // hack: value in @namespace should always be const
+            isConstCall = value && ctx.currClass.isNamespace;
             let fd = getClassField(ctx.currClass.symInfo, nm)
             // TODO: use or remove this code
             /*

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1333,14 +1333,14 @@ namespace pxt.py {
             }
             unifyTypeOf(target, fd.pyRetType)
             fd.isInstance = false
-            pref = ctx.currClass.isNamespace ? "export " : "static "
+            pref = ctx.currClass.isNamespace ? `export ${isConstCall ? "const" : "let"} ` : "static "
         }
         if (value)
             unifyTypeOf(target, typeOf(value))
         if (isConstCall || isUpperCase) {
             // first run would have "let" in it
             defvar(getName(target), {})
-            if (!/^(static|export) /.test(pref))
+            if (!/^static /.test(pref) && !/const/.test(pref))
                 pref += "const ";
             return B.mkStmt(B.mkText(pref), B.mkInfix(expr(target), "=", expr(value)))
         }

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1020,7 +1020,7 @@ namespace pxt.py {
             U.assert(!ctx.currClass)
             let topLev = isTopLevel()
             ctx.currClass = n
-            n.isNamespace = n.decorator_list.some(d => getFullName(d) == "namespace");
+            n.isNamespace = n.decorator_list.some(d => d.kind == "Name" && (<Name>d).id == "namespace");
             let nodes = n.isNamespace ?
                 [B.mkText("namespace "), quote(n.name)]
                 : [

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -293,7 +293,7 @@ namespace pxt.py {
                 .reduce((p, c) => p.concat(c), [])
                 .map(n => indent1(n));
 
-            return [`class ${name}:`].concat(stmts);
+            return [`@namespace`, `class ${name}:`].concat(stmts);
         }
         function emitTypeAliasDecl(s: ts.TypeAliasDeclaration): string[] {
             let typeStr = emitType(s.type)

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -280,9 +280,20 @@ namespace pxt.py {
                 return emitTypeAliasDecl(s)
             } else if (ts.isEmptyStatement(s)) {
                 return []
+            } else if (ts.isModuleDeclaration(s)) {
+                return emitModuleDeclaration(s);
             } else {
                 throw Error(`Not implemented: statement kind ${s.kind}`);
             }
+        }
+        function emitModuleDeclaration(s: ts.ModuleDeclaration): string[] {
+            let name = getName(s.name)
+            let stmts = s.body && s.body.getChildren()
+                .map(emitNode)
+                .reduce((p, c) => p.concat(c), [])
+                .map(n => indent1(n));
+
+            return [`class ${name}:`].concat(stmts);
         }
         function emitTypeAliasDecl(s: ts.TypeAliasDeclaration): string[] {
             let typeStr = emitType(s.type)

--- a/tests/python/game.py
+++ b/tests/python/game.py
@@ -1,3 +1,7 @@
+@namespace
+class SpriteKind:
+  Taco = 123
+
 class Foo:
   def qux2(self):
     z = 12


### PR DESCRIPTION
Fix python for Arcade "SpriteKind" support. Support for
```
@namespace
class SpriteKind:
   Taco = ...
```
compiles down to 
```
namespace SpriteKind {
   export const Taco = 
}
```
