### PR TITLE
precision not so optional anymore

### DIFF
--- a/pxtblocks/fields/field_colorwheel.ts
+++ b/pxtblocks/fields/field_colorwheel.ts
@@ -20,7 +20,7 @@ namespace pxtblockly {
          * @constructor
          */
         constructor(value_: any, params: any, opt_validator?: Function) {
-            super(String(value_), '0', '255', null, '10', 'Color', opt_validator);
+            super(String(value_), '0', '255', '1', '10', 'Color', opt_validator);
             this.params = params;
             if (this.params['min']) this.min_ = parseFloat(this.params['min']);
             if (this.params['max']) this.max_ = parseFloat(this.params['max']);

--- a/pxtblocks/fields/field_position.ts
+++ b/pxtblocks/fields/field_position.ts
@@ -21,7 +21,7 @@ namespace pxtblockly {
         private static eyedropperEventKey_: any;
 
         constructor(text: string, params: FieldPositionOptions, validator?: Function) {
-            super(text, '0', '100', null, '100', 'Value', validator);
+            super(text, '0', '100', '1', '100', 'Value', validator);
             this.params = params;
             if (!this.params.screenHeight) this.params.screenHeight = 120;
             if (!this.params.screenWidth) this.params.screenWidth = 160;

--- a/pxtblocks/fields/field_protractor.ts
+++ b/pxtblocks/fields/field_protractor.ts
@@ -25,7 +25,7 @@ namespace pxtblockly {
          * @constructor
          */
         constructor(value_: any, params: FieldProtractorOptions, opt_validator?: Function) {
-            super(String(value_), '0', '180', null, '15', lf("Angle"), opt_validator);
+            super(String(value_), '0', '180', '1', '15', lf("Angle"), opt_validator);
             this.params = params;
         }
 

--- a/pxtblocks/fields/field_speed.ts
+++ b/pxtblocks/fields/field_speed.ts
@@ -29,7 +29,7 @@ namespace pxtblockly {
          * @constructor
          */
         constructor(value_: any, params: FieldSpeedOptions, opt_validator?: Function) {
-            super(String(value_), '-100', '100', null, '10', 'Speed', opt_validator);
+            super(String(value_), '-100', '100', '1', '10', 'Speed', opt_validator);
             this.params = params;
             if (this.params['min']) this.min_ = parseFloat(this.params.min);
             if (this.params['max']) this.max_ = parseFloat(this.params.max);

--- a/pxtblocks/fields/field_turnratio.ts
+++ b/pxtblocks/fields/field_turnratio.ts
@@ -25,7 +25,7 @@ namespace pxtblockly {
          * @constructor
          */
         constructor(value_: any, params: FieldTurnRatioOptions, opt_validator?: Function) {
-            super(String(value_), '-200', '200', null, '10', 'TurnRatio', opt_validator);
+            super(String(value_), '-200', '200', '1', '10', 'TurnRatio', opt_validator);
             this.params = params;
             (this as any).sliderColor_ = '#a8aaa8';
         }


### PR DESCRIPTION
Crashing because the precision field is not optional anymore. All sliders are still broken becaseu parseFloat(minValue) evaluates to 0, the min = -infinity.

https://github.com/microsoft/pxt-blockly/blob/55ac033fcc974ae82a476b9516dabd95d7ec0811/core/field_slider.js#L47

might be good to bump minor too.