### PR TITLE
make on start breakpoints work again

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -870,7 +870,7 @@ namespace pxsim {
             function setupDebugger(numBreakpoints: number, userCodeGlobals?: string[]) {
                 breakpoints = new Uint8Array(numBreakpoints)
                 // start running and let user put a breakpoint on start
-                // breakpoints[0] = 1
+                breakpoints[0] = msg.breakOnStart ? 1 : 0;
                 userGlobals = userCodeGlobals;
                 return breakpoints
             }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1231

[this line](https://github.com/microsoft/pxt/pull/5781/files#diff-f29a90037ff77906dedbe5a91dbaed6eL756) got dropped with some perf changes, which was part of the [previous fix](https://github.com/microsoft/pxt/pull/5692) for this error. It looks like this is where the implementation was originally intended for on start breakpoints, as the line was just commented out?

![2019-08-26 14 23 58](https://user-images.githubusercontent.com/5615930/63724710-4b99a000-c80d-11e9-8f36-bba3377a283b.gif)
