### PR TITLE
Add image tags and gallery filter

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4314,6 +4314,7 @@ interface SpriteGlobalMeta {
     height?: number;
     blockIdentity: string;
     creator: string;
+    tags?: string;
     standaloneSprites?: string[];
 }
 
@@ -4514,8 +4515,10 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
                 }
 
                 ts += `    //% fixedInstance jres blockIdentity=${metaInfo.blockIdentity}\n`
-                if (info.tags)
-                    ts += `    //% tags="${info.tags}"\n`;
+                if (info.tags || metaInfo.tags) {
+                    const tags = `${metaInfo.tags || ""} ${info.tags || ""}`;
+                    ts += `    //% tags="${tags.trim()}"\n`;
+                }
                 ts += `    export const ${key} = ${metaInfo.creator}(hex\`\`);\n`
 
                 pxt.log(`add ${key}; ${JSON.stringify(jresources[key]).length} bytes`)

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4322,6 +4322,7 @@ interface SpriteInfo {
     height?: number;
     xSpacing?: number;
     ySpacing?: number;
+    tags?: string;
     frames?: string[];
 }
 
@@ -4442,7 +4443,6 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
         if (sheet.colorType == 0) {
             sheet.colorType = 6
             sheet.depth = 8
-            let transparent = palette[0][0] < 10 ? 0x00 : 0xff
             for (let i = 0; i < sheet.data.length; i += 4) {
                 if (closestColor(sheet.data, i, false) == 0)
                     sheet.data[i + 3] = 0x00
@@ -4514,6 +4514,8 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
                 }
 
                 ts += `    //% fixedInstance jres blockIdentity=${metaInfo.blockIdentity}\n`
+                if (info.tags)
+                    ts += `    //% tags="${info.tags}"\n`;
                 ts += `    export const ${key} = ${metaInfo.creator}(hex\`\`);\n`
 
                 pxt.log(`add ${key}; ${JSON.stringify(jresources[key]).length} bytes`)

--- a/docs/cli/buildsprites.md
+++ b/docs/cli/buildsprites.md
@@ -100,8 +100,38 @@ You can add tags that describe your sprites in the `meta.json` file.
 
 These can be used to filter sprites into (or out of) galleries in the image editor.
 
+These tags should be separated by spaces.
+If you want a tag to only be used to include the sprite in a gallery and not to exclude it,
+you can start the tag with a question mark ``?``.
+For example, if you have a sprite that is a pretty flower,
+that can be used as a flower but also on it's own,
+you might set it to have the following tags:
+
+``flower ?tile``
+
+Note that tags are **case insensitive**.
+
 You can add tags per PNG file as well. If both the `meta.json` and
 the `json` file for the specific PNG contain tags, then **both** sets are included.
+
+### Filters
+
+Tags can be used to **include** or **exclude** images from galleries.
+In blocks, these can be used with a filter defined for the Sprite Editor.
+This filter is a string containing a space separated series of tags.
+When the first character of a tag is an exclamation mark ``!``,
+that tag will be excluded from the gallery.
+
+For example, if a sprite editor is set to have the following filter:
+
+``flower !tile``
+
+Then the gallery will contain **only** sprites with the ``flower`` tag,
+that do not contain the ``tile`` tag.
+
+Note that filters are **case insensitive**, and can partially match tags;
+if you have a filter to include only ``flower`` images,
+it will also show ``flowery`` images.
 
 ## See Also
 

--- a/docs/cli/buildsprites.md
+++ b/docs/cli/buildsprites.md
@@ -1,6 +1,6 @@
 # pxt-buildsprites Manual Page
 
-### @description Encode sprite sheets into a Jres resource
+## @description Encode sprite sheets into a Jres resource
 
 Encode sprite sheets into a Jres resource
 
@@ -46,6 +46,8 @@ Example:
 }
 ```
 
+### Multiple sprites per file
+
 If your PNG files contain more than one sprite each, you can add the following
 to the `meta.json` file:
 
@@ -84,6 +86,22 @@ with different directions in which 16x16 sprite is going you would use the follo
 The frames will be called `images.castle.princessFront0` etc., where the namespace
 is taken from `meta.json` above, `princess` from file name, and the suffix from `frames`
 field.
+
+### Tags
+
+You can add tags that describe your sprites in the `meta.json` file.
+
+```json
+{
+    "tags": "character hero"
+    // ...
+}
+```
+
+These can be used to filter sprites into (or out of) galleries in the image editor.
+
+You can add tags per PNG file as well. If both the `meta.json` and
+the `json` file for the specific PNG contain tags, then **both** sets are included.
 
 ## See Also
 

--- a/docs/cli/buildsprites.md
+++ b/docs/cli/buildsprites.md
@@ -129,9 +129,7 @@ For example, if a sprite editor is set to have the following filter:
 Then the gallery will contain **only** sprites with the ``flower`` tag,
 that do not contain the ``tile`` tag.
 
-Note that filters are **case insensitive**, and can partially match tags;
-if you have a filter to include only ``flower`` images,
-it will also show ``flowery`` images.
+Note that filters are **case insensitive**.
 
 ## See Also
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -553,6 +553,7 @@ declare namespace ts.pxtc {
         group?: string;
         whenUsed?: boolean;
         jres?: string;
+        tags?: string; // Tags describing an element to filter and search for elements
         useLoc?: string; // The qName of another API whose localization will be used if this API is not translated and if both block definitions are identical
         topblock?: boolean;
         topblockWeight?: number;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -553,7 +553,7 @@ declare namespace ts.pxtc {
         group?: string;
         whenUsed?: boolean;
         jres?: string;
-        tags?: string; // Tags describing an element to filter and search for elements
+        tags?: string; // value used to describe an element in a gallery when filtering / searching
         useLoc?: string; // The qName of another API whose localization will be used if this API is not translated and if both block definitions are identical
         topblock?: boolean;
         topblockWeight?: number;

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -264,7 +264,7 @@ namespace pxtblockly {
             return parsed;
         }
 
-        if (opts.sizes != null) {
+        if (opts.sizes) {
             const pairs = opts.sizes.split(";");
             const sizes: [number, number][] = [];
             for (let i = 0; i < pairs.length; i++) {
@@ -295,7 +295,7 @@ namespace pxtblockly {
             }
         }
 
-        if (opts.filter != null) {
+        if (opts.filter) {
             parsed.filter = opts.filter;
         }
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -13,6 +13,8 @@ namespace pxtblockly {
 
         initWidth: string;
         initHeight: string;
+
+        filter?: string;
     }
 
     interface ParsedSpriteEditorOptions {
@@ -20,6 +22,7 @@ namespace pxtblockly {
         initColor: number;
         initWidth: number;
         initHeight: number;
+        filter?: string;
     }
 
     // 32 is specifically chosen so that we can scale the images for the default
@@ -83,9 +86,7 @@ namespace pxtblockly {
          * @private
          */
         showEditor_() {
-            const windowSize = goog.dom.getViewportSize();
-            const scrollOffset = goog.style.getViewportPageOffset(document);
-
+            const { sizes, initColor, filter} = this.params;
             // If there is an existing drop-down someone else owns, hide it immediately and clear it.
             Blockly.DropDownDiv.hideWithoutAnimation();
             Blockly.DropDownDiv.clearContent();
@@ -104,11 +105,15 @@ namespace pxtblockly {
                 Blockly.DropDownDiv.hideIfOwner(this);
             });
 
-            this.editor.setActiveColor(this.params.initColor, true);
-            if (!this.params.sizes.some(s => s[0] === this.state.width && s[1] === this.state.height)) {
-                this.params.sizes.push([this.state.width, this.state.height]);
+            this.editor.setActiveColor(initColor, true);
+            if (!sizes.some(s => s[0] === this.state.width && s[1] === this.state.height)) {
+                sizes.push([this.state.width, this.state.height]);
             }
-            this.editor.setSizePresets(this.params.sizes);
+            this.editor.setSizePresets(sizes);
+
+            if (filter) {
+                this.editor.setGalleryFilter(filter);
+            }
 
             goog.style.setHeight(contentDiv, this.editor.outerHeight() + 1);
             goog.style.setWidth(contentDiv, this.editor.outerWidth() + 1);
@@ -288,6 +293,10 @@ namespace pxtblockly {
                 parsed.initWidth = sizes[0][0];
                 parsed.initHeight = sizes[0][1];
             }
+        }
+
+        if (opts.filter != null) {
+            parsed.filter = opts.filter;
         }
 
         parsed.initColor = withDefault(opts.initColor, parsed.initColor);

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -94,13 +94,12 @@ namespace pxtsprite {
                 .filter(el => !!el);
 
             return target.filter(el =>
-                includeTags.every(tag => itemContainsTag(el, tag))
-                && excludeTags.every(tag => !itemContainsTag(el, tag))
+                includeTags.every(tag => el.tags.indexOf(tag) !== -1)
+                && excludeTags.every(tag => {
+                    const index = el.tags.indexOf(tag);
+                    return index === -1 || el.tags.charAt(index - 1) === "?";
+                })
             );
-
-            function itemContainsTag(item: GalleryItem, tag: string) {
-                return item.tags.indexOf(tag) !== -1;
-            }
         }
 
         protected buildDom() {
@@ -253,11 +252,12 @@ namespace pxtsprite {
             generateIcons(syms);
 
             return syms.map(sym => {
+                const { tags } = sym.attributes;
                 return {
                     qName: sym.qName,
                     src: sym.attributes.iconURL,
                     alt: sym.qName,
-                    tags: sym.attributes.tags.toLowerCase() || ""
+                    tags: (tags && tags.toLowerCase()) || ""
                 };
             });
         }

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -85,7 +85,7 @@ namespace pxtsprite {
         protected applyFilter(target: GalleryItem[], tags: string[]) {
             return target.filter(el =>
                 tags.every(tag => {
-                    if (tag.startsWith("!")) {
+                    if (tag.indexOf("!") === 0) {
                         return !itemContainsTag(el, tag.substring(1));
                     } else {
                         return itemContainsTag(el, tag);

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -78,16 +78,17 @@ namespace pxtsprite {
         }
 
         setFilter(filter: string) {
-            const filterPieces = filter && filter.split(" ").filter(el => !!el);
+            const filterPieces = filter && filter.split(" ");
             this.galleryItems = this.applyFilter(this.getGalleryItems("Image"), filterPieces);
         }
 
         protected applyFilter(target: GalleryItem[], tags: string[]) {
             const includeTags = tags
-                .filter(tag => tag.indexOf("!") !== 0);
+                .filter(tag => tag && tag.indexOf("!") !== 0);
             const excludeTags = tags
-                .filter(tag => tag.indexOf("!") === 0)
-                .map(el => el.substring(1));
+                .filter(tag => tag && tag.indexOf("!") === 0)
+                .map(el => el.substring(1))
+                .filter(el => !!el);
 
             return target.filter(el =>
                 includeTags.every(tag => itemContainsTag(el, tag))

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -3,6 +3,7 @@ namespace pxtsprite {
         qName: string;
         src: string;
         alt: string;
+        tags: string;
     }
 
     const COLUMNS = 4;
@@ -11,6 +12,7 @@ namespace pxtsprite {
         protected info: pxtc.BlocksInfo;
         protected contentDiv: HTMLDivElement;
         protected containerDiv: HTMLDivElement;
+        protected galleryItems: GalleryItem[];
 
         protected itemBorderColor: string;
         protected itemBackgroundColor: string;
@@ -75,11 +77,35 @@ namespace pxtsprite {
             this.containerDiv.style.height = height + "px";
         }
 
+        setFilter(filter: string) {
+            const filterPieces = filter && filter.split(" ");
+            this.galleryItems = this.applyFilter(this.getGalleryItems("Image"), filterPieces);
+        }
+
+        protected applyFilter(target: GalleryItem[], tags: string[]) {
+            return target.filter(el =>
+                tags.every(tag => {
+                    if (tag.startsWith("!")) {
+                        return !itemContainsTag(el, tag.substring(1));
+                    } else {
+                        return itemContainsTag(el, tag);
+                    }
+                })
+            );
+
+            function itemContainsTag(item: GalleryItem, tag: string) {
+                return item.tags.indexOf(tag) != -1 || item.qName.indexOf(tag) != -1
+            }
+        }
+
         protected buildDom() {
             while (this.contentDiv.firstChild) this.contentDiv.removeChild(this.contentDiv.firstChild);
             const totalWidth = this.containerDiv.clientWidth - 17;
             const buttonWidth = (Math.floor(totalWidth / COLUMNS) - 8) + "px";
-            this.getGalleryItems("Image").forEach((item, i) => this.mkButton(item.src, item.alt, item.qName, i, buttonWidth));
+            if (!this.galleryItems) {
+                this.galleryItems = this.getGalleryItems("Image");
+            }
+            this.galleryItems.forEach((item, i) => this.mkButton(item.src, item.alt, item.qName, i, buttonWidth));
         }
 
         protected initStyles() {
@@ -225,7 +251,8 @@ namespace pxtsprite {
                 return {
                     qName: sym.qName,
                     src: sym.attributes.iconURL,
-                    alt: sym.qName
+                    alt: sym.qName,
+                    tags: sym.attributes.tags || ""
                 };
             });
         }

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -85,13 +85,12 @@ namespace pxtsprite {
         protected applyFilter(target: GalleryItem[], tags: string[]) {
             tags = tags
                 .filter(el => !!el)
-                .map(el => el && el.toLowerCase());
+                .map(el => el.toLowerCase());
             const includeTags = tags
                 .filter(tag => tag.indexOf("!") !== 0);
             const excludeTags = tags
-                .filter(tag => tag.indexOf("!") === 0)
-                .map(el => el.substring(1))
-                .filter(el => !!el);
+                .filter(tag => tag.indexOf("!") === 0 && tag.length > 1)
+                .map(tag => tag.substring(1));
 
             return target.filter(el => checkInclude(el) && checkExclude(el));
 
@@ -101,13 +100,13 @@ namespace pxtsprite {
                         const ind = tag.indexOf(filterTag);
                         return ind === 0 || ind === 1 && tag.charAt(0) === "?";
                     })
-                )
+                );
             }
 
             function checkExclude(item: GalleryItem) {
                 return excludeTags.every(filterTag =>
                     !item.tags.some(tag => tag.indexOf(filterTag) === -1)
-                )
+                );
             }
         }
 

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -83,10 +83,13 @@ namespace pxtsprite {
         }
 
         protected applyFilter(target: GalleryItem[], tags: string[]) {
+            tags = tags
+                .filter(el => !!el)
+                .map(el => el && el.toLowerCase());
             const includeTags = tags
-                .filter(tag => tag && tag.indexOf("!") !== 0);
+                .filter(tag => tag.indexOf("!") !== 0);
             const excludeTags = tags
-                .filter(tag => tag && tag.indexOf("!") === 0)
+                .filter(tag => tag.indexOf("!") === 0)
                 .map(el => el.substring(1))
                 .filter(el => !!el);
 
@@ -254,7 +257,7 @@ namespace pxtsprite {
                     qName: sym.qName,
                     src: sym.attributes.iconURL,
                     alt: sym.qName,
-                    tags: sym.attributes.tags || ""
+                    tags: sym.attributes.tags.toLowerCase() || ""
                 };
             });
         }

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -78,7 +78,7 @@ namespace pxtsprite {
         }
 
         setFilter(filter: string) {
-            const filterPieces = filter && filter.split(" ");
+            const filterPieces = filter && filter.split(" ").filter(el => !!el);
             this.galleryItems = this.applyFilter(this.getGalleryItems("Image"), filterPieces);
         }
 
@@ -94,7 +94,7 @@ namespace pxtsprite {
             );
 
             function itemContainsTag(item: GalleryItem, tag: string) {
-                return item.tags.indexOf(tag) != -1 || item.qName.indexOf(tag) != -1
+                return item.tags.indexOf(tag) != -1;
             }
         }
 

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -3,7 +3,7 @@ namespace pxtsprite {
         qName: string;
         src: string;
         alt: string;
-        tags: string;
+        tags: string[];
     }
 
     const COLUMNS = 4;
@@ -93,13 +93,22 @@ namespace pxtsprite {
                 .map(el => el.substring(1))
                 .filter(el => !!el);
 
-            return target.filter(el =>
-                includeTags.every(tag => el.tags.indexOf(tag) !== -1)
-                && excludeTags.every(tag => {
-                    const index = el.tags.indexOf(tag);
-                    return index === -1 || el.tags.charAt(index - 1) === "?";
-                })
-            );
+            return target.filter(el => checkInclude(el) && checkExclude(el));
+
+            function checkInclude(item: GalleryItem) {
+                return includeTags.every(filterTag =>
+                    item.tags.some(tag => {
+                        const ind = tag.indexOf(filterTag);
+                        return ind === 0 || ind === 1 && tag.charAt(0) === "?";
+                    })
+                )
+            }
+
+            function checkExclude(item: GalleryItem) {
+                return excludeTags.every(filterTag =>
+                    !item.tags.some(tag => tag.indexOf(filterTag) === -1)
+                )
+            }
         }
 
         protected buildDom() {
@@ -259,12 +268,16 @@ namespace pxtsprite {
             generateIcons(syms);
 
             return syms.map(sym => {
-                const { tags } = sym.attributes;
+                const splitTags = (sym.attributes.tags || "")
+                    .toLowerCase()
+                    .split(" ")
+                    .filter(el => !!el);
+
                 return {
                     qName: sym.qName,
                     src: sym.attributes.iconURL,
                     alt: sym.qName,
-                    tags: (tags && tags.toLowerCase()) || ""
+                    tags: splitTags
                 };
             });
         }

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -83,18 +83,17 @@ namespace pxtsprite {
         }
 
         protected applyFilter(target: GalleryItem[], tags: string[]) {
+            const includeTags = tags.filter(tag => tag.indexOf("!") !== 0);
+            const excludeTags = tags.filter(tag => tag.indexOf("!") === 0).map(el => el.substring(1));
+
             return target.filter(el =>
-                tags.every(tag => {
-                    if (tag.indexOf("!") === 0) {
-                        return !itemContainsTag(el, tag.substring(1));
-                    } else {
-                        return itemContainsTag(el, tag);
-                    }
-                })
+                includeTags.every(tag => itemContainsTag(el, tag))
+                && excludeTags.every(tag => !itemContainsTag(el, tag))
+
             );
 
             function itemContainsTag(item: GalleryItem, tag: string) {
-                return item.tags.indexOf(tag) != -1;
+                return item.tags.indexOf(tag) !== -1;
             }
         }
 

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -83,13 +83,15 @@ namespace pxtsprite {
         }
 
         protected applyFilter(target: GalleryItem[], tags: string[]) {
-            const includeTags = tags.filter(tag => tag.indexOf("!") !== 0);
-            const excludeTags = tags.filter(tag => tag.indexOf("!") === 0).map(el => el.substring(1));
+            const includeTags = tags
+                .filter(tag => tag.indexOf("!") !== 0);
+            const excludeTags = tags
+                .filter(tag => tag.indexOf("!") === 0)
+                .map(el => el.substring(1));
 
             return target.filter(el =>
                 includeTags.every(tag => itemContainsTag(el, tag))
                 && excludeTags.every(tag => !itemContainsTag(el, tag))
-
             );
 
             function itemContainsTag(item: GalleryItem, tag: string) {

--- a/pxtlib/sprite-editor/gallery.ts
+++ b/pxtlib/sprite-editor/gallery.ts
@@ -95,17 +95,17 @@ namespace pxtsprite {
             return target.filter(el => checkInclude(el) && checkExclude(el));
 
             function checkInclude(item: GalleryItem) {
-                return includeTags.every(filterTag =>
-                    item.tags.some(tag => {
-                        const ind = tag.indexOf(filterTag);
-                        return ind === 0 || ind === 1 && tag.charAt(0) === "?";
-                    })
-                );
+                return includeTags.every(filterTag => {
+                    const optFilterTag = `?${filterTag}`;
+                    return item.tags.some(tag =>
+                        tag === filterTag || tag === optFilterTag
+                    )
+                });
             }
 
             function checkExclude(item: GalleryItem) {
                 return excludeTags.every(filterTag =>
-                    !item.tags.some(tag => tag.indexOf(filterTag) === -1)
+                    !item.tags.some(tag => tag === filterTag)
                 );
             }
         }

--- a/pxtlib/sprite-editor/spriteEditor.ts
+++ b/pxtlib/sprite-editor/spriteEditor.ts
@@ -301,6 +301,10 @@ namespace pxtsprite {
             this.bottomBar.setSizePresets(presets, this.columns, this.rows);
         }
 
+        setGalleryFilter(filter: string) {
+            this.gallery.setFilter(filter);
+        }
+
         canvasWidth() {
             return this.columns;
         }


### PR DESCRIPTION
Just on a per image editor type basis for now, can add search or user filtering later but probably needs some ui design / feels a bit separate

related prs:

* https://github.com/microsoft/pxt-common-packages/pull/953
* https://github.com/microsoft/pxt-arcade/pull/1271


makes it so you can filter things into or out of the image editor gallery based off tags:

![2019-08-30 13 51 51](https://user-images.githubusercontent.com/5615930/64050851-1acbaa80-cb2e-11e9-882d-3c54fa8e1770.gif)

Couple questions;

If we want to use these tags for some sort of search eventually, would need to extract them for localization; it seems like having these as commentAttributes as they are here would allow for that, but just want to confirm

I haven't document the format for the new fields in the docs, but for now its:

* **filter**: a string containing a series of tags, where tags beginning with "!" mean to exclude images with that tag and any other tag means it must be included. In [this](https://github.com/microsoft/pxt-common-packages/pull/953) pr, it's used to remove tiles and dialog images from _spriteImage ("!tile !dialog"), and only include tiles / dialog in the other two blocks
* **tags**: a string with the tags that describe this image; a "?" before a tag means it should not be used to exclude the image. e.g. there are certain tiles that also make sense as sprite types of images, e.g. the [the buttons here](https://github.com/microsoft/pxt-arcade/pull/1271/files#diff-507d0aab0c8cf8238c9c0ac5e6c85a5dR15)

Is that confusing / unmaintainable? I'm happy to go with a different approach, haven't spent too much time thinking of alternatives.