### PR TITLE
Support decompiling enums inside of namespaces

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -2720,13 +2720,27 @@ ${output}</xml>`;
                 return undefined;
 
                 function checkEnumArgument(enumArg: ts.Node) {
-                    if (enumArg.kind === SK.PropertyAccessExpression) {
-                        const enumName = (enumArg as PropertyAccessExpression).expression as Identifier;
-                        if (enumName.kind === SK.Identifier && enumName.text === paramInfo.type) {
-                            return true;
-                        }
+                    // Enums can be under namespaces, so split up the qualified name into parts
+                    const parts = paramInfo.type.split(".");
+
+                    const enumParts: string[] = [];
+                    while (enumArg.kind === SK.PropertyAccessExpression) {
+                        enumParts.unshift((enumArg as PropertyAccessExpression).name.text);
+                        enumArg = (enumArg as PropertyAccessExpression).expression;
                     }
-                    return false;
+
+                    if (enumArg.kind !== SK.Identifier) {
+                        return false;
+                    }
+
+                    enumParts.unshift((enumArg as Identifier).text);
+
+                    // Use parts.length, because enumParts also contains the enum member
+                    for (let i = 0; i < parts.length; i++) {
+                        if (parts[i] !== enumParts[i]) return false;
+                    }
+
+                    return true;
                 }
             }
         }

--- a/tests/decompile-test/baselines/nested_enums.blocks
+++ b/tests/decompile-test/baselines/nested_enums.blocks
@@ -1,0 +1,9 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="stop_animations">
+<field name="type">animation.AnimationTypes.All</field>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/nested_enums.ts
+++ b/tests/decompile-test/cases/nested_enums.ts
@@ -1,0 +1,1 @@
+animation.stopAnimation(animation.AnimationTypes.All)

--- a/tests/decompile-test/cases/testBlocks/enums.ts
+++ b/tests/decompile-test/cases/testBlocks/enums.ts
@@ -76,3 +76,25 @@ namespace enumTest {
         return arg;
     }
 }
+
+namespace animation {
+    export enum AnimationTypes {
+        //% block="all"
+        All,
+        //% block="frame"
+        ImageAnimation,
+        //% block="path"
+        MovementAnimation
+    }
+
+    /**
+     * Stops all animations (simple and looping) of the specified type on a sprite
+     * @param type the animation type to stop
+     * @param sprite the sprite to filter animations by
+     */
+    //% blockId=stop_animations
+    //% block="stop %type animations"
+    //% group="Animate"
+    export function stopAnimation(type: AnimationTypes) {
+    }
+}


### PR DESCRIPTION
Fixes the issue where the "stop all animations" block in arcade doesn't decompile. I couldn't find an issue for it.