### PR TITLE
Better resize logic for the sprite editor in narrow windows

### DIFF
--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -120,14 +120,27 @@ export class FieldEditorView implements pxt.react.FieldEditorView {
 
     protected resizeContentCore = () => {
         this.resizeFrameRef = undefined;
+        const bounds = this.editorBounds;
 
-        const padding = this.editorBounds.width < 500 ? 0 : Math.max(this.editorBounds.width, this.editorBounds.height) / 30;
+        let horizontalPadding = 20;
+        let verticalPadding = 20;
+
+
+        if (bounds.width - (horizontalPadding * 2) < 500) {
+            horizontalPadding = 0;
+            verticalPadding = 0;
+        }
+
+        if (bounds.height - (verticalPadding * 2) < 610) {
+            verticalPadding = Math.min(bounds.height - 610, 0) / 2;
+            horizontalPadding = 0;
+        }
 
         this.contentBounds = {
-            left: this.editorBounds.left + padding,
-            top: this.editorBounds.top + padding,
-            width: this.editorBounds.width - padding * 2,
-            height: this.editorBounds.height - padding * 2
+            left: bounds.left + horizontalPadding,
+            top: bounds.top + verticalPadding,
+            width: bounds.width - horizontalPadding * 2,
+            height: bounds.height - verticalPadding * 2
         };
 
         this.contentDiv.style.left = this.contentBounds.left + "px";
@@ -135,10 +148,10 @@ export class FieldEditorView implements pxt.react.FieldEditorView {
         this.contentDiv.style.width = this.contentBounds.width + "px";
         this.contentDiv.style.height = this.contentBounds.height + "px";
 
-        this.overlayDiv.style.left = this.editorBounds.left + "px";
-        this.overlayDiv.style.top = this.editorBounds.top + "px";
-        this.overlayDiv.style.width = this.editorBounds.width + "px";
-        this.overlayDiv.style.height = this.editorBounds.height + "px";
+        this.overlayDiv.style.left = bounds.left + "px";
+        this.overlayDiv.style.top = bounds.top + "px";
+        this.overlayDiv.style.width = bounds.width + "px";
+        this.overlayDiv.style.height = bounds.height + "px";
 
         if (this.componentRef && this.visible && this.componentRef.onResize) {
             this.componentRef.onResize();


### PR DESCRIPTION
The old sprite editor could go down to ~500px of viewport height and still be usable. The new sprite editor is taller, so the minimum viewport height it needs before the palette starts getting cut off is about ~800px.

This tweak drops that minimum height to about ~600px. If the workspace is too narrow, it will break the bounds of the editor and overlay the header/footer.
![sprite-resize](https://user-images.githubusercontent.com/13754588/66523724-7bdb8c00-eaa5-11e9-855c-34e7ef3edcbc.gif)

I think this should cover most reasonable screen sizes (including chromebooks)