### PR TITLE
Make simulator sounds quieter

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -395,6 +395,7 @@ namespace pxsim {
                 channels[0].remove()
             channels.push(ch)
 
+            /** Square waves are perceved as much louder than other sounds, so scale it down a bit to make it less jarring **/
             const scaleVol = (n: number, isSqWave?: boolean) => (n / 1024) / 2 * (isSqWave ? .7 : 1);
 
             const finish = () => {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -409,7 +409,6 @@ namespace pxsim {
                     return Promise.delay(timeOff).then(finish)
 
                 const soundWaveIdx = b.data[idx]
-                const flags = b.data[idx + 1]
                 const freq = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 2)
                 const duration = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 4)
                 const startVol = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 6)

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -395,7 +395,7 @@ namespace pxsim {
                 channels[0].remove()
             channels.push(ch)
 
-            const scaleVol = (n: number) => (n / 1024) / 2
+            const scaleVol = (n: number, isSqWave: boolean) => (n / 1024) / 2 * (isSqWave ? .7 : 1);
 
             const finish = () => {
                 ch.mute()
@@ -415,6 +415,10 @@ namespace pxsim {
                 const startVol = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 6)
                 const endVol = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 8)
                 const endFreq = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 10)
+
+                const isSquareWave = 11 <= soundWaveIdx && soundWaveIdx <= 15;
+                const scaledStart = scaleVol(startVol, isSquareWave);
+                const scaledEnd = scaleVol(endVol, isSquareWave);
 
                 if (!ctx || prevStop != instrStopId)
                     return Promise.delay(duration)
@@ -436,7 +440,7 @@ namespace pxsim {
                     currWave = soundWaveIdx
                     currFreq = freq
                     ch.gain = ctx.createGain()
-                    ch.gain.gain.value = scaleVol(startVol)
+                    ch.gain.gain.value = scaledStart;
 
                     if (endFreq != freq) {
                         if ((ch.generator as any).frequency != undefined) {
@@ -457,9 +461,9 @@ namespace pxsim {
 
                 idx += 12
 
-                ch.gain.gain.setValueAtTime(scaleVol(startVol), ctx.currentTime + (timeOff / 1000))
+                ch.gain.gain.setValueAtTime(scaledStart, ctx.currentTime + (timeOff / 1000))
                 timeOff += duration
-                ch.gain.gain.linearRampToValueAtTime(scaleVol(endVol), ctx.currentTime + (timeOff / 1000))
+                ch.gain.gain.linearRampToValueAtTime(scaledEnd, ctx.currentTime + (timeOff / 1000))
 
                 return loopAsync()
             }

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -395,7 +395,7 @@ namespace pxsim {
                 channels[0].remove()
             channels.push(ch)
 
-            const scaleVol = (n: number, isSqWave: boolean) => (n / 1024) / 2 * (isSqWave ? .7 : 1);
+            const scaleVol = (n: number, isSqWave?: boolean) => (n / 1024) / 2 * (isSqWave ? .7 : 1);
 
             const finish = () => {
                 ch.mute()

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -395,7 +395,7 @@ namespace pxsim {
                 channels[0].remove()
             channels.push(ch)
 
-            const scaleVol = (n: number) => (n / 1024) * 2
+            const scaleVol = (n: number) => (n / 1024) / 2
 
             const finish = () => {
                 ch.mute()


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1439 (though we'll probably want to play with it a bit more?)

easiest example of this being problematic is pressing `a` / `b` in https://makecode.com/_56E9mRCtHhyb vs a random youtube video (you probably want to put your volume down pretty low); the default volume in arcade (which is 128 out of 256) is *significantly* louder than youtube videos at max volume (e.g. https://www.youtube.com/watch?v=svYp2cqKoUQ or https://www.youtube.com/watch?v=zGP6zk7jcrQ, music videos seem to be a bit louder but nowhere near our volume) - with headphones in at min system volume on my mac, the square wave almost hurts my ears.

This scales down all volume to 1/4 the current volume in the sim. From a quick sample (@darzu and I), the perceived volume with this change (at default volume in arcade / 128) is roughly the same as a youtube video with the volume bar maxed.

Also scales down square waves a bit more as well, as the perceived volume for them is significantly higher than other types - I wouldn't say this is ideal, but it is fairly effective / with this change everything sounds about the 'right' volume to me. If we're good with this sort of change I'd say we should make an equivalent change for the hw implementations (though maybe that could be in the other direction, as some of the other sounds are relatively quiet on hardware and could be made louder relative to sq waves)