### PR TITLE
Stay in editor after loading tutorial from hash

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3727,12 +3727,12 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
         case "tutorial": // shortcut to a tutorial. eg: #tutorial:tutorials/getting-started
             pxt.tickEvent("hash.tutorial")
             editor.startTutorial(hash.arg);
-            pxt.BrowserUtils.changeHash("");
+            pxt.BrowserUtils.changeHash("editor");
             return true;
-        case "recipe": // shortcut to a tutorial. eg: #tutorial:tutorials/getting-started
+        case "recipe": // shortcut to a recipe. eg: #recipe:recipes/getting-started
             pxt.tickEvent("hash.recipe")
             editor.startTutorial(hash.arg, undefined, true);
-            pxt.BrowserUtils.changeHash("");
+            pxt.BrowserUtils.changeHash("editor");
             return true;
         case "home": // shortcut to home
             pxt.tickEvent("hash.home");


### PR DESCRIPTION
Kind of an edge case, but if the tutorial is loading and the window refreshes before the #editor is added (pretty hard to hit in the wild, but can repro consistently with a throttled connection + timed refreshing), it will load the home screen. Only comes up in Minecraft, because they are heavily using the #tutorial hash command and often have to work on a slow connection, I guess.