### PR TITLE
Fetch live translations for all minecraft apps

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -123,7 +123,7 @@ namespace pxt.BrowserUtils {
         return typeof window != "undefined" && !!(window as any).ipcRenderer;
     }
     export function isElectron() {
-        return isPxtElectron() || isIpcRenderer();
+        return isPxtElectron();
     }
 
     export function isLocalHost(): boolean {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -123,7 +123,7 @@ namespace pxt.BrowserUtils {
         return typeof window != "undefined" && !!(window as any).ipcRenderer;
     }
     export function isElectron() {
-        return isPxtElectron();
+        return isPxtElectron() || isIpcRenderer();
     }
 
     export function isLocalHost(): boolean {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3750,7 +3750,7 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             const useLang = mlang ? mlang[3] : (lang.getCookieLang() || theme.defaultLocale || (navigator as any).userLanguage || navigator.language);
             const locstatic = /staticlang=1/i.test(window.location.href);
-            const live = !(locstatic || pxt.BrowserUtils.isElectron() || theme.disableLiveTranslations) || (mlang && !!mlang[1]);
+            const live = !(locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations) || (mlang && !!mlang[1]);
             const force = !!mlang && !!mlang[2];
             const targetId = pxt.appTarget.id;
             const baseUrl = config.commitCdnUrl;


### PR DESCRIPTION
ipcRenderer is only used in Minecraft/Code Connection, and we want to fetch the live translations for those (instead of treating as Electron app)