### PR TITLE
buildsprites: ignore empty sprites

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4360,8 +4360,17 @@ function buildJResSpritesCoreAsync(parsed: commandParser.ParsedCommand) {
                     key = basename
                 }
 
-                let hex = pxtc.f4EncodeImg(img.width, img.height, bpp, (x, y) =>
-                    closestColor(img.data, 4 * (x + y * img.width)))
+                let hasNonTransparent = false;
+                let hex = pxtc.f4EncodeImg(img.width, img.height, bpp, (x, y) => {
+                    const col = closestColor(img.data, 4 * (x + y * img.width));
+                    if (col)
+                        hasNonTransparent = true;
+                    return col;
+                });
+
+                if (!hasNonTransparent)
+                    continue;
+
                 let data = Buffer.from(hex, "hex").toString(star.dataEncoding)
 
                 let storeIcon = false


### PR DESCRIPTION
when using buildsprites, ignore empty frames - right now it can be annoying to put in animation frames or tiles that don't have explicit names, as you have to densely pack them into the image, and then name each frame if it's not fully filled in - e.g. in https://github.com/microsoft/pxt-arcade/blob/master/libs/device/dungeon/purple.png, I had to list out names for each frame in the json file or else it would add 3 empty images into the gallery, and in https://github.com/microsoft/pxt-arcade/blob/master/libs/device/builtin/villager4.png I had to smush one frame from the last animation into the previous line (and also list out frame names again)

