### PR TITLE
Don't show Enum values in the drop-down if they are hidden

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2639,7 +2639,7 @@ namespace pxt.blocks {
     }
 
     function getEnumDropdownValues(apis: pxtc.ApisInfo, enumName: string) {
-        return pxt.Util.values(apis.byQName).filter(sym => sym.namespace === enumName);
+        return pxt.Util.values(apis.byQName).filter(sym => sym.namespace === enumName && !sym.attributes.blockHidden);
     }
 
     export function getFixedInstanceDropdownValues(apis: pxtc.ApisInfo, qName: string) {


### PR DESCRIPTION
If an enum value block is set to be hidden, don't show it in the drop-down. The only way the enum value is accessible is if previous programs included it or if the value is specified in the typescript.

![Hidden Enum](https://user-images.githubusercontent.com/13285164/59076069-d90dc980-8888-11e9-9f2f-fe446b1927fd.gif)

Needed for https://github.com/microsoft/pxt-microbit/pull/2138