### PR TITLE
Don't start the simulator if melody editor is visible

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -593,6 +593,10 @@ export class ProjectView
                 pxt.debug(`sim: skip blocks auto, !active`)
                 return;
             }
+            if (this.blocksEditor && this.blocksEditor.isDropdownDivVisible()) {
+                pxt.debug(`sim: skip blocks auto, field editor is open`);
+                return;
+            }
             this.runSimulator({ debug: !!this.state.debugging, background: true });
         },
         1000, true);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -162,6 +162,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
+    isDropdownDivVisible() {
+        return Blockly && Blockly.DropDownDiv && Blockly.DropDownDiv.isVisible();
+    }
+
     private saveBlockly(): string {
         // make sure we don't return an empty document before we get started
         // otherwise it may get saved and we're in trouble
@@ -456,7 +460,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
                 else if (ev.element == 'melody-editor') {
                     if (ev.newValue) {
-                        shouldRestartSim = this.parent.state.simState == pxt.editor.SimState.Running;
+                        shouldRestartSim = this.parent.state.simState != pxt.editor.SimState.Stopped;
                         this.parent.stopSimulator();
                     }
                     else {


### PR DESCRIPTION
If you are on a slow machine and you make a change right before you open the melody editor, the debounced compile callback will cause the simulator to start anyways. Changing the logic so that the simulator won't start if a dropdown is open in blockly (i.e. you are actively changing something).