### PR TITLE
Open doc pages from editor frame

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -397,11 +397,11 @@ namespace pxt.runner {
                     const docsUrl = pxt.webConfig.docsUrl || '/--docs';
                     let verPrefix = mp[2] || '';
                     let url = mp[3] == "doc" ? (pxt.webConfig.isStatic ? `/docs${mp[4]}.html` : `${mp[4]}`) : `${docsUrl}?md=${mp[4]}`;
-                    window.open(BrowserUtils.urlJoin(verPrefix, url), "_blank");
                     // notify parent iframe that we have completed the popout
                     if (window.parent)
-                        window.parent.postMessage(<pxsim.SimulatorDocsReadyMessage>{
-                            type: "popoutcomplete"
+                        window.parent.postMessage(<pxsim.SimulatorOpenDocMessage>{
+                            type: "opendoc",
+                            url: BrowserUtils.urlJoin(verPrefix, url)
                         }, "*");
                 }
                 break;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -58,8 +58,9 @@ namespace pxsim {
         type: "toplevelcodefinished";
     }
 
-    export interface SimulatorDocsReadyMessage extends SimulatorMessage {
-        type: "popoutcomplete";
+    export interface SimulatorOpenDocMessage extends SimulatorMessage {
+        type: "opendoc";
+        url: string;
     }
 
     export interface SimulatorStateMessage extends SimulatorMessage {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -917,7 +917,8 @@ export class ProjectView
 
     handleMessage(msg: pxsim.SimulatorMessage) {
         switch (msg.type) {
-            case "popoutcomplete":
+            case "opendoc":
+                window.open((msg as pxsim.SimulatorOpenDocMessage).url, "_blank");
                 this.setState({ sideDocsCollapsed: true, sideDocsLoadUrl: '' })
                 break;
             case "tutorial":
@@ -3682,7 +3683,7 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
 
-        if (m.type == "tutorial" || m.type == "popoutcomplete") {
+        if (m.type == "tutorial" || m.type == "opendoc") {
             if (theEditor && theEditor.editor)
                 theEditor.handleMessage(m);
             return;


### PR DESCRIPTION
Switches docs to open from the editor frame rather than the side doc frame

When the editor frame messages the side docs frame to open the page in a new tab, instead of the side docs frame opening the tab and sending a completion message, this sends back the url to be opened and the editor frame opens the tab instead.

Fixes Microsoft/pxt-microbit#2103 