### PR TITLE
support for loc strings in attribute

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -118,24 +118,24 @@ a mapping between the block field names and the function names.
 
 ## Custom block localization
 
-You can override the value used in ``block`` for a particular locale by provide a ``loc.block.LOCALE`` entry.
+You can override the value used in ``block`` for a particular locale by provide a ``block.loc.LOCALE`` entry.
 
 ```
-loc.block.LOCALE = blocksyntax
+block.loc.LOCALE = blocksyntax
 ```
 
 For example,
 
 ```typescript-ignore
 //% block="square $x"
-//% loc.block.fr="$x au carré"
+//% block.loc.fr="$x au carré"
 function square(x: number): number {}
 ```
 
 You can also override the ``jsDoc`` description and parameter info.
 
 ```
-loc.jsdoc.LOCALE = translated jsdoc
+jsdoc.loc.LOCALE = translated jsdoc
 PARAM.loc.LOCALE = parameter jsdoc
 ```
 
@@ -145,9 +145,9 @@ PARAM.loc.LOCALE = parameter jsdoc
     @param x the number to square
 **/
 //% block="square $x"
-//% loc.block.fr="$x au carré"
-//% loc.jsdoc.fr="Calcule le carré de x"
-//% x.param.fr="le nombre"
+//% block.loc.fr="$x au carré"
+//% jsdoc.loc.fr="Calcule le carré de x"
+//% x.loc.fr="le nombre"
 function square(x: number): number {}
 ```
 

--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -118,19 +118,39 @@ a mapping between the block field names and the function names.
 
 ## Custom block localization
 
-You can override the value used in ``block`` for a particular locale by provide a ``block.LOCALE`` entry.
+You can override the value used in ``block`` for a particular locale by provide a ``loc.block.LOCALE`` entry.
 
 ```
-block.LOCALE = blocksyntax
+loc.block.LOCALE = blocksyntax
 ```
 
 For example,
 
 ```typescript-ignore
 //% block="square $x"
-//% block.fr="$x au carré"
+//% loc.block.fr="$x au carré"
 function square(x: number): number {}
 ```
+
+You can also override the ``jsDoc`` description and parameter info.
+
+```
+loc.jsdoc.LOCALE = translated jsdoc
+PARAM.loc.LOCALE = parameter jsdoc
+```
+
+```typescript-ignore
+/**
+    Computes the square of x
+    @param x the number to square
+**/
+//% block="square $x"
+//% loc.block.fr="$x au carré"
+//% loc.jsdoc.fr="Calcule le carré de x"
+//% x.param.fr="le nombre"
+function square(x: number): number {}
+```
+
 
 ## Supported types
 

--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -116,6 +116,22 @@ a mapping between the block field names and the function names.
 * the block will automatically switch to external inputs when enough parameters are detected
 * Using `=type` in the block string for shadow blocks is deprecated. See "Specifying shadow blocks" for more details.
 
+## Custom block localization
+
+You can override the value used in ``block`` for a particular locale by provide a ``block.LOCALE`` entry.
+
+```
+block.LOCALE = blocksyntax
+```
+
+For example,
+
+```typescript-ignore
+//% block="square $x"
+//% block.fr="$x au carré"
+function square(x: number): number {}
+```
+
 ## Supported types
 
 The following [types](/playground#basic-types) are supported in function signatures that are meant to be exported:

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -567,6 +567,7 @@ declare namespace ts.pxtc {
         useLoc?: string; // The qName of another API whose localization will be used if this API is not translated and if both block definitions are identical
         topblock?: boolean;
         topblockWeight?: number;
+        locs?: pxt.Map<string>;
         // On namepspace
         subcategories?: string[];
         groups?: string[];

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -470,18 +470,22 @@ namespace ts.pxtc {
         if (pxtc.Util.userLanguage() == "en") return Promise.resolve(apis);
 
         const errors: pxt.Map<number> = {};
+        const langLower = lang.toLowerCase();
+        const attrJsLocsKey = langLower + "|jsdoc";
+        const attrBlockLocsKey = langLower + "|block";
         return mainPkg.localizationStringsAsync(lang)
             .then(loc => Util.values(apis.byQName).forEach(fn => {
                 if (apiLocalizationStrings)
                     Util.jsonMergeFrom(loc, apiLocalizationStrings);
-                const jsDoc = loc[fn.qName]
-                if (jsDoc) {
-                    fn.attributes.jsDoc = jsDoc;
+                const attrLocs = fn.attributes.locs || {};
+                const locJsDoc = loc[fn.qName] || attrLocs[attrJsLocsKey];
+                if (locJsDoc) {
+                    fn.attributes.jsDoc = locJsDoc;
                     if (fn.parameters)
                         fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || pi.description);
                 }
                 const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
-                let locBlock = loc[`${fn.qName}|block`];
+                let locBlock = loc[`${fn.qName}|block`] || attrLocs[attrBlockLocsKey];
 
                 if (!locBlock && fn.attributes.useLoc) {
                     const otherFn = apis.byQName[fn.attributes.useLoc];
@@ -498,6 +502,8 @@ namespace ts.pxtc {
 
                 let p = Promise.resolve();
                 if (locBlock && pxt.Util.isTranslationMode()) {
+                    // in translation mode, crowdin sends translation identifiers which break the block parsing
+                    // push identifier in DOM so that crowdin sends back the actual translation
                     fn.attributes.translationId = locBlock;
                     p = p.then(() => pxt.crowdin.inContextLoadAsync(locBlock))
                         .then(r => { locBlock = r; });
@@ -587,7 +593,10 @@ namespace ts.pxtc {
                     v0: string, v1: string, v2: string) => {
                     let v = v0 ? JSON.parse(v0) : (d0 ? (v0 || v1 || v2) : "true");
                     if (!v) v = "";
-                    if (U.endsWith(n, ".defl")) {
+                    if (U.startsWith(n, "block.")) {
+                        if (!res.locs) res.locs = {};
+                        res.locs[n.slice("block.".length).toLowerCase() + "|block"] = v;
+                    } else if (U.endsWith(n, ".defl")) {
                         if (v.indexOf(" ") > -1) {
                             res.paramDefl[n.slice(0, n.length - 5)] = `"${v}"`
                         } else {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -602,8 +602,8 @@ namespace ts.pxtc {
                     } else if (U.contains(n, ".loc.")) {
                         if (!res.locs) res.locs = {};
                         const p = n.slice(0, n.indexOf('.loc.'));
-                        const l = n.slice(n.indexOf('.loc.') + '.loc'.length);
-                        res.locs[p + "|param|" + l] = v;
+                        const l = n.slice(n.indexOf('.loc.') + '.loc.'.length);
+                        res.locs[l + "|param|" + p] = v;
                     } else if (U.endsWith(n, ".defl")) {
                         if (v.indexOf(" ") > -1) {
                             res.paramDefl[n.slice(0, n.length - 5)] = `"${v}"`

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -593,12 +593,12 @@ namespace ts.pxtc {
                     v0: string, v1: string, v2: string) => {
                     let v = v0 ? JSON.parse(v0) : (d0 ? (v0 || v1 || v2) : "true");
                     if (!v) v = "";
-                    if (U.startsWith(n, "loc.block.")) {
+                    if (U.startsWith(n, "block.loc.")) {
                         if (!res.locs) res.locs = {};
-                        res.locs[n.slice("loc.block.".length).toLowerCase() + "|block"] = v;
-                    } else if (U.startsWith(n, "loc.jsdoc.")) {
+                        res.locs[n.slice("block.loc.".length).toLowerCase() + "|block"] = v;
+                    } else if (U.startsWith(n, "jsdoc.loc.")) {
                         if (!res.locs) res.locs = {};
-                        res.locs[n.slice("loc.jsdoc.".length).toLowerCase() + "|jsdoc"] = v;
+                        res.locs[n.slice("jsdoc.loc.".length).toLowerCase() + "|jsdoc"] = v;
                     } else if (U.contains(n, ".loc.")) {
                         if (!res.locs) res.locs = {};
                         const p = n.slice(0, n.indexOf('.loc.'));

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -482,7 +482,7 @@ namespace ts.pxtc {
                 if (locJsDoc) {
                     fn.attributes.jsDoc = locJsDoc;
                     if (fn.parameters)
-                        fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || pi.description);
+                        fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || attrLocs[`${langLower}|param|${pi.name}`] || pi.description);
                 }
                 const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
                 let locBlock = loc[`${fn.qName}|block`] || attrLocs[attrBlockLocsKey];
@@ -593,9 +593,17 @@ namespace ts.pxtc {
                     v0: string, v1: string, v2: string) => {
                     let v = v0 ? JSON.parse(v0) : (d0 ? (v0 || v1 || v2) : "true");
                     if (!v) v = "";
-                    if (U.startsWith(n, "block.")) {
+                    if (U.startsWith(n, "loc.block.")) {
                         if (!res.locs) res.locs = {};
-                        res.locs[n.slice("block.".length).toLowerCase() + "|block"] = v;
+                        res.locs[n.slice("loc.block.".length).toLowerCase() + "|block"] = v;
+                    } else if (U.startsWith(n, "loc.jsdoc.")) {
+                        if (!res.locs) res.locs = {};
+                        res.locs[n.slice("loc.jsdoc.".length).toLowerCase() + "|jsdoc"] = v;
+                    } else if (U.contains(n, ".loc.")) {
+                        if (!res.locs) res.locs = {};
+                        const p = n.slice(0, n.indexOf('.loc.'));
+                        const l = n.slice(n.indexOf('.loc.') + '.loc'.length);
+                        res.locs[p + "|param|" + l] = v;
                     } else if (U.endsWith(n, ".defl")) {
                         if (v.indexOf(" ") > -1) {
                             res.paramDefl[n.slice(0, n.length - 5)] = `"${v}"`

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -454,17 +454,21 @@ describe("comment attribute parser", () => {
             /**
              * Bla
              */
-            //% block="$micros $whatever=oldShadowBlock"
-            //% loc.block.fr="FRENCH"
-            //% loc.block.es="SPANISH"
+            //% block="foo $bar"
+            //% block.loc.fr="FRENCH $bar"
+            //% block.loc.es="SPANISH $bar"
+            //% jsdoc.loc.fr="bli"
+            //% bar.loc.fr="bah"
         `)._def;
 
         checkLoc("fr", "FRENCH");
         checkLoc("es", "SPANISH");
 
         function checkLoc(name: string, shadow: string) {
-            chai.assert(parsed.locs["fr|block"] == "FRENCH");
-            chai.assert(parsed.locs["es|block"] == "SPANISH");
+            chai.assert(parsed.locs["fr|block"] == "FRENCH $bar");
+            chai.assert(parsed.locs["es|block"] == "SPANISH $bar");
+            chai.assert(parsed.locs["fr|jsdoc"] == "bli");
+            chai.assert(parsed.locs["fr|param|bar"] == "bah");
         }
     });
 

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -461,10 +461,10 @@ describe("comment attribute parser", () => {
             //% bar.loc.fr="bah"
         `);
 
-        chai.assert(parsed.locs["fr|block"] == "FRENCH $bar");
-        chai.assert(parsed.locs["es|block"] == "SPANISH $bar");
-        chai.assert(parsed.locs["fr|jsdoc"] == "bli");
-        chai.assert(parsed.locs["fr|param|bar"] == "bah");
+        chai.assert(parsed.locs["fr|block"] == "FRENCH $bar", JSON.stringify(parsed.locs));
+        chai.assert(parsed.locs["es|block"] == "SPANISH $bar", JSON.stringify(parsed.locs));
+        chai.assert(parsed.locs["fr|jsdoc"] == "bli", JSON.stringify(parsed.locs));
+        chai.assert(parsed.locs["fr|param|bar"] == "bah", JSON.stringify(parsed.locs));
 });
 
 });

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -450,7 +450,7 @@ describe("comment attribute parser", () => {
     });
 
     it("should allow block.LOCALE", () => {
-        const parsed = pxtc.parseCommentString(`
+        const parsed = ts.pxtc.parseCommentString(`
             /**
              * Bla
              */
@@ -459,7 +459,7 @@ describe("comment attribute parser", () => {
             //% block.loc.es="SPANISH $bar"
             //% jsdoc.loc.fr="bli"
             //% bar.loc.fr="bah"
-        `)._def;
+        `);
 
         checkLoc("fr", "FRENCH");
         checkLoc("es", "SPANISH");

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -455,8 +455,8 @@ describe("comment attribute parser", () => {
              * Bla
              */
             //% block="$micros $whatever=oldShadowBlock"
-            //% block.fr="FRENCH"
-            //% block.es="SPANISH"
+            //% loc.block.fr="FRENCH"
+            //% loc.block.es="SPANISH"
         `)._def;
 
         checkLoc("fr", "FRENCH");

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -461,16 +461,11 @@ describe("comment attribute parser", () => {
             //% bar.loc.fr="bah"
         `);
 
-        checkLoc("fr", "FRENCH");
-        checkLoc("es", "SPANISH");
-
-        function checkLoc(name: string, shadow: string) {
-            chai.assert(parsed.locs["fr|block"] == "FRENCH $bar");
-            chai.assert(parsed.locs["es|block"] == "SPANISH $bar");
-            chai.assert(parsed.locs["fr|jsdoc"] == "bli");
-            chai.assert(parsed.locs["fr|param|bar"] == "bah");
-        }
-    });
+        chai.assert(parsed.locs["fr|block"] == "FRENCH $bar");
+        chai.assert(parsed.locs["es|block"] == "SPANISH $bar");
+        chai.assert(parsed.locs["fr|jsdoc"] == "bli");
+        chai.assert(parsed.locs["fr|param|bar"] == "bah");
+});
 
 });
 

--- a/tests/blocklycompiler-test/commentparsing.spec.ts
+++ b/tests/blocklycompiler-test/commentparsing.spec.ts
@@ -448,6 +448,26 @@ describe("comment attribute parser", () => {
             chai.assert(parsed.parts.filter(p => p.kind === "param" && p.name === name && p.shadowBlockId == shadow).length === 1);
         }
     });
+
+    it("should allow block.LOCALE", () => {
+        const parsed = pxtc.parseCommentString(`
+            /**
+             * Bla
+             */
+            //% block="$micros $whatever=oldShadowBlock"
+            //% block.fr="FRENCH"
+            //% block.es="SPANISH"
+        `)._def;
+
+        checkLoc("fr", "FRENCH");
+        checkLoc("es", "SPANISH");
+
+        function checkLoc(name: string, shadow: string) {
+            chai.assert(parsed.locs["fr|block"] == "FRENCH");
+            chai.assert(parsed.locs["es|block"] == "SPANISH");
+        }
+    });
+
 });
 
 function brk(): pxtc.BlockBreak {


### PR DESCRIPTION
It's just much easier for extension writers to inline all the translations.