### PR TITLE
Implement inline-diff for single line changes

### DIFF
--- a/theme/github.less
+++ b/theme/github.less
@@ -14,23 +14,23 @@
     border-spacing: 0px;
     width: 100%;
 
-    pre {
-        margin: 0;
+    .change code {
+        white-space: pre;
     }
 
     .diff-added {
         background: @diffAddedBackground;
 
-        pre:hover {
-            background: @diffAddedHoverBackground;
+        .ch-added {
+            background: @diffAddedTokenBackground;
         }
     }
 
     .diff-removed {
         background: @diffRemovedBackground;
 
-        pre:hover {
-            background: @diffRemovedHoverBackground;
+        .ch-removed {
+            background: @diffRemovedTokenBackground;
         }
     }
 

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -224,9 +224,9 @@ default semantic
 @diffAddedBackground: #e6ffed;
 @diffMarkerBackground: #f1f8ff;
 @diffMarkerColor: rgba(27,31,35,.7);
-@diffHoverDarkenRatio: 10%;
-@diffRemovedHoverBackground:darken(@diffRemovedBackground, @diffHoverDarkenRatio);;
-@diffAddedHoverBackground: darken(@diffAddedBackground, @diffHoverDarkenRatio);;
+@diffTokenDarkenRatio: 10%;
+@diffRemovedTokenBackground:darken(@diffRemovedBackground, @diffTokenDarkenRatio);;
+@diffAddedTokenBackground: darken(@diffAddedBackground, @diffTokenDarkenRatio);;
 
 
 /*-------------------

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -369,6 +369,36 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         }
     }
 
+    private lineDiff(lineA: string, lineB: string) {
+        const df = pxt.github.diff(lineA.split("").join("\n"), lineB.split("").join("\n"), {
+            context: Infinity
+        })
+        const ja: JSX.Element[] = []
+        const jb: JSX.Element[] = []
+        for (let i = 0; i < df.length; ) {
+            let j = i
+            const mark = df[i][0]
+            while (df[j] && df[j][0] == mark)
+                j++
+            const chunk = df.slice(i, j).map(s => s.slice(2)).join("")
+            if (mark == " ") {
+                ja.push(<code key={i} className="ch-common">{chunk}</code>)
+                jb.push(<code key={i} className="ch-common">{chunk}</code>)
+            } else if (mark == "-") {
+                ja.push(<code key={i} className="ch-removed">{chunk}</code>)
+            } else if (mark == "+") {
+                jb.push(<code key={i} className="ch-added">{chunk}</code>)
+            } else {
+                pxt.Util.oops()
+            }
+            i = j
+        }
+        return {
+            a: <div className="inline-diff">{ja}</div>,
+            b: <div className="inline-diff">{jb}</div>
+        }
+    }
+
     private showDiff(f: pkg.File) {
         let cache = this.diffCache[f.name]
         if (!cache || cache.file !== f) {
@@ -387,7 +417,9 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         }
         const diffLines = pxt.github.diff(f.baseGitContent || "", f.content, { ignoreWhitespace: true })
         let lnA = 0, lnB = 0
-        const diffJSX = isBlocks ? [] : diffLines.map(ln => {
+        let lastMark = ""
+        let savedDiff: JSX.Element = null
+        const diffJSX = isBlocks ? [] : diffLines.map((ln, idx) => {
             const m = /^@@ -(\d+),\d+ \+(\d+),\d+/.exec(ln)
             if (m) {
                 lnA = parseInt(m[1]) - 1
@@ -398,17 +430,31 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                 if (ln[0] != "-")
                     lnB++
             }
+            const nextMark = diffLines[idx + 1] ? diffLines[idx + 1][0] : ""
+            const next2Mark = diffLines[idx + 2] ? diffLines[idx + 2][0] : ""
+            let currDiff = <code>{ln.slice(2)}</code>
+
+            if (savedDiff) {
+                currDiff = savedDiff
+                savedDiff = null
+            } else if (ln[0] == "-" && (lastMark == " " || lastMark == "@") && nextMark == "+"
+                && (next2Mark == " " || next2Mark == "@" || next2Mark == "")) {
+                const r = this.lineDiff(ln.slice(2), diffLines[idx + 1].slice(2))
+                currDiff = r.a
+                savedDiff = r.b
+            }
+            lastMark = ln[0]
             return (
                 <tr key={lnA + lnB} className={classes[ln[0]]}>
                     <td className="line-a" data-content={lnA}></td>
                     <td className="line-b" data-content={lnB}></td>
                     {ln[0] == "@"
-                        ? <td colSpan={2} className="change"><pre>{ln}</pre></td>
+                        ? <td colSpan={2} className="change"><code>{ln}</code></td>
                         : <td className="marker" data-content={ln[0]}></td>
                     }
                     {ln[0] == "@"
                         ? undefined
-                        : <td className="change"><pre>{ln.slice(2)}</pre></td>
+                        : <td className="change">{currDiff}</td>
                     }
                 </tr>)
         })


### PR DESCRIPTION
This also removes hover highlight. Github doesn't do it, and it seem too much together with inline diff markers.

The inline diff only kicks in for single-line changes (that a single line is updated, with at least one unchanged line above and below).
