### PR TITLE
divider line above headers

### DIFF
--- a/theme/docs.less
+++ b/theme/docs.less
@@ -46,6 +46,14 @@
     h1 {
         margin-bottom: .85em;
     }
+    h2 {
+        margin-top: 1.5em;
+
+        &:not(:first-of-type) {
+            padding-top: 1.5em;
+            border-top: 2px solid fade(@docsHeadingColor, 15%);
+        }
+    }
     /* Text color */
     p, ul li {
         color: @docsTextColor;


### PR DESCRIPTION
closes https://github.com/microsoft/pxt/issues/5985

I went with about 1/4 the white space around the divider as it felt pretty aggressive to me

<img width="1083" alt="Screen Shot 2019-10-03 at 2 48 25 PM" src="https://user-images.githubusercontent.com/5615930/66166712-e9db0b80-e5ec-11e9-923b-965eea5bf202.png">
<img width="1397" alt="Screen Shot 2019-10-03 at 2 47 02 PM" src="https://user-images.githubusercontent.com/5615930/66166713-e9db0b80-e5ec-11e9-848b-21e02951b551.png">
