### PR TITLE
Parsing metadata table, use hint comment syntax for v2

### DIFF
--- a/docs/writing-docs/tutorials.md
+++ b/docs/writing-docs/tutorials.md
@@ -166,13 +166,40 @@ The text in the heading is shown only when the tutorial is viewed as a help page
 
 The editor automatically parses the markdown and populates the user interface from each step section.
 
-In each step, just the first paragraph is displayed to the user in the tutorial caption. The complete text, block examples, etc. are displayed in the ``hint`` dialog when the user clicks the caption or hint button. If you include code snippets, images or videos, they are shown in the hint view also.
+### Metadata
+
+Tutorial metadata can be optionally specified in a table at the top of the document. The table is a key-value pairing of fields. The currrent fields are:
+
+* **v**: version, for the tutorial syntax. When unspecified, default is V1. Used in tutorial hint parsing.
+
+```markdown
+| v             | 2               |
+| field_name    | field_value     |
+```
+
+### Hints
+
+#### Default Syntax
+
+In each step, any text before the first code snippet or image is automatically displayed to the user in the tutorial caption. The remaining text, block examples, etc. are displayed in the ``hint`` dialog when the user clicks the caption or hint button.
+
+#### V2 Syntax
+
+If version 2 is specified in the tutorial metadata, the tutorial will only show hints that are explicitly defined with the hint tag, as follows: `<!-- HINT TEXT HERE -->`. One hint can be specified per step, and if no hint is specified all text (including blocks) will be displayed in the tutorial caption.
+
+````markdown
+<!-- Try clicking on the 'Basic' drawer to find the blocks you need! Your code should look like this:
+
+```blocks
+basic.showString("Micro!")
+``` -->
+````
 
 ### ~ hint
 
 **Simple, short descriptions**
 
-During an interaction, the first paragraph of the step description is shown in the caption. If the paragraph length goes beyond the display length of caption, a scroll bar appears in order to view the rest of the paragraph. It's best to keep the paragraph short enough to so all of it appears in the caption without requiring the user to scroll to see it all. If your instructions need more text, you can just create an additional step to split up the activity.
+During an interaction, the step description (all text before the first code block or image) is shown in the caption. If the paragraph length goes beyond the display length of caption, a "More" button appears in order to view the rest of the paragraph. It's best to keep the paragraph short enough to so all of it appears in the caption without requiring the user to click to see it all. If your instructions need more text, you can just create an additional step to split up the activity.
 
 ### ~
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -776,6 +776,11 @@ declare namespace pxt.tutorial {
         templateCode?: string;
     }
 
+    interface TutorialMetadata {
+        v: number; // version of tutorial markdown syntax
+        title?: string;
+    }
+
     interface TutorialStepInfo {
         fullscreen?: boolean;
         // no coding
@@ -784,7 +789,7 @@ declare namespace pxt.tutorial {
         hasHint?: boolean;
         contentMd?: string;
         headerContentMd?: string;
-        blockSolution?: string;
+        hintContentMd?: string;
     }
 
     interface TutorialOptions {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -65,8 +65,8 @@ namespace pxt.tutorial {
     }
 
     function parseTutorialSteps(tutorialmd: string): TutorialStepInfo[] {
+        const metadata = parseTutorialMetadata(tutorialmd);
         const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template)\s*\n([\s\S]*?)\n```/gmi;
-        const hintTextRegex = /(^[\s\S]*?\S)\s*((```|\!\[[\s\S]+?\]\(\S+?\))[\s\S]*)/mi;
 
         // Download tutorial markdown
         let steps = tutorialmd.split(/^##[^#].*$/gmi);
@@ -98,25 +98,58 @@ namespace pxt.tutorial {
         for (let i = 0; i < steps.length; i++) {
             const stepContent = steps[i].trim();
             const contentLines = stepContent.split('\n');
-            stepInfo[i].headerContentMd = contentLines[0];
-            stepInfo[i].contentMd = stepContent;
+            const info = stepInfo[i];
 
-            // everything after the first ``` section OR the first image is currently treated as a "hint"
-            let hintText = stepContent.match(hintTextRegex);
-            let blockSolution;
-            if (hintText && hintText.length > 2) {
-                stepInfo[i].headerContentMd = hintText[1];
-                blockSolution = hintText[2];
-                if (blockSolution) {
-                    // remove hidden snippets from the hint
-                    blockSolution = blockSolution.replace(hiddenSnippetRegex, '');
-                    stepInfo[i].blockSolution = blockSolution;
+            info.headerContentMd = contentLines[0];
+            info.contentMd = stepContent;
+
+            let hintContentMd;
+            if (metadata && metadata.v == 2) {
+                // v2: hint is explicitly defined in HTML comment form: <!-- HINT TEXT -->
+                const hintTextRegex = /<!--([\s\S]*?)-->/i;
+                info.headerContentMd = stepContent.replace(hintTextRegex, function (f, m) {
+                    hintContentMd = m;
+                    return "";
+                });
+            } else {
+                // v1: everything after the first ``` section OR the first image is treated as a "hint"
+                const hintTextRegex = /(^[\s\S]*?\S)\s*((```|\!\[[\s\S]+?\]\(\S+?\))[\s\S]*)/mi;
+                let hintText = stepContent.match(hintTextRegex);
+                if (hintText && hintText.length > 2) {
+                    info.headerContentMd = hintText[1];
+                    hintContentMd = hintText[2];
                 }
             }
 
-            stepInfo[i].hasHint = blockSolution && blockSolution.length > 1;
+            // remove hidden snippets from the hint
+            if (hintContentMd) {
+                hintContentMd = hintContentMd.replace(hiddenSnippetRegex, '');
+                info.hintContentMd = hintContentMd;
+            }
+
+            info.hasHint = hintContentMd && hintContentMd.length > 1;
         }
         return stepInfo;
+    }
+
+    /*
+        Parses metadata table at the beginning of tutorial markown. Expects a series of
+        key-value pairs, in "| key | value |\n" format.
+    */
+    function parseTutorialMetadata(tutorialmd: string): TutorialMetadata {
+        let m: any = {};
+
+        const tableRegex = /(?:\|[\s\S]+?\|[\s\S]+?\|\n)*/i;
+        const keyValueRegex = /\|([\s\S]+?)\|([\s\S]+?)\|\n/gi;
+
+        const table = tutorialmd.match(tableRegex)[0];
+        table.replace(keyValueRegex, function (f, k, v) {
+            m[k.trim()] = v.trim();
+                return "";
+            });
+
+        const metadata = m as TutorialMetadata;
+        return metadata && metadata.v ? metadata :  null;
     }
 
     export function highlight(pre: HTMLPreElement): void {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -144,7 +144,7 @@ namespace pxt.tutorial {
 
         const table = tutorialmd.match(tableRegex)[0];
         table.replace(keyValueRegex, function (f, k, v) {
-            m[k.trim()] = v.trim();
+                m[k.trim()] = v.trim();
                 return "";
             });
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -159,7 +159,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
         if (!tutorialReady) return <div />;
 
         const step = tutorialStepInfo[tutorialStep];
-        const tutorialHint = step.blockSolution;
+        const tutorialHint = step.hintContentMd;
         const fullText = step.contentMd;
 
         if (!step.unplugged) {


### PR DESCRIPTION
Expects 2-column table in key-value format at the start of markdown file, and hint in <!-- HINT --> comment syntax

Fixes microsoft/pxt-minecraft/issues/842