### PR TITLE
Set tutorial card z index above block fields

### DIFF
--- a/theme/themes/pxt/globals/zindex.variables
+++ b/theme/themes/pxt/globals/zindex.variables
@@ -48,7 +48,7 @@
 @editorLogoZIndex: ((@blocklyFlyoutZIndex)-1); /* Should be below the flyouts blocklyFlyout and @monacoFlyoutZIndex */
 
 /* Tutorial */
-@tutorialCardZIndex: @simulatorZIndex+1;
+@tutorialCardZIndex:  (@dimmerZIndex)-5;
 @tutorialLightboxCardZIndex: @tutorialCardZIndex+1;
 
 /* Extension frames */


### PR DESCRIPTION
Fixes microsoft/pxt-minecraft/issues/1104