### PR TITLE
Unify pxt.json stringifycation

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1056,7 +1056,7 @@ function uploadCoreAsync(opts: UploadOptions) {
                             // path config before storing
                             const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
                             if (/^\//.test(config.icon)) config.icon = opts.localDir + "docs" + config.icon;
-                            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
+                            res[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(config);
                         })
                         data = Buffer.from((isJs ? targetJsPrefix : '') + JSON.stringify(trg, null, 2), "utf8")
                     } else {
@@ -1075,7 +1075,7 @@ function uploadCoreAsync(opts: UploadOptions) {
                             // path config before storing
                             const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
                             if (config.icon) config.icon = uploadArtFile(config.icon);
-                            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
+                            res[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(config);
                         })
                         content = JSON.stringify(trg, null, 4);
                         if (isJs)
@@ -2007,7 +2007,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         .filter(ip => fs.existsSync("docs" + ip))
                         .forEach(ip => config.icon = ip);
 
-                res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
+                res[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(config);
             })
 
             // Trim redundant API info from packages

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -935,7 +935,7 @@ namespace pxt.cpp {
                 private: true,
                 dependencies: res.npmDependencies,
             }
-            res.generatedFiles["/package.json"] = JSON.stringify(packageJson, null, 4) + "\n"
+            res.generatedFiles["/package.json"] = JSON.stringify(packageJson, null, 4)
         } else if (isCodal) {
             let cs = compileService
             let cfg = U.clone(cs.codalDefinitions) || {}
@@ -955,7 +955,7 @@ namespace pxt.cpp {
                 k = k.replace(/^codal\./, "device.").toUpperCase().replace(/\./g, "_")
                 cfg[k] = v
             })
-            res.generatedFiles["/codal.json"] = JSON.stringify(codalJson, null, 4) + "\n"
+            res.generatedFiles["/codal.json"] = JSON.stringify(codalJson, null, 4)
             pxt.debug(`codal.json: ${res.generatedFiles["/codal.json"]}`);
         } else if (isPlatformio) {
             const iniLines = compileService.platformioIni.slice()

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -935,7 +935,7 @@ namespace pxt.cpp {
                 private: true,
                 dependencies: res.npmDependencies,
             }
-            res.generatedFiles["/package.json"] = JSON.stringify(packageJson, null, 4)
+            res.generatedFiles["/package.json"] = JSON.stringify(packageJson, null, 4) + "\n"
         } else if (isCodal) {
             let cs = compileService
             let cfg = U.clone(cs.codalDefinitions) || {}
@@ -955,7 +955,7 @@ namespace pxt.cpp {
                 k = k.replace(/^codal\./, "device.").toUpperCase().replace(/\./g, "_")
                 cfg[k] = v
             })
-            res.generatedFiles["/codal.json"] = JSON.stringify(codalJson, null, 4)
+            res.generatedFiles["/codal.json"] = JSON.stringify(codalJson, null, 4) + "\n"
             pxt.debug(`codal.json: ${res.generatedFiles["/codal.json"]}`);
         } else if (isPlatformio) {
             const iniLines = compileService.platformioIni.slice()

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1212,7 +1212,7 @@ namespace pxt.github {
                 }
             }
         }
-        return JSON.stringify(r, null, 4);
+        return pxt.Package.stringifyConfig(r);
 
         function mergeFiles(fA: string[], fO: string[], fB: string[]): string[] {
             const r: string[] = [];

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -235,7 +235,7 @@ cache:
                 newCfg[f] = configMap[f]
         }
 
-        files[pxt.CONFIG_NAME] = JSON.stringify(newCfg, null, 4)
+        files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(newCfg);
 
         return files
     }

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -151,7 +151,7 @@ namespace pxt {
             // path config before storing
             const config = JSON.parse(res[pxt.CONFIG_NAME]) as pxt.PackageConfig;
             if (config.icon) config.icon = pxt.BrowserUtils.patchCdn(config.icon);
-            res[pxt.CONFIG_NAME] = JSON.stringify(config, null, 4);
+            res[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(config);
         })
 
         // patch any pre-configured query url appTheme overrides

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -5,6 +5,11 @@
 
 namespace pxt {
     export class Package {
+        static stringifyConfig(config: pxt.PackageConfig): string {
+            // github adds a newline when web editing
+            return JSON.stringify(config, null, 4) + "\n"
+        }
+
         static getConfigAsync(pkgTargetVersion: string, id: string, fullVers: string): Promise<pxt.PackageConfig> {
             return Promise.resolve().then(() => {
                 if (pxt.github.isGithubId(fullVers)) {
@@ -109,7 +114,7 @@ namespace pxt {
         saveConfig() {
             const cfg = U.clone(this.config)
             delete cfg.additionalFilePaths
-            const text = JSON.stringify(cfg, null, 4)
+            const text = pxt.Package.stringifyConfig(cfg);
             this.host().writeFile(this, pxt.CONFIG_NAME, text)
         }
 
@@ -919,7 +924,7 @@ namespace pxt {
                             cfg.dependencies[k] = v
                         }
                     })
-                    files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4)
+                    files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
                     for (let f of this.getFiles()) {
                         // already stored
                         if (f == pxt.CONFIG_NAME) continue;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -119,7 +119,7 @@ namespace pxt.runner {
                             dependencies.forEach((d: string) => {
                                 addPackageToConfig(cfg, d);
                             });
-                            files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
+                            files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
                         }
                         return Promise.resolve()
                     } else if (proto == "docs") {
@@ -134,7 +134,7 @@ namespace pxt.runner {
 
                         if (!cfg.yotta) cfg.yotta = {};
                         cfg.yotta.ignoreConflicts = true;
-                        files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
+                        files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
                         epkg.setFiles(files);
                         return Promise.resolve();
                     } else if (proto == "invalid") {
@@ -176,7 +176,7 @@ namespace pxt.runner {
     function emptyPrjFiles() {
         let p = appTarget.tsprj
         let files = U.clone(p.files)
-        files[pxt.CONFIG_NAME] = JSON.stringify(p.config, null, 4)
+        files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(p.config);
         files["main.blocks"] = "";
         return files
     }
@@ -277,7 +277,7 @@ namespace pxt.runner {
                         //set the custom doc name from the URL.
                         let cfg = JSON.parse(epkg.files[pxt.CONFIG_NAME]) as pxt.PackageConfig;
                         cfg.name = window.location.href.split('/').pop().split(/[?#]/)[0];;
-                        epkg.files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
+                        epkg.files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
 
                         //Propgate the change to main package
                         mainPkg.config.name = cfg.name;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1969,7 +1969,7 @@ export class ProjectView
                 cfg.files.push(codeStop);
             }
         }
-        files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
+        files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
         return workspace.installAsync({
             name: cfg.name,
             meta: {},
@@ -2851,7 +2851,7 @@ export class ProjectView
         let f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
         let config = JSON.parse(f.content) as pxt.PackageConfig;
         config.name = name;
-        return f.setContentAsync(JSON.stringify(config, null, 4))
+        return f.setContentAsync(pxt.Package.stringifyConfig(config);)
             .then(() => {
                 if (this.state.header)
                     this.setState({

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2851,7 +2851,7 @@ export class ProjectView
         let f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
         let config = JSON.parse(f.content) as pxt.PackageConfig;
         config.name = name;
-        return f.setContentAsync(pxt.Package.stringifyConfig(config);)
+        return f.setContentAsync(pxt.Package.stringifyConfig(config))
             .then(() => {
                 if (this.state.header)
                     this.setState({

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2851,7 +2851,7 @@ export class ProjectView
         let f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
         let config = JSON.parse(f.content) as pxt.PackageConfig;
         config.name = name;
-        return f.setContentAsync(JSON.stringify(config, null, 4) + "\n")
+        return f.setContentAsync(JSON.stringify(config, null, 4))
             .then(() => {
                 if (this.state.header)
                     this.setState({

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -758,7 +758,10 @@ ${content}
                     </h3>
                     {needsCommit ?
                         <CommmitComponent parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} />
-                        : <div className="ui segment">{lf("No local changes found.")}</div>}
+                        : <div className="ui segment">
+                            {lf("No local changes found.")}
+                            {lf("Your project is saved in GitHub.")}
+                        </div>}
                     {displayDiffFiles.length ? <div className="ui">
                         {displayDiffFiles.map(df => this.showDiff(isBlocksMode, df))}
                     </div> : undefined}

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -251,7 +251,7 @@ export class EditorPackage {
             try {
                 let cfg = <pxt.PackageConfig>JSON.parse(cfgFile.content)
                 update(cfg);
-                return cfgFile.setContentAsync(JSON.stringify(cfg, null, 4))
+                return cfgFile.setContentAsync(pxt.Package.stringifyConfig(cfg))
                     .then(() => this.ksPkg.loadConfig())
             } catch (e) { }
         }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -251,7 +251,7 @@ export class EditorPackage {
             try {
                 let cfg = <pxt.PackageConfig>JSON.parse(cfgFile.content)
                 update(cfg);
-                return cfgFile.setContentAsync(JSON.stringify(cfg, null, 4) + "\n")
+                return cfgFile.setContentAsync(JSON.stringify(cfg, null, 4))
                     .then(() => this.ksPkg.loadConfig())
             } catch (e) { }
         }

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -52,7 +52,7 @@ export class Editor extends srceditor.Editor {
             return;
         }
         const f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
-        f.setContentAsync(JSON.stringify(this.config, null, 4)).then(() => {
+        f.setContentAsync(pxt.Package.stringifyConfig(cfg)).then(() => {
             pkg.mainPkg.config.name = c.name;
             this.parent.setState({ projectName: c.name });
             this.parent.forceUpdate()
@@ -169,7 +169,7 @@ export class Editor extends srceditor.Editor {
     }
 
     getCurrentSource() {
-        return JSON.stringify(this.config, null, 4)
+        return pxt.Package.stringifyConfig(this.config);
     }
 
     acceptsFile(file: pkg.File) {

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -52,7 +52,7 @@ export class Editor extends srceditor.Editor {
             return;
         }
         const f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
-        f.setContentAsync(JSON.stringify(this.config, null, 4) + "\n").then(() => {
+        f.setContentAsync(JSON.stringify(this.config, null, 4)).then(() => {
             pkg.mainPkg.config.name = c.name;
             this.parent.setState({ projectName: c.name });
             this.parent.forceUpdate()
@@ -169,7 +169,7 @@ export class Editor extends srceditor.Editor {
     }
 
     getCurrentSource() {
-        return JSON.stringify(this.config, null, 4) + "\n"
+        return JSON.stringify(this.config, null, 4)
     }
 
     acceptsFile(file: pkg.File) {

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -52,7 +52,7 @@ export class Editor extends srceditor.Editor {
             return;
         }
         const f = pkg.mainEditorPkg().lookupFile("this/" + pxt.CONFIG_NAME);
-        f.setContentAsync(pxt.Package.stringifyConfig(cfg)).then(() => {
+        f.setContentAsync(pxt.Package.stringifyConfig(c)).then(() => {
             pkg.mainPkg.config.name = c.name;
             this.parent.setState({ projectName: c.name });
             this.parent.forceUpdate()

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -182,7 +182,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                     // Set the name in the pxt.json (config)
                     let cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig
                     cfg.name = clonedHeader.name
-                    files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4);
+                    files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
                     return clonedHeader;
                 })
                 .then((clonedHeader) => workspace.saveAsync(clonedHeader, files))

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -821,7 +821,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
         const testFiles = pxtjson.testFiles || (pxtjson.testFiles = []);
         if (testFiles.indexOf("test.ts") < 0) {
             testFiles.push("test.ts");
-            currFiles[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
+            currFiles[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(pxtjson);
         }
     }
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -374,7 +374,7 @@ export function duplicateAsync(h: Header, text: ScriptText, rename?: boolean): P
         h.name = createDuplicateName(h);
         let cfg = JSON.parse(text[pxt.CONFIG_NAME]) as pxt.PackageConfig
         cfg.name = h.name
-        text[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4)
+        text[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
     delete h._rev
     delete (h as any)._id
@@ -500,7 +500,7 @@ export async function bumpAsync(hd: Header, newVer = "") {
     let files = await getTextAsync(hd.id)
     let cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig
     cfg.version = newVer || bumpedVersion(cfg)
-    files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4)
+    files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     await saveAsync(hd, files)
     return await commitAsync(hd, {
         message: cfg.version,
@@ -692,7 +692,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         }
         if (!cfg.name) {
             cfg.name = parsed.fullName.replace(/[^\w\-]/g, "")
-            files[pxt.CONFIG_NAME] = JSON.stringify(cfg, null, 4)
+            files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
         }
     }
 
@@ -821,7 +821,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
         const testFiles = pxtjson.testFiles || (pxtjson.testFiles = []);
         if (testFiles.indexOf("test.ts") < 0) {
             testFiles.push("test.ts");
-            currFiles[pxt.CONFIG_NAME] = JSON.stringify(pxtjson, null, 4);
+            currFiles[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
         }
     }
 


### PR DESCRIPTION
We need to consistently add a newline after JSON.stringify because github does add it when manually editing the pxt.json file. Otherwise it leads to weird "whitespace only changes" situations with github integration.
Adding a helper class and consistently using it to serialize.