### PR TITLE
support for throw, try, catch, finally

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -55,6 +55,8 @@ and might not be available in your editor.
 * initializers for class fields
 * lambda functions with more than three arguments
 * using generic functions as values and nested generic functions
+* binding with arrays or objects: `let [a, b] = ...; let { x, y } = ...`
+* exceptions (`throw`, `try ... catch`, `try ... finally`)
 
 The following used to be disallowed, but should be supported now,
 though they require testing:
@@ -80,9 +82,6 @@ We generally stay away from the more dynamic parts of JavaScript.  Things you ma
 
 * object destructuring with initializers
 * shorthand properties (`{a, b: 1}` parsed as `{a: a, b: 1}`)
-* exceptions (`throw`, `try ... catch`, `try ... finally`);
-  currently all exceptions just stop the program
-* binding with arrays or objects: `let [a, b] = ...; let { x, y } = ...`
 * `delete` statement (on object literals)
 * spread and reset operators (statically typed)
 * support of `enums` as run-time arrays

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -45,6 +45,10 @@ namespace ts.pxtc {
     //   - registers for runtime calls (r0, r1,r2,r3)
     //   - r5 is for captured locals in lambda
     //   - r6 for global{}
+    //   - r4 and r7 are used as temporary
+    //   - C code assumes the following are calee saved: r4-r7, r8-r11
+    //   - r12 is intra-procedure scratch and can be treated like r0-r3
+    //   - r13 is sp, r14 is lr, r15 is pc
     // - for calls to user functions, all arguments passed on stack
 
     export abstract class AssemblerSnippets {
@@ -819,8 +823,18 @@ ${baseLabel}_nochk:
             return { id: "builtin" + typeNo, classNo: typeNo, lastSubtypeNo: typeNo } as any
         }
 
+        private emitBeginTry(topExpr: ir.Expr) {
+            // this.write(`adr r0, ${topExpr.args[0].data}`)
+            this.emitExprInto(topExpr.args[0], "r0")
+            this.write(`bl _pxt_save_exception_state`)
+        }
+
         private emitRtCall(topExpr: ir.Expr, genCall: () => void = null) {
             let name: string = topExpr.data
+
+            if (name == "pxt::beginTry") {
+                return this.emitBeginTry(topExpr)
+            }
 
             let maskInfo = topExpr.mask || { refMask: 0 }
             let convs = maskInfo.conversions || []
@@ -1162,10 +1176,16 @@ ${baseLabel}_nochk:
             .section code
             _pxt_lambda_trampoline:
                 push {${r3} r4, r5, r6, r7, lr}
+                mov r4, r8
+                mov r5, r9
+                mov r6, r10
+                mov r7, r11
+                push {r4, r5, r6, r7} ; save high registers
                 mov r4, r1
                 mov r5, r2
                 mov r6, r3
-                mov r7, r0`)
+                mov r7, r0
+                `)
             // TODO should inline this?
             this.emitInstanceOf(this.builtInClassNo(pxt.BuiltInType.RefAction), "validate")
             this.write(`
@@ -1184,7 +1204,42 @@ ${baseLabel}_nochk:
                 mov r0, r6   ; or pop the thread context
                 bl pxt::popThreadContext
                 mov r0, r7 ; restore result
+                pop {r4, r5, r6, r7} ; restore high registers
+                mov r8, r4
+                mov r9, r5
+                mov r10, r6
+                mov r11, r7
                 pop {${r3} r4, r5, r6, r7, pc}`)
+
+            this.write(`
+            .section code
+            ; r0 - try frame
+            ; r1 - handler PC
+            _pxt_save_exception_state:
+                push {r0, lr}
+                ${this.t.callCPP("pxt::beginTry")}
+                pop {r1, r4}
+                str r1, [r0, #1*4] ; PC
+                mov r1, sp
+                str r1, [r0, #2*4] ; SP
+                str r5, [r0, #3*4] ; lambda ptr
+                bx r4
+                `)
+
+            this.write(`
+            .section code
+            ; r0 - try frame
+            ; r1 - thread context
+            _pxt_restore_exception_state:
+                mov r6, r1
+                ldr r1, [r0, #2*4] ; SP
+                mov sp, r1
+                ldr r5, [r0, #3*4] ; lambda ptr
+                ldr r1, [r0, #1*4] ; PC
+                movs r0, #1
+                orrs r1, r0
+                bx r1
+                `)
 
             this.write(`
             .section code

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -264,7 +264,11 @@ switch (step) {
                     else if (typeof e.data == "number") return e.data + ""
                     else throw oops("invalid data: " + typeof e.data);
                 case EK.PointerLiteral:
-                    return e.jsInfo;
+                    if (e.ptrlabel()) {
+                        return e.ptrlabel().lblId + "";
+                    } else {
+                        return e.jsInfo;
+                    }
                 case EK.SharedRef:
                     let arg = e.args[0]
                     U.assert(!!arg.currUses) // not first use

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -534,6 +534,12 @@ _start_${name}:
 
         function emitRtCall(topExpr: ir.Expr) {
             let name: string = topExpr.data
+
+            if (name == "pxt::beginTry") {
+                write(`try ${topExpr.args[0].data}`)
+                return
+            }
+
             name = U.lookup(vmCallMap, name) || name
 
             clearStack()

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3710,7 +3710,9 @@ ${lbl}: .short 0xffff
             emitBrk(node)
 
             const lcatch = proc.mkLabel("catch")
+            lcatch.lblName = "_catch_" + getNodeId(node)
             const lfinally = proc.mkLabel("finally")
+            lfinally.lblName = "_finally_" + getNodeId(node)
 
             if (node.finallyBlock)
                 proc.emitExpr(beginTry(lfinally))

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -854,7 +854,7 @@ ${hex.hexPrelude()}
     .word _pxt_iface_member_names
     .word _pxt_lambda_trampoline@fn
     .word _pxt_perf_counters
-    .word 0 ; reserved
+    .word _pxt_restore_exception_state@fn
     .word 0 ; reserved
 `
         let snippets: AssemblerSnippets = null;

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -76,6 +76,12 @@ namespace ts.pxtc.ir {
             return copy
         }
 
+        ptrlabel() {
+            if (this.jsInfo as any instanceof Stmt)
+                return this.jsInfo as any as Stmt
+            return null
+        }
+
         isExpr() { return true }
 
         isPure() {
@@ -620,6 +626,13 @@ namespace ts.pxtc.ir {
                         U.assert(e.args[0].totalUses > 0, "e.args[0].totalUses > 0")
                         e.args[0].totalUses++;
                         return e;
+                    case EK.PointerLiteral:
+                        const pl = e.ptrlabel()
+                        if (pl) {
+                            if (!pl.lblNumUses) pl.lblNumUses = 0
+                            pl.lblNumUses++
+                        }
+                        break
                 }
                 iterargs(e, cntuses)
                 return e

--- a/pxtcompiler/emitter/vm.ts
+++ b/pxtcompiler/emitter/vm.ts
@@ -122,6 +122,7 @@ namespace ts.pxtc.vm {
         "jmp       $lbl",
         "jmpnz     $lbl",
         "jmpz      $lbl",
+        "try       $lbl",
         "push",
         "pop",
     ]

--- a/tests/compile-test/lang-test0/51exceptions.ts
+++ b/tests/compile-test/lang-test0/51exceptions.ts
@@ -1,15 +1,47 @@
 namespace exceptions {
-    function bar(n: number) {
+    function immediate(k: number) {
+        try {
+            pause(1)
+            if (k > 0)
+                throw "hl" + k
+            pause(1)
+            glb1++
+        } catch (e) {
+            assert(e == "hl" + k)
+            glb1 += 10
+            if (k >= 10)
+                throw e
+        } finally {
+            x += glb1
+        }
+    }
+
+    function throwVal(n: number) {
         pause(1)
         if (n > 0)
             throw "hel" + n
         pause(1)
     }
 
-    function foo(k: number) {
+
+    function higherorder(k: number) {
+        try {
+            [1].map(() => throwVal(k))
+            glb1++
+        } catch (e) {
+            assert(e == "hel" + k)
+            glb1 += 10
+            if (k >= 10)
+                throw e
+        } finally {
+            x += glb1
+        }
+    }
+
+    function callingThrowVal(k: number) {
         try {
             pause(1)
-            bar(k)
+            throwVal(k)
             pause(1)
             glb1++
         } catch (e) {
@@ -23,10 +55,9 @@ namespace exceptions {
     }
 
     function nested() {
-        glb1 = x = 0
         try {
             try {
-                foo(10)
+                callingThrowVal(10)
             } catch (e) {
                 assert(glb1 == 10 && x == 10)
                 glb1++
@@ -38,14 +69,32 @@ namespace exceptions {
     }
 
     export function run() {
-        glb1 = 0
-        x = 0
-        foo(1)
+        glb1 = x = 0
+
+        callingThrowVal(1)
         assert(glb1 == 10 && x == 10)
-        foo(0)
+        callingThrowVal(0)
         assert(glb1 == 11 && x == 21)
-        foo(3)
+        callingThrowVal(3)
         assert(glb1 == 21 && x == 42)
+
+        glb1 = x = 0
+        immediate(1)
+        assert(glb1 == 10 && x == 10)
+        immediate(0)
+        assert(glb1 == 11 && x == 21)
+        immediate(3)
+        assert(glb1 == 21 && x == 42)
+
+        glb1 = x = 0
+        higherorder(1)
+        assert(glb1 == 10 && x == 10)
+        higherorder(0)
+        assert(glb1 == 11 && x == 21)
+        higherorder(3)
+        assert(glb1 == 21 && x == 42)
+
+        glb1 = x = 0
         nested()
         assert(glb1 == 11)
     }

--- a/tests/compile-test/lang-test0/51exceptions.ts
+++ b/tests/compile-test/lang-test0/51exceptions.ts
@@ -96,6 +96,7 @@ namespace exceptions {
     }
 
     export function run() {
+        msg("test exn")
         glb1 = x = 0
         callingThrowVal(1)
         assert(glb1 == 10 && x == 10)
@@ -112,6 +113,7 @@ namespace exceptions {
         glb1 = x = 0
         nested()
         assert(glb1 == 11)
+        msg("test exn done")
     }
 }
 

--- a/tests/compile-test/lang-test0/51exceptions.ts
+++ b/tests/compile-test/lang-test0/51exceptions.ts
@@ -1,0 +1,54 @@
+namespace exceptions {
+    function bar(n: number) {
+        pause(1)
+        if (n > 0)
+            throw "hel" + n
+        pause(1)
+    }
+
+    function foo(k: number) {
+        try {
+            pause(1)
+            bar(k)
+            pause(1)
+            glb1++
+        } catch (e) {
+            assert(e == "hel" + k)
+            glb1 += 10
+            if (k >= 10)
+                throw e
+        } finally {
+            x += glb1
+        }
+    }
+
+    function nested() {
+        glb1 = x = 0
+        try {
+            try {
+                foo(10)
+            } catch (e) {
+                assert(glb1 == 10 && x == 10)
+                glb1++
+                throw e
+            }
+        } catch (ee) {
+            assert(glb1 == 11)
+        }
+    }
+
+    export function run() {
+        glb1 = 0
+        x = 0
+        foo(1)
+        assert(glb1 == 10 && x == 10)
+        foo(0)
+        assert(glb1 == 11 && x == 21)
+        foo(3)
+        assert(glb1 == 21 && x == 42)
+        nested()
+        assert(glb1 == 11)
+    }
+}
+
+exceptions.run();

--- a/tests/compile-test/lang-test0/51exceptions.ts
+++ b/tests/compile-test/lang-test0/51exceptions.ts
@@ -38,6 +38,23 @@ namespace exceptions {
         }
     }
 
+    function lambda(k:number) {
+        function inner() {
+            try {
+                throwVal(k)
+                glb1++
+            } catch (e) {
+                assert(e == "hel" + k)
+                glb1 += 10
+                if (k >= 10)
+                    throw e
+            } finally {
+                x += glb1
+            }
+        }
+        inner()
+    }
+
     function callingThrowVal(k: number) {
         try {
             pause(1)
@@ -68,9 +85,18 @@ namespace exceptions {
         }
     }
 
+    function test3(fn:(k:number)=>void) {
+        glb1 = x = 0
+        fn(1)
+        assert(glb1 == 10 && x == 10)
+        fn(0)
+        assert(glb1 == 11 && x == 21)
+        fn(3)
+        assert(glb1 == 21 && x == 42)
+    }
+
     export function run() {
         glb1 = x = 0
-
         callingThrowVal(1)
         assert(glb1 == 10 && x == 10)
         callingThrowVal(0)
@@ -78,21 +104,10 @@ namespace exceptions {
         callingThrowVal(3)
         assert(glb1 == 21 && x == 42)
 
-        glb1 = x = 0
-        immediate(1)
-        assert(glb1 == 10 && x == 10)
-        immediate(0)
-        assert(glb1 == 11 && x == 21)
-        immediate(3)
-        assert(glb1 == 21 && x == 42)
-
-        glb1 = x = 0
-        higherorder(1)
-        assert(glb1 == 10 && x == 10)
-        higherorder(0)
-        assert(glb1 == 11 && x == 21)
-        higherorder(3)
-        assert(glb1 == 21 && x == 42)
+        test3(callingThrowVal)
+        test3(immediate)
+        test3(higherorder)
+        test3(lambda)
 
         glb1 = x = 0
         nested()

--- a/tests/compile-test/lang-test0/pxt.json
+++ b/tests/compile-test/lang-test0/pxt.json
@@ -53,6 +53,7 @@
         "48instanceof.ts",
         "49unicode.ts",
         "50indexedtypes.ts",
+        "51exceptions.ts",
         "99final.ts"
     ],
     "public": true,


### PR DESCRIPTION
This is the last big JS language feature missing. Yay!

Depends on https://github.com/microsoft/pxt-common-packages/pull/900

Notes:
* it's supported in ARM, VM and JS (all targets)
* entering/leaving `try` block has a small runtime cost (~one allocation)
* `throw` is very cheap, and independent of call stack depth
* any value can be thrown (including strings, classes, `null`, numbers, `undefined`)
* exceptions currently do not contain stack traces; it would be relatively easy to add in JS, but rather hard in hardware
* we need to think if and how we use this in APIs
* runtime should possibly throw an exceptions in some places instead of panic'ing
* debugger should have an option to stop on exception thrown and unhandled/handled (should be easy to distinguish - just check `runtime.currTryFrame() != null`; may need to distinguish finally from catch though)
* this was easier to implement than I initially imagined, mainly because we no longer do reference counting