### PR TITLE
Fix missing break/continue statement

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -103,8 +103,8 @@ declare namespace pxt {
         onStartWeight?: number;
         onStartUnDeletable?: boolean;
         pauseUntilBlock?: BlockOptions;
-        breakBlock?: BlockOptions;
-        continueBlock?: BlockOptions;
+        breakBlock?: boolean;
+        continueBlock?: boolean;
         extraBlocks?: BlockToolboxDefinition[];  // deprecated
         assetExtensions?: string[];
         palette?: string[];

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1252,62 +1252,56 @@ namespace pxt.blocks {
         };
 
         // break statement
-        if (pxt.appTarget.runtime && pxt.appTarget.runtime.breakBlock) {
-            const blockOptions = pxt.appTarget.runtime.breakBlock;
-            const blockDef = pxt.blocks.getBlockDefinition(ts.pxtc.TS_BREAK_TYPE);
-            Blockly.Blocks[pxtc.TS_BREAK_TYPE] = {
-                init: function () {
-                    const color = blockOptions.color || pxt.toolbox.getNamespaceColor('loops');
+        const breakBlockDef = pxt.blocks.getBlockDefinition(ts.pxtc.TS_BREAK_TYPE);
+        Blockly.Blocks[pxtc.TS_BREAK_TYPE] = {
+            init: function () {
+                const color = pxt.toolbox.getNamespaceColor('loops');
 
-                    this.jsonInit({
-                        "message0": blockDef.block["message0"],
-                        "inputsInline": true,
-                        "previousStatement": null,
-                        "nextStatement": null,
-                        "colour": color
-                    });
+                this.jsonInit({
+                    "message0": breakBlockDef.block["message0"],
+                    "inputsInline": true,
+                    "previousStatement": null,
+                    "nextStatement": null,
+                    "colour": color
+                });
 
-                    setHelpResources(this,
-                        ts.pxtc.TS_BREAK_TYPE,
-                        blockDef.name,
-                        blockDef.tooltip,
-                        blockDef.url,
-                        color,
-                        undefined/*colourSecondary*/,
-                        undefined/*colourTertiary*/,
-                        false/*undeletable*/
-                    );
-                }
+                setHelpResources(this,
+                    ts.pxtc.TS_BREAK_TYPE,
+                    breakBlockDef.name,
+                    breakBlockDef.tooltip,
+                    breakBlockDef.url,
+                    color,
+                    undefined/*colourSecondary*/,
+                    undefined/*colourTertiary*/,
+                    false/*undeletable*/
+                );
             }
         }
 
         // continue statement
-        if (pxt.appTarget.runtime && pxt.appTarget.runtime.continueBlock) {
-            const blockOptions = pxt.appTarget.runtime.continueBlock;
-            const blockDef = pxt.blocks.getBlockDefinition(ts.pxtc.TS_CONTINUE_TYPE);
-            Blockly.Blocks[pxtc.TS_CONTINUE_TYPE] = {
-                init: function () {
-                    const color = blockOptions.color || pxt.toolbox.getNamespaceColor('loops');
+        const continueBlockDef = pxt.blocks.getBlockDefinition(ts.pxtc.TS_CONTINUE_TYPE);
+        Blockly.Blocks[pxtc.TS_CONTINUE_TYPE] = {
+            init: function () {
+                const color = pxt.toolbox.getNamespaceColor('loops');
 
-                    this.jsonInit({
-                        "message0": blockDef.block["message0"],
-                        "inputsInline": true,
-                        "previousStatement": null,
-                        "nextStatement": null,
-                        "colour": color
-                    });
+                this.jsonInit({
+                    "message0": continueBlockDef.block["message0"],
+                    "inputsInline": true,
+                    "previousStatement": null,
+                    "nextStatement": null,
+                    "colour": color
+                });
 
-                    setHelpResources(this,
-                        ts.pxtc.TS_BREAK_TYPE,
-                        blockDef.name,
-                        blockDef.tooltip,
-                        blockDef.url,
-                        color,
-                        undefined/*colourSecondary*/,
-                        undefined/*colourTertiary*/,
-                        false/*undeletable*/
-                    );
-                }
+                setHelpResources(this,
+                    ts.pxtc.TS_BREAK_TYPE,
+                    continueBlockDef.name,
+                    continueBlockDef.tooltip,
+                    continueBlockDef.url,
+                    color,
+                    undefined/*colourSecondary*/,
+                    undefined/*colourTertiary*/,
+                    false/*undeletable*/
+                );
             }
         }
     }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2272,9 +2272,7 @@ ${output}</xml>`;
             case SK.ModuleDeclaration:
                 return checkNamespaceDeclaration(node as ts.NamespaceDeclaration);
             case SK.BreakStatement:
-                return pxt.appTarget.runtime && !!pxt.appTarget.runtime.breakBlock ? undefined : lf("Unsupported in blocks.");
             case SK.ContinueStatement:
-                return pxt.appTarget.runtime && !!pxt.appTarget.runtime.continueBlock ? undefined : lf("Unsupported in blocks.");
             case SK.DebuggerStatement:
             case SK.EmptyStatement:
                 return undefined;

--- a/tests/common/testUtils.ts
+++ b/tests/common/testUtils.ts
@@ -33,8 +33,8 @@ export const testAppTarget: pxt.TargetBundle = {
     blocksprj: undefined,
     runtime: {
         pauseUntilBlock: { category: "Loops", color: "0x0000ff" },
-        breakBlock: {},
-        continueBlock: {},
+        breakBlock: true,
+        continueBlock: true,
         bannedCategories: ["banned"]
     },
     corepkg: undefined


### PR DESCRIPTION
Break and continue blocks should always be defined in case the user decide to decompile TS code with those keywords.
The service does not have pxtarget information to properly filter those out at compile time... so it's a way to get the blocks.
The pxttarget flags breakBlock and continueBlock decide wheter they are visible in the loops category.
Fix for https://github.com/microsoft/pxt/issues/5922
@FranklinWhale 