### PR TITLE
Adding a @tutorialCompleted macro and editor extension

### DIFF
--- a/docs/writing-docs/tutorials.md
+++ b/docs/writing-docs/tutorials.md
@@ -21,7 +21,7 @@ When a tutorial is chosen in the editor, the tutorial runner converts the conten
 
 **A real example**
 
-See the micro:bit tutorials [**flashing-heart.md**](https://github.com/Microsoft/pxt-microbit/blob/master/docs/projects/flashing-heart.md) and 
+See the micro:bit tutorials [**flashing-heart.md**](https://github.com/Microsoft/pxt-microbit/blob/master/docs/projects/flashing-heart.md) and
 [**rock-paper-scissors.md**](https://github.com/Microsoft/pxt-microbit/blob/master/docs/projects/rock-paper-scissors.md).
 
 ### ~
@@ -124,7 +124,7 @@ a ``"editor": "js"`` entry for JavaScript tutorials and ``"editor": "py"`` entry
 
 ## Format
 
-The tutorial markdown has a format that the guides the tutorial runner in making a sequence of interactions: 
+The tutorial markdown has a format that the guides the tutorial runner in making a sequence of interactions:
 
 ### Title
 
@@ -202,6 +202,20 @@ If you want to display your tutorial step in a dialog and then have it skip to t
 # Flash-a-rama
 
 ## It's time to code! @unplugged
+
+```
+
+
+### TutorialCompleted
+
+Used to signify that this step in the tutorial is the "last step" even if more steps are present in the markdown. This has no impact on how tutorial progress is displayed; it is only used by MakeCode editors that do something external when a tutorial is completed.
+
+```markdown
+# Flash-a-rama
+
+## This is the last step @tutorialCompleted
+
+## This is a bonus activity that comes after the last step
 
 ```
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -778,6 +778,7 @@ declare namespace pxt.tutorial {
         fullscreen?: boolean;
         // no coding
         unplugged?: boolean;
+        tutorialCompleted?: boolean;
         hasHint?: boolean;
         contentMd?: string;
         headerContentMd?: string;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -341,6 +341,9 @@ namespace pxt.editor {
         toolboxOptions?: IToolboxOptions;
         blocklyPatch?: (pkgTargetVersion: string, dom: Element) => void;
         webUsbPairDialogAsync?: (confirmAsync: (options: any) => Promise<number>) => Promise<number>;
+
+        // Used with the @tutorialCompleted macro. See docs/writing-docs/tutorials.md for more info
+        onTutorialCompleted?: () => void;
     }
 
     export interface FieldExtensionOptions {

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -20,4 +20,5 @@ namespace pxt.commands {
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
     export let webUsbPairDialogAsync: (confirmAsync: (options: any) => Promise<number>) => Promise<number> = undefined;
+    export let onTutorialCompleted: () => void = undefined;
 }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -79,7 +79,8 @@ namespace pxt.tutorial {
         tutorialmd.replace(newAuthoring ? /^##[^#](.*)$/gmi : /^###[^#](.*)$/gmi, (f, s) => {
             let info: TutorialStepInfo = {
                 fullscreen: /@(fullscreen|unplugged)/.test(s),
-                unplugged: /@unplugged/.test(s)
+                unplugged: /@unplugged/.test(s),
+                tutorialCompleted: /@tutorialCompleted/.test(s)
             }
             stepInfo.push(info);
             return ""

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -937,6 +937,9 @@ export class ProjectView
             this.setState({ tutorialOptions: tutorialOptions });
             const fullscreen = tutorialOptions.tutorialStepInfo[step].fullscreen;
             if (fullscreen) this.showTutorialHint();
+
+            const isCompleted = tutorialOptions.tutorialStepInfo[step].tutorialCompleted;
+            if (isCompleted && pxt.commands.onTutorialCompleted) pxt.commands.onTutorialCompleted();
             // Hide flyouts and popouts
             this.editor.closeFlyout();
         }
@@ -3614,6 +3617,9 @@ function initExtensionsAsync(): Promise<void> {
             }
             if (res.webUsbPairDialogAsync) {
                 pxt.commands.webUsbPairDialogAsync = res.webUsbPairDialogAsync;
+            }
+            if (res.onTutorialCompleted) {
+                pxt.commands.onTutorialCompleted = res.onTutorialCompleted;
             }
         });
 }


### PR DESCRIPTION
This lets MakeCode targets register a callback to run whenever a tutorial is completed. The callback only runs on steps with the `@tutorialCompleted` tag, it won't run on any tutorials that do not have that annotation. I tried to make that clear in the documentation but if anyone has a less confusing way of putting it, I'm open to suggestions!