### PR TITLE
adding options for break / continue

### DIFF
--- a/common-docs/blocks/loops/break.md
+++ b/common-docs/blocks/loops/break.md
@@ -4,7 +4,7 @@ Break out of the current loop and continue the program.
 
 ```block
 while(true) {
-    if (Math.random() > 0.5) {
+    if (Math.randomRange(0, 10) > 5) {
         break;
     }
 }

--- a/common-docs/blocks/loops/continue.md
+++ b/common-docs/blocks/loops/continue.md
@@ -4,7 +4,7 @@ Skip the rest of the code in a loop and start the loop again.
 
 ```block
 while(true) {
-    if (Math.random() > 0.5) {
+    if (Math.randomRange(0, 10) > 5) {
         // skip the rest of the loop
         continue;
     }

--- a/docs/playground-runner.html
+++ b/docs/playground-runner.html
@@ -80,7 +80,9 @@
             tsprj: undefined,
             blocksprj: undefined,
             runtime: {
-                pauseUntilBlock: { category: "Loops", color: "0x0000ff" }
+                pauseUntilBlock: { category: "Loops", color: "0x0000ff" },
+                breakBlock: { category: "Loops", color: "0x0000ff" },
+                continueBlock: { category: "Loops", color: "0x0000ff" }
             },
             corepkg: undefined
         });

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -103,6 +103,8 @@ declare namespace pxt {
         onStartWeight?: number;
         onStartUnDeletable?: boolean;
         pauseUntilBlock?: BlockOptions;
+        breakBlock?: BlockOptions;
+        continueBlock?: BlockOptions;
         extraBlocks?: BlockToolboxDefinition[];  // deprecated
         assetExtensions?: string[];
         palette?: string[];

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -612,7 +612,7 @@ namespace pxt.blocks {
         block.setPreviousStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
         block.setNextStatement(!(hasHandlers && !fn.attributes.handlerStatement) && fn.retType == "void");
 
-        block.setTooltip( /^__/.test(fn.namespace) ? "" : fn.attributes.jsDoc);
+        block.setTooltip(/^__/.test(fn.namespace) ? "" : fn.attributes.jsDoc);
         function buildBlockFromDef(def: pxtc.ParsedBlockDef, expanded = false) {
             let anonIndex = 0;
             let firstParam = !expanded && !!comp.thisParameter;
@@ -919,9 +919,9 @@ namespace pxt.blocks {
                     output.push("Boolean");
                     break;
                 case "T":
-                    // The type is generic, so accept any checks. This is mostly used with functions that
-                    // get values from arrays. This could be improved if we ever add proper type
-                    // inference for generic types
+                // The type is generic, so accept any checks. This is mostly used with functions that
+                // get values from arrays. This could be improved if we ever add proper type
+                // inference for generic types
                 case "any":
                     return null;
                 case "void":
@@ -1252,46 +1252,64 @@ namespace pxt.blocks {
         };
 
         // break statement
-        Blockly.Blocks[pxtc.TS_BREAK_TYPE] = {
-            init: function () {
-                let that: Blockly.Block = this;
-                that.setColour(pxt.toolbox.getNamespaceColor('loops'))
-                that.setPreviousStatement(true);
-                that.setNextStatement(true);
-                that.setInputsInline(false);
-                that.appendDummyInput()
-                    .appendField(new Blockly.FieldLabel(lf("break"), undefined))
+        if (pxt.appTarget.runtime && pxt.appTarget.runtime.breakBlock) {
+            const blockOptions = pxt.appTarget.runtime.breakBlock;
+            const blockDef = pxt.blocks.getBlockDefinition(ts.pxtc.TS_BREAK_TYPE);
+            Blockly.Blocks[pxtc.TS_BREAK_TYPE] = {
+                init: function () {
+                    const color = blockOptions.color || pxt.toolbox.getNamespaceColor('loops');
 
-                setHelpResources(this,
-                    pxtc.TS_BREAK_TYPE,
-                    lf("Break statement"),
-                    lf("Break out of the current loop or switch"),
-                    '/blocks/loops/break',
-                    pxt.toolbox.getNamespaceColor('loops')
-                );
+                    this.jsonInit({
+                        "message0": blockDef.block["message0"],
+                        "inputsInline": true,
+                        "previousStatement": null,
+                        "nextStatement": null,
+                        "colour": color
+                    });
+
+                    setHelpResources(this,
+                        ts.pxtc.TS_BREAK_TYPE,
+                        blockDef.name,
+                        blockDef.tooltip,
+                        blockDef.url,
+                        color,
+                        undefined/*colourSecondary*/,
+                        undefined/*colourTertiary*/,
+                        false/*undeletable*/
+                    );
+                }
             }
-        };
+        }
 
-        // loops statement
-        Blockly.Blocks[pxtc.TS_CONTINUE_TYPE] = {
-            init: function () {
-                let that: Blockly.Block = this;
-                that.setColour(pxt.toolbox.getNamespaceColor('loops'))
-                that.setPreviousStatement(true);
-                that.setNextStatement(true);
-                that.setInputsInline(false);
-                that.appendDummyInput()
-                    .appendField(new Blockly.FieldLabel(lf("continue"), undefined))
+        // continue statement
+        if (pxt.appTarget.runtime && pxt.appTarget.runtime.continueBlock) {
+            const blockOptions = pxt.appTarget.runtime.continueBlock;
+            const blockDef = pxt.blocks.getBlockDefinition(ts.pxtc.TS_CONTINUE_TYPE);
+            Blockly.Blocks[pxtc.TS_CONTINUE_TYPE] = {
+                init: function () {
+                    const color = blockOptions.color || pxt.toolbox.getNamespaceColor('loops');
 
-                setHelpResources(this,
-                    pxtc.TS_CONTINUE_TYPE,
-                    lf("Continue statement"),
-                    lf("The continue statement breaks one iteration (in the loop) and continues with the next iteration in the loop."),
-                    '/blocks/loops/continue',
-                    pxt.toolbox.getNamespaceColor('loops')
-                );
+                    this.jsonInit({
+                        "message0": blockDef.block["message0"],
+                        "inputsInline": true,
+                        "previousStatement": null,
+                        "nextStatement": null,
+                        "colour": color
+                    });
+
+                    setHelpResources(this,
+                        ts.pxtc.TS_BREAK_TYPE,
+                        blockDef.name,
+                        blockDef.tooltip,
+                        blockDef.url,
+                        color,
+                        undefined/*colourSecondary*/,
+                        undefined/*colourTertiary*/,
+                        false/*undeletable*/
+                    );
+                }
             }
-        };
+        }
     }
 
     export let onShowContextMenu: (workspace: Blockly.Workspace,
@@ -2402,7 +2420,7 @@ namespace pxt.blocks {
             // The logic for setting the output check relies on the internals of PXT
             // too much to be refactored into pxt-blockly, so we need to monkey patch
             // it here
-            Blockly.Blocks["argument_reporter_custom"].domToMutation = function(xmlElement: Element) {
+            Blockly.Blocks["argument_reporter_custom"].domToMutation = function (xmlElement: Element) {
                 const typeName = xmlElement.getAttribute('typename');
                 this.typeName_ = typeName;
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2272,7 +2272,9 @@ ${output}</xml>`;
             case SK.ModuleDeclaration:
                 return checkNamespaceDeclaration(node as ts.NamespaceDeclaration);
             case SK.BreakStatement:
+                return pxt.appTarget.runtime && !!pxt.appTarget.runtime.breakBlock ? undefined : lf("Unsupported in blocks.");
             case SK.ContinueStatement:
+                return pxt.appTarget.runtime && !!pxt.appTarget.runtime.continueBlock ? undefined : lf("Unsupported in blocks.");
             case SK.DebuggerStatement:
             case SK.EmptyStatement:
                 return undefined;

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -703,5 +703,23 @@ namespace pxt.blocks {
                 message0: Util.lf("pause until %1")
             }
         };
+        _blockDefinitions[pxtc.TS_BREAK_TYPE] = {
+            name: Util.lf("break"),
+            tooltip: Util.lf("Break out of the current loop or switch"),
+            url: '/blocks/loops/break',
+            category: 'loops',
+            block: {
+                message0: Util.lf("break")
+            }
+        }
+        _blockDefinitions[pxtc.TS_CONTINUE_TYPE] = {
+            name: Util.lf("continue"),
+            tooltip: Util.lf("Skip current iteration and continues with the next iteration in the loop"),
+            url: '/blocks/loops/continue',
+            category: 'loops',
+            block: {
+                message0: Util.lf("continue")
+            }
+        }
     }
 }

--- a/tests/common/testUtils.ts
+++ b/tests/common/testUtils.ts
@@ -33,6 +33,8 @@ export const testAppTarget: pxt.TargetBundle = {
     blocksprj: undefined,
     runtime: {
         pauseUntilBlock: { category: "Loops", color: "0x0000ff" },
+        breakBlock: {},
+        continueBlock: {},
         bannedCategories: ["banned"]
     },
     corepkg: undefined


### PR DESCRIPTION
Same as pauseUntil, enabled in pxtarget.json. ``break`` is generally useful to break out of loops without having to declare a variable.