### PR TITLE
Only bump the var suffix in blockSetVariable when it's assigned somewhere

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -429,8 +429,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.parent.setState({ hideEditorFloats: false });
                 workspace.fireEvent({ type: 'create', editor: 'blocks', blockId } as pxt.editor.events.CreateEvent);
             }
-            else if (ev.type == 'var_create') {
-                // a new variable was created,
+            else if (ev.type == 'var_create' || ev.type == "delete") {
+                // a new variable was created or blocks were removed,
                 // clear the toolbox caches as some blocks may need to be recomputed
                 this.clearFlyoutCaches();
             }


### PR DESCRIPTION
closes https://github.com/microsoft/pxt-arcade/issues/1237

make the variable suffix bumping only occur when the variable has been assigned, rather than just existing. This helps a few cases where the current behavior is annoying

1. when you're dragging out mySprites and then renaming them immediately and still getting a bunch of variables (at take your kid to work day they were regularly getting to mySprite5 and mySprite6 from messing around)
2. when you drag out another block (e.g. you see ``move mySprite with buttons`` under controller and want to see what it does) and then get ``mySprite2`` when there is no ``mySprite``
3. when you're following a tutorial, but drag the wrong thing at first, and then the block you want isn't there (again from take your kids to work day, pretty common for them to be hesitant to drag out the block even though it's just ``mySprite2`` instead of ``mySprite``)

![2019-08-26 19 14 43](https://user-images.githubusercontent.com/5615930/63735945-5a487d00-c836-11e9-8147-cd08fe94b79b.gif)
