### PR TITLE
fix toc for now

### DIFF
--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -96,8 +96,9 @@ function setupSidebar() {
     for (var i = 0; i < accordions.length; i++) {
         var nodes = accordions.item(i).getElementsByClassName("title");
         for (var j = 0; j < nodes.length; j++) {
-            var hrefNode = nodes.item(j).getElementsByTagName("a").item(0);
-            var iNode = nodes.item(j).getElementsByTagName("i").item(0);
+            var menuItem = nodes.item(j);
+            var hrefNode = menuItem.getElementsByTagName("a").item(0);
+            var iNode = menuItem.getElementsByTagName("i").item(0);
             iNode.onclick = function (e) {
                 if (hrefNode.hasAttribute("aria-expanded") && hrefNode.getAttribute("aria-expanded") === "true") {
                     hrefNode.setAttribute("aria-expanded", "false");
@@ -105,6 +106,10 @@ function setupSidebar() {
                     hrefNode.setAttribute("aria-expanded", "true");
                 }
             };
+            if (!hrefNode) {
+                hrefNode = menuItem;
+                menuItem.setAttribute("tabindex", "0");
+            }
             hrefNode.onkeydown = function (e) {
                 var charCode = (typeof e.which == "number") ? e.which : e.keyCode
                 if (charCode === 39) { // Right key

--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -110,26 +110,6 @@
     <div class="divider"></div>
 </aside>
 
-<aside id=toc-dropdown class=menu>
-    <nav div class="ui simple dropdown item" title="@TITLE@">
-        @NAME@
-        <i class="dropdown icon"></i>
-        <div class="menu">
-            @ITEMS@
-        </div>
-    </nav>
-</aside>
-
-<aside id=toc-dropdown class=menu>
-    <nav class="item" title="@TITLE@">
-        <i class="dropdown icon"></i> @NAME@
-        <div class="menu">
-            @ITEMS@
-        </div>
-    </nav>
-</aside>
-
-
 <!-- TOC in the sidebar -->
 <aside id=item class=toc>
     <a class="item @ACTIVE@" href="@LINK@" role="menuitem">@NAME@</a>
@@ -151,10 +131,10 @@
     </div>
 </aside>
 
-<aside id=toc-dropdown-noheading class=toc>
+<aside id=toc-dropdown-noHeading class=toc>
     <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
         <div class="@ACTIVE@ title">
-            <i class="dropdown icon"></i>
+            <i class="right chevron icon"></i>
         </div>
         <div class="@ACTIVE@ content">
             @ITEMS@
@@ -176,10 +156,10 @@
     </div>
 </aside>
 
-<aside id=top-dropdown-noheading class=toc>
+<aside id=top-dropdown-noHeading class=toc>
     <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
         <div class="@ACTIVE@ title">
-            <i class="dropdown icon"></i>
+            <i class="right chevron icon"></i>
         </div>
         <div class="@ACTIVE@ content">
             @ITEMS@

--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -161,3 +161,52 @@
         </div>
     </div>
 </aside>
+
+<!-- TODO: duplicates of above for compatability with docsrender.ts;
+    remove with pxtlib/docsrender.ts TOC TODOs after cloud bump. -->
+<aside id=top-dropdown class=toc>
+    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
+        <div class="@ACTIVE@ title">
+            <i class="right chevron icon"></i>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@" href="@LINK@">@NAME@</a>
+        </div>
+        <div class="@ACTIVE@ content">
+            @ITEMS@
+        </div>
+    </div>
+</aside>
+
+<aside id=top-dropdown-noheading class=toc>
+    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
+        <div class="@ACTIVE@ title">
+            <i class="dropdown icon"></i>
+        </div>
+        <div class="@ACTIVE@ content">
+            @ITEMS@
+        </div>
+    </div>
+</aside>
+
+<aside id=inner-dropdown class=toc>
+    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
+        <div class="@ACTIVE@ title">
+            <i class="right chevron icon"></i>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@" href="@LINK@">@NAME@</a>
+        </div>
+        <div class="@ACTIVE@ content">
+            @ITEMS@
+        </div>
+    </div>
+</aside>
+
+<aside id=nested-dropdown class=toc>
+    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
+        <div class="@ACTIVE@ title">
+            <i class="right chevron icon"></i>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@" href="@LINK@">@NAME@</a>
+        </div>
+        <div class="@ACTIVE@ content">
+            @ITEMS@
+        </div>
+    </div>
+</aside>

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -202,7 +202,6 @@ namespace pxt.docs {
         };
         TOC.forEach(isCurrentTOC)
 
-        let currentTocEntry: TOCMenuEntry;
         let recTOC = (m: TOCMenuEntry, lev: number) => {
             let templ = toc["item"]
             let mparams: Map<string> = {
@@ -215,7 +214,6 @@ namespace pxt.docs {
             if (tocPath.indexOf(m) >= 0) {
                 mparams["ACTIVE"] = 'active';
                 mparams["EXPANDED"] = 'true';
-                currentTocEntry = m;
                 breadcrumb.push({
                     name: m.name,
                     href: m.path

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -161,7 +161,13 @@ namespace pxt.docs {
                 NAME: m.name,
             }
             if (m.subitems) {
-                templ = menus["toc-dropdown"]
+                /** TODO: when all targets bumped to include https://github.com/microsoft/pxt/pull/6013,
+                 * swap templ assignments below with the commented out version, and remove
+                 * top-dropdown, top-dropdown-noheading, inner-dropdown, and nested-dropdown from
+                 * docfiles/macros.html **/
+                if (lev == 0) templ = menus["top-dropdown"]
+                else templ = menus["inner-dropdown"]
+                // templ = menus["toc-dropdown"]
                 mparams["ITEMS"] = m.subitems.map(e => recMenu(e, lev + 1)).join("\n")
             } else {
                 if (/^-+$/.test(m.name)) {
@@ -218,11 +224,23 @@ namespace pxt.docs {
                 mparams["EXPANDED"] = 'false';
             }
             if (m.subitems && m.subitems.length > 0) {
-                if (m.name !== "") {
-                    templ = toc["toc-dropdown"]
-                } else {
-                    templ = toc["toc-dropdown-noHeading"]
-                }
+                /** TODO: when all targets bumped to include https://github.com/microsoft/pxt/pull/6013,
+                 * swap templ assignments below with the commented out version, and remove
+                 * top-dropdown, top-dropdown-noheading, inner-dropdown, and nested-dropdown from
+                 * docfiles/macros.html **/
+                if (lev == 0) {
+                    if (m.name !== "") {
+                        templ = toc["top-dropdown"]
+                    } else {
+                        templ = toc["top-dropdown-noHeading"]
+                    }
+                } else if (lev == 1) templ = toc["inner-dropdown"]
+                else templ = toc["nested-dropdown"]
+                // if (m.name !== "") {
+                //     templ = toc["toc-dropdown"]
+                // } else {
+                //     templ = toc["toc-dropdown-noHeading"]
+                // }
                 mparams["ITEMS"] = m.subitems.map(e => recTOC(e, lev + 1)).join("\n")
             } else {
                 if (/^-+$/.test(m.name)) {


### PR DESCRIPTION
There was a change to pxtlib/docsrender that relied on docfiles macros being updated, which can't be applied until all targets have the new & improved macros in their docfiles - that is, until all targets are bumped to a version of pxt containing that PR.

this should fix TOC for now in both situations, with some TODOs to clean it up later