### PR TITLE
Add defaults when loading api cache, and remove them when saving

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1905,7 +1905,7 @@ function buildSimAsync() {
 function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
     function leanSymbol(sym: pxtc.SymbolInfo) {
         const isEmpty = (v: any) => !v || Object.keys(v).length == 0
-        const attrs = U.clone(sym.attributes)
+        let attrs = U.clone(sym.attributes)
         if (attrs.callingConvention == 0)
             delete attrs.callingConvention
         if (isEmpty(attrs.paramDefl))
@@ -1917,6 +1917,8 @@ function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
         delete attrs._source
         delete attrs.shim
         delete attrs._name
+        if (isEmpty(attrs))
+            attrs = undefined
         return {
             kind: sym.kind == 7 ? undefined : sym.kind,
             retType: sym.retType == "void" ? undefined : sym.retType,
@@ -1929,7 +1931,7 @@ function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
                 default: p.default,
                 options: isEmpty(p.options) ? undefined : p.options,
                 isEnum: p.isEnum || undefined
-            })) : null,
+            })) : undefined,
             isInstance: sym.isInstance || undefined,
             isReadOnly: sym.isReadOnly || undefined,
         } as any

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1902,6 +1902,51 @@ function buildSimAsync() {
     return buildFolderAsync(simDir(), true, pxt.appTarget.id === "common" ? "common-sim" : "sim");
 }
 
+function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
+    function leanSymbol(sym: pxtc.SymbolInfo) {
+        const isEmpty = (v: any) => !v || Object.keys(v).length == 0
+        const attrs = U.clone(sym.attributes)
+        if (attrs.callingConvention == 0)
+            delete attrs.callingConvention
+        if (isEmpty(attrs.paramDefl))
+            delete attrs.paramDefl
+        if (isEmpty(attrs.paramHelp))
+            delete attrs.paramHelp
+        if (!attrs.jsDoc)
+            delete attrs.jsDoc
+        delete attrs._source
+        delete attrs.shim
+        delete attrs._name
+        return {
+            kind: sym.kind == 7 ? undefined : sym.kind,
+            retType: sym.retType == "void" ? undefined : sym.retType,
+            attributes: attrs,
+            parameters: sym.parameters ? sym.parameters.map(p => ({
+                name: p.name,
+                description: p.description || undefined,
+                type: p.type == "number" ? undefined : p.type,
+                initializer: p.initializer,
+                default: p.default,
+                options: isEmpty(p.options) ? undefined : p.options,
+                isEnum: p.isEnum || undefined
+            })) : null,
+            isInstance: sym.isInstance || undefined,
+            isReadOnly: sym.isReadOnly || undefined,
+        } as any
+    }
+
+    inf = U.clone(inf)
+
+    for (const pkgName of Object.keys(inf)) {
+        const byQName = inf[pkgName].apis.byQName
+        for (const apiName of Object.keys(byQName)) {
+            byQName[apiName] = leanSymbol(byQName[apiName])
+        }
+    }
+
+    return inf
+}
+
 function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
     let cfg = readLocalPxTarget()
     updateDefaultProjects(cfg);
@@ -2034,7 +2079,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                 });
             }
 
-            cfg.apiInfo = builtInfo;
+            cfg.apiInfo = compressApiInfo(builtInfo);
             nodeutil.writeFileSync(apiInfoPath, JSON.stringify(cfg.apiInfo));
 
             let info = travisInfo()

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1905,7 +1905,7 @@ function buildSimAsync() {
 function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
     function leanSymbol(sym: pxtc.SymbolInfo) {
         const isEmpty = (v: any) => !v || Object.keys(v).length == 0
-        let attrs = U.clone(sym.attributes)
+        let attrs: pxtc.CommentAttrs = U.clone(sym.attributes || ({} as any))
         if (attrs.callingConvention == 0)
             delete attrs.callingConvention
         if (isEmpty(attrs.paramDefl))

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -48,7 +48,7 @@ namespace pxt {
                     namespace: apiName.slice(0, lastDot),
                     name: apiName.slice(lastDot + 1),
                     fileName: "",
-                    attributes: sym.attributes,
+                    attributes: sym.attributes || ({} as any),
                     retType: sym.retType || "void",
                     parameters: sym.parameters ? sym.parameters.map(p => ({
                         name: p.name,

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -35,6 +35,41 @@ namespace pxt {
 
     let apiInfo: Map<PackageApiInfo>;
     export function setBundledApiInfo(inf: Map<PackageApiInfo>) {
+        for (const pkgName of Object.keys(inf)) {
+            const byQName = inf[pkgName].apis.byQName
+            for (const apiName of Object.keys(byQName)) {
+                const sym = byQName[apiName]
+                const lastDot = apiName.lastIndexOf(".")
+                // re-create the object - this will hint the JIT that these are objects of the same type
+                // and the same hidden class should be used
+                const newsym = byQName[apiName] = {
+                    kind: sym.kind || 7,
+                    qName: apiName,
+                    namespace: apiName.slice(0, lastDot),
+                    name: apiName.slice(lastDot + 1),
+                    fileName: "",
+                    attributes: sym.attributes,
+                    retType: sym.retType || "void",
+                    parameters: sym.parameters ? sym.parameters.map(p => ({
+                        name: p.name,
+                        description: p.description || "",
+                        type: p.type || "number",
+                        initializer: p.initializer,
+                        default: p.default,
+                        options: p.options || {},
+                        isEnum: !!p.isEnum
+                    })) : null,
+                    isInstance: !!sym.isInstance,
+                    isReadOnly: !!sym.isReadOnly,
+                }
+                const attr = newsym.attributes
+                if (!attr.paramDefl) attr.paramDefl = {}
+                if (!attr.callingConvention) attr.callingConvention = 0
+                if (!attr.paramHelp) attr.paramHelp = {}
+                if (!attr.jsDoc) attr.jsDoc = ""
+                attr._name = newsym.name.replace(/@.*/, "")
+            }
+        }
         apiInfo = inf;
     }
 


### PR DESCRIPTION
Could you take a look if this makes sense? It seems to work for me.

It cuts the size of the API info from 31M to 11M and compressed size from 2.6M to 2.0M (1.2M of the compressed size is sources of our packages).

In future we could use the same scheme for cached API info in indexdb.