### PR TITLE
fix maker colors / docs light theme

### DIFF
--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -1,4 +1,4 @@
-<footer class="ui vertical footer segment hideprint docs" aria-hidden="false">
+<footer class="ui vertical footer segment hideprint docs @tocclass@" aria-hidden="false">
     <div class="ui center aligned container">
         <div class="ui horizontal link list">
             <a

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -1,5 +1,5 @@
 body#root {
-    font-size: 12pt;    
+    font-size: 12pt;
 }
 
 #docs ul {
@@ -30,7 +30,7 @@ body#root {
 #root .editor-image {
     margin: 2em auto;
     display: block;
-    max-width: 80%;    
+    max-width: 80%;
 }
 
 pre {
@@ -52,7 +52,7 @@ code {
 }
 
 p code, li code {
-    background-color: rgba(0,0,0,0.04);    
+    background-color: rgba(0,0,0,0.04);
 }
 
 p code:before, p code:after,
@@ -81,7 +81,7 @@ div.blocks-svg-list > svg {
 code {
     white-space: pre-wrap;
 }
-code.lang-ghost, code.lang-config, code.lang-package 
+code.lang-ghost, code.lang-config, code.lang-package
 { display: none;}
 
 code.lang-block::before,
@@ -191,7 +191,7 @@ svg {
 }
 
 #pagemenu {
-    border-radius: 0;    
+    border-radius: 0;
 }
 
 #pagemenu .ui.item .header {
@@ -215,7 +215,7 @@ svg {
 }
 .fixed.menu:after,
 .fixed.menu .item:before {
-    /* semantic loves to add pseudo elements; 
+    /* semantic loves to add pseudo elements;
     disable these ones because they interfere with flex-box */
     content:none;
 }
@@ -441,6 +441,6 @@ print only stuff
         display: none !important;
     }
     body.pushable {
-        background: #fff !important;        
+        background: #fff !important;
     }
 }

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -28,6 +28,14 @@
 @docsCardBorderColor: #e9eef2;
 @docsCardHoverBorderColor: #1dacf4;
 
+.docs.fixed.main.menu {
+    .item,
+    .item>a:not(.ui) {
+        background: transparent;
+        color: hsla(0,0%,100%,.9);
+    }
+}
+
 #docs .footer,
 .ui.menu.fixed.docs,
 #docs {

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -28,18 +28,13 @@
 @docsCardBorderColor: #e9eef2;
 @docsCardHoverBorderColor: #1dacf4;
 
-.docs.fixed.main.menu {
-    .item,
-    .item>a:not(.ui) {
-        background: transparent;
-        color: hsla(0,0%,100%,.9);
-    }
-}
-
 #docs .footer,
 .ui.menu.fixed.docs,
 #docs {
     background: hsl(@docsHue, 15%, 20%);
+    &.lighttoc {
+        background: hsl(@docsHue, 25%, 85%);
+    }
 }
 
 #docs {
@@ -291,7 +286,7 @@
         margin-bottom: 0;
 
         a.item {
-            color: #72a3d3;
+            color: rgba(18, 74, 130, 1.0);
 
             i.icon {
                 width: auto;
@@ -330,6 +325,33 @@
 
         .poweredBy .item {
             padding-right: .5em;
+        }
+        &.lighttoc {
+            a.item {
+                color: rgb(22, 83, 130);
+
+                i.icon {
+                    color: rgba(0, 0, 0, .6);
+                }
+
+                &:hover, &:focus {
+                    i.icon {
+                        color: rgba(0, 0, 0, 0.8);
+                    }
+                }
+            }
+            .divider {
+                border-top: 1px solid rgba(0,0,0,0.3);
+                border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+            }
+
+            .ui.divided.horizontal.list > .item:not(:first-child) {
+                border-left: 1px solid rgba(0, 0, 0, .4);
+            }
+
+            span.item {
+                color: rgba(0, 0, 0, .6);
+            }
         }
     }
 }
@@ -411,11 +433,11 @@
         content: none;
     }
     /* indented content
-        Note: we're annoyingly specific with these selectors 
+        Note: we're annoyingly specific with these selectors
         because we need to override Semantic's default behavior
     */
     .accordion.item .content:not(.style),
-    .accordion.item .accordion .title~.content:not(.ui), 
+    .accordion.item .accordion .title~.content:not(.ui),
     .accordion.item .title~.content:not(.ui) {
         padding: 0 0 0 0.25rem;
         margin: 0 0 0 0.5rem;

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -31,9 +31,9 @@
 #docs .footer,
 .ui.menu.fixed.docs,
 #docs {
-    background: hsl(@docsHue, 15%, 20%);
-    &.lighttoc {
-        background: hsl(@docsHue, 25%, 85%);
+    background: hsl(@docsHue, 25%, 85%);
+    &.inverted {
+        background: hsl(@docsHue, 15%, 20%);
     }
 }
 
@@ -286,32 +286,32 @@
         margin-bottom: 0;
 
         a.item {
-            color: rgba(18, 74, 130, 1.0);
+            color: rgb(22, 83, 130, 1.0);
 
             i.icon {
                 width: auto;
                 padding: 0 .25em !important;
-                color: rgba(255, 255, 255, .6);
+                color: rgba(0, 0, 0, .6);
             }
 
             &:hover, &:focus {
                 i.icon {
-                    color: rgba(255, 255, 255, 0.8);
+                    color: rgba(0, 0, 0, 0.8);
                 }
             }
         }
 
         .divider {
-            border-top: 1px solid rgba(255,255,255,0.3);
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            border-top: 1px solid rgba(0, 0, 0, 0.3);
+            border-bottom: 1px solid rgba(0, 0, 0, 0.1);
         }
 
         .ui.divided.horizontal.list > .item:not(:first-child) {
-            border-left: 1px solid rgba(255, 255, 255, .4);
+            border-left: 1px solid rgba(0, 0, 0, .4);
         }
 
         span.item {
-            color: rgba(255, 255, 255, .6);
+            color: rgba(0, 0, 0, .6);
         }
 
         span.item, img {
@@ -326,31 +326,31 @@
         .poweredBy .item {
             padding-right: .5em;
         }
-        &.lighttoc {
+        &.inverted {
             a.item {
-                color: rgb(22, 83, 130);
+                color: rgba(114, 163, 211, 1.0);
 
                 i.icon {
-                    color: rgba(0, 0, 0, .6);
+                    color: rgba(255, 255, 255, .6);
                 }
 
                 &:hover, &:focus {
                     i.icon {
-                        color: rgba(0, 0, 0, 0.8);
+                        color: rgba(255, 255, 255, 0.8);
                     }
                 }
             }
             .divider {
-                border-top: 1px solid rgba(0,0,0,0.3);
-                border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+                border-top: 1px solid rgba(255, 255, 255, 0.3);
+                border-bottom: 1px solid rgba(255, 255, 255, 0.1);
             }
 
             .ui.divided.horizontal.list > .item:not(:first-child) {
-                border-left: 1px solid rgba(0, 0, 0, .4);
+                border-left: 1px solid rgba(255, 255, 255, .4);
             }
 
             span.item {
-                color: rgba(0, 0, 0, .6);
+                color: rgba(255, 255, 255, .6);
             }
         }
     }


### PR DESCRIPTION
just adds back in support for a light theme to docs; it's actually easy enough to support when you're otherwise just changing the hue. Can add light coloring to the ToC if we want too I suppose?

![2019-10-10 15 33 19](https://user-images.githubusercontent.com/5615930/66611707-3a65e200-eb74-11e9-8e6a-957865e159ee.gif)
