### PR TITLE
Adding support for nb as defined in crowdin

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -937,6 +937,7 @@ namespace ts.pxtc.Util {
         "lt": { englishName: "Lithuanian", localizedName: "Lietuvių" },
         "nl": { englishName: "Dutch", localizedName: "Nederlands" },
         "no": { englishName: "Norwegian", localizedName: "Norsk" },
+        "nb": { englishName: "Norwegian Bokmal", localizedName: "Norsk bokmål" },
         "pl": { englishName: "Polish", localizedName: "Polski" },
         "pt-BR": { englishName: "Portuguese (Brazil)", localizedName: "Português (Brasil)" },
         "pt-PT": { englishName: "Portuguese (Portugal)", localizedName: "Português (Portugal)" },


### PR DESCRIPTION
https://support.crowdin.com/api/language-codes/
Minecraft sends us nb-no and should be handled with "nb" here