### PR TITLE
Adding analytics to share page

### DIFF
--- a/docfiles/package.html
+++ b/docfiles/package.html
@@ -64,7 +64,7 @@
     </script>
 
     <!-- @include footer.html -->
-    <!-- Do not add analytics!!!! -->
+    <!-- @include tracking.html -->
 </body>
 
 </html>

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -60,7 +60,7 @@ const script = @JSON@;
 </script>
 
     <!-- @include footer.html -->
-    <!-- Do not add analytics!!!! -->
+    <!-- @include tracking.html -->
 </body>
 
 </html>


### PR DESCRIPTION
Adding analytics to share page. 

Share key is scrubbed in the analytics appInsights.trackPageView event