### PR TITLE
Add target option to name project when created

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -343,6 +343,7 @@ declare namespace pxt {
         recipes?: boolean; // inlined tutorials
         checkForHwVariantWebUSB?: boolean; // check for hardware variant using webusb before compiling
         leanShare?: boolean; // use leanscript.html instead of script.html for sharing pages
+        nameProjectFirst?: boolean;
     }
 
     interface SocialOptions {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -296,6 +296,8 @@ namespace pxt.editor {
 
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;
 
+        askForProjectNameAsync(): Promise<string>;
+
         pushScreenshotHandler(handler: (msg: ScreenshotData) => void): void;
         popScreenshotHandler(): void;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -104,6 +104,7 @@ export class ProjectView
     scriptManagerDialog: scriptmanager.ScriptManagerDialog;
     importDialog: projects.ImportDialog;
     exitAndSaveDialog: projects.ExitAndSaveDialog;
+    newProjectNameDialog: projects.NewProjectNameDialog;
     chooseHwDialog: projects.ChooseHwDialog;
     chooseRecipeDialog: tutorial.ChooseRecipeDialog;
     prevEditorId: string;
@@ -2869,6 +2870,10 @@ export class ProjectView
         }
     }
 
+    askForProjectNameAsync() {
+        return this.newProjectNameDialog.askNameAsync()
+    }
+
     showPackageDialog() {
         this.scriptSearch.showExtensions();
     }
@@ -3210,6 +3215,10 @@ export class ProjectView
         this.exitAndSaveDialog = c;
     }
 
+    private handleNewProjectNameDialogRef = (c: projects.NewProjectNameDialog) => {
+        this.newProjectNameDialog = c;
+    }
+
     private handleShareEditorRef = (c: share.ShareEditor) => {
         this.shareEditor = c;
     }
@@ -3359,6 +3368,7 @@ export class ProjectView
                 {inHome ? <projects.ImportDialog parent={this} ref={this.handleImportDialogRef} /> : undefined}
                 {inHome && targetTheme.scriptManager ? <scriptmanager.ScriptManagerDialog parent={this} ref={this.handleScriptManagerDialogRef} onClose={this.handleScriptManagerDialogClose} /> : undefined}
                 {sandbox ? undefined : <projects.ExitAndSaveDialog parent={this} ref={this.handleExitAndSaveDialogRef} />}
+                {sandbox ? undefined : <projects.NewProjectNameDialog parent={this} ref={this.handleNewProjectNameDialogRef} />}
                 {hwDialog ? <projects.ChooseHwDialog parent={this} ref={this.handleChooseHwDialogRef} /> : undefined}
                 {recipes ? <tutorial.ChooseRecipeDialog parent={this} ref={this.handleChooseRecipeDialogRef} /> : undefined}
                 {sandbox || !sharingEnabled ? undefined : <share.ShareEditor parent={this} ref={this.handleShareEditorRef} loading={this.state.publishing} />}


### PR DESCRIPTION
This adds a dialog that pops up when a new project is created using the big button in the home screen. We've discussed that with David a few months back. This is controlled by appTheme option (to be enabled for Arcade).

With the new `settings` namespace, the storage resets when the name changes, and also stays on device when the name is the same on two programs. Because of that it's more important now to name projects.

If you hit "Create!" with no name, you get "Untitled".

![Sep-04-2019 17-49-26](https://user-images.githubusercontent.com/10673976/64303315-69b57d80-cf3c-11e9-9139-265866cbac42.gif)
