### PR TITLE
Fix debug resume frame exception

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1136,6 +1136,7 @@ namespace pxsim {
                     }
                     U.assert(__this.loopLock == lock)
                     __this.loopLock = null;
+                    __this.otherFrames.push(s);
                     loop(s);
                     flushLoopLock();
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt/issues/6091
Fixes https://github.com/microsoft/pxt-arcade/issues/1400

I think this was just an oversight, all of the rest of the calls to loop() looked good...