### PR TITLE
Need to change variable name because it conflicts with color namespace

### DIFF
--- a/common-docs/javascript/types.md
+++ b/common-docs/javascript/types.md
@@ -64,8 +64,8 @@ As in other languages, we use the type `string` to refer to textual data.
 Use double quotes (`"`) or single quotes (`'`) to surround string data.
 
 ```typescript
-let color: string = "blue";
-color = 'red';
+let myColor: string = "blue";
+myColor = 'red';
 ```
 
 You can also use *template strings*, which can span multiple lines and have embedded expressions.


### PR DESCRIPTION
The new color package in pxt-common-packages has a namespace named `color`, which unfortunately conflicts with any global variables named color. This was causing checkdocs to fail on pxt-adafruit when I updated to the latest common packages. Not sure if the color package has shipped yet, but we might want to reconsider the name.

In the meantime, I'm fixing it here so that I can get a build of pxt-adafruit going.