### PR TITLE
Displaying python snippets in monaco flyout for 'snippetsOnly' blocks

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1759,6 +1759,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             return undefined;
         const qName = fn.qName;
         const snippetName = (isPython ? (fn.pySnippetName || fn.pyName) : undefined) || fn.snippetName || fn.name;
+        const snippet = isPython ? fn.pySnippet : fn.snippet;
 
         let monacoBlockArea = document.createElement('div');
         monacoBlockArea.className = `monacoBlock ${isDisabled ? 'monacoDisabledBlock' : ''}`;
@@ -1774,7 +1775,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         color = pxt.toolbox.convertColor(color);
 
         const methodToken = document.createElement('span');
-        methodToken.textContent = fn.snippetOnly ? fn.snippet : snippetName;
+        methodToken.textContent = fn.snippetOnly ? snippet : snippetName;
         monacoBlock.appendChild(methodToken);
 
         if (!isDisabled) {
@@ -1783,11 +1784,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 pxt.tickEvent("monaco.toolbox.itemclick", undefined, { interactiveConsent: true });
                 monacoEditor.hideFlyout();
 
-                let snip = isPython ? fn.pySnippet : fn.snippet;
-                let p = snip ? Promise.resolve(snip) : compiler.snippetAsync(qName, isPython);
-                p.done(snippet => {
+                let p = snippet ? Promise.resolve(snippet) : compiler.snippetAsync(qName, isPython);
+                p.done(snip => {
                     let currPos = monacoEditor.editor.getPosition();
-                    this.insertSnippet(currPos, snippet);
+                    this.insertSnippet(currPos, snip);
                     // Fire a create event
                     workspace.fireEvent({ type: 'create', editor: 'ts', blockId: fn.attributes.blockId } as pxt.editor.events.CreateEvent);
                 });
@@ -1798,7 +1798,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     monacoFlyout.style.transform = "translateX(-9999px)";
                 });
 
-                const snippet = isPython ? fn.pySnippet : fn.snippet;
                 if (!snippet)
                     e.dataTransfer.setData('text', 'qName:' + qName); // IE11 only supports text
                 else

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -245,6 +245,8 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     name: "Math.randomRange",
                     snippetName: "randomRange",
                     snippet: `Math.randomRange(0, 10)`,
+                    pySnippetName: `randint`,
+                    pySnippet: `randint(0, 10)`,
                     attributes: {
                         weight: 65,
                         jsDoc: lf("Returns a random number between min and max")


### PR DESCRIPTION
microsoft/pxt-minecraft/issues/884

+ small fix for randint python snippet & name (microsoft/pxt-minecraft/issues/850)