### PR TITLE
Allow extensions to display banned block categories

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -714,6 +714,7 @@ declare namespace ts.pxtc {
         name?: string;
         warnDiv?: boolean; // warn when emitting division operator
         apisInfo?: ApisInfo;
+        bannedCategories?: string[];
 
         syntaxInfo?: SyntaxInfo;
 

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -70,6 +70,7 @@ declare namespace pxt {
         skipLocalization?: boolean;
         snippetBuilders?: SnippetConfig[];
         experimentalHw?: boolean;
+        requiredCategories?: string[]; // ensure that those block categories are visible
     }
 
     interface PackageExtension {

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -224,13 +224,13 @@ namespace ts.pxtc {
         return res
     }
 
-    export function decompile(opts: CompileOptions, fileName: string, includeGreyBlockMessages = false, bannedCategories?: string[]) {
+    export function decompile(opts: CompileOptions, fileName: string, includeGreyBlockMessages = false) {
         let program = getTSProgram(opts);
 
         let file = program.getSourceFile(fileName);
         annotate(program, fileName, target || (pxt.appTarget && pxt.appTarget.compile));
         const apis = getApiInfo(program, opts.jres);
-        const blocksInfo = pxtc.getBlocksInfo(apis, bannedCategories);
+        const blocksInfo = pxtc.getBlocksInfo(apis, opts.bannedCategories);
         const decompileOpts: decompiler.DecompileBlocksOptions = {
             snippetMode: false,
             alwaysEmitOnStart: opts.alwaysDecompileOnStart,

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -938,8 +938,7 @@ namespace ts.pxtc.service {
             return compile(v.options)
         },
         decompile: v => {
-            const bannedCategories = v.blocks ? v.blocks.bannedCategories : undefined;
-            return decompile(v.options, v.fileName, false, bannedCategories);
+            return decompile(v.options, v.fileName, false);
         },
         pydecompile: v => {
             let program = getTSProgram(v.options);

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1011,11 +1011,11 @@ namespace ts.pxtc.service {
                 return undefined;
             return ts.pxtc.service.getSnippet(lastApiInfo.apis, v.runtime, fn, n as FunctionLikeDeclaration, !!o.python)
         },
-        blocksInfo: v => blocksInfoOp(v as any, v.runtime.bannedCategories),
+        blocksInfo: v => blocksInfoOp(v as any, v.blocks && v.blocks.bannedCategories),
         apiSearch: v => {
             const SEARCH_RESULT_COUNT = 7;
             const search = v.search;
-            const blockInfo = blocksInfoOp(search.localizedApis, v.runtime.bannedCategories); // caches
+            const blockInfo = blocksInfoOp(search.localizedApis, v.blocks && v.blocks.bannedCategories); // caches
 
             if (search.localizedStrings) {
                 pxt.Util.setLocalizedStrings(search.localizedStrings);

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -766,6 +766,39 @@ namespace pxt {
             return this._jres
         }
 
+        // undefined == uncached
+        // null == cached but no hit
+        // array == means something go found...
+        private _resolvedBannedCategories: string[];
+        resolveBannedCategories(): string[] {
+            if (this._resolvedBannedCategories !== undefined)
+                return this._resolvedBannedCategories; // cache hit
+
+            let bannedCategories: string[] = [];
+            if (pxt.appTarget && pxt.appTarget.runtime
+                && pxt.appTarget.runtime.bannedCategories
+                && pxt.appTarget.runtime.bannedCategories.length) {
+                bannedCategories = pxt.appTarget.runtime.bannedCategories.slice();
+                // scan for unbanned categories
+                Object.keys(this.deps)
+                    .map(dep => this.deps[dep])
+                    .filter(dep => !!dep)
+                    .map(pk => pxt.Util.jsonTryParse(pk.readFile(pxt.CONFIG_NAME)) as pxt.PackageConfig)
+                    .filter(config => config && config.requiredCategories)
+                    .forEach(config => config.requiredCategories.forEach(rc => {
+                        const i = bannedCategories.indexOf(rc);
+                        if (i > -1)
+                            bannedCategories.splice(i, 1);
+                    }));
+                this._resolvedBannedCategories = bannedCategories;
+            }
+
+            this._resolvedBannedCategories = bannedCategories;
+            if (!this._resolvedBannedCategories.length)
+                this._resolvedBannedCategories = null;
+            return this._resolvedBannedCategories;
+        }
+
         getCompileOptionsAsync(target: pxtc.CompileTarget = this.getTargetOptions()): Promise<pxtc.CompileOptions> {
             let opts: pxtc.CompileOptions = {
                 sourceFiles: [],
@@ -787,6 +820,7 @@ namespace pxt {
 
             return this.loadAsync()
                 .then(() => {
+                    opts.bannedCategories = this.resolveBannedCategories();
                     opts.target.preferredEditor = this.getPreferredEditor()
                     pxt.debug(`building: ${this.sortedDeps().map(p => p.config.name).join(", ")}`)
                     let ext = cpp.getExtensionInfo(this)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -438,13 +438,8 @@ namespace ts.pxtc {
             }
         }
 
-        if (pxt.appTarget && pxt.appTarget.runtime && Array.isArray(pxt.appTarget.runtime.bannedCategories)) {
-            filterCategories(pxt.appTarget.runtime.bannedCategories)
-        }
-
-        if (categoryFilters) {
+        if (categoryFilters)
             filterCategories(categoryFilters);
-        }
 
         return {
             apis: info,

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -385,7 +385,8 @@ export function getBlocksAsync(): Promise<pxtc.BlocksInfo> {
     return cachedBlocks
         ? Promise.resolve(cachedBlocks)
         : getApisInfoAsync().then(info => {
-            cachedBlocks = pxtc.getBlocksInfo(info);
+            const bannedCategories = pkg.mainEditorPkg().resolveBannedCategories();
+            cachedBlocks = pxtc.getBlocksInfo(info, bannedCategories);
             return cachedBlocks;
         });
 }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -332,8 +332,7 @@ export function apiSearchAsync(searchFor: pxtc.service.SearchOptions) {
             searchFor.localizedStrings = pxt.Util.getLocalizedStrings();
             return workerOpAsync("apiSearch", {
                 search: searchFor,
-                blocks: blocksOptions(),
-                runtime: pxt.appTarget.runtime
+                blocks: blocksOptions()
             });
         });
 }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -640,8 +640,8 @@ export function getPackagesWithErrors(): pkg.EditorPackage[] {
 }
 
 function blocksOptions(): pxtc.service.BlocksOptions {
-    if (pxt.appTarget && pxt.appTarget.runtime && pxt.appTarget.runtime.bannedCategories && pxt.appTarget.runtime.bannedCategories.length) {
-        return { bannedCategories: pxt.appTarget.runtime.bannedCategories };
-    }
+    const bannedCategories = pkg.mainEditorPkg().resolveBannedCategories();
+    if (bannedCategories)
+        return {  bannedCategories };
     return undefined;
 }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -241,7 +241,7 @@ export function decompileBlocksSnippetAsync(code: string, blockInfo?: ts.pxtc.Bl
 }
 
 function decompileCoreAsync(opts: pxtc.CompileOptions, fileName: string): Promise<pxtc.CompileResult> {
-    return workerOpAsync("decompile", { options: opts, fileName: fileName, blocks: blocksOptions() })
+    return workerOpAsync("decompile", { options: opts, fileName: fileName })
 }
 
 export function pyDecompileAsync(fileName: string): Promise<pxtc.CompileResult> {
@@ -385,7 +385,7 @@ export function getBlocksAsync(): Promise<pxtc.BlocksInfo> {
     return cachedBlocks
         ? Promise.resolve(cachedBlocks)
         : getApisInfoAsync().then(info => {
-            const bannedCategories = pkg.mainEditorPkg().resolveBannedCategories();
+            const bannedCategories = pkg.mainPkg.resolveBannedCategories();
             cachedBlocks = pxtc.getBlocksInfo(info, bannedCategories);
             return cachedBlocks;
         });
@@ -640,7 +640,7 @@ export function getPackagesWithErrors(): pkg.EditorPackage[] {
 }
 
 function blocksOptions(): pxtc.service.BlocksOptions {
-    const bannedCategories = pkg.mainEditorPkg().resolveBannedCategories();
+    const bannedCategories = pkg.mainPkg.resolveBannedCategories();
     if (bannedCategories)
         return {  bannedCategories };
     return undefined;

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -198,7 +198,6 @@ export class EditorPackage {
     }
 
     updateConfigAsync(update: (cfg: pxt.PackageConfig) => void) {
-        this._resolvedBannedCategories = undefined;
         let cfgFile = this.files[pxt.CONFIG_NAME]
         if (cfgFile) {
             try {
@@ -365,39 +364,6 @@ export class EditorPackage {
     lookupFile(name: string) {
         if (name.indexOf("pxt_modules/") === 0) name = name.slice(12);
         return this.filterFiles(f => f.getName() == name)[0]
-    }
-
-    // undefined == uncached
-    // null == cached but no hit
-    // array == means something go found...
-    private _resolvedBannedCategories: string[];
-    resolveBannedCategories(): string[] {
-        if (this._resolvedBannedCategories !== undefined)
-            return this._resolvedBannedCategories; // cache hit
-
-        let bannedCategories: string[] = [];
-        if (pxt.appTarget && pxt.appTarget.runtime
-            && pxt.appTarget.runtime.bannedCategories
-            && pxt.appTarget.runtime.bannedCategories.length) {
-            bannedCategories = pxt.appTarget.runtime.bannedCategories.slice();
-            // scan for unbanned categories
-            this.pkgAndDeps()
-                .map(pk => pk.getKsPkg())
-                .filter(pk => !!pk)
-                .map(pk => pxt.Util.jsonTryParse(pk.readFile(pxt.CONFIG_NAME)) as pxt.PackageConfig)
-                .filter(config => config && config.requiredCategories)
-                .forEach(config => config.requiredCategories.forEach(rc => {
-                    const i = bannedCategories.indexOf(rc);
-                    if (i > -1)
-                        bannedCategories.splice(i, 1);
-                }));
-            this._resolvedBannedCategories = bannedCategories;
-        }
-
-        this._resolvedBannedCategories = bannedCategories;
-        if (!this._resolvedBannedCategories.length)
-            this._resolvedBannedCategories = null;
-        return this._resolvedBannedCategories;
     }
 }
 

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -365,6 +365,34 @@ export class EditorPackage {
         if (name.indexOf("pxt_modules/") === 0) name = name.slice(12);
         return this.filterFiles(f => f.getName() == name)[0]
     }
+
+    private _resolvedBannedCategories: string[];
+    resolveBannedCategories(): string[] {
+        if (this._resolvedBannedCategories !== undefined) return this._resolvedBannedCategories;
+
+        let bannedCategories: string[] = [];
+        if (pxt.appTarget && pxt.appTarget.runtime && pxt.appTarget.runtime.bannedCategories && pxt.appTarget.runtime.bannedCategories.length) {
+            bannedCategories = pxt.appTarget.runtime.bannedCategories.slice();
+            // scan for unbanned categories
+            this.pkgAndDeps()
+                .map(pk => pk.getKsPkg())
+                .filter(pk => !!pk)
+                .map(pk => pxt.Util.jsonTryParse(pk.readFile(pxt.CONFIG_NAME)) as pxt.PackageConfig)
+                .filter(config => config && config.requiredCategories)
+                .forEach(config => config.requiredCategories.forEach(rc => {
+                    const i = bannedCategories.indexOf(rc);
+                    if (i > -1)
+                        bannedCategories.splice(i, 1);
+                }));
+            this._resolvedBannedCategories = bannedCategories;
+        }
+
+        this._resolvedBannedCategories = bannedCategories;
+        if (!this._resolvedBannedCategories.length)
+            this._resolvedBannedCategories = null;
+
+        return this._resolvedBannedCategories;
+    }
 }
 
 class Host

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -198,6 +198,7 @@ export class EditorPackage {
     }
 
     updateConfigAsync(update: (cfg: pxt.PackageConfig) => void) {
+        this._resolvedBannedCategories = undefined;
         let cfgFile = this.files[pxt.CONFIG_NAME]
         if (cfgFile) {
             try {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -366,12 +366,18 @@ export class EditorPackage {
         return this.filterFiles(f => f.getName() == name)[0]
     }
 
+    // undefined == uncached
+    // null == cached but no hit
+    // array == means something go found...
     private _resolvedBannedCategories: string[];
     resolveBannedCategories(): string[] {
-        if (this._resolvedBannedCategories !== undefined) return this._resolvedBannedCategories;
+        if (this._resolvedBannedCategories !== undefined)
+            return this._resolvedBannedCategories; // cache hit
 
         let bannedCategories: string[] = [];
-        if (pxt.appTarget && pxt.appTarget.runtime && pxt.appTarget.runtime.bannedCategories && pxt.appTarget.runtime.bannedCategories.length) {
+        if (pxt.appTarget && pxt.appTarget.runtime
+            && pxt.appTarget.runtime.bannedCategories
+            && pxt.appTarget.runtime.bannedCategories.length) {
             bannedCategories = pxt.appTarget.runtime.bannedCategories.slice();
             // scan for unbanned categories
             this.pkgAndDeps()
@@ -390,7 +396,6 @@ export class EditorPackage {
         this._resolvedBannedCategories = bannedCategories;
         if (!this._resolvedBannedCategories.length)
             this._resolvedBannedCategories = null;
-
         return this._resolvedBannedCategories;
     }
 }


### PR DESCRIPTION
In Arcade, the feather and edge-connector packages rely heavily on the "pins" category. This category is hidden by default in Arcade through the global setting in pxtarget.json

This change allows an extension to require a block category, in which case it is not hidden anymore.

![showpins](https://user-images.githubusercontent.com/4175913/62332318-e5bb3200-b473-11e9-9be8-82854b9859f5.gif)
