### PR TITLE
Fixing two API cache bugs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2008,12 +2008,12 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
 
             // Trim redundant API info from packages
             const coreDirname = "libs/" + pxt.appTarget.corepkg;
-            const blocksInfo = builtInfo[coreDirname];
+            const coreInfo = builtInfo[coreDirname];
 
-            if (blocksInfo) {
+            if (coreInfo) {
                 Object.keys(builtInfo).filter(k => k !== coreDirname).map(k => builtInfo[k]).forEach(info => {
-                    deleteOverlappingKeys(blocksInfo.apis.byQName, info.apis.byQName)
-                    deleteOverlappingKeys(blocksInfo.apis.jres, info.apis.jres)
+                    deleteRedundantSymbols(coreInfo.apis.byQName, info.apis.byQName)
+                    deleteRedundantSymbols(coreInfo.apis.jres, info.apis.jres)
                 });
             }
 
@@ -2048,6 +2048,33 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
         .then(() => {
             console.log("target.json built.")
         })
+}
+
+function deleteRedundantSymbols(core: pxt.Map<pxtc.SymbolInfo | pxt.JRes>, trg: pxt.Map<pxtc.SymbolInfo | pxt.JRes>) {
+    const ignoredKeys = ["fileName", "pkg"]
+
+    for (const key of Object.keys(trg)) {
+        if (flatJSONEquals(core[key], trg[key])) delete trg[key];
+    }
+
+    function flatJSONEquals(a: any, b: any) {
+        if (a === b) return true;
+
+        const tp = typeof a;
+        if (tp !== typeof b || tp !== "object") return false;
+
+        const keysa = Object.keys(a).filter(k => ignoredKeys.indexOf(k) === -1);
+        const keysb = Object.keys(b).filter(k => ignoredKeys.indexOf(k) === -1);
+
+        if (keysa.length !== keysb.length) return false;
+
+        for (const key of keysa) {
+            if (keysb.indexOf(key) === -1) return false;
+            if (!flatJSONEquals(a[key], b[key])) return false;
+        }
+
+        return true;
+    }
 }
 
 function pxtVersion(): string {
@@ -5983,12 +6010,6 @@ function initGlobals() {
     g.pxt = pxt;
     g.ts = ts;
     g.pxtc = pxtc;
-}
-
-function deleteOverlappingKeys(src: any, trg: any) {
-    for (const key of Object.keys(trg)) {
-        if (src[key]) delete trg[key];
-    }
 }
 
 initGlobals();

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -417,6 +417,15 @@ interface BundledPackage {
 async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Map<pxt.PackageApiInfo>): Promise<pxtc.ApisInfo> {
     if (!bundled) return null;
 
+    const corePkg = bundled["libs/" + pxt.appTarget.corepkg];
+    if (!corePkg) return null;
+
+    // If the project has a TypeScript file beside main.ts, it could export blocks so we can't use the cache
+    const files = project.getAllFiles();
+    if (Object.keys(files).some(filename => filename != "main.ts" && filename.indexOf("/") === -1 && pxt.Util.endsWith(filename, ".ts"))) {
+        return null;
+    }
+
     const bundledPackages: BundledPackage[] = pxt.appTarget.bundleddirs.map(dirname => {
         const pack = pxt.appTarget.bundledpkgs[dirname.substr(dirname.lastIndexOf("/") + 1)];
 
@@ -431,9 +440,6 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
 
     const usedPackages = project.pkgAndDeps();
     const externalPackages: pkg.EditorPackage[] = [];
-    const corePkg = bundled["libs/" + pxt.appTarget.corepkg];
-    if (!corePkg) return null;
-
     const usedInfo: pxt.PackageApiInfo[] = [corePkg];
 
     for (const dep of usedPackages) {


### PR DESCRIPTION
1. In Minecraft we have a package that overrides APIs in the core package, so tweaking the cache logic so that it will override the APIs if they are different. Nothing changes for GitHub packages
1. Fixes the `custom.ts` scenario for exporting blocks from the user project