### PR TITLE
Fix python<->typescript runtime trace tests

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1574,7 +1574,7 @@ namespace pxt.py {
         "micropython.const": { n: "", t: tpNumber }
     }
 
-    function getFunMap(): Map<FunOverride> {
+    function getPy2TsFunMap(): Map<FunOverride> {
         let funMap: Map<FunOverride> = {};
         Object.keys(pxtc.ts2PyFunNameMap).forEach(k => {
             let tsOverride = pxtc.ts2PyFunNameMap[k];
@@ -1596,7 +1596,7 @@ namespace pxt.py {
         return funMap
     }
 
-    const funMap: Map<FunOverride> = getFunMap();
+    const py2TsFunMap: Map<FunOverride> = getPy2TsFunMap();
 
     function isSuper(v: py.Expr) {
         return isCallTo(v, "super") && (v as py.Call).args.length == 0
@@ -1761,16 +1761,16 @@ namespace pxt.py {
             }
 
             if (!fun) {
-                let over = U.lookup(funMap, nm)
+                let over = U.lookup(py2TsFunMap, nm)
                 if (over)
                     methName = ""
 
                 if (methName) {
                     nm = t2s(recvTp) + "." + methName
-                    over = U.lookup(funMap, nm)
+                    over = U.lookup(py2TsFunMap, nm)
                     if (!over && typeCtor(find(recvTp)) == "@array") {
                         nm = "Array." + methName
-                        over = U.lookup(funMap, nm)
+                        over = U.lookup(py2TsFunMap, nm)
                     }
                 }
 
@@ -2007,7 +2007,7 @@ namespace pxt.py {
         let v = lookupSymbol(n.id)
         if (!v) {
             // check if the symbol has an override py<->ts mapping
-            let over = U.lookup(funMap, n.id)
+            let over = U.lookup(py2TsFunMap, n.id)
             if (over) {
                 v = lookupSymbol(over.n)
             }

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -128,6 +128,9 @@ namespace pxt.py {
             if (sym && sym.pyQName) {
                 return sym.pyQName
             }
+            else if (tsExp in pxtc.ts2PyFunNameMap) {
+                return pxtc.ts2PyFunNameMap[tsExp].n
+            }
             return null
         }
         function getName(name: ts.Identifier | ts.BindingPattern | ts.PropertyName | ts.EntityName): string {
@@ -1046,7 +1049,7 @@ namespace pxt.py {
                 const args = argExps
                     .map(([a, _]) => a)
                     .join(", ");
-                return  [`${recv}.${fn}(${args})`, sup]
+                return [`${recv}.${fn}(${args})`, sup]
             }
 
             let args = argExps

--- a/tests/runtime-trace-tests/tracerunner.ts
+++ b/tests/runtime-trace-tests/tracerunner.ts
@@ -257,7 +257,7 @@ function compileTsToJs(filename: string): ts.Program {
         target: ts.ScriptTarget.ES5,
         module: ts.ModuleKind.ES2015,
         // noLib: true,
-        // skipLibCheck: true
+        skipLibCheck: true
     }
     return ts.pxtc.plainTscCompileFiles([filename], cOpts)
 }

--- a/tests/runtime-trace-tests/tracerunner.ts
+++ b/tests/runtime-trace-tests/tracerunner.ts
@@ -66,6 +66,12 @@ describe("convert between ts<->py ", () => {
     });
 });
 
+// we use this simple wrapper to enfore content type of "string". writeFileSync
+// accepts "any" and we've had bugs where objects get inadvertently written
+function writeFileStringSync(filePath: string, content: string) {
+    fs.writeFileSync(filePath, content)
+}
+
 async function testTsOrPy(tsOrPyFile: string): Promise<void> {
     let ext = path.extname(tsOrPyFile)
     let isPy = ext === ".py"
@@ -78,7 +84,7 @@ async function testTsOrPy(tsOrPyFile: string): Promise<void> {
     let recordBaseline = (bl: string) => {
         baseline = bl
         baselineFile = tsOrPyFile + ".baseline"
-        fs.writeFileSync(baselineFile, baseline)
+        writeFileStringSync(baselineFile, baseline)
     }
     if (isPy) {
         let pyFile = tsOrPyFile
@@ -120,13 +126,13 @@ async function testTsOrPy(tsOrPyFile: string): Promise<void> {
         let errFile = inFile + `.${fnName}_error`;
         return convert(inFile)
             .error(r => {
-                fs.writeFileSync(errFile, JSON.stringify(r))
+                writeFileStringSync(errFile, JSON.stringify(r))
                 return `${fnName} failed to convert '${inFile}'. Error saved at:\n${errFile}\nError is:\n${r}\n`
             })
             .then(async outFile => {
                 let outTrace = await runConverted(outFile)
                 if (!util.compareBaselines(outTrace, baseline)) {
-                    fs.writeFileSync(errFile, outTrace)
+                    writeFileStringSync(errFile, outTrace)
                     return Promise.reject(new Error(
                         `${fnName} incorrectly converted:\n` +
                         `${inFile}\n${fs.readFileSync(inFile, "utf8")}\nto:\n${outFile}\n${fs.readFileSync(outFile, "utf8")}\n` +
@@ -142,12 +148,12 @@ async function testTsOrPy(tsOrPyFile: string): Promise<void> {
         return STS(tsFile)
             .catch(error => {
                 let errStr = `${error}`
-                fs.writeFileSync(errFile, errStr)
+                writeFileStringSync(errFile, errStr)
                 return Promise.reject(new Error(`Static Typescript failed to run on:\n${tsFile}\nError saved at:\n${errFile}\nError is:\n${errStr}\n`))
             })
             .then(outTrace => {
                 if (!util.compareBaselines(outTrace, baseline)) {
-                    fs.writeFileSync(errFile, outTrace)
+                    writeFileStringSync(errFile, outTrace)
                     return Promise.reject(new Error(
                         `Static Typescript produced a different trace than node.js when run on:\n${tsFile}\n` +
                         `Baseline:\n${baseline}\nIncorrect trace:\n${outTrace}\n` +
@@ -230,21 +236,22 @@ function runNodeJsAsync(nodeArgs: string): Promise<string> {
 async function convertTs2Py(tsFile: string): Promise<string> {
     let pyCode = await util.ts2pyAsync(tsFile)
     const pyFile = path.join(util.replaceFileExtension(tsFile, ".ts.py"));
-    fs.writeFileSync(pyFile, pyCode)
+    writeFileStringSync(pyFile, pyCode)
     return pyFile
 }
 
 async function convertPy2Ts(pyFile: string): Promise<string> {
     let tsCode = await util.py2tsAsync(pyFile)
+    console.dir(tsCode)
     const tsFile = path.join(util.replaceFileExtension(pyFile, ".py.ts"));
-    fs.writeFileSync(tsFile, tsCode)
+    writeFileStringSync(tsFile, tsCode.ts)
     return tsFile
 }
 
 function emitJsFiles(prog: ts.Program, file?: ts.SourceFile): string[] {
     let jsFiles: string[] = []
     prog.emit(file, (f, data) => {
-        fs.writeFileSync(f, data)
+        writeFileStringSync(f, data)
         jsFiles.push(f)
     });
     return jsFiles


### PR DESCRIPTION
Fixed three issues:
- `skipLibCheck` is necessary for plain TS compilation (sometimes, depending on NPM installs it seems)
- fix writing an object ([object Object]) instead of typescript code in test case due to "any" type usage
- fix how we py decompile built-ins like "console.log"

now "jake testtraces" works again