### PR TITLE
shorten debounce so save actually occurs after typing

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2555,14 +2555,17 @@ export class ProjectView
             })
     }
 
-    private debouncedSaveProjectName = Util.debounce(() => {
-        this.saveProjectNameAsync().done();
-    }, 500, false);
+    private debouncedSaveProjectName: () => void;
 
     updateHeaderName(name: string) {
         this.setState({
             projectName: name
         })
+        if (!this.debouncedSaveProjectName) {
+            this.debouncedSaveProjectName = Util.debounce(() => {
+                this.saveProjectNameAsync().done();
+            }, pxt.options.light ? 2000 : 500, false);
+        }
         this.debouncedSaveProjectName();
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2557,7 +2557,7 @@ export class ProjectView
 
     private debouncedSaveProjectName = Util.debounce(() => {
         this.saveProjectNameAsync().done();
-    }, 2000, false);
+    }, 500, false);
 
     updateHeaderName(name: string) {
         this.setState({


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/993 (in most cases)

issue was mainly just that the debounce timeout was so long that it basically never triggered.

This one doesn't fully fix the issue, as you can still escape without the rename saving if you keep typing while clicking close, but that seems like a bit of a rabbit hole to poll for the most up to date name everywhere it is saved - wanted to put up the 'easy fix' that fixes it in most cases before doing that.

Maybe worth lowering the debounce timeout down to 250ms? 500 ms seems to fix the most common case for me at least (click into textbox, type type type, move mouse to go to home screen, click out)