### PR TITLE
Allow for config values to be null

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -816,6 +816,11 @@ namespace pxt.cpp {
 
         // merge optional settings
         U.jsonCopyFrom(optSettings, currSettings);
+        U.iterMap(optSettings, (k, v) => {
+            if (v === null) {
+                delete optSettings[k];
+            }
+        })
         const configJson = U.jsonUnFlatten(optSettings)
         if (isDockerMake) {
             let packageJson = {

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -107,7 +107,6 @@ export class Editor extends srceditor.Editor {
         // update cfg
         if (Object.keys(cfg).length) {
             if (!this.config.yotta) this.config.yotta = {};
-            Object.keys(cfg).filter(k => cfg[k] === null).forEach(k => delete cfg[k]);
             this.config.yotta.config = Util.jsonUnFlatten(cfg);
         } else {
             if (this.config.yotta) {

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -71,7 +71,7 @@ export class Editor extends srceditor.Editor {
         this.parent.forceUpdate();
     }
 
-    private depConfig() {
+    private optionaldepConfig() {
         // will contain all flatton configs
         let cfg: any = {};
         // look at all config coming dependencies
@@ -82,7 +82,7 @@ export class Editor extends srceditor.Editor {
     }
 
     isUserConfigActive(uc: pxt.CompilationConfig) {
-        let cfg = this.depConfig();
+        let cfg = this.optionaldepConfig();
         if (this.config.yotta && this.config.yotta.config)
             Util.jsonMergeFrom(cfg, this.config.yotta.config);
         // flatten configs
@@ -93,21 +93,20 @@ export class Editor extends srceditor.Editor {
     }
 
     applyUserConfig(uc: pxt.CompilationConfig) {
-        const depcfg = Util.jsonFlatten(this.depConfig());
-        const cfg = Util.jsonFlatten(this.config.yotta ? this.config.yotta.config : {});
-        const ucfg = Util.jsonFlatten(uc.config);
+        const depcfg = Util.jsonFlatten(this.optionaldepConfig());
+        const prjcfg = Util.jsonFlatten(this.config.yotta ? this.config.yotta.config : {});
+        const usercfg = Util.jsonFlatten(uc.config);
         if (this.isUserConfigActive(uc)) {
-            Object.keys(ucfg).forEach(k => {
-                if (depcfg[k]) cfg[k] = 0;
-                else delete cfg[k]
+            Object.keys(usercfg).forEach(k => {
+                delete prjcfg[k];
             });
         } else {
-            Object.keys(ucfg).forEach(k => cfg[k] = ucfg[k]);
+            Object.keys(usercfg).forEach(k => prjcfg[k] = usercfg[k]);
         }
         // update cfg
-        if (Object.keys(cfg).length) {
+        if (Object.keys(prjcfg).length) {
             if (!this.config.yotta) this.config.yotta = {};
-            this.config.yotta.config = Util.jsonUnFlatten(cfg);
+            this.config.yotta.config = Util.jsonUnFlatten(prjcfg);
         } else {
             if (this.config.yotta) {
                 delete this.config.yotta.config;


### PR DESCRIPTION
The current setup for configs is to allow for dependencies to set the config values. If there is a field defined in a dependency but not the pxt.json, then it will take the dependency's value. 

PXT also currently strips out all fields set to null in the config. This becomes problematic with the pairing options for Microbit because a couple of the user config options contain null values. [See here](https://github.com/microsoft/pxt-microbit/blob/65a05bf2d5064ff8ee3d5207a01bd01510ed5a91/libs/core/pxt.json#L77). Without the value being set, the dependency's value will be used instead making the combination of these values being invalid and not aligning to a single option.

This change simply removes the code in which we strip out those fields that are set to null.

I'm not 100% why it was used or really how to test these changes so any advice would be appreciated.

Fixes Microsoft/pxt-microbit#2045