### PR TITLE
use heap sort for sorting large arrays

### DIFF
--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -99,11 +99,28 @@ namespace helpers {
         arr[j] = temp;
     }
 
-    function sortHelper<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
-        if (arr.length <= 0 || !callbackfn) {
-            return arr;
+    function sortHelper<T>(arr: T[], callbackfn: (value1: T, value2: T) => number): T[] {
+        if (arr.length > 1 && callbackfn) {
+            if (arr.length < 50) {
+                // simple selection sort for small arrays
+                const len = arr.length;
+                for (let i = 0; i < len - 1; ++i) {
+                    for (let j = i + 1; j < len; ++j) {
+                        if (callbackfn(arr[i], arr[j]) > 0) {
+                            swap(arr, i, j);
+                        }
+                    }
+                }
+            } else {
+                // heap sort for larger arrays
+                arr =  heapSort(arr, callbackfn);
+            }
         }
 
+        return arr;
+    }
+
+    function heapSort<T>(arr: T[], callbackfn: (value1: T, value2: T) => number): T[] {
         function buildMaxHeap(a: T[]) {
             let i = Math.floor(a.length / 2 - 1);
 
@@ -119,11 +136,11 @@ namespace helpers {
                 const right = left + 1;
                 let curr = i;
 
-                if (left < max && callbackfn(heap[curr], heap[left])) {
+                if (left < max && callbackfn(heap[curr], heap[left]) < 0) {
                     curr = left;
                 }
 
-                if (right < max && callbackfn(heap[curr], heap[right])) {
+                if (right < max && callbackfn(heap[curr], heap[right]) < 0) {
                     curr = right;
                 }
 
@@ -133,6 +150,7 @@ namespace helpers {
                 i = curr;
             }
         }
+
         buildMaxHeap(arr);
 
         for (let i = arr.length - 1; i > 0; --i) {

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -103,15 +103,43 @@ namespace helpers {
         if (arr.length <= 0 || !callbackfn) {
             return arr;
         }
-        let len = arr.length;
-        // simple selection sort.
-        for (let i = 0; i < len - 1; ++i) {
-            for (let j = i + 1; j < len; ++j) {
-                if (callbackfn(arr[i], arr[j]) > 0) {
-                    swap(arr, i, j);
-                }
+
+        function buildMaxHeap(a: T[]) {
+            let i = Math.floor(a.length / 2 - 1);
+
+            while (i >= 0) {
+                heapify(a, i, a.length);
+                i -= 1;
             }
         }
+
+        function heapify(heap: T[], i: number, max: number) {
+            while (i < max) {
+                const left = 2 * i + 1;
+                const right = left + 1;
+                let curr = i;
+
+                if (left < max && callbackfn(heap[curr], heap[left])) {
+                    curr = left;
+                }
+
+                if (right < max && callbackfn(heap[curr], heap[right])) {
+                    curr = right;
+                }
+
+                if (curr == i) return;
+
+                swap(heap, i, curr);
+                i = curr;
+            }
+        }
+        buildMaxHeap(arr);
+
+        for (let i = arr.length - 1; i > 0; --i) {
+            swap(arr, 0, i);
+            heapify(arr, 0, i);
+        }
+
         return arr;
     }
 

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -99,11 +99,28 @@ namespace helpers {
         arr[j] = temp;
     }
 
-    function sortHelper<T>(arr: T[], callbackfn?: (value1: T, value2: T) => number): T[] {
-        if (arr.length <= 0 || !callbackfn) {
-            return arr;
+    function sortHelper<T>(arr: T[], callbackfn: (value1: T, value2: T) => number): T[] {
+        if (arr.length > 1 && callbackfn) {
+            if (arr.length < 50) {
+                // simple selection sort for small arrays
+                const len = arr.length;
+                for (let i = 0; i < len - 1; ++i) {
+                    for (let j = i + 1; j < len; ++j) {
+                        if (callbackfn(arr[i], arr[j]) > 0) {
+                            swap(arr, i, j);
+                        }
+                    }
+                }
+            } else {
+                // heap sort for larger arrays
+                arr =  heapSort(arr, callbackfn);
+            }
         }
 
+        return arr;
+    }
+
+    function heapSort<T>(arr: T[], callbackfn: (value1: T, value2: T) => number): T[] {
         function buildMaxHeap(a: T[]) {
             let i = Math.floor(a.length / 2 - 1);
 
@@ -119,11 +136,11 @@ namespace helpers {
                 const right = left + 1;
                 let curr = i;
 
-                if (left < max && callbackfn(heap[curr], heap[left])) {
+                if (left < max && callbackfn(heap[curr], heap[left]) < 0) {
                     curr = left;
                 }
 
-                if (right < max && callbackfn(heap[curr], heap[right])) {
+                if (right < max && callbackfn(heap[curr], heap[right]) < 0) {
                     curr = right;
                 }
 
@@ -133,6 +150,7 @@ namespace helpers {
                 i = curr;
             }
         }
+
         buildMaxHeap(arr);
 
         for (let i = arr.length - 1; i > 0; --i) {

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -103,15 +103,43 @@ namespace helpers {
         if (arr.length <= 0 || !callbackfn) {
             return arr;
         }
-        let len = arr.length;
-        // simple selection sort.
-        for (let i = 0; i < len - 1; ++i) {
-            for (let j = i + 1; j < len; ++j) {
-                if (callbackfn(arr[i], arr[j]) > 0) {
-                    swap(arr, i, j);
-                }
+
+        function buildMaxHeap(a: T[]) {
+            let i = Math.floor(a.length / 2 - 1);
+
+            while (i >= 0) {
+                heapify(a, i, a.length);
+                i -= 1;
             }
         }
+
+        function heapify(heap: T[], i: number, max: number) {
+            while (i < max) {
+                const left = 2 * i + 1;
+                const right = left + 1;
+                let curr = i;
+
+                if (left < max && callbackfn(heap[curr], heap[left])) {
+                    curr = left;
+                }
+
+                if (right < max && callbackfn(heap[curr], heap[right])) {
+                    curr = right;
+                }
+
+                if (curr == i) return;
+
+                swap(heap, i, curr);
+                i = curr;
+            }
+        }
+        buildMaxHeap(arr);
+
+        for (let i = arr.length - 1; i > 0; --i) {
+            swap(arr, 0, i);
+            heapify(arr, 0, i);
+        }
+
         return arr;
     }
 


### PR DESCRIPTION
Separated from https://github.com/microsoft/pxt/pull/5606

use heap sort for sorting arrays with length > 50. Went with heap sort because:

* javascript sort is not guaranteed to be stable, and none of our use cases require it to be (and typical general purpose fast sorts will require extra space)
* only uses O(1) extra memory (quick sort typically requires O(log(n)) extra space https://en.wikipedia.org/wiki/Quicksort#Space_complexity, although I don't know if that would ever actually matter in our case)
* Θ(n*log(n)) runtime

marking as draft as I'll want to do some perf tests to see if the difference is actually noticeable for typical use cases (e.g. sorting spritelikes in arcade). Also would want to write the start of the libs tests runner before merging either way