### PR TITLE
Fix backspace to delete selected area on marquee tool

### DIFF
--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -403,7 +403,7 @@ namespace pxtsprite {
                 this.altDown = true;
             }
 
-            if (this.activeTool === PaintTool.Marquee && this.state.floatingLayer) {
+            if (this.state.floatingLayer) {
                 let didSomething = true;
 
                 switch (event.keyCode) {

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -405,8 +405,12 @@ namespace pxtsprite {
 
             if (this.activeTool === PaintTool.Marquee && this.state.floatingLayer) {
                 let didSomething = true;
+
                 switch (event.keyCode) {
-                    case 8: // Backspace
+                    case 8: // backspace
+                    case 46: // delete
+                        event.preventDefault();
+                        event.stopPropagation();
                         this.state.floatingLayer = undefined;
                         break;
                     case 37: // Left arrow


### PR DESCRIPTION
fixes issue that I noticed here https://github.com/microsoft/pxt/pull/5618#discussion_r289266523 and then immediately forgot about. Now just deletes the section like it was intended to rather than deleting the entire block

current:

![2019-06-18 14 55 04](https://user-images.githubusercontent.com/5615930/59722666-18b5a900-91d9-11e9-8ae8-6adad772f792.gif)

this change:

![2019-06-18 14 52 55](https://user-images.githubusercontent.com/5615930/59722621-f7ed5380-91d8-11e9-8ace-1c20fa47be50.gif)

Also made it so the marquee tool shortcuts keyboard trigger even if you have another tool selected, as the layer itself is still visible at that point - can revert that portion if it's preferred to keep them just to when the marquee tool is selected, though
