### PR TITLE
recenter images in tutorial hints

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -298,6 +298,14 @@ span.highlight-line {
     }
 }
 
+.ui.modal.hintdialog,
+.tutorialsegment .tutorialmessage {
+    img {
+        margin-left: auto;
+        margin-right: auto;
+    }
+}
+
 .tutorialhint {
     position: absolute;
     max-width: 100%;
@@ -521,12 +529,12 @@ span.highlight-line {
 @media only screen and (max-height: @tallEditorBreakpoint) and (min-width: @largestMobileScreen) {
     .tutorial #tutorialcard {
         padding-left: 0.5rem;
-        padding-right: 0.5rem;        
+        padding-right: 0.5rem;
     }
     .tutorial #tutorialcard .content {
         font-size: 10pt;
     }
-    
+
     .modal.hintdialog img.ui.centered.image {
         max-height:12rem;
     }


### PR DESCRIPTION
Previously images were getting the center class from in docsrender.ts, but with docs2.0 being left aligned that changed.

<img width="1050" alt="Screen Shot 2019-10-18 at 11 30 58 AM" src="https://user-images.githubusercontent.com/5615930/67119899-f63e9700-f19c-11e9-987b-cb896c74bb0c.png">
