### PR TITLE
Added line break to fix typo

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -526,6 +526,7 @@ export function showImportUrlDialogAsync() {
                     </h3>
                     <p>
                         {lf("The content below is provided by a user, and is not endorsed by Microsoft.")}
+                        <br />
                         {lf("If you think it's not appropriate, please report abuse through Settings -> Report Abuse.")}
                     </p>
                 </div>


### PR DESCRIPTION
Puts a line break between the two sentences in this dialog

## Before
![image](https://user-images.githubusercontent.com/13285164/58740452-77031f00-83c5-11e9-997b-3348139ad24d.png)

## After
![image](https://user-images.githubusercontent.com/13285164/58740483-a2860980-83c5-11e9-938b-a75e229deb59.png)

Fixes microsoft/pxt-adafruit#1042
