### PR TITLE
Bump pxt-blockly to 2.1.6, update color parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.5",
-    "pxt-blockly": "2.1.5",
+    "pxt-blockly": "2.1.6",
     "react": "16.8.3",
     "react-dom": "16.3.1",
     "react-modal": "3.3.2",

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -89,6 +89,7 @@ namespace pxt.toolbox {
      * Convert blockly hue to rgb
      */
     export function convertColor(colour: string): string {
+        colour = parseHex(colour); // convert from 0x hex encoding if necessary
         const hue = parseInt(colour);
         if (!isNaN(hue)) {
             return hueToRgb(hue);
@@ -162,6 +163,11 @@ namespace pxt.toolbox {
     function componentToHex(c: number) {
         const hex = c.toString(16);
         return hex.length == 1 ? "0" + hex : hex;
+    }
+
+    function parseHex(s: string) {
+        if (s.substring(0, 2) == "0x") return "#"+ s.substring(2);
+        return s;
     }
 
     export function fadeColor(hex: string, luminosity: number, lighten: boolean): string {

--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -166,7 +166,7 @@ namespace pxt.toolbox {
     }
 
     function parseHex(s: string) {
-        if (s.substring(0, 2) == "0x") return "#"+ s.substring(2);
+        if (s.substring(0, 2) == "0x") return "#" + s.substring(2);
         return s;
     }
 


### PR DESCRIPTION
- Hex parsing fix
- Decimal/negative number fix