### PR TITLE
Fixing array inference bug when arrays are assigned to empty

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -219,7 +219,7 @@ namespace pxt.blocks {
                     }
                 }
             }
-            return tp || ground("Array");
+            return tp || mkPoint(null);
         }
         else if (check === "T") {
             const func = e.stdCallTable[b.type];

--- a/tests/blocklycompiler-test/baselines/empty_array_inference.ts
+++ b/tests/blocklycompiler-test/baselines/empty_array_inference.ts
@@ -1,0 +1,5 @@
+let listC: number[][] = []
+let listA: number[] = []
+let listB = [123, 234]
+listC.push(listA)
+listC.push(listB)

--- a/tests/blocklycompiler-test/cases/empty_array_inference.blocks
+++ b/tests/blocklycompiler-test/cases/empty_array_inference.blocks
@@ -1,0 +1,81 @@
+<xml xmlns="https://developers.google.com/blockly/xml">
+<variables>
+<variable id="T0Fu4P9JbSx@uH_Tp#Ub">listA</variable>
+<variable id="i0/By*+{-oBVouljDE_*">listC</variable>
+<variable id="8#w^JPqRI4lkika+26P7">listB</variable>
+</variables>
+<block type="pxt-on-start" x="0" y="0">
+<statement name="HANDLER">
+<block type="variables_set">
+<field name="VAR" id="i0/By*+{-oBVouljDE_*">listC</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+<block type="lists_create_with">
+<mutation items="0" />
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR" id="T0Fu4P9JbSx@uH_Tp#Ub">listA</field>
+<breakpoint xmlns="http://www.w3.org/1999/xhtml"></breakpoint>
+<value name="VALUE">
+<block type="lists_create_with">
+<mutation items="0" />
+</block>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR" id="8#w^JPqRI4lkika+26P7">listB</field>
+<value name="VALUE">
+<block type="lists_create_with">
+<mutation items="2" />
+<value name="ADD0">
+<shadow type="math_number">
+<field name="NUM">123</field>
+</shadow>
+</value>
+<value name="ADD1">
+<shadow type="math_number">
+<field name="NUM">234</field>
+</shadow>
+</value>
+</block>
+</value>
+<next>
+<block type="array_push">
+<value name="list">
+<block type="variables_get">
+<field name="VAR" id="i0/By*+{-oBVouljDE_*">listC</field>
+</block>
+</value>
+<value name="value">
+<block type="variables_get">
+<field name="VAR" id="T0Fu4P9JbSx@uH_Tp#Ub">listA</field>
+</block>
+</value>
+<next>
+<block type="array_push">
+<value name="list">
+<block type="variables_get">
+<field name="VAR" id="i0/By*+{-oBVouljDE_*">listC</field>
+</block>
+</value>
+<value name="value">
+<block type="variables_get">
+<field name="VAR" id="8#w^JPqRI4lkika+26P7">listB</field>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -287,6 +287,10 @@ describe("blockly compiler", function () {
         it("should handle functions with list return types", (done: () => void) => {
             blockTestAsync("array_return_type").then(done, done);
         });
+
+        it("should correctly infer types for arrays initialized to empty", (done: () => void) => {
+            blockTestAsync("empty_array_inference").then(done, done);
+        });
     });
 
     describe("compiling logic", () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1341
