### PR TITLE
Bump pxt-blockly to 2.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.5",
-    "pxt-blockly": "2.1.7",
+    "pxt-blockly": "2.1.8",
     "react": "16.8.3",
     "react-dom": "16.3.1",
     "react-modal": "3.3.2",


### PR DESCRIPTION
Strips old xml namespaces from imported projects