### PR TITLE
Try to fix imported project with no TS files

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -733,7 +733,8 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
 
     const cfgText = await downloadAsync(pxt.CONFIG_NAME)
     let cfg = pxt.Package.parseAndValidConfig(cfgText);
-    if (!cfg || !cfg.files.length) {
+    // invalid cfg or no TypeScript files
+    if (!cfg || !cfg.files.filter(f => /\.ts$/.test(f)).length) {
         if (hd) // not importing
             U.userError(lf("Invalid pxt.json file."));
         cfg = pxt.github.reconstructConfig(commit);

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -737,6 +737,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
     if (!cfg || !cfg.files.find(f => /\.ts$/.test(f))) {
         if (hd) // not importing
             U.userError(lf("Invalid pxt.json file."));
+        pxt.log(`github: reconstructing pxt.json`)
         cfg = pxt.github.reconstructConfig(commit);
         files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -552,14 +552,13 @@ export async function commitAsync(hd: Header, options: CommitOptions = {}) {
     if (treeUpdate.tree.length == 0)
         U.userError(lf("Nothing to commit!"))
 
-    let blocksScreenshotSha: string;
     let blocksDiffSha: string;
     if (options
         && treeUpdate.tree.find(e => e.path == "main.blocks")) {
         if (options.blocksScreenshotAsync) {
             const png = await options.blocksScreenshotAsync();
             if (png)
-                blocksScreenshotSha = await addToTree(BLOCKS_PREVIEW_PATH, png);
+                await addToTree(BLOCKS_PREVIEW_PATH, png);
         }
         if (options.blocksDiffScreenshotAsync) {
             const png = await options.blocksDiffScreenshotAsync();

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -734,7 +734,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
     const cfgText = await downloadAsync(pxt.CONFIG_NAME)
     let cfg = pxt.Package.parseAndValidConfig(cfgText);
     // invalid cfg or no TypeScript files
-    if (!cfg || !cfg.files.filter(f => /\.ts$/.test(f)).length) {
+    if (!cfg || !cfg.files.find(f => /\.ts$/.test(f))) {
         if (hd) // not importing
             U.userError(lf("Invalid pxt.json file."));
         cfg = pxt.github.reconstructConfig(commit);

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -738,6 +738,12 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
             U.userError(lf("Invalid pxt.json file."));
         pxt.log(`github: reconstructing pxt.json`)
         cfg = pxt.github.reconstructConfig(commit);
+        // ensure that there is at least 1 ts file in the project
+        if (!cfg.files.find(f => /\.ts$/.test(f))) {
+            cfg.files.push("main.ts");
+            if (!justJSON)
+                files["main.ts"] = "\n";
+        }
         files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
 


### PR DESCRIPTION
When an existing github project is imported, it might contain markdown files (.md) but no typescript file. We want to make sure that the project has at least 1 ts file.