### PR TITLE
Getting rid of tutorial parsing duplication

### DIFF
--- a/docs/static/tutorial-tool/tutorial.js
+++ b/docs/static/tutorial-tool/tutorial.js
@@ -13,8 +13,7 @@ var targets = [
         endpoints: [
             {
                 name: "nether",
-                url: "https://minecraft.makecode.com/beta?ipc=1&inGame=1&nether=1&controller=1",
-                config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"core\": \"*\",\n        \"builder\": \"*\",\n        \"nether\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"blocksprj\"\n}"
+                url: "https://minecraft.makecode.com/beta?ipc=1&inGame=1&nether=1&controller=1"
             },
             {
                 name: "beta",
@@ -24,8 +23,7 @@ var targets = [
                 name: "released",
                 url: "https://minecraft.makecode.com?ipc=1&inGame=1&controller=1"
             }
-        ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"core\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ]\n}"
+        ]
     }, {
         name: "Arcade",
         id: "arcade",
@@ -38,8 +36,7 @@ var targets = [
                 name: "released",
                 url: "https://arcade.makecode.com?controller=1"
             }
-        ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"device\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"blocksprj\"\n}"
+        ]
     }, {
         name: "Adafruit",
         id: "adafruit",
@@ -52,8 +49,7 @@ var targets = [
                 name: "released",
                 url: "https://makecode.adafruit.com?controller=1"
             }
-        ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"circuit-playground\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"tsprj\"\n}"
+        ]
     }, {
         name: "Micro:bit",
         id: "microbit",
@@ -66,8 +62,7 @@ var targets = [
                 name: "released",
                 url: "https://makecode.microbit.org?controller=1"
             }
-        ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"core\": \"*\",\n        \"radio\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"blocksprj\"\n}"
+        ]
     }, {
         name: "LEGO EV3",
         id: "ev3",
@@ -80,12 +75,10 @@ var targets = [
                 name: "released",
                 url: "https://makecode.mindstorms.com?controller=1"
             }
-        ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"ev3\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ]\n}"
+        ]
     }
 ];
 var selectedEndpoint;
-var selectedConfig;
 var selectedId;
 editor.onDidChangeModelContent(debounce(function () {
     localStorage.setItem(STORAGE_KEY, editor.getValue());
@@ -96,56 +89,19 @@ loadIframe(localStorage.getItem(ENDPOINT_KEY));
 initDropdown();
 document.getElementById("run-button").addEventListener("click", function () {
     var md = editor.getValue();
-    var proj = createProject(md);
-    sendMessage("importproject", proj);
+    sendMessage("importtutorial", md);
 });
 window.addEventListener("message", receiveMessage, false);
-function createProject(md) {
-    return {
-        "text": {
-            "main.blocks": "<xml xmlns=\"http://www.w3.org/1999/xhtml\">\n  <block type=\"pxt-on-start\" id=\",{,HjW]u:lVGcDRS_Cu|\" x=\"-247\" y=\"113\"></block>\n</xml>",
-            "main.ts": "\n",
-            "README.md": " ",
-            "pxt.json": selectedConfig
-        },
-        "header": createHeader(md)
-    };
-}
-function createHeader(md) {
-    var tutorialOptions = {
-        tutorial: "test",
-        tutorialName: "filename",
-        tutorialMd: md,
-        tutorialRecipe: false
-    };
-    var header = {
-        blobCurrent: false,
-        editor: "blocksprj",
-        githubCurrent: false,
-        id: "2159df60-887b-4097-47d5-d0a45bb1ab01",
-        meta: {},
-        modificationTime: 1562968671,
-        name: "test-project",
-        path: "test-project",
-        pubCurrent: false,
-        pubId: "",
-        recentUse: 1562968671,
-        target: selectedId,
-        tutorial: tutorialOptions
-    };
-    return header;
-}
 var pendingMsgs = {};
-function sendMessage(action, proj) {
+function sendMessage(action, md) {
     console.log('send ' + action);
     var msg = {
         type: "pxteditor",
         id: Math.random().toString(),
         action: action
     };
-    if (action == 'importproject') {
-        var prj = JSON.parse(JSON.stringify(proj));
-        msg.project = prj;
+    if (action == 'importtutorial') {
+        msg.markdown = md;
         msg.response = true;
     }
     else if (action == 'renderblocks') {
@@ -206,21 +162,6 @@ function debounce(func, wait, immediate) {
         return timeout;
     };
 }
-function fixURL(url) {
-    if (url.indexOf("http") === -1) {
-        url = "https://" + url;
-    }
-    if (url.indexOf("#") !== -1) {
-        url = url.split("#")[0];
-    }
-    if (url.indexOf("?") === -1) {
-        url += "?";
-    }
-    if (url.indexOf("controller=1") === -1) {
-        url += "controller=1";
-    }
-    return url;
-}
 function initDropdown() {
     var s = document.getElementById("endpoint-select");
     for (var _i = 0, targets_1 = targets; _i < targets_1.length; _i++) {
@@ -238,7 +179,7 @@ function initDropdown() {
     });
 }
 function loadIframe(selected) {
-    if (selectedConfig && selected === selectedEndpoint)
+    if (selected === selectedEndpoint)
         return;
     for (var _i = 0, targets_2 = targets; _i < targets_2.length; _i++) {
         var target = targets_2[_i];
@@ -247,7 +188,6 @@ function loadIframe(selected) {
             if (!selected || selected === target.name + "-" + endpoint.name) {
                 iframe.setAttribute("src", endpoint.url);
                 selectedEndpoint = target.name + "-" + endpoint.name;
-                selectedConfig = endpoint.config || target.config;
                 selectedId = target.id;
                 return;
             }

--- a/docs/static/tutorial-tool/tutorial.ts
+++ b/docs/static/tutorial-tool/tutorial.ts
@@ -22,13 +22,11 @@ interface TargetInfo {
     name: string;
     id: string;
     endpoints: TargetEndpoint[];
-    config: string;
 }
 
 interface TargetEndpoint {
     name: string;
     url: string;
-    config?: string;
 }
 
 const targets: TargetInfo[] = [
@@ -39,7 +37,6 @@ const targets: TargetInfo[] = [
             {
                 name: "nether",
                 url: "https://minecraft.makecode.com/beta?ipc=1&inGame=1&nether=1&controller=1",
-                config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"core\": \"*\",\n        \"builder\": \"*\",\n        \"nether\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"blocksprj\"\n}"
             },
             {
                 name: "beta",
@@ -50,7 +47,6 @@ const targets: TargetInfo[] = [
                 url: "https://minecraft.makecode.com?ipc=1&inGame=1&controller=1"
             }
         ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"core\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ]\n}"
     }, {
         name: "Arcade",
         id: "arcade",
@@ -64,7 +60,6 @@ const targets: TargetInfo[] = [
                 url: "https://arcade.makecode.com?controller=1"
             }
         ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"device\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"blocksprj\"\n}"
     }, {
         name: "Adafruit",
         id: "adafruit",
@@ -78,7 +73,6 @@ const targets: TargetInfo[] = [
                 url: "https://makecode.adafruit.com?controller=1"
             }
         ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"circuit-playground\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"tsprj\"\n}"
     }, {
         name: "Micro:bit",
         id: "microbit",
@@ -92,7 +86,6 @@ const targets: TargetInfo[] = [
                 url: "https://makecode.microbit.org?controller=1"
             }
         ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"core\": \"*\",\n        \"radio\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ],\n    \"preferredEditor\": \"blocksprj\"\n}"
     }, {
         name: "LEGO EV3",
         id: "ev3",
@@ -106,12 +99,10 @@ const targets: TargetInfo[] = [
                 url: "https://makecode.mindstorms.com?controller=1"
             }
         ],
-        config: "{\n    \"name\": \"Untitled\",\n    \"dependencies\": {\n        \"ev3\": \"*\"\n    },\n    \"description\": \"\",\n    \"files\": [\n        \"main.blocks\",\n        \"main.ts\",\n        \"README.md\"\n    ]\n}"
     }
 ];
 
 let selectedEndpoint: string;
-let selectedConfig: string;
 let selectedId: string;
 
 editor.onDidChangeModelContent(debounce(() => {
@@ -126,55 +117,15 @@ initDropdown();
 
 document.getElementById("run-button").addEventListener("click", () => {
     const md = editor.getValue();
-    const proj = createProject(md);
 
-    sendMessage("importproject", proj);
+    sendMessage("importtutorial", md);
 })
 
 window.addEventListener("message", receiveMessage, false);
 
-function createProject(md: string) {
-    return {
-        "text": {
-            "main.blocks": "<xml xmlns=\"http://www.w3.org/1999/xhtml\">\n  <block type=\"pxt-on-start\" id=\",{,HjW]u:lVGcDRS_Cu|\" x=\"-247\" y=\"113\"></block>\n</xml>",
-            "main.ts": "\n",
-            "README.md": " ",
-            "pxt.json": selectedConfig
-          },
-        "header": createHeader(md)
-    }
-}
-
-function createHeader(md: string) {
-    const tutorialOptions = {
-        tutorial: "test",
-        tutorialName: "filename",
-        tutorialMd: md,
-        tutorialRecipe: false,
-    };
-
-    const header = {
-        blobCurrent: false,
-        editor: "blocksprj",
-        githubCurrent: false,
-        id: "2159df60-887b-4097-47d5-d0a45bb1ab01",
-        meta: {},
-        modificationTime: 1562968671,
-        name: "test-project",
-        path: "test-project",
-        pubCurrent: false,
-        pubId: "",
-        recentUse: 1562968671,
-        target: selectedId,
-        tutorial: tutorialOptions
-    };
-
-    return header;
-}
-
 const pendingMsgs: {[index: string]: any} = {};
 
-function sendMessage(action: string, proj?: any) {
+function sendMessage(action: string, md?: string) {
     console.log('send ' + action)
 
     const msg: any = {
@@ -182,9 +133,8 @@ function sendMessage(action: string, proj?: any) {
         id: Math.random().toString(),
         action: action
     };
-    if(action == 'importproject') {
-        const prj = JSON.parse(JSON.stringify(proj));
-        msg.project = prj;
+    if(action == 'importtutorial') {
+        msg.markdown = md;
         msg.response = true;
     } else if (action == 'renderblocks') {
         msg.response = true;
@@ -245,27 +195,6 @@ function debounce(func: (...args: any[]) => any, wait: number, immediate?: boole
     };
 }
 
-
-function fixURL(url: string) {
-    if (url.indexOf("http") === -1) {
-        url = "https://" + url;
-    }
-
-    if (url.indexOf("#") !== -1) {
-        url = url.split("#")[0];
-    }
-
-    if (url.indexOf("?") === -1) {
-        url += "?"
-    }
-
-    if (url.indexOf("controller=1") === -1) {
-        url += "controller=1";
-    }
-
-    return url;
-}
-
 function initDropdown() {
     const s = document.getElementById("endpoint-select");
 
@@ -284,14 +213,13 @@ function initDropdown() {
 }
 
 function loadIframe(selected: string) {
-    if (selectedConfig && selected === selectedEndpoint) return;
+    if (selected === selectedEndpoint) return;
 
     for (const target of targets) {
         for (const endpoint of target.endpoints) {
             if (!selected || selected === `${target.name}-${endpoint.name}`) {
                 iframe.setAttribute("src", endpoint.url);
                 selectedEndpoint = `${target.name}-${endpoint.name}`;
-                selectedConfig = endpoint.config || target.config;
                 selectedId = target.id;
                 return;
             }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -170,6 +170,7 @@ namespace pxt.editor {
         loadHeaderAsync(h: pxt.workspace.Header): Promise<void>;
         reloadHeaderAsync(): Promise<void>;
         importProjectAsync(prj: pxt.workspace.Project, editorState?: pxt.editor.EditorState): Promise<void>;
+        importTutorialAsync(markdown: string): Promise<void>;
         overrideTypescriptFile(text: string): void;
         overrideBlocksFile(text: string): void;
 

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -43,6 +43,7 @@ namespace pxt.editor {
         | "closeflyout"
         | "newproject"
         | "importproject"
+        | "importtutorial"
         | "proxytosim" // EditorMessageSimulatorMessageProxyRequest
         | "undo"
         | "redo"
@@ -163,6 +164,12 @@ namespace pxt.editor {
         // (optional) filtering argument
         filters?: pxt.editor.ProjectFilters;
         searchBar?: boolean;
+    }
+
+    export interface EditorMessageImportTutorialRequest extends EditorMessageRequest {
+        action: "importtutorial";
+        // markdown to load
+        markdown: string;
     }
 
     export interface EditorMessageRenderBlocksRequest extends EditorMessageRequest {
@@ -329,6 +336,11 @@ namespace pxt.editor {
                                             filters: load.filters,
                                             searchBar: load.searchBar
                                         }));
+                                }
+                                case "importtutorial": {
+                                    const load = data as EditorMessageImportTutorialRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.importTutorialAsync(load.markdown));
                                 }
                                 case "proxytosim": {
                                     const simmsg = data as EditorMessageSimulatorMessageProxyRequest;

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -1,6 +1,3 @@
-/**
- * Any changes in this file need to be ported over to /docs/static/tutorial-tool/tutorial.ts
- */
 namespace pxt.tutorial {
     export function parseTutorial(tutorialmd: string): TutorialInfo {
         const [steps, activities] = parseTutorialSteps(tutorialmd);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1469,7 +1469,7 @@ export class ProjectView
 
     importTutorialAsync(md: string) {
         try {
-            const [options, editor] = getTutorialOptions(md, "untitled", "untitled", "", false);
+            const { options, editor } = getTutorialOptions(md, "untitled", "untitled", "", false);
             const dependencies = pxt.gallery.parsePackagesFromMarkdown(md);
 
             return this.createProjectAsync({
@@ -2944,7 +2944,7 @@ export class ProjectView
             if (!md)
                 throw new Error(lf("Tutorial not found"));
 
-            const [options, editor] = getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
+            const { options, editor } = getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
 
             // start a tutorial within the context of an existing program
             if (recipe) {
@@ -3909,7 +3909,7 @@ document.addEventListener("DOMContentLoaded", () => {
 })
 
 
-function getTutorialOptions(md: string, tutorialId: string, filename: string, reportId: string, recipe: boolean): [pxt.tutorial.TutorialOptions, string] {
+function getTutorialOptions(md: string, tutorialId: string, filename: string, reportId: string, recipe: boolean): { options: pxt.tutorial.TutorialOptions, editor: string} {
     // FIXME: Remove this once arcade documentation has been updated from enums to namespace for spritekind
     md = pxt.tutorial.patchArcadeSnippets(md);
 
@@ -3932,5 +3932,5 @@ function getTutorialOptions(md: string, tutorialId: string, filename: string, re
         templateCode: tutorialInfo.templateCode
     };
 
-    return [tutorialOptions, tutorialInfo.editor];
+    return { options: tutorialOptions, editor: tutorialInfo.editor };
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1462,6 +1462,17 @@ export class ProjectView
                 pubCurrent: false
             }
         }
+
+        if (h.tutorial && !h.tutorial.tutorialStepInfo) {
+            h.tutorial = getTutorialOptions(
+                h.tutorial.tutorialMd,
+                h.tutorial.tutorial,
+                h.tutorial.tutorialName,
+                h.tutorial.tutorialReportId,
+                h.tutorial.tutorialRecipe
+            );
+        }
+
         return workspace.installAsync(h, project.text)
             .then(hd => this.loadHeaderAsync(hd, editorState));
     }
@@ -2932,20 +2943,7 @@ export class ProjectView
             if (!tutorialInfo)
                 throw new Error(lf("Invalid tutorial format"));
 
-            const tutorialOptions: pxt.tutorial.TutorialOptions = {
-                tutorial: tutorialId,
-                tutorialName: tutorialInfo.title || filename,
-                tutorialReportId: reportId,
-                tutorialStep: 0,
-                tutorialReady: true,
-                tutorialHintCounter: 0,
-                tutorialStepInfo: tutorialInfo.steps,
-                tutorialActivityInfo: tutorialInfo.activities,
-                tutorialMd: md,
-                tutorialCode: tutorialInfo.code,
-                tutorialRecipe: !!recipe,
-                templateCode: tutorialInfo.templateCode
-            };
+            const tutorialOptions = getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
 
             // start a tutorial within the context of an existing program
             if (recipe) {
@@ -3908,3 +3906,30 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }, false);
 })
+
+
+function getTutorialOptions(md: string, tutorialId: string, filename: string, reportId: string, recipe: boolean) {
+    // FIXME: Remove this once arcade documentation has been updated from enums to namespace for spritekind
+    md = pxt.tutorial.patchArcadeSnippets(md);
+
+    const tutorialInfo = pxt.tutorial.parseTutorial(md);
+    if (!tutorialInfo)
+        throw new Error(lf("Invalid tutorial format"));
+
+    const tutorialOptions: pxt.tutorial.TutorialOptions = {
+        tutorial: tutorialId,
+        tutorialName: tutorialInfo.title || filename,
+        tutorialReportId: reportId,
+        tutorialStep: 0,
+        tutorialReady: true,
+        tutorialHintCounter: 0,
+        tutorialStepInfo: tutorialInfo.steps,
+        tutorialActivityInfo: tutorialInfo.activities,
+        tutorialMd: md,
+        tutorialCode: tutorialInfo.code,
+        tutorialRecipe: !!recipe,
+        templateCode: tutorialInfo.templateCode
+    };
+
+    return tutorialOptions;
+}


### PR DESCRIPTION
In v1 of the tutorial tool I just duplicated the tutorial parsing code because I didn't want to make changes to pxt. Now that it's shipped, I'm removing the duplication and adding an editorcontroller message that imports a tutorial from just the markdown.

This will temporarily break the tutorial tool for all targets until they get bumped. We should do a bump of mc with these changes ASAP once this is merged, so I'm putting the "DO NOT MERGE" label on it