### PR TITLE
Adds error notification to Github 404

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -674,8 +674,10 @@ export async function importGithubAsync(id: string) {
             isEmpty = true
             sha = await pxt.github.getRefAsync(parsed.fullName, parsed.tag)
         }
-        else if (e.statusCode == 404)
-            U.userError(lf("No such repository or branch."))
+        else if (e.statusCode == 404) {
+            core.errorNotification(lf("Sorry, that repository looks invalid."));
+            U.userError(lf("No such repository or branch."));
+        }
     }
     return await githubUpdateToAsync(null, repoid, sha, {})
         .then(hd => {


### PR DESCRIPTION
This fixes https://github.com/microsoft/pxt-arcade/issues/1108 by adding the error message where it detects the 404 error. 

Problem
![nofeedback2](https://user-images.githubusercontent.com/6301646/60370619-f1ff2b80-99ab-11e9-884c-d70af2369064.gif)

Fix
![feedback-fix](https://user-images.githubusercontent.com/6301646/60370623-f4fa1c00-99ab-11e9-9b29-cfb8293f3970.gif)
