### PR TITLE
restart sim on contrast change

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3112,8 +3112,8 @@ export class ProjectView
         const highContrastOn = !this.state.highContrast;
         pxt.tickEvent("app.highcontrast", { on: highContrastOn ? 1 : 0 });
         this.setState({ highContrast: highContrastOn }, () => {
-            if (!!this.state.header) { // in editor
-                this.restartSimulator()
+            if (this.isSimulatorRunning) {  // if running, send updated high contrast state.
+                this.startSimulator()
             }
         });
         core.setHighContrast(highContrastOn);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3112,7 +3112,7 @@ export class ProjectView
         const highContrastOn = !this.state.highContrast;
         pxt.tickEvent("app.highcontrast", { on: highContrastOn ? 1 : 0 });
         this.setState({ highContrast: highContrastOn }, () => {
-            if (this.isSimulatorRunning) {  // if running, send updated high contrast state.
+            if (this.isSimulatorRunning()) {  // if running, send updated high contrast state.
                 this.startSimulator()
             }
         });


### PR DESCRIPTION
fix issue noted in https://github.com/microsoft/pxt-microbit/pull/2409; high contrast mode wasn't being toggled in the sim because this call to restart was just doing the fast restart, not updating the theme / state.