### PR TITLE
remove tpwr command from BMP backend of GDB

### DIFF
--- a/cli/gdb.ts
+++ b/cli/gdb.ts
@@ -898,7 +898,7 @@ export async function startAsync(gdbArgs: string[]) {
     if (bmpPort) {
         bmpMode = true
         trg = "target extended-remote " + bmpPort
-        trg += "\nmonitor tpwr enable\nmonitor swdp_scan\nattach 1"
+        trg += "\nmonitor swdp_scan\nattach 1"
         pxt.log("Using Black Magic Probe at " + bmpPort)
         monReset = "run"
         monResetHalt = "run"


### PR DESCRIPTION
This command only works on original BMP and isn't really needed