### PR TITLE
inclusive build flag to upload docs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -361,7 +361,7 @@ function travisAsync() {
     // upload locs on build on master
     const uploadLocs = /^(master|v\d+\.\d+\.\d+)$/.test(process.env.TRAVIS_BRANCH)
         && /^false$/.test(process.env.TRAVIS_PULL_REQUEST)
-        && !pxt.appTarget.disableDocsUpload;
+        && pxt.appTarget.uploadDocs;
 
     console.log("TRAVIS_TAG:", rel);
     console.log("TRAVIS_BRANCH:", process.env.TRAVIS_BRANCH);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5896,7 +5896,8 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
         name: "uploadtrgtranslations",
         help: "upload translations for target",
         flags: {
-            docs: { description: "upload markdown docs folder as well" }
+            docs: { description: "upload markdown docs folder as well" },
+            test: { description: "test run, do not upload files to crowdin"}
         },
         advanced: true
     }, crowdin.uploadTargetTranslationsAsync);

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -47,7 +47,7 @@ declare namespace pxt {
         appTheme: AppTheme;
         compileService?: TargetCompileService;
         ignoreDocsErrors?: boolean;
-        disableDocsUpload?: boolean;
+        uploadDocs?: boolean; // enable uploading to crowdin on master or v* builds
         variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
         queryVariants?: Map<AppTarget>; // patches on top of the current AppTarget using query url regex
         unsupportedBrowsers?: BrowserOptions[]; // list of unsupported browsers for a specific target (eg IE11 in arcade). check browserutils.js browser() function for strings

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -9,7 +9,7 @@ namespace pxt.crowdin {
     }
 
     function multipartPostAsync(key: string, uri: string, data: any = {}, filename: string = null, filecontents: string = null): Promise<ts.pxtc.Util.HttpResponse> {
-        if (key == TEST_KEY) {
+        if (testMode || key == TEST_KEY) {
             const resp = {
                 success: true
             }

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -1,10 +1,29 @@
 namespace pxt.crowdin {
     export const KEY_VARIABLE = "CROWDIN_KEY";
+    export let testMode = false;
+    export const TEST_KEY = "!!!testmode!!!";
+
+    export function setTestMode() {
+        pxt.crowdin.testMode = true;
+        pxt.log(`CROWDIN TEST MODE - files will NOT be uploaded`);
+    }
+
+    function multipartPostAsync(key: string, uri: string, data: any = {}, filename: string = null, filecontents: string = null): Promise<ts.pxtc.Util.HttpResponse> {
+        if (key == TEST_KEY) {
+            const resp = {
+                success: true
+            }
+            return Promise.resolve({ statusCode: 200, headers: {}, text: JSON.stringify(resp), json: resp })
+        }
+        return Util.multipartPostAsync(uri, data, filename, filecontents);
+    }
 
     function apiUri(branch: string, prj: string, key: string, cmd: string, args?: Map<string>) {
         Util.assert(!!prj && !!key && !!cmd);
         const apiRoot = "https://api.crowdin.com/api/project/" + prj + "/";
-        let suff = "?key=" + key;
+        let suff = "?";
+        if (!testMode)
+            suff = "key=" + key;
         if (branch) {
             if (!args) args = {};
             args["branch"] = branch;
@@ -88,7 +107,7 @@ namespace pxt.crowdin {
         name = normalizeFileName(name);
         pxt.debug(`create directory ${branch || ""}/${name}`)
         if (!incr) incr = mkIncr(name);
-        return Util.multipartPostAsync(apiUri(branch, prj, key, "add-directory"), { json: "true", name: name })
+        return multipartPostAsync(key, apiUri(branch, prj, key, "add-directory"), { json: "true", name: name })
             .then(resp => {
                 pxt.debug(`crowdin resp: ${resp.statusCode}`)
                 // 400 returned by folder already exists
@@ -137,7 +156,7 @@ namespace pxt.crowdin {
             opts["json"] = "";
             opts["escape_quotes"] = "0";
             incr();
-            return Util.multipartPostAsync(apiUri(branch, prj, key, op), opts, filename, data)
+            return multipartPostAsync(key, apiUri(branch, prj, key, op), opts, filename, data)
                 .then(resp => handleResponseAsync(resp))
         }
 


### PR DESCRIPTION
Instead of always uploading, a "uploadDocs: true" has to be present in pxtarget.json as well. This allows to selectively enable branches to upload to crowdin.
- [x] revert of https://github.com/microsoft/pxt/pull/6206
- [x] uploadDocs required in target.config to upload to crowdin.
- [x] test mode