### PR TITLE
Changing the MemTranslationDb time entry

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -839,7 +839,7 @@ namespace pxt.BrowserUtils {
             const r = this.mem.get(lang, filename, branch);
             if (r) return Promise.resolve(r);
 
-            return this.db.getAsync<cEntry>(IndexedDbTranslationDb.TABLE, id)
+            return this.db.getAsync<ITranslationDbEntry>(IndexedDbTranslationDb.TABLE, id)
                 .then((res) => {
                     if (res) {
                         // store in-memory so that we don't try to download again

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -668,7 +668,7 @@ namespace pxt.BrowserUtils {
             }
         }
         setAsync(lang: string, filename: string, branch: string, etag: string, strings?: pxt.Map<string>, md?: string): Promise<void> {
-            this.set(lang, filename, branch, etag, Date.now(), strings);
+            this.set(lang, filename, branch, etag, Util.now(), strings);
             return Promise.resolve();
         }
         clearAsync() {
@@ -855,7 +855,7 @@ namespace pxt.BrowserUtils {
         setAsync(lang: string, filename: string, branch: string, etag: string, strings?: pxt.Map<string>, md?: string): Promise<void> {
             lang = (lang || "en-US").toLowerCase(); // normalize locale
             const id = this.mem.key(lang, filename, branch);
-            let time = Date.now();
+            let time = Util.now();
             this.mem.set(lang, filename, branch, etag, time, strings, md);
 
             if (strings) {


### PR DESCRIPTION
This used to 24 hours ahead of current time (Date.now). But indexdb stored just the current time. 
This means once cached in the MemTranslationDb the cache never expires for that session. 

It is unclear how this is better, when the time stamp just should match the existing timestamp. Caller of the getAsync decides how to expire the cache. 