### PR TITLE
Animated melody editor and other fixes

### DIFF
--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -432,10 +432,54 @@ namespace pxtblockly {
         }
 
         private playNote(rowNumber: number, colNumber?: number): void {
-            let tone: number = 0;
             let count: number = ++this.soundingKeys;
 
-            switch (rowNumber) {
+            if (this.isPlaying) {
+                this.timeouts.push(setTimeout(() => {
+                    this.playToneCore(rowNumber);
+                }, colNumber * this.getDuration()));
+
+                this.timeouts.push(setTimeout(() => {
+                    pxt.AudioContextManager.stop();
+                }, (colNumber + 1) * this.getDuration()));
+            }
+            else {
+                this.playToneCore(rowNumber);
+                this.timeouts.push(setTimeout(() => {
+                    if (this.soundingKeys == count)
+                        pxt.AudioContextManager.stop();
+                }, this.getDuration()));
+            }
+        }
+
+        protected queueToneForColumn(column: number, delay: number, duration: number) {
+            const start = setTimeout(() => {
+                ++this.soundingKeys;
+                pxt.AudioContextManager.stop();
+
+                for (let i = 0; i < this.numRow; i++) {
+                    if (this.melody.getValue(i, column)) {
+                        this.playToneCore(i);
+                    }
+                }
+                this.highlightColumn(column, true);
+                this.timeouts = this.timeouts.filter(t => t !== start);
+            }, delay);
+
+            const end = setTimeout(() => {
+                // pxt.AudioContextManager.stop();
+                this.timeouts = this.timeouts.filter(t => t !== end);
+                this.highlightColumn(column, false);
+            }, delay + duration)
+
+            this.timeouts.push(start);
+            this.timeouts.push(end);
+        }
+
+        protected playToneCore(row: number) {
+            let tone: number = 0;
+
+            switch (row) {
                 case 0: tone = 523; break; // Tenor C
                 case 1: tone = 494; break; // Middle B
                 case 2: tone = 440; break; // Middle A
@@ -446,24 +490,16 @@ namespace pxtblockly {
                 case 7: tone = 262; break; // Middle C
             }
 
-            if (this.isPlaying) { // when melody is playing
-                // start note
-                this.timeouts.push(setTimeout(() => {
-                    pxt.AudioContextManager.tone(tone);
-                }, colNumber * this.getDuration()));
-                // stop note
-                this.timeouts.push(setTimeout(() => {
-                    pxt.AudioContextManager.stop();
-                }, (colNumber + 1) * this.getDuration()));
-            } else { // when a single note is selected
-                // start note
-                pxt.AudioContextManager.tone(tone);
-                // stop note
-                this.timeouts.push(setTimeout(() => {
-                    if (this.soundingKeys == count)
-                        pxt.AudioContextManager.stop();
-                }, this.getDuration()));
-            }
+            pxt.AudioContextManager.tone(tone);
+        }
+
+        private highlightColumn(col: number, on: boolean) {
+            const cells = this.cells.map(row => row[col]);
+
+            cells.forEach(cell => {
+                if (on) pxt.BrowserUtils.addClass(cell, "playing")
+                else pxt.BrowserUtils.removeClass(cell, "playing")
+            });
         }
 
         private createGridDisplay(): SVGSVGElement {
@@ -531,11 +567,7 @@ namespace pxtblockly {
         private playMelody() {
             if (this.isPlaying) {
                 for (let i = 0; i < this.numCol; i++) {
-                    for (let j = 0; j < this.numRow; j++) {
-                        if (this.melody.getValue(j, i)) {
-                            this.playNote(j, i);
-                        }
-                    }
+                    this.queueToneForColumn(i, i * this.getDuration(), this.getDuration());
                 }
                 this.timeouts.push(setTimeout( // call the melody again after it finishes
                     () => this.playMelody(), (this.numCol) * this.getDuration()));
@@ -549,6 +581,8 @@ namespace pxtblockly {
                 while (this.timeouts.length) clearTimeout(this.timeouts.shift());
                 pxt.AudioContextManager.stop();
                 this.isPlaying = false;
+
+                this.cells.forEach(row => row.forEach(cell => pxt.BrowserUtils.removeClass(cell, "playing")));
             }
         }
 

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -404,7 +404,7 @@ namespace pxtblockly {
             this.invalidString = null;
             this.melody.updateMelody(row, col);
 
-            if (this.melody.getValue(row, col)) {
+            if (this.melody.getValue(row, col) && !this.isPlaying) {
                 this.playNote(row, col);
             }
 
@@ -552,15 +552,24 @@ namespace pxtblockly {
         }
 
         private togglePlay() {
-            if (pxt.BrowserUtils.containsClass(this.playIcon, "play icon")) {
-                pxt.BrowserUtils.removeClass(this.playIcon, "play icon");
-                pxt.BrowserUtils.addClass(this.playIcon, "stop icon");
+            if (!this.isPlaying) {
                 this.isPlaying = true;
                 this.playMelody();
             } else {
+                this.stopMelody();
+            }
+
+            this.updatePlayButton();
+        }
+
+        private updatePlayButton() {
+            if (this.isPlaying) {
+                pxt.BrowserUtils.removeClass(this.playIcon, "play icon");
+                pxt.BrowserUtils.addClass(this.playIcon, "stop icon");
+            }
+            else {
                 pxt.BrowserUtils.removeClass(this.playIcon, "stop icon");
                 pxt.BrowserUtils.addClass(this.playIcon, "play icon");
-                this.stopMelody();
             }
         }
 
@@ -588,6 +597,7 @@ namespace pxtblockly {
 
         private showGallery() {
             this.stopMelody();
+            this.updatePlayButton();
             this.gallery.show((result: string) => {
                 if (result) {
                     this.melody.parseNotes(result);

--- a/theme/melodyeditor.less
+++ b/theme/melodyeditor.less
@@ -63,22 +63,62 @@
 #melody-editor-gallery {
     overflow-y: scroll;
     overflow-x: hidden;
-    padding: 10px 35px 10px 10px;
+    padding: 0.75rem;
     background: #4f0643;
     max-height: 350px;
 }
 
 .melody-gallery-button {
     text-align: center;
-    display: inline-block;
-    padding: 5px;
-    margin: 4px;
+    display: flex;
     border-radius: 4px;
-    outline: none;
-    border: 1px solid;
     transition: box-shadow .1s;
     cursor: pointer;
-    line-height: 35px;
+    background-color: #dcdcdc;
+
+    width: 100%;
+    margin-bottom: 0.75rem;
+    height: 2.75rem;
+    line-height: 2.5rem;
+}
+
+.melody-gallery-button .melody-color-block {
+    margin-top: 0.5rem;
+}
+
+.melody-editor-button.left-button {
+    flex-grow: 1;
+    border-radius: 4px 0 0 4px;
+    border-left: 1px #ffffff solid;
+    border-bottom: 1px #ffffff solid;
+    border-top: 1px #ffffff solid;
+    padding-left: 0.5rem;
+    padding-right: 0.3rem;
+}
+
+.melody-editor-button.right-button {
+    min-width: 2.75rem;
+    padding-left: 0.3rem;
+    border-radius: 0 4px 4px 0;
+    border-left: 1px solid #4f0643;
+    border-right: 1px #ffffff solid;
+    border-bottom: 1px #ffffff solid;
+    border-top: 1px #ffffff solid;
+}
+
+.melody-editor-button {
+    background-color: #dcdcdc;
+    color: rgb(0, 0, 0, 0.6);
+
+    transition: color .1s, background-color .1s;
+}
+.melody-editor-button:hover {
+    background-color: #cacbcd;
+    color: rgb(0, 0, 0, 0.8);
+}
+
+.melody-editor-button.right-button .icon {
+    opacity: 0.9;
 }
 
 .melody-gallery-play-icon {
@@ -255,5 +295,5 @@
 }
 
 .playing {
-    fill-opacity: 0.8;
+    fill-opacity: 0.7;
 }

--- a/theme/melodyeditor.less
+++ b/theme/melodyeditor.less
@@ -253,3 +253,7 @@
     fill: #DCDCDC;
     background: #DCDCDC;
 }
+
+.playing {
+    fill-opacity: 0.8;
+}


### PR DESCRIPTION
![melody-editor-updates](https://user-images.githubusercontent.com/13754588/63555405-98bc0000-c4f5-11e9-817c-0354069c7d8b.gif)


Changes include:
* Melody editor highlights columns as they play
* Clicking on a note while the melody is playing no longer triggers that note
* Changing notes as the melody plays now immediately changes the sound (it used to wait for the next measure)
* Gallery cards now consist of two attached buttons to make the left side look more clickable
* Fixed the tones in the melody editor so that they no longer "clip" when a note ends
* A lot of other tiny bug fixes

I am planning to also fix the sound clipping in the simulator but that will be a separate PR.