### PR TITLE
Remove reference to IE11 from docs as a supported browsers

### DIFF
--- a/common-docs/browsers.md
+++ b/common-docs/browsers.md
@@ -8,7 +8,6 @@ Windows 10:
 * Microsoft Edge
 * Google Chrome
 * Mozilla Firefox
-* Internet Explorer 11 (Exception: for MakeCode Arcade use one of the other browsers)
 
 ## Mac
 
@@ -63,13 +62,6 @@ version of one of the following:
 
 ![](/static/configurations/osx-version.png)
 
-### Internet Explorer
-
-* Click on the Settings icon in the top right
-* Click 'About Internet Explorer'
-* This window will be displayed:
-
-![](/static/configurations/ie-version.png)
 
 ### Microsoft Edge
 

--- a/common-docs/browsers/linux.md
+++ b/common-docs/browsers/linux.md
@@ -7,7 +7,6 @@ Please see [here][technical] for technical information on which browsers are
 supported, or [here][versions] to check which version you are using.
 
 [edge]: https://www.microsoft.com/en-us/windows/microsoft-edge
-[ie]: https://www.microsoft.com/en-us/download/internet-explorer.aspx
 [firefox]: https://www.mozilla.org/en-US/firefox/new/
 [chrome]: https://www.google.com/chrome/
 [opera]: https://www.opera.com

--- a/common-docs/browsers/technical.md
+++ b/common-docs/browsers/technical.md
@@ -1,8 +1,8 @@
 # Technical information about browser support
 
 Visiting [@homeurl@][] requires that you use a recent version of a modern
-browser, such as Microsoft Edge, Google Chrome, Mozilla Firefox, Safari, Opera,
-or IE11.  This is because the editor uses modern web technologies such as [web
+browser, such as Microsoft Edge, Google Chrome, Mozilla Firefox, Safari, Opera.
+This is because the editor uses modern web technologies such as [web
 workers][] to enable compiling [TypeScript][] in the browser, and includes the
 same [Monaco][] editor that powers [Visual Studio Code][].
 
@@ -21,9 +21,8 @@ browsers**, but if you can't then you must use at least:
 | ------------------- | --------------- | -------------- | ----------- | ---------- | ---------- |
 | - - - - - - - - - - - - - - - - - - - | - - - - - - - - - - - - - - - | - - - - - - - - - - - - - - | - - - - - - - - - - - | - - - - - - - - - - | - - - - - - - - - - |
 | Microsoft Edge      | 12              | March 2015     | Windows 10+ | N/A        | N/A        |
-| Internet Explorer   | 11              | October 2013   | Windows 7+  | N/A        | N/A        |
-| Mozilla Firefox     | 31 ESR          | July 2014      | Windows XP+ | OS X 10.6+ | N/A        |
-| Google Chrome       | 38              | October 2014   | Windows XP+ | OS X 10.6+ | Android 5+ |
+| Mozilla Firefox     | 60              | May 2018       | Windows 7+  | OS X 10.6+ | N/A        |
+| Google Chrome       | 60              | October 2018   | Windows 7+  | OS X 10.6+ | Android 5+ |
 | Safari              | 9               | September 2015 | N/A         | OS X 10.9+ | N/A        |
 | Opera               | 21              | May 2014       | Windows 7+  | OS X 10.9+ | N/A        |
 | Mobile Safari       | 9               | September 2015 | N/A         | N/A        | iOS 9+     |

--- a/common-docs/browsers/windows.md
+++ b/common-docs/browsers/windows.md
@@ -1,7 +1,7 @@
 # Recommended browser for Windows
 
 We recommend [Microsoft Edge][edge] if you are running Windows 10, but users on
-Windows 7 or higher can use [Internet Explorer 11][ie] or recent versions of
+Windows 7 or higher can use [Microsoft Edge beta][edgebeta] or recent versions of
 [Mozilla Firefox][firefox], [Google Chrome][chrome], or [Opera][opera].
 
 
@@ -9,7 +9,7 @@ Please see [here][technical] for technical information on which browsers are
 supported, or [here][versions] to check which version you are using.
 
 [edge]: https://www.microsoft.com/en-us/windows/microsoft-edge
-[ie]: https://www.microsoft.com/en-us/download/internet-explorer.aspx
+[edgebeta]: https://www.microsoftedgeinsider.com/en-us/download/
 [firefox]: https://www.mozilla.org/en-US/firefox/new/
 [chrome]: https://www.google.com/chrome/
 [opera]: https://www.opera.com


### PR DESCRIPTION
We will still support IE11 on microbit for at least this school year. This removes reference to IE11 as supported browsers to discourage users. Also updates some of the chrome versions. 