### PR TITLE
Update the contact page with forum link

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -18,6 +18,11 @@ Let's get you to the right place.
 - For help on setting up MakeCode and Minecraft, follow the [setup guide](https://minecraft.makecode.com/setup).
 - Running into issues with Code Connection, MakeCode for Minecraft, or Minecraft Education Edition? Post your question on [Minecraft EE Tech Support](https://education.minecraft.net/technical-support).
 
+### Arcade
+
+- Have a question, or running into an issue? Check out the [MakeCode forums](https://forum.makecode.com).
+- Think you've found a bug on MakeCode Arcade? File it [here](https://github.com/microsoft/pxt-arcade/issues/new?labels=bug).
+
 ### LEGO® MINDSTORMS® Education EV3
 
 - For help on downloading from MakeCode, see the [troubleshooting](https://makecode.mindstorms.com/troubleshoot) guide.
@@ -36,14 +41,12 @@ Let's get you to the right place.
 
 Discuss a topic or look for an answer to a question on the [MakeCode Forum](https://forum.makecode.com).
 
-
 ## I'm a developer!
 
-- Have a question? Ask it on [stack overflow](https://stackoverflow.com/), we monitor the ``makecode`` tag.
 - Think you've found a bug that affects the entire MakeCode platform? File your issue [here](https://github.com/microsoft/pxt/issues/new?labels=bug).
 - Have an idea you'd like to share with us? File a feature request [here](https://github.com/microsoft/pxt/issues/new?labels=enhancement).
 - Want to speak directly to the team? Ask your question on
-    - Gitter [**Deprecated** => **Moved to Discord**] [![Join the chat at https://gitter.im/makecode-community/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/makecode-community/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+    - Forum https://forum.makecode.com/
     - Discord [**Active**] [![Join the Discord channel at https://aka.ms/makecodecommunity](https://img.shields.io/badge/discord-join%20chat-blue.svg?)](https://aka.ms/makecodecommunity)
 
 ## Contact the MakeCode team

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -37,7 +37,7 @@ Let's get you to the right place.
 Discuss a topic or look for an answer to a question on the [MakeCode Forum](https://forum.makecode.com).
 
 
-# I'm a developer!
+## I'm a developer!
 
 - Have a question? Ask it on [stack overflow](https://stackoverflow.com/), we monitor the ``makecode`` tag.
 - Think you've found a bug that affects the entire MakeCode platform? File your issue [here](https://github.com/microsoft/pxt/issues/new?labels=bug).
@@ -46,6 +46,6 @@ Discuss a topic or look for an answer to a question on the [MakeCode Forum](http
     - Gitter [**Deprecated** => **Moved to Discord**] [![Join the chat at https://gitter.im/makecode-community/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/makecode-community/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
     - Discord [**Active**] [![Join the Discord channel at https://aka.ms/makecodecommunity](https://img.shields.io/badge/discord-join%20chat-blue.svg?)](https://aka.ms/makecodecommunity)
 
-# Contact the MakeCode team
+## Contact the MakeCode team
 
 For all other enquiries, please send us an email at ``makecode at microsoft dot com``.

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -47,7 +47,7 @@ Discuss a topic or look for an answer to a question on the [MakeCode Forum](http
 - Have an idea you'd like to share with us? File a feature request [here](https://github.com/microsoft/pxt/issues/new?labels=enhancement).
 - Want to speak directly to the team? Ask your question on
     - Forum https://forum.makecode.com/
-    - Discord [**Active**] [![Join the Discord channel at https://aka.ms/makecodecommunity](https://img.shields.io/badge/discord-join%20chat-blue.svg?)](https://aka.ms/makecodecommunity)
+    - Discord [![Join the Discord channel at https://aka.ms/makecodecommunity](https://img.shields.io/badge/discord-join%20chat-blue.svg?)](https://aka.ms/makecodecommunity)
 
 ## Contact the MakeCode team
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,25 +1,44 @@
 # Hello, we're excited to hear from you!
+
 Let's get you to the right place.
 
-# micro:bit
+## MakeCode editors
+
+### micro:bit
+
 - Have a question, or running into an issue? Check out the [micro:bit Support Forums](https://support.microbit.org/).
 - Think you've found a bug on MakeCode for micro:bit? File it [here](https://github.com/microsoft/pxt-microbit/issues/new?labels=bug).
 
-# Adafruit - Circuit Playground Express
+### Adafruit Circuit Playground Express
 - Have a question, or running into an issue? Check out the [Adafruit Support Forums](https://www.adafruit.com/support).
 - Think you've found a bug on MakeCode for Circuit Playground Express? File it [here](https://github.com/microsoft/pxt-adafruit/issues/new?labels=bug).
 
-# Minecraft
+### Minecraft
+
 - For help on setting up MakeCode and Minecraft, follow the [setup guide](https://minecraft.makecode.com/setup).
 - Running into issues with Code Connection, MakeCode for Minecraft, or Minecraft Education Edition? Post your question on [Minecraft EE Tech Support](https://education.minecraft.net/technical-support).
 
-# Chibitronics - Chibi Chip
+### LEGO® MINDSTORMS® Education EV3
+
+- For help on downloading from MakeCode, see the [troubleshooting](https://makecode.mindstorms.com/troubleshoot) guide.
+- For general [support]( https://www.lego.com/service/).
+- Information about [FIRST LEGO League](https://makecode.mindstorms.com/fll).
+
+### Chibitronics Chibi Chip
+
 - Think you've found a bug on MakeCode for Chibi Chip? File it [here](https://github.com/microsoft/pxt-chibitronics/issues/new?labels=bug).
 
-# Wonder Workshop - Cue
+### Wonder Workshop Cue
+
 - For any assistance regarding Cue or MakeCode for Cue, check out the [Wonder Workshop Support Forums](https://help.makewonder.com/).
 
+## MakeCode Forum
+
+Discuss a topic or look for an answer to a question on the [MakeCode Forum](https://forum.makecode.com).
+
+
 # I'm a developer!
+
 - Have a question? Ask it on [stack overflow](https://stackoverflow.com/), we monitor the ``makecode`` tag.
 - Think you've found a bug that affects the entire MakeCode platform? File your issue [here](https://github.com/microsoft/pxt/issues/new?labels=bug).
 - Have an idea you'd like to share with us? File a feature request [here](https://github.com/microsoft/pxt/issues/new?labels=enhancement).
@@ -28,4 +47,5 @@ Let's get you to the right place.
     - Discord [**Active**] [![Join the Discord channel at https://aka.ms/makecodecommunity](https://img.shields.io/badge/discord-join%20chat-blue.svg?)](https://aka.ms/makecodecommunity)
 
 # Contact the MakeCode team
+
 For all other enquiries, please send us an email at ``makecode at microsoft dot com``.


### PR DESCRIPTION
Add the forum link to the page. Also, include EV3 in the editor's contacts., a few formatting adjustments.

Closes #6074 