### PR TITLE
Blockly fixes for context menu, flyout trash icon, workspace scroll

### DIFF
--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -8577,6 +8577,14 @@ declare module Blockly {
             EDITABLE: boolean;
     
             /**
+             *  * Serializable fields are saved by the XML renderer, non-serializable fields
+             * are not. Editable fields should also be serializable.
+             * @type {boolean}
+             * @const
+             */
+            SERIALIZABLE: boolean;
+    
+            /**
              * Used to tell if the field needs to be rendered the next time the block is
              * rendered. Image fields are statically sized, and only need to be
              * rendered at initialization.

--- a/localtypings/blockly.d.ts
+++ b/localtypings/blockly.d.ts
@@ -155,6 +155,7 @@ declare module Blockly {
         hasCategories?: boolean;
         trashcan?: boolean;
         collapse?: boolean;
+        inline?: boolean;
         comments?: boolean;
         disable?: boolean;
         scrollbars?: boolean;
@@ -177,6 +178,11 @@ declare module Blockly {
             minScale?: number;
             scaleSpeed?: number;
             startScale?: number;
+        };
+        move?: {
+            scrollbars?: boolean;
+            wheel?: boolean;
+            drag?: boolean;
         };
         enableRealTime?: boolean;
         rtl?: boolean;
@@ -8903,12 +8909,17 @@ declare module Blockly {
             getNumRestrictor(opt_min: number|string|any /*undefined*/, opt_max: number|string|any /*undefined*/, opt_precision: number|string|any /*undefined*/): RegExp;
     
             /**
-             * Set the constraints for this field.
-             * @param {number=} opt_min Minimum number allowed.
-             * @param {number=} opt_max Maximum number allowed.
-             * @param {number=} opt_precision Step allowed between numbers
+             * Set the maximum, minimum and precision constraints on this field.
+             * Any of these properties may be undefiend or NaN to be disabled.
+             * Setting precision (usually a power of 10) enforces a minimum step between
+             * values. That is, the user's value will rounded to the closest multiple of
+             * precision. The least significant digit place is inferred from the precision.
+             * Integers values can be enforces by choosing an integer precision.
+             * @param {number|string|undefined} min Minimum value.
+             * @param {number|string|undefined} max Maximum value.
+             * @param {number|string|undefined} precision Precision for value.
              */
-            setConstraints_(opt_min?: number, opt_max?: number, opt_precision?: number): void;
+            setConstraints_(min: number|string|any /*undefined*/, max: number|string|any /*undefined*/, precision: number|string|any /*undefined*/): void;
     
             /**
              * Show the inline free-text editor on top of the text and the num-pad if

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.5",
-    "pxt-blockly": "2.1.3",
+    "pxt-blockly": "2.1.4",
     "react": "16.8.3",
     "react-dom": "16.3.1",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1385,7 +1385,8 @@ namespace pxt.blocks {
         const blockDrag = (<any>Blockly).BlockDragger.prototype.dragBlock;
         (<any>Blockly).BlockDragger.prototype.dragBlock = function (e: any, currentDragDeltaXY: any) {
             const blocklyToolboxDiv = document.getElementsByClassName('blocklyToolboxDiv')[0] as HTMLElement;
-            const blocklyTreeRoot = document.getElementsByClassName('blocklyTreeRoot')[0] as HTMLElement;
+            const blocklyTreeRoot = document.getElementsByClassName('blocklyTreeRoot')[0] as HTMLElement
+                || document.getElementsByClassName('blocklyFlyout')[0] as HTMLElement;
             const trashIcon = document.getElementById("blocklyTrashIcon");
             if (blocklyTreeRoot && trashIcon) {
                 const distance = calculateDistance(blocklyTreeRoot.getBoundingClientRect(), e.clientX);
@@ -1393,14 +1394,16 @@ namespace pxt.blocks {
                     const opacity = distance / 200;
                     trashIcon.style.opacity = `${1 - opacity}`;
                     trashIcon.style.display = 'block';
-                    blocklyTreeRoot.style.opacity = `${opacity}`;
-                    if (distance < 50) {
-                        pxt.BrowserUtils.addClass(blocklyToolboxDiv, 'blocklyToolboxDeleting');
+                    if (blocklyToolboxDiv) {
+                        blocklyTreeRoot.style.opacity = `${opacity}`;
+                        if (distance < 50) {
+                            pxt.BrowserUtils.addClass(blocklyToolboxDiv, 'blocklyToolboxDeleting');
+                        }
                     }
                 } else {
                     trashIcon.style.display = 'none';
                     blocklyTreeRoot.style.opacity = '1';
-                    pxt.BrowserUtils.removeClass(blocklyToolboxDiv, 'blocklyToolboxDeleting');
+                    if (blocklyToolboxDiv) pxt.BrowserUtils.removeClass(blocklyToolboxDiv, 'blocklyToolboxDeleting');
                 }
             }
             return blockDrag.call(this, e, currentDragDeltaXY);
@@ -1416,12 +1419,13 @@ namespace pxt.blocks {
         (<any>Blockly).BlockDragger.prototype.endBlockDrag = function (e: any, currentDragDeltaXY: any) {
             blockEndDrag.call(this, e, currentDragDeltaXY);
             const blocklyToolboxDiv = document.getElementsByClassName('blocklyToolboxDiv')[0] as HTMLElement;
-            const blocklyTreeRoot = document.getElementsByClassName('blocklyTreeRoot')[0] as HTMLElement;
+            const blocklyTreeRoot = document.getElementsByClassName('blocklyTreeRoot')[0] as HTMLElement
+                || document.getElementsByClassName('blocklyFlyout')[0] as HTMLElement;
             const trashIcon = document.getElementById("blocklyTrashIcon");
             if (trashIcon && blocklyTreeRoot) {
                 trashIcon.style.display = 'none';
                 blocklyTreeRoot.style.opacity = '1';
-                pxt.BrowserUtils.removeClass(blocklyToolboxDiv, 'blocklyToolboxDeleting');
+                if (blocklyToolboxDiv) pxt.BrowserUtils.removeClass(blocklyToolboxDiv, 'blocklyToolboxDeleting');
             }
         }
     }

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -151,6 +151,12 @@ span.blocklyTreeLabel, text.blocklyText {
     color: @trashIconColor;
 }
 
+.flyoutOnly #blocklyTrashIcon {
+    top: auto;
+    bottom: 5%;
+    left: 10rem;
+}
+
 .blocklyToolboxDelete .blocklyTreeLabel {
     cursor: url("<<<PATH>>>/handdelete.cur") auto;
 }
@@ -222,7 +228,7 @@ div.blocklyTreeIcon span {
         line-height: @blocklyRowHeightWide;
         min-height: @blocklyRowHeightWide;
     }
-    #blocklyTrashIcon {
+    #root:not(.flyoutOnly) #blocklyTrashIcon {
         width: @blocklyRowWidthWide;
     }
 }
@@ -240,7 +246,7 @@ div.blocklyTreeIcon span {
         line-height: @blocklyRowHeightComputer;
         min-height: @blocklyRowHeightComputer;
     }
-    #blocklyTrashIcon {
+    #root:not(.flyoutOnly) #blocklyTrashIcon {
         width: @blocklyRowWidthComputer;
     }
 }
@@ -259,7 +265,7 @@ div.blocklyTreeIcon span {
         line-height: @blocklyRowHeightTablet;
         min-height: @blocklyRowHeightTablet;
     }
-    #blocklyTrashIcon {
+    #root:not(.flyoutOnly) #blocklyTrashIcon {
         width: @blocklyRowWidthTablet;
     }
     div.blocklyTreeRoot div div div div div.blocklyTreeRow {
@@ -280,7 +286,7 @@ div.blocklyTreeIcon span {
         line-height: @blocklyRowHeightMobile;
         min-height: @blocklyRowHeightMobile;
     }
-    #blocklyTrashIcon {
+    #root:not(.flyoutOnly) #blocklyTrashIcon {
         width: @blocklyRowWidthMobile;
     }
 }
@@ -326,7 +332,7 @@ div.blocklyTreeIcon span {
         border-left-width: 8px !important;
     }
     /* Blockly trash icon */
-    #blocklyTrashIcon {
+    #root:not(.flyoutOnly) #blocklyTrashIcon {
         font-size: 3rem;
     }
     /* Hide the blockly toolbox search */

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -578,12 +578,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     zoomIn() {
         if (!this.editor) return;
-        this.editor.zoomCenter(2);
+        this.editor.zoomCenter(0.8);
     }
 
     zoomOut() {
         if (!this.editor) return;
-        this.editor.zoomCenter(-2);
+        this.editor.zoomCenter(-0.8);
     }
 
     setScale(scale: number) {
@@ -945,13 +945,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 colour: pxt.appTarget.appTheme.coloredToolbox,
                 inverted: pxt.appTarget.appTheme.invertedToolbox
             },
+            move: {
+                wheel: true
+            },
             zoom: {
                 enabled: false,
                 controls: false,
-                wheel: true,
                 maxScale: 2.5,
                 minScale: .2,
-                scaleSpeed: 1.05,
+                scaleSpeed: 1.5,
                 startScale: pxt.BrowserUtils.isMobile() ? 0.7 : 0.9
             },
             rtl: Util.isUserLanguageRtl()


### PR DESCRIPTION
Changes for:
- Context menu options (fixes https://github.com/microsoft/pxt/issues/6001)
- Scroll wheel binding to "move" instead of "zoom"/improved zoom parameters
- Trash icon for flyoutOnly block drag
- Variable XML generation
- Console warnings

Requires https://github.com/microsoft/pxt-blockly/pull/250, https://github.com/microsoft/pxt-blockly/pull/251