### PR TITLE
Add a video to `User Tutorials` page

### DIFF
--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -4,9 +4,15 @@ This guide explains how users can publish their own [tutorials](/writing-docs/tu
 
 There are 2 ways of sharing a tutorial: use a shared script or publish it in a [GitHub](https://github.com) repository.
 
-For a quick introdution to writing and sharing a user tutorial, watch this video:
+## ~ hint
 
-![User tutorial video](#)
+#### Custom tutorial example
+
+For a quick introduction on writing and sharing a user tutorial, see this video:
+
+https://youtu.be/lZucrzDgoIE
+
+## ~
 
 ## Authoring
 

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -4,6 +4,10 @@ This guide explains how users can publish their own [tutorials](/writing-docs/tu
 
 There are 2 ways of sharing a tutorial: use a shared script or publish it in a [GitHub](https://github.com) repository.
 
+For a quick introdution to writing and sharing a user tutorial, watch this video:
+
+![User tutorial video](#)
+
 ## Authoring
 
 Author the tutorial content in the **README.md** file in your project. The format is the same as what's documented in [tutorials](/writing-docs/tutorials). 


### PR DESCRIPTION
I've created a video showing how to make a shared user tutorial. If it's seems ok, maybe someone can put it up to YouTube and I can add it to the 'User Tutorials' page:

https://microsoft-my.sharepoint.com/:v:/p/v-gani/EY1k6lxsbhlPubBRsWt1R04BZTfb0BnQoCIyWLiUy06MIw?e=7kcpdz