### PR TITLE
Add lifecycle functions before and after tutorial code

### DIFF
--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -526,3 +526,11 @@ declare namespace Math {
     //% shim=Math_::idiv
     function idiv(x: number, y: number): number;
 }
+
+declare namespace _lifecycle {
+    //% shim=__lifecycle::onCodeStart
+    export function onCodeStart(arg: any): void;
+
+    //% shim=__lifecycle::onCodeStop
+    export function onCodeStop(arg: any): void;
+}

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -527,10 +527,10 @@ declare namespace Math {
     function idiv(x: number, y: number): number;
 }
 
-declare namespace _lifecycle {
-    //% shim=__lifecycle::onCodeStart
-    export function onCodeStart(arg: any): void;
+declare namespace control {
+    //% shim=_control::_onCodeStart
+    export function _onCodeStart(arg: any): void;
 
-    //% shim=__lifecycle::onCodeStop
-    export function onCodeStop(arg: any): void;
+    //% shim=_control::_onCodeStop
+    export function _onCodeStop(arg: any): void;
 }

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -526,3 +526,11 @@ declare namespace Math {
     //% shim=Math_::idiv
     function idiv(x: number, y: number): number;
 }
+
+declare namespace _lifecycle {
+    //% shim=__lifecycle::onCodeStart
+    export function onCodeStart(arg: any): void;
+
+    //% shim=__lifecycle::onCodeStop
+    export function onCodeStop(arg: any): void;
+}

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -527,10 +527,10 @@ declare namespace Math {
     function idiv(x: number, y: number): number;
 }
 
-declare namespace _lifecycle {
-    //% shim=__lifecycle::onCodeStart
-    export function onCodeStart(arg: any): void;
+declare namespace control {
+    //% shim=_control::_onCodeStart
+    export function _onCodeStart(arg: any): void;
 
-    //% shim=__lifecycle::onCodeStop
-    export function onCodeStop(arg: any): void;
+    //% shim=_control::_onCodeStop
+    export function _onCodeStop(arg: any): void;
 }

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -803,6 +803,8 @@ declare namespace pxt.tutorial {
         explicitHints?: boolean; // tutorial expects explicit hints in `#### ~ tutorialhint` format
         flyoutOnly?: boolean; // no categories, display all blocks in flyout
         hideIteration?: boolean; // hide step control in tutorial
+        codeStart?: string; // command to run when code starts (MINECRAFT HOC ONLY)
+        codeStop?: string; // command to run when code stops (MINECRAFT HOC ONLY)
     }
 
     interface TutorialStepInfo {

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -125,9 +125,9 @@ namespace ts.pxtc {
         }
 
         // run post-processing code last, if present
-        const post_idx = opts.sourceFiles.indexOf("_onCodeStop.ts")
-        if (post_idx >= 0) {
-            opts.sourceFiles.splice(post_idx, 1)
+        const postIdx = opts.sourceFiles.indexOf("_onCodeStop.ts")
+        if (postIdx >= 0) {
+            opts.sourceFiles.splice(postIdx, 1)
             opts.sourceFiles.push("_onCodeStop.ts")
         }
 

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -124,6 +124,13 @@ namespace ts.pxtc {
             opts.sourceFiles.push("main.ts")
         }
 
+        // run post-processing code last, if present
+        const post_idx = opts.sourceFiles.indexOf("_onCodeStop.ts")
+        if (post_idx >= 0) {
+            opts.sourceFiles.splice(post_idx, 1)
+            opts.sourceFiles.push("_onCodeStop.ts")
+        }
+
         res.times["conversions"] = U.cpuUs() - startTime
 
         return res
@@ -333,6 +340,14 @@ namespace ts.pxtc {
             tsFiles.push("main.ts")
             hasMain = true;
         }
+
+        // run post-processing code last, if present
+        const post_idx = tsFiles.indexOf("_onCodeStop.ts")
+        if (post_idx >= 0) {
+            tsFiles.splice(post_idx, 1)
+            tsFiles.push("_onCodeStop.ts")
+        }
+
         // TODO: ensure that main.ts is last???
         const program = createProgram(tsFiles, options, host, old);
         annotate(program, "main.ts", target || (pxt.appTarget && pxt.appTarget.compile));

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -351,6 +351,10 @@ namespace pxt.editor {
 
         // Used with the @tutorialCompleted macro. See docs/writing-docs/tutorials.md for more info
         onTutorialCompleted?: () => void;
+
+        // Used with @codeStart, @codeStop metadata (MINECRAFT HOC ONLY)
+        onCodeStart?: () => void;
+        onCodeStop?: () => void;
     }
 
     export interface FieldExtensionOptions {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -22,7 +22,9 @@ namespace pxt.docs {
         "activities": "<!-- activities -->",
         "explicitHints": "<!-- hints -->",
         "flyoutOnly": "<!-- flyout -->",
-        "hideIteration": "<!-- iter -->"
+        "hideIteration": "<!-- iter -->",
+        "codeStart": "<!-- start -->",
+        "codeStop": "<!-- stop -->"
     }
 
     function replaceAll(replIn: string, x: string, y: string) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1891,12 +1891,12 @@ export class ProjectView
         if (options.tutorial && options.tutorial.metadata) {
             if (options.tutorial.metadata.codeStart) {
                 let codeStart = "_onCodeStart.ts";
-                files[codeStart] = "_lifecycle.onCodeStart('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStart) + "')";
+                files[codeStart] = "control._onCodeStart('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStart) + "')";
                 cfg.files.splice(cfg.files.indexOf("main.ts"), 0, codeStart);
             }
             if (options.tutorial.metadata.codeStop) {
                 let codeStop = "_onCodeStop.ts";
-                files[codeStop] = "_lifecycle.onCodeStop('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStop) + "')";
+                files[codeStop] = "control._onCodeStop('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStop) + "')";
                 cfg.files.push(codeStop);
             }
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1888,6 +1888,18 @@ export class ProjectView
             cfg.files.push("main.py");
             files["main.py"] = "\n";
         }
+        if (options.tutorial && options.tutorial.metadata) {
+            if (options.tutorial.metadata.codeStart) {
+                let codeStart = "_onCodeStart.ts";
+                files[codeStart] = "_lifecycle.onCodeStart('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStart) + "')";
+                cfg.files.splice(cfg.files.indexOf("main.ts"), 0, codeStart);
+            }
+            if (options.tutorial.metadata.codeStop) {
+                let codeStop = "_onCodeStop.ts";
+                files[codeStop] = "_lifecycle.onCodeStop('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStop) + "')";
+                cfg.files.push(codeStop);
+            }
+        }
         files["pxt.json"] = JSON.stringify(cfg, null, 4) + "\n";
         return workspace.installAsync({
             name: cfg.name,


### PR DESCRIPTION
For the hour of code, the Minecraft team wants to be able to send a command when the code in "onStart" starts, and when it ends. This generates codeStart/codeStop files for a tutorial project & inserts them before and after main.ts. The files call "onCodeStart"/"onCodeStop", which are implemented by the target.