### PR TITLE
Add check to see if frameElement exists

### DIFF
--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -103,7 +103,7 @@
         (function () {
         var loading = document.getElementById('loading');
         var id = /id(?:[:=])([^&?]+)/i.exec(window.location.href);
-        var code = window.frameElement.getAttribute('data-code')
+        var code = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
         var localToken = /local_token(?:[:=])([^&?]+)/i.exec(window.location.href);
         var hex = !!/hex(?:[:=])1/i.exec(window.location.href);
         var footer = !/nofooter(?:[:=])1/i.exec(window.location.href);

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -103,7 +103,6 @@
         (function () {
         var loading = document.getElementById('loading');
         var id = /id(?:[:=])([^&?]+)/i.exec(window.location.href);
-        var code = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
         var localToken = /local_token(?:[:=])([^&?]+)/i.exec(window.location.href);
         var hex = !!/hex(?:[:=])1/i.exec(window.location.href);
         var footer = !/nofooter(?:[:=])1/i.exec(window.location.href);
@@ -113,6 +112,10 @@
         var light = !!/light(?:[:=])1/i.exec(window.location.href);
         var fullScreen = !!/fullscreen(?:[:=])1/i.exec(window.location.href);
         var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
+
+        var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
+        var codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
+        var code = codeFromData || (codeFromSrc ? codeFromSrc[1] : undefined);
 
         if (!id && !code && !debugSim) {
             console.error("missing id or code");


### PR DESCRIPTION
Adds a check to see if window has access to same origin features like frameElement before trying to use them.

Fixes https://github.com/microsoft/pxt-microbit/issues/2152