### PR TITLE
add back autofocus for buttons on home screen

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -661,6 +661,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                 className={`approve huge positive`}
                 onClick={this.handleDetailClick}
                 onKeyDown={sui.fireClickOnEnter}
+                autoFocus={true}
             />
 
         return <div className="ui grid stackable padded">


### PR DESCRIPTION
accidentally dropped this from https://github.com/microsoft/pxt/pull/6127 when i was getting the focus to propagate correctly for links, and didn't notice until after that got merged.