### PR TITLE
Fix array inference regression when vars are only assigned []

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -71,8 +71,8 @@ namespace pxt.blocks {
             public link: Point,
             public type: string,
             public parentType?: Point,
-            public childType?: Point
-
+            public childType?: Point,
+            public isArrayType?: boolean
         ) { }
     }
 
@@ -145,13 +145,14 @@ namespace pxt.blocks {
 
         p1.link = _p2;
         _p1.link = _p2;
+        _p1.isArrayType = _p2.isArrayType;
         p1.type = null;
         p2.type = t;
     }
 
     // Ground types.
-    function mkPoint(t: string): Point {
-        return new Point(null, t);
+    function mkPoint(t: string, isArrayType = false): Point {
+        return new Point(null, t, null, null, isArrayType);
     }
     const pNumber = mkPoint("number");
     const pBoolean = mkPoint("boolean");
@@ -219,7 +220,9 @@ namespace pxt.blocks {
                     }
                 }
             }
-            return tp || mkPoint(null);
+
+            if (tp) tp.isArrayType = true;
+            return tp || mkPoint(null, true);
         }
         else if (check === "T") {
             const func = e.stdCallTable[b.type];
@@ -473,7 +476,7 @@ namespace pxt.blocks {
         // assigned to), just unify it with int...
         e.allVariables.forEach((v: VarInfo) => {
             if (getConcreteType(v.type).type == null)
-                union(v.type, ground(pNumber.type));
+                union(v.type, ground(v.type.isArrayType ? "number[]" : pNumber.type));
         });
 
         function connectionCheck(i: Blockly.Input) {
@@ -512,6 +515,8 @@ namespace pxt.blocks {
         else if (!c.type) {
             c.parentType = p;
         }
+
+        p.isArrayType = true;
     }
 
     function getConcreteType(point: Point, found: Point[] = []) {
@@ -770,7 +775,7 @@ namespace pxt.blocks {
             t = find(t);
         }
 
-        if (isArrayType(t.type)) {
+        if (isArrayType(t.type) || t.isArrayType) {
             return mkText("[]");
         }
 

--- a/tests/blocklycompiler-test/baselines/just_empty_array.ts
+++ b/tests/blocklycompiler-test/baselines/just_empty_array.ts
@@ -1,0 +1,4 @@
+let list: number[] = []
+function doSomething () {
+    list = []
+}

--- a/tests/blocklycompiler-test/cases/just_empty_array.blocks
+++ b/tests/blocklycompiler-test/cases/just_empty_array.blocks
@@ -1,0 +1,20 @@
+<xml xmlns="https://developers.google.com/blockly/xml">
+<variables>
+<variable id="PZJKN]1!XrDxHe`+(NM%">list</variable>
+</variables>
+<block type="function_definition" x="0" y="16">
+<mutation name="doSomething" functionid=";PBXo6rs4B^lRZgUFhnT" />
+<field name="function_name">doSomething</field>
+<statement name="STACK">
+<block type="variables_set">
+<field name="VAR" id="PZJKN]1!XrDxHe`+(NM%">list</field>
+<value name="VALUE">
+<block type="lists_create_with">
+<mutation items="0" />
+</block>
+</value>
+</block>
+</statement>
+</block>
+<block type="pxt-on-start" x="390" y="10" />
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -291,6 +291,10 @@ describe("blockly compiler", function () {
         it("should correctly infer types for arrays initialized to empty", (done: () => void) => {
             blockTestAsync("empty_array_inference").then(done, done);
         });
+
+        it("should give variables that are only assigned the empty array a type of number[]", (done: () => void) => {
+            blockTestAsync("just_empty_array").then(done, done);
+        });
     });
 
     describe("compiling logic", () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2508
Fixes https://github.com/microsoft/pxt-arcade/issues/1444

This was regressed by https://github.com/microsoft/pxt/pull/6112. Our blockly compiler tries to make any variable that doesn't have a narrowed type into a number. I'm adding a hack to fix this very specific case of assigning a variable to an empty array and nothing else. We can't narrow the type based on the empty array, but we need to use number[] and not number.