### PR TITLE
Fix keyboard shortcuts in the share dialog on arcade

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -331,7 +331,7 @@ declare namespace pxt {
         simScreenshotKey?: string; // keyboard key name
         simScreenshotMaxUriLength?: number; // maximum base64 encoded length to be uploaded
         simGif?: boolean; // record gif of the simulator
-        simGifKey?: boolean; // shortcut to start stop
+        simGifKey?: string; // shortcut to start stop
         simGifTransparent?: string; // specify the gif transparency color
         simGifQuality?: number; // generated gif quality (pixel sampling size) - 30 (poor) - 1 (best), default 16
         simGifMaxFrames?: number; // maximum number of frames, default 64

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -142,7 +142,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         if (this.state.recordingState == ShareRecordingState.GifRecording) {
             if (this._gifEncoder.addFrame(msg.data, msg.delay))
                 this.gifRender();
-        } else if (this.state.recordingState == ShareRecordingState.ScreenshotSnap) {
+        } else if (this.state.recordingState == ShareRecordingState.ScreenshotSnap || this.state.recordingState === ShareRecordingState.None) {
             // received a screenshot
             this.setState({ screenshotUri: pxt.BrowserUtils.imageDataToPNG(msg.data), recordingState: ShareRecordingState.None, recordError: undefined })
         } else {
@@ -164,6 +164,14 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         if (Object.keys(newState).length > 0) {
             this.setState(newState);
         }
+    }
+
+    componentDidMount() {
+        document.addEventListener("keydown", this.handleKeyDown);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener("keydown", this.handleKeyDown);
     }
 
     shouldComponentUpdate(nextProps: ShareEditorProps, nextState: ShareEditorState, nextContext: any): boolean {
@@ -495,6 +503,21 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         const container = document.getElementById("shareLoanedSimulator");
         if (container && this.loanedSimulator && !this.loanedSimulator.parentNode)
             container.appendChild(this.loanedSimulator);
+    }
+
+    protected handleKeyDown = (e: KeyboardEvent) => {
+        const targetTheme = pxt.appTarget.appTheme;
+        const pressed = e.key.toLocaleLowerCase();
+
+        // Don't fire events if they are typing in a name
+        if (document.activeElement && document.activeElement.tagName === "INPUT") return;
+
+        if (targetTheme.simScreenshotKey && pressed === targetTheme.simScreenshotKey.toLocaleLowerCase()) {
+            this.handleScreenshotClick();
+        }
+        else if (targetTheme.simGifKey && pressed === targetTheme.simGifKey.toLocaleLowerCase()) {
+            this.handleRecordClick();
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1397

There were two issues here:

1. The keyboard shortcuts only worked if the simulator had focus
1. The shortcut for capturing a screenshot never worked because it required you to press the button first