### PR TITLE
TOC menu fixes

### DIFF
--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -131,15 +131,19 @@
     </div>
 </aside>
 
-<aside id=toc-dropdown-noHeading class=toc>
+<aside id=toc-dropdown-noLink class=toc>
     <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
         <div class="@ACTIVE@ title">
             <i class="right chevron icon"></i>
+            <a class="header" role="treeitem" aria-expanded="@EXPANDED@">@NAME@</a>
         </div>
         <div class="@ACTIVE@ content">
             @ITEMS@
         </div>
     </div>
+</aside>
+
+<aside id=toc-dropdown-noHeading class=toc>
 </aside>
 
 <!-- TODO: duplicates of above for compatability with docsrender.ts;
@@ -157,14 +161,6 @@
 </aside>
 
 <aside id=top-dropdown-noHeading class=toc>
-    <div class="ui @tocclass@ accordion item visible" title="@TITLE@">
-        <div class="@ACTIVE@ title">
-            <i class="right chevron icon"></i>
-        </div>
-        <div class="@ACTIVE@ content">
-            @ITEMS@
-        </div>
-    </div>
 </aside>
 
 <aside id=inner-dropdown class=toc>

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -161,13 +161,17 @@ namespace pxt.docs {
                 NAME: m.name,
             }
             if (m.subitems) {
-                /** TODO: when all targets bumped to include https://github.com/microsoft/pxt/pull/6013,
-                 * swap templ assignments below with the commented out version, and remove
-                 * top-dropdown, top-dropdown-noheading, inner-dropdown, and nested-dropdown from
-                 * docfiles/macros.html **/
-                if (lev == 0) templ = menus["top-dropdown"]
-                else templ = menus["inner-dropdown"]
-                // templ = menus["toc-dropdown"]
+                if (!!menus["toc-dropdown"]) {
+                    templ = menus["toc-dropdown"]
+                }
+                else {
+                    /** TODO: when all targets bumped to include https://github.com/microsoft/pxt/pull/6058,
+                     * swap templ assignments below with the commented out version, and remove
+                     * top-dropdown, top-dropdown-noheading, inner-dropdown, and nested-dropdown from
+                     * docfiles/macros.html **/
+                    if (lev == 0) templ = menus["top-dropdown"]
+                    else templ = menus["inner-dropdown"]
+                }
                 mparams["ITEMS"] = m.subitems.map(e => recMenu(e, lev + 1)).join("\n")
             } else {
                 if (/^-+$/.test(m.name)) {
@@ -222,10 +226,28 @@ namespace pxt.docs {
                 mparams["EXPANDED"] = 'false';
             }
             if (m.subitems && m.subitems.length > 0) {
-                if (m.path !== "") {
-                    templ = toc["toc-dropdown"]
-                } else {
-                    templ = toc["toc-dropdown-noLink"]
+                if (!!toc["toc-dropdown"]) {
+                    // if macros support "toc-*", use them
+                    if (m.name !== "") {
+                        templ = toc["toc-dropdown"]
+                    } else {
+                        templ = toc["toc-dropdown-noLink"]
+                    }
+                }
+                else {
+                    // if macros don't support "toc-*"
+                    /** TODO: when all targets bumped to include https://github.com/microsoft/pxt/pull/6058,
+                     * delete this else branch, and remove
+                     * top-dropdown, top-dropdown-noheading, inner-dropdown, and nested-dropdown from
+                     * docfiles/macros.html **/
+                    if (lev == 0) {
+                        if (m.name !== "") {
+                            templ = toc["top-dropdown"]
+                        } else {
+                            templ = toc["top-dropdown-noHeading"]
+                        }
+                    } else if (lev == 1) templ = toc["inner-dropdown"]
+                    else templ = toc["nested-dropdown"]
                 }
                 mparams["ITEMS"] = m.subitems.map(e => recTOC(e, lev + 1)).join("\n")
             } else {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -869,7 +869,6 @@ ${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}#${opts.repo.
         let tokens = markedInstance.lexer(summaryMD, options);
         let wasListStart = false
         tokens.forEach((token: any) => {
-            console.dir(token)
             switch (token.type) {
                 case "heading":
                     if (token.depth == 3) {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -222,23 +222,11 @@ namespace pxt.docs {
                 mparams["EXPANDED"] = 'false';
             }
             if (m.subitems && m.subitems.length > 0) {
-                /** TODO: when all targets bumped to include https://github.com/microsoft/pxt/pull/6013,
-                 * swap templ assignments below with the commented out version, and remove
-                 * top-dropdown, top-dropdown-noheading, inner-dropdown, and nested-dropdown from
-                 * docfiles/macros.html **/
-                if (lev == 0) {
-                    if (m.name !== "") {
-                        templ = toc["top-dropdown"]
-                    } else {
-                        templ = toc["top-dropdown-noHeading"]
-                    }
-                } else if (lev == 1) templ = toc["inner-dropdown"]
-                else templ = toc["nested-dropdown"]
-                // if (m.path !== "") {
-                //     templ = toc["toc-dropdown"]
-                // } else {
-                //     templ = toc["toc-dropdown-noLink"]
-                // }
+                if (m.path !== "") {
+                    templ = toc["toc-dropdown"]
+                } else {
+                    templ = toc["toc-dropdown-noLink"]
+                }
                 mparams["ITEMS"] = m.subitems.map(e => recTOC(e, lev + 1)).join("\n")
             } else {
                 if (/^-+$/.test(m.name)) {


### PR DESCRIPTION
The drop downs where appearing blank:

![image](https://user-images.githubusercontent.com/6453828/66612903-684d2580-eb78-11e9-8354-c02ccccee740.png)

Now this is fixed by this PR in two ways:

1. if docsrenderer is updated:
we handle the menus correctly
![image](https://user-images.githubusercontent.com/6453828/66612917-79963200-eb78-11e9-9e9b-4dfcdd03a9f4.png)

2. if docsrenderer is not updated:
we hide the menus (there is no way to show them correctly without updates to docsrenderer.ts)
![image](https://user-images.githubusercontent.com/6453828/66612991-bf52fa80-eb78-11e9-8b72-26579d80b1c3.png)

So this PR is safe and backwards compatible with both modes. When the docrenderer change hits the backend, we'll see (1) but if macros.html reaches targets before it's updated we'll see (2)