### PR TITLE
Add formatting provider for Python

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -9,6 +9,7 @@ import * as toolboxeditor from "./toolboxeditor"
 import * as compiler from "./compiler"
 import * as sui from "./sui";
 import * as snippets from "./monacoSnippets"
+import * as pyhelper from "./monacopyhelper";
 import * as simulator from "./simulator";
 import * as toolbox from "./toolbox";
 import * as workspace from "./workspace";
@@ -170,6 +171,22 @@ class HoverProvider implements monaco.languages.HoverProvider {
                 }
                 return res
             });
+    }
+}
+
+class FormattingProvider implements monaco.languages.DocumentRangeFormattingEditProvider {
+    protected isPython: boolean = false;
+
+    constructor(public editor: Editor, public python: boolean) {
+        this.isPython = python;
+    }
+
+    provideDocumentRangeFormattingEdits(model: monaco.editor.IReadOnlyModel, range: monaco.Range, options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.Thenable<monaco.editor.ISingleEditOperation[]> {
+        return Promise.resolve().then(p => {
+            return this.isPython
+                ? pyhelper.provideDocumentRangeFormattingEdits(model, range, options, token)
+                : null;
+        });
     }
 }
 
@@ -657,6 +674,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             monaco.languages.registerCompletionItemProvider("python", new CompletionProvider(this, true));
             monaco.languages.registerSignatureHelpProvider("python", new SignatureHelper(this, true));
             monaco.languages.registerHoverProvider("python", new HoverProvider(this, true));
+            monaco.languages.registerDocumentRangeFormattingEditProvider("python", new FormattingProvider(this, true));
 
             this.editorViewZones = [];
 

--- a/webapp/src/monacopyhelper.ts
+++ b/webapp/src/monacopyhelper.ts
@@ -12,7 +12,7 @@ function getIndent(s: string): number {
 }
 
 function setIndent(i: number, s: string): string {
-    return new Array(i+1).join(' ') + s.trim();
+    return new Array(i + 1).join(' ') + s.trim();
 }
 
 function getLine(source: string, model: monaco.editor.IReadOnlyModel, lineNumber: number): string {
@@ -34,7 +34,7 @@ export function provideDocumentRangeFormattingEdits(model: monaco.editor.IReadOn
     const s =  model.getOffsetAt({ lineNumber: range.startLineNumber, column: range.startColumn });
     const e =  model.getOffsetAt({ lineNumber: range.endLineNumber, column: range.endColumn });
     const lines = source.slice(s, e).split('\n');
-    const codeLines = lines.map((s, i) => !!s ? i : -1).filter(i => i >=0);
+    const codeLines = lines.map((s, i) => !!s ? i : -1).filter(i => i >= 0);
 
     let prev;
     if (partial) {

--- a/webapp/src/monacopyhelper.ts
+++ b/webapp/src/monacopyhelper.ts
@@ -1,0 +1,71 @@
+const INDENT = 4;
+
+interface Line {
+    text: string,
+    index: number,
+    indent: number
+}
+
+function getIndent(s: string): number {
+    if (!s) return 0;
+    return s.match(/^\s*/)[0].length || 0;
+}
+
+function setIndent(i: number, s: string): string {
+    return new Array(i+1).join(' ') + s.trim();
+}
+
+function getLine(source: string, model: monaco.editor.IReadOnlyModel, lineNumber: number): string {
+    return source.slice(model.getOffsetAt({ lineNumber: lineNumber, column: 0}),
+                        model.getOffsetAt({ lineNumber: lineNumber + 1, column: 0}) );
+}
+
+// checks to see if the line ends in a colon, indicating the start of a code block
+function isCodeBlock(s: string): boolean {
+    s = s.trim();
+    return s[s.length - 1] == ':';
+}
+
+export function provideDocumentRangeFormattingEdits(model: monaco.editor.IReadOnlyModel, range: monaco.Range, options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.editor.ISingleEditOperation[] {
+    const source = model.getValue();
+
+    // TODO indentation for paste blocks
+    const partial = range.startLineNumber != 0;
+    const s =  model.getOffsetAt({ lineNumber: range.startLineNumber, column: range.startColumn });
+    const e =  model.getOffsetAt({ lineNumber: range.endLineNumber, column: range.endColumn });
+    const lines = source.slice(s, e).split('\n');
+    const codeLines = lines.map((s, i) => !!s ? i : -1).filter(i => i >=0);
+
+    let prev;
+    if (partial) {
+        prev = getLine(source, model, range.startLineNumber - 1);
+    }
+
+    for (let i = 0; i < codeLines.length; i++) {
+        let currIndex = codeLines[i];
+        let curr = lines[currIndex];
+        let next = lines[codeLines[i + 1]];
+
+        if (prev) {
+            let prevIndent = getIndent(prev);
+            let nextIndent = getIndent(next);
+
+            // TODO additional heuristics based on position of next line?
+            if (isCodeBlock(prev)) {
+                // at the start of a code block, add one additional indent
+                let indent = prevIndent + INDENT;
+                lines[currIndex] = setIndent(indent, curr);
+            } else if (next && prevIndent == nextIndent && prevIndent != getIndent(curr)  && !isCodeBlock(curr)) {
+                // if previous and next line have same indent, adjust current to match
+                lines[currIndex] = setIndent(prevIndent, curr);
+            }
+        }
+
+        prev = lines[currIndex];
+    }
+
+    return [{
+        text: lines.join('\n'),
+        range: range
+    }];
+}


### PR DESCRIPTION
Simple Python formatting provider (called on snippet insertion, paste, etc--same as Typescript formatter). 

Currently formats in two cases:
- If the previous line ends with a colon, indents one space
- If the previous and next lines have matching indents (and the current line is not the start of a code block), matches current indent to previous

TODO: experimenting with some additional rules for pasted blocks and using the next line, but I suspect fewer rules/more straightforward processing might be better here.