### PR TITLE
 Restore modal for @unplugged steps, CSS fixes

### DIFF
--- a/common-docs/blocks/math.md
+++ b/common-docs/blocks/math.md
@@ -101,6 +101,38 @@ let minval = Math.min(0, 1);
 let maxval = Math.max(8, 2);
 ```
 
+## Round
+
+If a number has a fractional part, you can make the number change to be the closest, next integer value. This is called _rounding_. Rounding the number `6.78` will make it be `7` and rounding `9.3` will give you `9`. If a number has a fractional part greater than or equal to `0.5`, the number will round up to the next whole integer value. Otherwise, it will round down to the next lowest integer value.
+
+```block
+let rounded = Math.round(5.5)
+```
+
+## Ceiling
+
+To make a number change to the next higher whole number (integer), get the number's _ceiling_ value. The ceiling value for `1.234` is `2` since that is the next higher whole number.
+
+```block
+let nextup = Math.ceil(8.435)
+```
+
+## Floor
+
+To make a number change to the next lower whole number (integer), get the number's _floor_ value. The floor value for `8.76` is `8` since that is the next lower whole number.
+
+```block
+let nextdown = Math.floor(4.97)
+```
+
+## Truncate
+
+The fractional part of number is removed by _truncating_ the number. If a number has the value `54.234` its truncated value is `54`.
+
+```block
+let nonfraction = Math.trunc(87.23455)
+```
+
 ## Random value
 
 Make up any number from a minimum value to a some maximum value. If you want a random number up to

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -816,6 +816,11 @@ namespace pxt.cpp {
 
         // merge optional settings
         U.jsonCopyFrom(optSettings, currSettings);
+        U.iterMap(optSettings, (k, v) => {
+            if (v === null) {
+                delete optSettings[k];
+            }
+        })
         const configJson = U.jsonUnFlatten(optSettings)
         if (isDockerMake) {
             let packageJson = {

--- a/pxtsim/allocator.ts
+++ b/pxtsim/allocator.ts
@@ -14,6 +14,7 @@ namespace pxsim {
     export interface AllocatorResult {
         partsAndWires: PartAndWiresInst[];
         requiresBreadboard?: boolean;
+        hideBreadboard?: boolean;
         parts: pxsim.visuals.IBoardPart<any>[];
         wires: pxsim.visuals.Wire[];
     }
@@ -756,7 +757,7 @@ namespace pxsim {
                 const all = [basicWires].concat(partsAndWires)
                     .filter(pw => pw.assembly && pw.assembly.length); // only keep steps with something to do
                 // hide breadboard if not used
-                const requiresBreadboard = all.some(r =>
+                const hideBreadboard = !all.some(r =>
                     (r.part && r.part.breadboardConnections && r.part.breadboardConnections.length > 0)
                     || r.wires && r.wires.some(w => (w.end.type == "breadboard" && (<BBLoc>w.end).style != "croc") || (w.start.type == "breadboard" && (<BBLoc>w.start).style != "croc")));
 
@@ -764,7 +765,7 @@ namespace pxsim {
                     partsAndWires: all,
                     wires: [],
                     parts: [],
-                    requiresBreadboard: requiresBreadboard
+                    hideBreadboard
                 }
             } else {
                 return {

--- a/pxtsim/visuals/boardhost.ts
+++ b/pxtsim/visuals/boardhost.ts
@@ -100,6 +100,8 @@ namespace pxsim.visuals {
                     this.addAll(allocRes);
                     if (!allocRes.requiresBreadboard && !opts.forceBreadboardRender)
                         useBreadboardView = false;
+                    else if (allocRes.hideBreadboard && this.breadboard)
+                        this.breadboard.hide();
                 }
             }
 

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -270,7 +270,7 @@ span.highlight-line {
 }
 
 #tutorialcard .prevbutton:hover, #tutorialcard .nextbutton:hover {
-    background-color: #cacbcd;
+    background-color: @lightGrey;
 
     > i, > span, > i.orange {
         color: @black!important;
@@ -370,16 +370,6 @@ span.highlight-line {
 .avatar-container .tooltip:before {
     background-color: @blue;
     color: @white;
-}
-
-.showTooltip .avatar-container:hover .tooltip,
-.showTooltip .avatar-container:hover .tooltip:before {
-    display: block;
-}
-
-#tutorialcard:not(.showTooltip) .tooltip,
-#tutorialcard:not(.showTooltip) .tooltip:before {
-    display: none;
 }
 
 /*******************************

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -344,6 +344,7 @@ span.highlight-line {
     background: none;
     box-shadow: none;
     text-align: center;
+    min-height: 3em;
 }
 
 .shake {

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -284,6 +284,7 @@ span.highlight-line {
 #tutorialcard .ui.button.hintbutton {
     position: absolute;
     color: white; // match menubutton color
+    border-radius: 50%;
 }
 
 /*******************************

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -71,7 +71,7 @@ export class Editor extends srceditor.Editor {
         this.parent.forceUpdate();
     }
 
-    private depConfig() {
+    private optionaldepConfig() {
         // will contain all flatton configs
         let cfg: any = {};
         // look at all config coming dependencies
@@ -82,7 +82,7 @@ export class Editor extends srceditor.Editor {
     }
 
     isUserConfigActive(uc: pxt.CompilationConfig) {
-        let cfg = this.depConfig();
+        let cfg = this.optionaldepConfig();
         if (this.config.yotta && this.config.yotta.config)
             Util.jsonMergeFrom(cfg, this.config.yotta.config);
         // flatten configs
@@ -93,22 +93,20 @@ export class Editor extends srceditor.Editor {
     }
 
     applyUserConfig(uc: pxt.CompilationConfig) {
-        const depcfg = Util.jsonFlatten(this.depConfig());
-        const cfg = Util.jsonFlatten(this.config.yotta ? this.config.yotta.config : {});
-        const ucfg = Util.jsonFlatten(uc.config);
+        const depcfg = Util.jsonFlatten(this.optionaldepConfig());
+        const prjcfg = Util.jsonFlatten(this.config.yotta ? this.config.yotta.config : {});
+        const usercfg = Util.jsonFlatten(uc.config);
         if (this.isUserConfigActive(uc)) {
-            Object.keys(ucfg).forEach(k => {
-                if (depcfg[k]) cfg[k] = 0;
-                else delete cfg[k]
+            Object.keys(usercfg).forEach(k => {
+                delete prjcfg[k];
             });
         } else {
-            Object.keys(ucfg).forEach(k => cfg[k] = ucfg[k]);
+            Object.keys(usercfg).forEach(k => prjcfg[k] = usercfg[k]);
         }
         // update cfg
-        if (Object.keys(cfg).length) {
+        if (Object.keys(prjcfg).length) {
             if (!this.config.yotta) this.config.yotta = {};
-            Object.keys(cfg).filter(k => cfg[k] === null).forEach(k => delete cfg[k]);
-            this.config.yotta.config = Util.jsonUnFlatten(cfg);
+            this.config.yotta.config = Util.jsonUnFlatten(prjcfg);
         } else {
             if (this.config.yotta) {
                 delete this.config.yotta.config;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -435,7 +435,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron orange large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">
                     <div className="avatar-container">
-                        <div role="button" className={`avatar-image ${this.props.pokeUser ? 'shake' : ''}`} onClick={this.hintOnClick} onKeyDown={sui.fireClickOnEnter}></div>
+                        <div role="button" className={`avatar-image ${hasHint && this.props.pokeUser ? 'shake' : ''}`} onClick={this.hintOnClick} onKeyDown={sui.fireClickOnEnter}></div>
                         {hasHint && <sui.Button className="ui circular small label blue hintbutton hidelightbox" icon="lightbulb outline" tabIndex={-1} onClick={this.hintOnClick} onKeyDown={sui.fireClickOnEnter} />}
                         {hasHint && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={this.hintOnClick} />}
                         {hasHint && <TutorialHint ref="tutorialhint" parent={this.props.parent} />}
@@ -445,8 +445,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                         <div className="content">
                             <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} />
                         </div>
-                        {this.state.showSeeMore && !tutorialStepExpanded ? <sui.Button className="fluid compact attached bottom grey" icon="chevron down" tabIndex={0} text={lf("More...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} /> : undefined}
-                        {this.state.showSeeMore && tutorialStepExpanded ? <sui.Button className="fluid compact attached bottom grey" icon="chevron up" tabIndex={0} text={lf("Less...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                        {this.state.showSeeMore && !tutorialStepExpanded ? <sui.Button className="fluid compact attached bottom lightgrey" icon="chevron down" tabIndex={0} text={lf("More...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                        {this.state.showSeeMore && tutorialStepExpanded ? <sui.Button className="fluid compact attached bottom lightgrey" icon="chevron up" tabIndex={0} text={lf("Less...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                     </div>
                     <sui.Button ref="tutorialok" id="tutorialOkButton" className="large green okbutton showlightbox" text={lf("Ok")} onClick={this.closeLightbox} onKeyDown={sui.fireClickOnEnter} />
                 </div>

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -54,7 +54,6 @@ export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
 
     openTutorialStep(step: number) {
         let options = this.props.parent.state.tutorialOptions;
-        options.tutorialStep = step;
         pxt.tickEvent(`tutorial.step`, { tutorial: options.tutorial, step: step }, { interactiveConsent: true });
         this.props.parent.setTutorialStep(step);
     }
@@ -150,7 +149,6 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
         this.setState({ visible: false });
         const nextStep = tutorialStep + 1;
 
-        options.tutorialStep = nextStep;
         pxt.tickEvent(`tutorial.hint.next`, { tutorial: tutorial, step: nextStep });
         this.props.parent.setTutorialStep(nextStep);
     }


### PR DESCRIPTION
Restore modal for @unplugged steps
CSS fixes from design: remove tooltip hover, update chevron color

Modal addresses:
microsoft/pxt-microbit/issues/2118
microsoft/pxt-microbit/issues/2116 (issue 1)