### PR TITLE
add aria label for text input boxes

### DIFF
--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -135,7 +135,7 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
                         onChange={this.handleInputChange}
                         value={inputValue}
                         placeholder={options.placeholder}
-                        aria-label={lf(`text prompt for {0}`, options.placeholder)}
+                        aria-label={options.placeholder}
                     />
                     {inputError ? <div className="ui error message">{inputError}</div> : undefined}
                 </div> : undefined}

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -127,7 +127,16 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
                 modalDidOpen={this.modalDidOpen}
             >
                 {options.type == 'prompt' ? <div className="ui fluid icon input">
-                    <input autoFocus className={`ui input ${inputError ? "error" : ""}`} type="text" ref="promptInput" onChange={this.handleInputChange} value={inputValue} placeholder={options.placeholder} />
+                    <input
+                        autoFocus
+                        className={`ui input ${inputError ? "error" : ""}`}
+                        type="text"
+                        ref="promptInput"
+                        onChange={this.handleInputChange}
+                        value={inputValue}
+                        placeholder={options.placeholder}
+                        aria-label={lf(`text prompt for {0}`, options.placeholder)}
+                    />
                     {inputError ? <div className="ui error message">{inputError}</div> : undefined}
                 </div> : undefined}
                 {options.jsx}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2332; prompts that used this dialog (this one, duplicate in project list view, blockly create a variable, etc - anything using promptAsync) all had this bug. Change in here was just adding the aria-label, rest is just splitting up the line as it was long / getting hard to parse.