### PR TITLE
Override semantic to always display tooltip

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -178,6 +178,11 @@ div.blocklyTooltipDiv {
     overflow-wrap: break-word;
 }
 
+div.blocklyTooltipDiv .ui.card .content .description {
+    /* override semantic, tooltip text should always be visible*/
+    display: inline;
+}
+
 #blocks-editor-field-div {
     position: absolute;
     z-index: @blocklyDropdownDivZIndex;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1292