### PR TITLE
Github experience

### DIFF
--- a/theme/github.less
+++ b/theme/github.less
@@ -5,6 +5,10 @@
 /* Reference import */
 @import (reference) "semantic.less";
 
+.ui.button.editortools-btn.editortools-github-btn {
+    margin-left: 0.25rem;
+}
+
 /*-------------------
    Github view and diffs
 --------------------*/

--- a/theme/themes/pxt/elements/segment.overrides
+++ b/theme/themes/pxt/elements/segment.overrides
@@ -1,3 +1,7 @@
 /*******************************
          Site Overrides
 *******************************/
+
+.ui.transparent.segment {
+    background-color: unset;
+}

--- a/theme/themes/pxt/modules/dropdown.overrides
+++ b/theme/themes/pxt/modules/dropdown.overrides
@@ -15,6 +15,14 @@
     justify-content: center;
 }
 
+
+.ui.dropdown .ui.item .avatar > img {
+    height: 1.5rem;
+    width: 1.5rem;
+    display: inline-block;
+}
+
+
 /* Small + Large Monitor */
 @media only screen and (min-width: @computerBreakpoint) {
     .ui.dropdown .avatar {

--- a/theme/themes/pxt/modules/dropdown.overrides
+++ b/theme/themes/pxt/modules/dropdown.overrides
@@ -2,13 +2,14 @@
         User Overrides
 *******************************/
 
-.ui.dropdown .avatar > img, .ui.dropdown .avatar > .initials {
+.ui.dropdown > .avatar > img, 
+.ui.dropdown > .avatar > .initials {
     height: 2.5rem;
     width: 2.5rem;
     border-radius: 100%;
 }
 
-.ui.dropdown .avatar > .initials {
+.ui.dropdown > .avatar > .initials {
     background-color: @secondaryColor;
     display: flex;
     align-items: center;
@@ -16,16 +17,21 @@
 }
 
 
-.ui.dropdown .ui.item .avatar > img {
-    height: 1.5rem;
-    width: 1.5rem;
+.ui.dropdown .ui.item > .avatar {
+    margin-right: 0.5rem;
+    vertical-align: middle;
     display: inline-block;
+    > img {
+        height: 1.5rem;
+        width: 1.5rem;
+        border-radius: 100%;
+    }
 }
 
 
 /* Small + Large Monitor */
 @media only screen and (min-width: @computerBreakpoint) {
-    .ui.dropdown .avatar {
+    .ui.dropdown > .avatar {
         margin-left: -0.5rem;
         margin-right: -0.5rem;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3464,10 +3464,7 @@ export class ProjectView
         const showFileList = !sandbox
             && !(isBlocks
                 || (pkg.mainPkg && pkg.mainPkg.config && (pkg.mainPkg.config.preferredEditor == pxt.BLOCKS_PROJECT_NAME)));
-        // show github if token or if always vis
         const hasCloud = this.hasCloud();
-        const cloudProvider = hasCloud && this.getData("sync:provider");
-        const showGithub = cloudProvider == "github";
         return (
             <div id='root' className={rootClasses}>
                 {greenScreen ? <greenscreen.WebCam close={this.toggleGreenScreen} /> : undefined}
@@ -3494,7 +3491,6 @@ export class ProjectView
                                 <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={this.openSimSerial} />
                                 <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.openDeviceSerial} />
                             </div> : undefined}
-                        {showGithub ? <filelist.GithubTreeItem parent={this} /> : undefined}
                         {showFileList ? <filelist.FileList parent={this} /> : undefined}
                         {!isHeadless && <div id="filelistOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.toggleSimulatorFullscreen}></div>}
                     </div>

--- a/webapp/src/cloud.tsx
+++ b/webapp/src/cloud.tsx
@@ -144,7 +144,6 @@ export class UserMenu extends data.Component<UserMenuProps, {}> {
         const profile = user && user.profile;
         const userPhoto = user && user.photo;
         const userInitials = user && user.initials;
-        const provider = this.getData("sync:provider");
         const providericon = this.getData("sync:providericon") || "";
 
         return <sui.DropdownMenu role="menuitem" avatarImage={userPhoto} avatarInitials={userInitials}
@@ -156,7 +155,6 @@ export class UserMenu extends data.Component<UserMenuProps, {}> {
                 <i className={`ui icon ${providericon}`} />
                 {lf("Signed in as {0}", user.userName || user.name)}
             </a> : undefined}
-            {user && provider == "github" && header && !header.githubId ? <sui.Item role="menuitem" text={lf("New repository")} onClick={this.createRepository} /> : undefined}
             {user ? <div className="ui divider" /> : undefined}
             {user ? <sui.Item role="menuitem" icon="sign out" text={lf("Sign out")} onClick={this.logout} /> : undefined}
             {!user ? <sui.Item role="menuitem" icon="sign in" text={lf("Sign in")} onClick={this.login} /> : undefined}

--- a/webapp/src/cloud.tsx
+++ b/webapp/src/cloud.tsx
@@ -117,7 +117,6 @@ export class UserMenu extends data.Component<UserMenuProps, {}> {
 
         this.logout = this.logout.bind(this);
         this.login = this.login.bind(this);
-        this.createRepository = this.createRepository.bind(this);
     }
 
     login() {
@@ -130,15 +129,7 @@ export class UserMenu extends data.Component<UserMenuProps, {}> {
         this.props.parent.cloudSignOut();
     }
 
-    createRepository() {
-        pxt.tickEvent("github.usermenu.create", undefined, { interactiveConsent: true });
-        const { projectName, header } = this.props.parent.state;
-        cloudsync.githubProvider().createRepositoryAsync(projectName, header)
-            .done(r => r && this.props.parent.reloadHeaderAsync());
-    }
-
     renderCore() {
-        const header = this.props.parent.state.header;
         const user = this.getUser();
         const title = user && user.name ? lf("{0}'s Account", user.name) : lf("Sign in");
         const profile = user && user.profile;

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -235,7 +235,8 @@ export class ProviderBase {
         pxt.storage.removeLocal(this.name + "token")
         pxt.storage.removeLocal(this.name + "tokenExp")
         pxt.storage.removeLocal(this.name + "AutoLogin")
-        pxt.storage.removeLocal("cloudUser")
+        if (this.hasSync())
+            pxt.storage.removeLocal("cloudUser")
         invalidateData();
     }
 }
@@ -371,7 +372,7 @@ export function resetAsync() {
 function updateNameAsync() {
     const provider = currentProvider;
     let user = pxt.storage.getLocal("cloudUser");
-    if (user || !provider)
+    if (user || !provider || !provider.hasSync())
         return Promise.resolve()
     return provider.getUserInfoAsync()
         .then(info => {

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -269,7 +269,8 @@ import * as onedrive from "./onedrive";
 import * as googledrive from "./googledrive";
 import * as githubprovider from "./githubprovider";
 
-export function providers(): IdentityProvider[] {
+// All identity providers, including hithub
+function identityProviders(): IdentityProvider[] {
     if (!allProviders) {
         allProviders = {}
         const cl = pxt.appTarget.cloud
@@ -288,8 +289,15 @@ export function providers(): IdentityProvider[] {
     return pxt.Util.values(allProviders);
 }
 
+/**
+ * All cloud synchronization providers
+ */
+export function providers(): Provider[] {
+    return identityProviders().filter(p => p.hasSync()).map(p => <Provider>p);
+}
+
 export function githubProvider(): githubprovider.GithubProvider {
-    return providers().filter(p => p.name == githubprovider.PROVIDER_NAME)[0] as githubprovider.GithubProvider;
+    return identityProviders().filter(p => p.name == githubprovider.PROVIDER_NAME)[0] as githubprovider.GithubProvider;
 }
 
 // this is generally called by the provier's loginCheck() function
@@ -590,7 +598,7 @@ export function syncAsync(): Promise<void> {
 }
 
 export function loginCheck() {
-    const provs = providers()
+    const provs = identityProviders();
     if (!provs.length)
         return
 

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -284,7 +284,7 @@ import * as onedrive from "./onedrive";
 import * as googledrive from "./googledrive";
 import * as githubprovider from "./githubprovider";
 
-// All identity providers, including hithub
+// All identity providers, including github
 function identityProviders(): IdentityProvider[] {
     if (!allProviders) {
         allProviders = {}

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import * as data from "./data";
 import * as sui from "./sui";
+import * as githubbutton from "./githubbutton";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -96,12 +97,12 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const hasUndo = this.props.parent.editor.hasUndo();
         const hasRedo = this.props.parent.editor.hasRedo();
         return [<EditorToolbarButton icon='xicon undo' className={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo")} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} onButtonClick={this.undo} view={this.getViewString(view)} key="undo" />,
-                <EditorToolbarButton icon='xicon redo' className={`editortools-btn redo-editortools-btn} ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo")} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} onButtonClick={this.redo} view={this.getViewString(view)} key="redo" />]
+        <EditorToolbarButton icon='xicon redo' className={`editortools-btn redo-editortools-btn} ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo")} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} onButtonClick={this.redo} view={this.getViewString(view)} key="redo" />]
     }
 
     private getZoomControl(view: View): JSX.Element[] {
         return [<EditorToolbarButton icon='minus circle' className="editortools-btn zoomout-editortools-btn" title={lf("Zoom Out")} onButtonClick={this.zoomOut} view={this.getViewString(view)} key="minus" />,
-                <EditorToolbarButton icon='plus circle' className="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onButtonClick={this.zoomIn} view={this.getViewString(view)} key="plus" />]
+        <EditorToolbarButton icon='plus circle' className="editortools-btn zoomin-editortools-btn" title={lf("Zoom In")} onButtonClick={this.zoomIn} view={this.getViewString(view)} key="plus" />]
     }
 
     private getSaveInput(view: View, showSave: boolean, id?: string, projectName?: string): JSX.Element[] {
@@ -116,15 +117,20 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         if (view != View.Mobile) {
             saveInput.push(<label htmlFor={id} className="accessible-hidden" key="label">{lf("Type a name for your project")}</label>);
             saveInput.push(<EditorToolbarSaveInput id={id} view={this.getViewString(view)} key="input"
-                            type="text"
-                            aria-labelledby={id}
-                            placeholder={lf("Pick a name...")}
-                            value={projectName || ''}
-                            onChangeValue={this.saveProjectName} />)
+                type="text"
+                aria-labelledby={id}
+                placeholder={lf("Pick a name...")}
+                value={projectName || ''}
+                onChangeValue={this.saveProjectName} />)
         }
 
         if (showSave) {
-            saveInput.push(<EditorToolbarButton icon='save' className={`${view == View.Computer ? 'small' : 'large'} right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view={this.getViewString(view)} key="save" />)
+            const sizeClass = view == View.Computer ? 'small' : 'large';
+            saveInput.push(<EditorToolbarButton icon='save' className={`${sizeClass} right attached editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view={this.getViewString(view)} key="save" />)
+        }
+
+        if (pxt.appTarget.cloud && pxt.appTarget.cloud.githubPackages) {
+            saveInput.push(<githubbutton.GithubButton parent={this.props.parent} />)
         }
 
         return saveInput;
@@ -136,7 +142,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         if (home) return <div />; // Don't render if we're in the home screen
 
         const targetTheme = pxt.appTarget.appTheme;
-        const sandbox = pxt.shell.isSandboxMode();
         const isController = pxt.shell.isControllerMode();
         const readOnly = pxt.shell.isReadOnly();
         const tutorial = tutorialOptions ? tutorialOptions.tutorial : false;
@@ -289,7 +294,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     </div>}
                                 <div className="row" style={showUndoRedo || showZoomControls ? { paddingTop: 0 } : {}}>
                                     <div className="column">
-                                        {trace && <EditorToolbarButton key='tracebtn' className={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onButtonClick={this.toggleTrace} view='tablet' /> }
+                                        {trace && <EditorToolbarButton key='tracebtn' className={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onButtonClick={this.toggleTrace} view='tablet' />}
                                         {debug && <EditorToolbarButton key='debugbtn' className={`large debug-button ${debugging ? 'orange' : ''}`} icon="icon bug" title={debugTooltip} onButtonClick={this.toggleDebugging} view='tablet' />}
                                     </div>
                                 </div>

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -5,9 +5,6 @@ import * as data from "./data";
 import * as sui from "./sui";
 import * as pkg from "./package";
 import * as core from "./core";
-import * as dialogs from "./dialogs";
-import * as workspace from "./workspace";
-import * as cloudsync from "./cloudsync";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -274,60 +271,6 @@ namespace custom {
                 {!meta.numErrors ? null : <span className='ui label red'>{meta.numErrors}</span>}
             </div>
             {showFiles ? pxt.Util.concat(pkg.allEditorPkgs().map(p => this.filesWithHeader(p))) : undefined}
-        </div>;
-    }
-}
-
-interface GithubTreeItemState {
-    pushPulling?: boolean;
-}
-
-export class GithubTreeItem extends sui.UIElement<ISettingsProps, GithubTreeItemState> {
-    constructor(props: ISettingsProps) {
-        super(props);
-        this.state = {};
-        this.handleClick = this.handleClick.bind(this);
-        this.handleButtonKeydown = this.handleButtonKeydown.bind(this);
-    }
-
-    private handleButtonKeydown(e: React.KeyboardEvent<HTMLElement>) {
-        e.stopPropagation();
-    }
-
-    private handleClick(e: React.MouseEvent<HTMLElement>) {
-        e.stopPropagation();
-        const { githubId } = this.props.parent.state.header;
-        if (githubId) {
-            pxt.tickEvent("github.filelist.nav")
-            const gitf = pkg.mainEditorPkg().lookupFile("this/" + pxt.github.GIT_JSON);
-            this.props.parent.setSideFile(gitf);
-        }
-    }
-
-    renderCore() {
-        const header = this.props.parent.state.header;
-        if (!header) return <div />;
-
-        const { githubId } = header;
-        const ghid = pxt.github.parseRepoId(githubId);
-        if (!ghid) return <div />;
-
-        const targetTheme = pxt.appTarget.appTheme;
-        const mainPkg = pkg.mainEditorPkg()
-        const meta: pkg.PackageMeta = ghid ? this.getData("open-pkg-meta:" + mainPkg.getPkgId()) : undefined;
-
-        return <div role="tree" className={`ui tiny vertical ${targetTheme.invertedMenu ? `inverted` : ''} menu filemenu landscape only hidefullscreen`}>
-            <div
-                key="github-status"
-                className="item link"
-                onClick={this.handleClick}
-                tabIndex={0}
-                role="button"
-                onKeyDown={sui.fireClickOnEnter}>
-                {ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName}
-                <i className="github icon" />
-                {meta && meta.numFilesGitModified ? <i className="up arrow icon" /> : undefined}
-            </div>
         </div>;
     }
 }

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -52,7 +52,7 @@ export class GithubButton extends sui.UIElement<ISettingsProps, GithubButtonStat
         // new github repo
         if (!ghid)
             return <sui.Button className={`ui icon button editortools-btn editortools-github-btn`}
-                icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")} 
+                icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")}
                 onClick={this.createRepository} />
 
         // existing repo

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -51,19 +51,18 @@ export class GithubButton extends sui.UIElement<ISettingsProps, GithubButtonStat
         const ghid = pxt.github.parseRepoId(githubId);
         // new github repo
         if (!ghid)
-            return <sui.Button icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")} onClick={this.createRepository} />
+            return <sui.Button className={`ui icon button editortools-btn editortools-github-btn`}
+                icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")} onClick={this.createRepository} />
 
         // existing repo
         const targetTheme = pxt.appTarget.appTheme;
         const mainPkg = pkg.mainEditorPkg()
         const meta: pkg.PackageMeta = ghid ? this.getData("open-pkg-meta:" + mainPkg.getPkgId()) : undefined;
-        const text = ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName;
 
-        return <div role="button" className={`ui button`}>
-                <i className="github icon" />
-                {meta && meta.numFilesGitModified ? <i className="up arrow icon" /> : undefined}
-                {text}
-            </div>;
+        return <div role="button" className={`ui icon button editortools-btn editortools-github-btn`} title={text} onClick={this.handleClick}>
+            <i className="github icon" />
+            {meta && meta.numFilesGitModified ? <i className="up arrow icon" /> : undefined}
+        </div>;
     }
 }
 

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -59,12 +59,14 @@ export class GithubButton extends sui.UIElement<ISettingsProps, GithubButtonStat
         //const targetTheme = pxt.appTarget.appTheme;
         const mainPkg = pkg.mainEditorPkg()
         const meta: pkg.PackageMeta = this.getData("open-pkg-meta:" + mainPkg.getPkgId());
-        const text = ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName;
+        const modified = meta && !!meta.numFilesGitModified;
+        const repoName = ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName;
+        const title = lf("Review and commit changes for {0}", repoName);
 
         return <div role="button" className={`ui icon button editortools-btn editortools-github-btn`}
-            title={text} onClick={this.handleClick}>
+            title={title} onClick={this.handleClick}>
             <i className="github icon" />
-            {meta && meta.numFilesGitModified ? <i className="up arrow icon" /> : undefined}
+            {modified ? <i className="up arrow icon" /> : undefined}
         </div>;
     }
 }

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -52,14 +52,17 @@ export class GithubButton extends sui.UIElement<ISettingsProps, GithubButtonStat
         // new github repo
         if (!ghid)
             return <sui.Button className={`ui icon button editortools-btn editortools-github-btn`}
-                icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")} onClick={this.createRepository} />
+                icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")} 
+                onClick={this.createRepository} />
 
         // existing repo
-        const targetTheme = pxt.appTarget.appTheme;
+        //const targetTheme = pxt.appTarget.appTheme;
         const mainPkg = pkg.mainEditorPkg()
-        const meta: pkg.PackageMeta = ghid ? this.getData("open-pkg-meta:" + mainPkg.getPkgId()) : undefined;
+        const meta: pkg.PackageMeta = this.getData("open-pkg-meta:" + mainPkg.getPkgId());
+        const text = ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName;
 
-        return <div role="button" className={`ui icon button editortools-btn editortools-github-btn`} title={text} onClick={this.handleClick}>
+        return <div role="button" className={`ui icon button editortools-btn editortools-github-btn`}
+            title={text} onClick={this.handleClick}>
             <i className="github icon" />
             {meta && meta.numFilesGitModified ? <i className="up arrow icon" /> : undefined}
         </div>;

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -13,8 +13,8 @@ export class GithubProvider extends cloudsync.ProviderBase {
     }
 
     logout() {
-        super.logout();
         pxt.github.token = undefined;
+        super.logout();
     }
 
     hasSync(): boolean {
@@ -31,18 +31,17 @@ export class GithubProvider extends cloudsync.ProviderBase {
 
     loginAsync(redirect?: boolean, silent?: boolean): Promise<cloudsync.ProviderLoginResponse> {
         this.loginCheck()
-        if (this.token())
-            return Promise.resolve({ accessToken: this.token() } as cloudsync.ProviderLoginResponse);
+        let p = Promise.resolve();
+        if (!this.token()) {
+            // auth flow
+            const cl = pxt.appTarget && pxt.appTarget.cloud && pxt.appTarget.cloud.cloudProviders && pxt.appTarget.cloud.cloudProviders[this.name];
+            if (cl)
+                p = p.then(() => this.oauthLoginAsync());
+            else
+                p = p.then(() => this.showGithubLoginAsync());
+        }
+        return p.then(() => { return { accessToken: this.token() } as cloudsync.ProviderLoginResponse; });
 
-        // auth flow
-        const cl = pxt.appTarget && pxt.appTarget.cloud && pxt.appTarget.cloud.cloudProviders && pxt.appTarget.cloud.cloudProviders[this.name];
-        if (cl)
-            return this.oauthLoginAsync().then(() => undefined);
-
-        // dev token
-        return this.showGithubLoginAsync().then(() => {
-            return { accessToken: this.token() } as cloudsync.ProviderLoginResponse;
-        });
     }
 
     private oauthLoginAsync(): Promise<void> {
@@ -164,6 +163,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
                                 pxt.tickEvent("github.token.ok");
                             }
                         })
+                        .then(() => cloudsync.syncAsync())
                 }
             }).finally(() => core.hideLoading(LOAD_ID))
     }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -630,7 +630,6 @@ ${content}
         const gs = this.getGitJson();
         // don't use gs.prUrl, as it gets cleared often
         const url = `https://github.com/${githubId.fullName}${master ? "" : `/tree/${githubId.tag}`}`;
-        const testurl = `${window.location.href.replace(/#.*$/, '')}#testproject:${this.props.parent.state.header.id}`;
         const needsToken = !pxt.github.token;
         // this will show existing PR if any
         const prUrl = !gs.isFork && master ? null :
@@ -648,7 +647,6 @@ ${content}
                             className={needsPull === true ? "positive" : ""}
                             text={lf("Pull changes")} textClass={"landscape only"} title={lf("Pull changes from GitHub to get your code up-to-date.")} onClick={this.handlePullClick} onKeyDown={sui.fireClickOnEnter} />
                         {!needsToken ? <sui.Link className="ui button" icon="user plus" href={`https://github.com/${githubId.fullName}/settings/collaboration`} target="_blank" title={lf("Invite collaborators.")} onKeyDown={sui.fireClickOnEnter} /> : undefined}
-                        <sui.Link className="ui button" icon="flask" href={testurl} title={lf("Open test project for extension.")} target={`${pxt.appTarget.id}testproject`} onKeyDown={sui.fireClickOnEnter} />
                         <sui.Link className="ui button" icon="github" href={url} title={lf("Open repository in GitHub.")} target="_blank" onKeyDown={sui.fireClickOnEnter} />
                     </div>
                 </div>
@@ -773,12 +771,24 @@ class NoChangesComponent extends sui.StatelessUIElement<GitHubViewProps> {
 
     renderCore() {
         const { needsToken, githubId, master, gs } = this.props;
+        const header = this.props.parent.props.parent.state.header;
         const needsLicenseMessage = !needsToken && gs.commit && !gs.commit.tree.tree.some(f =>
             /^LICENSE/.test(f.path.toUpperCase()) || /^COPYING/.test(f.path.toUpperCase()))
+        const testurl = header && `${window.location.href.replace(/#.*$/, '')}#testproject:${header.id}`;
         return <div>
             <div className="ui segment">{lf("No local changes found.")}</div>
             {master ? <div className="ui transparent segment">
                 <div className="ui header">{lf("Extension zone")}</div>
+                <div className="ui field">
+                    <a href={testurl}
+                        role="button" className="ui button"
+                        target={`${pxt.appTarget.id}testproject`} rel="noopener noreferrer">
+                        {lf("Test Extension")}
+                    </a>
+                    <span>
+                        {lf("Open a test project that uses this extension.")}
+                    </span>
+                </div>
                 {gs.commit && gs.commit.tag ?
                     <div className="ui field">
                         <p>{lf("Current release: {0}", gs.commit.tag)}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -770,12 +770,16 @@ class ExtensionZone extends sui.StatelessUIElement<GitHubViewProps> {
         if (needsCommit)
             core.confirmAsync({
                 header: lf("Commit your changes..."),
-                body: lf("You need to commit your local changes to create a release.")
+                body: lf("You need to commit your local changes to create a release."),
+                agreeLbl: lf("Ok"),
+                hideAgree: true
             });
         else if (master)
             core.confirmAsync({
                 header: lf("Checkout the master branch..."),
-                body: lf("You need to checkout the master branch to create a release.")
+                body: lf("You need to checkout the master branch to create a release."),
+                agreeLbl: lf("Ok"),
+                hideAgree: true
             });
         else
             cloudsync.githubProvider()

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -800,6 +800,7 @@ class ExtensionZone extends sui.StatelessUIElement<GitHubViewProps> {
                 <div className="ui field">
                     <sui.Button text={lf("Create release")}
                         disabled={!canRelease}
+                        title={canRelease ? lf("Bump up the version number and create a release on GitHub.") : lf("Commit your changed and move to the master branch to create a release.")}
                         onClick={this.handleBumpClick}
                         onKeyDown={sui.fireClickOnEnter} />
                     <span>

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -775,34 +775,35 @@ class NoChangesComponent extends sui.StatelessUIElement<GitHubViewProps> {
         const { needsToken, githubId, master, gs } = this.props;
         const needsLicenseMessage = !needsToken && gs.commit && !gs.commit.tree.tree.some(f =>
             /^LICENSE/.test(f.path.toUpperCase()) || /^COPYING/.test(f.path.toUpperCase()))
-        const inverted = pxt.appTarget.appTheme.invertedMenu;
         return <div>
-            <p>{lf("No local changes found.")}</p>
-            {master ? <div className="ui divider"></div> : undefined}
-            {master ? gs.commit && gs.commit.tag ?
-                <div className="ui field">
-                    <p>{lf("Current release: {0}", gs.commit.tag)}
-                        {sui.helpIconLink("/github/release", lf("Learn about releases."))}
-                    </p>
-                </div>
-                :
-                <div className="ui field">
-                    <sui.Button className="primary" text={lf("Create release")} onClick={this.handleBumpClick} onKeyDown={sui.fireClickOnEnter} />
-                    <span>
-                        {lf("Bump up the version number and create a release on GitHub.")}
-                        {sui.helpIconLink("/github/release#license", lf("Learn more about extension releases."))}
-                    </span>
-                </div> : undefined}
-            {master && needsLicenseMessage ? <div className={`ui ${inverted ? 'inverted' : ''} message`}>
-                <div className="content">
-                    {lf("Your project doesn't seem to have a license. This makes it hard for others to use it.")}
-                    {" "}
+            <div className="ui segment">{lf("No local changes found.")}</div>
+            {master ? <div className="ui transparent segment">
+                <div className="ui header">{lf("Extension zone")}</div>
+                {gs.commit && gs.commit.tag ?
+                    <div className="ui field">
+                        <p>{lf("Current release: {0}", gs.commit.tag)}
+                            {sui.helpIconLink("/github/release", lf("Learn about releases."))}
+                        </p>
+                    </div>
+                    :
+                    <div className="ui field">
+                        <sui.Button text={lf("Create release")} onClick={this.handleBumpClick} onKeyDown={sui.fireClickOnEnter} />
+                        <span>
+                            {lf("Bump up the version number and create a release on GitHub.")}
+                            {sui.helpIconLink("/github/release", lf("Learn more about extension releases."))}
+                        </span>
+                    </div>}
+                {needsLicenseMessage ? <div className={`ui field`}>
                     <a href={`https://github.com/${githubId.fullName}/community/license/new?branch=${githubId.tag}&template=mit`}
-                        role="button" className="ui link"
+                        role="button" className="ui button"
                         target="_blank" rel="noopener noreferrer">
                         {lf("Add license")}
                     </a>
-                </div>
+                    <span>
+                        {lf("Your project doesn't seem to have a license.")}
+                        {sui.helpIconLink("/github/license", lf("Learn more about licenses."))}
+                    </span>
+                </div> : undefined}
             </div> : undefined}
         </div>
     }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -646,7 +646,7 @@ ${content}
                         <sui.Button icon={`${needsPull === true ? "down arrow" : needsPull === false ? "check" : "sync"}`}
                             className={needsPull === true ? "positive" : ""}
                             text={lf("Pull changes")} textClass={"landscape only"} title={lf("Pull changes from GitHub to get your code up-to-date.")} onClick={this.handlePullClick} onKeyDown={sui.fireClickOnEnter} />
-                        {!needsToken ? <sui.Link className="ui button" icon="user plus" href={`https://github.com/${githubId.fullName}/settings/collaboration`} target="_blank" title={lf("Invite collaborators.")} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                        {!needsToken && !isBlocksMode ? <sui.Link className="ui button" icon="user plus" href={`https://github.com/${githubId.fullName}/settings/collaboration`} target="_blank" title={lf("Invite collaborators.")} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                         <sui.Link className="ui button" icon="github" href={url} title={lf("Open repository in GitHub.")} target="_blank" onKeyDown={sui.fireClickOnEnter} />
                     </div>
                 </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -308,11 +308,12 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
+            <div className="ui divider"></div>
             {showSigninGithub ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
             {showSignoutGithub ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
-            <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
             <div className="ui divider"></div>
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />
+            <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
             {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback")} target="_blank" rel="noopener noreferrer" >{lf("Give Feedback")}</a> : undefined}
         </sui.DropdownMenu>;
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -295,13 +295,12 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
             <div className="ui divider"></div>
             {!githubUser ? <sui.Item role="menuitem" title={lf("Host your code on GitHub and work together with friends on projects.")} text={lf("Sign in with GitHub")} icon="github" onClick={this.signInGithub} /> : undefined}
-            {githubUser ? <a className="ui item" title={lf("Signed in as {0} with GitHub", githubUser.name)} role="menuitem" href={githubUser.profile} target="_blank" rel="noopener noreferrer">
-                <div className="avatar">
+            {githubUser ? <div className="ui item" title={lf("Sign out {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
+                <div className="avatar" role="presentation">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
                 </div>
-                {githubUser.userName}
-            </a> : undefined}
-            {githubUser ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
+                {lf("Sign out")}
+            </div> : undefined}
             <div className="ui divider"></div>
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -308,7 +308,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
             <div className="ui divider"></div>
-            {!githubUser ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
+            {!githubUser ? <sui.Item role="menuitem" title={lf("Host your code on GitHub and work together with friends on projects.")} text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
             {githubUser ? <a className="ui item" title={lf("Signed in as {0} with GitHub", githubUser.name)} role="menuitem" href={githubUser.profile} target="_blank" rel="noopener noreferrer">
                 <div className="avatar">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -309,7 +309,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
             <div className="ui divider"></div>
             {!githubUser ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
-            {githubUser ? <a className="ui item" role="menuitem" href={githubUser.profile} target="_blank" rel="noopener noreferrer">
+            {githubUser ? <a className="ui item" title={lf("Signed in as {0} with GitHub", githubUser.name)} role="menuitem" href={githubUser.profile} target="_blank" rel="noopener noreferrer">
                 <div className="avatar">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
                 </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -218,6 +218,79 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     }
 }
 
+// This Component overrides shouldComponentUpdate, be sure to update that if the state is updated
+export interface ProjectSettingsMenuProps extends ISettingsProps {
+    highContrast: boolean;
+}
+export interface ProjectSettingsMenuState {
+    highContrast?: boolean;
+}
+
+export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps, ProjectSettingsMenuState> {
+
+    constructor(props: ProjectSettingsMenuProps) {
+        super(props);
+        this.state = {
+        }
+
+        this.showLanguagePicker = this.showLanguagePicker.bind(this);
+        this.toggleHighContrast = this.toggleHighContrast.bind(this);
+        this.showResetDialog = this.showResetDialog.bind(this);
+        this.showAboutDialog = this.showAboutDialog.bind(this);
+    }
+
+    showLanguagePicker() {
+        pxt.tickEvent("home.langpicker", undefined, { interactiveConsent: true });
+        this.props.parent.showLanguagePicker();
+    }
+
+    toggleHighContrast() {
+        pxt.tickEvent("home.togglecontrast", undefined, { interactiveConsent: true });
+        this.props.parent.toggleHighContrast();
+    }
+
+    toggleGreenScreen() {
+        pxt.tickEvent("home.togglegreenscreen", undefined, { interactiveConsent: true });
+        this.props.parent.toggleGreenScreen();
+    }
+
+    showResetDialog() {
+        pxt.tickEvent("home.reset", undefined, { interactiveConsent: true });
+        this.props.parent.showResetDialog();
+    }
+
+    showAboutDialog() {
+        pxt.tickEvent("home.about");
+        this.props.parent.showAboutDialog();
+    }
+
+    componentWillReceiveProps(nextProps: ProjectSettingsMenuProps) {
+        const newState: ProjectSettingsMenuState = {};
+        if (nextProps.highContrast != undefined) {
+            newState.highContrast = nextProps.highContrast;
+        }
+        if (Object.keys(newState).length > 0) this.setState(newState)
+    }
+
+    shouldComponentUpdate(nextProps: ProjectSettingsMenuProps, nextState: ProjectSettingsMenuState, nextContext: any): boolean {
+        return this.state.highContrast != nextState.highContrast;
+    }
+
+    renderCore() {
+        const { highContrast } = this.state;
+        const targetTheme = pxt.appTarget.appTheme;
+
+        return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
+            {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
+            {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
+            <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
+            <div className="ui divider"></div>
+            <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />
+            {targetTheme.feedbackUrl ? <a className="ui item" href={targetTheme.feedbackUrl} role="menuitem" title={lf("Give Feedback")} target="_blank" rel="noopener noreferrer" >{lf("Give Feedback")}</a> : undefined}
+        </sui.DropdownMenu>;
+    }
+}
+
 export class ProjectsMenu extends data.Component<ISettingsProps, {}> {
 
     constructor(props: ISettingsProps) {
@@ -259,6 +332,7 @@ export class ProjectsMenu extends data.Component<ISettingsProps, {}> {
             {/* <div className="ui item home mobile hide"><sui.Icon icon={`icon home large`} /> <span>{lf("Home")}</span></div> */}
             <div className="right menu">
                 {!showCloudHead ? undefined : <cloud.UserMenu parent={this.props.parent} />}
+                <ProjectSettingsMenu parent={this.props.parent} highContrast={this.props.parent.state.highContrast} greenScreen={this.props.parent.state.greenScreen}  />
                 <a href={targetTheme.organizationUrl} target="blank" rel="noopener" className="ui item logo organization" onClick={this.orgIconClick}>
                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo
                         ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={targetTheme.organizationWideLogo || targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -238,6 +238,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
         this.showResetDialog = this.showResetDialog.bind(this);
         this.showAboutDialog = this.showAboutDialog.bind(this);
+        this.signInGithub = this.signOutGithub.bind(this);
         this.signOutGithub = this.signOutGithub.bind(this);
     }
 
@@ -278,6 +279,15 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         return this.state.highContrast != nextState.highContrast;
     }
 
+    signInGithub() {
+        pxt.tickEvent("home.github.signin");
+        const githubProvider = cloudsync.githubProvider();
+        if (githubProvider) {
+            githubProvider.loginAsync()
+                .done(() => this.props.parent.forceUpdate());
+        }
+    }
+
     signOutGithub() {
         pxt.tickEvent("home.github.signout");
         const githubProvider = cloudsync.githubProvider();
@@ -292,12 +302,14 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         const targetTheme = pxt.appTarget.appTheme;
         const githubProvider = cloudsync.githubProvider();
 
+        const showSigninGithub = githubProvider && !pxt.github.token;
         const showSignoutGithub = githubProvider && !!pxt.github.token;
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
-            {showSignoutGithub ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} />}
+            {showSigninGithub ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signInGithub} /> : undefined}
+            {showSignoutGithub ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
             <div className="ui divider"></div>
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -238,7 +238,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
         this.showResetDialog = this.showResetDialog.bind(this);
         this.showAboutDialog = this.showAboutDialog.bind(this);
-        this.signInGithub = this.signOutGithub.bind(this);
+        this.signInGithub = this.signInGithub.bind(this);
         this.signOutGithub = this.signOutGithub.bind(this);
     }
 
@@ -308,7 +308,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
-            {showSigninGithub ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signInGithub} /> : undefined}
+            {showSigninGithub ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
             {showSignoutGithub ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
             <div className="ui divider"></div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -6,6 +6,7 @@ import * as data from "./data";
 import * as sui from "./sui";
 import * as core from "./core";
 import * as cloud from "./cloud";
+import * as cloudsync from "./cloudsync";
 
 import * as discourse from "./discourse";
 import * as codecard from "./codecard"
@@ -237,6 +238,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
         this.showResetDialog = this.showResetDialog.bind(this);
         this.showAboutDialog = this.showAboutDialog.bind(this);
+        this.signOutGithub = this.signOutGithub.bind(this);
     }
 
     showLanguagePicker() {
@@ -276,13 +278,26 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         return this.state.highContrast != nextState.highContrast;
     }
 
+    signOutGithub() {
+        pxt.tickEvent("home.github.signout");
+        const githubProvider = cloudsync.githubProvider();
+        if (githubProvider) {
+            githubProvider.logout();
+            this.props.parent.forceUpdate();
+        }
+    }
+
     renderCore() {
         const { highContrast } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
+        const githubProvider = cloudsync.githubProvider();
+
+        const showSignoutGithub = githubProvider && !!pxt.github.token;
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
+            {showSignoutGithub ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} />}
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
             <div className="ui divider"></div>
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -267,18 +267,6 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         this.props.parent.showAboutDialog();
     }
 
-    componentWillReceiveProps(nextProps: ProjectSettingsMenuProps) {
-        const newState: ProjectSettingsMenuState = {};
-        if (nextProps.highContrast != undefined) {
-            newState.highContrast = nextProps.highContrast;
-        }
-        if (Object.keys(newState).length > 0) this.setState(newState)
-    }
-
-    shouldComponentUpdate(nextProps: ProjectSettingsMenuProps, nextState: ProjectSettingsMenuState, nextContext: any): boolean {
-        return this.state.highContrast != nextState.highContrast;
-    }
-
     signInGithub() {
         pxt.tickEvent("home.github.signin");
         const githubProvider = cloudsync.githubProvider();
@@ -291,10 +279,8 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
     signOutGithub() {
         pxt.tickEvent("home.github.signout");
         const githubProvider = cloudsync.githubProvider();
-        if (githubProvider) {
+        if (githubProvider)
             githubProvider.logout();
-            this.props.parent.forceUpdate();
-        }
     }
 
     renderCore() {
@@ -308,7 +294,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
             <div className="ui divider"></div>
-            {!githubUser ? <sui.Item role="menuitem" title={lf("Host your code on GitHub and work together with friends on projects.")} text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
+            {!githubUser ? <sui.Item role="menuitem" title={lf("Host your code on GitHub and work together with friends on projects.")} text={lf("Sign in with GitHub")} icon="github" onClick={this.signInGithub} /> : undefined}
             {githubUser ? <a className="ui item" title={lf("Signed in as {0} with GitHub", githubUser.name)} role="menuitem" href={githubUser.profile} target="_blank" rel="noopener noreferrer">
                 <div className="avatar">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -300,17 +300,22 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
     renderCore() {
         const { highContrast } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
-        const githubProvider = cloudsync.githubProvider();
 
-        const showSigninGithub = githubProvider && !pxt.github.token;
-        const showSignoutGithub = githubProvider && !!pxt.github.token;
+        const githubUser = this.getData("github:user") as pxt.editor.UserInfo;
 
+        // tslint:disable react-a11y-anchors
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
             <div className="ui divider"></div>
-            {showSigninGithub ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
-            {showSignoutGithub ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
+            {!githubUser ? <sui.Item role="menuitem" text={lf("Sign in with GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
+            {githubUser ? <a className="ui item" role="menuitem" href={githubUser.profile} target="_blank" rel="noopener noreferrer">
+                <div className="avatar">
+                    <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
+                </div>
+                {githubUser.userName}
+            </a> : undefined}
+            {githubUser ? <sui.Item role="menuitem" text={lf("Sign out from GitHub")} icon="github" onClick={this.signOutGithub} /> : undefined}
             <div className="ui divider"></div>
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -347,7 +347,7 @@ export class ProjectsMenu extends data.Component<ISettingsProps, {}> {
             {/* <div className="ui item home mobile hide"><sui.Icon icon={`icon home large`} /> <span>{lf("Home")}</span></div> */}
             <div className="right menu">
                 {!showCloudHead ? undefined : <cloud.UserMenu parent={this.props.parent} />}
-                <ProjectSettingsMenu parent={this.props.parent} highContrast={this.props.parent.state.highContrast} greenScreen={this.props.parent.state.greenScreen}  />
+                <ProjectSettingsMenu parent={this.props.parent} highContrast={this.props.parent.state.highContrast} />
                 <a href={targetTheme.organizationUrl} target="blank" rel="noopener" className="ui item logo organization" onClick={this.orgIconClick}>
                     {targetTheme.organizationWideLogo || targetTheme.organizationLogo
                         ? <img className={`ui logo ${targetTheme.organizationWideLogo ? " portrait hide" : ''}`} src={targetTheme.organizationWideLogo || targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />
@@ -685,9 +685,9 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     protected getUrl() {
         const { url, youTubeId } = this.props;
         return (youTubeId && !url) ?
-                `https://youtu.be/${youTubeId}`
-                :
-                ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
+            `https://youtu.be/${youTubeId}`
+            :
+            ((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : '');
     }
 
     handleDetailClick() {
@@ -875,8 +875,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                             description={lf("Open a shared project URL or GitHub repo")}
                             onClick={this.importUrl}
                         /> : undefined}
-
-                    {pxt.github.token ?
+                    {pxt.appTarget.cloud && pxt.appTarget.cloud.githubPackages ?
                         <codecard.CodeCardView
                             ariaLabel={lf("Clone or create your own GitHub repository")}
                             role="button"

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -836,10 +836,12 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
         this.props.parent.showImportUrlDialog();
     }
 
-    private cloneGithub() {
+    private async cloneGithub() {
         pxt.tickEvent("github.projects.clone", undefined, { interactiveConsent: true });
         this.hide();
-        this.props.parent.showImportGithubDialog();
+        await cloudsync.githubProvider().loginAsync();
+        if (pxt.github.token)
+            this.props.parent.showImportGithubDialog();
     }
 
     renderCore() {


### PR DESCRIPTION
Round 2 on github signin.

Test build: https://arcade.makecode.com/app/9e6ac0d23e6cbde4d6a341a2c8979cb96a8c15d9-1db5da5931

- [x] add gearwheel menu on home scree: about, reset, language, high contrast, sign in/out of github
![image](https://user-images.githubusercontent.com/4175913/68039673-e12c3280-fc89-11e9-8e27-e2d65d0f3435.png)
![image](https://user-images.githubusercontent.com/4175913/68045620-2dca3a80-fc97-11e9-9d80-4dca1847c012.png)
- [x] move github out of bubble head menu
- [x] your github repo always visible in import menu
- [x] move github status button next to save button
![image](https://user-images.githubusercontent.com/4175913/68039937-729ba480-fc8a-11e9-9283-37688d505b49.png)
![image](https://user-images.githubusercontent.com/4175913/68039775-16388500-fc8a-11e9-8159-80a907647417.png)
- [x] group extension stuff into a "zone" (hidden in blocks)
![image](https://user-images.githubusercontent.com/4175913/68045653-45a1be80-fc97-11e9-9143-09df826df1ad.png)
- [x] minimalist experience in blocks (no extension stuff)
![image](https://user-images.githubusercontent.com/4175913/68045703-5eaa6f80-fc97-11e9-8bbe-65cb4d7ed519.png)
