### PR TITLE
Sprite editor fixes

### DIFF
--- a/pxtlib/sprite-editor/bitmap.ts
+++ b/pxtlib/sprite-editor/bitmap.ts
@@ -2,7 +2,10 @@ namespace pxtsprite {
     // These are the characters used to output literals (but we support aliases for some of these)
     const hexChars = [".", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"];
 
-    export type Coord = [number, number];
+    export interface Coord{
+        x: number,
+        y: number
+    }
 
     /**
      * 16-color sprite

--- a/pxtlib/sprite-editor/bitmap.ts
+++ b/pxtlib/sprite-editor/bitmap.ts
@@ -2,7 +2,7 @@ namespace pxtsprite {
     // These are the characters used to output literals (but we support aliases for some of these)
     const hexChars = [".", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"];
 
-    export interface Coord{
+    export interface Coord {
         x: number,
         y: number
     }

--- a/pxtlib/sprite-editor/canvasGrid.ts
+++ b/pxtlib/sprite-editor/canvasGrid.ts
@@ -56,7 +56,7 @@ namespace pxtsprite {
         }
 
         repaint(): void {
-            this.clearContext(this.paintLayer.getContext("2d"));
+            this.clearContext(this.context);
             this.drawImage();
             if (this.state.floatingLayer) this.drawFloatingLayer();
             else this.hideOverlay();
@@ -345,8 +345,7 @@ namespace pxtsprite {
             if (!this.state.floatingLayer) {
                 return;
             }
-            const context = this.paintLayer.getContext("2d");
-            this.drawImage(this.state.floatingLayer, context, this.state.layerOffsetX, this.state.layerOffsetY, true);
+            this.drawImage(this.state.floatingLayer, this.context, this.state.layerOffsetX, this.state.layerOffsetY, true);
 
             this.drawSelectionAnimation();
         }
@@ -378,6 +377,7 @@ namespace pxtsprite {
         }
 
         private clearContext(context: CanvasRenderingContext2D) {
+            // Paint Layer has the same dimensions as all other contexts
             context.clearRect(0, 0, this.paintLayer.width, this.paintLayer.height);
         }
 

--- a/pxtlib/sprite-editor/canvasGrid.ts
+++ b/pxtlib/sprite-editor/canvasGrid.ts
@@ -71,6 +71,11 @@ namespace pxtsprite {
 
             if (cursor) {
                 this.repaint();
+                if (edit.showPreview) {
+                    edit.drawCursor(col, row, (c, r) => {
+                        this.drawColor(c, r, edit.color);
+                    });
+                }
                 this.context.strokeStyle = "#898989";
                 this.context.strokeRect((col + cursor.offsetX) * this.cellWidth, (row + cursor.offsetY) * this.cellHeight, cursor.width * this.cellWidth, cursor.height * this.cellHeight);
             }

--- a/pxtlib/sprite-editor/canvasGrid.ts
+++ b/pxtlib/sprite-editor/canvasGrid.ts
@@ -295,6 +295,11 @@ namespace pxtsprite {
             edit.start(col, row, this.state);
         }
 
+        onEditEnd(col: number, row: number, edit: Edit) {
+            edit.end(col, row, this.state);
+            this.drawFloatingLayer();
+        }
+
         protected drawImage(image = this.image, context = this.context, left = 0, top = 0, transparency = !this.lightMode) {
             for (let c = 0; c < image.width; c++) {
                 for (let r = 0; r < image.height; r++) {

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -103,6 +103,12 @@ namespace pxtsprite {
                     const color = this.state.image.get(col, row);
                     this.sidebar.setColor(color);
                 } else {
+                    this.paintSurface.onEditEnd(col, row, this.edit);
+                    if (this.state.floatingLayer && !this.paintSurface.state.floatingLayer) {
+                        this.pushState(true);
+                        this.state = this.paintSurface.state.copy();
+                        this.rePaint();
+                    }
                     this.commit();
                     this.shiftAction();
                 }

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -337,10 +337,10 @@ namespace pxtsprite {
                 const ch = this.closeHandler;
                 this.closeHandler = undefined;
                 ch();
-                if (this.state.floatingLayer) {
-                    this.state.mergeFloatingLayer();
-                    this.pushState(true);
-                }
+            }
+            if (this.state.floatingLayer) {
+                this.state.mergeFloatingLayer();
+                this.pushState(true);
             }
         }
 

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -203,8 +203,14 @@ namespace pxtsprite {
         showPreview = true;
 
         protected doEditCore(state: CanvasState) {
-            const tl = this.topLeft();
-            const br = this.bottomRight();
+            let tl = this.topLeft();
+            tl[0] -= Math.floor(this.toolWidth / 2);
+            tl[1] -= Math.floor(this.toolWidth / 2);
+
+            let br = this.bottomRight();
+            br[0] += Math.floor(this.toolWidth / 2);
+            br[1] += Math.floor(this.toolWidth / 2);
+
             for (let i = 0; i < this.toolWidth; i++) {
                 this.drawRectangle(state,   
                     [tl[0] + i, tl[1] + i],

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -229,7 +229,7 @@ namespace pxtsprite {
             br.y += Math.floor(this.toolWidth / 2);
 
             for (let i = 0; i < this.toolWidth; i++) {
-                this.drawRectangle(state,   
+                this.drawRectangle(state,
                     {x: tl.x + i, y: tl.y + i},
                     {x: br.x - i, y: br.y - i}
                 );

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -46,6 +46,7 @@ namespace pxtsprite {
         protected startCol: number;
         protected startRow: number;
         isStarted: boolean;
+        showPreview: boolean;
 
         constructor (protected canvasWidth: number, protected canvasHeight: number, public color: number, protected toolWidth: number) {
         }
@@ -70,6 +71,10 @@ namespace pxtsprite {
 
         getCursor(): Cursor {
             return new Cursor(this.toolWidth, this.toolWidth);
+        }
+
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            draw(col, row);
         }
     }
 
@@ -96,6 +101,7 @@ namespace pxtsprite {
      */
     export class PaintEdit extends Edit {
         protected mask: Bitmask;
+        showPreview = true;
 
         constructor (canvasWidth: number, canvasHeight: number, color: number, toolWidth: number) {
             super(canvasWidth, canvasHeight, color, toolWidth);
@@ -153,6 +159,10 @@ namespace pxtsprite {
             }
         }
 
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            this.drawCore(col, row, draw);
+        }
+
         protected drawCore(col: number, row: number, setPixel: (col: number, row: number) => void) {
             col = col - Math.floor(this.toolWidth / 2);
             row = row - Math.floor(this.toolWidth / 2);
@@ -173,6 +183,8 @@ namespace pxtsprite {
      * Tool for drawing filled rectangles
      */
     export class RectangleEdit extends SelectionEdit {
+        showPreview = true;
+
         protected doEditCore(state: CanvasState) {
             const tl = this.topLeft();
             const br = this.bottomRight();
@@ -188,11 +200,13 @@ namespace pxtsprite {
      * Tool for drawing empty rectangles
      */
     export class OutlineEdit extends SelectionEdit {
+        showPreview = true;
+
         protected doEditCore(state: CanvasState) {
             const tl = this.topLeft();
             const br = this.bottomRight();
             for (let i = 0; i < this.toolWidth; i++) {
-                this.drawRectangle(state,
+                this.drawRectangle(state,   
                     [tl[0] + i, tl[1] + i],
                     [br[0] - i, br[1] - i]
                 );
@@ -217,6 +231,8 @@ namespace pxtsprite {
      * Tool for drawing straight lines
      */
     export class LineEdit extends SelectionEdit {
+        showPreview = true;
+
         protected doEditCore(state: CanvasState) {
             this.bresenham(this.startCol, this.startRow, this.endCol, this.endRow, state);
         }
@@ -254,6 +270,10 @@ namespace pxtsprite {
             }
         }
 
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            this.drawCore(col, row, draw);
+        }
+
         // This is surely not the most efficient approach for drawing thick lines...
         protected drawCore(col: number, row: number, draw: (c: number, r: number) => void) {
             col = col - Math.floor(this.toolWidth / 2);
@@ -273,6 +293,8 @@ namespace pxtsprite {
      * Tool for circular outlines
      */
     export class CircleEdit extends SelectionEdit {
+        showPreview = true;
+
         protected doEditCore(state: CanvasState) {
             const tl = this.topLeft();
             const br = this.bottomRight();
@@ -320,6 +342,7 @@ namespace pxtsprite {
     export class FillEdit extends Edit {
         protected col: number;
         protected row: number;
+        showPreview = true;
 
         start(col: number, row: number, state: CanvasState) {
             this.isStarted = true;
@@ -366,6 +389,7 @@ namespace pxtsprite {
 
     export class MarqueeEdit extends SelectionEdit {
         protected isMove = false;
+        showPreview = false;
 
         start(cursorCol: number, cursorRow: number, state: CanvasState) {
             this.isStarted = true;

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -225,6 +225,26 @@ namespace pxtsprite {
                 state.image.set(br[0], r, this.color);
             }
         }
+
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            this.drawCore(col, row, draw);
+        }
+
+        protected drawCore(col: number, row: number, setPixel: (col: number, row: number) => void) {
+            col = col - Math.floor(this.toolWidth / 2);
+            row = row - Math.floor(this.toolWidth / 2);
+            for (let i = 0; i < this.toolWidth; i++) {
+                for (let j = 0; j < this.toolWidth; j++) {
+                    const c = col + i;
+                    const r = row + j;
+
+                    if (c >= 0 && c < this.canvasWidth && r >= 0 && r < this.canvasHeight) {
+                        setPixel(col + i, row + j);
+                    }
+                }
+            }
+        }
+
     }
 
     /**
@@ -336,6 +356,10 @@ namespace pxtsprite {
                 }
             }
         }
+
+        getCursor(): Cursor {
+            return new Cursor(1, 1);
+        }
     }
 
 
@@ -383,6 +407,10 @@ namespace pxtsprite {
                     q.push([x, y]);
                 }
             }
+        }
+
+        getCursor(): Cursor {
+            return new Cursor(1, 1);
         }
     }
 

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -66,6 +66,7 @@ namespace pxtsprite {
             this.startCol = cursorCol;
             this.startRow = cursorRow;
 
+            state.mergeFloatingLayer();
         }
 
 

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -221,12 +221,12 @@ namespace pxtsprite {
 
         protected doEditCore(state: CanvasState) {
             let tl = this.topLeft();
-            tl.x -= Math.floor(this.toolWidth / 2);
-            tl.y -= Math.floor(this.toolWidth / 2);
+            tl.x -= this.toolWidth >> 1;
+            tl.y -= this.toolWidth >> 1;
 
             let br = this.bottomRight();
-            br.x += Math.floor(this.toolWidth / 2);
-            br.y += Math.floor(this.toolWidth / 2);
+            br.x += this.toolWidth >> 1;
+            br.y += this.toolWidth >> 1;
 
             for (let i = 0; i < this.toolWidth; i++) {
                 this.drawRectangle(state,

--- a/pxtlib/sprite-editor/tools.ts
+++ b/pxtlib/sprite-editor/tools.ts
@@ -88,11 +88,17 @@ namespace pxtsprite {
         }
 
         protected topLeft(): Coord {
-            return [Math.min(this.startCol, this.endCol), Math.min(this.startRow, this.endRow)];
+            return {
+                x: Math.min(this.startCol, this.endCol),
+                y: Math.min(this.startRow, this.endRow)
+            };
         }
 
         protected bottomRight(): Coord {
-            return [Math.max(this.startCol, this.endCol), Math.max(this.startRow, this.endRow)];
+            return {
+                x: Math.max(this.startCol, this.endCol),
+                y: Math.max(this.startRow, this.endRow)
+        };
         }
     }
 
@@ -188,8 +194,8 @@ namespace pxtsprite {
         protected doEditCore(state: CanvasState) {
             const tl = this.topLeft();
             const br = this.bottomRight();
-            for (let c = tl[0]; c <= br[0]; c++) {
-                for (let r = tl[1]; r <= br[1]; r++) {
+            for (let c = tl.x; c <= br.x; c++) {
+                for (let r = tl.y; r <= br.y; r++) {
                     state.image.set(c, r, this.color);
                 }
             }
@@ -204,31 +210,31 @@ namespace pxtsprite {
 
         protected doEditCore(state: CanvasState) {
             let tl = this.topLeft();
-            tl[0] -= Math.floor(this.toolWidth / 2);
-            tl[1] -= Math.floor(this.toolWidth / 2);
+            tl.x -= Math.floor(this.toolWidth / 2);
+            tl.y -= Math.floor(this.toolWidth / 2);
 
             let br = this.bottomRight();
-            br[0] += Math.floor(this.toolWidth / 2);
-            br[1] += Math.floor(this.toolWidth / 2);
+            br.x += Math.floor(this.toolWidth / 2);
+            br.y += Math.floor(this.toolWidth / 2);
 
             for (let i = 0; i < this.toolWidth; i++) {
                 this.drawRectangle(state,   
-                    [tl[0] + i, tl[1] + i],
-                    [br[0] - i, br[1] - i]
+                    {x: tl.x + i, y: tl.y + i},
+                    {x: br.x - i, y: br.y - i}
                 );
             }
         }
 
         protected drawRectangle(state: CanvasState, tl: Coord, br: Coord) {
-            if (tl[0] > br[0] || tl[1] > br[1]) return;
+            if (tl.x > br.x || tl.y > br.y) return;
 
-            for (let c = tl[0]; c <= br[0]; c++) {
-                state.image.set(c, tl[1], this.color);
-                state.image.set(c, br[1], this.color);
+            for (let c = tl.x; c <= br.x; c++) {
+                state.image.set(c, tl.y, this.color);
+                state.image.set(c, br.y, this.color);
             }
-            for (let r = tl[1]; r <= br[1]; r++) {
-                state.image.set(tl[0], r, this.color);
-                state.image.set(br[0], r, this.color);
+            for (let r = tl.y; r <= br.y; r++) {
+                state.image.set(tl.x, r, this.color);
+                state.image.set(br.x, r, this.color);
             }
         }
 
@@ -324,8 +330,8 @@ namespace pxtsprite {
         protected doEditCore(state: CanvasState) {
             const tl = this.topLeft();
             const br = this.bottomRight();
-            const dx = br[0] - tl[0];
-            const dy = br[1] - tl[1];
+            const dx = br.x - tl.x;
+            const dy = br.y - tl.y;
 
             const radius = Math.floor(Math.hypot(dx, dy));
             const cx = this.startCol;
@@ -395,22 +401,22 @@ namespace pxtsprite {
 
             const mask = new Bitmask(state.width, state.height);
             mask.set(this.col, this.row);
-            const q: Coord[] = [[this.col, this.row]];
+            const q: Coord[] = [{x: this.col, y: this.row}];
             while (q.length) {
-                const [c, r] = q.pop();
-                if (state.image.get(c, r) === replColor) {
-                    state.image.set(c, r, this.color);
-                    tryPush(c + 1, r);
-                    tryPush(c - 1, r);
-                    tryPush(c, r + 1);
-                    tryPush(c, r - 1);
+                const curr = q.pop();
+                if (state.image.get(curr.x, curr.y) === replColor) {
+                    state.image.set(curr.x, curr.y, this.color);
+                    tryPush(curr.x + 1, curr.y);
+                    tryPush(curr.x - 1, curr.y);
+                    tryPush(curr.x, curr.y + 1);
+                    tryPush(curr.x, curr.y - 1);
                 }
             }
 
             function tryPush(x: number, y: number) {
                 if (x >= 0 && x < mask.width && y >= 0 && y < mask.height && !mask.get(x, y)) {
                     mask.set(x, y);
-                    q.push([x, y]);
+                    q.push({x: x, y: y});
                 }
             }
         }


### PR DESCRIPTION
Fixes a variety of Sprite Editor bugs

## Bugs Fixed
### Preview Not Shown
Fixes https://github.com/microsoft/pxt-arcade/issues/1029
### Marquee Tool Shows Outlines
![Selection Outlines](https://user-images.githubusercontent.com/13285164/59641571-f3f8fd00-9116-11e9-8e04-344a79ffe778.gif)
### Marquee Tool can't select bottom or right cells
Fixes https://github.com/microsoft/pxt-arcade/issues/1031
### Can't deselect Marquee Tool if whole screen is selected
If the whole screen is selected, there is currently no way to deselect the selection. This change makes it so a single click, inside or outside of the selection deselects.
### Selection disappears when showing block preview
![Selection Disappears](https://user-images.githubusercontent.com/13285164/59642160-d331a700-9118-11e9-8c35-6785418f551c.gif)
### Top left of the Rectangle Tool starts at click instead of top left of tool when clicked
The top left of the rectangle that is being drawn is set to the center of the preview. This makes the cursor inaccurate. It should be the top left of the rectangle is the top left of the cursor. This way if a user is using a wider tool, all pixels shown colored in cursor are actually painted.
### Circle Tool should show tool width of 1 on preview
The circle tool should show as 1x1 pixel for all tool width until other widths are supported.

