### PR TITLE
make snippet buttons fire event on keyboard action

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -71,7 +71,6 @@ namespace pxt.runner {
         $btn.find('i').attr("class", icon);
         $btn.find('span').text(label);
 
-
         addFireClickOnEnter($btn);
         return $btn;
     }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -81,7 +81,7 @@ namespace pxt.runner {
             const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
             if (charCode === 13 /* enter */ || charCode === 32 /* space */) {
                 e.preventDefault();
-                (e.currentTarget as HTMLElement).click();
+                e.currentTarget.click();
             }
         });
     }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -70,7 +70,20 @@ namespace pxt.runner {
         $btn.attr("title", label);
         $btn.find('i').attr("class", icon);
         $btn.find('span').text(label);
+
+
+        addFireClickOnEnter($btn);
         return $btn;
+    }
+
+    function addFireClickOnEnter(el: JQuery<HTMLElement>) {
+        el.keypress(e => {
+            const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
+            if (charCode === 13 /* enter */ || charCode === 32 /* space */) {
+                e.preventDefault();
+                (e.currentTarget as HTMLElement).click();
+            }
+        });
     }
 
     function fillWithWidget(


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/948; make snippet buttons so they work with keyboard navigation

Implementation is just copied from https://github.com/microsoft/pxt/blob/922fac34bc6fc9e9d0b9858e9e440933aba69291/webapp/src/sui.tsx#L48