### PR TITLE
align docs content left

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -10,8 +10,12 @@ body#root {
     list-style-type: none;
 }
 
+#docs ol {
+    padding-left: 1em;
+}
+
 #docs ul li:before {
-  margin: 0 1em; 
+  margin-right: 1em;
   content: "\25CF";
 }
 
@@ -357,6 +361,10 @@ svg {
         margin-bottom: 2em;
         padding-left: 2em;
         padding-right: 2em;
+    }
+
+    #docs .ui.container.mainbody {
+        margin-left: 0 !important;
     }
 }
 

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -369,7 +369,7 @@ namespace pxt.docs {
 
     export function setupRenderer(renderer: marked.Renderer) {
         renderer.image = function (href: string, title: string, text: string) {
-            let out = '<img class="ui centered image" src="' + href + '" alt="' + text + '"';
+            let out = '<img class="ui image" src="' + href + '" alt="' + text + '"';
             if (title) {
                 out += ' title="' + title + '"';
             }


### PR DESCRIPTION
closes https://github.com/microsoft/pxt/issues/5986

Align all docs content to the left:

![2019-10-03 15 27 40](https://user-images.githubusercontent.com/5615930/66168542-5f95a600-e5f2-11e9-8fcd-c8355641315b.gif)

![2019-10-03 15 24 08](https://user-images.githubusercontent.com/5615930/66168498-41c84100-e5f2-11e9-984e-e17d91a79b8d.gif)

