### PR TITLE
Always convert value of ElementAccessExpression to string for delete

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3039,7 +3039,7 @@ ${lbl}: .short 0xffff
             } else if (node.expression.kind == SK.ElementAccessExpression) {
                 const inner = node.expression as ElementAccessExpression
                 objExpr = inner.expression
-                keyExpr = () => emitExpr(asString(inner.argumentExpression))
+                keyExpr = () => emitExpr(ts.isStringLiteral(inner.argumentExpression) ? inner.argumentExpression : ts.createTemplateExpression(ts.createTemplateHead(""), [ts.createTemplateSpan(inner.argumentExpression, ts.createTemplateTail(""))]))
             } else {
                 throw userError(9276, lf("expression not supported as argument to 'delete'"))
             }

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3039,7 +3039,7 @@ ${lbl}: .short 0xffff
             } else if (node.expression.kind == SK.ElementAccessExpression) {
                 const inner = node.expression as ElementAccessExpression
                 objExpr = inner.expression
-                keyExpr = () => emitExpr(inner.argumentExpression)
+                keyExpr = () => emitExpr(asString(inner.argumentExpression))
             } else {
                 throw userError(9276, lf("expression not supported as argument to 'delete'"))
             }

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3039,7 +3039,7 @@ ${lbl}: .short 0xffff
             } else if (node.expression.kind == SK.ElementAccessExpression) {
                 const inner = node.expression as ElementAccessExpression
                 objExpr = inner.expression
-                keyExpr = () => emitExpr(ts.isStringLiteral(inner.argumentExpression) ? inner.argumentExpression : ts.createTemplateExpression(ts.createTemplateHead(""), [ts.createTemplateSpan(inner.argumentExpression, ts.createTemplateTail(""))]))
+                keyExpr = () => emitExpr(ts.isStringLiteral(inner.argumentExpression) || ts.isTemplateExpression(inner.argumentExpression) ? inner.argumentExpression : ts.createTemplateExpression(ts.createTemplateHead(""), [ts.createTemplateSpan(inner.argumentExpression, ts.createTemplateTail(""))]))
             } else {
                 throw userError(9276, lf("expression not supported as argument to 'delete'"))
             }


### PR DESCRIPTION
Fixes microsoft/pxt-microbit#2513

If the `argumentExpression` of the `ElementAccessExpression` in a `DeleteExpression` is not a `StringLiteral` or `TemplateExpression`, wrap the whole `argumentExpression` in a `TemplateExpression`.