### PR TITLE
set max height for snippets

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -441,4 +441,10 @@ print only stuff
     body.pushable {
         background: #fff !important;        
     }
+    .codesnippet .blocks-svg-list,
+    .codesnippet code,
+    pre {
+        max-height: inherit;
+        overflow: inherit;
+    }
 }

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -66,6 +66,18 @@ code.hljs {
     padding: 0 !important;
 }
 
+.codesnippet .blocks-svg-list,
+.codesnippet code {
+    max-height: 35em;
+    overflow-y: scroll;
+    overflow-x: overlay;
+}
+
+pre {
+    max-height: 50em;
+    overflow: hidden;
+}
+
 .ui[class*="5:3"].embed {
     padding-bottom: 83%;
     background:transparent !important;


### PR DESCRIPTION
quick draft for https://github.com/microsoft/pxt/issues/6010 in case we like that behavior:

![2019-10-08 16 19 30](https://user-images.githubusercontent.com/5615930/66440602-6a807a00-e9e8-11e9-8985-367a8f999cc3.gif)

mainly for safe keeping till the design meeting / a consensus. 

