### PR TITLE
Hide project settings by default

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -283,6 +283,7 @@ declare namespace pxt {
         debugger?: boolean; // debugger button
         selectLanguage?: boolean; // add language picker to settings menu
         availableLocales?: string[]; // the list of enabled language codes
+        showProjectSettings?: boolean; // show a link to pxt.json in the cogwheel menu
         useUploadMessage?: boolean; // change "Download" text to "Upload"
         downloadIcon?: string; // which icon io use for download
         blockColors?: Map<string>; // block namespace colors, used for build in categories

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -275,12 +275,13 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const showSimCollapse = !readOnly && !isController && !!targetTheme.simCollapseInMenu;
         const showGreenScreen = targetTheme.greenScreen || /greenscreen=1/i.test(window.location.href);
         const showPrint = targetTheme.print && !pxt.BrowserUtils.isIE();
+        const showProjectSettings = targetTheme.showProjectSettings;
 
         // Electron does not currently support webusb
         const showPairDevice = pxt.usb.isEnabled && !pxt.BrowserUtils.isElectron();
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
-            <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} />
+            {showProjectSettings ? <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} /> : undefined}
             {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} /> : undefined}
             {boards ? <sui.Item role="menuitem" icon="microchip" text={lf("Change Board")} onClick={this.showBoardDialog} /> : undefined}
             {showPrint ? <sui.Item role="menuitem" icon="print" text={lf("Print...")} onClick={this.print} /> : undefined}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-adafruit/issues/1082

In all of our editors besides micro:bit, the project settings is only a fancy text box where you can rename the project (which you can also do in the main editor). If you are unlucky enough to click on the "edit settings as text", there is a good chance you'll break your project completely. This PR hides the project settings from the cogwheel. They are still accessible via the file explorer (just click on `pxt.json` in the user project).

In micro:bit, the radio pairing options are in that editor so I'm turning it on:
https://github.com/microsoft/pxt-microbit/pull/2401