### PR TITLE
un-lexically nest function

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1369,19 +1369,20 @@ namespace pxt.py {
             let tupNames = tup.elts
                 .map(e => e as py.Name)
                 .map(convertName)
-            function convertName(n: py.Name) {
-                // TODO resuse with Name expr
-                markInfoNode(n, "identifierCompletion")
-                typeOf(n)
-                let v = lookupName(n)
-                return possibleDef(n, /*excludeLet*/true)
-            }
             targs.push(B.mkCommaSep(tupNames))
             targs.push(B.mkText("]"))
             let res = B.mkStmt(B.mkInfix(B.mkGroup(targs), "=", expr(value)))
             return res
         }
         return B.mkStmt(B.mkText(pref), B.mkInfix(expr(target), "=", expr(value)))
+
+        function convertName(n: py.Name) {
+            // TODO resuse with Name expr
+            markInfoNode(n, "identifierCompletion")
+            typeOf(n)
+            let v = lookupName(n)
+            return possibleDef(n, /*excludeLet*/true)
+        }
     }
 
     function possibleDef(n: py.Name, excludeLet: boolean = false) {


### PR DESCRIPTION
Lexically nested functions are not allowed in strict mode in old safari (I'm personally very surprised they're allowed in any strict modes)

should fix https://github.com/microsoft/pxt-microbit/issues/2237, although I haven't yet tested this patch on the current microbit build (not sure which branches to use) - but this fixes it at the point it was first broken, and I don't think this is a common paradigm