### PR TITLE
Small fixes, CSS updates

### DIFF
--- a/pxtlib/toolbox.ts
+++ b/pxtlib/toolbox.ts
@@ -166,6 +166,7 @@ namespace pxt.toolbox {
     }
 
     function parseHex(s: string) {
+        if (!s) return "#000000";
         if (s.substring(0, 2) == "0x") return "#" + s.substring(2);
         return s;
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -434,6 +434,11 @@ div.simframe > iframe {
     position: relative;
 }
 
+.ui.button.big-play-button {
+    /* Fixes an error in some webkit browsers where icons get repositioned on hover */
+    position: relative;
+}
+
 /* Icon and text */
 .ui.item.link.dbg-btn > .icon-and-text.icon ~ .ui.text,
 .ui.item.link > .icon-and-text.icon ~ .ui.text.exit-debugmode-btn,
@@ -993,6 +998,11 @@ p.ui.font.small {
         bottom: 3px;
         .includePoweredByLogos(); // set the @poweredBySmall variable
         background-image: @poweredBySmall;
+    }
+    #root.headless.transparentEditorTools {
+        #editortools {
+            margin-bottom: 1.5rem;
+        }
     }
 }
 

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -387,7 +387,7 @@ span.highlight-line {
 #tutorialcard.seemore {
     .tutorialsegment > button {
         position: relative;
-        top: -1rem;
+        top: -0.75rem;
         width: auto;
         margin: auto;
         padding: 0.5rem 0.8rem;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -388,10 +388,6 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             if (!!options.tutorialStepInfo[step].unplugged) {
                 this.removeHintOnClick();
             }
-
-            if (!this.state.showHintTooltip) {
-                this.showHint(true); // re-bind events after tutorial DOM loaded
-            }
         }
     }
 


### PR DESCRIPTION
Fixes for:
- Null check on parseHex for toolbox colors
- Hint displaying on first step of all tutorials
- CSS fixes (margin on "less" button, big play button blocked by scrollbar, big play icon repositions on hover in mac)

Fixes https://github.com/microsoft/pxt/issues/6087
Fixes https://github.com/microsoft/pxt-minecraft/issues/1281