### PR TITLE
Display undo/redo for tutorials, rerender labels on zoom, fix create …

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -453,7 +453,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 pxt.tickEvent("blocks.create", { "block": blockId });
                 if (ev.xml.tagName == 'SHADOW')
                     this.cleanUpShadowBlocks();
-                this.parent.setState({ hideEditorFloats: false });
+                if (!this.parent.state.tutorialOptions || !this.parent.state.tutorialOptions.metadata  || !this.parent.state.tutorialOptions.metadata.flyoutOnly)
+                    this.parent.setState({ hideEditorFloats: false });
                 workspace.fireEvent({ type: 'create', editor: 'blocks', blockId } as pxt.editor.events.CreateEvent);
             }
             else if (ev.type == "var_create" || ev.type == "var_rename" || ev.type == "delete") {

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -56,11 +56,13 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     zoomIn(view?: string) {
         pxt.tickEvent("editortools.zoomIn", { view: view, collapsed: this.getCollapsedState() }, { interactiveConsent: true });
         this.props.parent.editor.zoomIn();
+        this.props.parent.forceUpdate();
     }
 
     zoomOut(view?: string) {
         pxt.tickEvent("editortools.zoomOut", { view: view, collapsed: this.getCollapsedState() }, { interactiveConsent: true });
         this.props.parent.editor.zoomOut();
+        this.props.parent.forceUpdate();
     }
 
     startStopSimulator(view?: string) {
@@ -157,7 +159,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const hasUndo = this.props.parent.editor.hasUndo();
 
         const showProjectRename = !tutorial && !readOnly && !isController && !targetTheme.hideProjectRename && !debugging;
-        const showUndoRedo = !tutorial && !readOnly && !debugging;
+        const showUndoRedo = !readOnly && !debugging;
         const showZoomControls = true;
 
         const trace = !!targetTheme.enableTrace;


### PR DESCRIPTION
…block in flyoutOnly

- Display undo/redo for tutorials
- Rerender labels on zoom (fixes https://github.com/microsoft/pxt-minecraft/issues/1319)
- Fix create block drag in flyoutOnly mode