### PR TITLE
Snippet Builder improvements

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -164,12 +164,15 @@ declare namespace pxt {
         mimeType: string;
     }
 
+    type SnippetOutputType = 'blocks'
+    type SnippetOutputBehavior = /*assumed default*/'merge' | 'replace'
     interface SnippetConfig {
         name: string;
         namespace: string;
         group?: string;
         label: string;
-        outputType: string;
+        outputType: SnippetOutputType;
+        outputBehavior?: SnippetOutputBehavior;
         initialOutput?: string;
         questions: SnippetQuestions[];
     }

--- a/pxtblocks/blocklytraverse.ts
+++ b/pxtblocks/blocklytraverse.ts
@@ -1,0 +1,36 @@
+/// <reference path="../localtypings/blockly.d.ts" />
+/// <reference path="../built/pxtlib.d.ts" />
+
+namespace pxt.blocks {
+    export function findRootBlocks(xmlDOM: Element, type?: string): Element[] {
+        let blocks: Element[] = []
+        for (const child in xmlDOM.children) {
+            const xmlChild = xmlDOM.children[child];
+
+            if (xmlChild.tagName === 'block') {
+                if (type) {
+                    const childType = xmlChild.getAttribute('type');
+
+                    if (childType && childType === type) {
+                        blocks.push(xmlChild)
+                    }
+                } else {
+                    blocks.push(xmlChild)
+                }
+            } else {
+                const childChildren = findRootBlock(xmlChild);
+                if (childChildren) {
+                    blocks = blocks.concat(childChildren)
+                }
+            }
+        }
+        return blocks;
+    }
+
+    export function findRootBlock(xmlDOM: Element, type?: string): Element {
+        let blks = findRootBlocks(xmlDOM, type)
+        if (blks.length)
+            return blks[0]
+        return null
+    }
+}

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -451,6 +451,9 @@ class Host
         let fromWorkspaceAsync = (arg: string) =>
             workspace.getTextAsync(arg)
                 .then(scr => {
+                    if (!scr) {
+                        return Promise.reject(new Error(`Cannot find text for package '${arg}' in the workspace.`));
+                    }
                     epkg.setFiles(scr)
                     if (epkg.isTopLevel() && epkg.header)
                         return workspace.recomputeHeaderFlagsAsync(epkg.header, scr)
@@ -469,7 +472,9 @@ class Host
             return fromWorkspaceAsync(pkg.verArgument())
         } else if (proto == "file") {
             let arg = pkg.verArgument()
-            if (arg[0] == ".") arg = resolvePath(pkg.parent.verArgument() + "/" + arg)
+            if (arg[0] == ".") {
+                arg = resolvePath(pkg.parent.verArgument() + "/" + arg)
+            }
             return fromWorkspaceAsync(arg)
         } else if (proto == "embed") {
             epkg.setFiles(pxt.getEmbeddedScript(pkg.verArgument()))

--- a/webapp/src/snippetBuilder.tsx
+++ b/webapp/src/snippetBuilder.tsx
@@ -37,39 +37,6 @@ interface SnippetBuilderState {
     actions?: sui.ModalButton[];
 }
 
-// helper functions
-function findRootBlocks(xmlDOM: Element, type?: string): Element[] {
-    let blocks: Element[] = []
-    for (const child in xmlDOM.children) {
-        const xmlChild = xmlDOM.children[child];
-
-        if (xmlChild.tagName === 'block') {
-            if (type) {
-                const childType = xmlChild.getAttribute('type');
-
-                if (childType && childType === type) {
-                    blocks.push(xmlChild)
-                }
-            } else {
-                blocks.push(xmlChild)
-            }
-        } else {
-            const childChildren = findRootBlock(xmlChild);
-            if (childChildren) {
-                blocks = blocks.concat(childChildren)
-            }
-        }
-    }
-    return blocks;
-}
-
-function findRootBlock(xmlDOM: Element, type?: string): Element {
-    let blks = findRootBlocks(xmlDOM, type)
-    if (blks.length)
-        return blks[0]
-    return null
-}
-
 /**
  * Snippet builder takes a static config file and builds a modal with inputs and outputs based on config settings.
  * An output type is attached to the start of your markdown allowing you to define a number of markdown output. (blocks, lang)
@@ -303,7 +270,7 @@ export class SnippetBuilder extends data.Component<SnippetBuilderProps, SnippetB
             .then(resp => {
                 // get the root blocks (e.g. on_start) from the new code
                 const newXml = Blockly.Xml.textToDom(resp);
-                const newBlocksDom = findRootBlocks(newXml)
+                const newBlocksDom = pxt.blocks.findRootBlocks(newXml)
 
                 // get the existing root blocks
                 let existingBlocks = mainWorkspace.getTopBlocks(true);
@@ -337,7 +304,7 @@ export class SnippetBuilder extends data.Component<SnippetBuilderProps, SnippetB
                 // merge them
                 function merge(pair: { newB: Element, exB: Blockly.Block }) {
                     let { newB, exB } = pair;
-                    const firstChild = findRootBlock(newB)
+                    const firstChild = pxt.blocks.findRootBlock(newB)
                     const toAttach = Blockly.Xml.domToBlock(firstChild, mainWorkspace);
                     exB.getInput("HANDLER").connection.connect(toAttach.previousConnection);
                 }

--- a/webapp/src/snippetBuilder.tsx
+++ b/webapp/src/snippetBuilder.tsx
@@ -14,7 +14,7 @@ import { InputHandler } from './snippetBuilderInputHandler';
 type ISettingsProps = pxt.editor.ISettingsProps;
 
 interface SnippetBuilderProps extends ISettingsProps {
-    mainWorkspace: Blockly.Workspace;
+    mainWorkspace: Blockly.WorkspaceSvg;
     config: pxt.SnippetConfig;
 }
 
@@ -349,6 +349,11 @@ export class SnippetBuilder extends data.Component<SnippetBuilderProps, SnippetB
                     Blockly.Xml.domToBlock(newB, mainWorkspace);
                 }
                 toAttach.forEach(attach)
+
+                // if there wasn't more than one existing block, reformat the code
+                if (existingBlocks.length <= 1) {
+                    pxt.blocks.layout.flow(mainWorkspace, { useViewWidth: true });
+                }
             }).catch((e) => {
                 core.errorNotification(e);
                 throw new Error(`Failed to decompile snippet output`);

--- a/webapp/src/snippetBuilder.tsx
+++ b/webapp/src/snippetBuilder.tsx
@@ -296,6 +296,7 @@ export class SnippetBuilder extends data.Component<SnippetBuilderProps, SnippetB
     injectBlocksToWorkspace() {
         const { tsOutput } = this.state;
         const { mainWorkspace } = this.props
+        const { outputBehavior } = this.state.config;
 
         compiler.getBlocksAsync()
             .then(blocksInfo => compiler.decompileBlocksSnippetAsync(this.replaceTokens(tsOutput), blocksInfo))
@@ -305,7 +306,15 @@ export class SnippetBuilder extends data.Component<SnippetBuilderProps, SnippetB
                 const newBlocksDom = findRootBlocks(newXml)
 
                 // get the existing root blocks
-                const existingBlocks = mainWorkspace.getTopBlocks(true);
+                let existingBlocks = mainWorkspace.getTopBlocks(true);
+
+                // if we're replacing all existing blocks, do that first
+                if (outputBehavior === "replace") {
+                    existingBlocks.forEach(b => {
+                        b.dispose(false);
+                    })
+                    existingBlocks = []
+                }
 
                 // determine which blocks should merge together
                 // TODO: handle parameter mismatch like on_collision's "kind" field.


### PR DESCRIPTION
Helps me prototype the mod-a-game experience and they're generally useful improvements for the SnippetBuilder.

- Allow SnippetBuilder to emit many top-level blocks
- Add support for external .ts files that has snippet content (much easier authoring experience for large snippets)
- Auto-format if <2 existing blocks
- Adds "replace" output mode that replaces all old blocks

The implementation isn't perfect yet since it cannot distinguish on event parameters (on_game_update 500ms vs 1000ms) but it's already more useful for a few scenarios. TODO included in code.

Tested using this custom package: https://github.com/darzu/ModGame