### PR TITLE
fix delete in electron app on mac

### DIFF
--- a/webapp/src/fileworkspace.ts
+++ b/webapp/src/fileworkspace.ts
@@ -47,7 +47,7 @@ function setAsync(h: Header, prevVersion: pxt.workspace.Version, text?: ScriptTe
         config: null,
         header: h,
         path: h.path,
-        isDeleted: text === delText
+        isDeleted: h.isDeleted
     }
 
     if (text) {

--- a/webapp/src/fileworkspace.ts
+++ b/webapp/src/fileworkspace.ts
@@ -39,8 +39,6 @@ function getAsync(h: Header) {
         })
 }
 
-const delText = {}
-
 function setAsync(h: Header, prevVersion: pxt.workspace.Version, text?: ScriptText): Promise<pxt.workspace.Version> {
     let pkg: pxt.FsPkg = {
         files: [],
@@ -84,7 +82,8 @@ function setAsync(h: Header, prevVersion: pxt.workspace.Version, text?: ScriptTe
 }
 
 function deleteAsync(h: Header, prevVer: any) {
-    return setAsync(h, prevVer, delText)
+    h.isDeleted = true;
+    return setAsync(h, prevVer, {});
 }
 
 async function listAsync(): Promise<Header[]> {


### PR DESCRIPTION
makes deleting a project in the electron app on mac actually delete the project

Issue was that https://github.com/microsoft/pxt/blob/7a2f76aee965c687813743ea09ea6fffb1ca2c85/webapp/src/app.tsx#L1079 was setting the text to a new instance of {}, which is not equal to ``delText``.

``delText`` was added in a rather large pr for cloud sync (https://github.com/microsoft/pxt/pull/4550/files#diff-b91ea3a494edc6744e928a35b7b150b5R42); if there does need to be distinction between `h.isDeleted` and `pkg.isDeleted` for cloud sync, I could just make it read from ``pkg.header.isDeleted`` on the electron app side instead