### PR TITLE
remove Times New Roman

### DIFF
--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -38,7 +38,6 @@
 @importGoogleFonts: false;
 
 @docsHeaderFont: "Helvetica Neue", Helvetica, Arial, sans-serif;
-@docsPageFont: "Times New Roman", serif;
 
 @emSize      : 18px;
 @fontSize    : 18px;


### PR DESCRIPTION
Not sure why we would want Times New Roman. Looks bad and everyone's first instinct is that something broke:
![image](https://user-images.githubusercontent.com/6453828/66022838-0ae41500-e4a4-11e9-8320-8914ecaf9213.png)

after:
![image](https://user-images.githubusercontent.com/6453828/66022859-19cac780-e4a4-11e9-905e-2a28d07a00f4.png)

maybe I'm missing something