### PR TITLE
compilation speedup and ref-counting removal

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2822,6 +2822,9 @@ export function timeAsync() {
         mainPkg.getCompileOptionsAsync(mainPkg.getTargetOptions())
             .then(opts => pxtc.compile(opts))
             .then(res => {
+                U.iterMap(res.times, (k, v) => {
+                    res.times[k] = Math.round(v / 1000)
+                })
                 if (!min) {
                     min = res.times
                 } else {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2845,6 +2845,15 @@ export function timeAsync() {
         .then(loop)
         .then(loop)
         .then(loop)
+        .then(loop)
+        .then(loop)
+        .then(loop)
+        .then(loop)
+        .then(loop)
+        .then(loop)
+        .then(loop)
+        .then(loop)
+        .then(loop)
         .then(() => console.log("MIN", min))
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2817,21 +2817,17 @@ export function augmnetDocsAsync(parsed: commandParser.ParsedCommand) {
 
 export function timeAsync() {
     ensurePkgDir();
-    let min: Map<number> = null;
+    let min: Map<number[]> = {};
     let loop = () =>
         mainPkg.getCompileOptionsAsync(mainPkg.getTargetOptions())
             .then(opts => pxtc.compile(opts))
             .then(res => {
                 U.iterMap(res.times, (k, v) => {
-                    res.times[k] = Math.round(v / 1000)
+                    v = Math.round(v / 1000)
+                    res.times[k] = v
+                    if (!min[k]) min[k] = []
+                    min[k].push(v)
                 })
-                if (!min) {
-                    min = res.times
-                } else {
-                    U.iterMap(min, (k, v) => {
-                        min[k] = Math.min(v, res.times[k])
-                    })
-                }
                 console.log(res.times)
             })
     return loop()
@@ -2857,7 +2853,12 @@ export function timeAsync() {
         .then(loop)
         .then(loop)
         .then(loop)
-        .then(() => console.log("MIN", min))
+        .then(() => {
+            U.iterMap(min, (k, v) => {
+                v.sort((a, b) => a - b)
+            })
+            console.log(min)
+        })
 }
 
 export function exportCppAsync(parsed: commandParser.ParsedCommand) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2818,9 +2818,12 @@ export function augmnetDocsAsync(parsed: commandParser.ParsedCommand) {
 export function timeAsync() {
     ensurePkgDir();
     let min: Map<number[]> = {};
+    const opts = mainPkg.getTargetOptions()
+    // opts.isNative = true
+    let copts: pxtc.CompileOptions
     let loop = () =>
-        mainPkg.getCompileOptionsAsync(mainPkg.getTargetOptions())
-            .then(opts => pxtc.compile(opts))
+        Promise.resolve()
+            .then(() => pxtc.compile(copts))
             .then(res => {
                 U.iterMap(res.times, (k, v) => {
                     v = Math.round(v / 1000)
@@ -2830,7 +2833,11 @@ export function timeAsync() {
                 })
                 console.log(res.times)
             })
-    return loop()
+    return mainPkg.getCompileOptionsAsync(opts)
+        .then(r => {
+            copts = r
+        })
+        .then(loop)
         .then(loop)
         .then(loop)
         .then(loop)

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -267,6 +267,10 @@ function init() {
     Util.isNodeJS = true;
     Util.httpRequestCoreAsync = nodeHttpRequestAsync;
     Util.sha256 = sha256;
+    Util.cpuUs = () => {
+        const p = process.cpuUsage()
+        return p.system + p.user
+    }
     Util.getRandomBuf = buf => {
         let tmp = crypto.randomBytes(buf.length)
         for (let i = 0; i < buf.length; ++i)

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -60,9 +60,9 @@ namespace ts.pxtc {
 
             if (node.operatorToken.kind == SK.PlusToken || node.operatorToken.kind == SK.PlusEqualsToken) {
                 if (isStringType(lt) || (isStringType(rt) && node.operatorToken.kind == SK.PlusToken)) {
-                    pxtInfo(node).exprInfo = { 
-                        leftType: checker.typeToString(lt), 
-                        rightType: checker.typeToString(rt) 
+                    pxtInfo(node).exprInfo = {
+                        leftType: checker.typeToString(lt),
+                        rightType: checker.typeToString(rt)
                     }
                 }
             }

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -1,9 +1,5 @@
 namespace ts.pxtc {
 
-    interface IdentifierInfo {
-        isGlobal: boolean;
-    }
-
     /**
      * Traverses the AST and injects information about function calls into the expression
      * nodes. The decompiler consumes this information later
@@ -45,10 +41,7 @@ namespace ts.pxtc {
                     case SyntaxKind.Identifier:
                         const decl: Declaration = getDecl(child);
                         if (decl && decl.getSourceFile().fileName !== "main.ts" && decl.kind == SyntaxKind.VariableDeclaration) {
-                            const info: IdentifierInfo = {
-                                isGlobal: true
-                            };
-                            (child as any).identifierInfo = info;
+                            pxtInfo(child).flags |= PxtNodeFlags.IsGlobalIdentifier;
                         }
                         break;
 
@@ -67,7 +60,10 @@ namespace ts.pxtc {
 
             if (node.operatorToken.kind == SK.PlusToken || node.operatorToken.kind == SK.PlusEqualsToken) {
                 if (isStringType(lt) || (isStringType(rt) && node.operatorToken.kind == SK.PlusToken)) {
-                    (node as any).exprInfo = { leftType: checker.typeToString(lt), rightType: checker.typeToString(rt) } as BinaryExpressionInfo;
+                    pxtInfo(node).exprInfo = { 
+                        leftType: checker.typeToString(lt), 
+                        rightType: checker.typeToString(rt) 
+                    }
                 }
             }
 

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -143,8 +143,7 @@ namespace ts.pxtc {
                 args: args,
                 isExpression: hasRet
             };
-
-            (node as any).callInfo = callInfo;
+            pxtInfo(node).callInfo = callInfo;
         }
 
         function getDecl(node: Node): Declaration {
@@ -178,8 +177,9 @@ namespace ts.pxtc {
 
         function typeOf(node: Node) {
             let r: Type;
-            if ((node as any).typeOverride)
-                return (node as any).typeOverride as Type
+            const info = pxtInfo(node)
+            if (info.typeCache)
+                return info.typeCache
             if (isExpression(node))
                 r = checker.getContextualType(<Expression>node)
             if (!r) {

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -167,9 +167,9 @@ namespace ts.pxtc {
                 decl = {
                     kind: SK.PropertySignature,
                     symbol: { isBogusSymbol: true, name: namedNode.name.getText() },
-                    isBogusFunction: true,
                     name: namedNode.name,
                 } as any
+                pxtInfo(decl).flags |= PxtNodeFlags.IsBogusFunction
             }
 
             return decl

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -549,14 +549,6 @@ ${baseLabel}_nochk:
                     // this is there because we need different addresses for breakpoints
                     this.write(this.t.nop())
                     break;
-                case ir.EK.Incr:
-                    this.emitExpr(e.args[0])
-                    this.emitCallRaw("pxt::incr")
-                    break;
-                case ir.EK.Decr:
-                    this.emitExpr(e.args[0])
-                    this.emitCallRaw("pxt::decr")
-                    break;
                 case ir.EK.FieldAccess:
                     this.emitExpr(e.args[0])
                     return this.emitFieldAccess(e)

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -92,10 +92,7 @@ namespace ts.pxtc {
         emit_int(v: number, reg: string) { return "TBD(emit_int)" }
 
         obj_header(vt: string) {
-            if (target.gc)
-                return `.word ${vt}`
-            else
-                return `.short ${pxt.REFCNT_FLASH}, ${vt}>>${target.vtableShift}`
+            return `.word ${vt}`
         }
 
         string_literal(lbl: string, strLit: string) {
@@ -507,11 +504,8 @@ ${baseLabel}_nochk:
                             this.write(this.t.emit_int(cell.index, reg))
                             off = reg
                         }
-                        if (target.gc) {
-                            this.write(this.t.load_reg_src_off("r7", "r6", "#0"))
-                            this.write(this.t.load_reg_src_off(reg, "r7", off, false, false, inf))
-                        } else
-                            this.write(this.t.load_reg_src_off(reg, "r6", off, false, false, inf))
+                        this.write(this.t.load_reg_src_off("r7", "r6", "#0"))
+                        this.write(this.t.load_reg_src_off(reg, "r7", off, false, false, inf))
                     } else {
                         let [src, imm, idx] = this.cellref(cell)
                         this.write(this.t.load_reg_src_off(reg, src, imm, idx))
@@ -580,63 +574,17 @@ ${baseLabel}_nochk:
                 lbl += "_chk"
             }
 
-            if (target.gc) {
-                let off = info.idx * 4 + 4
-                let xoff = "#" + off
-                if (off > 124) {
-                    this.write(this.t.emit_int(off, "r3"))
-                    xoff = "r3"
-                }
-                if (store)
-                    this.write(`str r1, [r0, ${xoff}]`)
-                else
-                    this.write(`ldr r0, [r0, ${xoff}]`)
-                return
+            let off = info.idx * 4 + 4
+            let xoff = "#" + off
+            if (off > 124) {
+                this.write(this.t.emit_int(off, "r3"))
+                xoff = "r3"
             }
-
-            this.emitLabelledHelper(lbl, () => {
-                let off = info.idx * 4 + 4
-                let xoff = "#" + off
-                if (off > 124) {
-                    this.write(this.t.emit_int(off, "r3"))
-                    xoff = "r3"
-                }
-
-                this.write(`mov r7, lr`)
-
-                if (store) {
-                    this.write(`push {r0, r1}`)
-                    this.write(`ldr r0, [r0, ${xoff}]`)
-                    this.write(`bl _pxt_decr`)
-                    this.write(`pop {r0, r1}`)
-                    if (off > 124)
-                        this.write(this.t.emit_int(off, "r3"))
-                    this.write(`str r1, [r0, ${xoff}]`)
-                    if (info.needsCheck)
-                        this.write(`ldrh r2, [r0, #0]`)
-                } else {
-                    this.write(`ldr r4, [r0, ${xoff}]`)
-                }
-
-
-                if (info.needsCheck) {
-                    // already decremented, but need to check for refcnt=0
-                    this.write(`cmp r2, #1`)
-                    this.write(`bne .notzero`)
-                    this.write(`bl pxt::deleteRefObject`)
-                    this.write(`.notzero:`)
-                } else {
-                    // need to decrement
-                    this.write(`bl _pxt_decr`)
-                }
-
-                if (!store) {
-                    this.write(`mov r0, r4`)
-                    this.write(`bl _pxt_incr`)
-                }
-
-                this.write(`bx r7`)
-            })
+            if (store)
+                this.write(`str r1, [r0, ${xoff}]`)
+            else
+                this.write(`ldr r0, [r0, ${xoff}]`)
+            return
         }
 
         private emitClassCall(procid: ir.ProcId) {
@@ -719,15 +667,8 @@ ${baseLabel}_nochk:
                     mov r4, lr
                 `)
 
-                if (getset && !target.gc) {
-                    this.write("movs r3, #0")
-                    this.write("str r3, [sp, #0] ; clear so it won't get decr()ed outside")
-                }
-
                 if (getset == "set") {
                     this.write("ldr r2, [sp, #4] ; ld-val")
-                    if (!target.gc)
-                        this.write("str r3, [sp, #4] ; clear so it won't get decr()ed outside")
                 }
 
                 this.write(this.t.callCPP(getset == "set" ? "pxtrt::mapSet" : "pxtrt::mapGet"))
@@ -742,50 +683,22 @@ ${baseLabel}_nochk:
 
             this.write(".field:")
             if (getset == "set") {
-                if (target.gc) {
-                    this.write(`
+                this.write(`
                         ldr r3, [sp, #4] ; ld-val
                         str r3, [r0, r2] ; store field
                         bx lr
                     `)
-                } else {
-                    this.write(`
-                        ldr r7, [r0, r2] ; load field
-                        ldr r3, [sp, #4] ; ld-val
-                        str r7, [sp, #4] ; save previous value - it will get decr()ed outside
-                        str r3, [r0, r2] ; store field
-                        bx lr
-                    `)
-                }
             } else if (getset == "get") {
-                if (target.gc) {
-                    this.write(`
+                this.write(`
                         ldr r0, [r0, r2] ; load field
                         bx lr
                     `)
-                } else {
-                    this.write(`
-                        mov r4, lr
-                        ldr r0, [r0, r2] ; load field
-                        bl _pxt_incr
-                        bx r4
-                    `)
-                }
+
             } else {
-                if (target.gc) {
-                    this.write(`
+                this.write(`
                         ldr r0, [r0, r2] ; load field
                     `)
-                } else {
-                    this.write(`
-                        mov r4, lr
-                        ldr r7, [r0, r2] ; load field
-                        bl _pxt_decr
-                        mov r0, r7
-                        bl _pxt_incr
-                        mov lr, r4
-                    `)
-                }
+
             }
 
             if (!getset) {
@@ -847,23 +760,6 @@ ${baseLabel}_nochk:
             this.write(`beq .fail`) // null
 
             this.write(`ldr r3, [r0, #0]`)
-
-            if (!target.gc) {
-                this.write(`lsls ${r2}, r3, #30`)
-                this.write(`beq .fail`) // C++ class - TODO remove
-                if (decr) {
-                    this.write(`lsls ${r2}, r3, #31`)
-                    this.write(`beq .inflash`)
-                    this.write(`uxth ${r2}, r3`)
-                    this.write(`subs ${r2}, #2`)
-                    this.write(`blt .fail`) // ref-cnt underflow!
-                    this.write(`strh ${r2}, [r0, #0]`)
-                    this.write(`.inflash:`)
-                }
-                this.write(`lsrs r3, r3, #16`)
-                this.write(`lsls r3, r3, #${target.vtableShift}`)
-            }
-
             this.write("; vtable in R3")
         }
 
@@ -914,53 +810,9 @@ ${baseLabel}_nochk:
                     console.log(allArgs.map(a => a.toString()))
                     U.oops(`wrong uses: ${r.currUses} ${r.totalUses}`)
                 }
-            }
-
-            for (let r of nonRefs) {
                 r.currUses = 1
             }
-
-            if (target.gc || refs.length == 0) {
-                // no helper in that case
-                for (let r of refs) {
-                    r.currUses = 1
-                }
-                this.clearStack()
-                return
-            }
-
-            const s0 = this.exprStack.length
-            const decr = this.redirectOutput(() => {
-                this.write(this.t.mov("r7", "r0"))
-                this.write(this.t.mov("r4", "lr"))
-                let k = 0
-                while (refs.length > 0) {
-                    this.clearStack(true)
-                    let s0 = this.exprStack[0]
-                    let idx = refs.indexOf(s0)
-                    if (idx >= 0) {
-                        this.exprStack.shift()
-                        refs.splice(idx, 1)
-                        this.write(this.t.pop_fixed(["r0"]))
-                        this.write(this.t.inline_decr(k++))
-                    } else {
-                        break
-                    }
-                }
-                while (refs.length > 0) {
-                    let r = refs.shift()
-                    r.currUses = 1
-                    this.write(this.loadFromExprStack("r0", r))
-                    this.write(this.t.inline_decr(k++))
-                }
-                this.clearStack()
-                this.write(this.t.mov("r0", "r7"))
-                this.write(this.t.helper_ret())
-            })
-            const numPops = s0 - this.exprStack.length
-
-            this.emitHelper(`@dummystack ${numPops}\n` + decr, "clr" + numArgs)
-            this.write(`@dummystack ${-numPops}`)
+            this.clearStack()
         }
 
         private builtInClassNo(typeNo: pxt.BuiltInType): ClassInfo {
@@ -1149,12 +1001,9 @@ ${baseLabel}_nochk:
         private alignExprStack(numargs: number) {
             let interAlign = this.stackAlignmentNeeded(numargs)
             if (interAlign) {
-                if (!target.gc)
-                    this.write(this.t.push_locals(interAlign))
                 for (let i = 0; i < interAlign; ++i) {
                     // r5 should be safe to push on gc stack
-                    if (target.gc)
-                        this.write(`push {r5} ; align`)
+                    this.write(`push {r5} ; align`)
                     this.pushDummy()
                 }
             }
@@ -1183,35 +1032,16 @@ ${baseLabel}_nochk:
                         hasAlign = true
                         this.write("push {lr} ; align")
                     }
-                    if (target.gc) {
-                        this.write(`
+                    this.write(`
                             push {r0, r2, lr}
                             mov r0, r1
                         `)
-                    } else {
-                        this.write(`
-                            mov r7, r1
-                            push {r0, r2, lr}
-                            bl _pxt_incr
-                            ldr r0, [sp, #4]
-                            bl _pxt_incr
-                            mov r0, r7
-                        `)
-                    }
+
                 } else {
-                    if (target.gc) {
-                        this.write(`
+                    this.write(`
                             push {r0, lr}
                             mov r0, r1
                         `)
-                    } else {
-                        this.write(`
-                            mov r7, r1
-                            push {r0, lr}
-                            bl _pxt_incr
-                            mov r0, r7
-                        `)
-                    }
                 }
 
                 this.write(`
@@ -1222,18 +1052,8 @@ ${baseLabel}_nochk:
                     bl .dowork
                 `)
 
-                if (!target.gc) {
-                    this.write("mov r7, r0")
-                    for (let i = 0; i < numargs; ++i) {
-                        this.write("pop {r0}")
-                        this.write("bl _pxt_decr")
-                    }
-                    if (hasAlign)
-                        this.write(this.t.pop_locals(1))
-                    this.write("mov r0, r7")
-                } else {
-                    this.write(this.t.pop_locals(numargs + (hasAlign ? 1 : 0)))
-                }
+
+                this.write(this.t.pop_locals(numargs + (hasAlign ? 1 : 0)))
 
                 this.write("pop {pc}")
 
@@ -1337,8 +1157,6 @@ ${baseLabel}_nochk:
         }
 
         private emitLambdaTrampoline() {
-            let gcNo = target.gc ? ";" : ""
-            let rfNo = !target.gc ? ";" : ""
             let r3 = target.stackAlign ? "r3," : ""
             this.write(`
             .section code
@@ -1351,25 +1169,20 @@ ${baseLabel}_nochk:
             // TODO should inline this?
             this.emitInstanceOf(this.builtInClassNo(pxt.BuiltInType.RefAction), "validate")
             this.write(`
-                ${rfNo}mov r0, sp
+                mov r0, sp
                 push {r4, r5, r6, r7} ; push args and the lambda
-                ${rfNo}mov r1, sp
-                ${rfNo}bl pxt::pushThreadContext
-                ${gcNo}bl pxtrt::getGlobalsPtr
+                mov r1, sp
+                bl pxt::pushThreadContext
                 mov r6, r0          ; save ctx or globals
                 mov r5, r7          ; save lambda for closure
-                ${gcNo}mov r0, r7
-                ${gcNo}bl _pxt_incr        ; make sure lambda stays alive
                 ldr r0, [r5, #8]    ; ld fnptr
                 movs r4, #3         ; 3 args
                 blx r0              ; execute the actual lambda
                 mov r7, r0          ; save result
                 @dummystack 4
                 add sp, #4*4        ; remove arguments and lambda
-                ${gcNo}mov r0, r5   ; decrement lambda
-                ${gcNo}bl _pxt_decr
-                ${rfNo}mov r0, r6   ; or pop the thread context
-                ${rfNo}bl pxt::popThreadContext
+                mov r0, r6   ; or pop the thread context
+                bl pxt::popThreadContext
                 mov r0, r7 ; restore result
                 pop {${r3} r4, r5, r6, r7, pc}`)
 
@@ -1389,26 +1202,16 @@ ${baseLabel}_nochk:
                 cmp r7, #0
                 beq .fail
                 push {r0, lr}
-                ${gcNo}bl _pxt_incr
                 movs r4, #1
                 blx r7
-                ${rfNo}str r0, [sp, #0]
-                ${gcNo}mov r7, r0
-                ${gcNo}pop {r0}
-                ${gcNo}bl _pxt_decr
-                ${gcNo}mov r0, r7
-                ${gcNo}push {r7}
+                str r0, [sp, #0]
                 b .numops
 
             .fail: ; not an object or no toString
                 push {r0, lr}
             .numops:
                 ${this.t.callCPP("numops::toString")}
-                ${rfNo}pop {r1}
-                ${gcNo}mov r7, r0
-                ${gcNo}pop {r0}
-                ${gcNo}bl _pxt_decr
-                ${gcNo}mov r0, r7
+                pop {r1}
                 pop {pc}
             `)
         }
@@ -1588,22 +1391,15 @@ ${baseLabel}_nochk:
                 this.write(`str r1, [sp, #4*${i}]`)
             }
 
-            let gcNo = target.gc ? ";" : ""
-
             this.write(`
                 str r5, [sp, #4*${numargs}]
                 mov r1, lr
                 str r1, [sp, #4*${numargs + 1}]
                 mov r5, r0
                 ldr r7, [r5, #8]
-                ${gcNo}ldr r0, [sp, #4*${numargs}]
-                ${gcNo}bl _pxt_incr
                 blx r7
-                ${gcNo}mov r7, r0
                 ldr r4, [sp, #4*${numargs + 1}]
                 ldr r5, [sp, #4*${numargs}]
-                ${gcNo}mov r0, r5
-                ${gcNo}bl _pxt_decr
             `)
 
             // move arguments back where they were
@@ -1614,7 +1410,6 @@ ${baseLabel}_nochk:
 
             this.write(`
                 add sp, #8
-                ${gcNo}mov r0, r7
                 bx r4
             `)
 
@@ -1634,12 +1429,8 @@ ${baseLabel}_nochk:
                             off = "r1"
                         }
 
-                        if (target.gc) {
-                            this.write(this.t.load_reg_src_off("r7", "r6", "#0"))
-                            this.write(this.t.load_reg_src_off("r0", "r7", off, false, true, inf))
-                        } else {
-                            this.write(this.t.load_reg_src_off("r0", "r6", off, false, true, inf))
-                        }
+                        this.write(this.t.load_reg_src_off("r7", "r6", "#0"))
+                        this.write(this.t.load_reg_src_off("r0", "r7", off, false, true, inf))
                     } else {
                         let [reg, imm, off] = this.cellref(cell)
                         this.write(this.t.load_reg_src_off("r0", reg, imm, off, true))
@@ -1723,26 +1514,10 @@ ${baseLabel}_nochk:
 
             this.write(`bl ${this.proc.label()}_nochk`)
 
-            if (target.gc) {
-                let stackSize = numargs + (needsAlign ? 1 : 0)
-                this.write(`@dummystack ${stackSize}`)
-                this.write(`add sp, #4*${stackSize}`)
-                this.write(`pop {pc}`)
-            } else {
-                this.emitLabelledHelper(`clr_and_ret_${numargs}`, () => {
-                    this.write(`@dummystack ${numpush}`)
-                    this.write(`mov r7, r0`)
-                    for (let i = numargs; i > 0; i--) {
-                        this.write(`pop {r0}`)
-                        this.write(`bl _pxt_decr`)
-                    }
-                    this.write(`mov r0, r7`)
-                    if (needsAlign)
-                        this.write(`pop {r1, pc}`)
-                    else
-                        this.write(`pop {pc}`)
-                })
-            }
+            let stackSize = numargs + (needsAlign ? 1 : 0)
+            this.write(`@dummystack ${stackSize}`)
+            this.write(`add sp, #4*${stackSize}`)
+            this.write(`pop {pc}`)
         }
 
         private emitCallRaw(name: string) {

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -101,7 +101,6 @@ namespace ts.pxtc {
         let writeRaw = (s: string) => { resText += s + "\n"; }
         let write = (s: string) => { resText += "    " + s + "\n"; }
         let EK = ir.EK;
-        let refCounting = !!bin.target.jsRefCounting
 
         writeRaw(`
 var ${proc.label()} ${bin.procs[0] == proc ? "= entryPoint" : ""} = function (s) {
@@ -129,8 +128,7 @@ switch (step) {
         if (proc.args.length) {
             write(`if (s.lambdaArgs) {`)
             proc.args.forEach((l, i) => {
-                // TODO incr needed?
-                write(`  ${locref(l)} = ${refCounting ? "pxtrt.incr" : ""}(s.lambdaArgs[${i}]);`)
+                write(`  ${locref(l)} = (s.lambdaArgs[${i}]);`)
             })
             write(`  s.lambdaArgs = null;`)
             write(`}`)
@@ -299,7 +297,6 @@ switch (step) {
                     let info = e.data as FieldAccessInfo
                     let shimName = info.shimName
                     if (shimName) {
-                        assert(!refCounting)
                         emitExpr(e.args[0])
                         write(`r0 = r0${shimName};`)
                         return
@@ -406,7 +403,7 @@ switch (step) {
 
             let procid = topExpr.data as ir.ProcId
             let proc = procid.proc
-            let frameRef = `s.tmp_${frameIdx}`
+            const frameRef = `s.tmp_${frameIdx}`
             let lblId = ++lblIdx
             write(`${frameRef} = { fn: ${proc ? proc.label() : null}, parent: s };`)
 

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -295,16 +295,6 @@ switch (step) {
                 case EK.Nop:
                     write("// nop")
                     break
-                case EK.Incr:
-                    emitExpr(e.args[0])
-                    if (refCounting)
-                        write(`pxtrt.incr(r0);`)
-                    break;
-                case EK.Decr:
-                    emitExpr(e.args[0])
-                    if (refCounting)
-                        write(`pxtrt.decr(r0);`)
-                    break;
                 case EK.FieldAccess:
                     let info = e.data as FieldAccessInfo
                     let shimName = info.shimName

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -65,8 +65,6 @@ namespace ts.pxtc {
 
     export function jsEmit(bin: Binary) {
         let jssource = "'use strict';\n"
-        if (!bin.target.jsRefCounting)
-            jssource += "pxsim.noRefCounting();\n"
         jssource += "pxsim.setTitle(" + JSON.stringify(bin.options.name || "") + ");\n"
         let cfg: pxt.Map<number> = {}
         let cfgKey: pxt.Map<number> = {}

--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -22,8 +22,6 @@ namespace ts.pxtc {
         "numops::ands": "_numops_ands",
         "pxt::toInt": "_numops_toInt",
         "pxt::fromInt": "_numops_fromInt",
-        "pxt::incr": "_pxt_incr",
-        "pxt::decr": "_pxt_decr",
     }
 
     // snippets for ARM Thumb assembly

--- a/pxtcompiler/emitter/backthumb.ts
+++ b/pxtcompiler/emitter/backthumb.ts
@@ -196,10 +196,7 @@ ${lbl}:`
         }
 
         load_vtable(trg: string, src: string) {
-            if (target.gc)
-                return `ldr ${trg}, [${src}, #0]`
-            else
-                return `ldrh ${trg}, [${src}, #2]\n    lsls ${trg}, ${trg}, #${target.vtableShift}`
+            return `ldr ${trg}, [${src}, #0]`
         }
 
         lambda_init() {
@@ -213,14 +210,10 @@ ${lbl}:`
         }
 
         saveThreadStack() {
-            if (target.gc)
-                return "mov r7, sp\n    str r7, [r6, #4]\n"
-            else
-                return ""
+            return "mov r7, sp\n    str r7, [r6, #4]\n"
         }
 
         restoreThreadStack() {
-            // TODO only for debug build!
             if (target.gc && target.switches.gcDebug)
                 return "movs r7, #0\n    str r7, [r6, #4]\n"
             else
@@ -250,8 +243,7 @@ ${lbl}:`
 
             const boxedOp = (op: string) => {
                 let r = ".boxed:\n"
-                if (target.gc)
-                    r += `
+                r += `
                     ${this.pushLR()}
                     push {r0, r1}
                     ${this.saveThreadStack()}
@@ -259,19 +251,6 @@ ${lbl}:`
                     ${this.restoreThreadStack()}
                     add sp, #8
                     ${this.popPC()}
-                `
-                else
-                    r += `
-                    push {r4, lr}
-                    push {r0, r1}
-                    ${op}
-                    movs r4, r0
-                    pop {r0}
-                    bl _pxt_decr
-                    pop {r0}
-                    bl _pxt_decr
-                    movs r0, r4
-                    pop {r4, pc}
                 `
                 return r
             }
@@ -366,24 +345,6 @@ _pxt_${op}_${off}:
                     }
                 }
 
-            }
-
-            let ops = ["incr", "decr"]
-            if (target.gc) ops = []
-
-            for (let op of ops) {
-                r += ".section code\n"
-                withLDR(op)
-                r += `_pxt_${op}:\n${inlineIncrDecr(op)}`
-
-                r += ".section code\n"
-                withLDR(op + "_pushR0", true)
-                r += `
-_pxt_${op}_pushR0:
-    push {r0}
-    @dummystack -1
-    ${inlineIncrDecr(op)}
-`
             }
 
             /*

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -477,10 +477,6 @@ _start_${name}:
                 case EK.Nop:
                     write("; nop")
                     break
-                case EK.Incr:
-                case EK.Decr:
-                    U.oops()
-                    break;
                 case EK.FieldAccess:
                     let info = e.data as FieldAccessInfo
                     emitExpr(e.args[0])

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -532,7 +532,7 @@ ${output}</xml>`;
         function isEventExpression(expr: ts.ExpressionStatement): boolean {
             if (expr.expression.kind == SK.CallExpression) {
                 const call = expr.expression as ts.CallExpression;
-                const callInfo: pxtc.CallInfo = (call as any).callInfo
+                const callInfo = pxtInfo(call).callInfo;
                 if (!callInfo) {
                     error(expr)
                     return false;
@@ -997,7 +997,7 @@ ${output}</xml>`;
         }
 
         function getPropertyAccessExpression(n: ts.PropertyAccessExpression, asField = false, blockId?: string): OutputNode {
-            let callInfo = (n as any).callInfo as pxtc.CallInfo;
+            let callInfo = pxtInfo(n).callInfo;
             if (!callInfo) {
                 error(n);
                 return undefined;
@@ -1033,7 +1033,7 @@ ${output}</xml>`;
             let value = U.htmlEscape(attributes.blockId || callInfo.qName);
 
             const [parent,] = getParent(n);
-            const parentCallInfo: pxtc.CallInfo = parent && (parent as any).callInfo;
+            const parentCallInfo: pxtc.CallInfo = parent && pxtInfo(parent).callInfo;
             if (asField || !(blockId || attributes.blockIdentity) || parentCallInfo && parentCallInfo.qName === attributes.blockIdentity) {
                 return {
                     kind: "text",
@@ -1080,7 +1080,7 @@ ${output}</xml>`;
         }
 
         function getTaggedTemplateExpression(t: ts.TaggedTemplateExpression): ExpressionNode {
-            const callInfo: pxtc.CallInfo = (t as any).callInfo;
+            const callInfo: pxtc.CallInfo = pxtInfo(t).callInfo;
 
             let api: SymbolInfo;
             const paramInfo = getParentParameterInfo(t);
@@ -1109,7 +1109,7 @@ ${output}</xml>`;
         function getParentParameterInfo(n: ts.Expression) {
             if (n.parent && n.parent.kind === SK.CallExpression) {
                 const call = n.parent as CallExpression;
-                const info = (call as any).callInfo;
+                const info = pxtInfo(call).callInfo;
                 const index = call.arguments.indexOf(n);
                 if (info && index !== -1) {
                     const blockInfo = blocksInfo.apis.byQName[info.qName];
@@ -1453,7 +1453,7 @@ ${output}</xml>`;
             }
 
             function checkBooleanCallExpression(n: CallExpression) {
-                const callInfo: pxtc.CallInfo = (n.expression as any).callInfo;
+                const callInfo: pxtc.CallInfo = pxtc.pxtInfo(n.expression).callInfo;
                 if (callInfo) {
                     const api = env.blocks.apis.byQName[callInfo.qName];
                     if (api && api.retType == "boolean") {
@@ -1559,7 +1559,7 @@ ${output}</xml>`;
         }
 
         function getPropertyBlock(left: ts.PropertyAccessExpression, right: ts.Expression, tp: string): StatementNode | ExpressionNode {
-            const info: pxtc.CallInfo = (left as any).callInfo
+            const info: pxtc.CallInfo = pxtc.pxtInfo(left).callInfo
             const sym = env.blocks.apis.byQName[info ? info.qName : ""]
             if (!sym || !sym.attributes.blockCombine) {
                 error(left);
@@ -1645,7 +1645,7 @@ ${output}</xml>`;
         }
 
         function getCallStatement(node: ts.CallExpression, asExpression: boolean): StatementNode | ExpressionNode {
-            const info: pxtc.CallInfo = (node as any).callInfo
+            const info: pxtc.CallInfo = pxtc.pxtInfo(node).callInfo
             const attributes = attrs(info);
 
             if (info.qName == "Math.pow") {
@@ -1810,7 +1810,7 @@ ${output}</xml>`;
                     // in a parameter that is of an enum type. By default, enum parameters
                     // are dropdown fields (not value inputs) so we want to decompile the
                     // inner enum value as a field and not the shim block as a value
-                    const shimCall: pxtc.CallInfo = (e as any).callInfo;
+                    const shimCall: pxtc.CallInfo = pxtc.pxtInfo(e).callInfo;
                     const shimAttrs: CommentAttrs = shimCall && attrs(shimCall);
                     if (shimAttrs && shimAttrs.shim === "TD_ID" && paramInfo.isEnum) {
                         e = unwrapNode(shimCall.args[0]) as ts.Expression;
@@ -1880,7 +1880,7 @@ ${output}</xml>`;
                         }
                         break;
                     case SK.PropertyAccessExpression:
-                        const callInfo = (e as any).callInfo as pxtc.CallInfo;
+                        const callInfo = pxtc.pxtInfo(e).callInfo as pxtc.CallInfo;
                         const aName = U.htmlEscape(param.definitionName);
                         const argAttrs = attrs(callInfo);
 
@@ -2360,8 +2360,8 @@ ${output}</xml>`;
             let fail = false;
             if (n.parameters.length) {
                 let parent = getParent(n)[0];
-                if (parent && (parent as any).callInfo) {
-                    let callInfo: pxtc.CallInfo = (parent as any).callInfo;
+                if (parent && pxtc.pxtInfo(parent).callInfo) {
+                    let callInfo: pxtc.CallInfo = pxtc.pxtInfo(parent).callInfo;
                     if (env.attrs(callInfo).mutate === "objectdestructuring") {
                         fail = n.parameters[0].name.kind !== SK.ObjectBindingPattern
                     }
@@ -2415,7 +2415,7 @@ ${output}</xml>`;
         }
 
         function checkCall(n: ts.CallExpression, env: DecompilerEnv, asExpression = false, topLevel = false) {
-            const info: pxtc.CallInfo = (n as any).callInfo;
+            const info: pxtc.CallInfo = pxtc.pxtInfo(n).callInfo;
             if (!info) {
                 return Util.lf("Function call not supported in the blocks");
             }
@@ -2525,7 +2525,7 @@ ${output}</xml>`;
             if (api) {
                 const ns = env.blocks.apis.byQName[api.namespace];
                 if (ns && ns.attributes.fixedInstances && !ns.attributes.decompileIndirectFixedInstances && info.args.length) {
-                    const callInfo: pxtc.CallInfo = (info.args[0] as any).callInfo;
+                    const callInfo: pxtc.CallInfo = pxtc.pxtInfo(info.args[0]).callInfo;
                     if (!callInfo || !env.attrs(callInfo).fixedInstance) {
                         return Util.lf("Fixed instance APIs can only be called directly from the fixed instance");
                     }
@@ -2599,7 +2599,7 @@ ${output}</xml>`;
                         return undefined;
                     }
                     else if (e.kind === SK.CallExpression) {
-                        const callInfo: pxtc.CallInfo = (e as any).callInfo;
+                        const callInfo: pxtc.CallInfo = pxtc.pxtInfo(e).callInfo;
                         const attributes = env.attrs(callInfo);
                         if (callInfo && attributes.shim === "TD_ID" && callInfo.args && callInfo.args.length === 1) {
                             const arg = unwrapNode(callInfo.args[0]);
@@ -2689,7 +2689,7 @@ ${output}</xml>`;
                             }
                         }
 
-                        const callInfo: pxtc.CallInfo = (e as any).callInfo;
+                        const callInfo = pxtc.pxtInfo(e).callInfo;
 
                         if (callInfo && env.attrs(callInfo).fixedInstance) {
                             return undefined;
@@ -2864,7 +2864,7 @@ ${output}</xml>`;
                 return text === "0" || isEmptyString(text);
             }
             else {
-                const callInfo: pxtc.CallInfo = (decl.initializer as any).callInfo
+                const callInfo: pxtc.CallInfo = pxtc.pxtInfo(decl.initializer).callInfo
                 if (callInfo && callInfo.isAutoCreate)
                     return true
             }
@@ -2971,7 +2971,7 @@ ${output}</xml>`;
         }
 
         function checkPropertyAccessExpression(n: ts.PropertyAccessExpression, env: DecompilerEnv) {
-            const callInfo: pxtc.CallInfo = (n as any).callInfo;
+            const callInfo: pxtc.CallInfo = pxtc.pxtInfo(n).callInfo;
             if (callInfo) {
                 const attributes = env.attrs(callInfo);
                 const blockInfo = env.compInfo(callInfo);
@@ -2990,7 +2990,7 @@ ${output}</xml>`;
                     let fail = true;
 
                     if (parent) {
-                        const parentInfo: pxtc.CallInfo = (parent as any).callInfo;
+                        const parentInfo: pxtc.CallInfo = pxtc.pxtInfo(parent).callInfo;
                         if (parentInfo && parentInfo.args) {
                             const api = env.blocks.apis.byQName[parentInfo.qName];
                             const instance = api.kind == pxtc.SymbolKind.Method || api.kind == pxtc.SymbolKind.Property;
@@ -3045,7 +3045,7 @@ ${output}</xml>`;
     }
 
     function checkTaggedTemplateExpression(t: ts.TaggedTemplateExpression, env: DecompilerEnv) {
-        const callInfo: pxtc.CallInfo = (t as any).callInfo;
+        const callInfo: pxtc.CallInfo = pxtc.pxtInfo(t).callInfo;
 
         if (!callInfo) {
             return Util.lf("Invalid tagged template");
@@ -3231,7 +3231,7 @@ ${output}</xml>`;
                 return op != SK.PlusPlusToken && op != SK.MinusMinusToken;
             }
             case SK.CallExpression:
-                const callInfo: pxtc.CallInfo = (expr as any).callInfo
+                const callInfo: pxtc.CallInfo = pxtc.pxtInfo(expr).callInfo
                 assert(!!callInfo);
                 return callInfo.isExpression;
             case SK.ParenthesizedExpression:

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -833,7 +833,7 @@ ${output}</xml>`;
             if (n.kind === SK.BinaryExpression) {
                 const b = n as ts.BinaryExpression;
                 if (b.operatorToken.getText() === "+" || b.operatorToken.kind == SK.PlusEqualsToken) {
-                    const info: BinaryExpressionInfo = (n as any).exprInfo;
+                    const info: BinaryExpressionInfo = pxtInfo(n).exprInfo;
                     return !!info;
                 }
             }
@@ -3100,7 +3100,7 @@ ${output}</xml>`;
     }
 
     function isDeclaredElsewhere(node: ts.Identifier) {
-        return (node as any).identifierInfo && (node as any).identifierInfo.isGlobal;
+        return !! (pxtInfo(node).flags & PxtNodeFlags.IsGlobalIdentifier)
     }
 
     function hasStatementInput(info: CallInfo, attributes: CommentAttrs): boolean {

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -94,7 +94,7 @@ namespace ts.pxtc {
     }
 
     export function compile(opts: CompileOptions) {
-        let startTime = Date.now()
+        let startTime = U.cpuUs()
         let res: CompileResult = {
             outfiles: {},
             diagnostics: [],
@@ -198,7 +198,7 @@ namespace ts.pxtc {
             res.diagnostics = patchUpDiagnostics(program.getSemanticDiagnostics(), opts.ignoreFileResolutionErrors);
         }
 
-        let emitStart = U.now()
+        let emitStart = U.cpuUs()
         res.times["typescript"] = emitStart - startTime
 
         if (opts.ast) {
@@ -207,7 +207,7 @@ namespace ts.pxtc {
 
         if (opts.ast || opts.forceEmit || res.diagnostics.length == 0) {
             const binOutput = compileBinary(program, host, opts, res, entryPoint);
-            res.times["compilebinary"] = U.now() - emitStart
+            res.times["compilebinary"] = U.cpuUs() - emitStart
             res.diagnostics = res.diagnostics.concat(patchUpDiagnostics(binOutput.diagnostics))
         }
 
@@ -219,7 +219,7 @@ namespace ts.pxtc {
                 res.outfiles[f.slice(6)] = opts.fileSystem[f]
         }
 
-        res.times["all"] = U.now() - startTime;
+        res.times["all"] = U.cpuUs() - startTime;
         pxt.tickEvent(`compile`, res.times);
         return res
     }

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -162,10 +162,6 @@ namespace ts.pxtc {
         throw e;
     }
 
-    function noRefCounting() {
-        return !target.jsRefCounting && !target.isNative
-    }
-
     export function isStackMachine() {
         return target.isNative && target.nativeType == NATIVE_TYPE_VM
     }
@@ -2260,8 +2256,6 @@ ${lbl}: .short 0xffff
                     addDefaultParametersAndTypeCheck(checker.getResolvedSignature(node), args, ctorAttrs)
                     let compiled = args.map((x) => emitExpr(x))
                     if (ctorAttrs.shim) {
-                        if (!noRefCounting())
-                            U.userError("shim=... on constructor not supported right now")
                         // TODO need to deal with refMask and tagged ints here
                         // we drop 'obj' variable
                         return ir.rtcall(ctorAttrs.shim, compiled)

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -747,6 +747,7 @@ namespace ts.pxtc {
         target = opts.target
         const diagnostics = createDiagnosticCollection();
         checker = program.getTypeChecker();
+        let startTime = U.cpuUs();
         let classInfos: pxt.Map<ClassInfo> = {}
         let usedDecls: pxt.Map<Node> = {}
         let usedWorkList: Declaration[] = []
@@ -846,7 +847,9 @@ namespace ts.pxtc {
         layOutGlobals()
         pruneMethodsAndRecompute()
         emitVTables()
-
+        let pass0 = U.cpuUs()
+        res.times["pass0"] = pass0 - startTime
+      
         if (diagnostics.getModificationCount() == 0) {
             reset();
             bin.finalPass = true
@@ -864,11 +867,16 @@ namespace ts.pxtc {
             }
             res.configData.sort((a, b) => a.key - b.key)
 
+            let pass1 = U.cpuUs()
+            res.times["pass1"] = pass1 - pass0
             catchErrors(rootFunction, finalEmit)
+            res.times["passFinal"] = U.cpuUs() - pass1
         }
 
         if (opts.ast) {
+            let pre = U.cpuUs()
             annotate(program, entryPoint, target);
+            res.times["passAnnotate"] = U.cpuUs() - pre
         }
 
         // 12k for decent arcade game

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1548,7 +1548,6 @@ ${lbl}: .short 0xffff
                     ir.numlit(getIfaceMemberId(keyName)),
                     emitExpr(p.initializer)
                 ];
-                // internal decr on all args
                 proc.emitExpr(ir.rtcall("pxtrt::mapSet", args))
             })
             return expr
@@ -3379,7 +3378,6 @@ ${lbl}: .short 0xffff
                 inner = emitExpr(expr)
             if (isStackMachine())
                 return inner
-            // in all cases decr is internal, so no mask
             return ir.rtcall("numops::toBoolDecr", [inner])
         }
         function emitIfStatement(node: IfStatement) {

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -20,6 +20,7 @@ namespace ts.pxtc {
         callInfo: CallInfo = null;
         proc: ir.Procedure = null;
         flags = PxtNodeFlags.None;
+        commentAttrs: CommentAttrs = null;
         constructor(public wave: number, public id: number) { }
     }
 
@@ -455,19 +456,15 @@ namespace ts.pxtc {
         return parseCommentString(cmts)
     }
 
-    interface NodeWithAttrs extends Node {
-        pxtCommentAttrs: CommentAttrs;
-    }
-
-    export function parseComments(node0: Node): CommentAttrs {
-        if (!node0 || pxtInfo(node0).flags & PxtNodeFlags.IsBogusFunction) return parseCommentString("")
-        let node = node0 as NodeWithAttrs
-        let cached = node.pxtCommentAttrs
-        if (cached)
-            return cached
+    export function parseComments(node: Node): CommentAttrs {
+        const pinfo = node ? pxtInfo(node) : null
+        if (!pinfo || pinfo.flags & PxtNodeFlags.IsBogusFunction)
+            return parseCommentString("")
+        if (pinfo.commentAttrs)
+            return pinfo.commentAttrs
         let res = parseCommentString(getComments(node))
         res._name = getName(node)
-        node.pxtCommentAttrs = res
+        pinfo.commentAttrs = res
         return res
     }
 

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -14,16 +14,17 @@ namespace ts.pxtc {
         IsGlobalIdentifier = 0x0004,
     }
     export class PxtNode {
+        flags = PxtNodeFlags.None;
         typeCache: Type = null;
         symbolCache: Symbol = null;
         functionInfo: FunctionAddInfo = null;
         variableInfo: VariableAddInfo = null;
         callInfo: CallInfo = null;
         proc: ir.Procedure = null;
-        flags = PxtNodeFlags.None;
         commentAttrs: CommentAttrs = null;
         exprInfo: BinaryExpressionInfo = null;
         valueOverride: ir.Expr = null;
+        declCache: Declaration = undefined;
         constructor(public wave: number, public id: number) { }
     }
 
@@ -1702,6 +1703,9 @@ ${lbl}: .short 0xffff
 
         function getDecl(node: Node): Declaration {
             if (!node) return null
+            const pinfo = pxtInfo(node)
+            if (pinfo.declCache !== undefined)
+                return pinfo.declCache
             let sym = checker.getSymbolAtLocation(node)
             let decl: Declaration
             if (sym) {
@@ -1727,6 +1731,7 @@ ${lbl}: .short 0xffff
                 pxtInfo(decl).flags |= PxtNodeFlags.IsBogusFunction
             }
 
+            pinfo.declCache = decl || null
             return decl
         }
         function isRefCountedExpr(e: Expression) {

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -849,7 +849,7 @@ namespace ts.pxtc {
         emitVTables()
         let pass0 = U.cpuUs()
         res.times["pass0"] = pass0 - startTime
-      
+
         if (diagnostics.getModificationCount() == 0) {
             reset();
             bin.finalPass = true
@@ -1941,7 +1941,6 @@ ${lbl}: .short 0xffff
                 }
             }
             let attrs = parseComments(decl)
-            let hasRet = !(typeOf(node).flags & TypeFlags.Void)
             let args = callArgs.slice(0)
 
             if (isMethod && !recv && !isStatic(decl) && funcExpr.kind == SK.PropertyAccessExpression)
@@ -3256,10 +3255,12 @@ ${lbl}: .short 0xffff
                 return handleAssignment(node);
             }
 
-            let lt = typeOf(node.left)
-            let rt = typeOf(node.right)
+            let lt: Type = null
+            let rt: Type = null
 
             if (node.operatorToken.kind == SK.PlusToken || node.operatorToken.kind == SK.PlusEqualsToken) {
+                lt = typeOf(node.left)
+                rt = typeOf(node.right)
                 if (isStringType(lt) || (isStringType(rt) && node.operatorToken.kind == SK.PlusToken)) {
                     pxtInfo(node).exprInfo = {
                         leftType: checker.typeToString(lt),

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -408,12 +408,7 @@ namespace ts.pxtc {
                 vt ^= 1
                 if (vt & 3) oops("Unaligned vt: " + vt)
 
-                if (target.gc) {
-                    pxt.HF2.write32(headerBytes, 0, vt)
-                } else {
-                    pxt.HF2.write16(headerBytes, 0, parseInt(pxt.REFCNT_FLASH))
-                    pxt.HF2.write16(headerBytes, 2, vt >> target.vtableShift)
-                }
+                pxt.HF2.write32(headerBytes, 0, vt)
 
                 let len = 0
                 if (isString)
@@ -688,7 +683,7 @@ ${lbl}: ${snippets.obj_header("pxt::number_vt")}
         // 4 words header
         // 4 or 2 mem mgmt methods
         // 1 toString
-        return 4 + (target.gc ? 4 : 2) + 1
+        return 4 + 4 + 1
     }
 
     const primes = [
@@ -788,10 +783,8 @@ ${info.id}_VT:
 
         addPtr("pxt::RefRecord_destroy")
         addPtr("pxt::RefRecord_print")
-        if (target.gc) {
-            addPtr("pxt::RefRecord_scan")
-            addPtr("pxt::RefRecord_gcsize")
-        }
+        addPtr("pxt::RefRecord_scan")
+        addPtr("pxt::RefRecord_gcsize")
         let toStr = info.toStringMethod
         addPtr(toStr ? toStr.vtLabel() : "0")
 

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -452,22 +452,22 @@ namespace ts.pxtc.ir {
 
     export class Procedure extends Node {
         numArgs = 0;
-        info: FunctionAddInfo;
-        seqNo: number;
+        info: FunctionAddInfo = null;
+        seqNo: number = -1;
         isRoot = false;
         locals: Cell[] = [];
         captured: Cell[] = [];
         args: Cell[] = [];
-        parent: Procedure;
-        debugInfo: ProcDebugInfo;
-        fillDebugInfo: (th: assembler.File) => void;
-        classInfo: ClassInfo;
-        perfCounterName: string;
+        parent: Procedure = null;
+        debugInfo: ProcDebugInfo = null;
+        fillDebugInfo: (th: assembler.File) => void = null;
+        classInfo: ClassInfo = null;
+        perfCounterName: string = null;
         perfCounterNo = 0;
 
         body: Stmt[] = [];
         lblNo = 0;
-        action: ts.FunctionLikeDeclaration;
+        action: ts.FunctionLikeDeclaration = null;
 
         reset() {
             this.body = []

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -428,10 +428,6 @@ namespace ts.pxtc.ir {
         isThis?: boolean;
     }
 
-    export interface ProcQuery {
-        action: ts.FunctionLikeDeclaration;
-    }
-
     function noRefCount(e: ir.Expr): boolean {
         switch (e.exprKind) {
             case ir.EK.Sequence:
@@ -487,10 +483,6 @@ namespace ts.pxtc.ir {
 
         label() {
             return getFunctionLabel(this.action)
-        }
-
-        matches(id: ProcQuery) {
-            return (this.action == id.action)
         }
 
         toString(): string {

--- a/pxtcompiler/emitter/thumb.ts
+++ b/pxtcompiler/emitter/thumb.ts
@@ -418,15 +418,6 @@ namespace ts.pxtc.thumb {
                 singleReg(ln) == lnNext.numArgs[0] && lnNext.numArgs[1] == 0) {
                 // RULE: push {rX}; ldr rX, [sp, #0] -> push {rX}
                 lnNext.update("")
-            } else if (lnop == "bl" && lnNext.getOp() == "push" &&
-                /^_pxt_(incr|decr)$/.test(ln.words[1]) && singleReg(lnNext) == 0) {
-                ln.update("bl " + ln.words[1] + "_pushR0")
-                lnNext.update("@dummystack 1")
-            } else if (lnop == "ldr" && ln.getOpExt() == "ldr $r5, [sp, $i1]" && lnNext.getOp() == "bl" &&
-                /^_pxt_(incr|decr)(_pushR0)?$/.test(lnNext.words[1]) && ln.numArgs[0] == 0 && ln.numArgs[1] <= 32
-                && lnNext2 && lnNext2.getOp() != "push") {
-                ln.update("bl " + lnNext.words[1] + "_" + ln.numArgs[1])
-                lnNext.update("")
             } else if (lnNext2 && lnop == "push" && singleReg(ln) >= 0 && preservesReg(lnNext, singleReg(ln)) &&
                 lnNext2.getOp() == "pop" && singleReg(ln) == singleReg(lnNext2)) {
                 // RULE: push {rX}; movs rY, #V; pop {rX} -> movs rY, #V (when X != Y)

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -798,6 +798,9 @@ namespace ts.pxtc.Util {
         return Math.round(now() / 1000)
     }
 
+    // node.js overrides this to use process.cpuUsage()
+    export let cpuUs = () => Date.now() * 1000;
+
     export function getMime(filename: string) {
         let m = /\.([a-zA-Z0-9]+)$/.exec(filename)
         if (m)

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -288,7 +288,7 @@ namespace pxt.runner {
             return null;
 
         let call = estmt.expression as ts.CallExpression;
-        let info = (<any>call).callInfo as pxtc.CallInfo;
+        let info = pxtc.pxtInfo(call).callInfo;
 
         return info;
     }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -10,15 +10,9 @@ namespace pxsim {
         }
     }
 
-    export let refCounting = true;
     export let title = "";
     let cfgKey: Map<number> = {}
     let cfg: Map<number> = {}
-
-    export function noRefCounting() {
-        refCounting = false;
-        if (runtime) runtime.refCounting = false;
-    }
 
     export function getConfig(id: number) {
         if (cfg.hasOwnProperty(id + ""))
@@ -65,7 +59,6 @@ namespace pxsim {
 
     export class RefObject {
         id: number;
-        refcnt: number = 1;
 
         constructor() {
             if (runtime)
@@ -78,7 +71,7 @@ namespace pxsim {
 
         print() {
             if (runtime && runtime.refCountingDebug)
-                console.log(`RefObject id:${this.id} refs:${this.refcnt}`)
+                console.log(`RefObject id:${this.id}`)
         }
 
         // render a debug preview string
@@ -105,8 +98,7 @@ namespace pxsim {
         constructor(
             public func: LabelFn,
             public caps: any[],
-            public args: any[],
-            public cb: ResumeFn) { }
+            public args: any[]) { }
     }
 
     export interface VTable {
@@ -123,8 +115,6 @@ namespace pxsim {
         vtable: VTable;
 
         destroy() {
-            for (let k of Object.keys(this.fields))
-                decr(this.fields[k])
             this.fields = null
             this.vtable = null
         }
@@ -152,15 +142,13 @@ namespace pxsim {
         }
 
         destroy() {
-            for (let i = 0; i < this.len; ++i)
-                decr(this.fields[i])
             this.fields = null
             this.func = null
         }
 
         print() {
             if (runtime && runtime.refCountingDebug)
-                console.log(`RefAction id:${this.id} refs:${this.refcnt} len:${this.fields.length}`)
+                console.log(`RefAction id:${this.id} len:${this.fields.length}`)
         }
     }
 
@@ -176,16 +164,7 @@ namespace pxsim {
 
         export function runAction(a: RefAction, args: any[]) {
             let cb = getResume();
-
-            if (a instanceof RefAction) {
-                pxtrt.incr(a)
-                cb(new FnWrapper(a.func, a.fields, args, () => {
-                    pxtrt.decr(a)
-                }))
-            } else {
-                // no-closure case
-                cb(new FnWrapper(<any>a, null, args, null))
-            }
+            cb(new FnWrapper(<any>a, null, args))
         }
 
         export function dumpPerfCounters() {
@@ -203,12 +182,11 @@ namespace pxsim {
         v: any = null;
 
         destroy() {
-            decr(this.v)
         }
 
         print() {
             if (runtime && runtime.refCountingDebug)
-                console.log(`RefRefLocal id:${this.id} refs:${this.refcnt} v:${this.v}`)
+                console.log(`RefRefLocal id:${this.id} v:${this.v}`)
         }
     }
 
@@ -232,7 +210,6 @@ namespace pxsim {
         destroy() {
             super.destroy()
             for (let i = 0; i < this.data.length; ++i) {
-                decr(this.data[i].val);
                 this.data[i].val = 0;
             }
             this.data = []
@@ -240,7 +217,7 @@ namespace pxsim {
 
         print() {
             if (runtime && runtime.refCountingDebug)
-                console.log(`RefMap id:${this.id} refs:${this.refcnt} size:${this.data.length}`)
+                console.log(`RefMap id:${this.id} size:${this.data.length}`)
         }
 
         toAny(): any {
@@ -262,32 +239,6 @@ namespace pxsim {
         return v;
     }
 
-    export function decr(v: any): void {
-        if (!runtime || !runtime.refCounting) return
-        if (v instanceof RefObject) {
-            let o = <RefObject>v
-            check(o.refcnt > 0)
-            if (--o.refcnt == 0) {
-                runtime.unregisterLiveObject(o);
-                o.destroy()
-            }
-        }
-    }
-
-    export function initString(v: string) {
-        return v
-    }
-
-    export function incr(v: any) {
-        if (!runtime || !runtime.refCounting) return v
-        if (v instanceof RefObject) {
-            let o = <RefObject>v
-            check(o.refcnt > 0)
-            o.refcnt++
-        }
-        return v;
-    }
-
     export function dumpLivePointers() {
         if (runtime) runtime.dumpLivePointers();
     }
@@ -295,10 +246,9 @@ namespace pxsim {
         export function toString(v: any) {
             if (v === null) return "null"
             else if (v === undefined) return "undefined"
-            return initString(v.toString())
+            return v.toString()
         }
         export function toBoolDecr(v: any) {
-            decr(v)
             return !!v
         }
         export function toBool(v: any) {
@@ -314,9 +264,6 @@ namespace pxsim {
     }
 
     export namespace pxtcore {
-        export let incr = pxsim.incr;
-        export let decr = pxsim.decr;
-
         export function ptrOfLiteral(v: any) {
             return v;
         }
@@ -361,9 +308,6 @@ namespace pxsim {
     }
 
     export namespace pxtrt {
-        export let incr = pxsim.incr;
-        export let decr = pxsim.decr;
-
         export function toInt8(v: number) {
             return ((v & 0xff) << 24) >> 24
         }
@@ -406,12 +350,10 @@ namespace pxsim {
         }
 
         export function stringToBool(s: string) {
-            decr(s)
             return s ? 1 : 0
         }
 
         export function ptrToBool(v: any) {
-            decr(v)
             return v ? 1 : 0
         }
 
@@ -421,11 +363,10 @@ namespace pxsim {
         }
 
         export function ldlocRef(r: RefRefLocal) {
-            return incr(r.v)
+            return (r.v)
         }
 
         export function stlocRef(r: RefRefLocal, v: any) {
-            decr(r.v)
             r.v = v;
         }
 
@@ -467,12 +408,9 @@ namespace pxsim {
             }
             let i = map.findIdx(key);
             if (i < 0) {
-                decr(map);
                 return undefined;
             }
-            let r = incr(map.data[i].val);
-            decr(map)
-            return r;
+            return (map.data[i].val);
         }
 
         export const mapSetGeneric = mapSetByString
@@ -491,10 +429,8 @@ namespace pxsim {
                     val: val,
                 });
             } else {
-                decr(map.data[i].val);
                 map.data[i].val = val;
             }
-            decr(map)
         }
 
         export function keysOf(v: RefMap) {
@@ -522,7 +458,6 @@ namespace pxsim {
 
         export function switch_eq(a: any, b: any) {
             if (a == b) {
-                decr(b)
                 return true
             }
             return false
@@ -588,7 +523,6 @@ namespace pxsim {
                     .done()
             }
             pxtrt.nullCheck(a)
-            incr(a)
             loop()
         }
     }

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -164,7 +164,12 @@ namespace pxsim {
 
         export function runAction(a: RefAction, args: any[]) {
             let cb = getResume();
-            cb(new FnWrapper(<any>a, null, args))
+            if (a instanceof RefAction) {
+                cb(new FnWrapper(a.func, a.fields, args))
+            } else {
+                // no-closure case
+                cb(new FnWrapper(<any>a, null, args))
+            }
         }
 
         export function dumpPerfCounters() {

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -39,7 +39,6 @@ namespace pxsim {
         destroy() {
             let data = this.data
             for (let i = 0; i < data.length; ++i) {
-                decr(data[i]);
                 data[i] = 0;
             }
             this.data = [];
@@ -113,7 +112,6 @@ namespace pxsim {
 
         export function push(c: RefCollection, x: any) {
             pxtrt.nullCheck(c)
-            incr(x);
             c.push(x);
         }
 
@@ -127,7 +125,6 @@ namespace pxsim {
         export function getAt(c: RefCollection, x: number) {
             pxtrt.nullCheck(c)
             let tmp = c.getAt(x);
-            incr(tmp);
             return tmp;
         }
 
@@ -141,17 +138,11 @@ namespace pxsim {
 
         export function insertAt(c: RefCollection, x: number, y: number) {
             pxtrt.nullCheck(c)
-            incr(y);
             c.insertAt(x, y);
         }
 
         export function setAt(c: RefCollection, x: number, y: any) {
             pxtrt.nullCheck(c)
-            if (c.isValidIndex(x)) {
-                //if there is an existing element handle refcount
-                decr(c.getAt(x));
-            }
-            incr(y);
             c.setAt(x, y);
         }
 
@@ -249,7 +240,6 @@ namespace pxsim {
         export function eq(x: number, y: number) { return pxtrt.nullFix(x) == pxtrt.nullFix(y); }
         export function eqDecr(x: number, y: number) {
             if (pxtrt.nullFix(x) == pxtrt.nullFix(y)) {
-                decr(y);
                 return true;
             } else {
                 return false
@@ -260,7 +250,7 @@ namespace pxsim {
         export function div(x: number, y: number) { return Math.floor(x / y) | 0; }
         export function mod(x: number, y: number) { return x % y; }
         export function bnot(x: number) { return ~x; }
-        export function toString(x: number) { return initString(x + ""); }
+        export function toString(x: number) { return (x + ""); }
     }
 
     export namespace thumb {
@@ -318,7 +308,7 @@ namespace pxsim {
         }
 
         export function fromCharCode(code: number) {
-            return initString(String.fromCharCode(code));
+            return (String.fromCharCode(code));
         }
 
         export function toNumber(s: string) {
@@ -328,12 +318,12 @@ namespace pxsim {
         // TODO check edge-conditions
 
         export function concat(a: string, b: string) {
-            return initString(a + b);
+            return (a + b);
         }
 
         export function substring(s: string, i: number, j: number) {
             pxtrt.nullCheck(s)
-            return initString(s.slice(i, i + j));
+            return (s.slice(i, i + j));
         }
 
         export function equals(s1: string, s2: string) {
@@ -348,7 +338,6 @@ namespace pxsim {
 
         export function compareDecr(s1: string, s2: string) {
             if (s1 == s2) {
-                decr(s2)
                 return 0;
             }
             if (s1 < s2) return -1;
@@ -360,7 +349,7 @@ namespace pxsim {
         }
 
         export function substr(s: string, start: number, length?: number) {
-            return initString(s.substr(start, length));
+            return (s.substr(start, length));
         }
 
         function inRange(s: string, i: number) {
@@ -369,7 +358,7 @@ namespace pxsim {
         }
 
         export function charAt(s: string, i: number) {
-            return initString(s.charAt(i));
+            return (s.charAt(i));
         }
 
         export function charCodeAt(s: string, i: number) {


### PR DESCRIPTION
This improves "compileBinary" by ~25%, and overall compilation by ~15%.

TS compiler is now about half of compilation time (on jumpy platformer). I think further gains will have to come from some sort of incremental compilation.

This also removes support for non-GC build (which I'm 100% sure were broken before, but now it's really gone).