### PR TITLE
Fix crash in jsEmit when there's no code to run

### DIFF
--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -181,7 +181,7 @@ namespace ts.pxtc {
             jssource += `const ${v} = pxsim.BufferMethods.createBufferFromHex("${k}")\n`
         })
 
-        jssource += `\nreturn ${bin.procs[0].label()}\n})\n`
+        jssource += `\nreturn ${bin.procs[0] ? bin.procs[0].label() : "null"}\n})\n`
 
         bin.writeFile(BINARY_JS, jssource)
     }


### PR DESCRIPTION
fixes:
```
building /Users/michal/src/pxt-32/libs/hw---samd51
device.d.ts(1,1): error TS9200: Cannot read property 'label' of undefined
```
in arcade build (which were ignored and mostly harmless)