### PR TITLE
better placement of galleries on mobile

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -7,7 +7,8 @@
 
 @import (reference) "semantic.less";
 @carouselArrowSize: 60px;
-@carouselArrowSizeMobile: 40px;
+@carouselArrowSizeTablet: 40px;
+@carouselArrowSizeMobile: 20px;
 
 @homeCarouselArrowZIndex: @homeScreenZIndex+1; /* Show the carousel above the home screen */
 @homeDetailViewZIndex: @homeCarouselArrowZIndex+1; /* Show the detail view above the carousel arrows */
@@ -337,7 +338,7 @@
         .getting-started-segment {
             height: 250px;
             .getting-started {
-                padding: @carouselArrowSizeMobile;
+                padding: @carouselArrowSizeTablet;
                 margin-top: 40px;
             }
             .getting-started-header {
@@ -352,26 +353,21 @@
                 padding: 0 !important;
             }
             .column.right.aligned {
-                padding-right: @carouselArrowSizeMobile !important;
+                padding-right: @carouselArrowSizeTablet !important;
             }
             .ui.header {
-                padding-left: @carouselArrowSizeMobile;
+                padding-left: @carouselArrowSizeTablet;
             }
         }
     }
     .carouselcontainer {
-        padding: 2rem @carouselArrowSizeMobile !important;
+        padding: 2rem @carouselArrowSizeTablet !important;
     }
     .carouselarrow {
-        width: @carouselArrowSizeMobile;
-        font-size: @carouselArrowSizeMobile / 1.18 !important;
+        width: @carouselArrowSizeTablet;
+        font-size: @carouselArrowSizeTablet / 1.18 !important;
     }
-}
 
-
-/* <= Tablet (Mobile + Tablet) */
-
-@media only screen and (max-width: @largestTabletScreen) {
     .projectsdialog {
         .ui.card, .ui.cards>.card {
             width: 200px;
@@ -391,6 +387,33 @@
 /* Mobile only */
 
 @media only screen and (max-width: @largestMobileScreen) {
+    /* Carousel */
+    .projectsdialog {
+        .getting-started-segment {
+            .getting-started {
+                padding: @carouselArrowSizeMobile;
+            }
+        }
+        .ui.segment.tabsegment {
+            padding-top: calc(@mobileMenuHeight + 2rem) !important;
+        }
+        .gallerysegment {
+            .column.right.aligned {
+                padding-right: @carouselArrowSizeMobile !important;
+            }
+            .ui.header {
+                padding-left: @carouselArrowSizeMobile;
+            }
+        }
+    }
+    .carouselcontainer {
+        padding: 2rem @carouselArrowSizeMobile !important;
+    }
+    .carouselarrow {
+        width: @carouselArrowSizeMobile;
+        font-size: @carouselArrowSizeMobile / 1.18 !important;
+    }
+
     .projectsdialog {
         .ui.card, .ui.cards>.card {
             width: 9rem;


### PR DESCRIPTION
Tighter placement of galleries on mobile (vs tablet) by reducing margin to 20px in mobile.

## old
![arcade makecode com_beta(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/4175913/68941885-e4c8ba80-075b-11ea-82a2-9a1b93dd2463.png)
## new
![localhost_3232_index html(iPhone 6_7_8)](https://user-images.githubusercontent.com/4175913/68941897-ef834f80-075b-11ea-87d7-4fc213816a6b.png)
