### PR TITLE
Array default values with shadow blocks

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -160,6 +160,28 @@ export function showNumber(v: number, interval: number = 150): void
 
 **Playground examples**: [Range](https://makecode.com/playground#field-editors-range), [Default values](https://makecode.com/playground#basic-default-values)
 
+
+## Array default values
+
+For array type parameters, set the shadow ID to "lists_create_with":
+
+```typescript-ignore
+//% block="$myParam"
+//% myParam.shadow="lists_create_with"
+function myFunction(myParam: number[]): void {}
+```
+
+To populate the array with blocks, set the default value of the parameter as well.
+
+```typescript-ignore
+//% block="$myParam"
+//% myParam.shadow="lists_create_with"
+//% myParam.defl="inner_shadow_block"
+function myFunction(myParam: number[]): void {}
+```
+
+The above will create a block that has an array by default with "inner_shadow_blocks" inside the array.
+
 ## Input formats
 
 ### Inline input
@@ -361,7 +383,7 @@ name in the block definition string (`msg`).
 
 You can have blocks themselves define an enumeration dynamically. The block will specify some inital members but additional ones are added by selecting the "Add a new &lt;enum_name&gt;..." option in the parameter dropdown.
 
-You first create a shadow block that defines the enumeration and has the initial members. 
+You first create a shadow block that defines the enumeration and has the initial members.
 
 ```typescript-ignore
 //% shim=ENUM_GET
@@ -396,7 +418,7 @@ Enums are emitted at the top of user code only if the block is used in the
 project (or if it was used in the past). If the user changes the value of
 the enum in TypeScript then those changes should persist when switching back to blocks.
 
-When a function uses an enum shadow block, the incoming argument 
+When a function uses an enum shadow block, the incoming argument
 should be of type `number` (don't use the `enum` type).
 
 ```typescript-ignore
@@ -621,7 +643,7 @@ namespace Widgets {
 }
 ```
 
-To ensure there's a valid instance of the class when the block is used, the `blockSetVariable` attribute sets a variable to the new instance. In the example above, the `blockSetVariable` attribute will automatically create an instance of `Gizmo` and set the `gizmo` variable to it. The `gizmo` variable is created if it doesn't exist already. This allows a valid instance of `Gizmo` to be created by default when the block is pulled into the editor. 
+To ensure there's a valid instance of the class when the block is used, the `blockSetVariable` attribute sets a variable to the new instance. In the example above, the `blockSetVariable` attribute will automatically create an instance of `Gizmo` and set the `gizmo` variable to it. The `gizmo` variable is created if it doesn't exist already. This allows a valid instance of `Gizmo` to be created by default when the block is pulled into the editor.
 
 **Playground examples**: [Factories](https://makecode.com/playground#factories)
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -143,34 +143,29 @@ namespace pxt.blocks {
         shadow.setAttribute("type", shadowId || (isArray ? 'lists_create_with' : typeInfo && typeInfo.block || p.type));
         shadow.setAttribute("colour", (Blockly as any).Colours.textField);
 
-        // if an array of booleans, numbers, or strings
-        if (isArray && typeInfo && !shadowId) {
-            const mut = document.createElement('mutation');
-            mut.setAttribute("items", "3");
-            shadow.appendChild(mut);
-            for (let i = 0; i < 3; i++) {
-                const innerValue = document.createElement("value");
-                innerValue.setAttribute("name", "ADD" + i);
-                const innerShadow = document.createElement("shadow");
-                innerShadow.setAttribute("type", typeInfo.block);
-                const field = document.createElement("field");
-                field.setAttribute("name", typeInfo.field);
+        if (isArray) {
+            // if an array of booleans, numbers, or strings
+            if (typeInfo && !shadowId) {
+                let fieldValues: string[];
+
                 switch (isArray) {
                     case "number":
-                        field.appendChild(document.createTextNode("" + (i + 1)));
+                        fieldValues = ["1", "2", "3"];
                         break;
                     case "string":
-                        field.appendChild(document.createTextNode(String.fromCharCode('a'.charCodeAt(0) + i)));
+                        fieldValues = ["a", "b", "c"];
                         break;
                     case "boolean":
-                        field.appendChild(document.createTextNode("FALSE"));
+                        fieldValues = ["FALSE", "FALSE", "FALSE"];
                         break;
                 }
-                innerShadow.appendChild(field);
-                innerValue.appendChild(innerShadow);
-                shadow.appendChild(innerValue);
+                buildArrayShadow(shadow, typeInfo.block, typeInfo.field, fieldValues);
+                return value;
             }
-            return value;
+            else if (shadowId && defaultValue) {
+                buildArrayShadow(shadow, defaultValue);
+                return value;
+            }
         }
         if (typeInfo && (!shadowId || typeInfo.block === shadowId || shadowId === "math_number_minmax")) {
             const field = document.createElement("field");
@@ -243,6 +238,30 @@ namespace pxt.blocks {
         }
 
         return value;
+    }
+
+    function buildArrayShadow(shadow: Element, blockType: string, fieldName?: string, fieldValues?: string[]) {
+        const itemCount = fieldValues ? fieldValues.length : 2;
+        const mut = document.createElement('mutation');
+        mut.setAttribute("items", "" + itemCount);
+        shadow.appendChild(mut);
+
+        for (let i = 0; i < itemCount; i++) {
+            const innerValue = document.createElement("value");
+            innerValue.setAttribute("name", "ADD" + i);
+            const innerShadow = document.createElement("shadow");
+            innerShadow.setAttribute("type", blockType);
+            if (fieldName) {
+                const field = document.createElement("field");
+                field.setAttribute("name", fieldName);
+                if (fieldValues) {
+                    field.appendChild(document.createTextNode(fieldValues[i]));
+                }
+                innerShadow.appendChild(field);
+            }
+            innerValue.appendChild(innerShadow);
+            shadow.appendChild(innerValue);
+        }
     }
 
     export function createFlyoutHeadingLabel(name: string, color?: string, icon?: string, iconClass?: string) {

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -167,12 +167,12 @@ namespace pxt.blocks {
                     }
 
                     const defName = def ? def.name : (bInfo ? bInfo.params[defIndex++] : p.name);
-                    const isVar = (def && def.shadowBlockId) === "variables_get";
+                    const isVarOrArray = def && (def.shadowBlockId === "variables_get" || def.shadowBlockId == "lists_create_with");
 
                     (res.parameters as BlockParameter[]).push({
                         actualName: p.name,
                         type: p.type,
-                        defaultValue: isVar ? (def.varName || p.default) : p.default,
+                        defaultValue: isVarOrArray ? (def.varName || p.default) : p.default,
                         definitionName: defName,
                         shadowBlockId: def && def.shadowBlockId,
                         isOptional: defParameters ? defParameters.indexOf(def) >= optionalStart : false,


### PR DESCRIPTION
Lets you specify the *inner* shadow block for array shadow blocks. For example, in the animation API that @dannytech and @dharinirajah have been making the default value in the array should be images:

![Screen Shot 2019-08-07 at 5 29 21 PM](https://user-images.githubusercontent.com/13754588/62666923-44802000-b93a-11e9-96b9-8b210a55b6c8.png)

To use this, all you need to do is set the `defl` for the parameter on the API to the block ID of the shadow. For example,

```typescript
    //% blockId=run_image_animation
    //% block="%sprite=variables_get(mySprite) animate frames %frames=lists_create_with with interval %frameInterval=timePicker ms"
    //% group="Animate"
    //% frames.defl=screen_image_picker
    export function runImageAnimation(sprite: Sprite, frames: Image[], frameInterval?: number): void {
}
```

(note the `frames.defl` line)
 