### PR TITLE
Fix alignment of icons in non-transparent editor toolbad

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1162,7 +1162,7 @@ p.ui.font.small {
     .hideEditorFloats #editortools {
         height: @editorToolsCollapsedHeight;
     }
-    .hideEditorFloats #editortools > div > div > .ui.grid {
+    .hideEditorFloats.transparentEditorTools #editortools > div > div > .ui.grid {
         margin: auto;
     }
     .hideEditorFloats #editorToolbarArea {


### PR DESCRIPTION
The fix for Minecraft ( https://github.com/microsoft/pxt/pull/5738 ) seems to have unwanted sideeffects for other editors. This fix restricts that fix to the transparentEditor scenario.

On a small view with editor toolbar collapsed, the buttons are misplaced.
![image](https://user-images.githubusercontent.com/4175913/68515392-9f752c00-0235-11ea-9edd-971b2925d2f2.png)
