### PR TITLE
github improvements

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3330,8 +3330,10 @@ export class ProjectView
         }
         const isRTL = pxt.Util.isUserLanguageRtl();
         const showRightChevron = (this.state.collapseEditorTools || isRTL) && !(this.state.collapseEditorTools && isRTL); // Collapsed XOR RTL
-        // don't show in sandbox or show if github always or don't show in blocks/serial
-        const showFileList = !sandbox && !(isBlocks || this.editor == this.serialEditor);
+        // don't show in sandbox or is blocks editor or previous editor is blocks
+        const showFileList = !sandbox
+            && !(isBlocks
+                || (pkg.mainPkg && pkg.mainPkg.config && (pkg.mainPkg.config.preferredEditor == pxt.BLOCKS_PROJECT_NAME)));
         // show github if token or if always vis
         const showGithub = !!pxt.github.token || (isBlocks && targetTheme.alwaysGithubItemBlocks) || (!isBlocks && targetTheme.alwaysGithubItem);
         return (

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -597,8 +597,8 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
         }
     }
 
-    function onPublicChanged(v: boolean) {
-        v = !!v;
+    function onPublicChanged(e: React.ChangeEvent<HTMLSelectElement>) {
+        let v = e.currentTarget.selectedIndex == 0;
         if (repoPublic != v) {
             repoPublic = v;
             coretsx.forceUpdate();
@@ -613,7 +613,7 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
             const nameErr = repoNameError();
             return <div className="ui form">
                 <p>
-                    {lf("Host your code on GitHub and work together with friends on projects.")}
+                    {lf("Host your code on GitHub and work together with friends.")}
                     <sui.Link href="https://github.com/about" target="_blank" icon="question circle" />
                 </p>
                 <div className="ui field">
@@ -622,7 +622,12 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
                 <div className="ui field">
                     <sui.Input type="text" value={repoDescription} onChange={onDescriptionChanged} label={lf("Repository description")} placeholder={lf("MakeCode extension for my gadget")} class="fluid" />
                 </div>
-                <sui.Checkbox checked={repoPublic} inputLabel={repoPublic ? lf("Public repository, anyone can look at your code.") : lf("Private repository, your code is only visible to you.")} onChange={onPublicChanged} />
+                <div className="ui field">
+                    <select className="ui dropdown" onChange={onPublicChanged}>
+                        <option aria-selected={repoPublic} value="true">{lf("Public repository, anyone can look at your code.")}</option>
+                        <option aria-selected={!repoPublic} value="false">{lf("Private repository, your code is only visible to you.")}</option>
+                    </select>
+                </div>
             </div>
         },
     }).then(res => {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -598,7 +598,7 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
     }
 
     function onPublicChanged(e: React.ChangeEvent<HTMLSelectElement>) {
-        let v = e.currentTarget.selectedIndex == 0;
+        const v = e.currentTarget.selectedIndex == 0;
         if (repoPublic != v) {
             repoPublic = v;
             coretsx.forceUpdate();

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -613,7 +613,7 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
             </div> : undefined}
             {!needsToken && needsCommitMessage ? <div className="ui warning message">
                 <div className="content">
-                    {lf("You need to commit your changes first, before you can pull from GitHub.")}
+                    {lf("You need to commit your changes before you can pull from GitHub.")}
                 </div>
             </div> : undefined}
         </div>

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -561,8 +561,9 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                             {lf("Pull request")}
                         </a>}
                     <h3 className="header">
+                        <i className="large github icon" />
                         <span className="repo-name">{githubId.fullName}</span>
-                        <span onClick={this.handleBranchClick} role="button" className="repo-branch">{"#" + githubId.tag}</span>
+                        <span onClick={this.handleBranchClick} role="button" className="repo-branch">{"#" + githubId.tag}<i className="dropdown icon"/></span>
                     </h3>
                     {needsCommit ?
                         <CommmitComponent parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} />

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -603,7 +603,6 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
 
     renderCore() {
         const { needsCommitMessage } = this.props.parent.state;
-        const { gs, githubId } = this.props;
         const needsToken = !pxt.github.token;
 
         return <div>

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -603,24 +603,25 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
     renderCore() {
         const { needsCommitMessage } = this.props.parent.state;
         const { gs, githubId } = this.props;
+        const needsToken = !pxt.github.token;
         const needsLicenseMessage = gs.commit && !gs.commit.tree.tree.some(f =>
             /^LICENSE/.test(f.path.toUpperCase()) || /^COPYING/.test(f.path.toUpperCase()))
 
         return <div>
-            {!pxt.github.token ? <div className="ui info message join">
+            {needsToken ? <div className="ui info message join">
                 <p>{lf("Host your code on GitHub and work together with friends on projects.")}</p>
                 <sui.Button className="tiny green" text={lf("Sign in")} onClick={this.handleSignInClick} />
             </div> : undefined}
-            {needsCommitMessage ? <div className="ui warning message">
+            {!needsToken && needsCommitMessage ? <div className="ui warning message">
                 <div className="content">
                     {lf("You need to commit your changes first, before you can pull from GitHub.")}
                 </div>
             </div> : undefined}
-            {needsLicenseMessage ? <div className="ui warning message">
+            {!needsToken && needsLicenseMessage ? <div className="ui warning message">
                 <div className="content">
                     <span>{lf("Your project doesn't seem to have a license. This makes it hard for others to use it.")}</span>
                     <a href={`https://github.com/${githubId.fullName}/community/license/new?branch=${githubId.tag}&template=mit`}
-                        role="button" className="ui basic button"
+                        role="button" className="ui link"
                         target="_blank" rel="noopener noreferrer">
                         {lf("Add license")}
                     </a>

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -684,9 +684,10 @@ class NoChangesComponent extends sui.StatelessUIElement<GitHubViewProps> {
                     </p>
                     <sui.Button className="primary" text={lf("Create release")} onClick={this.handleBumpClick} onKeyDown={sui.fireClickOnEnter} />
                 </div> : undefined}
-            {master && needsLicenseMessage ? <div className="ui warning message">
+            {master && needsLicenseMessage ? <div className="ui message">
                 <div className="content">
-                    <span>{lf("Your project doesn't seem to have a license. This makes it hard for others to use it.")}</span>
+                    {lf("Your project doesn't seem to have a license. This makes it hard for others to use it.")}
+                    {" "}
                     <a href={`https://github.com/${githubId.fullName}/community/license/new?branch=${githubId.tag}&template=mit`}
                         role="button" className="ui link"
                         target="_blank" rel="noopener noreferrer">

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -604,8 +604,6 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
         const { needsCommitMessage } = this.props.parent.state;
         const { gs, githubId } = this.props;
         const needsToken = !pxt.github.token;
-        const needsLicenseMessage = gs.commit && !gs.commit.tree.tree.some(f =>
-            /^LICENSE/.test(f.path.toUpperCase()) || /^COPYING/.test(f.path.toUpperCase()))
 
         return <div>
             {needsToken ? <div className="ui info message join">
@@ -615,16 +613,6 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
             {!needsToken && needsCommitMessage ? <div className="ui warning message">
                 <div className="content">
                     {lf("You need to commit your changes first, before you can pull from GitHub.")}
-                </div>
-            </div> : undefined}
-            {!needsToken && needsLicenseMessage ? <div className="ui warning message">
-                <div className="content">
-                    <span>{lf("Your project doesn't seem to have a license. This makes it hard for others to use it.")}</span>
-                    <a href={`https://github.com/${githubId.fullName}/community/license/new?branch=${githubId.tag}&template=mit`}
-                        role="button" className="ui link"
-                        target="_blank" rel="noopener noreferrer">
-                        {lf("Add license")}
-                    </a>
                 </div>
             </div> : undefined}
         </div>
@@ -682,7 +670,9 @@ class NoChangesComponent extends sui.StatelessUIElement<GitHubViewProps> {
     }
 
     renderCore() {
-        const { needsToken, githubId, master } = this.props;
+        const { needsToken, githubId, master, gs } = this.props;
+        const needsLicenseMessage = !needsToken && gs.commit && !gs.commit.tree.tree.some(f =>
+            /^LICENSE/.test(f.path.toUpperCase()) || /^COPYING/.test(f.path.toUpperCase()))
         return <div>
             <p>{lf("No local changes found.")}</p>
             {master ? <div className="ui divider"></div> : undefined}
@@ -694,6 +684,16 @@ class NoChangesComponent extends sui.StatelessUIElement<GitHubViewProps> {
                     </p>
                     <sui.Button className="primary" text={lf("Create release")} onClick={this.handleBumpClick} onKeyDown={sui.fireClickOnEnter} />
                 </div> : undefined}
+            {master && needsLicenseMessage ? <div className="ui warning message">
+                <div className="content">
+                    <span>{lf("Your project doesn't seem to have a license. This makes it hard for others to use it.")}</span>
+                    <a href={`https://github.com/${githubId.fullName}/community/license/new?branch=${githubId.tag}&template=mit`}
+                        role="button" className="ui link"
+                        target="_blank" rel="noopener noreferrer">
+                        {lf("Add license")}
+                    </a>
+                </div>
+            </div> : undefined}
         </div>
     }
 }


### PR DESCRIPTION
- [x] don't show warnings when user is not signed in
- [x] don't expand explorer when coming from blocks
- [x] moving license message under create release
- [x] adding notch on branch to indicate menu
![image](https://user-images.githubusercontent.com/4175913/65258509-d8a3e200-dab7-11e9-9eca-5b5474ecf602.png)
- [x] use dropdown instead of toggle for publi/cprivate
![image](https://user-images.githubusercontent.com/4175913/65252295-8d84d180-daad-11e9-870c-6052b051e469.png)
