### PR TITLE
Telemetry fix

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -250,7 +250,7 @@ namespace pxt.BrowserUtils {
         if (!hasLoggedBrowser) {
             pxt.log(`Browser: ${browser()} ${versionString} on ${os()}`)
             if (!isSupported) {
-                pxt.tickEvent(`browser.unsupported.${navigator.userAgent}`)
+                pxt.tickEvent("browser.unsupported", {useragent : navigator.userAgent})
             }
             hasLoggedBrowser = true
         }

--- a/pxtlib/webble.ts
+++ b/pxtlib/webble.ts
@@ -170,7 +170,7 @@ namespace pxt.webBluetooth {
                     this.txCharacteristic.addEventListener('characteristicvaluechanged', this.handleValueChanged);
                     return this.txCharacteristic.startNotifications()
                 }).then(() => {
-                    pxt.tickEvent(`webble.${this.id}.connected`);
+                    pxt.tickEvent(`webble.connected`, {id : this.id});
                 });
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3863,7 +3863,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         lang.setCookieLang(useLang);
                         lang.setInitialLang(useLang);
                     } else {
-                        pxt.tickEvent("unavailablelocale", {lang : useLang,  force : (force? "true" : "false")});
+                        pxt.tickEvent("unavailablelocale", {lang : useLang,  force : (force ? "true" : "false")});
                     }
                     pxt.tickEvent("locale", {lang : pxt.Util.userLanguage(), live : (live ? "true" : "false")});
                     // Download sim translations and save them in the sim

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1513,7 +1513,7 @@ export class ProjectView
 
         const importer = this.hexFileImporters.filter(fi => fi.canImport(data))[0];
         if (importer) {
-            pxt.tickEvent("import." + importer.id);
+            pxt.tickEvent("import",{ id : importer.id });
             core.hideDialog();
             core.showLoading("importhex", lf("loading project..."))
             pxt.editor.initEditorExtensionsAsync()
@@ -3863,10 +3863,9 @@ document.addEventListener("DOMContentLoaded", () => {
                         lang.setCookieLang(useLang);
                         lang.setInitialLang(useLang);
                     } else {
-                        pxt.tickEvent("unavailablelocale." + useLang + (force ? ".force" : ""));
+                        pxt.tickEvent("unavailablelocale", {lang : useLang,  force : (force? "true" : "false")});
                     }
-                    pxt.tickEvent("locale." + pxt.Util.userLanguage() + (live ? ".live" : ""));
-
+                    pxt.tickEvent("locale", {lang : pxt.Util.userLanguage(), live : (live ? "true" : "false")});
                     // Download sim translations and save them in the sim
                     // don't wait!
                     ts.pxtc.Util.downloadTranslationsAsync(

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -385,13 +385,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         });
 
         for (const block in deprecatedMap) {
-            if (deprecatedMap[block] === 0) {
-                delete deprecatedMap[block];
+            if (deprecatedMap[block] !== 0) {
+                pxt.tickEvent("blocks.usingDeprecated", {block : block});
             }
-        }
-
-        if (deprecatedBlocksFound) {
-            pxt.tickEvent("blocks.usingDeprecated", deprecatedMap);
         }
     }
 
@@ -429,7 +425,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
             if (ev.type == 'create') {
                 let blockId = ev.xml.getAttribute('type');
-                pxt.tickActivity("blocks.create", "blocks.create." + blockId);
+                pxt.tickEvent("blocks.create", {"block": blockId});
                 if (ev.xml.tagName == 'SHADOW')
                     this.cleanUpShadowBlocks();
                 this.parent.setState({ hideEditorFloats: false });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -386,7 +386,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         for (const block in deprecatedMap) {
             if (deprecatedMap[block] !== 0) {
-                pxt.tickEvent("blocks.usingDeprecated", {block : block});
+                pxt.tickEvent("blocks.usingDeprecated", {block : block, count : deprecatedMap[block] });
             }
         }
     }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -47,7 +47,7 @@ function reportDiagnosticErrors(errors: pxtc.KsDiagnostic[]) {
         errors.filter(err => err.code).forEach(err => counts[err.code] = (counts[err.code] || 0) + 1);
         const errorCounts = JSON.stringify(errors);
         if (errorCounts !== lastErrorCounts) {
-            pxt.tickEvent("dianostics", counts);
+            pxt.tickEvent("diagnostics", counts);
             lastErrorCounts = errorCounts;
         }
     } else {

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -29,7 +29,7 @@ export function setCookieLang(langId: string) {
     }
 
     if (langId !== getCookieLang()) {
-        pxt.tickEvent(`menu.lang.setcookielang.${langId}`);
+        pxt.tickEvent(`menu.lang.setcookielang`, {lang : langId});
         const expiration = new Date();
         expiration.setTime(expiration.getTime() + (pxt.Util.langCookieExpirationDays * 24 * 60 * 60 * 1000));
         document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}`;
@@ -62,14 +62,14 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
         setCookieLang(langId);
 
         if (langId !== initialLang) {
-            pxt.tickEvent(`menu.lang.changelang.${langId}`);
+            pxt.tickEvent(`menu.lang.changelang`, {lang : langId});
             pxt.winrt.releaseAllDevicesAsync()
                 .then(() => {
                     this.props.parent.reloadEditor();
                 })
                 .done();
         } else {
-            pxt.tickEvent(`menu.lang.samelang.${langId}`);
+            pxt.tickEvent(`menu.lang.samelang`, {lang : langId});
             this.hide();
         }
     }


### PR DESCRIPTION
This removes all the dynamic properties as  part of our telemetry

What we used to emit
EntityName : activity
PropertyName  :  blocks.create.forever
PropertyValue : 25

New telemetry
EntityName : block.create
PropertyName  :  block
PropertyValue : "blocks.create.forever"

Individual events are sent as part of count. We could add separate count PropertyName to the existing blocks.create as well. 
