### PR TITLE
Allow semicolons python

### DIFF
--- a/pxtpy/lexer.ts
+++ b/pxtpy/lexer.ts
@@ -539,6 +539,8 @@ namespace pxt.py {
                     let s = String.fromCharCode(i)
                     if (specialParse.hasOwnProperty(s)) {
                         asciiParse[i] = specialParse[s]
+                    } else if (i == 0x3b) {
+                        asciiParse[i] = () => addToken(TokenType.NewLine, "");
                     } else if (allOps.hasOwnProperty(s)) {
                         let canBeLengthened = false
                         let op = allOps[s]

--- a/pxtpy/lexer.ts
+++ b/pxtpy/lexer.ts
@@ -539,8 +539,6 @@ namespace pxt.py {
                     let s = String.fromCharCode(i)
                     if (specialParse.hasOwnProperty(s)) {
                         asciiParse[i] = specialParse[s]
-                    } else if (i == 0x3b) {
-                        asciiParse[i] = () => addToken(TokenType.NewLine, "");
                     } else if (allOps.hasOwnProperty(s)) {
                         let canBeLengthened = false
                         let op = allOps[s]

--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -668,7 +668,7 @@ namespace pxt.py {
             return finish(augAssign)
         }
 
-        if (peekToken().type == TokenType.NewLine) {
+        if (op == "Semicolon" || peekToken().type == TokenType.NewLine) {
             let exprStmt = mkAST("ExprStmt") as ExprStmt
             exprStmt.value = expr
             return finish(exprStmt)

--- a/tests/runtime-trace-tests/cases/semicolon_separator.py
+++ b/tests/runtime-trace-tests/cases/semicolon_separator.py
@@ -1,2 +1,4 @@
-x = 0;print(x)
-print(1);print(2);print(3)
+x = 0;print(x);
+print(1);print(2);print(3);
+x = 4;print(x)
+print(5);print(6);print(7)

--- a/tests/runtime-trace-tests/cases/semicolon_separator.py
+++ b/tests/runtime-trace-tests/cases/semicolon_separator.py
@@ -1,1 +1,2 @@
-print(1);print(2)
+x = 0;print(x)
+print(1);print(2);print(3)

--- a/tests/runtime-trace-tests/cases/semicolon_separator.py
+++ b/tests/runtime-trace-tests/cases/semicolon_separator.py
@@ -1,0 +1,1 @@
+print(1);print(2)


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/855

Turns out this was only failing for expressions without ops (typically call expressions) - 

```python
x = 0;print(x + "")
```

succeeds because it grabs the `=` as an operator, but

```python
print(1 + "");print(2 + "")
```

and

```python
x = 0;print(x + "");
```


booth failed because when it tried to grab the operator it grabbed the `;` and didn't recognize it.