### PR TITLE
Make lang pickers match

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1498,7 +1498,7 @@ img.pixelart {
 
 /** language modal **/
 #langmodal {
-    #availablelocales .langoption .header{
+    #availablelocales .langoption .header {
         color: #4c4ca6;
     }
 

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -89,7 +89,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 closeOnEscape
             >
                 <div id="langmodal">
-                    <div className="group">
+                    <div id="availablelocales">
                         <div className="ui cards centered" role="listbox">
                             {languageList.map(langId => {
                                 const lang = pxt.Util.allLanguages[langId];

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -105,7 +105,6 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                             )}
                         </div>
                     </div>
-                    <br/>
                     {targetTheme.crowdinProject ?
                         <div className="ui" id="langmodalfooter">
                             <sui.Link aria-label={lf("How do I add a new language?")} href="/translate" text={lf("How do I add a new language?")} target="_blank" />

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -89,21 +89,19 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 closeOnEscape
             >
                 <div id="langmodal">
-                    <div id="availablelocales">
-                        <div className="ui cards centered" role="listbox">
-                            {languageList.map(langId => {
-                                const lang = pxt.Util.allLanguages[langId];
-                                return <LanguageCard
-                                    key={langId}
-                                    langId={langId}
-                                    name={lang.localizedName}
-                                    ariaLabel={lang.englishName}
-                                    description={lang.englishName}
-                                    onClick={this.changeLanguage}
-                                />
-                                }
-                            )}
-                        </div>
+                    <div id="availablelocales" className="ui cards centered" role="listbox">
+                        {languageList.map(langId => {
+                            const lang = pxt.Util.allLanguages[langId];
+                            return <LanguageCard
+                                key={langId}
+                                langId={langId}
+                                name={lang.localizedName}
+                                ariaLabel={lang.englishName}
+                                description={lang.englishName}
+                                onClick={this.changeLanguage}
+                            />
+                            }
+                        )}
                     </div>
                     {targetTheme.crowdinProject ?
                         <div className="ui" id="langmodalfooter">

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -88,28 +88,30 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 closeOnDocumentClick
                 closeOnEscape
             >
-                <div className="group">
-                    <div className="ui cards centered" role="listbox">
-                        {languageList.map(langId => {
-                            const lang = pxt.Util.allLanguages[langId];
-                            return <LanguageCard
-                                key={langId}
-                                langId={langId}
-                                name={lang.localizedName}
-                                ariaLabel={lang.englishName}
-                                description={lang.englishName}
-                                onClick={this.changeLanguage}
-                            />
-                            }
-                        )}
+                <div id="langmodal">
+                    <div className="group">
+                        <div className="ui cards centered" role="listbox">
+                            {languageList.map(langId => {
+                                const lang = pxt.Util.allLanguages[langId];
+                                return <LanguageCard
+                                    key={langId}
+                                    langId={langId}
+                                    name={lang.localizedName}
+                                    ariaLabel={lang.englishName}
+                                    description={lang.englishName}
+                                    onClick={this.changeLanguage}
+                                />
+                                }
+                            )}
+                        </div>
                     </div>
+                    <br/>
+                    {targetTheme.crowdinProject ?
+                        <div className="ui" id="langmodalfooter">
+                            <sui.Link aria-label={lf("How do I add a new language?")} href="/translate" text={lf("How do I add a new language?")} target="_blank" />
+                            {!pxt.BrowserUtils.isIE() && <sui.Button aria-label={lf("Translate the editor")} onClick={this.translateEditor} text={lf("Translate the editor")} /> }
+                        </div> : undefined}
                 </div>
-                <br/>
-                {targetTheme.crowdinProject ?
-                    <div className="ui">
-                        {!pxt.BrowserUtils.isIE() ? <sui.Button aria-label={lf("Translate the editor")} onClick={this.translateEditor} text={lf("Translate the editor")} /> : undefined }
-                        <sui.Link className="button" role="button" aria-label={lf("Learn about translations")} href="/translate" text={lf("Learn about translations")} target="_blank" />
-                    </div> : undefined}
             </sui.Modal>
         );
     }
@@ -137,7 +139,7 @@ class LanguageCard extends sui.StatelessUIElement<LanguageCardProps> {
 
     renderCore() {
         const { name, ariaLabel, description } = this.props;
-        return <codecard.CodeCardView className={`card-selected`}
+        return <codecard.CodeCardView className={`card-selected langoption`}
             name={name}
             ariaLabel={ariaLabel}
             role="link"


### PR DESCRIPTION
Make the lang picker on the home page match the one added to the docs in https://github.com/microsoft/pxt/pull/6064

old -> new (new has colored headers for each code card, hard to tell since it loops)

![2019-11-14 11 22 02](https://user-images.githubusercontent.com/5615930/68889059-04ff6780-06d1-11ea-862c-3a0fe3b47a65.gif)

