### PR TITLE
don't center sim view for docs 2.0

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -877,7 +877,7 @@ namespace pxt.runner {
             let $c = $(c);
             let padding = '81.97%';
             if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
-            let $sim = $(`<div class="ui centered card"><div class="ui content">
+            let $sim = $(`<div class="ui card"><div class="ui content">
                     <div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;">
                     <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" allowfullscreen="allowfullscreen" frameborder="0" sandbox="allow-popups allow-forms allow-scripts allow-same-origin"></iframe>
                     </div>


### PR DESCRIPTION
leave them left aligned like everything else. This is for ```sim snippets

<img width="612" alt="Screen Shot 2019-10-16 at 5 38 38 PM" src="https://user-images.githubusercontent.com/5615930/66968865-e8253500-f03b-11e9-9a7e-79fe7ae196fb.png">
