### PR TITLE
fix tutorial colors in high contrast mode

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -61,6 +61,19 @@
         }
     }
 
+    p {
+        color: @HCtextColor !important;
+    }
+
+    #tutorialcard .prevbutton,
+    #tutorialcard .nextbutton {
+        &:hover, &:focus {
+            > i, > span, > i.orange {
+                color: @HCtextColor !important;
+            }
+        }
+    }
+
     @media all and (pointer:coarse) { /* If touch screen */
         *[tabindex='0'],
         *[tabindex*='d1'],

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -272,7 +272,7 @@ span.highlight-line {
         background-color: @lightGrey;
 
         > i, > span, > i.orange {
-            color: @black!important;
+            color: @black !important;
         }
     }
 }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1470

(also makes the faded next button show up as white instead of black)