### PR TITLE
make optional members of object literals default to undefined

### DIFF
--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -468,7 +468,7 @@ namespace pxsim {
             let i = map.findIdx(key);
             if (i < 0) {
                 decr(map);
-                return 0;
+                return undefined;
             }
             let r = incr(map.data[i].val);
             decr(map)


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1134