### PR TITLE
don't crash on --rebundle

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1962,7 +1962,11 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         isPrj = true
                 })
                 .then(() => options.quick ? null : testForBuildTargetAsync(isPrj || (!options.skipCore && isCore), builtInfo[dirname] && builtInfo[dirname].sha))
-                .then(({ options, api, sha: packageSha }) => {
+                .then(res => {
+                    if (!res)
+                        return;
+
+                    const { options, api, sha: packageSha } = res;
                     // For the projects, we need to save the base HEX file to the offline HEX cache
                     if (isPrj && pxt.appTarget.compile && pxt.appTarget.compile.hasHex) {
                         if (!options) {
@@ -1989,7 +1993,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                             sha: packageSha
                         };
                     }
-                })
+                });
         }, /*includeProjects*/ true))
         .then(() => {
             // patch icons in bundled packages

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -415,6 +415,9 @@ interface BundledPackage {
 }
 
 async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Map<pxt.PackageApiInfo>): Promise<pxtc.ApisInfo> {
+    if (!bundled || !bundled.length)
+        return null;
+
     const bundledPackages: BundledPackage[] = pxt.appTarget.bundleddirs.map(dirname => {
         const pack = pxt.appTarget.bundledpkgs[dirname.substr(dirname.lastIndexOf("/") + 1)];
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -415,8 +415,7 @@ interface BundledPackage {
 }
 
 async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Map<pxt.PackageApiInfo>): Promise<pxtc.ApisInfo> {
-    if (!bundled || !bundled.length)
-        return null;
+    if (!bundled) return null;
 
     const bundledPackages: BundledPackage[] = pxt.appTarget.bundleddirs.map(dirname => {
         const pack = pxt.appTarget.bundledpkgs[dirname.substr(dirname.lastIndexOf("/") + 1)];
@@ -432,7 +431,10 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
 
     const usedPackages = project.pkgAndDeps();
     const externalPackages: pkg.EditorPackage[] = [];
-    const usedInfo: pxt.PackageApiInfo[] = [bundled["libs/" + pxt.appTarget.corepkg]];
+    const corePkg = bundled["libs/" + pxt.appTarget.corepkg];
+    if (!corePkg) return null;
+
+    const usedInfo: pxt.PackageApiInfo[] = [corePkg];
 
     for (const dep of usedPackages) {
         if (dep.id === "built" || dep.isTopLevel()) continue;


### PR DESCRIPTION
I'm getting a crash on rebundle because it hits the `null` path and tries to destructure null