### PR TITLE
Clean for loop decompilation with numeric literal upper bounds

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1474,15 +1474,16 @@ ${output}</xml>`;
                 r.inputs = [getDraggableVariableBlock("VAR", renamed)];
 
                 if (condition.operatorToken.kind === SK.LessThanToken) {
-                    if (condition.right.kind === SK.NumericLiteral) {
-                        const decrementedValue = parseFloat(condition.right.getFullText()) - 1;
+                    const unwrappedRightSide = unwrapNode(condition.right);
+                    if (unwrappedRightSide.kind === SK.NumericLiteral) {
+                        const decrementedValue = parseFloat(unwrappedRightSide.getFullText()) - 1;
                         const valueField = getNumericLiteral(decrementedValue + "");
                         r.inputs.push(mkValue("TO", valueField, wholeNumberType));
                     } else {
                         const ex = mkExpr("math_arithmetic");
                         ex.fields = [getField("OP", "MINUS")];
                         ex.inputs = [
-                            getValue("A", condition.right, numberType),
+                            getValue("A", unwrappedRightSide, numberType),
                             getValue("B", 1, numberType)
                         ];
                         r.inputs.push(mkValue("TO", ex, wholeNumberType));

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1475,7 +1475,7 @@ ${output}</xml>`;
 
                 if (condition.operatorToken.kind === SK.LessThanToken) {
                     if (condition.right.kind === SK.NumericLiteral) {
-                        const decrementedValue = parseInt(condition.right.getFullText()) - 1;
+                        const decrementedValue = parseFloat(condition.right.getFullText()) - 1;
                         const valueField = getNumericLiteral(decrementedValue + "");
                         r.inputs.push(mkValue("TO", valueField, wholeNumberType));
                     } else {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1476,7 +1476,7 @@ ${output}</xml>`;
                 if (condition.operatorToken.kind === SK.LessThanToken) {
                     const unwrappedRightSide = unwrapNode(condition.right);
                     if (unwrappedRightSide.kind === SK.NumericLiteral) {
-                        const decrementedValue = parseFloat(unwrappedRightSide.getFullText()) - 1;
+                        const decrementedValue = parseFloat((unwrappedRightSide as LiteralExpression).text) - 1;
                         const valueField = getNumericLiteral(decrementedValue + "");
                         r.inputs.push(mkValue("TO", valueField, wholeNumberType));
                     } else {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1474,13 +1474,19 @@ ${output}</xml>`;
                 r.inputs = [getDraggableVariableBlock("VAR", renamed)];
 
                 if (condition.operatorToken.kind === SK.LessThanToken) {
-                    const ex = mkExpr("math_arithmetic");
-                    ex.fields = [getField("OP", "MINUS")];
-                    ex.inputs = [
-                        getValue("A", condition.right, numberType),
-                        getValue("B", 1, numberType)
-                    ];
-                    r.inputs.push(mkValue("TO", ex, wholeNumberType));
+                    if (condition.right.kind === SK.NumericLiteral) {
+                        const decrementedValue = parseInt(condition.right.getFullText()) - 1;
+                        const valueField = getNumericLiteral(decrementedValue + "");
+                        r.inputs.push(mkValue("TO", valueField, wholeNumberType));
+                    } else {
+                        const ex = mkExpr("math_arithmetic");
+                        ex.fields = [getField("OP", "MINUS")];
+                        ex.inputs = [
+                            getValue("A", condition.right, numberType),
+                            getValue("B", 1, numberType)
+                        ];
+                        r.inputs.push(mkValue("TO", ex, wholeNumberType));
+                    }
                 }
                 else if (condition.operatorToken.kind === SK.LessThanEqualsToken) {
                     r.inputs.push(getValue("TO", condition.right, wholeNumberType));

--- a/tests/decompile-test/baselines/always_enums.blocks
+++ b/tests/decompile-test/baselines/always_enums.blocks
@@ -9,18 +9,8 @@
 </value>
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
-<block type="math_arithmetic">
-<field name="OP">MINUS</field>
-<value name="A">
-<shadow type="math_number">
-<field name="NUM">4</field>
-</shadow>
-</value>
-<value name="B">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
+<block type="math_number">
+<field name="NUM">3</field>
 </block>
 </value>
 <statement name="DO">

--- a/tests/decompile-test/baselines/block_repeat.blocks
+++ b/tests/decompile-test/baselines/block_repeat.blocks
@@ -18,18 +18,8 @@
 </value>
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
-<block type="math_arithmetic">
-<field name="OP">MINUS</field>
-<value name="A">
-<shadow type="math_number">
-<field name="NUM">4</field>
-</shadow>
-</value>
-<value name="B">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
+<block type="math_number">
+<field name="NUM">3</field>
 </block>
 </value>
 <statement name="DO">

--- a/tests/decompile-test/baselines/for_loop_upper_bound.blocks
+++ b/tests/decompile-test/baselines/for_loop_upper_bound.blocks
@@ -150,7 +150,7 @@
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
 <block type="math_number">
-<field name="NUM">2.1415926</field>
+<field name="NUM">4.5</field>
 </block>
 </value>
 <statement name="DO">
@@ -184,18 +184,8 @@
 </value>
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
-<block type="math_arithmetic">
-<field name="OP">MINUS</field>
-<value name="A">
-<shadow type="math_number">
-<field name="NUM">-5</field>
-</shadow>
-</value>
-<value name="B">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
+<block type="math_number">
+<field name="NUM">2.1415926</field>
 </block>
 </value>
 <statement name="DO">
@@ -221,14 +211,6 @@
 </block>
 </statement>
 <next>
-<block type="variables_set">
-<field name="VAR">myNum</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">5</field>
-</shadow>
-</value>
-<next>
 <block type="pxt_controls_for">
 <value name="VAR">
 <shadow type="variables_get_reporter">
@@ -240,10 +222,9 @@
 <block type="math_arithmetic">
 <field name="OP">MINUS</field>
 <value name="A">
-<shadow type="math_number"><field name="NUM">0</field></shadow>
-<block type="variables_get">
-<field name="VAR">myNum</field>
-</block>
+<shadow type="math_number">
+<field name="NUM">-5</field>
+</shadow>
 </value>
 <value name="B">
 <shadow type="math_number">
@@ -275,6 +256,14 @@
 </block>
 </statement>
 <next>
+<block type="variables_set">
+<field name="VAR">myNum</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<next>
 <block type="pxt_controls_for">
 <value name="VAR">
 <shadow type="variables_get_reporter">
@@ -287,18 +276,8 @@
 <field name="OP">MINUS</field>
 <value name="A">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
-<block type="math_arithmetic">
-<field name="OP">ADD</field>
-<value name="A">
-<shadow type="math_number">
-<field name="NUM">5</field>
-</shadow>
-</value>
-<value name="B">
-<shadow type="math_number">
-<field name="NUM">3</field>
-</shadow>
-</value>
+<block type="variables_get">
+<field name="VAR">myNum</field>
 </block>
 </value>
 <value name="B">
@@ -330,6 +309,64 @@
 </value>
 </block>
 </statement>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">q</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">MINUS</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">3</field>
+</shadow>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue9</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">q</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+</block>
+</next>
 </block>
 </next>
 </block>

--- a/tests/decompile-test/baselines/for_loop_upper_bound.blocks
+++ b/tests/decompile-test/baselines/for_loop_upper_bound.blocks
@@ -1,0 +1,278 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">i</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_number">
+<field name="NUM">4</field>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">i</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">j</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_number">
+<field name="NUM">4.5</field>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue2</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">j</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">k</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_number">
+<field name="NUM">2.1415926</field>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue3</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">k</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">l</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">MINUS</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">-5</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue4</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">l</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+<next>
+<block type="variables_set">
+<field name="VAR">myNum</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">m</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">MINUS</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">myNum</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue5</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">m</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">n</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">MINUS</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">3</field>
+</shadow>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue6</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">n</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/baselines/for_loop_upper_bound.blocks
+++ b/tests/decompile-test/baselines/for_loop_upper_bound.blocks
@@ -45,7 +45,7 @@
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
 <block type="math_number">
-<field name="NUM">4.5</field>
+<field name="NUM">4</field>
 </block>
 </value>
 <statement name="DO">
@@ -80,7 +80,7 @@
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
 <block type="math_number">
-<field name="NUM">2.1415926</field>
+<field name="NUM">4</field>
 </block>
 </value>
 <statement name="DO">
@@ -114,18 +114,8 @@
 </value>
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
-<block type="math_arithmetic">
-<field name="OP">MINUS</field>
-<value name="A">
-<shadow type="math_number">
-<field name="NUM">-5</field>
-</shadow>
-</value>
-<value name="B">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
+<block type="math_number">
+<field name="NUM">4.5</field>
 </block>
 </value>
 <statement name="DO">
@@ -151,14 +141,6 @@
 </block>
 </statement>
 <next>
-<block type="variables_set">
-<field name="VAR">myNum</field>
-<value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">5</field>
-</shadow>
-</value>
-<next>
 <block type="pxt_controls_for">
 <value name="VAR">
 <shadow type="variables_get_reporter">
@@ -167,19 +149,8 @@
 </value>
 <value name="TO">
 <shadow type="math_whole_number"><field name="NUM">0</field></shadow>
-<block type="math_arithmetic">
-<field name="OP">MINUS</field>
-<value name="A">
-<shadow type="math_number"><field name="NUM">0</field></shadow>
-<block type="variables_get">
-<field name="VAR">myNum</field>
-</block>
-</value>
-<value name="B">
-<shadow type="math_number">
-<field name="NUM">1</field>
-</shadow>
-</value>
+<block type="math_number">
+<field name="NUM">2.1415926</field>
 </block>
 </value>
 <statement name="DO">
@@ -216,20 +187,9 @@
 <block type="math_arithmetic">
 <field name="OP">MINUS</field>
 <value name="A">
-<shadow type="math_number"><field name="NUM">0</field></shadow>
-<block type="math_arithmetic">
-<field name="OP">ADD</field>
-<value name="A">
 <shadow type="math_number">
-<field name="NUM">5</field>
+<field name="NUM">-5</field>
 </shadow>
-</value>
-<value name="B">
-<shadow type="math_number">
-<field name="NUM">3</field>
-</shadow>
-</value>
-</block>
 </value>
 <value name="B">
 <shadow type="math_number">
@@ -260,6 +220,120 @@
 </value>
 </block>
 </statement>
+<next>
+<block type="variables_set">
+<field name="VAR">myNum</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">o</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">MINUS</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">myNum</field>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue7</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">o</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">p</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">MINUS</field>
+<value name="A">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="math_arithmetic">
+<field name="OP">ADD</field>
+<value name="A">
+<shadow type="math_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">3</field>
+</shadow>
+</value>
+</block>
+</value>
+<value name="B">
+<shadow type="math_number">
+<field name="NUM">1</field>
+</shadow>
+</value>
+</block>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">newValue8</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="text_join">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="text">
+<field name="TEXT">hello number </field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="text"><field name="TEXT"></field></shadow>
+<block type="variables_get">
+<field name="VAR">p</field>
+</block>
+</value>
+</block>
+</value>
+</block>
+</statement>
+</block>
+</next>
+</block>
+</next>
 </block>
 </next>
 </block>

--- a/tests/decompile-test/cases/for_loop_upper_bound.ts
+++ b/tests/decompile-test/cases/for_loop_upper_bound.ts
@@ -1,0 +1,25 @@
+for (let i = 0; i < 5; i++) {
+    let newValue = "hello number " + i;
+}
+
+for (let i = 0; i < 5.5; i++) {
+    let newValue = "hello number " + i;
+}
+
+for (let i = 0; i < 3.1415926; i++) {
+    let newValue = "hello number " + i;
+}
+
+for (let i = 0; i < -5; i++) {
+    let newValue = "hello number " + i;
+}
+
+let myNum = 5;
+
+for (let i = 0; i < myNum; i++) {
+    let newValue = "hello number " + i;
+}
+
+for (let i = 0; i < 5 + 3; i++) {
+    let newValue = "hello number " + i;
+}

--- a/tests/decompile-test/cases/for_loop_upper_bound.ts
+++ b/tests/decompile-test/cases/for_loop_upper_bound.ts
@@ -2,6 +2,14 @@ for (let i = 0; i < 5; i++) {
     let newValue = "hello number " + i;
 }
 
+for (let i = 0; i < (5); i++) {
+    let newValue = "hello number " + i;
+}
+
+for (let i = 0; i < (((((5))))); i++) {
+    let newValue = "hello number " + i;
+}
+
 for (let i = 0; i < 5.5; i++) {
     let newValue = "hello number " + i;
 }

--- a/tests/decompile-test/cases/for_loop_upper_bound.ts
+++ b/tests/decompile-test/cases/for_loop_upper_bound.ts
@@ -14,6 +14,10 @@ for (let i = 0; i < 5.5; i++) {
     let newValue = "hello number " + i;
 }
 
+for (let i = 0; i < 5.5 /** comment trivia **/; i++) {
+    let newValue = "hello number " + i;
+}
+
 for (let i = 0; i < 3.1415926; i++) {
     let newValue = "hello number " + i;
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1034

Doesn't currently handle prefix unary expressions; can add the handling for that, but it seems really niche to add special handling for - negatives will always basically result in a no-op anyway, and having a unary + in front of a numeric literal is not something that I think I've ever seen :)

current behavior: test decompiles to these blocks:

![arcade-screenshot (10)](https://user-images.githubusercontent.com/5615930/59725808-f70def00-91e3-11e9-8fc4-e17f5879ce74.png)

new: test decompiles to these blocks:

![arcade-screenshot (6)](https://user-images.githubusercontent.com/5615930/59725785-da71b700-91e3-11e9-9a8a-d60ff9881b28.png)
