### PR TITLE
Give electron deploy priority

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -273,7 +273,7 @@ export function init(): void {
         };
     } else if (pxt.BrowserUtils.isPxtElectron()) {
         pxt.debug(`deploy: electron`);
-        pxt.commands.deployFallbackAsync = electron.driveDeployAsync;
+        pxt.commands.deployCoreAsync = electron.driveDeployAsync;
         pxt.commands.electronDeployAsync = electron.driveDeployAsync;
     } else if ((tryPairedDevice && shouldUseWebUSB) || !shouldUseWebUSB && hidbridge.shouldUse() && !pxt.appTarget.serial.noDeploy && !forceHexDownload) {
         pxt.debug(`deploy: hid`);

--- a/webapp/src/electron.ts
+++ b/webapp/src/electron.ts
@@ -30,7 +30,6 @@ export function initElectron(projectView: ProjectView): void {
         } else {
             pxt.tickEvent("electron.drivedeploy.failure");
             const err = new Error("electron drive deploy failed");
-            pxt.reportException(err)
             deployingDeferred.reject(err);
         }
     });


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2114

That error is thrown when a micro:bit is not connected to the app, so no need to report it to the cloud.

Also fixes the electron deploy (requires https://github.com/microsoft/pxt-microbit/pull/2142)