### PR TITLE
Fix unused classes with field assignments

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1563,7 +1563,7 @@ ${lbl}: .short 0xffff
             }
             if (node.initializer) {
                 let info = getClassInfo(typeOf(node.parent))
-                if (bin.finalPass && !info.ctor)
+                if (bin.finalPass && info.isUsed && !info.ctor)
                     userError(9209, lf("class field initializers currently require an explicit constructor"))
             }
             // do nothing


### PR DESCRIPTION
also move `usedDecls` to PxtNode

without this, the following fails, unless `new Foo()` is present somewhere

```typescript
class Foo {
    bar = 1;
    constructor() { }
}
```