### PR TITLE
updated logic to init project for github

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2592,7 +2592,7 @@ export function installAsync(parsed?: commandParser.ParsedCommand): Promise<void
         .then(() => {
             let tscfg = "tsconfig.json"
             if (!fs.existsSync(tscfg) && !fs.existsSync("../" + tscfg)) {
-                nodeutil.writeFileSync(tscfg, pxt.TS_CONFIG)
+                nodeutil.writeFileSync(tscfg, pxt.template.TS_CONFIG)
             }
         });
 
@@ -2706,7 +2706,7 @@ export function initAsync(parsed: commandParser.ParsedCommand) {
     if (fs.existsSync(pxt.CONFIG_NAME))
         U.userError(`${pxt.CONFIG_NAME} already present`)
 
-    const files = pxt.packageFiles(path.basename(path.resolve(".")).replace(/^pxt-/, ""))
+    const files = pxt.template.packageFiles(path.basename(path.resolve(".")).replace(/^pxt-/, ""))
 
     let configMap: Map<string> = JSON.parse(files[pxt.CONFIG_NAME])
     let initPromise = Promise.resolve();
@@ -2722,7 +2722,7 @@ export function initAsync(parsed: commandParser.ParsedCommand) {
         .then(() => {
             files[pxt.CONFIG_NAME] = JSON.stringify(configMap, null, 4) + "\n"
 
-            pxt.packageFilesFixup(files)
+            pxt.template.packageFilesFixup(files)
 
             U.iterMap(files, (k, v) => {
                 nodeutil.mkdirP(path.dirname(k))
@@ -4539,8 +4539,8 @@ function writeProjects(prjs: SavedProject[], outDir: string): string[] {
             nodeutil.writeFileSync(fullname, prj.files[fn])
         }
         // add default files if not present
-        const files = pxt.packageFiles(prj.name);
-        pxt.packageFilesFixup(files);
+        const files = pxt.template.packageFiles(prj.name);
+        pxt.template.packageFilesFixup(files);
         for (let fn in files) {
             if (prj.files[fn]) continue;
             const fullname = path.join(fdir, fn)

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -214,7 +214,10 @@ cache:
             "testFiles",
             "testDependencies",
             "public",
-            "targetVersions"
+            "targetVersions",
+            "preferredEditor",
+            "additionalFilePath",
+            "additionalFilePaths"
         ]
 
         config.files = pkgFiles.filter(s => !/test/.test(s));

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -1,5 +1,5 @@
-namespace pxt {
-    export const TS_CONFIG =             `{
+namespace pxt.template {
+    export const TS_CONFIG = `{
     "compilerOptions": {
         "target": "es5",
         "noImplicitAny": true,
@@ -9,13 +9,14 @@ namespace pxt {
     "exclude": ["pxt_modules/**/*test.ts"]
 }
 `;
-    const _defaultFiles: Map<string> = {
-        "tsconfig.json": TS_CONFIG,
+    function defaultFiles(): Map<string> {
+        return {
+            "tsconfig.json": TS_CONFIG,
 
-        "test.ts": `// tests go here; this will not be compiled when this package is used as a library
+            "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}
 `,
 
-        "Makefile": `all: deploy
+            "Makefile": `all: deploy
 
 build:
 \tpxt build
@@ -27,40 +28,43 @@ test:
 \tpxt test
 `,
 
-        "README.md": `# @NAME@
+            "README.md": `# @NAME@
 
 @DESCRIPTION@
 
-## Usage
+## ${lf("Use this extension")}
 
-This repository contains a MakeCode extension. To use it in MakeCode,
+${lf("This repository can be added as an **extension** in MakeCode.")}
 
-* open @HOMEURL@
-* click on **New Project**
-* click on **Extensions** under the gearwheel menu
-* search for the URL of this repository
+* ${lf("open @HOMEURL@")}
+* ${lf("click on **New Project**")}
+* ${lf("click on **Extensions** under the gearwheel menu")}
+* ${lf("search for the URL of this repository and import")}
 
-## Collaborators
+## ${lf("Edit this extension")}
 
-You can invite users to become collaborators to this repository. This will allow multiple users to work on the same project at the same time.
-[Learn more...](https://help.github.com/en/articles/inviting-collaborators-to-a-personal-repository)
+${lf("To edit this repository in MakeCode.")}
 
-To edit this repository in MakeCode,
+* ${lf("open @HOMEURL@")}
+* ${lf("click on **Import** then click on **Import URL**")}
+* ${lf("paste the repository URL and click import")}
 
-* open @HOMEURL@
-* click on **Import** then click on **Import URL**
-* paste the repository URL and click import
+## ${lf("Collaborators")}
 
-## Supported targets
+${lf("You can invite users to become collaborators to this repository.")}
+${lf("This will allow multiple users to work on the same project at the same time.")}
+[${lf("Learn more...")}](https://help.github.com/en/articles/inviting-collaborators-to-a-personal-repository)
+
+## ${lf("Supported targets")}
 
 * for PXT/@TARGET@
 * for PXT/@PLATFORM@
-(The metadata above is needed for package search.)
+${lf("(The metadata above is needed for package search.)")}
 
 `,
 
-        ".gitignore":
-            `built
+            ".gitignore":
+                `built
 node_modules
 yotta_modules
 yotta_targets
@@ -69,8 +73,8 @@ pxt_modules
 *.tgz
 .header.json
 `,
-        ".vscode/settings.json":
-            `{
+            ".vscode/settings.json":
+                `{
     "editor.formatOnType": true,
     "files.autoSave": "afterDelay",
     "files.watcherExclude": {
@@ -93,7 +97,7 @@ pxt_modules
         "**/pxt_modules": true
     }
 }`,
-        ".github/workflows/makecode.yml": `name: MakeCode CI
+            ".github/workflows/makecode.yml": `name: MakeCode CI
 
 on: [push]
 
@@ -121,7 +125,7 @@ jobs:
         env:
           CI: true
 `,
-        ".travis.yml": `language: node_js
+            ".travis.yml": `language: node_js
 node_js:
     - "8.9.4"
 script:
@@ -134,8 +138,8 @@ cache:
     directories:
     - npm_modules
     - pxt_modules`,
-        ".vscode/tasks.json":
-            `
+            ".vscode/tasks.json":
+                `
 // A task runner that calls the MakeCode (PXT) compiler
 {
     "version": "2.0.0",
@@ -172,28 +176,27 @@ cache:
     }]
 }
 `
+        }
     }
 
     export function packageFiles(name: string): pxt.Map<string> {
         let prj = pxt.appTarget.tsprj || pxt.appTarget.blocksprj;
         let config = U.clone(prj.config);
-        // remove blocks file
-        Object.keys(prj.files)
-            .filter(f => /\.blocks$/.test(f))
-            .forEach(f => delete prj.files[f]);
-        config.files = config.files.filter(f => !/\.blocks$/.test(f));
-
+        // clean up
+        delete (<any>config).installedVersion;
+        delete config.additionalFilePath;
+        delete config.additionalFilePaths;
+        // (keep blocks files)
+        config.preferredEditor = config.files.find(f => /\.blocks$/.test(f))
+            ? pxt.BLOCKS_PROJECT_NAME : pxt.JAVASCRIPT_PROJECT_NAME;
         config.name = name;
-        // by default, projects are not public
-        config.public = false;
-
-        if (!config.version) {
+        config.public = true;
+        if (!config.version)
             config.version = "0.0.0"
-        }
-
         const files: Map<string> = {};
-        for (const f in _defaultFiles)
-            files[f] = _defaultFiles[f];
+        const defFiles = defaultFiles();
+        for (const f in defFiles)
+            files[f] = defFiles[f];
         for (const f in prj.files)
             if (f != "README.md") // this one we need to keep
                 files[f] = prj.files[f];

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -180,8 +180,8 @@ cache:
     }
 
     export function packageFiles(name: string): pxt.Map<string> {
-        let prj = pxt.appTarget.tsprj || pxt.appTarget.blocksprj;
-        let config = U.clone(prj.config);
+        const prj = pxt.appTarget.blocksprj || pxt.appTarget.tsprj;
+        const config = U.clone(prj.config);
         // clean up
         delete (<any>config).installedVersion;
         delete config.additionalFilePath;

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -202,7 +202,7 @@ cache:
                 files[f] = prj.files[f];
 
         const pkgFiles = Object.keys(files).filter(s =>
-            /\.(md|ts|asm|cpp|h|py)$/.test(s))
+            /\.(blocks|md|ts|asm|cpp|h|py)$/.test(s))
 
         const fieldsOrder = [
             "name",
@@ -223,7 +223,7 @@ cache:
         config.files = pkgFiles.filter(s => !/test/.test(s));
         config.testFiles = pkgFiles.filter(s => /test/.test(s));
 
-        let configMap: Map<string> = config as any
+        const configMap: Map<string> = config as any
         // make it look nice
         const newCfg: any = {}
         for (const f of fieldsOrder) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3738,9 +3738,9 @@ async function importGithubProject(id: string) {
         let hd = workspace.getHeaders().find(h => h.githubId == id);
         if (!hd)
             hd = await workspace.importGithubAsync(id)
-        let text = await workspace.getTextAsync(hd.id)
+        const text = await workspace.getTextAsync(hd.id)
         if ((text[pxt.CONFIG_NAME] || "{}").length < 20) {
-            let ok = await core.confirmAsync({
+            const ok = await core.confirmAsync({
                 header: lf("Initialize MakeCode extension?"),
                 body: lf("We didn't find a valid pxt.json file in the repository. Would you like to create it and supporting files?"),
                 agreeLbl: lf("Initialize!")

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -602,10 +602,11 @@ function mergeError() {
 // requests token to user if needed
 async function ensureTokenAsync() {
     // check that we have a token first
-    if (!pxt.github.token)
+    if (!pxt.github.token) {
         await dialogs.showGithubLoginAsync();
-    if (!pxt.github.token)
-        U.userError(lf("Please sign in to GitHub to perform this operation."))
+        if (!pxt.github.token)
+            U.userError(lf("Please sign in to GitHub to perform this operation."))
+    }
 }
 
 async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -695,7 +695,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
 
 export async function exportToGithubAsync(hd: Header, repoid: string) {
     const parsed = pxt.github.parseRepoId(repoid);
-    const pfiles = pxt.packageFiles(hd.name);
+    const pfiles = pxt.template.packageFiles(hd.name);
     await pxt.github.putFileAsync(parsed.fullName, ".gitignore", pfiles[".gitignore"]);
     const sha = await pxt.github.getRefAsync(parsed.fullName, parsed.tag)
     const commit = await pxt.github.getCommitAsync(parsed.fullName, sha)
@@ -769,8 +769,8 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 
     let currFiles = await getTextAsync(hd.id);
 
-    const templateFiles = pxt.packageFiles(name);
-    pxt.packageFilesFixup(templateFiles, false);
+    const templateFiles = pxt.template.packageFiles(name);
+    pxt.template.packageFilesFixup(templateFiles, false);
 
     if (forceTemplateFiles) {
         U.jsonMergeFrom(currFiles, templateFiles);


### PR DESCRIPTION
A few updates to the logic to populate a github project; to align better with classroom. This PR fixes the following flow:

* teacher creates github classroom assignment with empty repo
* student gets assgiment and generates empty repo
* student imports empty repo in makecode (missing token handled)
* empty project populate landing on blocks

Todos:
- [x] leave .blocks files since we now support editing blocks
- [x] localize readme, clearer instructions
- [x] normalize pxt.json to avoid initial commit
- [x] ask before populating repo
- [x] check that token is available when populating repo
