### PR TITLE
always jump to error when one is available

### DIFF
--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -305,7 +305,8 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
     }
 
     renderCore() {
-        const { isActive, hasDelete, file, meta, ...rest } = this.props;
+        const { onClick, onItemClick, onItemRemove, onErrorClick, // keep these to avoid warnings with ...rest
+            isActive, hasDelete, file, meta, ...rest } = this.props;
 
         return <a
             onClick={this.handleClick}
@@ -366,7 +367,8 @@ class PackgeTreeItem extends sui.StatelessUIElement<PackageTreeItemProps> {
     }
 
     renderCore() {
-        const { version, isActive, hasRefresh, hasDelete, pkg: p, ...rest } = this.props;
+        const { onItemClick, onItemRemove, onItemRefresh, version, // keep these to avoid warnings with ...rest
+            isActive, hasRefresh, hasDelete, pkg: p, ...rest } = this.props;
 
         return <div className="header link item" role="treeitem"
             aria-selected={isActive} aria-expanded={isActive}


### PR DESCRIPTION
Fix for 
![image](https://user-images.githubusercontent.com/4175913/63709145-2ac05300-c7eb-11e9-9a31-cd93544aac50.png)

- no more nested <a>
- always jump to first error if available