### PR TITLE
use weights for all packages

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -371,8 +371,10 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                 return abeta ? 1 : -1;
 
             // use weight if core packages
-            if (a.core && b.core && a.weight != b.weight)
-                return -(a.weight || 0) + (b.weight || 0);
+            const aweight = a.weight === undefined ? 50 : a.weight;
+            const bweight = b.weight === undefined ? 50 : b.weight;
+            if (aweight != bweight)
+                return -aweight + bweight;
 
             // alphabetical sort
             return pxt.Util.strcmp(a.name, b.name)


### PR DESCRIPTION
Allows for better sorting of packages in extension dialog by really using the weights in ``pxt.json``.
![image](https://user-images.githubusercontent.com/4175913/62312484-251d5a80-b443-11e9-9ba1-bea0fdd0307e.png)
