### PR TITLE
Fixing runtime hang when resuming after breakpoints

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1167,7 +1167,7 @@ namespace pxsim {
                 clearTimeout(ts.id);
                 let elapsed = U.now() - ts.timestampCall;
                 let timeRemaining = ts.totalRuntime - elapsed;
-                if (timeRemaining < 0) timeRemaining = 0;
+                if (timeRemaining <= 0) timeRemaining = 1;
                 this.timeoutsPausedOnBreakpoint.push(new PausedTimeout(ts.fn, timeRemaining))
             });
             this.lastPauseTimestamp = U.now();

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1167,6 +1167,9 @@ namespace pxsim {
                 clearTimeout(ts.id);
                 let elapsed = U.now() - ts.timestampCall;
                 let timeRemaining = ts.totalRuntime - elapsed;
+
+                // Time reamining needs to be at least 1. Setting to 0 causes fibers
+                // to never resume after breaking
                 if (timeRemaining <= 0) timeRemaining = 1;
                 this.timeoutsPausedOnBreakpoint.push(new PausedTimeout(ts.fn, timeRemaining))
             });


### PR DESCRIPTION
Fixes the issue where the debugger sometimes doesn't resume after hitting a breakpoint.

To arrive at this fix, I basically resorted to logging all of the timeouts that were being resumed and noticed that it consistently hangs IFF the time remaining is set to 0. I have no clue why this fixes the issue, but I tested it pretty thoroughly and I can no longer reproduce it.

My best guess is that somewhere else in this same execution context, setTimeout is being called with an argument of 0 and the function that's being passed needs to be executed before the scheduled timeouts run. I haven't been able to confirm that theory yet so I'll keep digging