### PR TITLE
use short youtube link so links are same from home screen and docs

### DIFF
--- a/pxtblocks/codecardrenderer.ts
+++ b/pxtblocks/codecardrenderer.ts
@@ -15,7 +15,7 @@ namespace pxt.docs.codeCard {
             else if (card.software && !card.hardware) color = 'teal';
         }
         const url = card.url ? /^[^:]+:\/\//.test(card.url) ? card.url : ('/' + card.url.replace(/^\.?\/?/, ''))
-            : card.youTubeId ? `https://www.youtube.com/watch?v=${card.youTubeId}` : undefined;
+            : card.youTubeId ? `https://youtu.be/${card.youTubeId}` : undefined;
         const link = !!url;
         const div = (parent: HTMLElement, cls: string, tag = "div", text: string | number = ''): HTMLElement => {
             let d = document.createElement(tag);


### PR DESCRIPTION
Home screen vs docs page used a different format for youtube links ([noted here](https://github.com/microsoft/pxt-arcade/pull/1089#issuecomment-504147809)), which aren't interchangeable when defining a start time. This makes it so they use the same format link

e.g. currently the homescreen has
https://youtu.be/llgKiQGPb0k?t=438s for Re-MakeCode racing games (bottom row)

and https://www.youtube.com/watch?v=mZeyxi75Kyo?t=405s from the link in https://arcade.makecode.com/john-parks-workshop, causing the timestamp being ignored. (passing as `&t=405s` isn't an option as the homescreen will 404 off of that)