### PR TITLE
use qualified names in completions for monaco

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.10.0",
-    "pxt-monaco-typescript": "2.3.5",
+    "pxt-monaco-typescript": "2.3.6",
     "pxt-blockly": "2.1.12",
     "react": "16.8.3",
     "react-dom": "16.11.0",


### PR DESCRIPTION
This pulls in https://github.com/microsoft/pxt-monaco-typescript/pull/9, which fixed completions for functions that have callbacks with parameters in namespaces: fixes https://github.com/microsoft/pxt-arcade/issues/1435 and I suppose https://github.com/microsoft/pxt-microbit/issues/1110. I think I might have had another issue in arcade for it too at some point but I can't find it right away