### PR TITLE
Fix crash on m[x] = null

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3052,7 +3052,7 @@ ${lbl}: .short 0xffff
         function isNumberLike(e: Expression) {
             if (e.kind == SK.NullKeyword) {
                 let vo: ir.Expr = pxtInfo(e).valueOverride
-                if (vo !== undefined) {
+                if (vo != null) {
                     if (vo.exprKind == EK.NumberLiteral) {
                         if (opts.target.isNative)
                             return !!((vo.data as number) & 1)


### PR DESCRIPTION
introduced in https://github.com/microsoft/pxt/pull/5763 ; not sure why we're only seeing it now