### PR TITLE
Fix pause(0) and memory leak

### DIFF
--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -602,10 +602,7 @@ namespace pxsim {
 
         export function pause(ms: number) {
             let cb = getResume();
-            if (ms < 1)
-                cb()
-            else
-                runtime.schedule(() => { cb() }, ms)
+            runtime.schedule(() => { cb() }, ms)
         }
 
         export function runInBackground(a: RefAction) {

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -602,7 +602,10 @@ namespace pxsim {
 
         export function pause(ms: number) {
             let cb = getResume();
-            runtime.schedule(() => { cb() }, ms)
+            if (ms < 1)
+                cb()
+            else
+                runtime.schedule(() => { cb() }, ms)
         }
 
         export function runInBackground(a: RefAction) {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1257,23 +1257,25 @@ namespace pxsim {
             }
         }
 
-
         // Wrapper for the setTimeout
         schedule(fn: Function, timeout: number): number {
+            if (timeout <= 1) timeout = 1;
             if (this.pausedOnBreakpoint) {
                 this.timeoutsPausedOnBreakpoint.push(new PausedTimeout(fn, timeout));
                 return -1;
             }
+            const timestamp = U.now();
+            const to = new TimeoutScheduled(-1, fn, timeout, timestamp)
             // We call the timeout function and add its id to the timeouts scheduled.
-            if (timeout <= 0) return -1;
-            let timestamp = U.now();
-            let removeAndExecute = () => {
-                this.timeoutsScheduled.filter(ts => ts.timestampCall !== timestamp);
+            const removeAndExecute = () => {
+                const idx = this.timeoutsScheduled.indexOf(to)
+                if (idx >= 0)
+                    this.timeoutsScheduled.splice(idx, 1)
                 fn();
             }
-            let id = setTimeout(removeAndExecute, timeout);
-            this.timeoutsScheduled.push(new TimeoutScheduled(id, fn, timeout, timestamp));
-            return id;
+            to.id = setTimeout(removeAndExecute, timeout);
+            this.timeoutsScheduled.push(to);
+            return to.id;
         }
 
         // On breakpoint, pause all timeouts

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1259,7 +1259,7 @@ namespace pxsim {
 
         // Wrapper for the setTimeout
         schedule(fn: Function, timeout: number): number {
-            if (timeout <= 1) timeout = 1;
+            if (timeout <= 0) timeout = 0;
             if (this.pausedOnBreakpoint) {
                 this.timeoutsPausedOnBreakpoint.push(new PausedTimeout(fn, timeout));
                 return -1;


### PR DESCRIPTION
* pause(0) just hangs forever in current implementation; now it will yield to other threads
* there was also a memory leak in timeout implementation (`filter` doesn't modify the list)

Fixes https://github.com/microsoft/pxt-arcade/issues/1098
