### PR TITLE
always load blockly before trying to decompile examples

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1812,7 +1812,8 @@ export class ProjectView
                 if (loadBlocks) {
                     return this.createProjectAsync(opts)
                         .then(() => {
-                            return compiler.getBlocksAsync()
+                            return this.loadBlocklyAsync()
+                                .then(compiler.getBlocksAsync)
                                 .then(blocksInfo => compiler.decompileAsync("main.ts", blocksInfo))
                                 .then(resp => {
                                     pxt.debug(`example decompilation: ${resp.success}`)


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt/issues/5723

With slow internet connection blockly wouldn't be loaded until after it calls ``overrideBlocksFile``, which ends up calling ``pxt.blocks.saveWorkspaceXml`` and breaks in that case. I can get it to repro reliably when using the chrome debugger's ``fast 3g`` throttle setting.