### PR TITLE
Bug fixes in client docs rendering

### DIFF
--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -20,6 +20,8 @@ The MakeCode approach to solving this issue is to render the **JavaScript** code
 
 Here is an integration sample:
 
+* [React component](https://github.com/microsoft/pxt-react-extension-template/blob/master/src/components/snippet.tsx)
+* [HTML only](https://jsfiddle.net/ndyz1d57/80/)
 * [MkDocs plugin](https://microsoft.github.io/pxt-mkdocs-sample/)
 
 ## Custom rendering

--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -85,6 +85,7 @@ export interface RenderBlocksResponseMessage extends SimulatorMessage {
     uri?: string;
     width?: number;
     height?: number;
+    error?: string;
 }
 ```
 

--- a/docs/blocks-embed.md
+++ b/docs/blocks-embed.md
@@ -19,7 +19,8 @@ The MakeCode approach in solving this problem is to render the **JavaScript** co
 
 Here are some sample integrations for various documentation/blogging engines.
 
-* [GitBook plugin](https://plugins.gitbook.com/plugin/pxt)
+* [React component](https://github.com/microsoft/pxt-react-extension-template/blob/master/src/components/snippet.tsx)
+* [HTML only](https://jsfiddle.net/ndyz1d57/80/)
 * [MkDocs plugin](https://microsoft.github.io/pxt-mkdocs-sample/)
 
 ## Manual Implementation

--- a/docs/extensions/extensions.md
+++ b/docs/extensions/extensions.md
@@ -2,7 +2,13 @@
 
 An editor extension may have an associated editor extension hosted in the Github Pages section of the repo.
 
-* [pxt-neoanim](https://github.com/Microsoft/pxt-neoanim) is an example of specialized NeoPixel animation editor.
+## ~ hint
+
+A lot of the plumbing has been done for you in this React-based template...
+
+* [pxt-react-extension-template](https://github.com/microsoft/pxt-react-extension-template/generate) -- a React template to create an extension
+
+## ~
 
 ## Configuration
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -14,6 +14,7 @@ namespace ts.pxtc.decompiler {
     }
 
     export const FILE_TOO_LARGE_CODE = 9266;
+    export const DECOMPILER_ERROR = 9267;
     const SK = ts.SyntaxKind;
 
     /**
@@ -423,7 +424,18 @@ namespace ts.pxtc.decompiler {
                 }]);
             }
             else {
-                throw e;
+                // don't throw
+                pxt.reportException(e);
+                result.success = false;
+                result.diagnostics = pxtc.patchUpDiagnostics([{
+                    file,
+                    start: file.getFullStart(),
+                    length: file.getFullWidth(),
+                    messageText: e.message,
+                    category: ts.DiagnosticCategory.Error,
+                    code: DECOMPILER_ERROR
+                }]);
+                return result;
             }
         }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -458,6 +458,16 @@ namespace pxt.runner {
                         uri: res ? res.xml : undefined,
                         css: res ? res.css : undefined
                     }, "*");
+                })
+                .catch(e => {
+                    window.parent.postMessage(<pxsim.RenderBlocksResponseMessage>{
+                        source: "makecode",
+                        type: "renderblocks",
+                        id: msg.id,
+                        error: e.message
+                    }, "*");
+                })
+                .finally(() => {
                     jobPromise = undefined;
                     consumeQueue();
                 })

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -213,6 +213,7 @@ namespace pxsim {
         height?: number;
         css?: string;
         uri?: string;
+        error?: string;
     }
 
     export function print(delay: number = 0) {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -211,6 +211,8 @@ namespace pxsim {
         svg?: string;
         width?: number;
         height?: number;
+        css?: string;
+        uri?: string;
     }
 
     export function print(delay: number = 0) {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1702,7 +1702,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             labelIcon.setAttribute('role', 'presentation');
             labelIcon.style.display = 'inline-block';
             labelIcon.style.color = `${pxt.toolbox.convertColor(iconColor)}`;
-            if (icon.length === 1) {
+            if (icon && icon.length === 1) {
                 labelIcon.textContent = icon;
             }
             labelDiv.appendChild(labelIcon);


### PR DESCRIPTION
- [x] rendering server stops if any exception occurs, now making it more robust
- [x] report crashes to client to handle it
- [x] broken monaco if namespace is missing icon

As a side effect, decompilation never fails, it just becomes a big gray block.