### PR TITLE
Fix for IE and Edge Embed

### DIFF
--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -114,8 +114,9 @@
         var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
+        var codeFromData = undefined;
         try {
-            var codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
+            codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
         } catch (e) {
             /**
              *  Internet Explorer 11 and Microsoft Edge throw an exception when checking 

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -114,7 +114,14 @@
         var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
-        var codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
+        try {
+            var codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
+        } catch (e) {
+            /**
+             *  Internet Explorer 11 and Microsoft Edge throw an exception when checking 
+             *  if the frame element exists when the iframe is on a different origin
+             */
+        }
         var code = codeFromData || (codeFromSrc ? codeFromSrc[1] : undefined);
 
         if (!id && !code && !debugSim) {


### PR DESCRIPTION
IE and Edge can throw an exception when checking if a frameElement exists. This adds a check to see if that exception is thrown.

Fixes https://github.com/microsoft/pxt-microbit/issues/2218