### PR TITLE
Bump pxt-blockly to 2.1.9, begin to remove references to goog.dom.cre…

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.5",
-    "pxt-blockly": "2.1.8",
+    "pxt-blockly": "2.1.9",
     "react": "16.8.3",
     "react-dom": "16.3.1",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -285,7 +285,7 @@ namespace pxt.blocks {
 
     function createFlyoutLabel(name: string, color?: string, icon?: string, iconClass?: string): HTMLElement {
         // Add the Heading label
-        let headingLabel = goog.dom.createDom('label') as HTMLElement;
+        let headingLabel = Blockly.utils.xml.createElement('label') as HTMLElement;
         headingLabel.setAttribute('text', name);
         if (color) {
             headingLabel.setAttribute('web-icon-color', pxt.toolbox.convertColor(color));
@@ -303,7 +303,7 @@ namespace pxt.blocks {
     }
 
     export function createFlyoutButton(callbackkey: string, label: string) {
-        let button = goog.dom.createDom('button') as Element;
+        let button = Blockly.utils.xml.createElement('button') as Element;
         button.setAttribute('text', label);
         button.setAttribute('callbackkey', callbackkey);
         return button;
@@ -1986,7 +1986,7 @@ namespace pxt.blocks {
                 xmlList.push(headingLabel);
             }
 
-            let button = goog.dom.createDom('button') as HTMLElement;
+            let button = document.createElement('button') as HTMLElement;
             button.setAttribute('text', lf("Make a Variable..."));
             button.setAttribute('callbackkey', 'CREATE_VARIABLE');
 
@@ -2248,15 +2248,15 @@ namespace pxt.blocks {
                          *   </block>
                          * </xml>
                          */
-                        let xml = goog.dom.createDom('xml');
-                        let block = goog.dom.createDom('block');
+                        let xml = Blockly.utils.xml.createElement('xml');
+                        let block = Blockly.utils.xml.createElement('block');
                         block.setAttribute('type', this.defType_);
                         let xy = this.getRelativeToSurfaceXY();
                         let x = xy.x + (Blockly as any).SNAP_RADIUS * (this.RTL ? -1 : 1);
                         let y = xy.y + (Blockly as any).SNAP_RADIUS * 2;
                         block.setAttribute('x', x);
                         block.setAttribute('y', y);
-                        let field = goog.dom.createDom('field');
+                        let field = Blockly.utils.xml.createElement('field');
                         field.setAttribute('name', 'NAME');
                         field.appendChild(document.createTextNode(this.getProcedureCall()));
                         block.appendChild(field);
@@ -2336,7 +2336,7 @@ namespace pxt.blocks {
             const newFunctionTitle = lf("New function name:");
 
             // Add the "Make a function" button
-            let button = goog.dom.createDom('button');
+            let button = Blockly.utils.xml.createElement('button');
             button.setAttribute('text', newFunction);
             button.setAttribute('callbackkey', 'CREATE_FUNCTION');
 
@@ -2356,12 +2356,12 @@ namespace pxt.blocks {
                     x = xy.x + (Blockly as any).SNAP_RADIUS * (topBlock.RTL ? -1 : 1);
                     y = xy.y + (Blockly as any).SNAP_RADIUS * 2;
                 }
-                let xml = goog.dom.createDom('xml');
-                let block = goog.dom.createDom('block');
+                let xml = Blockly.utils.xml.createElement('xml');
+                let block = Blockly.utils.xml.createElement('block');
                 block.setAttribute('type', 'procedures_defnoreturn');
                 block.setAttribute('x', String(x));
                 block.setAttribute('y', String(y));
-                let field = goog.dom.createDom('field');
+                let field = Blockly.utils.xml.createElement('field');
                 field.setAttribute('name', 'NAME');
                 field.appendChild(document.createTextNode(name));
                 block.appendChild(field);
@@ -2420,7 +2420,7 @@ namespace pxt.blocks {
                     // <block type="procedures_callnoreturn" gap="16">
                     //   <field name="NAME">name</field>
                     // </block>
-                    let block = goog.dom.createDom('block');
+                    let block = Blockly.utils.xml.createElement('block');
                     block.setAttribute('type', templateName);
                     block.setAttribute('gap', '16');
                     block.setAttribute('colour', pxt.toolbox.getNamespaceColor('functions'));

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -21,6 +21,7 @@ namespace pxtblockly {
         private static TAB = "        ";
 
         public isFieldCustom_ = true;
+        public SERIALIZABLE = true;
 
         private params: any;
         private onColor = "#FFFFFF";
@@ -78,48 +79,50 @@ namespace pxtblockly {
         }
 
         private initMatrix() {
-            this.elt = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" />`);
+            if (!this.sourceBlock_.isInsertionMarker()) {
+                this.elt = pxsim.svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" id="field-matrix" />`);
 
-            // Initialize the matrix that holds the state
-            for (let i = 0; i < this.matrixWidth; i++) {
-                this.cellState.push([])
-                this.cells.push([]);
-                for (let j = 0; j < this.matrixHeight; j++) {
-                    this.cellState[i].push(false);
-                }
-            }
-
-            this.restoreStateFromString();
-
-            // Create the cells of the matrix that is displayed
-            for (let i = 0; i < this.matrixWidth; i++) {
-                for (let j = 0; j < this.matrixHeight; j++) {
-                    this.createCell(i, j);
-                }
-            }
-
-            this.updateValue();
-
-            if (this.xAxisLabel !== LabelMode.None) {
-                const y = this.matrixHeight * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_VERTICAL_MARGIN * 2 + FieldMatrix.BOTTOM_MARGIN
-                const xAxis = pxsim.svg.child(this.elt, "g", { transform: `translate(${0} ${y})` });
+                // Initialize the matrix that holds the state
                 for (let i = 0; i < this.matrixWidth; i++) {
-                    const x = this.getYAxisWidth() + i * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_HORIZONTAL_MARGIN) + FieldMatrix.CELL_WIDTH / 2 + FieldMatrix.CELL_HORIZONTAL_MARGIN / 2;
-                    const lbl = pxsim.svg.child(xAxis, "text", { x, class: "blocklyText" })
-                    lbl.textContent = this.getLabel(i, this.xAxisLabel);
+                    this.cellState.push([])
+                    this.cells.push([]);
+                    for (let j = 0; j < this.matrixHeight; j++) {
+                        this.cellState[i].push(false);
+                    }
                 }
-            }
 
-            if (this.yAxisLabel !== LabelMode.None) {
-                const yAxis = pxsim.svg.child(this.elt, "g", {});
-                for (let i = 0; i < this.matrixHeight; i++) {
-                    const y = i * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_WIDTH / 2 + FieldMatrix.CELL_VERTICAL_MARGIN * 2;
-                    const lbl = pxsim.svg.child(yAxis, "text", { x: 0, y, class: "blocklyText" })
-                    lbl.textContent = this.getLabel(i, this.yAxisLabel);
+                this.restoreStateFromString();
+
+                // Create the cells of the matrix that is displayed
+                for (let i = 0; i < this.matrixWidth; i++) {
+                    for (let j = 0; j < this.matrixHeight; j++) {
+                        this.createCell(i, j);
+                    }
                 }
-            }
 
-            this.fieldGroup_.appendChild(this.elt);
+                this.updateValue();
+
+                if (this.xAxisLabel !== LabelMode.None) {
+                    const y = this.matrixHeight * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_VERTICAL_MARGIN * 2 + FieldMatrix.BOTTOM_MARGIN
+                    const xAxis = pxsim.svg.child(this.elt, "g", { transform: `translate(${0} ${y})` });
+                    for (let i = 0; i < this.matrixWidth; i++) {
+                        const x = this.getYAxisWidth() + i * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_HORIZONTAL_MARGIN) + FieldMatrix.CELL_WIDTH / 2 + FieldMatrix.CELL_HORIZONTAL_MARGIN / 2;
+                        const lbl = pxsim.svg.child(xAxis, "text", { x, class: "blocklyText" })
+                        lbl.textContent = this.getLabel(i, this.xAxisLabel);
+                    }
+                }
+
+                if (this.yAxisLabel !== LabelMode.None) {
+                    const yAxis = pxsim.svg.child(this.elt, "g", {});
+                    for (let i = 0; i < this.matrixHeight; i++) {
+                        const y = i * (FieldMatrix.CELL_WIDTH + FieldMatrix.CELL_VERTICAL_MARGIN) + FieldMatrix.CELL_WIDTH / 2 + FieldMatrix.CELL_VERTICAL_MARGIN * 2;
+                        const lbl = pxsim.svg.child(yAxis, "text", { x: 0, y, class: "blocklyText" })
+                        lbl.textContent = this.getLabel(i, this.yAxisLabel);
+                    }
+                }
+
+                this.fieldGroup_.appendChild(this.elt);
+            }
         }
 
         private getLabel(index: number, mode: LabelMode) {

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -138,6 +138,7 @@ namespace pxtblockly {
     //  Class for a note input field.
     export class FieldNote extends Blockly.FieldNumber implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
+        public SERIALIZABLE = true;
         //  value of the field
         private note_: string;
 
@@ -349,6 +350,7 @@ namespace pxtblockly {
             }
             this.note_ = this.callValidator(note);
             this.setText(this.getNoteName_());
+            this.value_ = this.note_;
         }
 
         /**

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1318,7 +1318,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         })
 
         if (this.flyoutXmlList.length == 0) {
-            let label = goog.dom.createDom('label');
+            let label = Blockly.utils.xml.createElement('label');
             label.setAttribute('text', lf("No search results..."));
             this.flyoutXmlList.push(label);
         }
@@ -1329,7 +1329,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.flyoutXmlList = [];
         const topBlocks = this.getTopBlocks();
         if (topBlocks.length == 0) {
-            let label = goog.dom.createDom('label');
+            let label = Blockly.utils.xml.createElement('label');
             label.setAttribute('text', lf("No basic blocks..."));
             this.flyoutXmlList.push(label);
         } else {


### PR DESCRIPTION
…ateNote. Some small fixes for LED matrix (don't add element if block is insertion marker) and keyboard (set value in doValueUpdate)