### PR TITLE
allow intersection types in blocks

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -931,8 +931,9 @@ namespace pxt.blocks {
                     // to the blocks that accept any array (e.g. length, push, pop, etc)
                     if (isArrayType(subtype)) {
                         if (types.length > 1) {
-                            // type inference will potentially break non-trivial arrays until we have better
-                            // type handling in blocks, so escape and allow any block to be dropped in.
+                            // type inference will potentially break non-trivial arrays in intersections
+                            // until we have better type handling in blocks,
+                            // so escape and allow any block to be dropped in.
                             return null;
                         } else {
                             output.push("Array");

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -768,29 +768,23 @@ namespace pxt.blocks {
                             inputName = defName;
                             if (instance && part.name === "this") {
                                 inputCheck = pr.type;
-                            } else if (pr.type == "number") {
-                                if (pr.shadowBlockId && pr.shadowBlockId == "value") {
-                                    inputName = undefined;
-                                    fields.push(namedField(new Blockly.FieldTextInput("0", Blockly.FieldTextInput.numberValidator), defName));
-                                }
-                                else {
-                                    inputCheck = "Number"
-                                }
-                            } else if (pr.type == "boolean") {
-                                inputCheck = "Boolean"
-                            } else if (pr.type == "string") {
-                                if (pr.shadowOptions && pr.shadowOptions.toString) {
-                                    inputCheck = undefined;
-                                }
-                                else {
-                                    inputCheck = "String"
-                                }
-                            } else if (pr.type == "any") {
+                            } else if (pr.type == "number" && pr.shadowBlockId && pr.shadowBlockId == "value") {
+                                inputName = undefined;
+                                fields.push(namedField(new Blockly.FieldTextInput("0", Blockly.FieldTextInput.numberValidator), defName));
+                            } else if (pr.type == "string" && pr.shadowOptions && pr.shadowOptions.toString) {
                                 inputCheck = null;
                             } else if (pr.type.indexOf("|") !== -1) {
-                                inputCheck = pr.type.split(/\s*\|\s*/);
+                                const types = pr.type.split(/\s*\|\s*/);
+                                const intersectedTypes = types.map(type => getBlocklyCheckForType(type, info));
+
+                                if (intersectedTypes.some(type => !type)) {
+                                    // a member of the intersection was generic or any, allow any input
+                                    inputCheck = null;
+                                } else {
+                                    inputCheck = [].concat(...intersectedTypes);
+                                }
                             } else {
-                                inputCheck = pr.type == "T" ? undefined : (isArrayType(pr.type) ? ["Array", pr.type] : pr.type);
+                                inputCheck = getBlocklyCheckForType(pr.type, info);
                             }
                         }
                     }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -787,6 +787,8 @@ namespace pxt.blocks {
                                 }
                             } else if (pr.type == "any") {
                                 inputCheck = null;
+                            } else if (pr.type.indexOf("|") !== -1) {
+                                inputCheck = pr.type.split(/\s*\|\s*/);
                             } else {
                                 inputCheck = pr.type == "T" ? undefined : (isArrayType(pr.type) ? ["Array", pr.type] : pr.type);
                             }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -930,7 +930,13 @@ namespace pxt.blocks {
                     // We add "Array" to the front for array types so that they can be connected
                     // to the blocks that accept any array (e.g. length, push, pop, etc)
                     if (isArrayType(subtype)) {
-                        output.push("Array");
+                        if (types.length > 1) {
+                            // type inference will potentially break non-trivial arrays until we have better
+                            // type handling in blocks, so escape and allow any block to be dropped in.
+                            return null;
+                        } else {
+                            output.push("Array");
+                        }
                     }
 
                     // Blockly has no concept of inheritance, so we need to add all

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -773,16 +773,6 @@ namespace pxt.blocks {
                                 fields.push(namedField(new Blockly.FieldTextInput("0", Blockly.FieldTextInput.numberValidator), defName));
                             } else if (pr.type == "string" && pr.shadowOptions && pr.shadowOptions.toString) {
                                 inputCheck = null;
-                            } else if (pr.type.indexOf("|") !== -1) {
-                                const types = pr.type.split(/\s*\|\s*/);
-                                const intersectedTypes = types.map(type => getBlocklyCheckForType(type, info));
-
-                                if (intersectedTypes.some(type => !type)) {
-                                    // a member of the intersection was generic or any, allow any input
-                                    inputCheck = null;
-                                } else {
-                                    inputCheck = [].concat(...intersectedTypes);
-                                }
                             } else {
                                 inputCheck = getBlocklyCheckForType(pr.type, info);
                             }
@@ -914,36 +904,47 @@ namespace pxt.blocks {
      *      (e.g. type is void), and null if all checks should be accepted (e.g. type is generic)
      */
     function getBlocklyCheckForType(type: string, info: pxtc.BlocksInfo) {
-        switch (type) {
-            // Blockly capitalizes primitive types for its builtin math/string/logic blocks
-            case "number": return ["Number"];
-            case "string": return ["String"];
-            case "boolean": return ["Boolean"];
-            case "any": return null;
-            case "void": return undefined
-            default:
-                if (type !== "T") {
-                    // We add "Array" to the front for array types so that they can be connected
-                    // to the blocks that accept any array (e.g. length, push, pop, etc)
-                    const opt_check = isArrayType(type) ? ["Array"] : [];
-
-                    // Blockly has no concept of inheritance, so we need to add all
-                    // super classes to the check array
-                    const si_r = info.apis.byQName[type];
-                    if (si_r && si_r.extendsTypes && 0 < si_r.extendsTypes.length) {
-                        opt_check.push(...si_r.extendsTypes);
-                    } else {
-                        opt_check.push(type);
-                    }
-
-                    return opt_check;
-                } else {
+        const types = type.split(/\s*\|\s*/);
+        const output = [];
+        for (const subtype of types) {
+            switch (subtype) {
+                // Blockly capitalizes primitive types for its builtin math/string/logic blocks
+                case "number":
+                    output.push("Number");
+                    break;
+                case "string":
+                    output.push("String");
+                    break;
+                case "boolean":
+                    output.push("Boolean");
+                    break;
+                case "T":
                     // The type is generic, so accept any checks. This is mostly used with functions that
                     // get values from arrays. This could be improved if we ever add proper type
                     // inference for generic types
+                case "any":
                     return null;
-                }
+                case "void":
+                    return undefined;
+                default:
+                    // We add "Array" to the front for array types so that they can be connected
+                    // to the blocks that accept any array (e.g. length, push, pop, etc)
+                    if (isArrayType(subtype)) {
+                        output.push("Array");
+                    }
+
+                    // Blockly has no concept of inheritance, so we need to add all
+                    // super classes to the check array
+                    const si_r = info.apis.byQName[subtype];
+                    if (si_r && si_r.extendsTypes && 0 < si_r.extendsTypes.length) {
+                        output.push(...si_r.extendsTypes);
+                    } else {
+                        output.push(subtype);
+                    }
+            }
         }
+
+        return output;
     }
 
     function setOutputCheck(block: Blockly.Block, retType: string, info: pxtc.BlocksInfo) {


### PR DESCRIPTION
fix checks for blocks with params that have intersection types

Nice to support in general, but the case I'd be using it for is https://github.com/microsoft/pxt-arcade/issues/1254, as it's rejecting because it doesn't recognize sprite as a structural subtype of ParticleAnchor, and easiest fix without potentially breaking existing scripts / ability to remove from any ParticleAnchor is to make the type for the ``Sprite | ParticleAnchor``.

quick test / example:

```typescript
namespace info {

    //% block="test string int number $myInput"
    export function testBlock(myInput: string | number) { }

    //% block="test sprite int sprite[] $myInput"
    export function testBlock2(myInput: Sprite | Sprite[]) { }
}
```

![2019-09-05 15 14 56](https://user-images.githubusercontent.com/5615930/64387183-11d84e80-cff0-11e9-9681-b1c6aa63feba.gif)

Can't think of a place to add tests for this immediately, but if possible that seems like it would be good to do