### PR TITLE
Moving to indexdb for chrome embedview in minecraft

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3783,7 +3783,7 @@ document.addEventListener("DOMContentLoaded", () => {
     else if ((theme.allowParentController || isController) && pxt.BrowserUtils.isIFrame()) workspace.setupWorkspace("iframe");
     else if (isSandbox) workspace.setupWorkspace("mem");
     else if (pxt.winrt.isWinRT()) workspace.setupWorkspace("uwp");
-    else if (pxt.BrowserUtils.isIpcRenderer() && pxt.BrowserUtils.isSafari()) workspace.setupWorkspace("idb");
+    else if (pxt.BrowserUtils.isIpcRenderer()) workspace.setupWorkspace("idb");
     else if (pxt.BrowserUtils.isLocalHost() || pxt.BrowserUtils.isPxtElectron()) workspace.setupWorkspace("fs");
     Promise.resolve()
         .then(() => {

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -29,7 +29,7 @@ function migrateBrowserWorkspaceAsync(): Promise<void> {
         })
         .then((allDbHeaders) => {
                 if (allDbHeaders.length) {
-                    // There are already scripts using the prefix, so a migration has already happened
+                    // There are already scripts using the idbworkspace, so a migration has already happened
                     return Promise.resolve();
                 }
 

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -2,6 +2,7 @@
  * A workspace implementation that uses IndexedDB directly (bypassing PouchDB), to support WKWebview where PouchDB
  * doesn't work.
  */
+import * as browserworkspace from "./browserworkspace"
 
 type Header = pxt.workspace.Header;
 type ScriptText = pxt.workspace.ScriptText;
@@ -18,6 +19,38 @@ const HEADERS_TABLE = "headers";
 const KEYPATH = "id";
 
 let _db: pxt.BrowserUtils.IDBWrapper;
+
+// This function migrates existing projectes in pouchDb to indexDb
+// From browserworkspace to idbworkspace
+function migrateBrowserWorkspaceAsync(): Promise<void> {
+    return getDbAsync()
+        .then((db) => {
+            return db.getAllAsync<pxt.workspace.Header>(HEADERS_TABLE);
+        })
+        .then((allDbHeaders) => {
+                if (allDbHeaders.length) {
+                    // There are already scripts using the prefix, so a migration has already happened
+                    return Promise.resolve();
+                }
+
+                const copyProject = (h: pxt.workspace.Header): Promise<string> => {
+                    return browserworkspace.provider.getAsync(h)
+                        .then((resp) => {
+                            // Ignore metadata of the previous script so they get re-generated for the new copy
+                            delete (<any>h)._id;
+                            delete (<any>h)._rev;
+                            return setAsync(h, undefined, resp.text);
+                        })
+                };
+
+                return browserworkspace.provider.listAsync()
+                    .then((previousHeaders: pxt.workspace.Header[]) => {
+                        return Promise.map(previousHeaders, (h) => copyProject(h));
+                    })
+                    .then(() => { });
+        });
+
+}
 
 function getDbAsync(): Promise<pxt.BrowserUtils.IDBWrapper> {
     if (_db) {
@@ -39,7 +72,10 @@ function getDbAsync(): Promise<pxt.BrowserUtils.IDBWrapper> {
 }
 
 function listAsync(): Promise<pxt.workspace.Header[]> {
-    return getDbAsync()
+    return migrateBrowserWorkspaceAsync()
+        .then (() => {
+            return getDbAsync();
+        })
         .then((db) => {
             return db.getAllAsync<pxt.workspace.Header>(HEADERS_TABLE);
         });

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -5,7 +5,7 @@
 import * as db from "./db";
 import * as core from "./core";
 import * as data from "./data";
-import * as cloudworkspace from "./browserworkspace"
+import * as browserworkspace from "./browserworkspace"
 import * as fileworkspace from "./fileworkspace"
 import * as memoryworkspace from "./memoryworkspace"
 import * as iframeworkspace from "./iframeworkspace"
@@ -50,7 +50,7 @@ export function copyProjectToLegacyEditor(header: Header, majorVersion: number):
     if (!isBrowserWorkspace()) {
         return Promise.reject("Copy operation only works in browser workspace");
     }
-    return cloudworkspace.copyProjectToLegacyEditor(header, majorVersion);
+    return browserworkspace.copyProjectToLegacyEditor(header, majorVersion);
 }
 
 export function setupWorkspace(id: string) {
@@ -79,10 +79,12 @@ export function setupWorkspace(id: string) {
         case "cloud":
         case "browser":
         default:
-            impl = cloudworkspace.provider
+            impl = browserworkspace.provider
             break;
     }
 }
+
+
 
 export function getHeaders(withDeleted = false) {
     checkSession();
@@ -163,7 +165,7 @@ function checkSession() {
 }
 
 export function initAsync() {
-    if (!impl) impl = cloudworkspace.provider;
+    if (!impl) impl = browserworkspace.provider;
 
     // generate new workspace session id to avoid races with other tabs
     sessionID = ts.pxtc.Util.guidGen();
@@ -713,6 +715,7 @@ export function saveToCloudAsync(h: Header) {
     return cloudsync.saveToCloudAsync(h)
 }
 
+
 export function syncAsync(): Promise<pxt.editor.EditorSyncState> {
     checkSession();
 
@@ -786,7 +789,7 @@ export function listAssetsAsync(id: string): Promise<pxt.workspace.Asset[]> {
 }
 
 export function isBrowserWorkspace() {
-    return impl === cloudworkspace.provider;
+    return impl === browserworkspace.provider;
 }
 
 export function fireEvent(ev: pxt.editor.events.Event) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -84,8 +84,6 @@ export function setupWorkspace(id: string) {
     }
 }
 
-
-
 export function getHeaders(withDeleted = false) {
     checkSession();
     let r = allScripts.map(e => e.header).filter(h => (withDeleted || !h.isDeleted) && !h.isBackup)
@@ -714,7 +712,6 @@ export function saveToCloudAsync(h: Header) {
     checkSession();
     return cloudsync.saveToCloudAsync(h)
 }
-
 
 export function syncAsync(): Promise<pxt.editor.EditorSyncState> {
     checkSession();


### PR DESCRIPTION
We use indexdb (idbworkspace) in the webkit embed view of minecraft, but use pouchdb (browserworkspace) for chrome embed. There are issues in the wild due to pouchdb crashes.
See https://github.com/microsoft/pxt-minecraft/issues/1144

This change moves the chrome embed to use indexdb as well.  Old projects are imported first time (a.k.a when indexdb is empty). 