### PR TITLE
focus on full screen, only focus when simulator states changes from user action

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2370,7 +2370,7 @@ export class ProjectView
             default:
                 this.maybeShowPackageErrors(true);
                 this.startSimulator(opts);
-                simulator.driver.focus()
+                if (opts.clickTrigger) simulator.driver.focus();
                 break;
         }
     }
@@ -2446,6 +2446,7 @@ export class ProjectView
     toggleSimulatorFullscreen() {
         if (!this.state.fullscreen) {
             document.addEventListener('keydown', this.closeOnEscape);
+            simulator.driver.focus();
         } else {
             document.removeEventListener('keydown', this.closeOnEscape);
         }


### PR DESCRIPTION
When user clicks ``fullscreen`` button in sim toolbar, focus on simulator automatically.

Also adds a guard for startStopSimulator so that it only grabs focus to the simulator if the user has clicked on something to trigger it - I believe there was some interaction with auto run changes that made it take focus improperly at times, and we only ever want it to redirect focus when the buttons were explicitly pressed.