### PR TITLE
don't make sidedocs purple (/ docs color)

### DIFF
--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -5,6 +5,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <style>
+        #docs {
+            background: white !important;
+        }
         #content {
             margin-bottom: 3rem !important;
             margin-top: 0.5rem !important;
@@ -34,7 +37,6 @@
             max-height: calc(100% - 1em);
         }
 
-        
         div.blocks-svg-list > svg {
             margin-right: 1rem;
             margin-bottom: 1rem;


### PR DESCRIPTION
one of my docs2.0 coloring changes accidentally also applied to sidedocs in a weird way (current arcade beta):

<img width="488" alt="Screen Shot 2019-10-24 at 3 22 25 PM" src="https://user-images.githubusercontent.com/5615930/67529899-5ab49700-f672-11e9-9dcc-66fafc134cf1.png">

fixes that / makes the background white again

edit:

ahh, this applies to minecraft/beta too, might want to take this @abchatra:

<img width="459" alt="Screen Shot 2019-10-24 at 3 26 59 PM" src="https://user-images.githubusercontent.com/5615930/67530060-cb5bb380-f672-11e9-97c0-3a59cdb6e39d.png">
