### PR TITLE
Include docs in bundledDirs in static package

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2259,16 +2259,6 @@ function renderDocs(builtPackaged: string, localDir: string) {
     }
     pxt.log(`All docs written.`);
 
-    function appendDocsIfPresent(dir: string, folders: string[]) {
-        const docsDir = path.join(
-            dir,
-            "docs"
-        );
-        if (fs.existsSync(docsDir)) {
-            folders.push(docsDir);
-        }
-    }
-
     function getPackageDocs(dir: string, folders: string[], enqueued: Map<boolean>) {
         if (enqueued[dir])
             return;
@@ -2308,7 +2298,13 @@ function renderDocs(builtPackaged: string, localDir: string) {
             }
         }
 
-        appendDocsIfPresent(dir, folders);
+        const docsDir = path.join(
+            dir,
+            "docs"
+        );
+        if (fs.existsSync(docsDir)) {
+            folders.push(docsDir);
+        }
     }
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2207,7 +2207,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
     const docFolders = ["node_modules/pxt-core/common-docs"];
 
     if (fs.existsSync("node_modules/pxt-common-packages/docs")) {
-        docFolders.push("node_modules/pxt-core/common-docs");
+        docFolders.push("node_modules/pxt-common-packages/docs");
     }
 
     const handledDirectories = {}

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2210,9 +2210,9 @@ function renderDocs(builtPackaged: string, localDir: string) {
         docFolders.push("node_modules/pxt-core/common-docs");
     }
 
-    const enqueuedDirs = {}
+    const handledDirectories = {}
     for (const bundledDir of pxt.appTarget.bundleddirs || []) {
-        getPackageDocs(bundledDir, docFolders, enqueuedDirs);
+        getPackageDocs(bundledDir, docFolders, handledDirectories);
     }
 
     docFolders.push("docs");
@@ -2259,25 +2259,25 @@ function renderDocs(builtPackaged: string, localDir: string) {
     }
     pxt.log(`All docs written.`);
 
-    function getPackageDocs(dir: string, folders: string[], resolvedDirectories: Map<boolean>) {
-        if (resolvedDirectories[dir])
+    function getPackageDocs(dir: string, folders: string[], resolvedDirs: Map<boolean>) {
+        if (resolvedDirs[dir])
             return;
 
-        resolvedDirectories[dir] = true;
+        resolvedDirs[dir] = true;
 
         const jsonDir = path.join(dir, "pxt.json");
         const pxtjson = fs.existsSync(jsonDir) && (nodeutil.readJson(jsonDir) as pxt.PackageConfig);
 
         if (pxtjson) {
             if (pxtjson.additionalFilePath) {
-                getPackageDocs(path.join(dir, pxtjson.additionalFilePath), folders, resolvedDirectories);
+                getPackageDocs(path.join(dir, pxtjson.additionalFilePath), folders, resolvedDirs);
             }
 
             if (pxtjson.dependencies) {
                 Object.keys(pxtjson.dependencies).forEach(dep => {
                     const parts = /^file:(.+)$/i.exec(pxtjson.dependencies[dep]);
                     if (parts) {
-                        getPackageDocs(path.join(dir, parts[1]), folders, resolvedDirectories);
+                        getPackageDocs(path.join(dir, parts[1]), folders, resolvedDirs);
                     }
                 });
             }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2259,49 +2259,32 @@ function renderDocs(builtPackaged: string, localDir: string) {
     }
     pxt.log(`All docs written.`);
 
-    function getPackageDocs(dir: string, folders: string[], enqueued: Map<boolean>) {
-        if (enqueued[dir])
+    function getPackageDocs(dir: string, folders: string[], resolvedDirectories: Map<boolean>) {
+        if (resolvedDirectories[dir])
             return;
 
-        enqueued[dir] = true;
+        resolvedDirectories[dir] = true;
 
-        const pxtjson = nodeutil.readJson(
-            path.join(
-                dir,
-                "pxt.json"
-            )
-        ) as pxt.PackageConfig;
+        const jsonDir = path.join(dir, "pxt.json");
+        const pxtjson = fs.existsSync(jsonDir) && (nodeutil.readJson(jsonDir) as pxt.PackageConfig);
 
         if (pxtjson) {
             if (pxtjson.additionalFilePath) {
-                getPackageDocs(
-                    path.join(
-                        dir,
-                        pxtjson.additionalFilePath
-                    ),
-                    docFolders,
-                    enqueued
-                );
+                getPackageDocs(path.join(dir, pxtjson.additionalFilePath), folders, resolvedDirectories);
             }
 
             if (pxtjson.dependencies) {
                 Object.keys(pxtjson.dependencies).forEach(dep => {
                     const parts = /^file:(.+)$/i.exec(pxtjson.dependencies[dep]);
                     if (parts) {
-                        getPackageDocs(
-                            path.join(dir, parts[1]),
-                            folders,
-                            enqueued
-                        );
+                        getPackageDocs(path.join(dir, parts[1]), folders, resolvedDirectories);
                     }
                 });
             }
         }
 
-        const docsDir = path.join(
-            dir,
-            "docs"
-        );
+        const docsDir = path.join(dir, "docs");
+
         if (fs.existsSync(docsDir)) {
             folders.push(docsDir);
         }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1357

Almost none of the /reference docs in arcade were available in the electron app while offline, because they typically live with the code; e.g. https://github.com/microsoft/pxt-arcade/tree/master/libs/device/docs/reference/game and https://github.com/microsoft/pxt-common-packages/tree/master/libs/game/docs. This change packages up the docs from bundleddirs.

worth noting, in `getPackageDocs`, I'm recursing first to the additionalFilePath (typically where the package actually lives e.g. in common packages), then to any dependencies listed, and only after all that is done pushing the docs of the package to the render queue, so that the docs 'closest' to the repo get applied last / overwrite any previous ones. Intention here is that if you have the same reference doc in common-packages and the target, the common packages one should be overwritten by the targets version which would theoretically be more relevant.

also, only handling docs from local file dependencies (e.g. to common-packages, not to other github deps); can make it grab external dependencies as well, but I don't think we have any of those that immediately come to mind and I'm not sure they'd necessarily work in the offline app even if we did? 