### PR TITLE
Fix crash with top-level for-of

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3757,9 +3757,11 @@ ${lbl}: .short 0xffff
 
             //As the iterator isn't declared in the usual fashion we must mark it as used, otherwise no cell will be allocated for it
             markUsed(declList.declarations[0])
-            let iterVar = emitVariableDeclaration(declList.declarations[0]) // c
+            const iterVar = emitVariableDeclaration(declList.declarations[0]) // c
+            U.assert(!!iterVar || !bin.finalPass)
             //Start with undefined
-            proc.emitExpr(iterVar.storeByRef(emitLit(undefined)))
+            if (iterVar)
+                proc.emitExpr(iterVar.storeByRef(emitLit(undefined)))
             proc.stackEmpty()
 
             // Store the expression (it could be a string literal, for example) for the collection being iterated over
@@ -3790,7 +3792,8 @@ ${lbl}: .short 0xffff
             }
 
             // c = a[i]
-            proc.emitExpr(iterVar.storeByRef(ir.rtcall(indexer, [collectionVar.loadCore(), toInt(intVarIter.loadCore())])))
+            if (iterVar)
+                proc.emitExpr(iterVar.storeByRef(ir.rtcall(indexer, [collectionVar.loadCore(), toInt(intVarIter.loadCore())])))
 
             emit(node.statement);
             proc.emitLblDirect(l.cont);

--- a/tests/compile-test/lang-test0/44toplevelcode.ts
+++ b/tests/compile-test/lang-test0/44toplevelcode.ts
@@ -27,3 +27,5 @@ let unusedInit = incrXyz();
 
 assert(xyz == 13, "init2")
 xyz = 0
+
+for (let e of [""]) {}


### PR DESCRIPTION
Fixes `Cannot read property 'storeByRef' of null` in arcade build.

Introduced in incremental compilation PR https://github.com/microsoft/pxt/pull/5791