### PR TITLE
Fix slider position in the position picker

### DIFF
--- a/pxtblocks/fields/field_position.ts
+++ b/pxtblocks/fields/field_position.ts
@@ -86,6 +86,15 @@ namespace pxtblockly {
             const slider = contentDiv.getElementsByClassName("goog-slider-horizontal")[0] as HTMLDivElement;
             if (slider) {
                 slider.style.width = width + "px";
+
+                // Because we resized the slider, we need to update the handle position. The closure
+                // slider won't update unless the value changes so change it and un-change it
+                const value = parseFloat(this.getValue());
+
+                if (!isNaN(value) && value > this.getMin()) {
+                    this.setValue((value - 1) + "");
+                    this.setValue(value + "");
+                }
             }
 
             const setPos = (x: number, y: number) => {


### PR DESCRIPTION
Fixes the issue where the handle position in the slider of the position picker is in the wrong place. There isn't a bug filed, but here's a demonstration:

![2019-10-23 16 40 03](https://user-images.githubusercontent.com/13754588/67441980-e2879c00-f5b3-11e9-802e-b43d53f2eec7.gif)
