### PR TITLE
Translations in context in editor

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -374,7 +374,7 @@ export function expandHtml(html: string, params?: pxt.Map<string>) {
         theme: theme,
         // Note that breadcrumb and filepath expansion are not supported in the cloud
         // so we don't do them here either.
-    }    
+    }
     pxt.docs.prepTemplate(d)
     d.html = pxt.docs.renderConditionalMacros(d.html, params);
     return d.finish().replace(/@-(\w+)-@/g, (f, w) => "@" + w + "@")
@@ -936,9 +936,10 @@ export function serveAsync(options: ServeOptions) {
         if (opts["translate"]) {
             htmlParams["incontexttranslations"] = "1";
             opts["lang"] = pxt.Util.TRANSLATION_LOCALE;
+            opts["forcelang"] = pxt.Util.TRANSLATION_LOCALE;
         }
-        if (opts["lang"])
-            htmlParams["locale"] = opts["lang"] as string;
+        if (opts["lang"] || opts["forcelang"])
+            htmlParams["locale"] = (opts["lang"] as string || opts["forcelang"] as string); 
 
         if (pathname == "/") {
             res.writeHead(301, { location: '/index.html' })
@@ -1083,7 +1084,12 @@ export function serveAsync(options: ServeOptions) {
         for (let dir of dd) {
             let filename = path.resolve(path.join(dir, pathname))
             if (nodeutil.fileExistsSync(filename)) {
-                sendFile(filename)
+                if (/\.html$/.test(filename)) {
+                    let html = expandHtml(fs.readFileSync(filename, "utf8"), htmlParams)
+                    sendHtml(html)
+                } else {
+                    sendFile(filename)
+                }
                 return;
             }
         }

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -1130,7 +1130,7 @@ export function serveAsync(options: ServeOptions) {
         } else {
             const m = /^\/(v\d+)(.*)/.exec(pathname);
             if (m) pathname = m[2];
-            const lang = opts["translate"] ? "pxt" : opts["lang"] as string;
+            const lang = opts["lang"] as string || opts["forcelang"] as string;
             readMdAsync(pathname, lang)
                 .then(md => {
                     const mdopts = <pxt.docs.RenderOptions>{
@@ -1146,7 +1146,7 @@ export function serveAsync(options: ServeOptions) {
                     };
                     if (opts["translate"])
                         mdopts.pubinfo["incontexttranslations"] = "1";
-                    let html = pxt.docs.renderMarkdown(mdopts)
+                    const html = pxt.docs.renderMarkdown(mdopts)
                     sendHtml(html, U.startsWith(md, "# Not found") ? 404 : 200)
                 });
         }

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -933,11 +933,6 @@ export function serveAsync(options: ServeOptions) {
         let pathname = decodeURI(url.parse(req.url).pathname);
         const opts: pxt.Map<string | string[]> = querystring.parse(url.parse(req.url).query);
         const htmlParams: pxt.Map<string> = {};
-        if (opts["translate"]) {
-            htmlParams["incontexttranslations"] = "1";
-            opts["lang"] = pxt.Util.TRANSLATION_LOCALE;
-            opts["forcelang"] = pxt.Util.TRANSLATION_LOCALE;
-        }
         if (opts["lang"] || opts["forcelang"])
             htmlParams["locale"] = (opts["lang"] as string || opts["forcelang"] as string);
 
@@ -1130,7 +1125,9 @@ export function serveAsync(options: ServeOptions) {
         } else {
             const m = /^\/(v\d+)(.*)/.exec(pathname);
             if (m) pathname = m[2];
-            const lang = opts["lang"] as string || opts["forcelang"] as string;
+            const lang = (opts["translate"] && ts.pxtc.Util.TRANSLATION_LOCALE) 
+                || opts["lang"] as string 
+                || opts["forcelang"] as string;
             readMdAsync(pathname, lang)
                 .then(md => {
                     const mdopts = <pxt.docs.RenderOptions>{

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -374,8 +374,9 @@ export function expandHtml(html: string, params?: pxt.Map<string>) {
         theme: theme,
         // Note that breadcrumb and filepath expansion are not supported in the cloud
         // so we don't do them here either.
-    }
+    }    
     pxt.docs.prepTemplate(d)
+    d.html = pxt.docs.renderConditionalMacros(d.html, params);
     return d.finish().replace(/@-(\w+)-@/g, (f, w) => "@" + w + "@")
 }
 
@@ -932,6 +933,10 @@ export function serveAsync(options: ServeOptions) {
         let pathname = decodeURI(url.parse(req.url).pathname);
         const opts: pxt.Map<string | string[]> = querystring.parse(url.parse(req.url).query);
         const htmlParams: pxt.Map<string> = {};
+        if (opts["translate"]) {
+            htmlParams["incontexttranslations"] = "1";
+            opts["lang"] = pxt.Util.TRANSLATION_LOCALE;
+        }
         if (opts["lang"])
             htmlParams["locale"] = opts["lang"] as string;
 

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -939,7 +939,7 @@ export function serveAsync(options: ServeOptions) {
             opts["forcelang"] = pxt.Util.TRANSLATION_LOCALE;
         }
         if (opts["lang"] || opts["forcelang"])
-            htmlParams["locale"] = (opts["lang"] as string || opts["forcelang"] as string); 
+            htmlParams["locale"] = (opts["lang"] as string || opts["forcelang"] as string);
 
         if (pathname == "/") {
             res.writeHead(301, { location: '/index.html' })

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -376,7 +376,6 @@ export function expandHtml(html: string, params?: pxt.Map<string>) {
         // so we don't do them here either.
     }
     pxt.docs.prepTemplate(d)
-    d.html = pxt.docs.renderConditionalMacros(d.html, params);
     return d.finish().replace(/@-(\w+)-@/g, (f, w) => "@" + w + "@")
 }
 

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -1125,8 +1125,8 @@ export function serveAsync(options: ServeOptions) {
         } else {
             const m = /^\/(v\d+)(.*)/.exec(pathname);
             if (m) pathname = m[2];
-            const lang = (opts["translate"] && ts.pxtc.Util.TRANSLATION_LOCALE) 
-                || opts["lang"] as string 
+            const lang = (opts["translate"] && ts.pxtc.Util.TRANSLATION_LOCALE)
+                || opts["lang"] as string
                 || opts["forcelang"] as string;
             readMdAsync(pathname, lang)
                 .then(md => {

--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -12,7 +12,7 @@
 		var _jipt = [];
 		_jipt.push(['project', '@crowdinproject@']);
 		</script>
-		<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
 	<!-- @endif -->
 	<!-- @include meta.html -->
 	<!-- @include head.html -->

--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -11,6 +11,9 @@
 	<script type="text/javascript">
 		var _jipt = [];
 		_jipt.push(['project', '@crowdinproject@']);
+        _jipt.push(['escape', function() {
+            window.location.href = window.location.href.replace(/[$\?]translate=1/, '');
+        }]);
 		</script>
 	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
 	<!-- @endif -->

--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -11,10 +11,10 @@
 	<script type="text/javascript">
 		var _jipt = [];
 		_jipt.push(['project', '@crowdinproject@']);
-        _jipt.push(['escape', function() {
-            window.location.href = window.location.href.replace(/[$\?]translate=1/, '');
-        }]);
-		</script>
+		_jipt.push(['escape', function () {
+			window.location.href = window.location.href.replace(/[$\?]translate=1/, '');
+		}]);
+	</script>
 	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
 	<!-- @endif -->
 	<!-- @include meta.html -->
@@ -38,9 +38,10 @@
 				<!-- @include header.html -->
 
 				<div class="main ui container fluid mainbody">
-					<button id="printbtn" class="circular ui icon right floated button hideprint hidemobile" title="Print" aria-label="Print">
+					<button id="printbtn" class="circular ui icon right floated button hideprint hidemobile"
+						title="Print" aria-label="Print">
 						<i class="icon print"></i>
-					</button>							
+					</button>
 					@body@
 					<div class="hideprint">@github@</div>
 				</div>

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -193,8 +193,8 @@ function setupSemantic() {
         window.print();
     })
 
-    $('#translatebtn').on("click", function() {
-        window.location.href = window.location.href + (window.location.href.indexOf('?') > -1 ? "&" : "?") + "translate=1"        
+    $('#translatebtn').on("click", function () {
+        window.location.href = window.location.href.replace(/#.*/, '') + (window.location.href.indexOf('?') > -1 ? "&" : "?") + "translate=1"
     })
 
     if (/browsers$/i.test(window.location.href))
@@ -247,7 +247,7 @@ function renderSnippets() {
                     snippetClass: 'lang-blocks',
                     signatureClass: 'lang-sig',
                     blocksClass: 'lang-block',
-                    staticPythonClass: 'lang-spy', 
+                    staticPythonClass: 'lang-spy',
                     shuffleClass: 'lang-shuffle',
                     simulatorClass: 'lang-sim',
                     linksClass: 'lang-cards',

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -511,6 +511,7 @@ declare namespace ts.pxtc {
         undeletable?: boolean;
         callingConvention: ir.CallingConvention;
         block?: string; // format of the block, used at namespace level for category name
+        translationId?: string; // in-context translation id
         blockId?: string; // unique id of the block
         blockGap?: string; // pixels in toolbox after the block is inserted
         blockExternalInputs?: boolean; // force external inputs. Deprecated; see inlineInputMode.

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -2,6 +2,7 @@
 /// <reference path="../built/pxtlib.d.ts" />
 
 namespace pxt.blocks {
+    export let promptTranslateBlock: (blockId: string, blockTranslationId: string) => void;
 
     const typeDefaults: Map<{ field: string, block: string, defaultValue: string }> = {
         "string": {
@@ -432,14 +433,14 @@ namespace pxt.blocks {
             }
         }
 
-        if (pxt.Util.isTranslationLanguage()) {
+        if (pxt.Util.isTranslationLanguage() && pxt.blocks.promptTranslateBlock) {
             cachedBlock.block.customContextMenu = (options: any[]) => {
                 if (fn.attributes.translationId) {
                     options.push({
                         enabled: true,
-                        text: fn.attributes.translationId,
+                        text: lf("Translate this block"),
                         callback: function () {
-                            // do nothing
+                            pxt.blocks.promptTranslateBlock(id, fn.attributes.translationId);
                         }
                     })
                 }
@@ -1008,9 +1009,9 @@ namespace pxt.blocks {
                 if (blockd && blockd.translationId) {
                     options.push({
                         enabled: true,
-                        text: blockd.translationId,
+                        text: lf("Translate this block"),
                         callback: function () {
-                            // do nothing
+                            promptTranslateBlock(id, blockd.translationId);
                         }
                     })
                 }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -433,7 +433,8 @@ namespace pxt.blocks {
             }
         }
 
-        if (pxt.Util.isTranslationLanguage() && pxt.blocks.promptTranslateBlock) {
+        if (pxt.Util.isTranslationMode()
+            && pxt.blocks.promptTranslateBlock) {
             cachedBlock.block.customContextMenu = (options: any[]) => {
                 if (fn.attributes.translationId) {
                     options.push({
@@ -1003,7 +1004,8 @@ namespace pxt.blocks {
             blocksXml: xml ? (`<xml xmlns="http://www.w3.org/1999/xhtml">` + (cleanOuterHTML(xml) || `<block type="${id}"></block>`) + "</xml>") : undefined,
             url: url
         };
-        if (pxt.Util.isTranslationLanguage()) {
+        if (pxt.Util.isTranslationMode()
+            && pxt.blocks.promptTranslateBlock) {
             block.customContextMenu = (options: any[]) => {
                 const blockd = pxt.blocks.getBlockDefinition(block.type);
                 if (blockd && blockd.translationId) {
@@ -1011,7 +1013,7 @@ namespace pxt.blocks {
                         enabled: true,
                         text: lf("Translate this block"),
                         callback: function () {
-                            promptTranslateBlock(id, blockd.translationId);
+                            pxt.blocks.promptTranslateBlock(id, blockd.translationId);
                         }
                     })
                 }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -432,7 +432,7 @@ namespace pxt.blocks {
             }
         }
 
-        if (pxt.Util.userLanguage() == "pxt") {
+        if (pxt.Util.isTranslationLanguage()) {
             cachedBlock.block.customContextMenu = (options: any[]) => {
                 if (fn.attributes.translationId) {
                     options.push({
@@ -1002,7 +1002,7 @@ namespace pxt.blocks {
             blocksXml: xml ? (`<xml xmlns="http://www.w3.org/1999/xhtml">` + (cleanOuterHTML(xml) || `<block type="${id}"></block>`) + "</xml>") : undefined,
             url: url
         };
-        if (pxt.Util.userLanguage() == "pxt") {
+        if (pxt.Util.isTranslationLanguage()) {
             block.customContextMenu = (options: any[]) => {
                 const blockd = pxt.blocks.getBlockDefinition(block.type);
                 if (blockd && blockd.translationId) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -432,6 +432,20 @@ namespace pxt.blocks {
             }
         }
 
+        if (pxt.Util.userLanguage() == "pxt") {
+            cachedBlock.block.customContextMenu = (options: any[]) => {
+                if (fn.attributes.translationId) {
+                    options.push({
+                        enabled: true,
+                        text: fn.attributes.translationId,
+                        callback: function () {
+                            // do nothing
+                        }
+                    })
+                }
+            }
+        }
+
         cachedBlocks[id] = cachedBlock;
         Blockly.Blocks[id] = cachedBlock.block;
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1002,6 +1002,20 @@ namespace pxt.blocks {
             blocksXml: xml ? (`<xml xmlns="http://www.w3.org/1999/xhtml">` + (cleanOuterHTML(xml) || `<block type="${id}"></block>`) + "</xml>") : undefined,
             url: url
         };
+        if (pxt.Util.userLanguage() == "pxt") {
+            block.customContextMenu = (options: any[]) => {
+                const blockd = pxt.blocks.getBlockDefinition(block.type);
+                if (blockd && blockd.translationId) {
+                    options.push({
+                        enabled: true,
+                        text: blockd.translationId,
+                        callback: function () {
+                            // do nothing
+                        }
+                    })
+                }
+            };
+        }
     }
 
     export function installHelpResources(id: string, name: string, tooltip: any, url: string, colour: string, colourSecondary?: string, colourTertiary?: string) {

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -102,9 +102,6 @@ namespace pxt.blocks {
         // lower case first character
         nb = nb.replace(/^[A-Z]/, (m) => m.toLowerCase());
 
-        // replace _ with space
-        nb = nb.replace(/_+/g, ' ');
-
         return nb;
     }
 

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -729,21 +729,11 @@ namespace pxt.blocks {
 
         if (pxt.Util.isTranslationLanguage()) {
             Util.values(_blockDefinitions).filter(b => b.block && b.block.message0).forEach(b => {
-                const locBlock = b.block.message0;
-                const node = document.createElement("input") as HTMLInputElement;
-                node.type = "text";
-                node.setAttribute("class", "hidden");
-                node.value = locBlock;
-                const observer = new MutationObserver(() => {
-                    if (locBlock == node.value)
-                        return;
-                    b.translationId = locBlock;
-                    b.block.message0 = Util.rlf(node.value);
-                    node.remove();
-                    observer.disconnect();
-                });
-                observer.observe(node, { attributes: true });
-                document.body.appendChild(node);
+                pxt.crowdin.inContextLoadAsync(b.block.message0)
+                    .done(r => {
+                        b.translationId = b.block.message0;
+                        b.block.message0 = r;
+                    });
             })
         }
     }

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -102,6 +102,9 @@ namespace pxt.blocks {
         // lower case first character
         nb = nb.replace(/^[A-Z]/, (m) => m.toLowerCase());
 
+        // replace _ with space
+        nb = nb.replace(/_+/g, ' ');
+
         return nb;
     }
 

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -98,6 +98,10 @@ namespace pxt.blocks {
 
         // remove spaces before after pipe
         nb = nb.replace(/\s*\|\s*/g, '|');
+
+        // lower case first character
+        nb = nb.replace(/^[A-Z]/, (m) => m.toLowerCase());
+
         return nb;
     }
 

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -727,7 +727,7 @@ namespace pxt.blocks {
             }
         }
 
-        if (pxt.Util.isTranslationLanguage()) {
+        if (pxt.Util.isTranslationMode()) {
             Util.values(_blockDefinitions).filter(b => b.block && b.block.message0).forEach(b => {
                 pxt.crowdin.inContextLoadAsync(b.block.message0)
                     .done(r => {

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -276,6 +276,7 @@ namespace pxt.blocks {
         block?: Map<string>;
         blockTextSearch?: string; // Which block text to use for searching; if undefined, search uses all texts in BlockDefinition.block, joined with space
         tooltipSearch?: string; // Which tooltip to use for searching; if undefined, search uses all tooltips in BlockDefinition.tooltip, joined with space
+        translationId?: string;
     }
 
     let _blockDefinitions: Map<BlockDefinition>;
@@ -732,6 +733,7 @@ namespace pxt.blocks {
                 const observer = new MutationObserver(() => {
                     if (locBlock == node.value)
                         return;
+                    b.translationId = locBlock;
                     b.block.message0 = node.value;
                     node.remove();
                     observer.disconnect();

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -721,5 +721,24 @@ namespace pxt.blocks {
                 message0: Util.lf("continue")
             }
         }
+
+        if (pxt.Util.userLanguage() == "pxt") {
+            Util.values(_blockDefinitions).filter(b => b.block && b.block.message0).forEach(b => {
+                const locBlock = b.block.message0;
+                const node = document.createElement("input") as HTMLInputElement;
+                node.type = "text";
+                node.setAttribute("class", "hidden");
+                node.value = locBlock;
+                const observer = new MutationObserver(() => {
+                    if (locBlock == node.value)
+                        return;
+                    b.block.message0 = node.value;
+                    node.remove();
+                    observer.disconnect();
+                });
+                observer.observe(node, { attributes: true });
+                document.body.appendChild(node);
+            })
+        }
     }
 }

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -723,7 +723,7 @@ namespace pxt.blocks {
             }
         }
 
-        if (pxt.Util.userLanguage() == "pxt") {
+        if (pxt.Util.isTranslationLanguage()) {
             Util.values(_blockDefinitions).filter(b => b.block && b.block.message0).forEach(b => {
                 const locBlock = b.block.message0;
                 const node = document.createElement("input") as HTMLInputElement;
@@ -734,7 +734,7 @@ namespace pxt.blocks {
                     if (locBlock == node.value)
                         return;
                     b.translationId = locBlock;
-                    b.block.message0 = node.value;
+                    b.block.message0 = Util.rlf(node.value);
                     node.remove();
                     observer.disconnect();
                 });

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -84,7 +84,7 @@ namespace ts.pxtc.Util {
     }
 
     export const TRANSLATION_LOCALE = "pxt";
-    export function isTranslationLanguage(): boolean {
+    export function isTranslationMode(): boolean {
         return userLanguage() == TRANSLATION_LOCALE;
     }
 

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -83,6 +83,10 @@ namespace ts.pxtc.Util {
         return /^ar|dv|fa|ha|he|ks|ku|ps|ur|yi/i.test(_localizeLang);
     }
 
+    export function isTranslationLanguage(): boolean {
+        return userLanguage() == "pxt";
+    }
+
     export function _localize(s: string) {
         // Needs to be test in localhost / CLI
         /*if (!_didSetlocalizations && !_didReportLocalizationsNotSet) {

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -83,8 +83,9 @@ namespace ts.pxtc.Util {
         return /^ar|dv|fa|ha|he|ks|ku|ps|ur|yi/i.test(_localizeLang);
     }
 
+    export const TRANSLATION_LOCALE = "pxt";
     export function isTranslationLanguage(): boolean {
-        return userLanguage() == "pxt";
+        return userLanguage() == TRANSLATION_LOCALE;
     }
 
     export function _localize(s: string) {

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -260,4 +260,25 @@ namespace pxt.crowdin {
                 return allFiles;
             });
     }
+
+    export function inContextLoadAsync(text: string): Promise<string> {
+        const node = document.createElement("input") as HTMLInputElement;
+        node.type = "text";
+        node.setAttribute("class", "hidden");
+        node.value = text;
+        let p = new Promise<string>((resolve, reject) => {
+            const observer = new MutationObserver(() => {
+                if (text == node.value)
+                    return;
+                const r = Util.rlf(node.value); // get rid of {id}...
+                node.remove();
+                observer.disconnect();
+                resolve(r);
+            });
+            observer.observe(node, { attributes: true });
+        })
+        document.body.appendChild(node);
+
+        return p;
+    }
 }

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -398,6 +398,17 @@ namespace pxt.docs {
         }
     }
 
+    export function renderConditionalMacros(template: string, pubinfo: Map<string>): string {
+        return template
+            .replace(/<!--\s*@(ifn?def)\s+(\w+)\s*-->([^]*?)<!--\s*@endif\s*-->/g,
+                (full, cond, sym, inner) => {
+                    if ((cond == "ifdef" && pubinfo[sym]) || (cond == "ifndef" && !pubinfo[sym]))
+                        return `<!-- ${cond} ${sym} -->${inner}<!-- endif -->`
+                    else
+                        return `<!-- ${cond} ${sym} endif -->`
+                });
+    }
+
     export function renderMarkdown(opts: RenderOptions): string {
         let hasPubInfo = true
 
@@ -436,14 +447,8 @@ namespace pxt.docs {
                     return "<!-- include " + fn + " -->\n" + cont + "\n<!-- end include -->\n"
                 })
 
-        template = template
-            .replace(/<!--\s*@(ifn?def)\s+(\w+)\s*-->([^]*?)<!--\s*@endif\s*-->/g,
-                (full, cond, sym, inner) => {
-                    if ((cond == "ifdef" && pubinfo[sym]) || (cond == "ifndef" && !pubinfo[sym]))
-                        return `<!-- ${cond} ${sym} -->${inner}<!-- endif -->`
-                    else
-                        return `<!-- ${cond} ${sym} endif -->`
-                })
+        
+        template = renderConditionalMacros(template, pubinfo);
 
         if (opts.locale)
             template = translate(template, opts.locale).text

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -447,7 +447,7 @@ namespace pxt.docs {
                     return "<!-- include " + fn + " -->\n" + cont + "\n<!-- end include -->\n"
                 })
 
-        
+
         template = renderConditionalMacros(template, pubinfo);
 
         if (opts.locale)

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -634,9 +634,8 @@ namespace pxt {
             // live loc of bundled packages
             if (pxt.Util.localizeLive && this.id != "this" && pxt.appTarget.bundledpkgs[this.id]) {
                 pxt.debug(`loading live translations for ${this.id}`)
-                const code = pxt.Util.userLanguage();
                 return Promise.all(filenames.map(
-                    fn => pxt.Util.downloadLiveTranslationsAsync(code, `${targetId}/${fn}-strings.json`, theme.crowdinBranch)
+                    fn => pxt.Util.downloadLiveTranslationsAsync(lang, `${targetId}/${fn}-strings.json`, theme.crowdinBranch)
                         .then(tr => {
                             if (tr && Object.keys(tr).length) {
                                 Util.jsonMergeFrom(r, tr);

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -499,23 +499,8 @@ namespace ts.pxtc {
                 let p = Promise.resolve();
                 if (locBlock && pxt.Util.isTranslationLanguage()) {
                     fn.attributes.translationId = locBlock;
-                    const node = document.createElement("input") as HTMLInputElement;
-                    node.type = "text";
-                    node.id = locBlock;
-                    node.setAttribute("class", "hidden");
-                    node.value = locBlock;
-                    p = new Promise((resolve, reject) => {
-                        const observer = new MutationObserver(() => {
-                            if (locBlock == node.value)
-                                return;
-                            locBlock = Util.rlf(node.value); // get rid of {id}...
-                            node.remove();
-                            observer.disconnect();
-                            resolve();
-                        });
-                        observer.observe(node, { attributes: true });
-                    })
-                    document.body.appendChild(node);
+                    p = p.then(() => pxt.crowdin.inContextLoadAsync(locBlock))
+                        .then(r => { locBlock = r; });
                 }
                 return p.then(() => {
                     if (nsDoc) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -497,7 +497,7 @@ namespace ts.pxtc {
                 }
 
                 let p = Promise.resolve();
-                if (locBlock && pxt.Util.isTranslationLanguage()) {
+                if (locBlock && pxt.Util.isTranslationMode()) {
                     fn.attributes.translationId = locBlock;
                     p = p.then(() => pxt.crowdin.inContextLoadAsync(locBlock))
                         .then(r => { locBlock = r; });

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -496,28 +496,45 @@ namespace ts.pxtc {
                     }
                 }
 
-                if (nsDoc) {
-                    // Check for "friendly namespace"
-                    if (fn.attributes.block) {
-                        fn.attributes.block = locBlock || fn.attributes.block;
-                    } else {
-                        fn.attributes.block = nsDoc;
-                    }
+                let p = Promise.resolve();
+                if (locBlock) {
+                    fn.attributes.translationId = locBlock;
+                    const node = document.createElement("input") as HTMLInputElement;
+                    node.setAttribute("class", "hidden");
+                    node.value = locBlock;
+                    p = new Promise((resolve, reject) => {
+                        node.onchange = () => {
+                            locBlock = node.value;
+                            node.remove();
+                            resolve();
+                        }
+                    })
+                    document.body.appendChild(node);
                 }
-                else if (fn.attributes.block && locBlock) {
-                    const ps = pxt.blocks.compileInfo(fn);
-                    const oldBlock = fn.attributes.block;
-                    fn.attributes.block = pxt.blocks.normalizeBlock(locBlock, err => errors[`${fn.attributes.blockId}.${lang}`] = 1);
-                    fn.attributes._untranslatedBlock = oldBlock;
-                    if (oldBlock != fn.attributes.block) {
-                        const locps = pxt.blocks.compileInfo(fn);
-                        if (JSON.stringify(ps) != JSON.stringify(locps)) {
-                            pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`)
-                            fn.attributes.block = oldBlock;
+                return p.then(() => {
+                    if (nsDoc) {
+                        // Check for "friendly namespace"
+                        if (fn.attributes.block) {
+                            fn.attributes.block = locBlock || fn.attributes.block;
+                        } else {
+                            fn.attributes.block = nsDoc;
                         }
                     }
-                }
-                updateBlockDef(fn.attributes);
+                    else if (fn.attributes.block && locBlock) {
+                        const ps = pxt.blocks.compileInfo(fn);
+                        const oldBlock = fn.attributes.block;
+                        fn.attributes.block = pxt.blocks.normalizeBlock(locBlock, err => errors[`${fn.attributes.blockId}.${lang}`] = 1);
+                        fn.attributes._untranslatedBlock = oldBlock;
+                        if (oldBlock != fn.attributes.block) {
+                            const locps = pxt.blocks.compileInfo(fn);
+                            if (JSON.stringify(ps) != JSON.stringify(locps)) {
+                                pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`)
+                                fn.attributes.block = oldBlock;
+                            }
+                        }
+                    }
+                    updateBlockDef(fn.attributes);
+                })
             }))
             .then(() => apis)
             .finally(() => {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -497,17 +497,23 @@ namespace ts.pxtc {
                 }
 
                 let p = Promise.resolve();
-                if (locBlock) {
+                if (locBlock && pxt.Util.userLanguage() == "pxt") {
                     fn.attributes.translationId = locBlock;
                     const node = document.createElement("input") as HTMLInputElement;
+                    node.type = "text";
+                    node.id = locBlock;
                     node.setAttribute("class", "hidden");
                     node.value = locBlock;
                     p = new Promise((resolve, reject) => {
-                        node.onchange = () => {
+                        const observer = new MutationObserver(() => {
+                            if (locBlock == node.value)
+                                return;
                             locBlock = node.value;
                             node.remove();
+                            observer.disconnect();
                             resolve();
-                        }
+                        });
+                        observer.observe(node, { attributes: true });
                     })
                     document.body.appendChild(node);
                 }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -497,7 +497,7 @@ namespace ts.pxtc {
                 }
 
                 let p = Promise.resolve();
-                if (locBlock && pxt.Util.userLanguage() == "pxt") {
+                if (locBlock && pxt.Util.isTranslationLanguage()) {
                     fn.attributes.translationId = locBlock;
                     const node = document.createElement("input") as HTMLInputElement;
                     node.type = "text";
@@ -508,7 +508,7 @@ namespace ts.pxtc {
                         const observer = new MutationObserver(() => {
                             if (locBlock == node.value)
                                 return;
-                            locBlock = node.value;
+                            locBlock = Util.rlf(node.value); // get rid of {id}...
                             node.remove();
                             observer.disconnect();
                             resolve();

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -195,7 +195,7 @@ namespace pxt.runner {
         let live = false;
         let force = false;
         let lang: string = undefined;
-        if (/[&?]translate=1/.test(href)) {
+        if (/[&?]translate=1/.test(href) && !pxt.BrowserUtils.isIE()) {
             lang = ts.pxtc.Util.TRANSLATION_LOCALE;
             live = true;
             force = true;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -191,11 +191,21 @@ namespace pxt.runner {
         pxt.setAppTarget((window as any).pxtTargetBundle)
         Util.assert(!!pxt.appTarget);
 
-        const cookieValue = /PXT_LANG=(.*?)(?:;|$)/.exec(document.cookie);
-        const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
-        const lang = mlang ? mlang[3] : (cookieValue && cookieValue[1] || pxt.appTarget.appTheme.defaultLocale || (navigator as any).userLanguage || navigator.language);
-        const live = !pxt.appTarget.appTheme.disableLiveTranslations || (mlang && !!mlang[1]);
-        const force = !!mlang && !!mlang[2];
+        const href = window.location.href;
+        let live = false;
+        let force = false;
+        let lang: string = undefined;
+        if (/[&?]translate=1/.test(href)) {
+            lang = ts.pxtc.Util.TRANSLATION_LOCALE;
+            live = true;
+            force = true;
+        } else {
+            const cookieValue = /PXT_LANG=(.*?)(?:;|$)/.exec(document.cookie);
+            const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(href);
+            lang = mlang ? mlang[3] : (cookieValue && cookieValue[1] || pxt.appTarget.appTheme.defaultLocale || (navigator as any).userLanguage || navigator.language);
+            live = !pxt.appTarget.appTheme.disableLiveTranslations || (mlang && !!mlang[1]);
+            force = !!mlang && !!mlang[2];
+        }
         const versions = pxt.appTarget.versions;
 
         patchSemantic();

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1163,7 +1163,7 @@ namespace pxsim {
                 switch (msg.subtype) {
                     case "config":
                         let cfg = msg as DebuggerConfigMessage
-                        if (cfg.setBreakpoints) {
+                        if (cfg.setBreakpoints && breakpoints) {
                             breakpoints.fill(0)
                             for (let n of cfg.setBreakpoints)
                                 breakpoints[n] = 1

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -8,7 +8,7 @@
 	<!-- @ifdef incontexttranslations -->
 	<script type="text/javascript">
 		var _jipt = [];
-		_jipt.push(['project', '@crowdinproject@']);
+		_jipt.push(['project', 'kindscript']);
 		</script>
 	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
 	<!-- @endif -->

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -8,7 +8,10 @@
 	<!-- @ifdef incontexttranslations -->
 	<script type="text/javascript">
 		var _jipt = [];
-		_jipt.push(['project', 'kindscript']);
+        _jipt.push(['project', 'kindscript']);
+        _jipt.push(['escape', function() {
+            window.location.href = window.location.href.replace(/[$\?]translate=1/, '');
+        }]);
 		</script>
 	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
 	<!-- @endif -->

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -5,7 +5,13 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0">
-
+	<!-- @ifdef incontexttranslations -->
+	<script type="text/javascript">
+		var _jipt = [];
+		_jipt.push(['project', '@crowdinproject@']);
+		</script>
+	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+	<!-- @endif -->
     <!-- @include appmeta.html -->
 
     <link rel="stylesheet" data-rtl="/blb/rtlsemantic.css" href="/blb/semantic.css" type="text/css">

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -5,16 +5,20 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,height=device-height,user-scalable=no,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0">
-	<!-- @ifdef incontexttranslations -->
-	<script type="text/javascript">
+    <script type="text/javascript">
+    if(/[&?]translate=1/.test(window.location.href)) {
 		var _jipt = [];
         _jipt.push(['project', 'kindscript']);
         _jipt.push(['escape', function() {
             window.location.href = window.location.href.replace(/[$\?]translate=1/, '');
         }]);
-		</script>
-	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
-	<!-- @endif -->
+        let s = document.createElement("script");
+        s.setAttribute("type", "text/javascript");
+        s.setAttribute("src", "//cdn.crowdin.com/jipt/jipt.js");
+        document.head.insertBefore(s, document.head.firstElementChild);
+    }
+	</script>
+
     <!-- @include appmeta.html -->
 
     <link rel="stylesheet" data-rtl="/blb/rtlsemantic.css" href="/blb/semantic.css" type="text/css">

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3872,7 +3872,7 @@ document.addEventListener("DOMContentLoaded", () => {
             let live = false;
             let force = false;
             let useLang: string = undefined;
-            if (/[&?]translate=1/.test(href)) {
+            if (/[&?]translate=1/.test(href) && !pxt.BrowserUtils.isIE()) {
                 console.log(`translation mode`);
                 live = force = true;
                 useLang = ts.pxtc.Util.TRANSLATION_LOCALE;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3868,14 +3868,24 @@ document.addEventListener("DOMContentLoaded", () => {
     else if (pxt.BrowserUtils.isLocalHost() || pxt.BrowserUtils.isPxtElectron()) workspace.setupWorkspace("fs");
     Promise.resolve()
         .then(() => {
-            const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
-            if (mlang && window.location.hash.indexOf(mlang[0]) >= 0) {
-                pxt.BrowserUtils.changeHash(window.location.hash.replace(mlang[0], ""));
+            const href = window.location.href;
+            let live = false;
+            let force = false;
+            let useLang: string = undefined;
+            if (/[&?]translate=1/.test(href)) {
+                console.log(`translation mode`);
+                live = force = true;
+                useLang = ts.pxtc.Util.TRANSLATION_LOCALE;
+            } else {
+                const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
+                if (mlang && window.location.hash.indexOf(mlang[0]) >= 0) {
+                    pxt.BrowserUtils.changeHash(window.location.hash.replace(mlang[0], ""));
+                }
+                useLang = mlang ? mlang[3] : (lang.getCookieLang() || theme.defaultLocale || (navigator as any).userLanguage || navigator.language);
+                const locstatic = /staticlang=1/i.test(window.location.href);
+                live = !(locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations) || (mlang && !!mlang[1]);
+                force = !!mlang && !!mlang[2];
             }
-            const useLang = mlang ? mlang[3] : (lang.getCookieLang() || theme.defaultLocale || (navigator as any).userLanguage || navigator.language);
-            const locstatic = /staticlang=1/i.test(window.location.href);
-            const live = !(locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations) || (mlang && !!mlang[1]);
-            const force = !!mlang && !!mlang[2];
             const targetId = pxt.appTarget.id;
             const baseUrl = config.commitCdnUrl;
             const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1234,7 +1234,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         if (this.abstractShowFlyout(treeRow)) {
             // Cache blocks xml list for later
-            this.flyoutBlockXmlCache[cacheKey] = this.flyoutXmlList;
+            // don't cache when translating
+            if (!pxt.Util.isTranslationLanguage())
+                this.flyoutBlockXmlCache[cacheKey] = this.flyoutXmlList;
 
             this.showFlyoutInternal_(this.flyoutXmlList, cacheKey);
         }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -344,7 +344,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             })
         };
 
-        if (pxt.Util.isTranslationLanguage())
+        if (pxt.Util.isTranslationMode())
             pxt.blocks.promptTranslateBlock = dialogs.promptTranslateBlock;
     }
 
@@ -1239,7 +1239,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (this.abstractShowFlyout(treeRow)) {
             // Cache blocks xml list for later
             // don't cache when translating
-            if (!pxt.Util.isTranslationLanguage())
+            if (!pxt.Util.isTranslationMode())
                 this.flyoutBlockXmlCache[cacheKey] = this.flyoutXmlList;
 
             this.showFlyoutInternal_(this.flyoutXmlList, cacheKey);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -10,7 +10,8 @@ import * as toolbox from "./toolbox";
 import * as snippets from "./blocksSnippets";
 import * as workspace from "./workspace";
 import * as simulator from "./simulator";
-import { CreateFunctionDialog, CreateFunctionDialogState } from "./createFunction";
+import * as dialogs from "./dialogs";
+import { CreateFunctionDialog } from "./createFunction";
 import { initializeSnippetExtensions } from './snippetBuilder';
 
 import Util = pxt.Util;
@@ -342,6 +343,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 callback(value);
             })
         };
+
+        if (pxt.Util.isTranslationLanguage())
+            pxt.blocks.promptTranslateBlock = dialogs.promptTranslateBlock;
     }
 
     private initBlocklyToolbox() {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -871,9 +871,9 @@ export function promptTranslateBlock(blockid: string, blockTranslationId: string
         helpUrl: "/translate",
         jsx: <div>
             <div>
-            {lf("Update the block translation below.")} 
-            {lf("Do not translate variable names (%name, $name).")}
-            {lf("Once validated in Crowdin, translations may take 24h to be active.")}
+                {lf("Update the block translation below.")}
+                {lf("Do not translate variable names (%name, $name).")}
+                {lf("Once validated in Crowdin, translations may take 24h to be active.")}
             </div>
             <div className="ui basic segment">{blockTranslationId}</div>
         </div>

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -861,3 +861,20 @@ export function showCloudSignInDialog() {
         })
     }
 }
+
+export function promptTranslateBlock(blockid: string, blockTranslationId: string) {
+    core.confirmAsync({
+        header: lf("Translate this block"),
+        hideCancel: true,
+        hideAgree: true,
+        hasCloseIcon: true,
+        jsx: <div>
+            <div>
+            {lf("Update the block translation below.")} 
+            {lf("Do not translate variable names (%name, $name).")}
+            {lf("Once validated, translations may take 24h to be active.")}
+            </div>
+            <div className="blocktranslationtext">{blockTranslationId}</div>
+        </div>
+    }).done();
+}

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -868,13 +868,14 @@ export function promptTranslateBlock(blockid: string, blockTranslationId: string
         hideCancel: true,
         hideAgree: true,
         hasCloseIcon: true,
+        helpUrl: "/translate",
         jsx: <div>
             <div>
             {lf("Update the block translation below.")} 
             {lf("Do not translate variable names (%name, $name).")}
-            {lf("Once validated, translations may take 24h to be active.")}
+            {lf("Once validated in Crowdin, translations may take 24h to be active.")}
             </div>
-            <div className="blocktranslationtext">{blockTranslationId}</div>
+            <div className="ui basic segment">{blockTranslationId}</div>
         </div>
     }).done();
 }

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -29,7 +29,7 @@ export function setCookieLang(langId: string) {
     }
 
     if (langId !== getCookieLang()) {
-        pxt.tickEvent(`menu.lang.setcookielang`, {lang : langId});
+        pxt.tickEvent(`menu.lang.setcookielang`, { lang: langId });
         const expiration = new Date();
         expiration.setTime(expiration.getTime() + (pxt.Util.langCookieExpirationDays * 24 * 60 * 60 * 1000));
         document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}`;
@@ -69,14 +69,14 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
         setCookieLang(langId);
 
         if (langId !== initialLang) {
-            pxt.tickEvent(`menu.lang.changelang`, {lang : langId});
+            pxt.tickEvent(`menu.lang.changelang`, { lang: langId });
             pxt.winrt.releaseAllDevicesAsync()
                 .then(() => {
                     this.props.parent.reloadEditor();
                 })
                 .done();
         } else {
-            pxt.tickEvent(`menu.lang.samelang`, {lang : langId});
+            pxt.tickEvent(`menu.lang.samelang`, { lang: langId });
             this.hide();
         }
     }

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -58,7 +58,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
     translateEditor() {
         pxt.tickEvent("translate.editor.incontext")
         const sep = window.location.href.indexOf("?") < 0 ? "?" : "&";
-        window.location.href = window.location.href + sep + "translate=1"
+        window.location.href = window.location.pathname + sep + "translate=1" + (window.location.hash || "");
     }
 
     changeLanguage(langId: string) {
@@ -124,9 +124,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 {targetTheme.crowdinProject ?
                     <p>
                         <br /><br />
-                        <a href="/translate" target="_blank" rel="noopener noreferrer"
-                            aria-label={lf("Help us translate")}>{lf("Help us translate")}</a>
-                        | <div className="ui link" role="button" onClick={this.translateEditor}>{lf("Translate the editor")}</div>
+                        <span className="ui link" aria-label={lf("Help us translate")} onClick={this.translateEditor}>{lf("Translate the editor")}</span>
                     </p> : undefined}
             </sui.Modal>
         );

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -124,7 +124,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 {targetTheme.crowdinProject ?
                     <p>
                         <br /><br />
-                        <span className="ui button link" aria-label={lf("Help us translate")} onClick={this.translateEditor}>{lf("Translate the editor")}</span>
+                        <sui.Button aria-label={lf("Help us translate")} onClick={this.translateEditor} text={lf("Translate the editor")} />
                     </p> : undefined}
             </sui.Modal>
         );

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -56,7 +56,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
     }
 
     translateEditor() {
-        pxt.tickEvent("translate.editor")
+        pxt.tickEvent("translate.editor.incontext")
         const sep = window.location.href.indexOf("?") < 0 ? "?" : "&";
         window.location.href = window.location.href + sep + "translate=1"
     }

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -126,7 +126,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                         <br /><br />
                         <a href="/translate" target="_blank" rel="noopener noreferrer"
                             aria-label={lf("Help us translate")}>{lf("Help us translate")}</a>
-                        | <a onClick={this.translateEditor}>{lf("Translate the editor")}</a>
+                        | <div className="ui link" role="button" onClick={this.translateEditor}>{lf("Translate the editor")}</div>
                     </p> : undefined}
             </sui.Modal>
         );

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -45,6 +45,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
 
         this.hide = this.hide.bind(this);
         this.changeLanguage = this.changeLanguage.bind(this);
+        this.translateEditor = this.translateEditor.bind(this);
     }
 
     languageList(): string[] {
@@ -52,6 +53,12 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
             return pxt.appTarget.appTheme.availableLocales;
         }
         return defaultLanguages;
+    }
+
+    translateEditor() {
+        pxt.tickEvent("translate.editor")
+        const sep = window.location.href.indexOf("?") < 0 ? "?" : "&";
+        window.location.href = window.location.href + sep + "translate=1"
     }
 
     changeLanguage(langId: string) {
@@ -119,6 +126,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                         <br /><br />
                         <a href="/translate" target="_blank" rel="noopener noreferrer"
                             aria-label={lf("Help us translate")}>{lf("Help us translate")}</a>
+                        | <a onClick={this.translateEditor}>{lf("Translate the editor")}</a>
                     </p> : undefined}
             </sui.Modal>
         );

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -124,7 +124,8 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 {targetTheme.crowdinProject ?
                     <p>
                         <br /><br />
-                        <sui.Button aria-label={lf("Help us translate")} onClick={this.translateEditor} text={lf("Translate the editor")} />
+                        {!pxt.BrowserUtils.isIE() ? <sui.Button aria-label={lf("Translate the editor")} onClick={this.translateEditor} text={lf("Translate the editor")} /> : undefined }
+                        <sui.Link aria-label={lf("Learn about translations")} href="/translate" text={lf("Learn about translations")} target="_blank" />
                     </p> : undefined}
             </sui.Modal>
         );

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -122,11 +122,10 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                     </div>
                 </div>
                 {targetTheme.crowdinProject ?
-                    <p>
-                        <br /><br />
+                    <div className="ui">
                         {!pxt.BrowserUtils.isIE() ? <sui.Button aria-label={lf("Translate the editor")} onClick={this.translateEditor} text={lf("Translate the editor")} /> : undefined }
-                        <sui.Link aria-label={lf("Learn about translations")} href="/translate" text={lf("Learn about translations")} target="_blank" />
-                    </p> : undefined}
+                        <sui.Link className="button" role="button" aria-label={lf("Learn about translations")} href="/translate" text={lf("Learn about translations")} target="_blank" />
+                    </div> : undefined}
             </sui.Modal>
         );
     }

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -124,7 +124,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 {targetTheme.crowdinProject ?
                     <p>
                         <br /><br />
-                        <span className="ui link" aria-label={lf("Help us translate")} onClick={this.translateEditor}>{lf("Translate the editor")}</span>
+                        <span className="ui button link" aria-label={lf("Help us translate")} onClick={this.translateEditor}>{lf("Translate the editor")}</span>
                     </p> : undefined}
             </sui.Modal>
         );


### PR DESCRIPTION
Integration of the Crowdin In Context support in MakeCode. 

* not supported on ie
* live test (gearwheel -> language -> translate the editor): https://makecode.microbit.org/app/eafdb91f42807c21c8fe0214992be13211550d26-f42e68aeb6

<img width="699" alt="image" src="https://user-images.githubusercontent.com/4175913/66327153-2e152700-e8df-11e9-83fe-bd15f5c64e42.png">

Add a menu item in blocks context menu to translate.
![image](https://user-images.githubusercontent.com/4175913/66331457-733d5700-e8e7-11e9-9d9e-c09e039d5b33.png)

Crowdin has a nifty web widget that hooks into the DOM mutation events to provide live translation. It uses a fake language (code pxt) that contains guid strings; when crowding sees one of the guid added to the DOM tree, it swaps it with the current translation + button to edit.

Things get a bit more tricker for our blocs -- because we parse the translated string. Obviously parsing the GUID does not work. To work around this, MakeCode first add each block string into the DOM tree, let's crowdin modify it and then parses the block. It mostly works

No backend support needed.