### PR TITLE
Fixing leaked state in Blockly type inference

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -136,7 +136,7 @@ namespace pxt.blocks {
             _p1.parentType = null;
             union(pt, _p2.parentType);
         }
-        else if (_p1.parentType && !_p2.parentType) {
+        else if (_p1.parentType && !_p2.parentType && !_p2.type) {
             _p2.parentType = _p1.parentType;
         }
 
@@ -383,7 +383,6 @@ namespace pxt.blocks {
                         break;
                     case "pxt_controls_for_of":
                     case "controls_for_of":
-                        unionParam(e, b, "LIST", ground("Array"));
                         const listTp = returnType(e, getInputTargetBlock(b, "LIST"));
                         const elementTp = lookup(e, b, getLoopVariableField(b).getField("VAR").getText()).type;
                         genericLink(listTp, elementTp);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1131

In the Blockly compiler we declare a bunch of points for the primitive types (string, boolean, etc). The union logic was occasionally assigning those points a parent type which would then get leaked to other projects. This fixes that logic and also removes a useless line in the for-of logic.