### PR TITLE
Fixes table of content rendering

### DIFF
--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -110,25 +110,6 @@
     <div class="divider"></div>
 </aside>
 
-<aside id=toc-dropdown class=menu>
-    <nav div class="ui simple dropdown item" title="@TITLE@">
-        @NAME@
-        <i class="dropdown icon"></i>
-        <div class="menu">
-            @ITEMS@
-        </div>
-    </nav>
-</aside>
-
-<aside id=toc-dropdown class=menu>
-    <nav class="item" title="@TITLE@">
-        <i class="dropdown icon"></i> @NAME@
-        <div class="menu">
-            @ITEMS@
-        </div>
-    </nav>
-</aside>
-
 
 <!-- TOC in the sidebar -->
 <aside id=item class=toc>
@@ -139,7 +120,7 @@
     <div class="divider"></div>
 </aside>
 
-<aside id=toc-dropdown class=toc>
+<aside id=top-dropdown class=toc>
     <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
         <div class="@ACTIVE@ title">
             <i class="right chevron icon"></i>
@@ -151,7 +132,33 @@
     </div>
 </aside>
 
-<aside id=toc-dropdown-noheading class=toc>
+<!-- Tech debt: Duplicate of "top-dropdown", remove this once docsrenderer.ts doesn't depend on this -->
+<aside id=inner-dropdown class=toc>
+    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
+        <div class="@ACTIVE@ title">
+            <i class="right chevron icon"></i>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@" href="@LINK@">@NAME@</a>
+        </div>
+        <div class="@ACTIVE@ content">
+            @ITEMS@
+        </div>
+    </div>
+</aside>
+
+<!-- Tech debt: Duplicate of "top-dropdown", remove this once docsrenderer.ts doesn't depend on this -->
+<aside id=nested-dropdown class=toc>
+    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
+        <div class="@ACTIVE@ title">
+            <i class="right chevron icon"></i>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@" href="@LINK@">@NAME@</a>
+        </div>
+        <div class="@ACTIVE@ content">
+            @ITEMS@
+        </div>
+    </div>
+</aside>
+
+<aside id=top-dropdown-noHeading class=toc>
     <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
         <div class="@ACTIVE@ title">
             <i class="dropdown icon"></i>

--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -158,13 +158,6 @@
     </div>
 </aside>
 
+<!-- Don't render headerless dropdowns -->
 <aside id=top-dropdown-noHeading class=toc>
-    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
-        <div class="@ACTIVE@ title">
-            <i class="dropdown icon"></i>
-        </div>
-        <div class="@ACTIVE@ content">
-            @ITEMS@
-        </div>
-    </div>
 </aside>

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -161,7 +161,8 @@ namespace pxt.docs {
                 NAME: m.name,
             }
             if (m.subitems) {
-                templ = menus["toc-dropdown"]
+                if (lev == 0) templ = menus["top-dropdown"]
+                else templ = menus["inner-dropdown"]
                 mparams["ITEMS"] = m.subitems.map(e => recMenu(e, lev + 1)).join("\n")
             } else {
                 if (/^-+$/.test(m.name)) {
@@ -218,11 +219,14 @@ namespace pxt.docs {
                 mparams["EXPANDED"] = 'false';
             }
             if (m.subitems && m.subitems.length > 0) {
-                if (m.name !== "") {
-                    templ = toc["toc-dropdown"]
-                } else {
-                    templ = toc["toc-dropdown-noHeading"]
-                }
+                if (lev == 0) {
+                    if (m.name !== "") {
+                        templ = toc["top-dropdown"]
+                    } else {
+                        templ = toc["top-dropdown-noHeading"]
+                    }
+                } else if (lev == 1) templ = toc["inner-dropdown"]
+                else templ = toc["nested-dropdown"]
                 mparams["ITEMS"] = m.subitems.map(e => recTOC(e, lev + 1)).join("\n")
             } else {
                 if (/^-+$/.test(m.name)) {


### PR DESCRIPTION
This PR: https://github.com/microsoft/pxt/pull/6013
introduced a change that has to be rolled out to all editors simultaneously because of how the docs renderer <-> docfiles contract works.
This is too annoying to do, so this PR rolls back some of those changes and instead keeps the renderer as it was at the cost of some ugly code.

Eventually we should create a better contract between the renderer and the docfiles so changes like this aren't coupled.