### PR TITLE
support for setting large image as .mp4

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -185,8 +185,13 @@
             top: 0; right: 0;
             left: 30%; bottom: 0;
             padding: 0;
+            overflow:hidden;
             .image {
                 height: 400px;
+                background-size: cover;
+            }
+            .video {
+                width: 100%;
                 background-size: cover;
             }
         }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -710,9 +710,14 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     renderCore() {
         const { name, description, imageUrl, largeImageUrl, youTubeId, cardType, tags } = this.props;
 
-        const image = largeImageUrl || imageUrl || (youTubeId && `https://img.youtube.com/vi/${youTubeId}/0.jpg`);
+        let image = largeImageUrl || imageUrl || (youTubeId && `https://img.youtube.com/vi/${youTubeId}/0.jpg`);
         const tagColors: pxt.Map<string> = pxt.appTarget.appTheme.tagColors || {};
         const descriptions = description && description.split("\n");
+
+        if (/\.mp4$/.test(image) && pxt.BrowserUtils.isElectron()) {
+            // we don't support mp4 in electron, so try out luck as gif
+            image = image.replace(/\.mp4$/, ".gif");
+        }
 
         let clickLabel = lf("Show Instructions");
         if (cardType == "tutorial")
@@ -745,7 +750,8 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         return <div className="ui grid stackable padded">
             {image && <div className="imagewrapper">
-                <div className="image" style={{ backgroundImage: `url("${image}")` }} />
+                {/\.mp4$/.test(image) ? <video className="video" src={image} autoPlay={true} controls={false} loop={true} playsinline={true} />
+                    : <div className="image" style={{ backgroundImage: `url("${image}")` }} />}
             </div>}
             <div className="column twelve wide">
                 <div className="segment">

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -750,7 +750,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         return <div className="ui grid stackable padded">
             {image && <div className="imagewrapper">
-                {/\.mp4$/.test(image) ? <video className="video" src={image} autoPlay={true} controls={false} loop={true} playsinline={true} />
+                {/\.mp4$/.test(image) ? <video className="video" src={image} autoPlay={true} controls={false} loop={true} playsInline={true} />
                     : <div className="image" style={{ backgroundImage: `url("${image}")` }} />}
             </div>}
             <div className="column twelve wide">


### PR DESCRIPTION
We serve a large amount of large .gifs that could be 5x smaller as .mp4s.
- [x] support .mp4 files in largeimageurl
- [x] bail out of .gif in electron
![diff](https://user-images.githubusercontent.com/4175913/68364643-6b89f180-00e3-11ea-9c8f-83ddfe9d0597.gif)
