### PR TITLE
Treat globals defined inside loops as locals

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -426,6 +426,7 @@ namespace ts.pxtc {
 
     function getEnclosingFunction(node0: Node) {
         let node = node0
+        let hadLoop = false
         while (true) {
             node = node.parent
             if (!node)
@@ -439,7 +440,17 @@ namespace ts.pxtc {
                 case SK.ArrowFunction:
                 case SK.FunctionExpression:
                     return <FunctionLikeDeclaration>node
+                case SK.WhileStatement:
+                case SK.DoStatement:
+                case SK.ForInStatement:
+                case SK.ForOfStatement:
+                case SK.ForStatement:
+                    hadLoop = true
+                    break
                 case SK.SourceFile:
+                    // don't treat variables declared inside of top-level loops as global
+                    if (hadLoop)
+                        return _rootFunction
                     return null
             }
         }
@@ -567,6 +578,7 @@ namespace ts.pxtc {
 
     let lf = assembler.lf;
     let checker: TypeChecker;
+    let _rootFunction: FunctionDeclaration
     export let target: CompileTarget;
     export let compileOptions: CompileOptions;
     let lastSecondaryError: string
@@ -1003,6 +1015,7 @@ namespace ts.pxtc {
             pos: 0,
             end: 0,
         }
+        _rootFunction = rootFunction
         const pinfo = pxtInfo(rootFunction)
         pinfo.flags |= PxtNodeFlags.IsRootFunction | PxtNodeFlags.IsBogusFunction
 

--- a/tests/compile-test/lang-test0/44toplevelcode.ts
+++ b/tests/compile-test/lang-test0/44toplevelcode.ts
@@ -29,3 +29,14 @@ assert(xyz == 13, "init2")
 xyz = 0
 
 for (let e of [""]) {}
+
+s2 = ""
+for (let i = 0; i < 3; i++) {
+    let copy = i;
+    control.runInBackground(() => {
+        pause(10 * copy + 1);
+        s2 = s2 + copy;
+    });
+}
+pause(200)
+assert(s2 == "012")


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt/issues/2251
