### PR TITLE
Don't double toggle

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2884,7 +2884,7 @@ export class ProjectView
 
     showTutorialHint(showFullText?: boolean) {
         let tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
-        if (tc) tc.toggleHint(showFullText);
+        if (tc) tc.showHint(true, showFullText);
     }
 
     ///////////////////////////////////////////////////////////

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -233,6 +233,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     previousTutorialStep() {
+        this.removeHintOnClick();
         let options = this.props.parent.state.tutorialOptions;
         const currentStep = options.tutorialStep;
         const previousStep = currentStep - 1;
@@ -244,6 +245,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     nextTutorialStep() {
+        this.removeHintOnClick();
         let options = this.props.parent.state.tutorialOptions;
         const currentStep = options.tutorialStep;
         const nextStep = currentStep + 1;
@@ -256,6 +258,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
 
     finishTutorial() {
         this.closeLightbox();
+        this.removeHintOnClick();
         this.props.parent.completeTutorial();
     }
 
@@ -354,6 +357,10 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         // Clear any existing timers
         this.props.parent.stopPokeUserActivity();
 
+        this.removeHintOnClick();
+    }
+
+    private removeHintOnClick() {
         // cleanup hintOnClick
         document.removeEventListener('click', this.hintOnClick);
     }
@@ -380,7 +387,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             pxt.reportError("tutorial", "leaking hintonclick");
             return;
         }
-        evt.stopPropagation();
+        if (evt)
+            evt.stopPropagation();
         const { tutorialStepInfo, tutorialStep } = options;
         const step = tutorialStepInfo[tutorialStep];
         const unplugged = !!step.unplugged && tutorialStep < tutorialStepInfo.length - 1;
@@ -418,7 +426,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         if (th) { // mount/unmount document on click handlers
             if (!visible) {
                 if (th.elementRef) {
-                    document.removeEventListener('click', this.hintOnClick);
+                    this.removeHintOnClick();
                     th.elementRef.removeEventListener('click', this.expandedHintOnClick);
                 }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -411,27 +411,27 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         if (!this.hasHint()) return;
         this.closeLightbox();
         const th = this.refs["tutorialhint"] as TutorialHint;
-        if (!th) return;
+        if (th) { // mount/unmount document on click handlers
+            if (!visible) {
+                if (th.elementRef) {
+                    document.removeEventListener('click', this.hintOnClick);
+                    th.elementRef.removeEventListener('click', this.expandedHintOnClick);
+                }
 
-        if (!visible) {
-            if (th.elementRef) {
-                document.removeEventListener('click', this.hintOnClick);
-                th.elementRef.removeEventListener('click', this.expandedHintOnClick);
+                this.setState({ showHintTooltip: true });
+                this.props.parent.pokeUserActivity();
+            } else {
+                if (th.elementRef) {
+                    document.addEventListener('click', this.hintOnClick);
+                    th.elementRef.addEventListener('click', this.expandedHintOnClick);
+                }
+
+                this.setState({ showHintTooltip: false });
+                this.props.parent.stopPokeUserActivity();
+
+                const options = this.props.parent.state.tutorialOptions;
+                pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
             }
-
-            this.setState({ showHintTooltip: true });
-            this.props.parent.pokeUserActivity();
-        } else {
-            if (th.elementRef) {
-                document.addEventListener('click', this.hintOnClick);
-                th.elementRef.addEventListener('click', this.expandedHintOnClick);
-            }
-
-            this.setState({ showHintTooltip: false });
-            this.props.parent.stopPokeUserActivity();
-
-            const options = this.props.parent.state.tutorialOptions;
-            pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
         }
 
         th.showHint(visible, showFullText);

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -423,29 +423,28 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         if (!this.hasHint()) return;
         this.closeLightbox();
         const th = this.refs["tutorialhint"] as TutorialHint;
-        if (th) { // mount/unmount document on click handlers
-            if (!visible) {
-                if (th.elementRef) {
-                    this.removeHintOnClick();
-                    th.elementRef.removeEventListener('click', this.expandedHintOnClick);
-                }
+        if (!th) return; // mount/unmount document on click handlers
 
-                this.setState({ showHintTooltip: true });
-                this.props.parent.pokeUserActivity();
-            } else {
-                if (th.elementRef) {
-                    document.addEventListener('click', this.hintOnClick);
-                    th.elementRef.addEventListener('click', this.expandedHintOnClick);
-                }
-
-                this.setState({ showHintTooltip: false });
-                this.props.parent.stopPokeUserActivity();
-
-                const options = this.props.parent.state.tutorialOptions;
-                pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
+        if (!visible) {
+            if (th.elementRef) {
+                this.removeHintOnClick();
+                th.elementRef.removeEventListener('click', this.expandedHintOnClick);
             }
-        }
 
+            this.setState({ showHintTooltip: true });
+            this.props.parent.pokeUserActivity();
+        } else {
+            if (th.elementRef) {
+                document.addEventListener('click', this.hintOnClick);
+                th.elementRef.addEventListener('click', this.expandedHintOnClick);
+            }
+
+            this.setState({ showHintTooltip: false });
+            this.props.parent.stopPokeUserActivity();
+
+            const options = this.props.parent.state.tutorialOptions;
+            pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
+        }
         th.showHint(visible, showFullText);
     }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -124,7 +124,7 @@ export interface TutorialHintState {
 
 export class TutorialHint extends data.Component<ISettingsProps, TutorialHintState> {
     public elementRef: HTMLDivElement;
-    protected setRef: (el: HTMLDivElement) => void = (el) => {this.elementRef = el};
+    protected setRef: (el: HTMLDivElement) => void = (el) => { this.elementRef = el };
 
     constructor(props: ISettingsProps) {
         super(props);
@@ -154,7 +154,11 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
     }
 
     toggleHint(showFullText?: boolean) {
-        this.setState({ visible: !this.state.visible, showFullText: showFullText })
+        this.showHint(!this.state.visible, showFullText);
+    }
+
+    showHint(visible: boolean, showFullText?: boolean) {
+        this.setState({ visible, showFullText })
     }
 
     renderCore() {
@@ -170,7 +174,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
         if (!this.state.renderModal) {
             if (!tutorialHint) return <div />;
 
-            return <div className={`tutorialhint ${!visible ? 'hidden' : '' }`} ref={this.setRef}>
+            return <div className={`tutorialhint ${!visible ? 'hidden' : ''}`} ref={this.setRef}>
                 <md.MarkedContent markdown={this.state.showFullText ? fullText : tutorialHint} parent={this.props.parent} />
             </div>
         } else {
@@ -395,37 +399,42 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         if (tutorialCard && tutorialCard.firstElementChild && tutorialCard.firstElementChild.firstElementChild) {
             show = tutorialCard.clientHeight < tutorialCard.firstElementChild.firstElementChild.scrollHeight;
         }
-        this.setState({showSeeMore: show});
+        this.setState({ showSeeMore: show });
     }
 
     toggleHint(showFullText?: boolean) {
+        const th = this.refs["tutorialhint"] as TutorialHint;
+        this.showHint(!(th && th.state && th.state.visible), showFullText);
+    }
+
+    showHint(visible: boolean, showFullText?: boolean) {
         if (!this.hasHint()) return;
         this.closeLightbox();
-        let th = this.refs["tutorialhint"] as TutorialHint;
-        if (th) {
-            if (th.state && th.state.visible) {
-                if (th.elementRef) {
-                    document.removeEventListener('click', this.hintOnClick);
-                    th.elementRef.removeEventListener('click', this.expandedHintOnClick);
-                }
+        const th = this.refs["tutorialhint"] as TutorialHint;
+        if (!th) return;
 
-                this.setState({showHintTooltip : true});
-                this.props.parent.pokeUserActivity();
-            } else {
-                if (th.elementRef) {
-                    document.addEventListener('click', this.hintOnClick);
-                    th.elementRef.addEventListener('click', this.expandedHintOnClick);
-                }
-
-                this.setState({showHintTooltip : false});
-                this.props.parent.stopPokeUserActivity();
-
-                const options = this.props.parent.state.tutorialOptions;
-                pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
+        if (!visible) {
+            if (th.elementRef) {
+                document.removeEventListener('click', this.hintOnClick);
+                th.elementRef.removeEventListener('click', this.expandedHintOnClick);
             }
 
-            th.toggleHint(showFullText);
+            this.setState({ showHintTooltip: true });
+            this.props.parent.pokeUserActivity();
+        } else {
+            if (th.elementRef) {
+                document.addEventListener('click', this.hintOnClick);
+                th.elementRef.addEventListener('click', this.expandedHintOnClick);
+            }
+
+            this.setState({ showHintTooltip: false });
+            this.props.parent.stopPokeUserActivity();
+
+            const options = this.props.parent.state.tutorialOptions;
+            pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
         }
+
+        th.showHint(visible, showFullText);
     }
 
     renderCore() {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -375,12 +375,12 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     private hintOnClick(evt?: any) {
-        evt.stopPropagation();
         const options = this.props.parent.state.tutorialOptions;
         if (!options) {
             pxt.reportError("tutorial", "leaking hintonclick");
             return;
         }
+        evt.stopPropagation();
         const { tutorialStepInfo, tutorialStep } = options;
         const step = tutorialStepInfo[tutorialStep];
         const unplugged = !!step.unplugged && tutorialStep < tutorialStepInfo.length - 1;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -377,6 +377,10 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     private hintOnClick(evt?: any) {
         evt.stopPropagation();
         const options = this.props.parent.state.tutorialOptions;
+        if (!options) {
+            pxt.reportError("tutorial", "leaking hintonclick");
+            return;
+        }
         const { tutorialStepInfo, tutorialStep } = options;
         const step = tutorialStepInfo[tutorialStep];
         const unplugged = !!step.unplugged && tutorialStep < tutorialStepInfo.length - 1;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -420,10 +420,13 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     showHint(visible: boolean, showFullText?: boolean) {
-        if (!this.hasHint()) return;
+        if (!this.hasHint()) {
+            this.removeHintOnClick();
+            return;
+        }
         this.closeLightbox();
         const th = this.refs["tutorialhint"] as TutorialHint;
-        if (!th) return; // mount/unmount document on click handlers
+        if (!th) return;
 
         if (!visible) {
             if (th.elementRef) {


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/2172

- [x] use "showHint" instead of "toggle" to be more intentional about which state needs to be enabled
- [x] avoid double toggle by unregistering the hintOnClick between steps