### PR TITLE
Commit field editors (stable4.0)

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -256,6 +256,7 @@ namespace pxt.editor {
 
 
     export interface ExtensionOptions {
+        projectView: IProjectView;
         blocklyToolbox: ToolboxDefinition;
         monacoToolbox: ToolboxDefinition;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2695,6 +2695,7 @@ function initExtensionsAsync(): Promise<void> {
 
     pxt.debug('loading editor extensions...');
     const opts: pxt.editor.ExtensionOptions = {
+        projectView: theEditor,
         blocklyToolbox: blocklyToolbox.getToolboxDefinition(),
         monacoToolbox: monacoToolbox.getToolboxDefinition()
     };

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -369,7 +369,7 @@ export class ProjectView
     private autoRunBlocksSimulator = pxtc.Util.debounce(
         () => {
             if (Util.now() - this.lastChangeTime < 1000) return;
-            if (!this.state.active)
+            if (!this.state.active || this.state.collapseEditorTools)
                 return;
             this.runSimulator({ debug: !!this.state.debugging, background: true });
         },
@@ -378,7 +378,7 @@ export class ProjectView
     private autoRunSimulator = pxtc.Util.debounce(
         () => {
             if (Util.now() - this.lastChangeTime < 1000) return;
-            if (!this.state.active)
+            if (!this.state.active || this.state.collapseEditorTools)
                 return;
             this.runSimulator({ debug: !!this.state.debugging, background: true });
         },

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1421,12 +1421,13 @@ export class ProjectView
         if (this.checkForHwVariant())
             return;
 
+        this.beforeCompile();
         if (pxt.appTarget.compile.saveAsPNG && !pxt.hwVariant) {
+            this.editor.beforeCompile();
             this.saveAndCompile();
             return;
         }
 
-        this.beforeCompile();
         let userContextWindow: Window = undefined;
         if (!pxt.appTarget.compile.useModulator && pxt.BrowserUtils.isBrowserDownloadInSameWindow() && !pxt.BrowserUtils.isBrowserDownloadWithinUserContext())
             userContextWindow = window.open("");

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -114,6 +114,17 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
+    beforeCompile() {
+        // close all field editors to make sure
+        // that all changes are commited
+        // it is quite common for users to click download
+        // while a field editor is still opened and the changes are not commited
+        if (typeof Blockly === "undefined") return;
+
+        Blockly.DropDownDiv.hide();
+        Blockly.WidgetDiv.hide();
+    }
+
     private saveBlockly(): string {
         // make sure we don't return an empty document before we get started
         // otherwise it may get saved and we're in trouble


### PR DESCRIPTION
Usability bugs in ev3 editor:
- [x] collapse blockly field editor before compiling to force commiting changes. Since EV3 is heavy on field editor, a lot of changes were not picked up when pressing download
- [x] don't run simulator when collapsed
- [x] pass IProjectView to editor extension to allow restarting the compile process once paired with Bluetooth
