### PR TITLE
don't show bottom editor toolbar for editor that don't need it

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -123,10 +123,11 @@ pre {
 }
 
 .hideEditorToolbar #blocksArea,
-    .hideEditorToolbar #monacoEditor,
-    .hideEditorToolbar #pxtJsonEditor,
-    .hideEditorToolbar #serialEditor,
-    .hideEditorToolbar #filelist {
+.hideEditorToolbar #monacoEditor,
+.hideEditorToolbar #pxtJsonEditor,
+.hideEditorToolbar #serialEditor,
+.hideEditorToolbar #githubEditor,
+.hideEditorToolbar #filelist {
     bottom: 0rem !important;
 }
 
@@ -788,6 +789,10 @@ p.ui.font.small {
     }
     .collapse-button.ui.computer.only {
         display:none !important; // hide desktop simulator toggle
+    }
+
+    .hideEditorToolbar #filelist {
+        display:none !important;
     }
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3409,7 +3409,6 @@ export class ProjectView
         const inHome = this.state.home && !sandbox;
         const inEditor = !!this.state.header && !inHome;
         const { lightbox, greenScreen } = this.state;
-        const simDebug = !!targetTheme.debugger || inDebugMode;
         const flyoutOnly = this.state.editorState && this.state.editorState.hasCategories === false;
 
         const { hideEditorToolbar, transparentEditorToolbar } = targetTheme;
@@ -3420,7 +3419,7 @@ export class ProjectView
         const useSerialEditor = pxt.appTarget.serial && !!pxt.appTarget.serial.useEditor;
 
         const showSideDoc = sideDocs && this.state.sideDocsLoadUrl && !this.state.sideDocsCollapsed;
-        const showCollapseButton = !inHome && !inTutorial && !sandbox && !targetTheme.simCollapseInMenu && (!isHeadless || inDebugMode);
+        const showCollapseButton = showEditorToolbar && !inHome && !inTutorial && !sandbox && !targetTheme.simCollapseInMenu && (!isHeadless || inDebugMode);
         const shouldHideEditorFloats = (this.state.hideEditorFloats || this.state.collapseEditorTools) && (!inTutorial || isHeadless);
         const shouldCollapseEditorTools = this.state.collapseEditorTools && (!inTutorial || isHeadless);
         const logoWide = !!targetTheme.logoWide;


### PR DESCRIPTION
The editor toolbar is visible in table/mobile for editor that hide it (console, github)
![image](https://user-images.githubusercontent.com/4175913/68945641-b059fc00-0765-11ea-82d8-a6536499ff02.png)

This fixes the issue.
![repro](https://user-images.githubusercontent.com/4175913/68945649-b8b23700-0765-11ea-9f23-8a7ff871430a.gif)
