### PR TITLE
Fix webusb for microbit

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -60,7 +60,7 @@ function initTargetCommands() {
         pxt.debug(`loading cli extensions...`)
         let cli = require.main.require(cmdsjs)
         if (cli.deployAsync) {
-            pxt.commands.deployAsync.core = cli.deployAsync
+            pxt.commands.deployFallbackAsync = cli.deployAsync
         }
         if (cli.addCommands) {
             cli.addCommands(p)
@@ -3972,10 +3972,8 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
                     }
                     return null
                 case BuildOption.Deploy:
-                    if (pxt.commands.deployAsync.target)
-                        return pxt.commands.deployAsync.target(res)
-                    else if (pxt.commands.deployAsync.core)
-                        return pxt.commands.deployAsync.core(res)
+                    if (pxt.commands.hasDeployFn())
+                        return pxt.commands.deployAsync(res)
                     else {
                         pxt.log("no deploy functionality defined by this target")
                         return null;
@@ -6122,11 +6120,11 @@ export function mainCli(targetDir: string, args: string[] = process.argv.slice(2
                 initTargetCommands();
             }
 
-            if (!pxt.commands.deployAsync.core && build.thisBuild.deployAsync)
-                pxt.commands.deployAsync.core = build.thisBuild.deployAsync
+            if (!pxt.commands.deployFallbackAsync && build.thisBuild.deployAsync)
+                pxt.commands.deployFallbackAsync = build.thisBuild.deployAsync
 
             if (!args[0]) {
-                if (pxt.commands.deployAsync.core) {
+                if (pxt.commands.deployFallbackAsync) {
                     pxt.log("running 'pxt deploy' (run 'pxt help' for usage)")
                     args = ["deploy"]
                 } else {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -59,8 +59,8 @@ function initTargetCommands() {
     if (fs.existsSync(cmdsjs)) {
         pxt.debug(`loading cli extensions...`)
         let cli = require.main.require(cmdsjs)
-        if (cli.deployCoreAsync) {
-            pxt.commands.deployCoreAsync = cli.deployCoreAsync
+        if (cli.deployAsync) {
+            pxt.commands.deployAsync.core = cli.deployAsync
         }
         if (cli.addCommands) {
             cli.addCommands(p)
@@ -3972,11 +3972,14 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
                     }
                     return null
                 case BuildOption.Deploy:
-                    if (!pxt.commands.deployCoreAsync) {
+                    if (pxt.commands.deployAsync.target)
+                        return pxt.commands.deployAsync.target(res)
+                    else if (pxt.commands.deployAsync.core)
+                        return pxt.commands.deployAsync.core(res)
+                    else {
                         pxt.log("no deploy functionality defined by this target")
                         return null;
                     }
-                    return pxt.commands.deployCoreAsync(res);
                 case BuildOption.Run:
                     return runCoreAsync(res);
                 default:
@@ -6119,11 +6122,11 @@ export function mainCli(targetDir: string, args: string[] = process.argv.slice(2
                 initTargetCommands();
             }
 
-            if (!pxt.commands.deployCoreAsync && build.thisBuild.deployAsync)
-                pxt.commands.deployCoreAsync = build.thisBuild.deployAsync
+            if (!pxt.commands.deployAsync.core && build.thisBuild.deployAsync)
+                pxt.commands.deployAsync.core = build.thisBuild.deployAsync
 
             if (!args[0]) {
-                if (pxt.commands.deployCoreAsync) {
+                if (pxt.commands.deployAsync.core) {
                     pxt.log("running 'pxt deploy' (run 'pxt help' for usage)")
                     args = ["deploy"]
                 } else {

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -278,7 +278,6 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
     const filename = path.resolve(path.join(userProjectsDir, innerPath))
     const meth = req.method.toUpperCase()
     const cmd = meth + " " + elts[1]
-    const deployFn = pxt.commands.deployAsync.target || pxt.commands.deployAsync.core
     const readJsonAsync = () =>
         nodeutil.readResAsync(req)
             .then(buf => JSON.parse(buf.toString("utf8")))
@@ -308,9 +307,9 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
             .then(d => writePkgAssetAsync(innerPath, d))
     else if (cmd == "GET pkgasset")
         return readAssetsAsync(innerPath)
-    else if (cmd == "POST deploy" && deployFn)
+    else if (cmd == "POST deploy" && pxt.commands.hasDeployFn())
         return readJsonAsync()
-            .then(deployFn)
+            .then(pxt.commands.deployAsync)
             .then((boardCount) => {
                 return {
                     boardCount: boardCount

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -278,7 +278,7 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
     const filename = path.resolve(path.join(userProjectsDir, innerPath))
     const meth = req.method.toUpperCase()
     const cmd = meth + " " + elts[1]
-
+    const deployFn = pxt.commands.deployAsync.target || pxt.commands.deployAsync.core
     const readJsonAsync = () =>
         nodeutil.readResAsync(req)
             .then(buf => JSON.parse(buf.toString("utf8")))
@@ -308,9 +308,9 @@ function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elt
             .then(d => writePkgAssetAsync(innerPath, d))
     else if (cmd == "GET pkgasset")
         return readAssetsAsync(innerPath)
-    else if (cmd == "POST deploy" && pxt.commands.deployCoreAsync)
+    else if (cmd == "POST deploy" && deployFn)
         return readJsonAsync()
-            .then(pxt.commands.deployCoreAsync)
+            .then(deployFn)
             .then((boardCount) => {
                 return {
                     boardCount: boardCount

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -330,7 +330,7 @@ namespace pxt.editor {
         resourceImporters?: IResourceImporter[];
         beforeCompile?: () => void;
         patchCompileResultAsync?: (r: pxtc.CompileResult) => Promise<void>;
-        deployCoreAsync?: (r: pxtc.CompileResult) => Promise<void>;
+        deployAsync?: (r: pxtc.CompileResult) => Promise<void>;
         saveOnlyAsync?: (r: ts.pxtc.CompileResult) => Promise<void>;
         saveProjectAsync?: (project: pxt.cpp.HexFile) => Promise<void>;
         showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void>;

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -7,10 +7,12 @@ namespace pxt.commands {
 
     // overriden by targets
     export type DeployFnAsync = (r: ts.pxtc.CompileResult, d?: DeployOptions) => Promise<void>
-    export let deployAsync: {
-        core: DeployFnAsync,
-        target: DeployFnAsync
-    } = { core: undefined, target: undefined };
+    export let deployCoreAsync: DeployFnAsync = undefined;
+    export let deployFallbackAsync: DeployFnAsync = undefined;
+    export let hasDeployFn = () => deployCoreAsync || deployFallbackAsync
+    export let deployAsync: DeployFnAsync = (r: ts.pxtc.CompileResult, d?: DeployOptions) => {
+        return (deployCoreAsync || deployFallbackAsync)(r, d)
+    }
     export let patchCompileResultAsync: (r: pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -6,7 +6,11 @@ namespace pxt.commands {
     }
 
     // overriden by targets
-    export let deployCoreAsync: (r: ts.pxtc.CompileResult, d?: DeployOptions) => Promise<void> = undefined;
+    export type DeployFnAsync = (r: ts.pxtc.CompileResult, d?: DeployOptions) => Promise<void>
+    export let deployAsync: {
+        core: DeployFnAsync,
+        target: DeployFnAsync
+    } = { core: undefined, target: undefined };
     export let patchCompileResultAsync: (r: pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2004,7 +2004,8 @@ export class ProjectView
                         });
                     }
                 }
-                return pxt.commands.deployCoreAsync(resp, {
+                let doDeploy = pxt.commands.deployAsync.target || pxt.commands.deployAsync.core;
+                return doDeploy(resp, {
                     reportDeviceNotFoundAsync: (docPath, compileResult) => this.showDeviceNotFoundDialogAsync(docPath, compileResult),
                     reportError: (e) => core.errorNotification(e),
                     showNotification: (msg) => core.infoNotification(msg)
@@ -3420,9 +3421,9 @@ function initExtensionsAsync(): Promise<void> {
                     theEditor.resourceImporters.push(fi);
                 });
             }
-            if (res.deployCoreAsync) {
+            if (res.deployAsync) {
                 pxt.debug(`\tadded custom deploy core async`);
-                pxt.commands.deployCoreAsync = res.deployCoreAsync;
+                pxt.commands.deployAsync.target = res.deployAsync;
             }
             if (res.saveOnlyAsync) {
                 pxt.debug(`\tadded custom save only async`);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2004,8 +2004,7 @@ export class ProjectView
                         });
                     }
                 }
-                let doDeploy = pxt.commands.deployAsync.target || pxt.commands.deployAsync.core;
-                return doDeploy(resp, {
+                return pxt.commands.deployAsync(resp, {
                     reportDeviceNotFoundAsync: (docPath, compileResult) => this.showDeviceNotFoundDialogAsync(docPath, compileResult),
                     reportError: (e) => core.errorNotification(e),
                     showNotification: (msg) => core.infoNotification(msg)
@@ -3423,7 +3422,7 @@ function initExtensionsAsync(): Promise<void> {
             }
             if (res.deployAsync) {
                 pxt.debug(`\tadded custom deploy core async`);
-                pxt.commands.deployAsync.target = res.deployAsync;
+                pxt.commands.deployCoreAsync = res.deployAsync;
             }
             if (res.saveOnlyAsync) {
                 pxt.debug(`\tadded custom save only async`);

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -240,17 +240,17 @@ export function init(): void {
     const shouldUseWebUSB = pxt.usb.isEnabled && pxt.appTarget.compile.useUF2;
     if (isNativeHost()) {
         pxt.debug(`deploy: webkit host`);
-        pxt.commands.deployAsync.core = nativeHostDeployCoreAsync;
+        pxt.commands.deployFallbackAsync = nativeHostDeployCoreAsync;
         pxt.commands.saveOnlyAsync = nativeHostSaveCoreAsync;
     } else if (shouldUseWebUSB && pxt.appTarget.appTheme.autoWebUSBDownload) {
         pxt.debug(`deploy: webusb`);
-        pxt.commands.deployAsync.core = webusb.webUsbDeployCoreAsync;
+        pxt.commands.deployFallbackAsync = webusb.webUsbDeployCoreAsync;
     } else if (pxt.winrt.isWinRT()) { // windows app
         if (pxt.appTarget.serial && pxt.appTarget.serial.useHF2) {
             pxt.debug(`deploy: winrt`);
             pxt.winrt.initWinrtHid(() => hidbridge.initAsync(true).then(() => { }), () => hidbridge.disconnectWrapperAsync());
             pxt.HF2.mkPacketIOAsync = pxt.winrt.mkPacketIOAsync;
-            pxt.commands.deployAsync.core = winrtDeployCoreAsync;
+            pxt.commands.deployFallbackAsync = winrtDeployCoreAsync;
         } else {
             // If we're not using HF2, then the target is using their own deploy logic in extension.ts, so don't use
             // the wrapper callbacks
@@ -259,7 +259,7 @@ export function init(): void {
             if (pxt.appTarget.serial && pxt.appTarget.serial.rawHID) {
                 pxt.HF2.mkPacketIOAsync = pxt.winrt.mkPacketIOAsync;
             }
-            pxt.commands.deployAsync.core = pxt.winrt.driveDeployCoreAsync;
+            pxt.commands.deployFallbackAsync = pxt.winrt.driveDeployCoreAsync;
         }
         pxt.commands.browserDownloadAsync = pxt.winrt.browserDownloadAsync;
         pxt.commands.saveOnlyAsync = (resp: pxtc.CompileResult) => {
@@ -273,17 +273,17 @@ export function init(): void {
         };
     } else if (pxt.BrowserUtils.isPxtElectron()) {
         pxt.debug(`deploy: electron`);
-        pxt.commands.deployAsync.core = electron.driveDeployAsync;
+        pxt.commands.deployFallbackAsync = electron.driveDeployAsync;
         pxt.commands.electronDeployAsync = electron.driveDeployAsync;
     } else if ((tryPairedDevice && shouldUseWebUSB) || !shouldUseWebUSB && hidbridge.shouldUse() && !pxt.appTarget.serial.noDeploy && !forceHexDownload) {
         pxt.debug(`deploy: hid`);
-        pxt.commands.deployAsync.core = hidDeployCoreAsync;
+        pxt.commands.deployFallbackAsync = hidDeployCoreAsync;
     } else if (pxt.BrowserUtils.isLocalHost() && Cloud.localToken && !forceHexDownload) { // local node.js
         pxt.debug(`deploy: localhost`);
-        pxt.commands.deployAsync.core = localhostDeployCoreAsync;
+        pxt.commands.deployFallbackAsync = localhostDeployCoreAsync;
     } else { // in browser
         pxt.debug(`deploy: browser`);
-        pxt.commands.deployAsync.core = shouldUseWebUSB ? checkWebUSBThenDownloadAsync : browserDownloadDeployCoreAsync;
+        pxt.commands.deployFallbackAsync = shouldUseWebUSB ? checkWebUSBThenDownloadAsync : browserDownloadDeployCoreAsync;
     }
 }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -234,7 +234,7 @@ export function init(): void {
         pxt.HF2.mkPacketIOAsync = hidbridge.mkBridgeAsync;
     }
 
-    const shouldUseWebUSB = pxt.usb.isEnabled && pxt.appTarget.compile.useUF2;
+    const shouldUseWebUSB = pxt.usb.isEnabled && pxt.appTarget.compile.webUSB;
     if (isNativeHost()) {
         pxt.debug(`deploy: webkit host`);
         pxt.commands.deployCoreAsync = nativeHostDeployCoreAsync;

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -142,15 +142,12 @@ function nativeHostSaveCoreAsync(resp: pxtc.CompileResult): Promise<void> {
 }
 
 export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.DeployOptions): Promise<void> {
-    console.log("hidDeployCoreAsync")
     pxt.tickEvent(`hid.deploy`)
     // error message handled in browser download
     if (!resp.success)
         return browserDownloadDeployCoreAsync(resp);
     core.infoNotification(lf("Downloading..."));
     let f = resp.outfiles[pxtc.BINARY_UF2]
-    if (!f)
-        console.error("No UF2 file!") // TODO(dz)
     let blocks = pxtc.UF2.parseFile(pxt.Util.stringToUint8Array(atob(f)))
     return hidbridge.initAsync()
         .then(dev => dev.reflashAsync(blocks))
@@ -220,10 +217,7 @@ function localhostDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     return deploy()
 }
 
-// TODO(dz): choose deploy core function
-
 export function init(): void {
-    debugger;
     pxt.onAppTargetChanged = () => {
         pxt.debug('app target changed')
         init()
@@ -300,14 +294,11 @@ export function setWebUSBPaired(enabled: boolean) {
 }
 
 function checkWebUSBThenDownloadAsync(resp: pxtc.CompileResult) {
-    console.log("checkWebUSBThenDownloadAsync")
     return pxt.usb.isPairedAsync().then(paired => {
         if (paired) {
             setWebUSBPaired(true);
-            console.log("checkWebUSBThenDownloadAsync hidDeployCoreAsync")
             return hidDeployCoreAsync(resp);
         }
-        console.log("checkWebUSBThenDownloadAsync browserDownloadDeployCoreAsync")
         return browserDownloadDeployCoreAsync(resp);
     });
 }


### PR DESCRIPTION
Fixes WebUSB in microbit. The issue is that we set a "deployCoreAsync" function in pxt-core which can be overridden by the target (microbit may be the only one that does this) and we were reverting the target override after USB pairing. Likely introduced by https://github.com/microsoft/pxt/pull/5517.

The fix was to keep the pxt-core deploy function selection separate from the target's deploy function override and then always prefer the target's override if it exists at the callsite.

related: https://github.com/microsoft/pxt-microbit/pull/2115

fixes: https://github.com/microsoft/pxt-microbit/issues/2089

https://makecode.microbit.org/app/fc71444bb8dcd5f94c4ac4f8ca9c1ba0f0342c34-93265192c2

TODO:
- [x] microbit sibiling PR
- [x] test arcade webusb
- [x] test arcade download
- [x] test adafruit webusb
- [x] test adafruit download
- [x] test microbit download
