### PR TITLE
Fix minecraft EE homepage links on ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/marked": "0.3.0",
     "@types/mocha": "2.2.44",
     "@types/node": "8.0.53",
-    "@types/react": "16.0.25",
+    "@types/react": "16.4.7",
     "@types/react-dom": "16.0.3",
     "@types/react-redux": "5.0.0",
     "@types/request": "2.48.2",

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -574,9 +574,9 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     protected isLink() {
         const { cardType, url, youTubeId } = this.props;
 
-        return cardType === "forumUrl" || (!isCodeCardType(cardType) && (youTubeId || url));
+        return isCodeCardWithLink(cardType) && (youTubeId || url);
 
-        function isCodeCardType(value: string): value is pxt.CodeCardType {
+        function isCodeCardWithLink(value: string) {
             switch (value) {
                 case "file":
                 case "example":
@@ -586,10 +586,10 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                 case "template":
                 case "package":
                 case "hw":
-                case "forumUrl":
-                    return true;
-                default:
                     return false;
+                case "forumUrl":
+                default:
+                    return true;
             }
         }
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -649,7 +649,6 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         const action = this.isLink() ?
             <sui.Link
-                key={`action_${clickLabel}`}
                 href={this.getUrl()}
                 refCallback={this.linkRef}
                 target={'_blank'}
@@ -658,7 +657,6 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             />
             :
             <sui.Button
-                key={`action_${clickLabel}`}
                 text={clickLabel}
                 className={`approve huge positive`}
                 onClick={this.handleDetailClick}
@@ -683,7 +681,6 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                     <div className="actions">
                         {action}
                         {cardType === "forumUrl" && <sui.Button
-                            key="action_open"
                             text={lf("Open in Editor")}
                             className={`approve huge`}
                             onClick={this.handleOpenForumUrlInEditor}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -597,9 +597,9 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     protected getUrl() {
         const { url, youTubeId } = this.props;
         return (youTubeId && !url) ?
-                    `https://youtu.be/${youTubeId}`
-                    :
-                    ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
+                `https://youtu.be/${youTubeId}`
+                :
+                ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
     }
 
     handleDetailClick() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -559,7 +559,8 @@ export interface ProjectsDetailState {
 
 
 export class ProjectsDetail extends data.Component<ProjectsDetailProps, ProjectsDetailState> {
-    private actionRef: React.RefObject<HTMLAnchorElement>;
+    private linkRef: React.RefObject<HTMLAnchorElement>;
+
     constructor(props: ProjectsDetailProps) {
         super(props);
         this.state = {
@@ -567,7 +568,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         this.handleDetailClick = this.handleDetailClick.bind(this);
         this.handleOpenForumUrlInEditor = this.handleOpenForumUrlInEditor.bind(this);
-        this.actionRef = React.createRef<HTMLAnchorElement>();
+        this.linkRef = React.createRef<HTMLAnchorElement>();
     }
 
     protected isLink() {
@@ -622,8 +623,8 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
     componentDidMount() {
         // autofocus on linked action
-        if (this.actionRef && this.actionRef.current) {
-            this.actionRef.current.focus();
+        if (this.linkRef && this.linkRef.current) {
+            this.linkRef.current.focus();
         }
     }
 
@@ -650,7 +651,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             <sui.Link
                 key={`action_${clickLabel}`}
                 href={this.getUrl()}
-                refCallback={this.actionRef}
+                refCallback={this.linkRef}
                 target={'_blank'}
                 text={clickLabel}
                 className={`ui button approve huge positive`}

--- a/webapp/src/snippetBuilderInputHandler.tsx
+++ b/webapp/src/snippetBuilderInputHandler.tsx
@@ -193,7 +193,7 @@ class RangeInput extends data.Component<IRangeInputProps, {}> {
                             onChange={this.onChange}
                             aria-valuemin={input.min}
                             aria-valuemax={input.max}
-                            aria-valuenow={value}
+                            aria-valuenow={+value}
                             style={{
                                 marginLeft: 0
                             }}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -830,7 +830,7 @@ export class MenuItem extends data.Component<MenuItemProps, {}> {
                 role="tab"
                 aria-controls={ariaControls}
                 aria-selected={active}
-                aria-label={content || name}
+                aria-label={`${content || name}`}
             >
                 {icon ? <Icon icon={icon} /> : undefined}
                 {content || name}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -282,7 +282,7 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
 
     private handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
         if (this.isMouseDown) return;
-        // Use timeout to delay examination of activeElement until after blur/focus 
+        // Use timeout to delay examination of activeElement until after blur/focus
         // events have been processed.
         setTimeout(() => {
             let open = this.isChildFocused();
@@ -478,6 +478,7 @@ export interface LinkProps extends ButtonProps {
     download?: string;
     target?: string;
     rel?: string;
+    refCallback?: React.Ref<HTMLAnchorElement>
 }
 
 export class Link extends StatelessUIElement<LinkProps> {
@@ -489,6 +490,7 @@ export class Link extends StatelessUIElement<LinkProps> {
                 target={this.props.target}
                 rel={this.props.rel || (this.props.target ? "noopener noreferrer" : "")}
                 download={this.props.download}
+                ref={this.props.refCallback}
                 role={this.props.role}
                 title={this.props.title}
                 tabIndex={this.props.tabIndex || 0}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/1304

just use an anchor tag for links, and manually handle focus for the links.

needed to get a ref to the element, so this pulls in the newest @types for react that is supported for the current typescript so we can use createRef (added in 16.3). There were a few quick fixes from that bump (explicitly converting to string / number)