### PR TITLE
Add 'Localization Overview' video to the translate page

### DIFF
--- a/docs/translate.md
+++ b/docs/translate.md
@@ -14,6 +14,14 @@ The project below contains the resources from https://makecode.com and the menu 
 
 If you want to help with translating the editor, please sign in to Crowdin (or join first if you don't already have an account) and send us a translator request.
 
+### ~ hint
+
+Interested in how localization works in MakeCode? Watch this video for an overview of the process.
+
+[MakeCode localization video](#)
+
+### ~
+
 ## Languages
 
 On the Crowdin [home page](https://crowdin.com/project/kindscript) are the all of the languages enabled for the MakeCode project. You go here first to choose the language or languages you wish to participate in for translation.

--- a/docs/translate.md
+++ b/docs/translate.md
@@ -18,7 +18,7 @@ If you want to help with translating the editor, please sign in to Crowdin (or j
 
 Interested in how localization works in MakeCode? Watch this video for an overview of the process.
 
-[MakeCode localization video](https://youtu.be/XpdUzpBVKFU)
+https://youtu.be/XpdUzpBVKFU
 
 ### ~
 

--- a/docs/translate.md
+++ b/docs/translate.md
@@ -18,7 +18,7 @@ If you want to help with translating the editor, please sign in to Crowdin (or j
 
 Interested in how localization works in MakeCode? Watch this video for an overview of the process.
 
-[MakeCode localization video](#)
+[MakeCode localization video](https://youtu.be/XpdUzpBVKFU)
 
 ### ~
 


### PR DESCRIPTION
I made a video that gives an general overview of the localization process. This is one of maybe three videos to help people work on translation. I'm thinking of doing one for signing up to translate and another that talks about the translation tasks/activities.

[Localization video](https://microsoft-my.sharepoint.com/:v:/p/v-gani/EdA9BnEtYEhCrBc23fGFncgB7UJEbLoLy8qYNm-Dlcrn6Q?e=5tXoZM)