### PR TITLE
add step for selecting license, remove 'license' from readme

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -1,14 +1,14 @@
 namespace pxt {
     export const TS_CONFIG =             `{
-        "compilerOptions": {
-            "target": "es5",
-            "noImplicitAny": true,
-            "outDir": "built",
-            "rootDir": "."
-        },
-        "exclude": ["pxt_modules/**/*test.ts"]
-    }
-    `;
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "outDir": "built",
+        "rootDir": "."
+    },
+    "exclude": ["pxt_modules/**/*test.ts"]
+}
+`;
     const _defaultFiles: Map<string> = {
         "tsconfig.json": TS_CONFIG,
 
@@ -38,13 +38,10 @@ test:
 - [ ] Add "- beta" to the GitHub project description if you are still iterating it.
 - [ ] Turn on your automated build on https://travis-ci.org
 - [ ] Use "pxt bump" to create a tagged release on GitHub
+- [ ] On GitHub, create a new file named LICENSE. Select the MIT License template.
 - [ ] Get your package reviewed and approved @DOCS@extensions/approval
 
 Read more at @DOCS@extensions
-
-## License
-
-@LICENSE@
 
 ## Supported targets
 


### PR DESCRIPTION
The 'license' part in the readme is a bit misleading, as it being a header with nothing in it makes me think it's where I'm supposed to paste the license. This removes that, and adds a step to the todo list to create a license (not sure on the wording - e.g. should it actually say to use mit license).

Also fixes the spacing in the generated tsconfig, which was indented improperly

Current: https://github.com/jwunderl/pxt-test-fixes
this change: https://github.com/jwunderl/pxt-new-default

For what it's worth, here's the process for generating a license on github:

![2019-06-07 10 30 33](https://user-images.githubusercontent.com/5615930/59122785-7b24c480-8910-11e9-84f2-8f169edcae59.gif)
