### PR TITLE
Variable names for repeat blocks shouldn't conflict with user variables

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -984,10 +984,12 @@ namespace pxt.blocks {
     function compileControlsRepeat(e: Environment, b: Blockly.Block, comments: string[]): JsNode[] {
         let bound = compileExpression(e, getInputTargetBlock(b, "TIMES"), comments);
         let body = compileStatements(e, getInputTargetBlock(b, "DO"));
-        let valid = (x: string) => !e.renames.takenNames[x]
-        let name = "i";
-        for (let i = 0; !valid(name); i++)
-            name = "i" + i;
+        let valid = (x: string) => !lookup(e, b, x);
+
+        let name = "index";
+        // Start at 2 because index0 and index1 are bad names
+        for (let i = 2; !valid(name); i++)
+            name = "index" + i;
         return [
             mkText("for (let " + name + " = 0; "),
             mkInfix(mkText(name), "<", bound),

--- a/tests/blocklycompiler-test/baselines/loops.ts
+++ b/tests/blocklycompiler-test/baselines/loops.ts
@@ -1,4 +1,4 @@
-for (let i = 0; i < 0 + 0; i++) {
+for (let index = 0; index < 0 + 0; index++) {
     while (true) {
         for (let index = 0; index <= 4; index++) {
 

--- a/tests/blocklycompiler-test/baselines/loops_local_variables.ts
+++ b/tests/blocklycompiler-test/baselines/loops_local_variables.ts
@@ -1,11 +1,11 @@
 let index = 0
 let i = 0
-for (let i = 0; i < 4; i++) {
-  i = 0
-  for (let i = 0; i < 4; i++) {
-    index = 0
-  }
+for (let index2 = 0; index2 < 4; index2++) {
+    i = 0
+    for (let index2 = 0; index2 < 4; index2++) {
+        index = 0
+    }
 }
 for (let index = 0; index <= 4; index++) {
-  index = 0
+    index = 0
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2453

Also renames the variable we emit from `i` to `index` to better match our other for-loop blocks