### PR TITLE
potential fix for crash on access of optional params of interface

### DIFF
--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -449,7 +449,7 @@ switch (step) {
                         isSet = true
                 }
                 write(`${frameRef}.fn = ${frameRef}.arg0.vtable.iface["${isSet ? "set/" : ""}${bin.ifaceMembers[procid.ifaceIndex]}"];`)
-                write(`if (${frameRef}.fn === 13) {`)
+                write(`if (${frameRef}.fn === 13 || ${frameRef}.fn === undefined) {`)
                 let fld = `${frameRef}.arg0.fields["${bin.ifaceMembers[procid.ifaceIndex]}"]`
                 if (isSet) {
                     write(`  ${fld} = ${frameRef}.arg1;`)


### PR DESCRIPTION
Not sure this is the right fix as I haven't interacted with this part of the code much at all / don't have full context on it, but it works in the cases I've looked at / was fun to look through. I believe that cases where it would cause things to succeed inappropriately should all be handled as tsc errors already?

fixes https://github.com/microsoft/pxt-arcade/issues/1136, so that it succeeds in the sim like it does on hw