### PR TITLE
adding "variableName" option in snippet builder

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -180,7 +180,7 @@ declare namespace pxt {
         questions: SnippetQuestions[];
     }
 
-    type SnippetAnswerTypes = 'number' | 'text' | 'dropdown' | 'spriteEditor' | 'yesno' | string; // TODO(jb) Should include custom answer types for number, enums, string, image
+    type SnippetAnswerTypes = 'number' | 'text' | 'variableName' | 'dropdown' | 'spriteEditor' | 'yesno' | string; // TODO(jb) Should include custom answer types for number, enums, string, image
 
     interface SnippetGoToOptions {
         question?: number;

--- a/webapp/src/snippetBuilderInputHandler.tsx
+++ b/webapp/src/snippetBuilderInputHandler.tsx
@@ -27,7 +27,7 @@ export class InputHandler extends data.Component<InputHandlerProps, InputHandler
     }
 
     // Strip all non alphanumeric characters other than _
-    textOnChange = (v: string) => this.props.onChange(v.replace(/[^a-zA-Z0-9_]/g, '_'));
+    variableNameOnChange = (v: string) => this.props.onChange(ts.pxtc.escapeIdentifier(v));
 
     renderInput() {
         const { value, input, onChange } = this.props;
@@ -79,13 +79,14 @@ export class InputHandler extends data.Component<InputHandlerProps, InputHandler
                     )
                 }
             case 'text':
+            case 'variableName':
             default:
                 if (Snippet.isSnippetInputAnswerTypeOther(input)) {
                     return (
                         <sui.Input
                             label={input.label && input.label}
                             value={value || ''}
-                            onChange={this.textOnChange}
+                            onChange={input.type == 'variableName' ? this.variableNameOnChange : undefined}
                             autoFocus={true}
                             selectOnMount={true}
                         />

--- a/webapp/src/snippetBuilderInputHandler.tsx
+++ b/webapp/src/snippetBuilderInputHandler.tsx
@@ -27,6 +27,7 @@ export class InputHandler extends data.Component<InputHandlerProps, InputHandler
     }
 
     // Strip all non alphanumeric characters other than _
+    textOnChange = (v: string) => this.props.onChange(v);
     variableNameOnChange = (v: string) => this.props.onChange(ts.pxtc.escapeIdentifier(v));
 
     renderInput() {
@@ -86,7 +87,7 @@ export class InputHandler extends data.Component<InputHandlerProps, InputHandler
                         <sui.Input
                             label={input.label && input.label}
                             value={value || ''}
-                            onChange={input.type == 'variableName' ? this.variableNameOnChange : undefined}
+                            onChange={input.type == 'variableName' ? this.variableNameOnChange : this.textOnChange}
                             autoFocus={true}
                             selectOnMount={true}
                         />


### PR DESCRIPTION
Leave text alone, properly escape var name.