### PR TITLE
Allow one step tutorials, strip metadata before parsing, tests

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -3,9 +3,9 @@ namespace pxt.tutorial {
     const _h3Regex = /^###[^#](.*)$([\s\S]*?)(?=^###[^#]|$(?![\r\n]))/gmi;
 
     export function parseTutorial(tutorialmd: string): TutorialInfo {
-        const metadata = parseTutorialMetadata(tutorialmd);
-        const {steps, activities} = parseTutorialMarkdown(tutorialmd, metadata);
-        const title = parseTutorialTitle(tutorialmd);
+        const { metadata, body } = parseTutorialMetadata(tutorialmd);
+        const { steps, activities } = parseTutorialMarkdown(body, metadata);
+        const title = parseTutorialTitle(body);
         if (!steps)
             return undefined; // error parsing steps
 
@@ -15,7 +15,7 @@ namespace pxt.tutorial {
         let code = '';
         let templateCode: string;
         // Concatenate all blocks in separate code blocks and decompile so we can detect what blocks are used (for the toolbox)
-        tutorialmd
+        body
             .replace(/((?!.)\s)+/g, "\n")
             .replace(regex, function (m0, m1, m2) {
                 switch (m1) {
@@ -80,7 +80,7 @@ namespace pxt.tutorial {
             let steps = parseTutorialSteps(tutorialmd, null, metadata);
 
             // old: "### STEP" syntax (no activity header guaranteed)
-            if (!steps || steps.length <= 1) steps = parseTutorialSteps(tutorialmd, _h3Regex, metadata);
+            if (!steps || steps.length < 1) steps = parseTutorialSteps(tutorialmd, _h3Regex, metadata);
 
             return {steps: steps, activities: null};
         }
@@ -172,11 +172,11 @@ namespace pxt.tutorial {
         Parses metadata at the beginning of tutorial markown. Metadata is a key-value
         pair in the format: `### @KEY VALUE`
     */
-    function parseTutorialMetadata(tutorialmd: string): TutorialMetadata {
+    function parseTutorialMetadata(tutorialmd: string): {metadata: TutorialMetadata, body: string} {
         const metadataRegex = /### @(\S+) ([ \S]+)/gi;
         const m: any = {};
 
-        tutorialmd.replace(metadataRegex, function (f, k, v) {
+        const body = tutorialmd.replace(metadataRegex, function (f, k, v) {
             try {
                 m[k] = JSON.parse(v);
             } catch {
@@ -186,7 +186,7 @@ namespace pxt.tutorial {
             return "";
         });
 
-        return m as TutorialMetadata;
+        return { metadata: (m as TutorialMetadata), body};
     }
 
     export function highlight(pre: HTMLPreElement): void {

--- a/tests/tutorial-test/baselines/legacySteps.json
+++ b/tests/tutorial-test/baselines/legacySteps.json
@@ -1,0 +1,34 @@
+{
+    "editor": "blocksprj",
+    "title": "Getting started",
+    "steps": [
+        {
+            "fullscreen": true,
+            "unplugged": true,
+            "tutorialCompleted": false,
+            "contentMd": "Let's get started!",
+            "headerContentMd": "Let's get started!"
+        },
+        {
+            "fullscreen": true,
+            "unplugged": false,
+            "tutorialCompleted": false,
+            "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nbasic.showString(\"Micro!\")\n```",
+            "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
+            "hintContentMd": "```blocks\nbasic.showString(\"Micro!\")\n```",
+            "hasHint": true
+        },
+        {
+            "fullscreen": false,
+            "unplugged": false,
+            "tutorialCompleted": false,
+            "contentMd": "Click ``|Download|`` to transfer your code in your unknown macro!",
+            "headerContentMd": "Click ``|Download|`` to transfer your code in your unknown macro!"
+        }
+    ],
+    "activities": null,
+    "code": "\n { \n basic.showString(\"Micro!\")\n } \n",
+    "metadata": {
+        "flyoutOnly": true
+    }
+}

--- a/tests/tutorial-test/baselines/singleStep.json
+++ b/tests/tutorial-test/baselines/singleStep.json
@@ -1,0 +1,18 @@
+{
+    "editor": "blocksprj",
+    "title": "Getting started",
+    "steps": [
+        {
+            "fullscreen": true,
+            "unplugged": true,
+            "tutorialCompleted": false,
+            "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nbasic.showString(\"Micro!\")\n```",
+            "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
+            "hintContentMd": "```blocks\nbasic.showString(\"Micro!\")\n```",
+            "hasHint": true
+        }
+    ],
+    "activities": null,
+    "code": "\n { \n basic.showString(\"Micro!\")\n } \n",
+    "metadata": {}
+}

--- a/tests/tutorial-test/cases/legacySteps.md
+++ b/tests/tutorial-test/cases/legacySteps.md
@@ -1,0 +1,19 @@
+### @flyoutOnly true
+
+# Getting started
+
+### Introduction @unplugged
+
+Let's get started!
+
+### Step 1 @fullscreen
+
+Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.
+
+```blocks
+basic.showString("Micro!")
+```
+
+### Step 2
+
+Click ``|Download|`` to transfer your code in your unknown macro!

--- a/tests/tutorial-test/cases/singleStep.md
+++ b/tests/tutorial-test/cases/singleStep.md
@@ -1,0 +1,9 @@
+# Getting started
+
+## Introduction @unplugged
+
+Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.
+
+```blocks
+basic.showString("Micro!")
+```


### PR DESCRIPTION
Stripping metadata to ensure parsing of legacy tutorials (### Step) is supported