### PR TITLE
Fix python toolbox snippets for text, remove switch block

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -586,8 +586,13 @@ namespace pxt.py {
 
         let ct = t.classType
 
-        if (!ct && t.primType == "@array")
-            ct = lookupApi("Array")
+        if (!ct) {
+            if (t.primType == "@array") {
+                ct = lookupApi("Array")
+            } else if (t.primType == "string") {
+                ct = lookupApi("String")
+            }
+        }
 
         if (ct) {
             let f = getClassField(ct, n, checkOnly)

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -57,7 +57,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 },
                 {
                     name: "logic_if_else",
-                    snippetName: "if",
+                    snippetName: "if else",
                     snippet: `if (true) {\n\n} else {\n\n}`,
                     pySnippet: `if True:\n  pass\nelse:\n  pass`,
                     attributes: {
@@ -67,18 +67,25 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     }
                 },
                 {
-                    name: "logic_switch",
-
-                    snippetName: "switch",
-                    snippet:
-                        `switch(item) {
-            case 0:
-                break;
-            case 1:
-                break;
-        }`,
+                    name: "logic_and",
+                    snippetName: "and",
+                    snippet: `true && true`,
+                    pySnippet: `True and True`,
                     attributes: {
-                        jsDoc: lf("Runs different code based on a value")
+                        blockId: 'logic_compare',
+                        weight: 47,
+                        jsDoc: lf("Runs code if both specified conditions are true")
+                    }
+                },
+                {
+                    name: "logic_or",
+                    snippetName: "or",
+                    snippet: `true || false`,
+                    pySnippet: `True or False`,
+                    attributes: {
+                        blockId: 'logic_compare',
+                        weight: 46,
+                        jsDoc: lf("Runs code if either of two specified conditions is true")
                     }
                 }
             ],
@@ -513,6 +520,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     name: "text_substr",
                     snippetName: "substr",
                     snippet: `"".substr(0, 0)`,
+                    pySnippet: `""[0:1]`,
                     attributes: {
                         blockId: 'string_substr',
                         jsDoc: lf("Returns the part of a string starting at a given index with the given length")
@@ -523,6 +531,8 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     name: "text_charAt",
                     snippetName: "charAt",
                     snippet: `"".charAt(0)`,
+                    pySnippetName: "str[0]",
+                    pySnippet: `""[0]`,
                     attributes: {
                         blockId: 'string_get',
                         jsDoc: lf("Returns the character at the given index")


### PR DESCRIPTION
https://github.com/microsoft/pxt-minecraft/issues/850

- Fix for charAt, substr. TODO: parseInt, concat of string + any (require str() / int() casting which monaco currently thinks is an error, have not looked too deeply into it)
- Small fix for len(str) erroring in monaco