### PR TITLE
support for .simstate.json

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -113,7 +113,7 @@ async function readPkgAsync(logicalDirname: string, fileContents = false): Promi
         files: []
     };
 
-    for (let fn of pxt.allPkgFiles(cfg).concat([pxt.github.GIT_JSON])) {
+    for (let fn of pxt.allPkgFiles(cfg).concat([pxt.github.GIT_JSON, pxt.SIMSTATE_JSON])) {
         let st = await statOptAsync(path.join(dirname, fn))
         let ff: FsFile = {
             name: fn,
@@ -121,6 +121,9 @@ async function readPkgAsync(logicalDirname: string, fileContents = false): Promi
         }
 
         let thisFileContents = st && fileContents
+
+        if (!st && fn == pxt.SIMSTATE_JSON)
+            continue
 
         if (fn == pxt.github.GIT_JSON) {
             // skip .git.json altogether if missing

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -150,7 +150,7 @@ namespace ts.pxtc {
         jssource += `let yieldSteps = 1;\n`
         jssource += `ectx.setupYield(function() { yieldSteps = 100; })\n`
 
-        jssource += "pxsim.setTitle(" + JSON.stringify(bin.options.name || "") + ");\n"
+        jssource += "pxsim.setTitle(" + JSON.stringify(bin.getTitle()) + ");\n"
         let cfg: pxt.Map<number> = {}
         let cfgKey: pxt.Map<number> = {}
         for (let ce of bin.res.configData || []) {

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -4245,6 +4245,14 @@ ${lbl}: .short 0xffff
             this.numStmts = 0
         }
 
+        getTitle() {
+            const title = this.options.name || U.lf("Untitled")
+            if (title.length >= 90)
+                return title.slice(0, 87) + "..."
+            else
+                return title
+        }
+
         addProc(proc: ir.Procedure) {
             assert(!this.finalPass, "!this.finalPass")
             this.procs.push(proc)

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -855,7 +855,7 @@ ${hex.hexPrelude()}
     .word _pxt_lambda_trampoline@fn
     .word _pxt_perf_counters
     .word _pxt_restore_exception_state@fn
-    .word 0 ; reserved
+    .word ${bin.emitString(bin.getTitle())} ; name
 `
         let snippets: AssemblerSnippets = null;
         snippets = new ThumbSnippets()

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -386,6 +386,7 @@ namespace pxt {
     }
 
     export const CONFIG_NAME = "pxt.json"
+    export const SIMSTATE_JSON = ".simstate.json"
     export const SERIAL_EDITOR_FILE = "serial.txt"
     export const CLOUD_ID = "pxt/"
     export const BLOCKS_PROJECT_NAME = "blocksprj";

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -20,6 +20,7 @@ namespace pxsim {
         version?: string;
         clickTrigger?: boolean;
         breakOnStart?: boolean;
+        storedState?: Map<any>;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {
@@ -95,7 +96,9 @@ namespace pxsim {
     }
     export interface SimulatorCommandMessage extends SimulatorMessage {
         type: "simulator",
-        command: "modal" | "restart" | "reload"
+        command: "modal" | "restart" | "reload" | "setstate"
+        stateKey?: string;
+        stateValue?: any;
         header?: string;
         body?: string;
         copyable?: string;

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -153,6 +153,10 @@ namespace pxsim {
     }
 
     export namespace pxtcore {
+        export function seedAddRandom(num: number) {
+            // nothing yet
+        }
+
         export function mkAction(len: number, fn: LabelFn) {
             let r = new RefAction();
             r.len = len

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -358,6 +358,10 @@ namespace pxsim {
             return 0;
         }
 
+        export function programName() {
+            return pxsim.title;
+        }
+
         export function programSize() {
             return 0;
         }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -268,7 +268,6 @@ namespace pxsim {
         id: string;
         bus: pxsim.EventBus;
         runOptions: SimulatorRunMessage;
-        storedState: Map<any>;
         messageListeners: MessageListener[] = [];
 
         constructor() {
@@ -288,9 +287,14 @@ namespace pxsim {
             this.messageListeners.push(listener);
         }
 
+        get storedState(): Map<any> {
+            if (!this.runOptions) return {}
+            if (!this.runOptions.storedState)
+                this.runOptions.storedState = {}
+            return this.runOptions.storedState
+        }
         public initAsync(msg: SimulatorRunMessage): Promise<void> {
             this.runOptions = msg;
-            this.storedState = this.runOptions.storedState || {};
             return Promise.resolve()
         }
         public setStoredState(k: string, value: any) {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -268,6 +268,7 @@ namespace pxsim {
         id: string;
         bus: pxsim.EventBus;
         runOptions: SimulatorRunMessage;
+        storedState: Map<any>;
         messageListeners: MessageListener[] = [];
 
         constructor() {
@@ -289,7 +290,20 @@ namespace pxsim {
 
         public initAsync(msg: SimulatorRunMessage): Promise<void> {
             this.runOptions = msg;
+            this.storedState = this.runOptions.storedState || {};
             return Promise.resolve()
+        }
+        public setStoredState(k: string, value: any) {
+            if (value == null)
+                delete this.storedState[k]
+            else
+                this.storedState[k] = value
+            Runtime.postMessage({
+                type: "simulator",
+                command: "setstate",
+                stateKey: k,
+                stateValue: value
+            } as SimulatorCommandMessage)
         }
         public onDebuggerResume() { }
         public screenshotAsync(width?: number): Promise<ImageData> {
@@ -529,7 +543,7 @@ namespace pxsim {
             methods: src.methods,
             iface: src.iface,
             toStringMethod: src.toStringMethod
-          };
+        };
     }
 
     let mapVTable: VTable = null

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -51,6 +51,7 @@ namespace pxsim {
         version?: string;
         clickTrigger?: boolean;
         breakOnStart?: boolean;
+        storedState?: Map<any>;
     }
 
     export interface HwDebugger {
@@ -441,7 +442,8 @@ namespace pxsim {
                 refCountingDebug: opts.refCountingDebug,
                 version: opts.version,
                 clickTrigger: opts.clickTrigger,
-                breakOnStart: opts.breakOnStart
+                breakOnStart: opts.breakOnStart,
+                storedState: opts.storedState,
             }
             this.start();
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2503,7 +2503,7 @@ export class ProjectView
                     if (resp.outfiles[pxtc.BINARY_JS]) {
                         if (!cancellationToken.isCancelled()) {
                             pxt.debug(`sim: run`)
-                            simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute, 
+                            simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute,
                                 this.state.highContrast, pxt.options.light, opts.clickTrigger,
                                 pkg.mainEditorPkg().getSimState())
                             this.blocksEditor.setBreakpointsMap(resp.breakpoints);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -718,6 +718,9 @@ export class ProjectView
                         break;
                 }
             },
+            setState: (k, v) => {
+                pkg.mainEditorPkg().setSimState(k, v)
+            },
             editor: this.state.header ? this.state.header.editor : ''
         })
         this.forceUpdate(); // we now have editors prepared
@@ -2500,7 +2503,9 @@ export class ProjectView
                     if (resp.outfiles[pxtc.BINARY_JS]) {
                         if (!cancellationToken.isCancelled()) {
                             pxt.debug(`sim: run`)
-                            simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute, this.state.highContrast, pxt.options.light, opts.clickTrigger)
+                            simulator.run(pkg.mainPkg, opts.debug, resp, this.state.mute, 
+                                this.state.highContrast, pxt.options.light, opts.clickTrigger,
+                                pkg.mainEditorPkg().getSimState())
                             this.blocksEditor.setBreakpointsMap(resp.breakpoints);
                             this.textEditor.setBreakpointsMap(resp.breakpoints);
                             if (!cancellationToken.isCancelled()) {
@@ -3221,7 +3226,7 @@ export class ProjectView
         const logoWide = !!targetTheme.logoWide;
         const hwDialog = !sandbox && pxt.hasHwVariants();
         const recipes = !!targetTheme.recipes;
-        const expandedStyle = inTutorialExpanded ? this.getExpandedCardStyle() :  null;
+        const expandedStyle = inTutorialExpanded ? this.getExpandedCardStyle() : null;
 
         const collapseIconTooltip = this.state.collapseEditorTools ? lf("Show the simulator") : lf("Hide the simulator");
 
@@ -3938,7 +3943,7 @@ document.addEventListener("DOMContentLoaded", () => {
 })
 
 
-function getTutorialOptions(md: string, tutorialId: string, filename: string, reportId: string, recipe: boolean): { options: pxt.tutorial.TutorialOptions, editor: string} {
+function getTutorialOptions(md: string, tutorialId: string, filename: string, reportId: string, recipe: boolean): { options: pxt.tutorial.TutorialOptions, editor: string } {
     // FIXME: Remove this once arcade documentation has been updated from enums to namespace for spritekind
     md = pxt.tutorial.patchArcadeSnippets(md);
 

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -112,8 +112,6 @@ export class File implements pxt.editor.IFile {
     }
 }
 
-const SIM_STATE = ".simstate.json"
-
 export class EditorPackage {
     files: pxt.Map<File> = {};
     header: pxt.workspace.Header;
@@ -134,9 +132,9 @@ export class EditorPackage {
 
     getSimState() {
         if (!this.simState) {
-            if (!this.files[SIM_STATE])
-                this.setFile(SIM_STATE, "{}")
-            const f = this.files[SIM_STATE]
+            if (!this.files[pxt.SIMSTATE_JSON])
+                this.setFile(pxt.SIMSTATE_JSON, "{}")
+            const f = this.files[pxt.SIMSTATE_JSON]
             try {
                 this.simState = JSON.parse(f.content)
             } catch {
@@ -160,7 +158,7 @@ export class EditorPackage {
                 this.simStateSaveScheduled = false
                 if (!this.simState)
                     return
-                const f = this.files[SIM_STATE]
+                const f = this.files[pxt.SIMSTATE_JSON]
                 if (!f)
                     return
                 f.setContentAsync(JSON.stringify(this.simState)).done()

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -363,7 +363,7 @@ export class EditorPackage {
     sortedFiles() {
         let lst = Util.values(this.files)
         if (!pxt.options.debug)
-            lst = lst.filter(f => f.name != pxt.github.GIT_JSON)
+            lst = lst.filter(f => f.name != pxt.github.GIT_JSON && f.name != pxt.SIMSTATE_JSON)
         lst.sort((a, b) => a.weight() - b.weight() || Util.strcmp(a.name, b.name))
         return lst
     }

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -11,6 +11,7 @@ interface SimulatorConfig {
     highlightStatement(stmt: pxtc.LocationInfo, brk?: pxsim.DebuggerBreakpointMessage): boolean;
     restartSimulator(): void;
     onStateChanged(state: pxsim.SimulatorState): void;
+    setState(key: string, value: any): void;
     editor: string;
 }
 
@@ -162,6 +163,9 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         },
         onSimulatorCommand: (msg: pxsim.SimulatorCommandMessage): void => {
             switch (msg.command) {
+                case "setstate":
+                    cfg.setState(msg.stateKey, msg.stateValue);
+                    break
                 case "restart":
                     cfg.restartSimulator();
                     break;
@@ -246,7 +250,7 @@ export function setPending() {
 export function run(pkg: pxt.MainPackage, debug: boolean,
     res: pxtc.CompileResult, mute?: boolean,
     highContrast?: boolean, light?: boolean,
-    clickTrigger?: boolean) {
+    clickTrigger?: boolean, storedState?: pxt.Map<any>) {
     const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
     const parts = pxtc.computeUsedParts(res, true);
@@ -268,7 +272,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         refCountingDebug: pxt.options.debug,
         version: pkg.version(),
         clickTrigger: clickTrigger,
-        breakOnStart: debug
+        breakOnStart: debug,
+        storedState: storedState,
     }
     //if (pxt.options.debug)
     //    pxt.debug(JSON.stringify(opts, null, 2))


### PR DESCRIPTION
This adds a hidden `.simstate.json` file to project, which can be updated by the simulator code using `board().setStoredState()` API. This is used for `settings` namespace in https://github.com/microsoft/pxt-common-packages/pull/923

This also adds support for storing project name in generated native code and accessing it from the program using `control.programName()`.