### PR TITLE
Ask use to prepare repo when importing non-empty repo

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -195,19 +195,19 @@ function writePkgAsync(logicalDirname: string, data: FsPkg) {
                 if (f.name == pxt.CONFIG_NAME) {
                     try {
                         if (!pxt.Package.parseAndValidConfig(f.content)) {
-                            console.log("Trying to save invalid JSON config")
-                            console.log(f.content);
+                            pxt.log("Trying to save invalid JSON config")
+                            pxt.debug(f.content);
                             throwError(410)
                         }
                     } catch (e) {
-                        console.log("Trying to save invalid format JSON config")
-                        console.log(e)
-                        console.log(f.content);
+                        pxt.log("Trying to save invalid format JSON config")
+                        pxt.log(e)
+                        pxt.debug(f.content);
                         throwError(410)
                     }
                 }
                 if (buf.toString("utf8") !== f.prevContent) {
-                    console.log(`merge error for ${f.name}: previous content changed...`);
+                    pxt.log(`merge error for ${f.name}: previous content changed...`);
                     throwError(409)
                 }
             }, err => { }))

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -194,13 +194,15 @@ function writePkgAsync(logicalDirname: string, data: FsPkg) {
             .then(buf => {
                 if (f.name == pxt.CONFIG_NAME) {
                     try {
-                        let cfg: pxt.PackageConfig = JSON.parse(f.content)
-                        if (!cfg.name) {
+                        if (!pxt.Package.parseAndValidConfig(f.content)) {
                             console.log("Trying to save invalid JSON config")
+                            console.log(f.content);
                             throwError(410)
                         }
                     } catch (e) {
                         console.log("Trying to save invalid format JSON config")
+                        console.log(e)
+                        console.log(f.content);
                         throwError(410)
                     }
                 }

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -97,7 +97,7 @@ pxt_modules
         "**/pxt_modules": true
     }
 }`,
-            ".github/workflows/makecode.yml": `name: MakeCode CI
+            ".github/workflows/makecode.yml": `name: MakeCode
 
 on: [push]
 

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -123,20 +123,7 @@ jobs:
         env:
           CI: true
 `,
-            ".travis.yml": `language: node_js
-node_js:
-    - "8.9.4"
-script:
-    - "npm install -g pxt"
-    - "pxt target @TARGET@"
-    - "pxt install"
-    - "pxt build"
-sudo: false
-cache:
-    directories:
-    - npm_modules
-    - pxt_modules`,
-            ".vscode/tasks.json":
+        ".vscode/tasks.json":
                 `
 // A task runner that calls the MakeCode (PXT) compiler
 {

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -51,6 +51,8 @@ ${lf("To edit this repository in MakeCode.")}
 
 ## ${lf("Blocks preview")}
 
+${lf("This section shows the blocks code from the last commit in master.")}
+
 ![${lf("A rendered view of the blocks")}](https://raw.github.com/@REPO@/blob/master/.makecode/blocks.png)
 
 ## ${lf("Supported targets")}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3809,7 +3809,8 @@ async function importGithubProject(repoid: string) {
         let hd = workspace.getHeaders().find(h => h.githubId == repoid);
         if (!hd)
             hd = await workspace.importGithubAsync(repoid)
-        await theEditor.loadHeaderAsync(hd, null)
+        if (hd)
+            await theEditor.loadHeaderAsync(hd, null)
     } catch (e) {
         core.handleNetworkError(e)
     } finally {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -896,7 +896,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
     if (!files.filter(f => /\.ts$/.test(f)).length) {
         // add files from the template
         Object.keys(currFiles)
-            .filter(f => /\.(blocks|ts|py|asm|md|json)$/.test(f))
+            .filter(f => /\.(blocks|ts|py|asm|md)$/.test(f))
             .filter(f => f != pxt.CONFIG_NAME)
             .forEach(f => files.push(f));
     }
@@ -920,7 +920,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
     const allfiles = pxt.allPkgFiles(pxt.Package.parseAndValidConfig(currFiles[pxt.CONFIG_NAME]))
     const ignoredFiles = [GIT_JSON, pxt.SIMSTATE_JSON, pxt.SERIAL_EDITOR_FILE, pxt.CONFIG_NAME];
     Object.keys(currFiles)
-        .filter(f => ignoredFiles.indexOf(f) < 0 && allfiles.indexOf(f) > -1)
+        .filter(f => ignoredFiles.indexOf(f) < 0 && allfiles.indexOf(f) < 0)
         .forEach(f => delete currFiles[f]);
 
     await saveAsync(hd, currFiles)

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -910,7 +910,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 
     // remove files not in the package (only in git)
     currFiles = await getTextAsync(hd.id)
-    const allfiles = pxt.allPkgFiles(pxtjson)
+    const allfiles = pxt.allPkgFiles(pxt.Package.parseAndValidConfig(currFiles[pxt.CONFIG_NAME]))
     const ignoredFiles = [GIT_JSON, pxt.SIMSTATE_JSON, pxt.SERIAL_EDITOR_FILE, pxt.CONFIG_NAME];
     Object.keys(currFiles)
         .filter(f => ignoredFiles.indexOf(f) < 0 && allfiles.indexOf(f) > -1)

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -941,8 +941,10 @@ export async function importGithubAsync(id: string): Promise<Header> {
             // ask user before modifying project
             const r = await core.confirmAsync({
                 header: lf("Initialize repository for MakeCode?"),
-                body: lf("We need to add a few files to your repository to make it work with MakeCode."),
-                agreeLbl: lf("Ok"),
+                body: lf("We need to add a few files to your repository to make it work with MakeCode.")
+                    + " "
+                    + lf("Your existing files will not be modified."),
+                agreeLbl: lf("Ok")
             })
             if (!r) return Promise.resolve(undefined);
         }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -737,13 +737,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         if (hd) // not importing
             U.userError(lf("Invalid pxt.json file."));
         pxt.log(`github: reconstructing pxt.json`)
-        cfg = pxt.github.reconstructConfig(commit);
-        // ensure that there is at least 1 ts file in the project
-        if (!cfg.files.find(f => /\.ts$/.test(f))) {
-            cfg.files.push("main.ts");
-            if (!justJSON)
-                files["main.ts"] = "\n";
-        }
+        cfg = pxt.github.reconstructConfig(files, commit, pxt.appTarget.blocksprj || pxt.appTarget.tsprj);
         files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -889,7 +889,8 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
     if (!files.filter(f => /\.ts$/.test(f)).length) {
         // add files from the template
         Object.keys(currFiles)
-            .filter(f => /\.(blocks|ts|py|asm|md)$/.test(f))
+            .filter(f => /\.(blocks|ts|py|asm|md|json)$/.test(f))
+            .filter(f => f != pxt.CONFIG_NAME)
             .forEach(f => files.push(f));
     }
     // update test file if needed
@@ -909,8 +910,8 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 
     // remove files not in the package (only in git)
     currFiles = await getTextAsync(hd.id)
-    const allfiles = pxt.allPkgFiles(JSON.parse(currFiles[pxt.CONFIG_NAME]))
-    const ignoredFiles = [GIT_JSON, pxt.SIMSTATE_JSON, pxt.SERIAL_EDITOR_FILE];
+    const allfiles = pxt.allPkgFiles(pxtjson)
+    const ignoredFiles = [GIT_JSON, pxt.SIMSTATE_JSON, pxt.SERIAL_EDITOR_FILE, pxt.CONFIG_NAME];
     Object.keys(currFiles)
         .filter(f => ignoredFiles.indexOf(f) < 0 && allfiles.indexOf(f) > -1)
         .forEach(f => delete currFiles[f]);


### PR DESCRIPTION
When MakeCode tries to import an existing repository, it scan the existing files for pxt.json. 
If pxt.json is missing, it will ask the user if the project can be initialized. This happens when user creates repo with README.md for example.

- [x] show confirmation dialog to initialize repo
- [x] don't generate .travis.yml anymore
- [x] better pxt.json recostruction logic using target template