### PR TITLE
handle case when project gallery item name is undefined

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -414,7 +414,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                         {cards.map((scr, index) =>
                             <ProjectsCodeCard
                                 className="example"
-                                key={path + scr.name}
+                                key={path + (scr.name || scr.url)}
                                 name={scr.name}
                                 url={scr.url}
                                 imageUrl={scr.imageUrl}


### PR DESCRIPTION
LEGO has a category of cards without names. It generates react key clashes.