### PR TITLE
[stable5.15] integrate translation of docs

### DIFF
--- a/docfiles/docs.html
+++ b/docfiles/docs.html
@@ -5,7 +5,16 @@
 	<meta charset="UTF-8">
 	<title>@name@</title>
 	<meta name="Description" content="@description@" />
-
+	<!-- @ifdef incontexttranslations -->
+	<script type="text/javascript">
+		var _jipt = [];
+		_jipt.push(['project', '@crowdinproject@']);
+		_jipt.push(['escape', function () {
+			window.location.href = window.location.href.replace(/[$\?]translate=1/, '');
+		}]);
+	</script>
+	<script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+	<!-- @endif -->
 	<!-- @include meta.html -->
 	<!-- @include head.html -->
 

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -193,6 +193,10 @@ function setupSemantic() {
         window.print();
     })
 
+    $('#translatebtn').on("click", function () {
+        window.location.href = window.location.href.replace(/#.*/, '') + (window.location.href.indexOf('?') > -1 ? "&" : "?") + "translate=1"
+    })
+
     if (/browsers$/i.test(window.location.href))
         $('.ui.footer').append($('<div class="ui center aligned small container"/>').text('user agent: ' + navigator.userAgent))
 }
@@ -241,7 +245,7 @@ function renderSnippets() {
                     snippetClass: 'lang-blocks',
                     signatureClass: 'lang-sig',
                     blocksClass: 'lang-block',
-                    staticPythonClass: 'lang-spy', 
+                    staticPythonClass: 'lang-spy',
                     shuffleClass: 'lang-shuffle',
                     simulatorClass: 'lang-sim',
                     linksClass: 'lang-cards',

--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -22,6 +22,9 @@
             <a class="item" href="https://makecode.com/privacy" target="_blank" rel="noopener">Privacy &amp; Cookies</a>
             <a class="item" href="https://makecode.com/termsofuse" target="_blank" rel="noopener"> Terms Of Use</a>
             <a class="item" href="https://makecode.com/trademarks" target="_blank" rel="noopener">Trademarks</a>
+            <!-- @ifdef crowdinproject -->
+            <a id="translatebtn" tabindex="0" class="item">Translate this page</a>
+            <!-- @endif -->            
             <div class="item">© 2019 Microsoft</div>
         </div>
         <div class="ui container horizontal small divided link list">


### PR DESCRIPTION
Update docs html to support corwdin in context translation. 
(note: I have not ported the localhost server changes to test this locally to keep the patch small).

This fix is needed to enable in-context translations in micro:bit.