### PR TITLE
Emit ldlit in Thumb in the correct order

### DIFF
--- a/pxtcompiler/emitter/thumb.ts
+++ b/pxtcompiler/emitter/thumb.ts
@@ -288,7 +288,11 @@ namespace ts.pxtc.thumb {
                         }
                     }
                     let reg = line.words[1]
-                    let v = line.words[3]
+                    // make sure the key in values[] below doesn't look like integer
+                    // we rely on Object.keys() returning stuff in insertion order, and integers mess with it
+                    // see https://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys
+                    // or possibly https://www.stefanjudis.com/today-i-learned/property-order-is-predictable-in-javascript-objects-since-es2015/
+                    let v = "#" + line.words[3]
                     let lbl = U.lookup(values, v)
                     if (!lbl) {
                         lbl = "_ldlit_" + ++seq
@@ -305,7 +309,7 @@ namespace ts.pxtc.thumb {
                     txtLines.push(".balign 4")
                     for (let v of Object.keys(values)) {
                         let lbl = values[v]
-                        txtLines.push(lbl + ": .word " + v)
+                        txtLines.push(lbl + ": .word " + v.slice(1))
                     }
                     if (needsJumpOver)
                         txtLines.push(jmplbl + ":")

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -23,8 +23,10 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[]) {
         output += `${category} TS${diagnostic.code}: ${ts.pxtc.flattenDiagnosticMessageText(diagnostic.messageText, "\n")}\n`;
     }
 
-    if (output) // helpful for debugging
-        pxt.debug(output);
+    // people often ask about where to look for errors, and many will look in the console
+    // the output.txt has usability issues
+    if (output)
+        pxt.log(output);
 
     if (!output)
         output = U.lf("Everything seems fine!\n")


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1118

Gotta love JavaScript!

The second change is logging output.txt when there are errors to JS console, since this is usually where more advanced people would be looking.
