### PR TITLE
Use assignments in array examples

### DIFF
--- a/common-docs/reference/arrays/insert-at.md
+++ b/common-docs/reference/arrays/insert-at.md
@@ -25,11 +25,12 @@ myNumbers.insertAt(3, 2);
 Make a ordered array that has the numbers from a jumbled an array in order of lowest to highest.
 
 ```blocks
-let jumbled = [4, 5, 2, 1, 6, 9, 0, 3, 8, 7];
-let ordered = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+let removed = 0
+let jumbled = [4, 5, 2, 1, 6, 9, 0, 3, 8, 7]
+let ordered = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 for (let item of jumbled) {
-    ordered.insertAt(item, item);
-    ordered.removeAt(item + 1);
+    ordered.insertAt(item, item)
+    removed = ordered.removeAt(item + 1)
 }
 ```
 

--- a/common-docs/reference/arrays/unshift.md
+++ b/common-docs/reference/arrays/unshift.md
@@ -26,9 +26,9 @@ Make an array that simulates a train. Place the parts of the train in the right 
 ```blocks
 let count = 0
 let part = ""
+let train: string[] = []
 let parts = ["flatcar", "boxcar", "tanker", "engine", "flatcar", "caboose", "boxcar"]
 while (parts.length > 0) {
-    let train: string[] = []
     part = parts.shift()
     if (parts.length > 1) {
         if (part == "engine") {

--- a/common-docs/reference/arrays/unshift.md
+++ b/common-docs/reference/arrays/unshift.md
@@ -11,7 +11,8 @@ then you _unshift_ it into the array. You do it like this:
 
 ```block
 let thoseNumbers = [1, 2, 3];
-thoseNumbers.unshift(0);
+let head = 0;
+head = thoseNumbers.unshift(0);
 ```
 
 ## Parameters
@@ -23,20 +24,22 @@ thoseNumbers.unshift(0);
 Make an array that simulates a train. Place the parts of the train in the right order.
 
 ```blocks
-let train: string[] = []
+let count = 0
+let part = ""
 let parts = ["flatcar", "boxcar", "tanker", "engine", "flatcar", "caboose", "boxcar"]
 while (parts.length > 0) {
-    let part = parts.shift()
+    let train: string[] = []
+    part = parts.shift()
     if (parts.length > 1) {
         if (part == "engine") {
             parts.push(part)
         } else if (part == "caboose") {
             train.push(part)
         } else {
-            train.unshift(part);
+            count = train.unshift(part)
         }
     } else {
-        train.unshift(part);
+        count = train.unshift(part)
     }
 }
 ```


### PR DESCRIPTION
Use assignments for array removeAt() and unshift() so blocks decompile well.

RE: https://github.com/microsoft/pxt-adafruit/issues/1102