### PR TITLE
refactor icon logic for home screen/project manager

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -461,7 +461,6 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                     </div>
                 </div> : undefined}
                 {headers.slice(0, ProjectsCarousel.NUM_PROJECTS_HOMESCREEN).map((scr, index) => {
-                    const boardsvg = pxt.bundledSvg(scr.board);
                     const tutorialStep =
                         scr.tutorial ? scr.tutorial.tutorialStep
                             : scr.tutorialCompleted ? scr.tutorialCompleted.steps - 1
@@ -474,8 +473,6 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                         key={'local' + scr.id + scr.recentUse}
                         // ref={(view) => { if (index === 1) this.latestProject = view }}
                         cardType="file"
-                        className={scr.githubId ? "file github" : (boardsvg && scr.board) ? "file board" : "file"}
-                        imageUrl={scr.githubId ? undefined : boardsvg}
                         name={scr.name}
                         time={scr.recentUse}
                         url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}
@@ -522,8 +519,21 @@ export class ProjectsCodeCard extends sui.StatelessUIElement<ProjectsCodeCardPro
     }
 
     renderCore() {
-        const { scr, onCardClick, onLabelClick, onClick, ...rest } = this.props;
-        return <codecard.CodeCardView {...rest} onClick={this.handleClick}
+        let { scr, onCardClick, onLabelClick, onClick, cardType, imageUrl, className, ...rest } = this.props;
+
+        // compute icon
+        if (scr && cardType == "file") {
+            if (scr.githubId)
+                className = 'file github ' + className;
+            else if (scr.board) {
+                className = 'file board ' + className;
+                imageUrl = pxt.bundledSvg(scr.board)
+            }
+            else
+                className = 'file ' + className;
+        }
+
+        return <codecard.CodeCardView className={className} imageUrl={imageUrl} cardType={cardType} {...rest} onClick={this.handleClick}
             onLabelClicked={onLabelClick ? this.handleLabelClick : undefined} />
     }
 }

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -369,7 +369,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                                 return <ProjectsCodeCard
                                     key={'local' + scr.id + scr.recentUse}
                                     cardType="file"
-                                    className={`file ${isMarkedNew ? 'warning' : isSelected ? 'positive' : ''}`}
+                                    className={`${isMarkedNew ? 'warning' : isSelected ? 'positive' : ''}`}
                                     name={scr.name}
                                     time={scr.recentUse}
                                     url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}


### PR DESCRIPTION
Refactor logic that selects icon (mk logo/github/board) into component.
![image](https://user-images.githubusercontent.com/4175913/66174536-66301780-e60a-11e9-98a7-9f5025ac1a67.png)
