### PR TITLE
 Add argsNullable comment attribute

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -540,6 +540,7 @@ declare namespace ts.pxtc {
         callInDebugger?: boolean; // for getters, they will be invoked by the debugger.
         py2tsOverride?: string; // used to map functions in python that have an equivalent (but differently named) ts function
         pyHelper?: string; // used to specify functions on the _py namespace that provide implementations. Should be of the form py_class_methname
+        argsNullable?: boolean; // allow NULL to be passed to C++ shim function
 
         // on class
         snippet?: string; // value used to generate TS snippet

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -481,7 +481,7 @@ function ${id}(s) {
         function emitInstanceOf(info: ClassInfo, tp: string, r0 = "r0") {
             if (tp == "bool")
                 write(`r0 = ${checkSubtype(info)};`)
-            else if (tp == "validate" || tp == "validateDecr") {
+            else if (tp == "validate") {
                 write(`if (!${checkSubtype(info, r0)}) failedCast(${r0});`)
             } else {
                 U.oops()

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -380,7 +380,7 @@ _start_${name}:
         function emitInstanceOf(info: ClassInfo, tp: string) {
             if (tp == "bool") {
                 write(`checkinst ${info.id}_VT`)
-            } else if (tp == "validate" || tp == "validateDecr") {
+            } else if (tp == "validate") {
                 U.oops()
             } else {
                 U.oops()

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3305,7 +3305,8 @@ ${lbl}: .short 0xffff
                         convInfos.push({
                             argIdx: i,
                             method: "_validate",
-                            refTag: t
+                            refTag: t,
+                            refTagNullable: !!attrs.argsNullable
                         })
                     }
                     return r

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -39,6 +39,7 @@ namespace ts.pxtc.ir {
         method: string;
         returnsRef?: boolean;
         refTag?: pxt.BuiltInType;
+        refTagNullable?: boolean;
     }
 
     export interface MaskInfo {

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1028,8 +1028,9 @@ int main() {
             inc += "PXT_OBJS := $(addprefix bld/, $(PXT_C:.c=.o) $(PXT_S:.s=.o) $(PXT_CPP:.cpp=.o))\n"
             res.generatedFiles["/Makefile"] = makefile
             res.generatedFiles["/Makefile.inc"] = inc
-
         }
+
+        res.generatedFiles["/functions.json"] = JSON.stringify(res.functions, null, 1)
 
         let tmp = res.extensionFiles
         U.jsonCopyFrom(tmp, res.generatedFiles)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -557,7 +557,8 @@ namespace ts.pxtc {
         "decompileIndirectFixedInstances",
         "topblock",
         "callInDebugger",
-        "duplicateShadowOnDrag"
+        "duplicateShadowOnDrag",
+        "argsNullable"
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {


### PR DESCRIPTION
Normally, a call to `//% shim=...` function that takes a Buffer, Image, or Array will panic when passed `null` or `undefined`. With `//% argsNullable` the function will be passed `NULL` instead.

So far there only seems to be one instance in our library where this makes sense - spi.transfer(buffer, buffer), where one of the buffers can be `null`, but @jwunderl is adding image.equals.