### PR TITLE
Add checkdocsdirs property to appTarget for blanket run of checkdocs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5023,6 +5023,18 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
             Object.keys(targeConfig.galleries).forEach(gallery => todo.push(targeConfig.galleries[gallery]));
     }
 
+    const mdRegex = /\.md$/;
+    const targetDirs = pxt.appTarget.checkdocsdirs;
+    if (targetDirs) {
+        targetDirs.forEach(dir => {
+            pxt.log(`looking for markdown files in ${dir}`);
+            nodeutil.allFiles(dir, 3).filter(f => mdRegex.test(f))
+            .forEach(md => {
+                pushUrl(md.replace(mdRegex, ""), true);
+            });
+        })
+    }
+
     while (todo.length) {
         checked++;
         const entrypath = todo.pop();

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -49,7 +49,8 @@ declare namespace pxt {
         ignoreDocsErrors?: boolean;
         variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
         queryVariants?: Map<AppTarget>; // patches on top of the current AppTarget using query url regex
-        unsupportedBrowsers?: BrowserOptions[] // list of unsupported browsers for a specific target (eg IE11 in arcade). check browserutils.js browser() function for strings
+        unsupportedBrowsers?: BrowserOptions[]; // list of unsupported browsers for a specific target (eg IE11 in arcade). check browserutils.js browser() function for strings
+        checkdocsdirs?: string[]; // list of folders for checkdocs, irrespective of SUMMARY.md
     }
 
     interface BrowserOptions {


### PR DESCRIPTION
Currently will be used in minecraft as they add new tutorials