### PR TITLE
Warn when a variable is never assigned in blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -85,14 +85,27 @@ namespace pxt.blocks {
         children: Scope[];
     }
 
+    export enum BlockDeclarationType {
+        None = 0,
+        Argument,
+        Assigned,
+        Implicit
+    }
+
+    export interface BlockDiagnostic {
+        blockId: string;
+        message: string;
+    }
+
     export interface VarInfo {
         name: string;
         id: number;
 
         escapedName?: string;
         type?: Point;
-        alreadyDeclared?: boolean;
+        alreadyDeclared?: BlockDeclarationType;
         firstReference?: Blockly.Block;
+        isAssigned?: boolean;
     }
 
     function find(p: Point): Point {
@@ -1079,8 +1092,10 @@ namespace pxt.blocks {
 
         let bindString = binding.escapedName + " = ";
 
+        binding.isAssigned = true;
+
         if (isDef) {
-            binding.alreadyDeclared = true;
+            binding.alreadyDeclared = BlockDeclarationType.Assigned;
             const declaredType = getConcreteType(binding.type);
 
             bindString = `let ${binding.escapedName} = `;
@@ -1402,7 +1417,7 @@ namespace pxt.blocks {
         if (firstBlock && e.blockDeclarations[firstBlock.id]) {
             e.blockDeclarations[firstBlock.id].filter(v => !v.alreadyDeclared).forEach(varInfo => {
                 stmts.unshift(mkVariableDeclaration(varInfo, e.blocksInfo));
-                varInfo.alreadyDeclared = true;
+                varInfo.alreadyDeclared = BlockDeclarationType.Implicit;
             });
         }
         return mkBlock(stmts);
@@ -1552,7 +1567,7 @@ namespace pxt.blocks {
         }
     }
 
-    function compileWorkspace(e: Environment, w: Blockly.Workspace, blockInfo: pxtc.BlocksInfo): JsNode[] {
+    function compileWorkspace(e: Environment, w: Blockly.Workspace, blockInfo: pxtc.BlocksInfo): [JsNode[], BlockDiagnostic[]] {
         try {
             // all compiled top level blocks are events
             const topblocks = w.getTopBlocks(true).sort((a, b) => {
@@ -1655,7 +1670,22 @@ namespace pxt.blocks {
             });
 
             const leftoverVars = e.allVariables.filter(v => !v.alreadyDeclared).map(v => mkVariableDeclaration(v, blockInfo));
-            return stmtsEnums.concat(leftoverVars.concat(stmtsMain));
+
+            const diags: BlockDiagnostic[] = [];
+
+            e.allVariables.filter(v => v.alreadyDeclared === BlockDeclarationType.Implicit && !v.isAssigned).forEach(v => {
+                const t = getConcreteType(v.type);
+
+                // The primitive types all get initializers set to default values, other types are set to null
+                if (t.type === "string" || t.type === "number" || t.type === "boolean" || isArrayType(t.type)) return;
+
+                diags.push({
+                    blockId: v.firstReference && v.firstReference.id,
+                    message: lf("Variable '{0}' is never assigned", v.name)
+                });
+            });
+
+            return [stmtsEnums.concat(leftoverVars.concat(stmtsMain)), diags];
         } catch (err) {
             let be: Blockly.Block = (err as any).block;
             if (be) {
@@ -1669,7 +1699,7 @@ namespace pxt.blocks {
             removeAllPlaceholders();
         }
 
-        return [] // unreachable
+        return [null, null] // unreachable
     }
 
     export function callKey(e: Environment, b: Blockly.Block): string {
@@ -1733,6 +1763,7 @@ namespace pxt.blocks {
         source: string;
         sourceMap: SourceInterval[];
         stats: pxt.Map<number>;
+        diagnostics: BlockDiagnostic[];
     }
 
     export function findBlockId(sourceMap: SourceInterval[], loc: { start: number; length: number; }): string {
@@ -1754,12 +1785,12 @@ namespace pxt.blocks {
 
     export function compileAsync(b: Blockly.Workspace, blockInfo: pxtc.BlocksInfo): Promise<BlockCompilationResult> {
         const e = mkEnv(b, blockInfo);
-        const nodes = compileWorkspace(e, b, blockInfo);
-        const result = tdASTtoTS(e, nodes);
+        const [nodes, diags] = compileWorkspace(e, b, blockInfo);
+        const result = tdASTtoTS(e, nodes, diags);
         return result;
     }
 
-    function tdASTtoTS(env: Environment, app: JsNode[]): Promise<BlockCompilationResult> {
+    function tdASTtoTS(env: Environment, app: JsNode[], diags?: BlockDiagnostic[]): Promise<BlockCompilationResult> {
         let res = flattenNode(app)
 
         // Note: the result of format is not used!
@@ -1768,7 +1799,8 @@ namespace pxt.blocks {
             return {
                 source: res.output,
                 sourceMap: res.sourceMap,
-                stats: env.stats
+                stats: env.stats,
+                diagnostics: diags || []
             };
         })
 
@@ -2157,7 +2189,7 @@ namespace pxt.blocks {
                     const varNames = declaredVars.split(",");
                     varNames.forEach(vName => {
                         const info = findOrDeclareVariable(vName, currentScope);
-                        info.alreadyDeclared = true;
+                        info.alreadyDeclared = BlockDeclarationType.Argument;
                     });
                 }
             }
@@ -2187,7 +2219,7 @@ namespace pxt.blocks {
                     };
 
                     vars.forEach(v => {
-                        v.alreadyDeclared = true;
+                        v.alreadyDeclared = BlockDeclarationType.Assigned;
                         parentScope.declaredVars[v.name] = v;
                     });
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -770,6 +770,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
             }
         })
+        this.compilationResult.diagnostics.forEach(d => {
+            if (d.blockId) {
+                let b = this.editor.getBlockById(d.blockId) as Blockly.BlockSvg;
+                if (b) {
+                    b.setWarningText(d.message);
+                    b.setHighlightWarning(true);
+                }
+            }
+        })
         this.setBreakpointsFromBlocks();
     }
 


### PR DESCRIPTION
This PR aims to ease the pain a little bit on Arcade's most common error! Now, if a variable is referenced but never assigned (eg. you dragged out a Sprite block but forgot to change the dropdown) it gets flagged as an error. This only applies to user-declared variables, not locals or function arguments.

![never_assigned](https://user-images.githubusercontent.com/13754588/62740748-874f0000-b9ed-11e9-9530-747423ff9d7d.gif)

Note that this doesn't do any fancy control flow analysis or anything; if I were to drop the set block *after* the first reference it would also remove the error. Hopefully this will catch 90% of the issues and we can decide to do something more complete later.

Also, this error does not stop your game from compiling/running; it's basically linting.