### PR TITLE
fix typings for electron app

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -391,7 +391,7 @@ declare namespace pxt {
 
     interface PackageApiInfo {
         sha: string;
-        apis: pxtc.ApisInfo;
+        apis: ts.pxtc.ApisInfo;
     }
 }
 


### PR DESCRIPTION
quick patch to fix typings for electron app; pxtc is an alias for ts.pxtc created in pxtlib/commonutil which everything else includes, but the electron app just copies this typings folder over without that alias-ing so it got upset when trying to compile.