### PR TITLE
don't show hints for package snippets in tutorials

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -53,7 +53,7 @@ namespace pxt.tutorial {
     }
 
     function parseTutorialSteps(tutorialmd: string): TutorialStepInfo[] {
-        const hiddenSnippetRegex = /```(filterblocks|package)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config)\s*\n([\s\S]*?)\n```/gmi;
         const hintTextRegex = /(^[\s\S]*?\S)\s*((```|\!\[[\s\S]+?\]\(\S+?\))[\s\S]*)/mi;
 
         // Download tutorial markdown
@@ -95,7 +95,7 @@ namespace pxt.tutorial {
                 stepInfo[i].headerContentMd = hintText[1];
                 blockSolution = hintText[2];
                 if (blockSolution) {
-                    // remove hidden snippets
+                    // remove hidden snippets from the hint
                     blockSolution = blockSolution.replace(hiddenSnippetRegex, '');
                     stepInfo[i].blockSolution = blockSolution;
                 }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -53,7 +53,7 @@ namespace pxt.tutorial {
     }
 
     function parseTutorialSteps(tutorialmd: string): TutorialStepInfo[] {
-        const filterblocksRegex = /```(filterblocks)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package)\s*\n([\s\S]*?)\n```/gmi;
         const hintTextRegex = /(^[\s\S]*?\S)\s*((```|\!\[[\s\S]+?\]\(\S+?\))[\s\S]*)/mi;
 
         // Download tutorial markdown
@@ -96,7 +96,7 @@ namespace pxt.tutorial {
                 blockSolution = hintText[2];
                 if (blockSolution) {
                     // remove ```filterblocks ``` code, as it isn't displayed in the hint
-                    blockSolution = blockSolution.replace(filterblocksRegex, '');
+                    blockSolution = blockSolution.replace(hiddenSnippetRegex, '');
                     stepInfo[i].blockSolution = blockSolution;
                 }
             }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -95,7 +95,7 @@ namespace pxt.tutorial {
                 stepInfo[i].headerContentMd = hintText[1];
                 blockSolution = hintText[2];
                 if (blockSolution) {
-                    // remove ```filterblocks ``` code, as it isn't displayed in the hint
+                    // remove hidden snippets
                     blockSolution = blockSolution.replace(hiddenSnippetRegex, '');
                     stepInfo[i].blockSolution = blockSolution;
                 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1071

Package snippets are used to load the extensions for the other snippets on the page, and shouldn't be shown as hints