### PR TITLE
run tracetests as part of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - pip3 install --user typing
 before_script:
   - "npm install"
-  - "python --version"
 sudo: false
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 before_script:
   - "npm install"
+  - "python --version"
 sudo: false
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os: linux
 dist: trusty
 node_js:
   - "8.9.4"
+python:
+  - "3.7"
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 node_js:
   - "8.9.4"
 python:
-  - "3.7"
+  - "3.6"
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,12 @@ os: linux
 dist: trusty
 node_js:
   - "8.9.4"
-python:
-  - "3.6"
+python: "3.6"
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - pip3 install --user typing
+  - pip install --user typing
 before_script:
   - "npm install"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - pip install --user typing
+  - pyenv global 3.6
 before_script:
   - "npm install"
 sudo: false

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -77,7 +77,7 @@ function runKarma(that, flags) {
 
 task('default', ['updatestrings', 'built/pxt.js', 'built/pxt.d.ts', 'built/pxtrunner.js', 'built/backendutils.js', 'built/target.js', 'wapp', 'monaco-editor', 'built/web/pxtweb.js', 'built/tests/blocksrunner.js'], { parallelLimit: 10 })
 
-task('test', ['default', 'testfmt', 'testerr', 'testdecompiler', 'testpy', 'testlang', 'testtutorials', 'karma'])
+task('test', ['default', 'testfmt', 'testerr', 'testdecompiler', 'testpy', 'testlang', 'testtutorials', 'karma', 'testtraces'])
 
 task('clean', function () {
     ["built", "temp"].forEach(d => {

--- a/tests/runtime-trace-tests/tracerunner.ts
+++ b/tests/runtime-trace-tests/tracerunner.ts
@@ -34,7 +34,13 @@ pxt.setAppTarget(util.testAppTarget);
 // tests
 const casesDir = path.join(process.cwd(), "tests", "runtime-trace-tests", "cases");
 
-describe("convert between ts<->py ", () => {
+describe("convert between ts<->py ", async () => {
+    // debug info
+    console.log("Python3 version:")
+    console.log(await runProcAsync("python3 --version", ""))
+    console.log("node version:")
+    console.log(await runProcAsync("node --version", ""))
+
     // TODO: can this be moved to a mocha before() block?
     let tsAndPyFiles: string[]
 
@@ -73,12 +79,6 @@ function writeFileStringSync(filePath: string, content: string) {
 }
 
 async function testTsOrPy(tsOrPyFile: string): Promise<void> {
-    // debug info
-    console.log("Python3 version:")
-    console.log(await runProcAsync("python3 --version", ""))
-    console.log("node version:")
-    console.log(await runProcAsync("node --version", ""))
-
     let ext = path.extname(tsOrPyFile)
     let isPy = ext === ".py"
     let isTs = ext === ".ts"

--- a/tests/runtime-trace-tests/tracerunner.ts
+++ b/tests/runtime-trace-tests/tracerunner.ts
@@ -34,13 +34,7 @@ pxt.setAppTarget(util.testAppTarget);
 // tests
 const casesDir = path.join(process.cwd(), "tests", "runtime-trace-tests", "cases");
 
-describe("convert between ts<->py ", async () => {
-    // debug info
-    console.log("Python3 version:")
-    console.log(await runProcAsync("python3 --version", ""))
-    console.log("node version:")
-    console.log(await runProcAsync("node --version", ""))
-
+describe("convert between ts<->py ", () => {
     // TODO: can this be moved to a mocha before() block?
     let tsAndPyFiles: string[]
 

--- a/tests/runtime-trace-tests/tracerunner.ts
+++ b/tests/runtime-trace-tests/tracerunner.ts
@@ -242,7 +242,6 @@ async function convertTs2Py(tsFile: string): Promise<string> {
 
 async function convertPy2Ts(pyFile: string): Promise<string> {
     let tsCode = await util.py2tsAsync(pyFile)
-    console.dir(tsCode)
     const tsFile = path.join(util.replaceFileExtension(pyFile, ".py.ts"));
     writeFileStringSync(tsFile, tsCode.ts)
     return tsFile

--- a/tests/runtime-trace-tests/tracerunner.ts
+++ b/tests/runtime-trace-tests/tracerunner.ts
@@ -75,9 +75,9 @@ function writeFileStringSync(filePath: string, content: string) {
 async function testTsOrPy(tsOrPyFile: string): Promise<void> {
     // debug info
     console.log("Python3 version:")
-    runProcAsync("python3 --version", "")
+    console.log(await runProcAsync("python3 --version", ""))
     console.log("node version:")
-    runProcAsync("node --version", "")
+    console.log(await runProcAsync("node --version", ""))
 
     let ext = path.extname(tsOrPyFile)
     let isPy = ext === ".py"

--- a/tests/runtime-trace-tests/tracerunner.ts
+++ b/tests/runtime-trace-tests/tracerunner.ts
@@ -73,6 +73,12 @@ function writeFileStringSync(filePath: string, content: string) {
 }
 
 async function testTsOrPy(tsOrPyFile: string): Promise<void> {
+    // debug info
+    console.log("Python3 version:")
+    runProcAsync("python3 --version", "")
+    console.log("node version:")
+    runProcAsync("node --version", "")
+
     let ext = path.extname(tsOrPyFile)
     let isPy = ext === ".py"
     let isTs = ext === ".ts"


### PR DESCRIPTION
Enables the Python<->STS "runtime trace tests" which are our main correctness tests for Python<->STS in Travis CI.