### PR TITLE
use textColor less var for 'learn more' link

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -405,7 +405,7 @@ div.simframe > iframe {
 }
 
 .ui.card .extra.content a.learnmore {
-    color: rgba(0, 0, 0, .6);
+    color: @textColor;
 }
 
 /* Popup message */

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -412,7 +412,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                 description={description}>
                 <div className="ui">
                     {mode == ScriptSearchMode.Experiments ?
-                        <div className="ui message">
+                        <div className="ui message info">
                             <div className="header">{lf("WARNING: EXPERIMENTAL FEATURES AHEAD!")}</div>
                             {lf("Try out these features and tell us what you think!")}
                         </div> : undefined}


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-adafruit/issues/1098, will need to set the variable to white in adafruit

also make experiments header display properly like other text boxes, which I'm pretty sure I remember there being an issue for at some point but I don't see it