### PR TITLE
Fix micro bit static pkg / local serve pathing

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2210,7 +2210,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
         docFolders.push("node_modules/pxt-common-packages/docs");
     }
 
-    docFolders.push(...nodeutil.getBundledPackages());
+    docFolders.push(...nodeutil.getBundledPackagesDocs());
     docFolders.push("docs");
 
     for (const docFolder of docFolders) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2220,21 +2220,21 @@ function renderDocs(builtPackaged: string, localDir: string) {
     for (const docFolder of docFolders) {
         for (const f of nodeutil.allFiles(docFolder, 8)) {
             pxt.log(`rendering ${f}`)
-            const fileInDocs = "docs" + f.slice(docFolder.length);
-            let targetPath = path.join(dst, fileInDocs)
+            const pathUnderDocs = f.slice(docFolder.length + 1);
+            let targetPath = path.join(dst, "docs", pathUnderDocs);
             const dir = path.dirname(targetPath)
             if (!validatedDirs[dir]) {
                 nodeutil.mkdirP(dir)
                 validatedDirs[dir] = true
             }
             let buf = fs.readFileSync(f)
-            if (/\.(md|html)$/.test(fileInDocs)) {
+            if (/\.(md|html)$/.test(f)) {
                 const fileData = buf.toString("utf8");
                 let html = ""
-                if (U.endsWith(fileInDocs, ".md")) {
+                if (U.endsWith(f, ".md")) {
                     const md = nodeutil.resolveMd(
                         ".",
-                        fileInDocs.substr(5, fileInDocs.length - 8),
+                        pathUnderDocs.slice(0, -3),
                         fileData
                     );
                     // patch any /static/... url to /docs/static/...
@@ -2245,7 +2245,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                         template: docsTemplate,
                         markdown: patchedMd,
                         theme: pxt.appTarget.appTheme,
-                        filepath: fileInDocs,
+                        filepath: path.join("docs", pathUnderDocs),
                     });
 
                     // replace .md with .html for rendered page drop

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2251,7 +2251,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                     });
 
                     // replace .md with .html for rendered page drop
-                    outputFile = outputFile.slice(0, outputFile.length - 3) + ".html";
+                    outputFile = outputFile.slice(0, -3) + ".html";
                 } else {
                     html = server.expandHtml(fileData);
                 }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2202,7 +2202,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
     docsTemplate = U.replaceAll(docsTemplate, "/docfiles/", webpath + "docfiles/")
     docsTemplate = U.replaceAll(docsTemplate, "/--embed", webpath + "embed.js")
 
-    const dirs: Map<boolean> = {}
+    const validatedDirs: Map<boolean> = {}
 
     const docFolders = ["node_modules/pxt-core/common-docs"];
 
@@ -2224,9 +2224,9 @@ function renderDocs(builtPackaged: string, localDir: string) {
             f = "docs" + f.slice(docFolder.length)
             let dd = path.join(dst, f)
             let dir = path.dirname(dd)
-            if (!U.lookup(dirs, dir)) {
+            if (!validatedDirs[dir]) {
                 nodeutil.mkdirP(dir)
-                dirs[dir] = true
+                validatedDirs[dir] = true
             }
             let buf: Buffer;
             if (/\.(md|html)$/.test(f)) {
@@ -2243,6 +2243,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                         theme: pxt.appTarget.appTheme,
                         filepath: f,
                     });
+
                     dd = dd.slice(0, dd.length - 3) + ".html"
                 } else {
                     html = server.expandHtml(

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2243,6 +2243,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                         theme: pxt.appTarget.appTheme,
                         filepath: f,
                     });
+                    dd = dd.slice(0, dd.length - 3) + ".html"
                 } else {
                     html = server.expandHtml(
                         fs.readFileSync(origF, { encoding: "utf8"})
@@ -2252,7 +2253,6 @@ function renderDocs(builtPackaged: string, localDir: string) {
                     return beg + ` href="${webpath}docs${url}.html"`
                 })
                 buf = Buffer.from(html, "utf8")
-                dd = dd.slice(0, dd.length - 3) + ".html"
             } else {
                 buf = fs.readFileSync(origF);
             }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2210,11 +2210,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
         docFolders.push("node_modules/pxt-common-packages/docs");
     }
 
-    const handledDirectories = {}
-    for (const bundledDir of pxt.appTarget.bundleddirs || []) {
-        getPackageDocs(bundledDir, docFolders, handledDirectories);
-    }
-
+    docFolders.push(...nodeutil.getBundledPackages());
     docFolders.push("docs");
 
     for (const docFolder of docFolders) {
@@ -2267,37 +2263,6 @@ function renderDocs(builtPackaged: string, localDir: string) {
         pxt.log(`All docs written from ${docFolder}.`);
     }
     pxt.log(`All docs written.`);
-
-    function getPackageDocs(dir: string, folders: string[], resolvedDirs: Map<boolean>) {
-        if (resolvedDirs[dir])
-            return;
-
-        resolvedDirs[dir] = true;
-
-        const jsonDir = path.join(dir, "pxt.json");
-        const pxtjson = fs.existsSync(jsonDir) && (nodeutil.readJson(jsonDir) as pxt.PackageConfig);
-
-        if (pxtjson) {
-            if (pxtjson.additionalFilePath) {
-                getPackageDocs(path.join(dir, pxtjson.additionalFilePath), folders, resolvedDirs);
-            }
-
-            if (pxtjson.dependencies) {
-                Object.keys(pxtjson.dependencies).forEach(dep => {
-                    const parts = /^file:(.+)$/i.exec(pxtjson.dependencies[dep]);
-                    if (parts) {
-                        getPackageDocs(path.join(dir, parts[1]), folders, resolvedDirs);
-                    }
-                });
-            }
-        }
-
-        const docsDir = path.join(dir, "docs");
-
-        if (fs.existsSync(docsDir)) {
-            folders.push(docsDir);
-        }
-    }
 }
 
 export function serveAsync(parsed: commandParser.ParsedCommand) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2221,12 +2221,14 @@ function renderDocs(builtPackaged: string, localDir: string) {
         for (const f of nodeutil.allFiles(docFolder, 8)) {
             pxt.log(`rendering ${f}`)
             const pathUnderDocs = f.slice(docFolder.length + 1);
-            let targetPath = path.join(dst, "docs", pathUnderDocs);
-            const dir = path.dirname(targetPath);
-            if (!validatedDirs[dir]) {
-                nodeutil.mkdirP(dir)
-                validatedDirs[dir] = true
+            let outputFile = path.join(dst, "docs", pathUnderDocs);
+
+            const outputDir = path.dirname(outputFile);
+            if (!validatedDirs[outputDir]) {
+                nodeutil.mkdirP(outputDir);
+                validatedDirs[outputDir] = true;
             }
+
             let buf = fs.readFileSync(f);
             if (/\.(md|html)$/.test(f)) {
                 const fileData = buf.toString("utf8");
@@ -2239,7 +2241,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                     );
                     // patch any /static/... url to /docs/static/...
                     const patchedMd = md.replace(/\"\/static\//g, `"/docs/static/`);
-                    nodeutil.writeFileSync(targetPath, patchedMd, { encoding: "utf8" });
+                    nodeutil.writeFileSync(outputFile, patchedMd, { encoding: "utf8" });
 
                     html = pxt.docs.renderMarkdown({
                         template: docsTemplate,
@@ -2249,7 +2251,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                     });
 
                     // replace .md with .html for rendered page drop
-                    targetPath = targetPath.slice(0, targetPath.length - 3) + ".html";
+                    outputFile = outputFile.slice(0, outputFile.length - 3) + ".html";
                 } else {
                     html = server.expandHtml(fileData);
                 }
@@ -2260,7 +2262,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                 buf = Buffer.from(html, "utf8");
             }
 
-            nodeutil.writeFileSync(targetPath, buf)
+            nodeutil.writeFileSync(outputFile, buf)
         }
         pxt.log(`All docs written from ${docFolder}.`);
     }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2219,20 +2219,19 @@ function renderDocs(builtPackaged: string, localDir: string) {
 
     for (let docFolder of docFolders) {
         for (let f of nodeutil.allFiles(docFolder, 8)) {
-            let origF = f
             pxt.log(`rendering ${f}`)
-            f = "docs" + f.slice(docFolder.length)
-            let dd = path.join(dst, f)
-            let dir = path.dirname(dd)
+            const targetFile = "docs" + f.slice(docFolder.length);
+            let dd = path.join(dst, targetFile)
+            const dir = path.dirname(dd)
             if (!validatedDirs[dir]) {
                 nodeutil.mkdirP(dir)
                 validatedDirs[dir] = true
             }
             let buf: Buffer;
-            if (/\.(md|html)$/.test(f)) {
+            if (/\.(md|html)$/.test(targetFile)) {
                 let html = ""
-                if (U.endsWith(f, ".md")) {
-                    const md = nodeutil.resolveMd(".", f.substr(5, f.length - 8))
+                if (U.endsWith(targetFile, ".md")) {
+                    const md = nodeutil.resolveMd(".", targetFile.substr(5, targetFile.length - 8))
                     // patch any /static/... url to /docs/static/...
                     const patchedMd = md.replace(/\"\/static\//g, `"/docs/static/`);
                     nodeutil.writeFileSync(dd, patchedMd, { encoding: "utf8" });
@@ -2241,13 +2240,13 @@ function renderDocs(builtPackaged: string, localDir: string) {
                         template: docsTemplate,
                         markdown: patchedMd,
                         theme: pxt.appTarget.appTheme,
-                        filepath: f,
+                        filepath: targetFile,
                     });
 
                     dd = dd.slice(0, dd.length - 3) + ".html"
                 } else {
                     html = server.expandHtml(
-                        fs.readFileSync(origF, { encoding: "utf8"})
+                        fs.readFileSync(f, { encoding: "utf8"})
                     );
                 }
                 html = html.replace(/(<a[^<>]*)\shref="(\/[^<>"]*)"/g, (f, beg, url) => {
@@ -2255,7 +2254,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
                 })
                 buf = Buffer.from(html, "utf8")
             } else {
-                buf = fs.readFileSync(origF);
+                buf = fs.readFileSync(f);
             }
             nodeutil.writeFileSync(dd, buf)
         }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2222,15 +2222,15 @@ function renderDocs(builtPackaged: string, localDir: string) {
             pxt.log(`rendering ${f}`)
             const pathUnderDocs = f.slice(docFolder.length + 1);
             let targetPath = path.join(dst, "docs", pathUnderDocs);
-            const dir = path.dirname(targetPath)
+            const dir = path.dirname(targetPath);
             if (!validatedDirs[dir]) {
                 nodeutil.mkdirP(dir)
                 validatedDirs[dir] = true
             }
-            let buf = fs.readFileSync(f)
+            let buf = fs.readFileSync(f);
             if (/\.(md|html)$/.test(f)) {
                 const fileData = buf.toString("utf8");
-                let html = ""
+                let html = "";
                 if (U.endsWith(f, ".md")) {
                     const md = nodeutil.resolveMd(
                         ".",

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -493,7 +493,7 @@ export function resolveMd(root: string, pathname: string): string {
 
     const docs = path.join(root, "docs");
 
-    let tryRead = (fn: string) => {
+    const tryRead = (fn: string) => {
         if (fileExistsSync(fn + ".md"))
             return fs.readFileSync(fn + ".md", "utf8")
         if (fileExistsSync(fn + "/index.md"))
@@ -501,25 +501,25 @@ export function resolveMd(root: string, pathname: string): string {
         return null
     }
 
-    let targetMd = tryRead(path.join(docs, pathname))
+    const targetMd = tryRead(path.join(docs, pathname))
     if (targetMd && !/^\s*#+\s+@extends/m.test(targetMd))
         return targetMd
 
-    let dirs = [
+    const dirs = [
         path.join(root, "/node_modules/pxt-core/common-docs"),
     ]
     lastResolveMdDirs = dirs
-    for (let pkg of pxt.appTarget.bundleddirs) {
+    for (const pkg of pxt.appTarget.bundleddirs) {
         let d = path.join(pkg, "docs");
         if (!path.isAbsolute(d)) d = path.join(root, d);
         dirs.push(d)
 
-        let cfg = readPkgConfig(path.join(d, ".."))
-        for (let add of cfg.additionalFilePaths)
+        const cfg = readPkgConfig(path.join(d, ".."))
+        for (const add of cfg.additionalFilePaths)
             dirs.push(path.join(d, "..", add, "docs"))
     }
-    for (let d of dirs) {
-        let template = tryRead(path.join(d, pathname))
+    for (const d of dirs) {
+        const template = tryRead(path.join(d, pathname))
         if (template)
             return pxt.docs.augmentDocs(template, targetMd)
     }

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -489,8 +489,7 @@ export function fileExistsSync(p: string): boolean {
 export let lastResolveMdDirs: string[] = []
 
 // returns undefined if not found
-export function resolveMd(root: string, pathname: string): string {
-
+export function resolveMd(root: string, pathname: string, md?: string): string {
     const docs = path.join(root, "docs");
 
     const tryRead = (fn: string) => {
@@ -501,7 +500,7 @@ export function resolveMd(root: string, pathname: string): string {
         return null
     }
 
-    const targetMd = tryRead(path.join(docs, pathname))
+    const targetMd = md ? md : tryRead(path.join(docs, pathname))
     if (targetMd && !/^\s*#+\s+@extends/m.test(targetMd))
         return targetMd
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2514, and a few small bugs I saw along the way (e.g. `.html` files were being converted to ``.h.html`` files).

this was failing because`resolveMD` was failing to locate the files listed as dependencies of bundleddirs (e.g. http://localhost:3232/device/usb/troubleshooting goes to not found even though https://makecode.microbit.org/device/usb/troubleshooting works) -- so I fixed that by including the dependencies in those look ups in the same way https://github.com/microsoft/pxt/pull/6196 did.

Also, building a staticpkg is the only place that we already have the md file readily available when calling it so it seems better to just pass that along anyways.

Also did a quick pass at trying to clean things up a little bit to ideally make it easier to follow along in the future - e.g. using const to clarify when things will mutate, etc.

~I'll take another look at where bundleddirs is referenced real quick too, in case there are some other obvious spots that getting all of the dependencies as well would be needed~ Seems like we should probably grab bundled dirs in the same way in https://github.com/microsoft/pxt/blob/master/cli/crowdin.ts - it doesn't look like it will upload the dependencies docs there currently? @pelikhan 