### PR TITLE
Blockly merge (part 1)

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1580,7 +1580,7 @@ namespace pxt.blocks {
         }
         const api = e.stdCallTable[b.type];
         const key = callKey(e, b);
-        const hash = ts.pxtc.Util.codalHash16(key);
+        const hash = 1 + ts.pxtc.Util.codalHash16(key);
         if (api && api.attrs.afterOnStart)
             return hash;
         else
@@ -1725,6 +1725,8 @@ namespace pxt.blocks {
     export function callKey(e: Environment, b: Blockly.Block): string {
         if (b.type == ts.pxtc.ON_START_TYPE)
             return JSON.stringify({ name: ts.pxtc.ON_START_TYPE });
+        else if (b.type == ts.pxtc.FUNCTION_DEFINITION_TYPE)
+            return JSON.stringify({ type: "function", name: b.getFieldValue("function_name") });
 
         const call = e.stdCallTable[b.type];
         if (call) {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1579,12 +1579,12 @@ namespace pxt.blocks {
             return 0;
         }
         const api = e.stdCallTable[b.type];
-        if (api && api.attrs.afterOnStart) {
-            return 1;
-        }
-        else {
-            return -1;
-        }
+        const key = callKey(e, b);
+        const hash = ts.pxtc.Util.codalHash16(key);
+        if (api && api.attrs.afterOnStart)
+            return hash;
+        else
+            return -hash;
     }
 
     function compileWorkspace(e: Environment, w: Blockly.Workspace, blockInfo: pxtc.BlocksInfo): [JsNode[], BlockDiagnostic[]] {

--- a/pxtblocks/blocklydiff.ts
+++ b/pxtblocks/blocklydiff.ts
@@ -376,4 +376,9 @@ namespace pxt.blocks {
                 visDom(child, f);
         }
     }
+
+    export function mergeXml(xmlA: string, xmlO: string, xmlB: string): string {
+        // TODO
+        return undefined;
+    }
 }

--- a/pxtblocks/blocklydiff.ts
+++ b/pxtblocks/blocklydiff.ts
@@ -42,8 +42,6 @@ namespace pxt.blocks {
         }
     }
 
-    //const ADD_IMAGE_DATAURI =
-    //   'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4KCjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgdmVyc2lvbj0iMS4xIgogICBpZD0icmVwZWF0IgogICB4PSIwcHgiCiAgIHk9IjBweCIKICAgdmlld0JveD0iMCAwIDI0IDI0IgogICBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAyNCAyNDsiCiAgIHhtbDpzcGFjZT0icHJlc2VydmUiCiAgIGlua3NjYXBlOnZlcnNpb249IjAuOTEgcjEzNzI1IgogICBzb2RpcG9kaTpkb2NuYW1lPSJhZGQuc3ZnIj48bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGExNSI+PHJkZjpSREY+PGNjOldvcmsKICAgICAgICAgcmRmOmFib3V0PSIiPjxkYzpmb3JtYXQ+aW1hZ2Uvc3ZnK3htbDwvZGM6Zm9ybWF0PjxkYzp0eXBlCiAgICAgICAgICAgcmRmOnJlc291cmNlPSJodHRwOi8vcHVybC5vcmcvZGMvZGNtaXR5cGUvU3RpbGxJbWFnZSIgLz48ZGM6dGl0bGU+cmVwZWF0PC9kYzp0aXRsZT48L2NjOldvcms+PC9yZGY6UkRGPjwvbWV0YWRhdGE+PGRlZnMKICAgICBpZD0iZGVmczEzIiAvPjxzb2RpcG9kaTpuYW1lZHZpZXcKICAgICBwYWdlY29sb3I9IiNmZjQ4MjEiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgYm9yZGVyb3BhY2l0eT0iMSIKICAgICBvYmplY3R0b2xlcmFuY2U9IjEwIgogICAgIGdyaWR0b2xlcmFuY2U9IjEwIgogICAgIGd1aWRldG9sZXJhbmNlPSIxMCIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMCIKICAgICBpbmtzY2FwZTpwYWdlc2hhZG93PSIyIgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTY4MCIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSI5NjkiCiAgICAgaWQ9Im5hbWVkdmlldzExIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpbmtzY2FwZTp6b29tPSIxOS42NjY2NjciCiAgICAgaW5rc2NhcGU6Y3g9IjEyLjkxNTI1NCIKICAgICBpbmtzY2FwZTpjeT0iMTYuMDY3Nzk2IgogICAgIGlua3NjYXBlOndpbmRvdy14PSIwIgogICAgIGlua3NjYXBlOndpbmRvdy15PSIwIgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjAiCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0icmVwZWF0IiAvPjxzdHlsZQogICAgIHR5cGU9InRleHQvY3NzIgogICAgIGlkPSJzdHlsZTMiPgoJLnN0MHtmaWxsOiNDRjhCMTc7fQoJLnN0MXtmaWxsOiNGRkZGRkY7fQo8L3N0eWxlPjx0aXRsZQogICAgIGlkPSJ0aXRsZTUiPnJlcGVhdDwvdGl0bGU+PHJlY3QKICAgICBzdHlsZT0ib3BhY2l0eToxO2ZpbGw6I2ZmZmZmZjtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZTtzdHJva2Utd2lkdGg6MTtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjQ7c3Ryb2tlLWRhc2hhcnJheTpub25lO3N0cm9rZS1kYXNob2Zmc2V0OjA7c3Ryb2tlLW9wYWNpdHk6MC4wNzg0MzEzNyIKICAgICBpZD0icmVjdDQxNDMiCiAgICAgd2lkdGg9IjQuMDUwMDAwMiIKICAgICBoZWlnaHQ9IjEyLjM5NzA1IgogICAgIHg9IjkuOTc1MDAwNCIKICAgICB5PSItMTguMTk4NTI2IgogICAgIHJ4PSIwLjgxIgogICAgIHJ5PSIwLjgxIgogICAgIHRyYW5zZm9ybT0ic2NhbGUoMSwtMSkiIC8+PHJlY3QKICAgICBzdHlsZT0ib3BhY2l0eToxO2ZpbGw6I2ZmZmZmZjtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZTtzdHJva2Utd2lkdGg6MTtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjQ7c3Ryb2tlLWRhc2hhcnJheTpub25lO3N0cm9rZS1kYXNob2Zmc2V0OjA7c3Ryb2tlLW9wYWNpdHk6MC4wNzg0MzEzNyIKICAgICBpZD0icmVjdDQxNDMtMSIKICAgICB3aWR0aD0iNC4wNTAwMDAyIgogICAgIGhlaWdodD0iMTIuMzk3MTE5IgogICAgIHg9IjkuOTc1MDAwNCIKICAgICB5PSI1LjgwMTQ0MDciCiAgICAgcng9IjAuODEiCiAgICAgcnk9IjAuODEiCiAgICAgdHJhbnNmb3JtPSJtYXRyaXgoMCwxLDEsMCwwLDApIiAvPjxjaXJjbGUKICAgICBzdHlsZT0ib3BhY2l0eToxO2ZpbGw6bm9uZTtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6I2ZmZmZmZjtzdHJva2Utd2lkdGg6MjtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjQ7c3Ryb2tlLWRhc2hhcnJheTpub25lO3N0cm9rZS1kYXNob2Zmc2V0OjA7c3Ryb2tlLW9wYWNpdHk6MSIKICAgICBpZD0icGF0aDQxMzYiCiAgICAgY3g9IjEyIgogICAgIGN5PSIxMiIKICAgICByPSIxMC41MDMxOTEiIC8+PC9zdmc+';
     function diffWorkspaceNoEvents(oldWs: Blockly.Workspace, newWs: Blockly.Workspace, options?: DiffOptions): DiffResult {
         pxt.tickEvent("blocks.diff", { started: 1 })
         options = options || {};
@@ -344,37 +342,6 @@ namespace pxt.blocks {
             // not changed!
             return false;
         }
-
-        function normalizedDom(b: Blockly.Block, keepChildren?: boolean): string {
-            const dom = Blockly.Xml.blockToDom(b, true);
-            normalizeAttributes(dom);
-            visDom(dom, (e) => {
-                normalizeAttributes(e);
-                if (!keepChildren) {
-                    if (e.localName == "next")
-                        e.remove(); // disconnect or unplug not working propertly
-                    if (e.localName == "statement")
-                        e.remove();
-                }
-            })
-            return Blockly.Xml.domToText(dom);
-        }
-
-        function normalizeAttributes(e: Element) {
-            e.removeAttribute("id");
-            e.removeAttribute("x");
-            e.removeAttribute("y");
-            e.removeAttribute("deletable");
-            e.removeAttribute("editable");
-            e.removeAttribute("movable")
-        }
-
-        function visDom(el: Element, f: (e: Element) => void) {
-            if (!el) return;
-            f(el);
-            for (const child of Util.toArray(el.children))
-                visDom(child, f);
-        }
     }
 
     export function mergeXml(xmlA: string, xmlO: string, xmlB: string): string {
@@ -383,5 +350,36 @@ namespace pxt.blocks {
 
         // TODO merge
         return undefined;
+    }
+
+    function normalizedDom(b: Blockly.Block, keepChildren?: boolean): string {
+        const dom = Blockly.Xml.blockToDom(b, true);
+        normalizeAttributes(dom);
+        visDom(dom, (e) => {
+            normalizeAttributes(e);
+            if (!keepChildren) {
+                if (e.localName == "next")
+                    e.remove(); // disconnect or unplug not working propertly
+                if (e.localName == "statement")
+                    e.remove();
+            }
+        })
+        return Blockly.Xml.domToText(dom);
+    }
+
+    function normalizeAttributes(e: Element) {
+        e.removeAttribute("id");
+        e.removeAttribute("x");
+        e.removeAttribute("y");
+        e.removeAttribute("deletable");
+        e.removeAttribute("editable");
+        e.removeAttribute("movable")
+    }
+
+    function visDom(el: Element, f: (e: Element) => void) {
+        if (!el) return;
+        f(el);
+        for (const child of Util.toArray(el.children))
+            visDom(child, f);
     }
 }

--- a/pxtblocks/blocklydiff.ts
+++ b/pxtblocks/blocklydiff.ts
@@ -378,7 +378,10 @@ namespace pxt.blocks {
     }
 
     export function mergeXml(xmlA: string, xmlO: string, xmlB: string): string {
-        // TODO
+        if (xmlA == xmlO) return xmlB;
+        if (xmlB == xmlO) return xmlA;
+
+        // TODO merge
         return undefined;
     }
 }

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1177,6 +1177,9 @@ namespace pxt.github {
                     r[key] = vA;
             } else {
                 switch (key) {
+                    case "name":
+                        r[key] = mergeString(vA, vO, vB);
+                        break;
                     case "version": // pick highest version
                         r[key] = pxt.semver.strcmp(vA, vB) > 0 ? vA : vB;
                         break;
@@ -1213,6 +1216,10 @@ namespace pxt.github {
             }
         }
         return pxt.Package.stringifyConfig(r);
+
+        function mergeString(fA: string, fO: string, fB: string): string {
+            return fA == fO ? fB : fA;
+        }
 
         function mergeFiles(fA: string[], fO: string[], fB: string[]): string[] {
             const r: string[] = [];

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1178,7 +1178,7 @@ namespace pxt.github {
             } else {
                 switch (key) {
                     case "name":
-                        r[key] = mergeString(vA, vO, vB);
+                        r[key] = mergeName(vA, vO, vB);
                         break;
                     case "version": // pick highest version
                         r[key] = pxt.semver.strcmp(vA, vB) > 0 ? vA : vB;
@@ -1217,8 +1217,11 @@ namespace pxt.github {
         }
         return pxt.Package.stringifyConfig(r);
 
-        function mergeString(fA: string, fO: string, fB: string): string {
-            return fA == fO ? fB : fA;
+        function mergeName(fA: string, fO: string, fB: string): string {
+            if (fA == fO) return fB;
+            if (fB == fO) return fA;
+            if (fA == lf("Untitled")) return fB;
+            return fA;
         }
 
         function mergeFiles(fA: string[], fO: string[], fB: string[]): string[] {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -16,6 +16,8 @@ namespace ts.pxtc {
     export const TS_OUTPUT_TYPE = "typescript_expression";
     export const PAUSE_UNTIL_TYPE = "pxt_pause_until";
     export const COLLAPSED_BLOCK = "pxt_collapsed_block"
+    export const FUNCTION_DEFINITION_TYPE = "function_definition";
+
     export const BINARY_JS = "binary.js";
     export const BINARY_ASM = "binary.asm";
     export const BINARY_HEX = "binary.hex";

--- a/tests/blocklycompiler-test/baselines/draggable_primitive_reporter.ts
+++ b/tests/blocklycompiler-test/baselines/draggable_primitive_reporter.ts
@@ -1,6 +1,6 @@
-radio.onReceivedNumber(function (receivedNumber) {
-  basic.showNumber(receivedNumber)
-})
 radio.onReceivedString(function (receivedString) {
   basic.showString(receivedString)
+})
+radio.onReceivedNumber(function (receivedNumber) {
+  basic.showNumber(receivedNumber)
 })

--- a/tests/blocklycompiler-test/baselines/functions_v2.ts
+++ b/tests/blocklycompiler-test/baselines/functions_v2.ts
@@ -1,22 +1,22 @@
 // Describe this function...
-function foo_noarg () {
-
-}
-// Describe this function...
-function foo_num (num: number) {
-
-}
-// Describe this function...
 function foo_string (text: string) {
-
+		
 }
 // Describe this function...
 function foo_bool (bool: boolean) {
-
+    
 }
 // Describe this function...
 function foo_all (num: number, text: string, bool: boolean) {
-
+    
+}
+// Describe this function...
+function foo_num (num: number) {
+    
+}
+// Describe this function...
+function foo_noarg () {
+    
 }
 foo_noarg()
 foo_num(1)

--- a/tests/blocklycompiler-test/baselines/mc_old_chat_blocks.ts
+++ b/tests/blocklycompiler-test/baselines/mc_old_chat_blocks.ts
@@ -1,14 +1,14 @@
+player.onChatCommand("run",  [ChatArgument.number],function ({ number }) {
+  let string = 0
+  if (number == string) {
+
+  }
+})
 player.onChatCommand("jump",  [ChatArgument.string, ChatArgument.number],function ({ string, number }) {
   if (number == 0) {
 
   }
   if (string == "") {
-
-  }
-})
-player.onChatCommand("run",  [ChatArgument.number],function ({ number }) {
-  let string = 0
-  if (number == string) {
 
   }
 })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -448,9 +448,12 @@ export class ProjectView
             if (this.state.embedSimView) this.setState({ embedSimView: false });
             return;
         }
-        if (this.isJavaScriptActive() || (this.shouldTryDecompile && !this.state.embedSimView)) this.textEditor.openBlocks();
-        // any other editeable .ts or pxt.json
-        else if (this.isAnyEditeableJavaScriptOrPackageActive()) {
+
+        const mainBlocks = pkg.mainEditorPkg().files["main.blocks"];
+        if (this.isJavaScriptActive() || (this.shouldTryDecompile && !this.state.embedSimView))
+            this.textEditor.openBlocks();
+        // any other editeable .ts or pxt.json; or empty mainblocks
+        else if (this.isAnyEditeableJavaScriptOrPackageActive() || !mainBlocks.content) {
             this.saveFileAsync().then(() => this.textEditor.openBlocks());
         } else {
             const header = this.state.header;
@@ -460,7 +463,7 @@ export class ProjectView
                 this.textEditor.openBlocks();
             }
             else {
-                this.setFile(pkg.mainEditorPkg().files["main.blocks"])
+                this.setFile(mainBlocks)
             }
         }
 

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -510,7 +510,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         let diffJSX: JSX.Element;
         if (!content) {
             // the xml payload needs to be decompiled
-            diffJSX = <p>{lf("Your blocks were updated. Open the editor to view the changes.")}</p>
+            diffJSX = <div className="ui basic segment">{lf("Your blocks were updated. Go back to the editor to view the changes.")}</div>
         } else {
             const markdown =
                 `

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -377,7 +377,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
 
     async commitAsync() {
         this.setState({ needsCommitMessage: false });
-        this.showLoading(lf("commit and push..."));
+        this.showLoading(lf("commit and push changes to GitHub..."));
         try {
             await this.commitCoreAsync()
             await this.maybeReloadAsync()

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -506,15 +506,22 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
     private createBlocksDiffJSX(f: pkg.File): { diffJSX: JSX.Element, legendJSX?: JSX.Element, conflicts: number } {
         const baseContent = f.baseGitContent || "";
         const content = f.content;
-        const markdown =
-            `
+
+        let diffJSX: JSX.Element;
+        if (!content) {
+            // the xml payload needs to be decompiled
+            diffJSX = <p>{lf("Your blocks were updated. Open the editor to view the changes.")}</p>
+        } else {
+            const markdown =
+                `
 \`\`\`diffblocksxml
 ${baseContent}
 ---------------------
 ${content}
 \`\`\`
 `;
-        const diffJSX = <markedui.MarkedContent key={`diffblocksxxml${f.name}`} parent={this.props.parent} markdown={markdown} />
+            diffJSX = <markedui.MarkedContent key={`diffblocksxxml${f.name}`} parent={this.props.parent} markdown={markdown} />
+        }
         const legendJSX = <p className="legend">
             <span><span className="added icon"></span>{lf("added, changed or moved")}</span>
             <span><span className="deleted icon"></span>{lf("deleted")}</span>

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -664,7 +664,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
                 text = pxt.github.mergeDiff3Config(files[path], oldEnt.blobContent, treeEnt.blobContent);
                 if (!text) // merge failed?
                     throw mergeError()
-            } if (/\.blocks$/.test(path)) {
+            } else if (/\.blocks$/.test(path)) {
                 // blocks file, try merging the blocks or clear it so that ts merge picks it up
                 const d3 = pxt.blocks.mergeXml(files[path], oldEnt.blobContent, treeEnt.blobContent);
                 // if xml merge fails, leave an empty xml payload to force decompilation

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -670,7 +670,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
                 // blocks file, try merging the blocks or clear it so that ts merge picks it up
                 const d3 = pxt.blocks.mergeXml(files[path], oldEnt.blobContent, treeEnt.blobContent);
                 // if xml merge fails, leave an empty xml payload to force decompilation
-                blocksNeedDecompilation = blocksNeedDecompilation || !!d3;
+                blocksNeedDecompilation = blocksNeedDecompilation || !d3;
                 text = d3 || "";
             } else {
                 const d3 = pxt.github.diff3(files[path], oldEnt.blobContent, treeEnt.blobContent, lf("local changes"), lf("remote changes (pulled from Github)"))

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -640,7 +640,8 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         const oldEnt = lookupFile(gitjson.commit, path)
         const hasChanges = files[path] != null && (!oldEnt || oldEnt.blobContent != files[path])
         if (!treeEnt) {
-            // file in pxt.json but not in git: changes were merge from the cloud but not pushed yet
+            // file in pxt.json but not in git: 
+            // changes were merged from the cloud but not pushed yet
             if (options.tryDiff3 && hasChanges)
                 return files[path];
             if (!justJSON)
@@ -663,6 +664,11 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
                 text = pxt.github.mergeDiff3Config(files[path], oldEnt.blobContent, treeEnt.blobContent);
                 if (!text) // merge failed?
                     throw mergeError()
+            } if (/\.blocks$/.test(path)) {
+                // blocks file, try merging the blocks or clear it so that ts merge picks it up
+                const d3 = pxt.blocks.mergeXml(files[path], oldEnt.blobContent, treeEnt.blobContent);
+                // if xml merge fails, leave an empty xml payload to force decompilation
+                text = d3 || "";
             } else {
                 const d3 = pxt.github.diff3(files[path], oldEnt.blobContent, treeEnt.blobContent, lf("local changes"), lf("remote changes (pulled from Github)"))
                 if (!d3) // merge failed?

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -670,7 +670,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
                 // blocks file, try merging the blocks or clear it so that ts merge picks it up
                 const d3 = pxt.blocks.mergeXml(files[path], oldEnt.blobContent, treeEnt.blobContent);
                 // if xml merge fails, leave an empty xml payload to force decompilation
-                blocksNeedDecompilation = blocksNeedDecompilation && !!d3;
+                blocksNeedDecompilation = blocksNeedDecompilation || !!d3;
                 text = d3 || "";
             } else {
                 const d3 = pxt.github.diff3(files[path], oldEnt.blobContent, treeEnt.blobContent, lf("local changes"), lf("remote changes (pulled from Github)"))


### PR DESCRIPTION
This change mostly ensures that no corruption occurs if merge errors happen in a blocks file. The merging of blocks relies on merged TS -> blocks. The current logic works as follows: 
* if the merge is trivial (unmodified A or B, just grab the B or A)
* clear the .blocks file to force a TS -> blocks decompilation path
* ensure that no conflicts were found in TS merges

- [x] **stable sort of top level events in blocks** (to guarantee stable merge of decompile js) @riknoll fixed 3 tests
- [x] unmodified blocks blockly merge
- [x] bail out to TS merge and decompilation
- [x] don't allow merge if merge errors + blocks outdated