### PR TITLE
Hide user icon on import url dialog

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -519,7 +519,7 @@ export function showImportUrlDialogAsync() {
         },
         jsx: <div className="ui form">
             <div className="ui icon violet message">
-                <i className="user icon"></i>
+                <i className="user icon" aria-hidden={true}></i>
                 <div className="content">
                     <h3 className="header">
                         {lf("User-provided content")}


### PR DESCRIPTION
fixes the error listed in the screenshot in https://github.com/microsoft/pxt-microbit/issues/2379; when I read it before I found a different error and fixed that, but just noticed that there was a screenshot describing this specific error.