### PR TITLE
Fix Untranslatable Blockly Strings

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1945,6 +1945,7 @@ namespace pxt.blocks {
         msg.RENAME_VARIABLE = lf("Rename variable...");
         msg.DELETE_VARIABLE = lf("Delete the \"%1\" variable");
         msg.DELETE_VARIABLE_CONFIRMATION = lf("Delete %1 uses of the \"%2\" variable?");
+	msg.NEW_VARIABLE_DROPDOWN = lf("New variable...");
 
         // builtin variables_set
         const variablesSetId = "variables_set";
@@ -1985,6 +1986,9 @@ namespace pxt.blocks {
 
         // New variable dialog
         msg.NEW_VARIABLE_TITLE = lf("New variable name:");
+
+	// Rename variable dialog
+	msg.RENAME_VARIABLE_TITLE = lf("Rename all '%1' variables to:");
     }
 
     function initFunctions() {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1945,7 +1945,7 @@ namespace pxt.blocks {
         msg.RENAME_VARIABLE = lf("Rename variable...");
         msg.DELETE_VARIABLE = lf("Delete the \"%1\" variable");
         msg.DELETE_VARIABLE_CONFIRMATION = lf("Delete %1 uses of the \"%2\" variable?");
-	msg.NEW_VARIABLE_DROPDOWN = lf("New variable...");
+        msg.NEW_VARIABLE_DROPDOWN = lf("New variable...");
 
         // builtin variables_set
         const variablesSetId = "variables_set";
@@ -1987,8 +1987,8 @@ namespace pxt.blocks {
         // New variable dialog
         msg.NEW_VARIABLE_TITLE = lf("New variable name:");
 
-	// Rename variable dialog
-	msg.RENAME_VARIABLE_TITLE = lf("Rename all '%1' variables to:");
+        // Rename variable dialog
+        msg.RENAME_VARIABLE_TITLE = lf("Rename all '%1' variables to:");
     }
 
     function initFunctions() {


### PR DESCRIPTION
Make it possible to translate the two newly(?) introduced Blockly strings.

* New variable...
* Rename all '%1' variables to:

![image](https://user-images.githubusercontent.com/485416/59269573-5ae76380-8c8a-11e9-898b-139113d5d620.png)
![image](https://user-images.githubusercontent.com/485416/59269600-68045280-8c8a-11e9-9bb6-169e8ec3bd95.png)
