### PR TITLE
Bump pxt-blockly to 2.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.5",
-    "pxt-blockly": "2.1.11",
+    "pxt-blockly": "2.1.12",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
Allows custom image URL as Blockly workspace background (Minecraft HOC)