### PR TITLE
don't show close icon in tutorial modals

### DIFF
--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -182,7 +182,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
             }]
 
             return <sui.Modal isOpen={visible} className="hintdialog"
-                closeIcon={true} header={tutorialName} buttons={actions}
+                closeIcon={false} header={tutorialName} buttons={actions}
                 onClose={this.next} dimmer={true} longer={true}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>
                 <md.MarkedContent markdown={fullText} parent={this.props.parent} />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4175913/59207535-16f64080-8b5c-11e9-98a8-b91da6c4333e.png)
