### PR TITLE
don't crash when a reference project is missing

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -230,6 +230,9 @@ namespace pxt {
         }
 
         loadConfig() {
+            if (this.level != 0 && this.invalid())
+                return; // don't try load invalid dependency
+
             const confStr = this.readFile(pxt.CONFIG_NAME)
             if (!confStr)
                 U.userError(`extension ${this.id} is missing ${pxt.CONFIG_NAME}`)
@@ -677,7 +680,7 @@ namespace pxt {
         bundledStringsForFile(lang: string, filename: string): Map<string> {
             let r: Map<string> = {};
 
-            let [initialLang, baseLang]  = pxt.Util.normalizeLanguageCode(lang);
+            let [initialLang, baseLang] = pxt.Util.normalizeLanguageCode(lang);
             const files = this.config.files;
 
             let fn = `_locales/${initialLang}/${filename}-strings.json`;

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -480,8 +480,10 @@ class Host
         let fromWorkspaceAsync = (arg: string) =>
             workspace.getTextAsync(arg)
                 .then(scr => {
-                    if (!scr)
-                        return Promise.reject(new Error(`Cannot find text for package '${arg}' in the workspace.`));
+                    if (!epkg.isTopLevel() && !scr) {
+                        pkg.configureAsInvalidPackage(`cannot find '${arg}' in the workspace.`);
+                        return Promise.resolve();
+                    }
                     if (epkg.isTopLevel() && epkg.header)
                         return workspace.recomputeHeaderFlagsAsync(epkg.header, scr)
                             .then(() => epkg.setFiles(scr))

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -484,6 +484,8 @@ class Host
                         pkg.configureAsInvalidPackage(`cannot find '${arg}' in the workspace.`);
                         return Promise.resolve();
                     }
+                    if (!scr) // this should not happen;
+                        return Promise.reject(new Error(`Cannot find text for package '${arg}' in the workspace.`));
                     if (epkg.isTopLevel() && epkg.header)
                         return workspace.recomputeHeaderFlagsAsync(epkg.header, scr)
                             .then(() => epkg.setFiles(scr))


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt/issues/6193
With this change, we mark as invalid a workspace dependency that got deleted. The user can fix it in the explorer view.
![image](https://user-images.githubusercontent.com/4175913/69027516-0906e000-0984-11ea-9298-7719f111057d.png)

