### PR TITLE
checking for file sizes in docs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4604,8 +4604,20 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
     let urls: any = {};
     let checked = 0;
     let broken = 0;
-    let snipCount = 0;
     let snippets: CodeSnippet[] = [];
+
+    if (pxt.appTarget.cloud) {
+        pxt.log('checking for file sizes');
+        const maxSize = pxt.appTarget.cloud.maxFileSize || 5000000;
+        nodeutil.allFiles("docs")
+            .map(f => {
+                const stats = fs.statSync(f);
+                if (stats.size > maxSize) /* 5Mb */
+                    fatal(`${f} size is ${stats.size / 100000}Mb, keep files under ${maxSize}`);
+                else if (stats.size > 1000000)
+                    pxt.log(`  ${f} - ${stats.size / 100000}Mb`);
+            });
+    }
 
     // scan and fix image links
     if (fix) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4608,14 +4608,15 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
 
     if (pxt.appTarget.cloud) {
         pxt.log('checking for file sizes');
-        const maxSize = pxt.appTarget.cloud.maxFileSize || 5000000;
+        const mb = 1e6;
+        const maxSize = pxt.appTarget.cloud.maxFileSize || (5 * mb);
         nodeutil.allFiles("docs")
             .map(f => {
                 const stats = fs.statSync(f);
                 if (stats.size > maxSize) /* 5Mb */
-                    fatal(`${f} size is ${stats.size / 100000}Mb, keep files under ${maxSize}`);
-                else if (stats.size > 1000000)
-                    pxt.log(`  ${f} - ${stats.size / 100000}Mb`);
+                    fatal(`${f} size is ${stats.size / mb}Mb, keep files under ${maxSize / mb}`);
+                else if (stats.size > mb)
+                    pxt.log(`  ${f} - ${stats.size / mb}Mb`);
             });
     }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4611,14 +4611,18 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
         const mb = 1e6;
         const maxSize = pxt.appTarget.cloud.maxFileSize || (5 * mb);
         const warnSize = pxt.appTarget.cloud.warnFileSize || (1 * mb);
+        let toobig = 0;
         nodeutil.allFiles("docs")
             .map(f => {
                 const stats = fs.statSync(f);
-                if (stats.size > maxSize) /* 5Mb */
-                    fatal(`${f} size is ${stats.size / mb}Mb, keep files under ${maxSize / mb}`);
-                else if (stats.size > warnSize)
+                if (stats.size > warnSize)
                     pxt.log(`  ${f} - ${stats.size / mb}Mb`);
+                if (stats.size > maxSize) {/* 5Mb */
+                    toobig++;
+                }
             });
+        if (toobig && !pxt.appTarget.ignoreDocsErrors)
+            U.userError(`${toobig} files above allowed size (${maxSize / mb}Mb)`);
     }
 
     // scan and fix image links

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4629,7 +4629,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
     let broken = 0;
     let snippets: CodeSnippet[] = [];
 
-    const maxFileSize = checkFileSize(nodeutil.allFiles("docs"));
+    const maxFileSize = checkFileSize(nodeutil.allFiles("docs", 10, true, true, ".ignorelargefiles"));
     if (!pxt.appTarget.ignoreDocsErrors
         && maxFileSize > (pxt.appTarget.cloud.maxFileSize || (5000000)))
         U.userError(`files too big in docs folder`);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4610,12 +4610,13 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
         pxt.log('checking for file sizes');
         const mb = 1e6;
         const maxSize = pxt.appTarget.cloud.maxFileSize || (5 * mb);
+        const warnSize = pxt.appTarget.cloud.warnFileSize || (1 * mb);
         nodeutil.allFiles("docs")
             .map(f => {
                 const stats = fs.statSync(f);
                 if (stats.size > maxSize) /* 5Mb */
                     fatal(`${f} size is ${stats.size / mb}Mb, keep files under ${maxSize / mb}`);
-                else if (stats.size > mb)
+                else if (stats.size > warnSize)
                     pxt.log(`  ${f} - ${stats.size / mb}Mb`);
             });
     }

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -362,7 +362,7 @@ export function cp(srcFile: string, destDirectory: string) {
     fs.writeFileSync(dest, buf);
 }
 
-export function allFiles(top: string, maxDepth = 8, allowMissing = false, includeDirs = false): string[] {
+export function allFiles(top: string, maxDepth = 8, allowMissing = false, includeDirs = false, ignoredFileMarker: string = undefined): string[] {
     let res: string[] = []
     if (allowMissing && !existsDirSync(top)) return res
     for (const p of fs.readdirSync(top)) {
@@ -370,6 +370,9 @@ export function allFiles(top: string, maxDepth = 8, allowMissing = false, includ
         const inner = path.join(top, p)
         const st = fs.statSync(inner)
         if (st.isDirectory()) {
+            // check for ingored folder marker
+            if (ignoredFileMarker && fs.existsSync(path.join(inner, ignoredFileMarker)))
+                continue;
             if (maxDepth > 1)
                 Util.pushRange(res, allFiles(inner, maxDepth - 1))
             if (includeDirs)

--- a/docs/cli/checkdocs.md
+++ b/docs/cli/checkdocs.md
@@ -23,6 +23,10 @@ This command is also automatically run from a cloud build and will fail the buil
 
 Regex filter to select files to be scanned for snippets
 
+## Other
+
+Add a ``.ignorelargefiles`` file in a folder to disable large file checks under this folder.
+
 ## See Also
 
 [pxt](/cli) tool

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -142,6 +142,7 @@ declare namespace pxt {
         githubPackages?: boolean; // allow searching github for packages
         noGithubProxy?: boolean;
         cloudProviders?: pxt.Map<{}>;
+        maxFileSize?: number; // maximum file size in bytes
     }
 
     interface AppSimulator {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -143,6 +143,7 @@ declare namespace pxt {
         noGithubProxy?: boolean;
         cloudProviders?: pxt.Map<{}>;
         maxFileSize?: number; // maximum file size in bytes
+        warnFileSize?: number; // warn aboutfile size in bytes
     }
 
     interface AppSimulator {


### PR DESCRIPTION
Don't allow files > 5Mb in docs, flag any file > 1Mb.
![image](https://user-images.githubusercontent.com/4175913/67524660-f986c680-f665-11e9-9ac2-bd55560fd706.png)
- [x] checking "docs" in checkdocs (5mb max)
- [x] checking files in upload (15mb max)
- [x] support for ``.ignorelargefiles`` to avoid checking particular folders