### PR TITLE
add doc header field to apptheme

### DIFF
--- a/docfiles/tocheader.html
+++ b/docfiles/tocheader.html
@@ -8,7 +8,7 @@
                 </a>
             </div>
             <div>
-                @targetname@
+                @docsheader@
             </div>
         </div>
     </div>

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -213,6 +213,7 @@ declare namespace pxt {
         highContrastPortraitLogo?: string;
         rightLogo?: string;
         docsLogo?: string;
+        docsHeader?: string;
         organization?: string;
         organizationUrl?: string;
         organizationLogo?: string;

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -287,7 +287,7 @@ namespace pxt.docs {
             params["homeurl"] = html2Quote(theme.homeUrl);
         params["targetid"] = theme.id || "???";
         params["targetname"] = theme.name || "Microsoft MakeCode";
-        params["docsheader"] = theme.docsHeader || "Microsoft MakeCode";
+        params["docsheader"] = theme.docsHeader || "Documentation";
         params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui ${theme.logoWide ? "small" : "mini"} image" src="${theme.docsLogo}" />` : ""
         let ghURLs = d.ghEditURLs || []
         if (ghURLs.length) {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -286,7 +286,7 @@ namespace pxt.docs {
         if (theme.homeUrl)
             params["homeurl"] = html2Quote(theme.homeUrl);
         params["targetid"] = theme.id || "???";
-        params["targetname"] = theme.name || "Microsoft MakeCode";
+        params["targetname"] = theme.docsHeader || theme.name || "Microsoft MakeCode";
         params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui ${theme.logoWide ? "small" : "mini"} image" src="${theme.docsLogo}" />` : ""
         let ghURLs = d.ghEditURLs || []
         if (ghURLs.length) {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -286,7 +286,8 @@ namespace pxt.docs {
         if (theme.homeUrl)
             params["homeurl"] = html2Quote(theme.homeUrl);
         params["targetid"] = theme.id || "???";
-        params["targetname"] = theme.docsHeader || theme.name || "Microsoft MakeCode";
+        params["targetname"] = theme.name || "Microsoft MakeCode";
+        params["docsheader"] = theme.docsHeader || "Microsoft MakeCode";
         params["targetlogo"] = theme.docsLogo ? `<img aria-hidden="true" role="presentation" class="ui ${theme.logoWide ? "small" : "mini"} image" src="${theme.docsLogo}" />` : ""
         let ghURLs = d.ghEditURLs || []
         if (ghURLs.length) {


### PR DESCRIPTION
In theory should fix header name when combined with adding a docsHeader, eg https://github.com/microsoft/pxt-maker/pull/258

<img width="363" alt="Screen Shot 2019-10-17 at 11 36 50 AM" src="https://user-images.githubusercontent.com/5615930/67037477-721fdd00-f0d2-11e9-993a-729a0cc9fd35.png">

--->

<img width="334" alt="Screen Shot 2019-10-17 at 11 37 13 AM" src="https://user-images.githubusercontent.com/5615930/67037499-7c41db80-f0d2-11e9-8d56-acb9c38788b6.png">
