### PR TITLE
make element.containsClass helper allow for checking multiple classes

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -976,7 +976,7 @@ namespace pxt.BrowserUtils {
             if (el.classList) {
                 return el.classList.contains(cls);
             } else {
-                const classes = (el.className + "").split(/\s+/) as string[];
+                const classes = (el.className + "").split(/\s+/);
                 return !(classes.indexOf(cls) < 0);
             }
         }
@@ -991,7 +991,7 @@ namespace pxt.BrowserUtils {
             if (el.classList) {
                 el.classList.add(cls);
             } else {
-                const classes = (el.className + "").split(/\s+/) as string[];
+                const classes = (el.className + "").split(/\s+/);
                 if (classes.indexOf(cls) < 0) {
                     el.className.baseVal += " " + cls;
                 }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -967,12 +967,18 @@ namespace pxt.BrowserUtils {
     }
 
     // Keep these helpers unified with pxtsim/runtime.ts
-    export function containsClass(el: SVGElement | HTMLElement, cls: string) {
-        if (el.classList) {
-            return el.classList.contains(cls);
-        } else {
-            const classes = (el.className + "").split(/\s+/) as string[];
-            return !(classes.indexOf(cls) < 0)
+    export function containsClass(el: SVGElement | HTMLElement, classes: string) {
+        return classes
+            .split(/\s+/)
+            .every(cls => containsSingleClass(el, cls));
+
+        function containsSingleClass(el: SVGElement | HTMLElement, cls: string) {
+            if (el.classList) {
+                return el.classList.contains(cls);
+            } else {
+                const classes = (el.className + "").split(/\s+/) as string[];
+                return !(classes.indexOf(cls) < 0);
+            }
         }
     }
 

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -5,12 +5,18 @@ namespace pxsim {
     let tracePauseMs = 0;
     export namespace U {
         // Keep these helpers unified with pxtlib/browserutils.ts
-        export function containsClass(el: SVGElement | HTMLElement, cls: string) {
-            if (el.classList) {
-                return el.classList.contains(cls);
-            } else {
-                const classes = (el.className + "").split(/\s+/) as string[];
-                return !(classes.indexOf(cls) < 0)
+        export function containsClass(el: SVGElement | HTMLElement, classes: string) {
+            return classes
+                .split(/\s+/)
+                .every(cls => containsSingleClass(el, cls));
+
+            function containsSingleClass(el: SVGElement | HTMLElement, cls: string) {
+                if (el.classList) {
+                    return el.classList.contains(cls);
+                } else {
+                    const classes = (el.className + "").split(/\s+/) as string[];
+                    return !(classes.indexOf(cls) < 0);
+                }
             }
         }
 

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -14,7 +14,7 @@ namespace pxsim {
                 if (el.classList) {
                     return el.classList.contains(cls);
                 } else {
-                    const classes = (el.className + "").split(/\s+/) as string[];
+                    const classes = (el.className + "").split(/\s+/);
                     return !(classes.indexOf(cls) < 0);
                 }
             }
@@ -29,7 +29,7 @@ namespace pxsim {
                 if (el.classList) {
                     el.classList.add(cls);
                 } else {
-                    const classes = (el.className + "").split(/\s+/) as string[];
+                    const classes = (el.className + "").split(/\s+/);
                     if (classes.indexOf(cls) < 0) {
                         el.className.baseVal += " " + cls;
                     }


### PR DESCRIPTION
… at once

Kim noticed that this one wasn't working with multiple classes at once like add / remove class helpers do, so this fixes that.

Also remove some now unnecessary casts now that string is explicitly cast for the IE fix