### PR TITLE
Display github button in table + collapsed

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1165,7 +1165,7 @@ p.ui.font.small {
     .hideEditorFloats.transparentEditorTools #editortools > div > div > .ui.grid {
         margin: auto;
     }
-    .hideEditorFloats #editorToolbarArea {
+    .hideEditorFloats.transparentEditorTools #editorToolbarArea {
         padding-top: 0;
     }
     .hideEditorFloats #blocksArea, .hideEditorFloats #monacoEditor, .hideEditorFloats #msg {

--- a/theme/github.less
+++ b/theme/github.less
@@ -7,6 +7,7 @@
 
 .ui.button.editortools-btn.editortools-github-btn {
     margin-left: 0.25rem;
+    width: 3.7rem;
 }
 
 /*-------------------

--- a/theme/github.less
+++ b/theme/github.less
@@ -7,7 +7,7 @@
 
 .ui.button.editortools-btn.editortools-github-btn {
     margin-left: 0.25rem;
-    width: 3.7rem;
+    width: 4rem;
 }
 
 /*-------------------

--- a/theme/github.less
+++ b/theme/github.less
@@ -10,6 +10,15 @@
     width: 4rem;
 }
 
+/* Mobile only */
+@media only screen and (max-width: @largestMobileScreen) {
+    .ui.button.editortools-btn.editortools-github-btn {
+        margin-left: 0;
+        margin-right: 0.25rem;
+        width: auto;
+    }
+}
+
 /*-------------------
    Github view and diffs
 --------------------*/

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -196,12 +196,12 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             <div className="column mobile only">
                 {collapsed ?
                     <div className="ui grid">
-                        {!targetTheme.bigRunButton && <div className="left aligned column six wide">
+                        {!targetTheme.bigRunButton && <div className="left aligned column four wide">
                             <div className="ui icon small buttons">
                                 {compileBtn && <EditorToolbarButton className={`primary download-button download-button-full ${downloadButtonClasses}`} icon={downloadIcon} title={compileTooltip} ariaLabel={lf("Download your code")} onButtonClick={this.compile} view='mobile' />}
                             </div>
                         </div>}
-                        <div id="editorToolbarArea" className={`column right aligned ${targetTheme.bigRunButton ? 'sixteen' : 'ten'} wide`}>
+                        <div id="editorToolbarArea" className={`column right aligned ${targetTheme.bigRunButton ? 'sixteen' : 'twelve'} wide`}>
                             {!readOnly &&
                                 <div className="ui icon small buttons">
                                     {this.getSaveInput(mobile, showSave)}

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -166,6 +166,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const showProjectRename = !tutorial && !readOnly && !isController && !targetTheme.hideProjectRename && !debugging;
         const showUndoRedo = !readOnly && !debugging;
         const showZoomControls = true;
+        const showGithub = !!pxt.appTarget.cloud && !!pxt.appTarget.cloud.githubPackages;
 
         const trace = !!targetTheme.enableTrace;
         const tracing = this.props.parent.state.tracing;
@@ -249,6 +250,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                         </div>
                         {showSave && <div className="column four wide">
                             <EditorToolbarButton icon='save' className={`small editortools-btn save-editortools-btn ${saveButtonClasses}`} title={lf("Save")} ariaLabel={lf("Save the project")} onButtonClick={this.saveFile} view='tablet' />
+                            {showGithub && <githubbutton.GithubButton parent={this.props.parent} key={`githubbtntablet`} className={"small"} />}
                         </div>}
                         <div className={`column ${showSave ? 'six' : 'ten'} wide right aligned`}>
                             {showUndoRedo && <div className="ui icon small buttons">{this.getUndoRedo(tablet)}</div>}

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -3,14 +3,16 @@ import * as sui from "./sui";
 import * as pkg from "./package";
 import * as cloudsync from "./cloudsync";
 
-type ISettingsProps = pxt.editor.ISettingsProps;
+interface GithubButtonProps extends pxt.editor.ISettingsProps {
+    className?: string;
+}
 
 interface GithubButtonState {
     pushPulling?: boolean;
 }
 
-export class GithubButton extends sui.UIElement<ISettingsProps, GithubButtonState> {
-    constructor(props: ISettingsProps) {
+export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonState> {
+    constructor(props: GithubButtonProps) {
         super(props);
         this.state = {};
         this.handleClick = this.handleClick.bind(this);
@@ -51,7 +53,7 @@ export class GithubButton extends sui.UIElement<ISettingsProps, GithubButtonStat
         const ghid = pxt.github.parseRepoId(githubId);
         // new github repo
         if (!ghid)
-            return <sui.Button key="githubcreatebtn" className={`ui icon button editortools-btn editortools-github-btn`}
+            return <sui.Button key="githubcreatebtn" className={`ui icon button editortools-btn editortools-github-btn ${this.props.className || ""}`}
                 icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")}
                 onClick={this.createRepository} />
 

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -51,9 +51,10 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
 
         const { githubId } = header;
         const ghid = pxt.github.parseRepoId(githubId);
+        const defaultCls = "ui icon button editortools-btn editortools-github-btn"
         // new github repo
         if (!ghid)
-            return <sui.Button key="githubcreatebtn" className={`ui icon button editortools-btn editortools-github-btn ${this.props.className || ""}`}
+            return <sui.Button key="githubcreatebtn" className={`${defaultCls} ${this.props.className || ""}`}
                 icon="github" title={lf("create GitHub repository")} ariaLabel={lf("create GitHub repository")}
                 onClick={this.createRepository} />
 
@@ -65,10 +66,10 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
         const repoName = ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName;
         const title = lf("Review and commit changes for {0}", repoName);
 
-        return <div key="githubeditorbtn" role="button" className={`ui icon button editortools-btn editortools-github-btn`}
+        return <div key="githubeditorbtn" role="button" className={`${defaultCls} ${this.props.className || ""}`}
             title={title} onClick={this.handleClick}>
             <i className="github icon" />
-            {modified ? <i className="long arrow alternate up icon" /> : undefined}
+            {modified ? <i className="ui long arrow alternate up icon mobile hide" /> : undefined}
         </div>;
     }
 }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -901,8 +901,8 @@ class CommmitComponent extends sui.StatelessUIElement<GitHubViewProps> {
                     error={descrError} />
             </div>
             <div className="ui field">
-                <sui.Button className="primary" text={lf("Commit changes")} icon="long arrow alternate up" onClick={this.handleCommitClick} onKeyDown={sui.fireClickOnEnter} />
-                <span className="inline-help">{lf("Push your changes to GitHub.")}
+                <sui.Button className="primary" text={lf("Commit & push changes")} icon="long arrow alternate up" onClick={this.handleCommitClick} onKeyDown={sui.fireClickOnEnter} />
+                <span className="inline-help">{lf("Save your changes in GitHub.")}
                     {sui.helpIconLink("/github/commit", lf("Learn about commiting and pushing code into GitHub."))}
                 </span>
             </div>


### PR DESCRIPTION
- [x] missed the configuration of tablet + collapsed toolbar
- [x] reworded "commit" to "commit & push" to avoid confusion
- [x] shrink github button size in mobile
![image](https://user-images.githubusercontent.com/4175913/68947702-f9f91580-076a-11ea-8859-986cfd2f2fa4.png)
- [x] give more horizontal room for mobile buttons when collapsed (6/10) -> (4/12) + icon alignment issue
![image](https://user-images.githubusercontent.com/4175913/68948814-8b698700-076d-11ea-93f0-f4c87685c683.png)
