### PR TITLE
Break/continue statements

### DIFF
--- a/common-docs/blocks/loops.md
+++ b/common-docs/blocks/loops.md
@@ -5,10 +5,17 @@ for(let i = 0; i <= 5; i++) {}
 while(true) {}
 for(let i= 0; i < 5; i++) {}
 for(let value of [""]) {}
+break;
+continue;
 ```
 
 ### #specific
 
 ## See also #seealso
 
-[for](/blocks/loops/for), [while](/blocks/loops/while), [repeat](/blocks/loops/repeat), [for of](/blocks/for-of)
+[for](/blocks/loops/for), 
+[while](/blocks/loops/while), 
+[repeat](/blocks/loops/repeat), 
+[for of](/blocks/for-of),
+[break](/blocks/break),
+[continue](/blocks/continue)

--- a/common-docs/blocks/loops.md
+++ b/common-docs/blocks/loops.md
@@ -16,6 +16,6 @@ continue;
 [for](/blocks/loops/for), 
 [while](/blocks/loops/while), 
 [repeat](/blocks/loops/repeat), 
-[for of](/blocks/for-of),
-[break](/blocks/break),
-[continue](/blocks/continue)
+[for of](/blocks/loops/for-of),
+[break](/blocks/loops/break),
+[continue](/blocks/loops/continue)

--- a/common-docs/blocks/loops/break.md
+++ b/common-docs/blocks/loops/break.md
@@ -1,0 +1,13 @@
+# Break
+ 
+Break out of the current loop and continue the program.
+
+```block
+while(true) {
+    if (Math.randon() > 0.5) {
+        break;
+    }
+}
+```
+
+## #examples

--- a/common-docs/blocks/loops/break.md
+++ b/common-docs/blocks/loops/break.md
@@ -4,10 +4,18 @@ Break out of the current loop and continue the program.
 
 ```block
 while(true) {
-    if (Math.randon() > 0.5) {
+    if (Math.random() > 0.5) {
         break;
     }
 }
 ```
 
+When a program encounters a **break**, the loop that contains it will stop running at the place of the **break**. The program then continues by running the code right after the end of the loop.
+
+If a loop with a **break** is inside of another loop (nested loop), only the loop with the **break** will end. The outer loop will continue to run the code inside of it.
+
 ## #examples
+
+## See also #seealso
+
+[continue](/blocks/loops/continue)

--- a/common-docs/blocks/loops/continue.md
+++ b/common-docs/blocks/loops/continue.md
@@ -1,0 +1,16 @@
+# Continue
+
+Skip the rest of the current loop and start the iteration again.
+
+
+```block
+while(true) {
+    if (Math.randon() > 0.5) {
+        // skip current iteration
+        continue;
+    }
+    // do something
+}
+```
+
+## #examples

--- a/common-docs/blocks/loops/continue.md
+++ b/common-docs/blocks/loops/continue.md
@@ -1,16 +1,21 @@
 # Continue
 
-Skip the rest of the current loop and start the iteration again.
-
+Skip the rest of the code in a loop and start the loop again.
 
 ```block
 while(true) {
-    if (Math.randon() > 0.5) {
-        // skip current iteration
+    if (Math.random() > 0.5) {
+        // skip the rest of the loop
         continue;
     }
     // do something
 }
 ```
 
+When a program sees a **continue** inside of a loop, it skips running the rest of the code in the loop from the place of the **continue** to the end of the loop. The loop doesn't stop but continues to run again. If the loop uses iteration (a count or index value), like a [for](/blocks/loops/for) loop, it will start again with its next iteration.
+
 ## #examples
+
+## See also #seealso
+
+[break](/blocks/loops/break)

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -747,7 +747,7 @@ namespace pxt.blocks {
         const args: BlockParameter[] = (b as Blockly.FunctionCallBlock).getArguments().map(a => {
             return {
                 actualName: a.name,
-                definitionName: a .id
+                definitionName: a.id
             };
         });
 
@@ -1384,6 +1384,12 @@ namespace pxt.blocks {
             case pxtc.TS_DEBUGGER_TYPE:
                 r = compileDebuggeStatementBlock(e, b);
                 break;
+            case pxtc.TS_BREAK_TYPE:
+                r = compileBreakStatementBlock(e, b);
+                break;
+            case pxtc.TS_CONTINUE_TYPE:
+                r = compileContinueStatementBlock(e, b);
+                break;
             default:
                 let call = e.stdCallTable[b.type];
                 if (call) r = [compileCall(e, b, comments)];
@@ -1449,6 +1455,14 @@ namespace pxt.blocks {
             ]
         }
         return [];
+    }
+
+    function compileBreakStatementBlock(e: Environment, b: Blockly.Block) {
+        return [mkText("break;\n")]
+    }
+
+    function compileContinueStatementBlock(e: Environment, b: Blockly.Block) {
+        return [mkText("continue;\n")]
     }
 
     function prefixWithSemicolon(n: JsNode) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1266,7 +1266,7 @@ namespace pxt.blocks {
                     pxtc.TS_BREAK_TYPE,
                     lf("Break statement"),
                     lf("The break statement exits a switch statement or a loop "),
-                    '/javascript/break',
+                    '/blocks/break',
                     pxt.toolbox.getNamespaceColor('loops')
                 );
             }
@@ -1287,7 +1287,7 @@ namespace pxt.blocks {
                     pxtc.TS_CONTINUE_TYPE,
                     lf("Continue statement"),
                     lf("The continue statement breaks one iteration (in the loop) and continues with the next iteration in the loop."),
-                    '/javascript/continue',
+                    '/blocks/continue',
                     pxt.toolbox.getNamespaceColor('loops')
                 );
             }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1265,8 +1265,8 @@ namespace pxt.blocks {
                 setHelpResources(this,
                     pxtc.TS_BREAK_TYPE,
                     lf("Break statement"),
-                    lf("The break statement exits a switch statement or a loop "),
-                    '/blocks/break',
+                    lf("Break out of the current loop or switch"),
+                    '/blocks/loops/break',
                     pxt.toolbox.getNamespaceColor('loops')
                 );
             }
@@ -1287,7 +1287,7 @@ namespace pxt.blocks {
                     pxtc.TS_CONTINUE_TYPE,
                     lf("Continue statement"),
                     lf("The continue statement breaks one iteration (in the loop) and continues with the next iteration in the loop."),
-                    '/blocks/continue',
+                    '/blocks/loops/continue',
                     pxt.toolbox.getNamespaceColor('loops')
                 );
             }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1250,6 +1250,48 @@ namespace pxt.blocks {
                 }
             }
         };
+
+        // break statement
+        Blockly.Blocks[pxtc.TS_BREAK_TYPE] = {
+            init: function () {
+                let that: Blockly.Block = this;
+                that.setColour(pxt.toolbox.getNamespaceColor('loops'))
+                that.setPreviousStatement(true);
+                that.setNextStatement(true);
+                that.setInputsInline(false);
+                that.appendDummyInput()
+                    .appendField(new Blockly.FieldLabel(lf("break"), undefined))
+
+                setHelpResources(this,
+                    pxtc.TS_BREAK_TYPE,
+                    lf("Break statement"),
+                    lf("The break statement exits a switch statement or a loop "),
+                    '/javascript/break',
+                    pxt.toolbox.getNamespaceColor('loops')
+                );
+            }
+        };
+
+        // loops statement
+        Blockly.Blocks[pxtc.TS_CONTINUE_TYPE] = {
+            init: function () {
+                let that: Blockly.Block = this;
+                that.setColour(pxt.toolbox.getNamespaceColor('loops'))
+                that.setPreviousStatement(true);
+                that.setNextStatement(true);
+                that.setInputsInline(false);
+                that.appendDummyInput()
+                    .appendField(new Blockly.FieldLabel(lf("continue"), undefined))
+
+                setHelpResources(this,
+                    pxtc.TS_CONTINUE_TYPE,
+                    lf("Continue statement"),
+                    lf("The continue statement breaks one iteration (in the loop) and continues with the next iteration in the loop."),
+                    '/javascript/continue',
+                    pxt.toolbox.getNamespaceColor('loops')
+                );
+            }
+        };
     }
 
     export let onShowContextMenu: (workspace: Blockly.Workspace,

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -811,7 +811,7 @@ ${output}</xml>`;
             if (op === "&&" || op === "||") {
                 leftValue = getConditionalInput(leftName, n.left);
                 rightValue = getConditionalInput(rightName, n.right);
-            } else  {
+            } else {
                 leftValue = getValue(leftName, n.left, numberType);
                 rightValue = getValue(rightName, n.right, numberType);
             }
@@ -1187,6 +1187,12 @@ ${output}</xml>`;
                     case SK.DebuggerStatement:
                         stmt = getDebuggerStatementBlock(node);
                         break;
+                    case SK.BreakStatement:
+                        stmt = getBreakStatementBlock(node);
+                        break;
+                    case SK.ContinueStatement:
+                        stmt = getContinueStatementBlock(node);
+                        break;
                     case SK.EmptyStatement:
                         stmt = undefined; // don't generate blocks for empty statements
                         break;
@@ -1297,6 +1303,16 @@ ${output}</xml>`;
                 r.mutation[`line${i}`] = U.htmlEscape(p);
             });
 
+            return r;
+        }
+
+        function getContinueStatementBlock(node: ts.Node): StatementNode {
+            const r = mkStmt(pxtc.TS_CONTINUE_TYPE);
+            return r;
+        }
+
+        function getBreakStatementBlock(node: ts.Node): StatementNode {
+            const r = mkStmt(pxtc.TS_BREAK_TYPE);
             return r;
         }
 
@@ -2255,6 +2271,8 @@ ${output}</xml>`;
                 return checkEnumDeclaration(node as ts.EnumDeclaration, topLevel);
             case SK.ModuleDeclaration:
                 return checkNamespaceDeclaration(node as ts.NamespaceDeclaration);
+            case SK.BreakStatement:
+            case SK.ContinueStatement:
             case SK.DebuggerStatement:
             case SK.EmptyStatement:
                 return undefined;
@@ -3100,7 +3118,7 @@ ${output}</xml>`;
     }
 
     function isDeclaredElsewhere(node: ts.Identifier) {
-        return !! (pxtInfo(node).flags & PxtNodeFlags.IsGlobalIdentifier)
+        return !!(pxtInfo(node).flags & PxtNodeFlags.IsGlobalIdentifier)
     }
 
     function hasStatementInput(info: CallInfo, attributes: CommentAttrs): boolean {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -11,6 +11,8 @@ namespace ts.pxtc {
     export const HANDLER_COMMENT = "code goes here"; // TODO: Localize? (adding lf doesn't work because this is run before translations are downloaded)
     export const TS_STATEMENT_TYPE = "typescript_statement";
     export const TS_DEBUGGER_TYPE = "debugger_keyword";
+    export const TS_BREAK_TYPE = "break_keyword";
+    export const TS_CONTINUE_TYPE = "continue_keyword";
     export const TS_OUTPUT_TYPE = "typescript_expression";
     export const PAUSE_UNTIL_TYPE = "pxt_pause_until";
     export const BINARY_JS = "binary.js";

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -598,6 +598,22 @@ namespace pxt.runner {
                                 blocksXml: '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="controls_for_of"></block></xml>'
                             });
                             break;
+                        case ts.SyntaxKind.BreakStatement:
+                            addItem({
+                                name: ns ? "Loops" : "break",
+                                url: "blocks/loops" + (ns ? "" : "/break"),
+                                description: ns ? lf("Loops and repetition") : lf("Break out of the current loop."),
+                                blocksXml: '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="break_keyword"></block></xml>'
+                            });
+                            break;
+                        case ts.SyntaxKind.ContinueStatement:
+                            addItem({
+                                name: ns ? "Loops" : "continue",
+                                url: "blocks/loops" + (ns ? "" : "/continue"),
+                                description: ns ? lf("Loops and repetition") : lf("Skip iteration and continue the current loop."),
+                                blocksXml: '<xml xmlns="http://www.w3.org/1999/xhtml"><block type="continue_keyboard"></block></xml>'
+                            });
+                            break;
                         case ts.SyntaxKind.ForStatement:
                             let fs = stmt as ts.ForStatement;
                             // look for the 'repeat' loop style signature in the condition expression, explicitly: (let i = 0; i < X; i++)

--- a/tests/decompile-test/baselines/break_continue.blocks
+++ b/tests/decompile-test/baselines/break_continue.blocks
@@ -1,0 +1,40 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">i</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<statement name="DO">
+<block type="break_keyword">
+</block>
+</statement>
+<next>
+<block type="pxt_controls_for">
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">j</field>
+</shadow>
+</value>
+<value name="TO">
+<shadow type="math_whole_number">
+<field name="NUM">5</field>
+</shadow>
+</value>
+<statement name="DO">
+<block type="continue_keyword">
+</block>
+</statement>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/break_continue.ts
+++ b/tests/decompile-test/cases/break_continue.ts
@@ -1,0 +1,6 @@
+for (let i = 0; i <= 5; i++) {
+    break;
+}
+for (let i = 0; i <= 5; i++) {
+    continue;
+}

--- a/webapp/src/blocksSnippets.ts
+++ b/webapp/src/blocksSnippets.ts
@@ -72,7 +72,23 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                         </shadow>
                     </value>
                 </block>`
-                }
+                },
+                {
+                    name: "pxt_break",
+                    attributes: {
+                        blockId: "break_keyword",
+                        weight: 30
+                    },
+                    blockXml: `<block type="break_keyword"></block>`
+                },
+                {
+                    name: "pxt_continue",
+                    attributes: {
+                        blockId: "continue_keyword",
+                        weight: 29
+                    },
+                    blockXml: `<block type="continue_keyword"></block>`
+                },
             ],
             attributes: {
                 callingConvention: ts.pxtc.ir.CallingConvention.Plain,


### PR DESCRIPTION
Support for ``break``, ``continue`` in blocks (bottom of loops section). Will integrate into LEGO after.
![image](https://user-images.githubusercontent.com/4175913/65060707-3e179780-d92d-11e9-9e8d-a75aa94d870e.png)

- [x] blocks
- [x] (some) docs
- [x] hooked up in loops
- [x] decompiler test