### PR TITLE
Prevent duplicate function declarations in Python

### DIFF
--- a/pxtpy/ast.ts
+++ b/pxtpy/ast.ts
@@ -14,6 +14,8 @@ namespace pxt.py {
         pyAST?: AST;
         isProtected?: boolean;
         moduleTypeMarker?: {};
+
+        declared?: number; // A reference to the current iteration; used for detecting duplicate functions
     }
 
     export interface TypeOptions {
@@ -408,7 +410,7 @@ namespace pxt.py {
     }
     export interface Constant extends Expr {
         kind: "Constant";
-        value: any; // ??? 
+        value: any; // ???
     }
 
     // the following expression can appear in assignment context

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -930,7 +930,7 @@ namespace pxt.py {
 
             if (!inline) {
                 if (existing && existing.declared === currIteration) {
-                    error(n, 9520, "Duplicate function declaration");
+                    error(n, 9520, lf("Duplicate function declaration"));
                 }
 
                 sym.declared = currIteration;


### PR DESCRIPTION
The TypeScript compiler already handles most of these cases already since TypeScript does not allow duplicate function implementations. However, when we inline functions passed as arguments the name is lost in the transition. 


In other words, this was legal:

```python
def on_update():
    pass
game.on_update(on_update)

def on_update():
    pass
game.on_update(on_update)
```

while this was not:

```python
def on_update():
    pass

def on_update():
    pass

```

and now they both show up as errors.