### PR TITLE
don't crash on missing node

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -2030,7 +2030,7 @@ ${lbl}: .short 0xffff
             let decl = getDeclCore(node)
             markUsed(decl)
 
-            if (!decl && node.kind == SK.PropertyAccessExpression) {
+            if (!decl && node && node.kind == SK.PropertyAccessExpression) {
                 const namedNode = node as PropertyAccessExpression
                 decl = {
                     kind: SK.PropertySignature,


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-maker/issues/255