### PR TITLE
int() casting for python

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -29,6 +29,7 @@ namespace ts.pxtc {
             "pins.createBufferFromArray": { n: "bytes", t: ts.SyntaxKind.Unknown },
             "!!": { n: "bool", t: ts.SyntaxKind.BooleanKeyword },
             ".indexOf": { n: "Array.index", t: ts.SyntaxKind.NumberKeyword },
+            "parseInt": { n: "int", t: ts.SyntaxKind.NumberKeyword }
         }
 
     function renderDefaultVal(apis: pxtc.ApisInfo, p: pxtc.ParameterDesc, imgLit: boolean, cursorMarker: string): string {

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -510,6 +510,8 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     name: "text_parseInt",
                     snippetName: "parseInt",
                     snippet: `parseInt("5")`,
+                    pySnippetName: "int",
+                    pySnippet: `int("5")`,
                     attributes: {
                         blockId: 'string_parseint',
                         jsDoc: lf("Converts a number written as text into a number")


### PR DESCRIPTION
Text toolbox snippets except "compare" should work

https://github.com/microsoft/pxt-minecraft/issues/850