### PR TITLE
Fixing autorun issue for Minecraft

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2552,7 +2552,9 @@ export class ProjectView
             this.syncPreferredEditor()
 
             simulator.stop(false, true);
-            const autoRun = (this.state.autoRun || !!opts.clickTrigger) && this.isBlocksEditor();
+
+            const autoRun = this.autoRunOnStart() && this.isBlocksEditor() && (this.state.autoRun || !!opts.clickTrigger)  ;
+
             const state = this.editor.snapshotState()
             return this.setStateAsync({ simState: pxt.editor.SimState.Starting, autoRun: autoRun })
                 .then(() => (emptyRun ? Promise.resolve(compiler.emptyCompileResult()) : compiler.compileAsync(opts)))


### PR DESCRIPTION
Minecraft autorun issue https://github.com/microsoft/pxt-minecraft/issues/1280

Minecraft autorun is disabled and hence the play button should never change to pause button. 