### PR TITLE
Add workspace labels for flyoutOnly view

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -12,12 +12,17 @@
 @avatarSize: 4.5rem;
 @avatarMargin: @avatarSize + 0.5rem;
 @mobileAvatarMargin: 2rem;
+@workspaceHeaderHeight: 2rem;
 
 /*******************************
       Tutorial mode
 *******************************/
 .tutorial #maineditor .full-abs {
     top: @tutorialCardHeight;
+}
+
+.tutorial.flyoutOnly #maineditor .full-abs {
+    top: calc(@tutorialCardHeight + @workspaceHeaderHeight);
 }
 
 .tutorial #maineditor #monacoEditor {
@@ -438,6 +443,31 @@ span.highlight-line {
     stroke-linecap: round;
 }
 
+/*******************************
+        Workspace headers
+*******************************/
+#headers {
+    display: flex;
+    position: relative;
+    height: @workspaceHeaderHeight;
+    color: @white;
+    z-index: @simulatorZIndex;
+
+    #workspaceHeader {
+        flex: 1;
+    }
+
+    #flyoutHeader {
+        box-sizing: content-box;
+    }
+
+    div {
+        display: inline-block;
+        text-align: center;
+        line-height: 2rem;
+        font-weight: 800;
+    }
+}
 
 /*******************************
         Media Adjustments

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3157,9 +3157,13 @@ export class ProjectView
         if (tc) tc.showHint(true, showFullText);
     }
 
-    getExpandedCardStyle(): any {
+    getExpandedCardStyle(flyoutOnly?: boolean): any {
         let tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
-        return tc ? tc.getExpandedCardStyle('top') : null;
+        let margin = 2;
+        if (flyoutOnly) {
+            margin += 2;
+        }
+        return tc ? { 'top' : "calc(" + tc.getCardHeight() + "px + " + margin + "em)" } : null;
     }
 
     ///////////////////////////////////////////////////////////
@@ -3309,7 +3313,7 @@ export class ProjectView
         const inEditor = !!this.state.header && !inHome;
         const { lightbox, greenScreen } = this.state;
         const simDebug = !!targetTheme.debugger || inDebugMode;
-        const flyoutOnly = this.state.editorState && !this.state.editorState.hasCategories;
+        const flyoutOnly = this.state.editorState && this.state.editorState.hasCategories === false;
 
         const { hideEditorToolbar, transparentEditorToolbar } = targetTheme;
         const hideMenuBar = targetTheme.hideMenuBar || hideTutorialIteration;
@@ -3325,7 +3329,7 @@ export class ProjectView
         const logoWide = !!targetTheme.logoWide;
         const hwDialog = !sandbox && pxt.hasHwVariants();
         const recipes = !!targetTheme.recipes;
-        const expandedStyle = inTutorialExpanded ? this.getExpandedCardStyle() : null;
+        const expandedStyle = inTutorialExpanded ? this.getExpandedCardStyle(flyoutOnly) : null;
         const invertedTheme = targetTheme.invertedMenu && targetTheme.invertedMonaco;
 
         const collapseIconTooltip = this.state.collapseEditorTools ? lf("Show the simulator") : lf("Hide the simulator");
@@ -3389,9 +3393,10 @@ export class ProjectView
                         <notification.NotificationBanner parent={this} />
                         <container.MainMenu parent={this} />
                     </header>}
-                {inTutorial ? <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
+                {inTutorial && <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
                     <tutorial.TutorialCard ref={ProjectView.tutorialCardId} parent={this} pokeUser={this.state.pokeUserComponent == ProjectView.tutorialCardId} />
-                </div> : undefined}
+                    {flyoutOnly && <tutorial.WorkspaceHeader />}
+                </div>}
                 <div id="simulator" className="simulator">
                     <div id="filelist" className="ui items">
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0}>

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -269,7 +269,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             // Otherwise translate the blocks so that they are positioned on the top left
             this.editor.getTopComments(false).forEach(c => c.moveBy(-minX, -minY));
             this.editor.getTopBlocks(false).forEach(b => b.moveBy(-minX, -minY));
-            this.editor.scrollX = flyoutOnly ? (this.editor as any).flyout_.width_ + 10 : 10;
+            this.editor.scrollX = 10;
             this.editor.scrollY = 10;
 
             // Forces scroll to take effect
@@ -604,10 +604,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     display(): JSX.Element {
+        let flyoutOnly = this.parent.state.editorState && this.parent.state.editorState.hasCategories === false;
         return (
             <div>
                 <div id="blocksEditor"></div>
-                <toolbox.ToolboxTrashIcon />
+                <toolbox.ToolboxTrashIcon flyoutOnly={flyoutOnly} />
             </div>
         )
     }
@@ -1431,7 +1432,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
-    // For editors that have no toolb
+    // For editors that have no toolbox
     showFlyoutOnlyToolbox() {
         // Show a Flyout only with all the blocks
         const allCategories = this.getAllCategories();
@@ -1451,6 +1452,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             if (blockXmlList) xmlList = xmlList.concat(blockXmlList);
         })
         this.showFlyoutInternal_(xmlList);
+        this.parent.forceUpdate();
     }
 
     ///////////////////////////////////////////////////////////

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -868,10 +868,29 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
     }
 }
 
-export class ToolboxTrashIcon extends data.Component<{}, {}> {
+interface ToolboxTrashIconProps {
+    flyoutOnly?: boolean;
+}
+
+export class ToolboxTrashIcon extends data.Component<ToolboxTrashIconProps, {}> {
+    constructor(props: ToolboxTrashIconProps) {
+        super(props);
+    }
+
+    getStyle() {
+        let style: any = { opacity: 0, display: 'none' };
+        if (this.props.flyoutOnly) {
+            let flyout = document.querySelector('.blocklyFlyout');
+            if (flyout ) {
+                style["left"] = (flyout.clientWidth / 2);
+                style["transform"] = "translateX(-45%)";
+            }
+        }
+        return style;
+    }
 
     renderCore() {
-        return <div id="blocklyTrashIcon" style={{ opacity: 0, display: 'none' }}>
+        return <div id="blocklyTrashIcon" style={this.getStyle()}>
             <i className="trash icon" aria-hidden="true"></i>
         </div>
     }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -659,6 +659,8 @@ export class ChooseRecipeDialog extends data.Component<ISettingsProps, ChooseRec
 
 export class WorkspaceHeader extends data.Component<any, {}> {
     private flyoutWidth: number = 0;
+    private flyoutTitle: string = lf("Toolbox");
+    private workspaceTitle: string = lf("Workspace");
     constructor(props: any) {
         super(props);
     }
@@ -678,8 +680,8 @@ export class WorkspaceHeader extends data.Component<any, {}> {
 
     renderCore() {
         return <div id="headers">
-                    <div id="flyoutHeader" style={this.headerStyle()}>Toolbox</div>
-                    <div id="workspaceHeader">Workspace</div>
+                    <div id="flyoutHeader" style={this.headerStyle()}>{this.flyoutTitle}</div>
+                    <div id="workspaceHeader">{this.workspaceTitle}</div>
                </div>;
     }
 }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -466,8 +466,12 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.setState({ showSeeMore: show });
     }
 
+    getCardHeight() {
+        return this.cardHeight;
+    }
+
     getExpandedCardStyle(prop: string) {
-        return { [prop] : `calc(${this.cardHeight}px + 2rem)` }
+        return { [prop] : `calc(${this.getCardHeight()}px + 2rem)` }
     }
 
     toggleHint(showFullText?: boolean) {
@@ -650,5 +654,32 @@ export class ChooseRecipeDialog extends data.Component<ISettingsProps, ChooseRec
                 </div>
             </sui.Modal>
         )
+    }
+}
+
+export class WorkspaceHeader extends data.Component<any, {}> {
+    private flyoutWidth: number = 0;
+    constructor(props: any) {
+        super(props);
+    }
+
+    componentWillUpdate() {
+        let flyout = document.querySelector('.blocklyFlyout');
+        if (flyout) {
+            this.flyoutWidth = flyout.clientWidth;
+        }
+    }
+
+    private headerStyle() {
+        return {
+            width: this.flyoutWidth
+        }
+    }
+
+    renderCore() {
+        return <div id="headers">
+                    <div id="flyoutHeader" style={this.headerStyle()}>Toolbox</div>
+                    <div id="workspaceHeader">Workspace</div>
+               </div>;
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/67130215-78d35080-f1b5-11e9-9611-1e7858039306.png)

- Adds labels if "flyoutOnly" is specified in tutorial markdown
- Fixes issues with block centering for flyoutOnly
- Centers trash icon based on flyout size in flyoutOnly view
- Fixes microsoft/pxt-arcade#1402