### PR TITLE
string.indexOf block

### DIFF
--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -271,7 +271,7 @@ declare interface String {
     //% shim=String_::indexOf
     //% help=text/index-of
     //% blockId="string_indexof" blockNamespace="text"
-    //% block="index from %this=text|of %searchValue"
+    //% block="%this=text|find index of %searchValue"
     indexOf(searchValue: string, start?: number): number;
 
     /**

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -271,6 +271,7 @@ declare interface String {
     //% shim=String_::indexOf
     //% help=text/index-of
     //% blockId="string_indexof" blockNamespace="text"
+    //% block="index %this=text|of %searchValue"
     indexOf(searchValue: string, start?: number): number;
 
     /**
@@ -281,6 +282,7 @@ declare interface String {
     //% shim=String_::includes
     //% help=text/includes
     //% blockId="string_includes" blockNamespace="text"
+    //% block="%this=text|includes %searchValue"
     includes(searchValue: string, start?: number): boolean;
 
     /**
@@ -291,6 +293,7 @@ declare interface String {
     //% helper=stringSplit
     //% help=text/split
     //% blockId="string_split" blockNamespace="text"
+    //% block="split %this=text|at %separator"
     split(separator?: string, limit?: number): string[];
 
     [index: number]: string;

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -271,7 +271,7 @@ declare interface String {
     //% shim=String_::indexOf
     //% help=text/index-of
     //% blockId="string_indexof" blockNamespace="text"
-    //% block="index %this=text|of %searchValue"
+    //% block="index from %this=text|of %searchValue"
     indexOf(searchValue: string, start?: number): number;
 
     /**

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -271,7 +271,7 @@ declare interface String {
     //% shim=String_::indexOf
     //% help=text/index-of
     //% blockId="string_indexof" blockNamespace="text"
-    //% block="index from %this=text|of %searchValue"
+    //% block="%this=text|find index of %searchValue"
     indexOf(searchValue: string, start?: number): number;
 
     /**

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -271,6 +271,7 @@ declare interface String {
     //% shim=String_::indexOf
     //% help=text/index-of
     //% blockId="string_indexof" blockNamespace="text"
+    //% block="index from %this=text|of %searchValue"
     indexOf(searchValue: string, start?: number): number;
 
     /**
@@ -281,6 +282,7 @@ declare interface String {
     //% shim=String_::includes
     //% help=text/includes
     //% blockId="string_includes" blockNamespace="text"
+    //% block="%this=text|includes %searchValue"
     includes(searchValue: string, start?: number): boolean;
 
     /**
@@ -291,6 +293,7 @@ declare interface String {
     //% helper=stringSplit
     //% help=text/split
     //% blockId="string_split" blockNamespace="text"
+    //% block="split %this=text|at %separator"
     split(separator?: string, limit?: number): string[];
 
     [index: number]: string;


### PR DESCRIPTION
Add blocks for indexOf, includes, split.
Fix for https://github.com/microsoft/pxt-microbit/issues/1990
![image](https://user-images.githubusercontent.com/4175913/58884405-30e3df00-8695-11e9-94ed-ee85141b0c9b.png)
