### PR TITLE
Tutorial progress circle component

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -773,6 +773,7 @@ declare namespace pxt.tutorial {
         editor: string; // preferred editor or blocks by default
         title?: string;
         steps: TutorialStepInfo[];
+        activities: TutorialActivityInfo[];
         code: string; // all code
         templateCode?: string;
     }
@@ -791,6 +792,12 @@ declare namespace pxt.tutorial {
         contentMd?: string;
         headerContentMd?: string;
         hintContentMd?: string;
+        activity?: number;
+    }
+
+    interface TutorialActivityInfo {
+        name: string,
+        step: number
     }
 
     interface TutorialOptions {
@@ -798,6 +805,7 @@ declare namespace pxt.tutorial {
         tutorialName?: string; // tutorial title
         tutorialReportId?: string; // if this tutorial was user generated, the report abuse id
         tutorialStepInfo?: pxt.tutorial.TutorialStepInfo[];
+        tutorialActivityInfo?: pxt.tutorial.TutorialActivityInfo[];
         tutorialStep?: number; // current tutorial page
         tutorialReady?: boolean; // current tutorial page
         tutorialHintCounter?: number // count for number of times hint has been shown

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -3,7 +3,7 @@
  */
 namespace pxt.tutorial {
     export function parseTutorial(tutorialmd: string): TutorialInfo {
-        const steps = parseTutorialSteps(tutorialmd);
+        const [steps, activities] = parseTutorialSteps(tutorialmd);
         const title = parseTutorialTitle(tutorialmd);
         if (!steps)
             return undefined; // error parsing steps
@@ -47,6 +47,7 @@ namespace pxt.tutorial {
             editor: editor || pxt.BLOCKS_PROJECT_NAME,
             title: title,
             steps: steps,
+            activities: activities,
             code,
             templateCode
         };
@@ -67,44 +68,73 @@ namespace pxt.tutorial {
         return title && title.length > 1 ? title[1] : null;
     }
 
-    function parseTutorialSteps(tutorialmd: string): TutorialStepInfo[] {
+    function parseTutorialSteps(tutorialmd: string): [TutorialStepInfo[], TutorialActivityInfo[]] {
         const metadata = parseTutorialMetadata(tutorialmd);
         const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template)\s*\n([\s\S]*?)\n```/gmi;
 
         // Download tutorial markdown
-        let steps = tutorialmd.split(/^##[^#].*$/gmi);
-        let newAuthoring = true;
-        if (steps.length <= 1) {
-            // try again, using old logic.
-            steps = tutorialmd.split(/^###[^#].*$/gmi);
-            newAuthoring = false;
-        }
-        if (steps[0].indexOf("# Not found") == 0) {
-            pxt.debug(`tutorial not found`);
-            return undefined;
-        }
+        let activityInfo: TutorialActivityInfo[] = [];
         let stepInfo: TutorialStepInfo[] = [];
-        tutorialmd.replace(newAuthoring ? /^##[^#](.*)$/gmi : /^###[^#](.*)$/gmi, (f, s) => {
-            let info: TutorialStepInfo = {
-                fullscreen: /@(fullscreen|unplugged)/.test(s),
-                unplugged: /@unplugged/.test(s),
-                tutorialCompleted: /@tutorialCompleted/.test(s)
+        let activities = tutorialmd.split(/(?=^#[^#].*$)/gmi);
+
+        for (let i = 0; i < activities.length; i++) {
+            let activity = activities[i];
+            if (!activity) continue;
+
+            let name;
+            activity = activity.replace(/^#[^#](.*)$/mi, function (f, s) {
+                name = s;
+                return ""
+            });
+
+            let steps = activity.split(/(?=^##[^#].*$)/gmi);
+
+            let newAuthoring = true;
+            if (steps.length <= 1) {
+                // try again, using old logic.
+                steps = activity.split(/^###[^#].*$/gmi);
+                newAuthoring = false;
             }
-            stepInfo.push(info);
-            return ""
-        });
+            if (steps[0].indexOf("# Not found") == 0) {
+                pxt.debug(`tutorial not found`);
+                return undefined;
+            }
 
-        if (steps.length < 1)
-            return undefined; // Promise.resolve();
-        steps = steps.slice(1, steps.length); // Remove tutorial title
+            if (steps && steps.length > 0) {
+                activityInfo.push({
+                    name: name || lf("Activity ") + activityInfo.length,
+                    step: stepInfo.length
+                })
+            }
 
-        for (let i = 0; i < steps.length; i++) {
-            const stepContent = steps[i].trim();
-            const contentLines = stepContent.split('\n');
+            for (let j = 0; j < steps.length; j++) {
+                let step = steps[j];
+                let flags;
+                step = step.replace(newAuthoring ? /^##[^#](.*)$/gmi : /^###[^#](.*)$/gmi, function (f, s) {
+                    flags = s;
+                    return "";
+                }).trim();
+
+                if (!step) continue;
+
+                let info: TutorialStepInfo = {
+                    fullscreen: /@(fullscreen|unplugged)/.test(flags),
+                    unplugged: /@unplugged/.test(flags),
+                    tutorialCompleted: /@tutorialCompleted/.test(flags),
+                    contentMd: step.trim(),
+                    activity: i
+                }
+
+                stepInfo.push(info);
+            }
+        }
+
+        for (let i = 0; i < stepInfo.length; i++) {
             const info = stepInfo[i];
+            const stepContent = info.contentMd;
+            const contentLines = stepContent.split('\n');
 
             info.headerContentMd = contentLines[0];
-            info.contentMd = stepContent;
 
             let hintContentMd;
             if (metadata && metadata.v == 2) {
@@ -132,7 +162,7 @@ namespace pxt.tutorial {
 
             info.hasHint = hintContentMd && hintContentMd.length > 1;
         }
-        return stepInfo;
+        return [stepInfo, activityInfo];
     }
 
     /*

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -388,6 +388,43 @@ span.highlight-line {
     }
 }
 
+/*******************************
+      Tutorial Activity UI
+*******************************/
+#tutorialsteps .step-label {
+    margin: 0 1em;
+}
+
+#tutorialsteps .button.prevbutton,
+#tutorialsteps .button.nextbutton {
+    line-height: 1.4em;
+}
+
+#tutorialsteps .button.nextbutton .text {
+    margin-right: 0.5em;
+}
+
+#tutorialdropdown > .text {
+    margin: 0.5em;
+}
+
+/*******************************
+        Progress Circle
+*******************************/
+.progresscircle {
+    position: absolute;
+    width: 2.4em;
+    height: 2.4em;
+    margin-top: -0.4em;
+    margin-left: -0.2em;
+}
+
+.progresscircle path {
+    stroke: @white;
+    fill: none;
+    stroke-linecap: round;
+}
+
 
 /*******************************
         Media Adjustments
@@ -468,6 +505,10 @@ span.highlight-line {
 @media only screen and (max-width: @largestTabletScreen) {
     .avatar-container .tooltip {
         left: 5rem;
+    }
+
+    #tutorialdropdown {
+        width: auto;
     }
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -116,7 +116,7 @@ export class ProjectView
     private runToken: pxt.Util.CancellationToken;
 
     // component ID strings
-    private static readonly tutorialCardId = "tutorialcard";
+    static readonly tutorialCardId = "tutorialcard";
 
     constructor(props: IAppProps) {
         super(props);
@@ -2938,6 +2938,7 @@ export class ProjectView
                 tutorialReady: true,
                 tutorialHintCounter: 0,
                 tutorialStepInfo: tutorialInfo.steps,
+                tutorialActivityInfo: tutorialInfo.activities,
                 tutorialMd: md,
                 tutorialCode: tutorialInfo.code,
                 tutorialRecipe: !!recipe,

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -440,7 +440,10 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 {!inTutorial && homeEnabled ? <sui.Item className="icon openproject" role="menuitem" textClass="landscape only" icon="home large" ariaLabel={lf("Home screen")} text={lf("Home")} onClick={this.goHome} /> : null}
                 {showShare ? <sui.Item className="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project")} text={lf("Share")} icon="share alternate large" onClick={this.showShareDialog} /> : null}
                 {inTutorial && <sui.Item className="tutorialname" tabIndex={-1} textClass="landscape only" text={tutorialOptions.tutorialName} />}
-                {inTutorial && hasActivities && <tutorial.TutorialActivityDropdown parent={this.props.parent} currentActivity={tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity} activityInfo={tutorialOptions.tutorialActivityInfo} />}
+                {inTutorial && hasActivities && <tutorial.TutorialActivityDropdown
+                    parent={this.props.parent}
+                    currentActivity={tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity}
+                    activityInfo={tutorialOptions.tutorialActivityInfo} />}
             </div> : <div className="left menu">
                     <span id="logo" className="ui item logo">
                         <img className="ui mini image" src={rightLogo} tabIndex={0} onClick={this.launchFullEditor} onKeyDown={sui.fireClickOnEnter} alt={`${targetTheme.boardName} Logo`} />

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -405,6 +405,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const homeEnabled = !lockedEditor && !isController;
         const sandbox = pxt.shell.isSandboxMode();
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
+        const hasActivities = tutorialOptions && tutorialOptions.tutorialActivityInfo && tutorialOptions.tutorialActivityInfo.length > 1;
         const tutorialReportId = tutorialOptions && tutorialOptions.tutorialReportId;
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial && !debugging;
         const isRunning = simState == pxt.editor.SimState.Running;
@@ -438,7 +439,8 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 {(!lockedEditor && targetTheme.betaUrl) && <a href={`${targetTheme.betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta")}</a>}
                 {!inTutorial && homeEnabled ? <sui.Item className="icon openproject" role="menuitem" textClass="landscape only" icon="home large" ariaLabel={lf("Home screen")} text={lf("Home")} onClick={this.goHome} /> : null}
                 {showShare ? <sui.Item className="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project")} text={lf("Share")} icon="share alternate large" onClick={this.showShareDialog} /> : null}
-                {inTutorial ? <sui.Item className="tutorialname" tabIndex={-1} textClass="landscape only" text={tutorialOptions.tutorialName} /> : null}
+                {inTutorial && <sui.Item className="tutorialname" tabIndex={-1} textClass="landscape only" text={tutorialOptions.tutorialName} />}
+                {inTutorial && hasActivities && <tutorial.TutorialActivityDropdown parent={this.props.parent} currentActivity={tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity} activityInfo={tutorialOptions.tutorialActivityInfo} />}
             </div> : <div className="left menu">
                     <span id="logo" className="ui item logo">
                         <img className="ui mini image" src={rightLogo} tabIndex={0} onClick={this.launchFullEditor} onKeyDown={sui.fireClickOnEnter} alt={`${targetTheme.boardName} Logo`} />
@@ -454,7 +456,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                     <div className="ui item toggle"></div>
                 </div>
             </div> : undefined}
-            {inTutorial ? <tutorial.TutorialMenuItem parent={this.props.parent} /> : undefined}
+            {inTutorial && <tutorial.TutorialMenu parent={this.props.parent} />}
             {debugging && !inTutorial ? <sui.MenuItem className="debugger-menu-item centered" icon="large bug" name="Debug Mode" /> : undefined}
             <div className="right menu">
                 {debugging ? <sui.ButtonMenuItem className="exit-debugmode-btn" role="menuitem" icon="external" text={lf("Exit Debug Mode")} textClass="landscape only" onClick={this.toggleDebug} /> : undefined}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -68,8 +68,8 @@ export interface DropdownProps extends UiProps {
     tabIndex?: number;
     value?: string;
     title?: string;
+    id?: string;
     onChange?: (v: string) => void;
-
 }
 
 export interface DropdownState {
@@ -331,6 +331,7 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
         ])
         return (
             <div role="listbox" ref="dropdown" title={title} {...aria}
+                id={this.props.id}
                 className={classes}
                 onMouseDown={this.handleMouseDown}
                 onClick={this.handleClick}
@@ -1265,6 +1266,43 @@ export class Tooltip extends React.Component<TooltipProps, {}> {
             <ReactTooltip id={id} className={`pxt-tooltip ${className || ''}`} effect='solid' {...rest}>
                 {content}
             </ReactTooltip>
+        </div>
+    }
+}
+
+///////////////////////////////////////////////////////////
+////////////             SVG Loader           /////////////
+///////////////////////////////////////////////////////////
+
+
+export interface ProgressCircleProps {
+    progress: number; // progress in int from 1 - steps
+    steps: number; // max number of steps
+    stroke: number;
+}
+
+export class ProgressCircle extends React.Component<ProgressCircleProps, {}> {
+    protected radius: number = 100 / (2 * Math.PI); // 100 steps in circle
+    protected view: number;
+    constructor (props: ProgressCircleProps) {
+        super(props);
+        this.view = this.radius * 2 + this.props.stroke;
+    }
+
+    getPathStyle() {
+        return { strokeWidth: this.props.stroke }
+    }
+
+    render() {
+        let props = this.props;
+        let r = this.radius;
+
+        return <div className="progresscircle">
+            <svg viewBox={`0 0 ${this.view} ${this.view}`}>
+                <path style={this.getPathStyle()}
+                    strokeDasharray={`${Math.round(100 * props.progress / props.steps)}, 100`}
+                    d={`M${this.view/2} ${props.stroke/2} a ${r} ${r} 0 0 1 0 ${r * 2} a ${r} ${r} 0 0 1 0 -${r * 2}`} />
+            </svg>
         </div>
     }
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1301,7 +1301,7 @@ export class ProgressCircle extends React.Component<ProgressCircleProps, {}> {
             <svg viewBox={`0 0 ${this.view} ${this.view}`}>
                 <path style={this.getPathStyle()}
                     strokeDasharray={`${Math.round(100 * props.progress / props.steps)}, 100`}
-                    d={`M${this.view/2} ${props.stroke/2} a ${r} ${r} 0 0 1 0 ${r * 2} a ${r} ${r} 0 0 1 0 -${r * 2}`} />
+                    d={`M${this.view / 2} ${props.stroke / 2} a ${r} ${r} 0 0 1 0 ${r * 2} a ${r} ${r} 0 0 1 0 -${r * 2}`} />
             </svg>
         </div>
     }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -10,6 +10,7 @@ import * as md from "./marked";
 import * as compiler from "./compiler";
 import * as codecard from "./codecard";
 import { HintTooltip } from "./hinttooltip";
+import { ProjectView } from "./app";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -46,8 +47,35 @@ export function getUsedBlocksAsync(code: string): Promise<pxt.Map<number>> {
         });
 }
 
-export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
+export class TutorialMenu extends data.Component<ISettingsProps, {}> {
+    protected hasActivities: boolean;
     constructor(props: ISettingsProps) {
+        super(props);
+        let tutorialOptions = this.props.parent.state.tutorialOptions;
+        this.hasActivities = tutorialOptions && tutorialOptions.tutorialActivityInfo && tutorialOptions.tutorialActivityInfo.length > 1;
+    }
+
+    renderCore () {
+        let tutorialOptions = this.props.parent.state.tutorialOptions;
+        if (this.hasActivities) {
+            return <TutorialStepCircle parent={this.props.parent} />;
+        } else if (tutorialOptions.tutorialStepInfo.length < 8) {
+            return <TutorialMenuItem parent={this.props.parent} />;
+        } else {
+            return <div className="menu">
+                <TutorialMenuItem parent={this.props.parent} className="mobile hide" />
+                <TutorialStepCircle parent={this.props.parent} className="mobile only" />
+            </div>
+        }
+    }
+}
+
+interface ITutorialMenuProps extends ISettingsProps {
+    className?: string;
+}
+
+export class TutorialMenuItem extends data.Component<ITutorialMenuProps, {}> {
+    constructor(props: ITutorialMenuProps) {
         super(props);
 
         this.openTutorialStep = this.openTutorialStep.bind(this);
@@ -74,7 +102,7 @@ export class TutorialMenuItem extends data.Component<ISettingsProps, {}> {
             return "mobile hide";
         }
 
-        return <div className="ui item">
+        return <div className={`ui item ${this.props.className}`}>
             <div className="ui item tutorial-menuitem" role="menubar">
                 {tutorialStepInfo.map((step, index) =>
                     (index == currentStep) ?
@@ -114,6 +142,78 @@ export class TutorialMenuItemLink extends data.Component<TutorialMenuItemLinkPro
         return <a className={className} role="menuitem" aria-label={ariaLabel} tabIndex={0} onClick={this.handleClick} onKeyDown={sui.fireClickOnEnter}>
             {this.props.children}
         </a>;
+    }
+}
+
+interface ITutorialActivityDropdownProps extends ISettingsProps {
+    currentActivity: number;
+    activityInfo: pxt.tutorial.TutorialActivityInfo[];
+}
+
+export class TutorialActivityDropdown extends data.Component<ITutorialActivityDropdownProps, {}> {
+    constructor(props: ITutorialActivityDropdownProps) {
+        super(props);
+        this.handleActivitySelect = this.handleActivitySelect.bind(this);
+    }
+
+    handleActivitySelect = (value: number) => () => {
+        pxt.tickEvent(`tutorial.step`, { tutorial: this.props.parent.state.tutorialOptions.tutorial, step: value }, { interactiveConsent: true });
+        this.props.parent.setTutorialStep(value);
+    }
+
+    renderCore() {
+        let activity = this.props.activityInfo[this.props.currentActivity];
+        return <sui.DropdownMenu id="tutorialdropdown" role="menuitem" icon="angle down" rightIcon text={activity.name} title={lf("Select tutorial activity")} className={`item`}>
+            {this.props.activityInfo.map((activity, index) =>
+                <sui.Item role="menuitem" value={activity.step.toString()} key={index} text={activity.name} onClick={this.handleActivitySelect(activity.step)} />
+            )}
+        </sui.DropdownMenu>
+    }
+}
+
+export class TutorialStepCircle extends data.Component<ITutorialMenuProps, {}> {
+    constructor(props: ITutorialMenuProps) {
+        super(props);
+
+        this.openTutorialStep = this.openTutorialStep.bind(this);
+    }
+
+    handleNextClick = () => {
+        let options = this.props.parent.state.tutorialOptions;
+        this.openTutorialStep( options.tutorialStep + 1);
+    }
+
+    handlePrevClick = () => {
+        let options = this.props.parent.state.tutorialOptions;
+        this.openTutorialStep( options.tutorialStep - 1);
+    }
+
+    openTutorialStep(step: number) {
+        let options = this.props.parent.state.tutorialOptions;
+        pxt.tickEvent(`tutorial.step`, { tutorial: options.tutorial, step: step }, { interactiveConsent: true });
+        this.props.parent.setTutorialStep(step);
+    }
+
+    renderCore() {
+        const { tutorialReady, tutorialStepInfo, tutorialStep } = this.props.parent.state.tutorialOptions;
+        const currentStep = tutorialStep;
+        const hasPrev = tutorialReady && currentStep != 0;
+        const hasNext = tutorialReady && currentStep != tutorialStepInfo.length - 1;
+        const isRtl = false;
+
+        if (!tutorialReady) return <div />;
+
+        return <div id="tutorialsteps" className={`ui item ${this.props.className}`}>
+            <div className="ui item" role="menubar">
+                <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron orange large`} disabled={!hasPrev} className={`prevbutton left attached ${!hasPrev ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.handlePrevClick} onKeyDown={sui.fireClickOnEnter} />
+                <span className="step-label" key={'tutorialStep' + currentStep}>
+                    <sui.ProgressCircle progress={currentStep} steps={tutorialStepInfo.length} stroke={4.5} />
+                    <span className={`ui circular label blue selected ${!tutorialReady ? 'disabled' : ''}`}
+                        aria-label={lf("You are currently at tutorial step {0}.")}>{tutorialStep + 1}</span>
+                </span>
+                <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron orange large`} disabled={!hasNext} rightIcon className={`nextbutton right attached ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")} onClick={this.handleNextClick} onKeyDown={sui.fireClickOnEnter} />
+            </div>
+        </div>;
     }
 }
 


### PR DESCRIPTION
Initial components for circle display for tutorial with activity dropdown. The circle is always displayed if activities are present, and if the tutorial has 8+ steps it is displayed on mobile screen sizes.

Currently uses the H1 (#) tag as the divider for each activity, so it's backward-compatible with the current tutorials and activity segments can easily be added to existing tutorials by inserting H1 tags.

We could also use ## for activities, and ### for steps, using the version metadata to determine what kind of parsing to use, but that will make conversions a little more involved.

![tutorial-circle](https://user-images.githubusercontent.com/34112083/61983017-9082aa80-afb3-11e9-9f2c-1e5b3ba3cf2f.gif)

![tutorial-circle-mob](https://user-images.githubusercontent.com/34112083/61983018-9082aa80-afb3-11e9-9ab9-29f8f2014f5d.gif)

Will also bring this to the design meeting next week for additional CSS/style iteration