### PR TITLE
moved installedVersion to package

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -30,7 +30,7 @@ declare namespace pxt {
     interface PackageConfig {
         name: string;
         version?: string;
-        // installedVersion?: string; ignored going further
+        // installedVersion?: string; moved to Package class
         // url to icon -- support for built-in packages only
         icon?: string;
         // semver description for support target version

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -30,7 +30,7 @@ declare namespace pxt {
     interface PackageConfig {
         name: string;
         version?: string;
-        installedVersion?: string;
+        // installedVersion?: string; ignored going further
         // url to icon -- support for built-in packages only
         icon?: string;
         // semver description for support target version

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -35,7 +35,7 @@ namespace pxt {
         private resolvedVersion: string;
         public ignoreTests = false;
         public cppOnly = false;
-        public installedVersion: string;
+        public installedVersion: string; // resolve version
 
         constructor(public id: string, public _verspec: string, public parent: MainPackage, addedBy: Package) {
             if (addedBy) {
@@ -900,7 +900,7 @@ namespace pxt {
                     if (!allowPrivate && !this.config.public)
                         U.userError('Only packages with "public":true can be published')
                     let cfg = U.clone(this.config)
-                    delete (<any>cfg).installedVersion
+                    delete (<any>cfg).installedVersion // cleanup old pxt.json files
                     delete cfg.additionalFilePath
                     delete cfg.additionalFilePaths
                     if (!cfg.targetVersions) cfg.targetVersions = pxt.appTarget.versions;

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -35,6 +35,7 @@ namespace pxt {
         private resolvedVersion: string;
         public ignoreTests = false;
         public cppOnly = false;
+        public installedVersion: string;
 
         constructor(public id: string, public _verspec: string, public parent: MainPackage, addedBy: Package) {
             if (addedBy) {
@@ -201,8 +202,7 @@ namespace pxt {
                         pxt.debug(`skip download of invalid package ${this.id}`);
                         return undefined;
                     }
-                    if (!/^embed:/.test(verNo) &&
-                        this.config && this.config.installedVersion == verNo)
+                    if (!/^embed:/.test(verNo) && this.installedVersion == verNo)
                         return undefined;
                     pxt.debug('downloading ' + verNo)
                     return this.host().downloadPackageAsync(this)
@@ -220,7 +220,7 @@ namespace pxt {
                 U.userError(`extension ${this.id} is missing ${pxt.CONFIG_NAME}`)
             this.parseConfig(confStr);
             if (this.level != 0)
-                this.config.installedVersion = this.version()
+                this.installedVersion = this.version()
             this.saveConfig()
         }
 
@@ -848,7 +848,7 @@ namespace pxt {
                             name: this.config.name,
                             comment: this.config.description,
                             status: "unpublished",
-                            scriptId: this.config.installedVersion,
+                            scriptId: this.installedVersion,
                             cloudId: pxt.CLOUD_ID + appTarget.id,
                             editor: this.getPreferredEditor(),
                             targetVersions: pxt.appTarget.versions
@@ -900,7 +900,7 @@ namespace pxt {
                     if (!allowPrivate && !this.config.public)
                         U.userError('Only packages with "public":true can be published')
                     let cfg = U.clone(this.config)
-                    delete cfg.installedVersion
+                    delete (<any>cfg).installedVersion
                     delete cfg.additionalFilePath
                     delete cfg.additionalFilePaths
                     if (!cfg.targetVersions) cfg.targetVersions = pxt.appTarget.versions;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -783,10 +783,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
                 // Get extension packages
                 this.extensions = pkg.allEditorPkgs()
-                    .map(ep => ep.getKsPkg()).map(p => !!p && p.config)
+                    .map(ep => ep.getKsPkg())
                     // Make sure the package has extensions enabled, and is a github package.
                     // Extensions are limited to github packages and ghpages, as we infer their url from the installedVersion config
-                    .filter(config => !!config && !!config.extension && /^(file:|github:)/.test(config.installedVersion));
+                    .filter(p => !!p && p.config && !!p.config.extension && /^(file:|github:)/.test(p.installedVersion));
             })
     }
 
@@ -1017,7 +1017,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private openExtension(extensionName: string) {
-        const extension = this.extensions.filter(c => c.name == extensionName)[0];
+        const extension = this.extensions.filter(c => c.config.name == extensionName)[0];
         const parsedRepo = pxt.github.parseRepoId(extension.installedVersion);
         pxt.packagesConfigAsync()
             .then((config) => {
@@ -1027,9 +1027,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 const debug = pxt.BrowserUtils.isLocalHost() && /debugExtensions/i.test(window.location.href);
                 /* tslint:disable:no-http-string */
                 const url = debug ? "http://localhost:3232/extension.html"
-                    : localDebug ? extension.extension.localUrl : `https://${parsedRepo.owner}.github.io/${repoName}/`;
+                    : localDebug ? extension.config.extension.localUrl : `https://${parsedRepo.owner}.github.io/${repoName}/`;
                 /* tslint:enable:no-http-string */
-                this.parent.openExtension(extension.name, url, repoStatus == 0); // repoStatus can only be APPROVED or UNKNOWN at this point
+                this.parent.openExtension(extension.config.name, url, repoStatus == 0); // repoStatus can only be APPROVED or UNKNOWN at this point
             });
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1023,7 +1023,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             .then((config) => {
                 const repoStatus = pxt.github.repoStatus(parsedRepo, config);
                 const repoName = parsedRepo.fullName.substr(parsedRepo.fullName.indexOf(`/`) + 1);
-                const localDebug = pxt.BrowserUtils.isLocalHost() && /^file:/.test(extension.installedVersion) && extension.extension.localUrl;
+                const localDebug = pxt.BrowserUtils.isLocalHost() && /^file:/.test(extension.installedVersion) && extension.config.extension.localUrl;
                 const debug = pxt.BrowserUtils.isLocalHost() && /debugExtensions/i.test(window.location.href);
                 /* tslint:disable:no-http-string */
                 const url = debug ? "http://localhost:3232/extension.html"
@@ -1205,7 +1205,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
         // Add extension buttons
         if (!subns) {
-            this.extensions.forEach(config => {
+            this.extensions.forEach(extension => {
+                const config = extension.config;
                 const name = config.name;
                 const namespace = config.extension.namespace || name;
                 if (ns == namespace) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1020,9 +1020,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const extension = this.extensions.filter(c => c.config.name == extensionName)[0];
         const parsedRepo = pxt.github.parseRepoId(extension.installedVersion);
         pxt.packagesConfigAsync()
-            .then((config) => {
+            .then((packagesConfig) => {
                 const extensionConfig = extension.config;
-                const repoStatus = pxt.github.repoStatus(parsedRepo, config);
+                const repoStatus = pxt.github.repoStatus(parsedRepo, packagesConfig);
                 const repoName = parsedRepo.fullName.substr(parsedRepo.fullName.indexOf(`/`) + 1);
                 const localDebug = pxt.BrowserUtils.isLocalHost() && /^file:/.test(extension.installedVersion) && extensionConfig.extension.localUrl;
                 const debug = pxt.BrowserUtils.isLocalHost() && /debugExtensions/i.test(window.location.href);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1021,15 +1021,16 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const parsedRepo = pxt.github.parseRepoId(extension.installedVersion);
         pxt.packagesConfigAsync()
             .then((config) => {
+                const extensionConfig = extension.config;
                 const repoStatus = pxt.github.repoStatus(parsedRepo, config);
                 const repoName = parsedRepo.fullName.substr(parsedRepo.fullName.indexOf(`/`) + 1);
-                const localDebug = pxt.BrowserUtils.isLocalHost() && /^file:/.test(extension.installedVersion) && extension.config.extension.localUrl;
+                const localDebug = pxt.BrowserUtils.isLocalHost() && /^file:/.test(extension.installedVersion) && extensionConfig.extension.localUrl;
                 const debug = pxt.BrowserUtils.isLocalHost() && /debugExtensions/i.test(window.location.href);
                 /* tslint:disable:no-http-string */
                 const url = debug ? "http://localhost:3232/extension.html"
-                    : localDebug ? extension.config.extension.localUrl : `https://${parsedRepo.owner}.github.io/${repoName}/`;
+                    : localDebug ? extensionConfig.extension.localUrl : `https://${parsedRepo.owner}.github.io/${repoName}/`;
                 /* tslint:enable:no-http-string */
-                this.parent.openExtension(extension.config.name, url, repoStatus == 0); // repoStatus can only be APPROVED or UNKNOWN at this point
+                this.parent.openExtension(extensionConfig.name, url, repoStatus == 0); // repoStatus can only be APPROVED or UNKNOWN at this point
             });
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1018,10 +1018,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
                 // Get extension packages
                 this.extensions = pkg.allEditorPkgs()
-                    .map(ep => ep.getKsPkg()).map(p => !!p && p.config)
+                    .map(ep => ep.getKsPkg())
                     // Make sure the package has extensions enabled, and is a github package.
                     // Extensions are limited to github packages and ghpages, as we infer their url from the installedVersion config
-                    .filter(config => !!config && !!config.extension && /^(file:|github:)/.test(config.installedVersion));
+                    .filter(p => !!p && p.config && !!p.config.extension && /^(file:|github:)/.test(p.installedVersion));
 
                 if (this.giveFocusOnLoading) {
                     this.editor.focus();

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -457,7 +457,6 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                     key={'bundled' + scr.name}
                                     name={scr.name}
                                     description={scr.description}
-                                    url={"/" + scr.installedVersion}
                                     imageUrl={scr.icon}
                                     scr={scr}
                                     onCardClick={this.addBundle}

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -10,7 +10,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
     private searchSubset: pxt.Map<boolean | string>;
 
     protected toolbox: toolbox.Toolbox;
-    protected extensions: pxt.PackageConfig[];
+    protected extensions: pxt.Package[];
 
     abstract getBlocksForCategory(ns: string, subns?: string): toolbox.BlockDefinition[];
 
@@ -324,7 +324,8 @@ export abstract class ToolboxEditor extends srceditor.Editor {
     getNamespaces() {
         const namespaces: string[] = [];
         // Add extension namespaces if not already in
-        this.extensions.forEach(config => {
+        this.extensions.forEach(p => {
+            const config = p.config;
             const name = config.name;
             const namespace = config.extension.namespace || name;
             if (!this.extensionsMap[namespace]) this.extensionsMap[namespace] = config;


### PR DESCRIPTION
We keep a cache of the resolved version of a package in pxt.json. This is bad since it modifies program content and potential disastrous in the context of co-authoring and merging.

This change moves installedVersion to the package itself. Everything seems to work.

Note: not systematically cleaning on load as it would modify scripts and have some unintentional results.