### PR TITLE
base type check off of inferred type rather than explicit typing

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -1441,9 +1441,8 @@ ${output}</xml>`;
             function checkBooleanCallExpression(n: CallExpression) {
                 const callInfo: pxtc.CallInfo = (n.expression as any).callInfo;
                 if (callInfo) {
-                    const type = callInfo.decl.type;
-
-                    if (type && type.kind === SK.BooleanKeyword) {
+                    const api = env.blocks.apis.byQName[callInfo.qName];
+                    if (api && api.retType == "boolean") {
                         return undefined;
                     }
                 }

--- a/tests/decompile-test/baselines/inferred_boolean_conditionals.blocks
+++ b/tests/decompile-test/baselines/inferred_boolean_conditionals.blocks
@@ -1,0 +1,29 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="test_inferred_boolean_argument_output">
+</block>
+</value>
+<statement name="DO0">
+</statement>
+<next>
+<block type="controls_if">
+<mutation elseif="0" else="0" />
+<value name="IF0">
+<shadow type="logic_boolean"><field name="BOOL">TRUE</field></shadow>
+<block type="typescript_expression">
+<field name="EXPRESSION">testNamespace.inferredNumberOutput&#40;&#41;</field>
+</block>
+</value>
+<statement name="DO0">
+</statement>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/inferred_boolean_conditionals.ts
+++ b/tests/decompile-test/cases/inferred_boolean_conditionals.ts
@@ -1,0 +1,2 @@
+if (testNamespace.inferredBooleanOutput()) {}
+if (testNamespace.inferredNumberOutput()) {}

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -55,9 +55,17 @@ namespace testNamespace {
     //% block="Output Boolean arg %arg=logic_boolean"
     export function booleanArgumentOutput(arg: boolean): boolean { return true; }
 
+    //% blockId=test_inferred_boolean_argument_output
+    //% block="Output inferred boolean"
+    export function inferredBooleanOutput() { return true; }
+
     //% blockId=test_number_argument_output
     //% block="Output Number arg %arg"
     export function numberArgumentOutput(arg: number): number { return 0; }
+
+    //% blockId=test_inferred_number_argument_output
+    //% block="Output inferred number"
+    export function inferredNumberOutput() { return 0; }
 
     //% blockId=test_string_argument_output
     //% block="Output String arg %arg"


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1091

turns out ``callinfo.decl.type`` only includes explicit types (``: boolean``) and shouldn't be used directly, so this was requiring the type to be explicitly specified to decompile. Using the inferred types instead fixes the issue.

results of test:

![arcade-screenshot (12)](https://user-images.githubusercontent.com/5615930/59888149-24d96c00-937b-11e9-858c-08e9a99be598.png)
