### PR TITLE
do not issue error when cancelling github import dialogue

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2621,17 +2621,15 @@ export class ProjectView
     showImportGithubDialog() {
         dialogs.showImportGithubDialogAsync()
             .then(url => {
-                if (url) {
-                    if (url === "NEW") {
-                        dialogs.showCreateGithubRepoDialogAsync()
-                            .then(url => {
-                                if (url) {
-                                    importGithubProject(url);
-                                }
-                            })
-                    } else {
-                        importGithubProject(url);
-                    }
+                if (url === "NEW") {
+                    dialogs.showCreateGithubRepoDialogAsync()
+                        .then(url => {
+                            if (url) {
+                                importGithubProject(url);
+                            }
+                        })
+                } else if (url) {
+                    importGithubProject(url);
                 }
             }, e => {
                 core.errorNotification(lf("Sorry, that repository looks invalid."));

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2619,19 +2619,24 @@ export class ProjectView
     }
 
     showImportGithubDialog() {
-        dialogs.showImportGithubDialogAsync().done(url => {
-            if (url === "NEW") {
-                dialogs.showCreateGithubRepoDialogAsync()
-                    .then(url => {
-                        if (url)
-                            importGithubProject(url)
-                    })
-            } else if (!pxt.github.isGithubId(url)) {
-                core.errorNotification(lf("Sorry, the project url looks invalid."));
-            } else {
-                importGithubProject(url);
-            }
-        });
+        dialogs.showImportGithubDialogAsync()
+            .then(url => {
+                if (url) {
+                    if (url === "NEW") {
+                        dialogs.showCreateGithubRepoDialogAsync()
+                            .then(url => {
+                                if (url) {
+                                    importGithubProject(url);
+                                }
+                            })
+                    } else {
+                        importGithubProject(url);
+                    }
+                }
+            }, e => {
+                core.errorNotification(lf("Sorry, that repository looks invalid."));
+            })
+            .done();
     }
 
     showImportFileDialog(options?: pxt.editor.ImportFileOptions) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2107

The other error I mentioned in the issue, an exception that gets through whenever you create a new extension, is coming from the call in line 668 here:

https://github.com/microsoft/pxt/blob/20595b015c9ba303c24cfe67dedef0061bcec76d/webapp/src/workspace.ts#L667-L679

It gets propagated to the console before the catch handles it, presumably due to the restructuring of async / await functions to make them cross platform. I suppose it could be rewrittten to just use promises instead, but that seems like a bit much just to suppress an error in the console