### PR TITLE
auto focus on sim after clicking play button

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -95,6 +95,11 @@ namespace pxsim {
             this.setState(SimulatorState.Pending);
         }
 
+        focus() {
+            const frame = this.simFrames()[0];
+            if (frame) frame.focus();
+        }
+
         private setStarting() {
             this.setState(SimulatorState.Starting);
         }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -274,6 +274,7 @@ namespace pxsim {
                     else
                         this.start();
                 }
+                frame.focus()
                 return false;
             }
             wrapper.appendChild(i);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2278,6 +2278,7 @@ export class ProjectView
             default:
                 this.maybeShowPackageErrors(true);
                 this.startSimulator(opts);
+                simulator.driver.focus()
                 break;
         }
     }
@@ -2448,6 +2449,7 @@ export class ProjectView
             simulator.driver.stopSound();
             simulator.driver.restart(); // fast restart
         }
+        simulator.driver.focus()
         if (!isDebug) {
             this.blocksEditor.clearBreakpoints();
         }


### PR DESCRIPTION
no bad double click necessary anymore

![2019-09-04 13 00 46](https://user-images.githubusercontent.com/5615930/64287266-0ca5d180-cf14-11e9-8b0e-ff796e8f08c2.gif)

second commit also makes simtoolbar start and restart buttons focus on sim as well