### PR TITLE
Fix emit of object literals

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1519,7 +1519,8 @@ ${lbl}: .short 0xffff
                     userError(9264, "Shorthand properties not supported.")
                     return;
                 }
-                const keyName = p.name.getText();
+                const keyName = p.name.kind == SK.StringLiteral ?
+                    (p.name as StringLiteral).text : p.name.getText();
                 const args = [
                     expr,
                     ir.numlit(getIfaceMemberId(keyName)),


### PR DESCRIPTION
Without this patch we get:

```typescript
JSON.stringify({ "foo": 1, bar: 2 }) == '{"\"foo\"":1,"bar":2}'
```
