### PR TITLE
Set tutorial card expanded height to match content, autoexpand

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -816,6 +816,7 @@ declare namespace pxt.tutorial {
         tutorialCode?: string; // all tutorial code bundled
         tutorialRecipe?: boolean; // micro tutorial running within the context of a script
         templateCode?: string;
+        autoexpandStep?: boolean; // autoexpand tutorial card if instruction text overflows
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -8,8 +8,7 @@
 @inlineBlockColor: #D83B01;
 @highlightLineColor: #fcfc90;
 @tutorialCardHeight: 8rem;
-@tutorialCardExpandedHeight: 22rem;
-@seeMoreButtonHeight: 3.5rem;
+@seeMoreButtonHeight: 4rem;
 @avatarSize: 4.5rem;
 @avatarMargin: @avatarSize + 0.5rem;
 @mobileAvatarMargin: 2rem;
@@ -19,10 +18,6 @@
 *******************************/
 .tutorial #maineditor .full-abs {
     top: @tutorialCardHeight;
-}
-
-.tutorial.tutorialExpanded #maineditor .full-abs {
-    top: calc(@tutorialCardExpandedHeight - 0.5rem);
 }
 
 .tutorial #maineditor #monacoEditor {
@@ -66,7 +61,7 @@
 }
 
 .tutorial.tutorialExpanded #tutorialcard {
-    height: @tutorialCardExpandedHeight;
+    max-height: 20rem;
 }
 
 #root.dimmable.dimmed #tutorialcard.tutorialReady {
@@ -133,7 +128,7 @@ body#docs.tutorial {
 }
 
 .tutorial.tutorialExpanded #tutorialcard .ui.buttons {
-    height: calc(@tutorialCardExpandedHeight - 1.5rem);
+    height: 100%;
 }
 
 #tutorialcard .ui.tutorialsegment {
@@ -151,14 +146,13 @@ body#docs.tutorial {
 }
 
 .tutorial.tutorialExpanded #tutorialcard .tutorialmessage .content {
-    height: calc(@tutorialCardExpandedHeight - 5rem);
+    height: calc(~'100% - 3rem');
     overflow-y: auto;
 }
 
 #tutorialcard .tutorialmessage .content p,
 .tutorialhint p {
-    line-height: 30px !important;
-    margin-bottom: 30px;
+    line-height: 1.7em !important;
     color: @tutorialSegmentColor;
 }
 
@@ -166,13 +160,12 @@ body#docs.tutorial {
     width: ~'calc(100% - @{avatarMargin} - 0.5rem)';
     padding: 0.5rem;
     height: calc(@tutorialCardHeight - 1.5rem);
-    margin-bottom: 1rem;
     margin-left: @avatarMargin + 0.35rem;
     overflow: hidden;
 }
 
 .tutorial.tutorialExpanded #tutorialcard .tutorialmessage {
-    height: calc(@tutorialCardExpandedHeight - 1.5rem);
+    height: 100%;
 }
 
 #root.dimmable.dimmed .ui.segment.message {
@@ -397,11 +390,6 @@ span.highlight-line {
 
 #tutorialsteps .step-label {
     margin: 0 1em;
-}
-
-#tutorialsteps .button.prevbutton,
-#tutorialsteps .button.nextbutton {
-    line-height: 1.4em;
 }
 
 #tutorialsteps .button.nextbutton .text {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -937,6 +937,7 @@ export class ProjectView
     setTutorialInstructionsExpanded(value: boolean): void {
         const tutorialOptions = this.state.tutorialOptions;
         tutorialOptions.tutorialStepExpanded = value;
+        tutorialOptions.autoexpandStep = value;
         this.setState(
             { tutorialOptions: tutorialOptions },
             () => {
@@ -3059,6 +3060,11 @@ export class ProjectView
         if (tc) tc.showHint(true, showFullText);
     }
 
+    getExpandedCardStyle(): any {
+        let tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
+        return tc ? tc.getExpandedCardStyle('top') : null;
+    }
+
     ///////////////////////////////////////////////////////////
     ////////////     User alert/notifications     /////////////
     ///////////////////////////////////////////////////////////
@@ -3215,6 +3221,7 @@ export class ProjectView
         const logoWide = !!targetTheme.logoWide;
         const hwDialog = !sandbox && pxt.hasHwVariants();
         const recipes = !!targetTheme.recipes;
+        const expandedStyle = inTutorialExpanded ? this.getExpandedCardStyle() :  null;
 
         const collapseIconTooltip = this.state.collapseEditorTools ? lf("Show the simulator") : lf("Hide the simulator");
 
@@ -3291,7 +3298,7 @@ export class ProjectView
                 <div id="maineditor" className={(sandbox ? "sandbox" : "") + (inDebugMode ? "debugging" : "")} role="main" aria-hidden={inHome}>
                     {showCollapseButton && <sui.Button id='computertogglesim' className={`computer only collapse-button large`} icon={`inverted chevron ${showRightChevron ? 'right' : 'left'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
                     {showCollapseButton && <sui.Button id='mobiletogglesim' className={`mobile tablet only collapse-button large`} icon={`inverted chevron ${this.state.collapseEditorTools ? 'up' : 'down'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
-                    {this.allEditors.map(e => e.displayOuter())}
+                    {this.allEditors.map(e => e.displayOuter(expandedStyle))}
                 </div>
                 {inHome ? <div id="homescreen" className="full-abs">
                     <div className="ui home projectsdialog">
@@ -3951,7 +3958,8 @@ function getTutorialOptions(md: string, tutorialId: string, filename: string, re
         tutorialMd: md,
         tutorialCode: tutorialInfo.code,
         tutorialRecipe: !!recipe,
-        templateCode: tutorialInfo.templateCode
+        templateCode: tutorialInfo.templateCode,
+        autoexpandStep: true
     };
 
     return { options: tutorialOptions, editor: tutorialInfo.editor };

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -36,13 +36,18 @@ export class Editor implements pxt.editor.IEditor {
         return this.currSource
     }
 
+    getStyle(style?: any) {
+        let display = { display: this.isVisible ? "block" : "none" };
+        return Object.assign(display, style);
+    }
+
     getId() {
         return "editor"
     }
 
-    displayOuter() {
+    displayOuter(style?: any) {
         return (
-            <div className='full-abs' key={this.getId() } id={this.getId() } style={{ display: this.isVisible ? "block" : "none" }}>
+            <div className='full-abs' key={this.getId() } id={this.getId() } style={this.getStyle(style)}>
                 {this.display() }
             </div>
         )

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1300,7 +1300,8 @@ export class ProgressCircle extends React.Component<ProgressCircleProps, {}> {
         let r = this.radius;
 
         return <div className="progresscircle">
-            <svg viewBox={`0 0 ${this.view} ${this.view}`}>
+            <svg viewBox={`0 0 ${this.view} ${this.view}`} aria-labelledby="circletitle" role="img">
+                <title id="circletitle">Currently on step {props.progress} of {props.steps}</title>
                 <path style={this.getPathStyle()}
                     strokeDasharray={`${Math.round(100 * props.progress / props.steps)}, 100`}
                     d={`M${this.view / 2} ${props.stroke / 2} a ${r} ${r} 0 0 1 0 ${r * 2} a ${r} ${r} 0 0 1 0 -${r * 2}`} />

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -179,13 +179,13 @@ export class TutorialStepCircle extends data.Component<ITutorialMenuProps, {}> {
 
         return <div id="tutorialsteps" className={`ui item ${this.props.className}`}>
             <div className="ui item" role="menubar">
-                <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} disabled={!hasPrev} className={`prevbutton left attached ${!hasPrev ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.handlePrevClick} onKeyDown={sui.fireClickOnEnter} />
+                <sui.Button role="button" icon={`${isRtl ? 'right' : 'left'} chevron`} disabled={!hasPrev} className={`prevbutton left ${!hasPrev ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.handlePrevClick} onKeyDown={sui.fireClickOnEnter} />
                 <span className="step-label" key={'tutorialStep' + currentStep}>
                     <sui.ProgressCircle progress={currentStep + 1} steps={tutorialStepInfo.length} stroke={4.5} />
                     <span className={`ui circular label blue selected ${!tutorialReady ? 'disabled' : ''}`}
                         aria-label={lf("You are currently at tutorial step {0}.")}>{tutorialStep + 1}</span>
                 </span>
-                <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron large`} disabled={!hasNext} rightIcon className={`nextbutton right attached ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")} onClick={this.handleNextClick} onKeyDown={sui.fireClickOnEnter} />
+                <sui.Button role="button" icon={`${isRtl ? 'left' : 'right'} chevron`} disabled={!hasNext} rightIcon className={`nextbutton right ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")} onClick={this.handleNextClick} onKeyDown={sui.fireClickOnEnter} />
             </div>
         </div>;
     }
@@ -273,6 +273,7 @@ interface TutorialCardProps extends ISettingsProps {
 
 export class TutorialCard extends data.Component<TutorialCardProps, TutorialCardState> {
     private prevStep: number;
+    private cardHeight: number;
 
     public focusInitialized: boolean;
 
@@ -398,7 +399,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                 .then(() => pxsim.U.removeClass(tutorialCard, animationClasses));
         }
         if (this.prevStep != step) {
-            this.setShowSeeMore();
+            this.setShowSeeMore(options.autoexpandStep);
             this.prevStep = step;
 
             if (!!options.tutorialStepInfo[step].unplugged) {
@@ -412,7 +413,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     componentDidMount() {
-        this.setShowSeeMore();
+        this.setShowSeeMore(this.props.parent.state.tutorialOptions.autoexpandStep);
     }
 
     componentWillUnmount() {
@@ -468,14 +469,22 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         evt.stopPropagation();
     }
 
-    private setShowSeeMore() {
+    private setShowSeeMore(autoexpand?: boolean) {
         // compare scrollHeight of inner text with height of card to determine showSeeMore
         const tutorialCard = this.refs['tutorialmessage'] as HTMLElement;
         let show = false;
         if (tutorialCard && tutorialCard.firstElementChild && tutorialCard.firstElementChild.firstElementChild) {
             show = tutorialCard.clientHeight < tutorialCard.firstElementChild.firstElementChild.scrollHeight;
+            if (show) {
+                this.cardHeight = tutorialCard.firstElementChild.firstElementChild.scrollHeight;
+                if (autoexpand) this.props.parent.setTutorialInstructionsExpanded(true);
+            }
         }
         this.setState({ showSeeMore: show });
+    }
+
+    getExpandedCardStyle(prop: string) {
+        return { [prop] : `calc(${this.cardHeight}px + 5rem)` }
     }
 
     toggleHint(showFullText?: boolean) {
@@ -543,7 +552,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         }
 
         const isRtl = pxt.Util.isUserLanguageRtl();
-        return <div id="tutorialcard" className={`ui ${tutorialStepExpanded ? 'tutorialExpanded' : ''} ${tutorialReady ? 'tutorialReady' : ''} ${this.state.showSeeMore ? 'seemore' : ''}  ${this.state.showHintTooltip ? 'showTooltip' : ''} ${hasHint ? 'hasHint' : ''}`} >
+        return <div id="tutorialcard" className={`ui ${tutorialStepExpanded ? 'tutorialExpanded' : ''} ${tutorialReady ? 'tutorialReady' : ''} ${this.state.showSeeMore ? 'seemore' : ''}  ${this.state.showHintTooltip ? 'showTooltip' : ''} ${hasHint ? 'hasHint' : ''}`} style={tutorialStepExpanded ? this.getExpandedCardStyle('height') : null} >
             <div className='ui buttons'>
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron orange large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">


### PR DESCRIPTION
- set tutorial card expanded height to match content height
- autoexpand card if there is overflow (still displaying 'less' button)
- save card expand state per tutorial
- small css/accessibility updates

![tutorial-more](https://user-images.githubusercontent.com/34112083/62497467-f2e86180-b790-11e9-80f7-3544ede92838.gif)
