### PR TITLE
Enable undo button on project load

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -556,7 +556,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     hasUndo() {
-        return this.editor ? this.editor.undoStack_.length != 0 : false;
+        // undo is true if undoStack has items, or if both undo and redo are empty (first project load)
+        return this.editor ? this.editor.undoStack_.length != 0
+            || (this.editor.undoStack_.length == 0 && this.editor.redoStack_.length == 0) : false;
     }
 
     undo() {

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -96,8 +96,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     private getUndoRedo(view: View): JSX.Element[] {
         const hasUndo = this.props.parent.editor.hasUndo();
         const hasRedo = this.props.parent.editor.hasRedo();
-        return [<EditorToolbarButton icon='xicon undo' className={`editortools-btn undo-editortools-btn} ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo")} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} onButtonClick={this.undo} view={this.getViewString(view)} key="undo" />,
-        <EditorToolbarButton icon='xicon redo' className={`editortools-btn redo-editortools-btn} ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo")} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} onButtonClick={this.redo} view={this.getViewString(view)} key="redo" />]
+        return [<EditorToolbarButton icon='xicon undo' className={`editortools-btn undo-editortools-btn ${!hasUndo ? 'disabled' : ''}`} title={lf("Undo")} ariaLabel={lf("{0}, {1}", lf("Undo"), !hasUndo ? lf("Disabled") : "")} onButtonClick={this.undo} view={this.getViewString(view)} key="undo" />,
+        <EditorToolbarButton icon='xicon redo' className={`editortools-btn redo-editortools-btn ${!hasRedo ? 'disabled' : ''}`} title={lf("Redo")} ariaLabel={lf("{0}, {1}", lf("Redo"), !hasRedo ? lf("Disabled") : "")} onButtonClick={this.redo} view={this.getViewString(view)} key="redo" />]
     }
 
     private getZoomControl(view: View): JSX.Element[] {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1336, where "undo" is disabled by default and the editor buttons don't re-render on workspace drag. Rather than forcing a re-render, we just enable the undo button when the user has no actions. It will be disabled as usual if the user has performed actions & reached the end of the undo stack.