### PR TITLE
Fix race condition that prevented top-level breakpoints from hitting

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -19,6 +19,7 @@ namespace pxsim {
         localizedStrings?: Map<string>;
         version?: string;
         clickTrigger?: boolean;
+        breakOnStart?: boolean;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -713,7 +713,7 @@ namespace pxsim {
             let entryPoint: LabelFn;
             let pxtrt = pxsim.pxtrt
             let breakpoints: Uint8Array = null
-            let breakAlways = false
+            let breakAlways = !!msg.breakOnStart;
             let globals = this.globals
             let yieldSteps = yieldMaxSteps
             // ---

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -50,6 +50,7 @@ namespace pxsim {
         refCountingDebug?: boolean;
         version?: string;
         clickTrigger?: boolean;
+        breakOnStart?: boolean;
     }
 
     export interface HwDebugger {
@@ -64,6 +65,7 @@ namespace pxsim {
         private _currentRuntime: pxsim.SimulatorRunMessage;
         private listener: (ev: MessageEvent) => void;
         private traceInterval = 0;
+        private breakpointsSet = false;
         public runOptions: SimulatorRunOptions = {};
         public state = SimulatorState.Unloaded;
         public hwdbg: HwDebugger;
@@ -438,7 +440,8 @@ namespace pxsim {
                 localizedStrings: opts.localizedStrings,
                 refCountingDebug: opts.refCountingDebug,
                 version: opts.version,
-                clickTrigger: opts.clickTrigger
+                clickTrigger: opts.clickTrigger,
+                breakOnStart: opts.breakOnStart
             }
             this.start();
         }
@@ -448,6 +451,10 @@ namespace pxsim {
             this.start();
         }
 
+        public areBreakpointsSet() {
+            return this.breakpointsSet;
+        }
+
         private start() {
             this.clearDebugger();
             this.addEventListeners();
@@ -455,6 +462,8 @@ namespace pxsim {
             this.scheduleFrameCleanup();
 
             if (!this._currentRuntime) return; // nothing to do
+
+            this.breakpointsSet = false;
 
             // first frame
             let frame = this.simFrames()[0];
@@ -577,6 +586,7 @@ namespace pxsim {
         }
 
         public setBreakpoints(breakPoints: number[]) {
+            this.breakpointsSet = true;
             this.postDebuggerMessage("config", { setBreakpoints: breakPoints })
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -682,7 +682,7 @@ export class ProjectView
                 if (this.state.debugging && !simulator.driver.areBreakpointsSet() && brk && !brk.exceptionMessage) {
                     // The simulator has paused on the first statement, so we need to send the breakpoints
                     // and continue
-                    let breakpoints: number[];''
+                    let breakpoints: number[];
                     if (this.isAnyEditeableJavaScriptOrPackageActive()) {
                         breakpoints = this.textEditor.getBreakpoints();
                     }
@@ -692,7 +692,7 @@ export class ProjectView
 
                     breakpoints = breakpoints || [];
                     simulator.driver.setBreakpoints(breakpoints);
-        
+
                     if (breakpoints.indexOf(brk.breakpointId) === -1) {
                         this.dbgPauseResume();
                         return true;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -679,6 +679,25 @@ export class ProjectView
                 core.warningNotification(lf("Program Error: {0}", brk.exceptionMessage));
             },
             highlightStatement: (stmt, brk) => {
+                if (this.state.debugging && !simulator.driver.areBreakpointsSet() && brk && !brk.exceptionMessage) {
+                    // The simulator has paused on the first statement, so we need to send the breakpoints
+                    // and continue
+                    let breakpoints: number[];''
+                    if (this.isAnyEditeableJavaScriptOrPackageActive()) {
+                        breakpoints = this.textEditor.getBreakpoints();
+                    }
+                    else if (this.isBlocksActive()) {
+                        breakpoints = this.blocksEditor.getBreakpoints();
+                    }
+
+                    breakpoints = breakpoints || [];
+                    simulator.driver.setBreakpoints(breakpoints);
+        
+                    if (breakpoints.indexOf(brk.breakpointId) === -1) {
+                        this.dbgPauseResume();
+                        return true;
+                    }
+                }
                 if (this.editor) return this.editor.highlightStatement(stmt, brk);
                 return false;
             },
@@ -2291,11 +2310,9 @@ export class ProjectView
             simulator.driver.stopSound();
             simulator.driver.restart(); // fast restart
         }
-        // TODO: typescript breakpoints
-        if (isDebug)
-            this.blocksEditor.setBreakpointsFromBlocks();
-        else
+        if (!isDebug) {
             this.blocksEditor.clearBreakpoints();
+        }
     }
 
     startSimulator(opts?: pxt.editor.SimulatorStartOptions) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -42,12 +42,16 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             if (blockId) map[blockId] = breakpoint.id;
         });
         this.breakpointsByBlock = map;
-        this.setBreakpointsFromBlocks();
     }
 
     setBreakpointsFromBlocks(): void {
-        let breakpoints: number[] = []
-        let map = this.breakpointsByBlock;
+        this.breakpointsSet = this.getBreakpoints();
+        simulator.driver.setBreakpoints(this.breakpointsSet);
+    }
+
+    getBreakpoints() {
+        const breakpoints: number[] = []
+        const map = this.breakpointsByBlock;
         if (map && this.editor) {
             this.editor.getAllBlocks().forEach(block => {
                 if (map[block.id] && block.isBreakpointSet()) {
@@ -55,9 +59,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
             });
         }
-
-        this.breakpointsSet = breakpoints;
-        simulator.driver.setBreakpoints(breakpoints);
+        return breakpoints;
     }
 
     addBreakpointFromEvent(blockId: string) {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1039,10 +1039,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.breakpoints = new BreakpointCollection(breakpoints);
                 this.breakpoints.loadBreakpointsForFile(this.currFile, this.editor);
             }
-            else {
-                // The simulator got restarted
-                this.sendBreakpoints();
-            }
 
             if (this.fieldEditors) this.fieldEditors.clearRanges(this.editor);
             if (this.feWidget) this.feWidget.close();
@@ -1075,9 +1071,13 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.forceDiagnosticsUpdate();
     }
 
+    getBreakpoints() {
+        return this.breakpoints ? this.breakpoints.getActiveBreakpoints() : [];
+    }
+
     private sendBreakpoints() {
         if (this.breakpoints) {
-            simulator.driver.setBreakpoints(this.breakpoints.getActiveBreakpoints());
+            simulator.driver.setBreakpoints(this.getBreakpoints());
         }
     }
 

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -267,7 +267,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         localizedStrings: simTranslations,
         refCountingDebug: pxt.options.debug,
         version: pkg.version(),
-        clickTrigger: clickTrigger
+        clickTrigger: clickTrigger,
+        breakOnStart: debug
     }
     //if (pxt.options.debug)
     //    pxt.debug(JSON.stringify(opts, null, 2))

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -128,6 +128,10 @@ export class Editor implements pxt.editor.IEditor {
     updateBreakpoints() {
     }
 
+    getBreakpoints(): number[] {
+        return [];
+    }
+
     updateToolbox() {
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1068

We had a race condition where the simulator would start running before the webapp had a chance to send the breakpoints to the runtime. As a result, top level breakpoints (e.g. those in "on start") would sometimes not hit.

This PR fixes that by making the simulator pause on the first statement so that the webapp can send the breakpoints (and tell it to continue). Shouldn't be any change for users.