### PR TITLE
Call textToDomDocument directly for cached SVG elements

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -516,7 +516,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const activityName = tutorialOptions && tutorialOptions.tutorialActivityInfo ?
             tutorialOptions.tutorialActivityInfo[tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity].name :
             null;
-        const hideIteration = tutorialOptions && tutorialOptions.metadata.hideIteration;
+        const hideIteration = tutorialOptions && tutorialOptions.metadata && tutorialOptions.metadata.hideIteration;
         const tutorialReportId = tutorialOptions && tutorialOptions.tutorialReportId;
         const docMenu = targetTheme.docMenu && targetTheme.docMenu.length && !sandbox && !inTutorial && !debugging;
         const hc = !!this.props.parent.state.highContrast;

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -100,8 +100,8 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 wrapperDiv.className = 'ui segment raised loading';
                 if (MarkedContent.blockSnippetCache[code]) {
                     // Use cache
-                    const svg = Blockly.Xml.textToDom(pxt.blocks.layout.serializeSvgString(MarkedContent.blockSnippetCache[code]));
-                    wrapperDiv.appendChild(svg);
+                    const doc = Blockly.utils.xml.textToDomDocument(pxt.blocks.layout.serializeSvgString(MarkedContent.blockSnippetCache[code]));
+                    wrapperDiv.appendChild(doc.documentElement);
                     pxsim.U.removeClass(wrapperDiv, 'loading');
                 } else {
                     parent.renderBlocksAsync({


### PR DESCRIPTION
Fixes issue with viewing tutorial hints for the second time. 
Fixes https://github.com/microsoft/pxt-minecraft/issues/1311