### PR TITLE
Bundle docs from dependencies of bundleddirs

### DIFF
--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -114,11 +114,11 @@ function uploadDocsTranslationsAsync(srcDir: string, crowdinDir: string, branch:
 
 function uploadBundledTranslationsAsync(crowdinDir: string, branch: string, prj: string, key: string): Promise<void> {
     const todo: string[] = [];
-    nodeutil.getBundledPackagesDocs().forEach(docsDir => {
-        const locdir = path.join(docsDir, "..", "_locales");
+    pxt.appTarget.bundleddirs.forEach(dir => {
+        const locdir = path.join(dir, "_locales");
         if (fs.existsSync(locdir))
             fs.readdirSync(locdir)
-                .filter(f => /-strings\.json$/i.test(f) && !/node_modules/.test(f))
+                .filter(f => /-strings\.json$/i.test(f))
                 .forEach(f => todo.push(path.join(locdir, f)))
     });
 

--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -118,7 +118,7 @@ function uploadBundledTranslationsAsync(crowdinDir: string, branch: string, prj:
         const locdir = path.join(docsDir, "..", "_locales");
         if (fs.existsSync(locdir))
             fs.readdirSync(locdir)
-                .filter(f => /strings\.json$/i.test(f))
+                .filter(f => /-strings\.json$/i.test(f) && !/node_modules/.test(f))
                 .forEach(f => todo.push(path.join(locdir, f)))
     });
 

--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -60,14 +60,14 @@ export function internalUploadTargetTranslationsAsync(uploadDocs: boolean) {
                             pxt.log("uploading docs...");
                             return uploadDocsTranslationsAsync("docs", crowdinDir, cred.branch, cred.prj, cred.key)
                                 // scan for docs in bundled packages
-                                .then(() => Promise.all(pxt.appTarget.bundleddirs
-                                    // there must be a folder under .../docs
-                                    .filter(pkgDir => nodeutil.existsDirSync(path.join(pkgDir, "docs")))
-                                    // upload to crowdin
-                                    .map(pkgDir => uploadDocsTranslationsAsync(path.join(pkgDir, "docs"), crowdinDir, cred.branch, cred.prj, cred.key)
-                                    )).then(() => {
+                                .then(() => {
+                                    return Promise.all(
+                                        nodeutil.getBundledPackagesDocs()
+                                            .map(docsDir => uploadDocsTranslationsAsync(docsDir, crowdinDir, cred.branch, cred.prj, cred.key))
+                                    ).then(() => {
                                         pxt.log("docs uploaded");
-                                    }))
+                                    });
+                                });
                         }
                         pxt.log("skipping docs upload (not a release)");
                         return Promise.resolve();
@@ -114,8 +114,8 @@ function uploadDocsTranslationsAsync(srcDir: string, crowdinDir: string, branch:
 
 function uploadBundledTranslationsAsync(crowdinDir: string, branch: string, prj: string, key: string): Promise<void> {
     const todo: string[] = [];
-    pxt.appTarget.bundleddirs.forEach(dir => {
-        const locdir = path.join(dir, "_locales");
+    nodeutil.getBundledPackagesDocs().forEach(docsDir => {
+        const locdir = path.join(docsDir, "..", "_locales");
         if (fs.existsSync(locdir))
             fs.readdirSync(locdir)
                 .filter(f => /strings\.json$/i.test(f))
@@ -147,10 +147,14 @@ export function downloadTargetTranslationsAsync(parsed?: commandParser.ParsedCom
                 .then(() => downloadFilesAsync(cred, ["target-strings.json"], "target"))
                 .then(() => {
                     const files: string[] = [];
-                    pxt.appTarget.bundleddirs
-                        .filter(dir => !name || dir == "libs/" + name)
-                        .forEach(dir => {
-                            const locdir = path.join(dir, "_locales");
+                    nodeutil.getBundledPackagesDocs()
+                        .filter(dir => {
+                            if (!name) return true;
+                            const pkgName = /^(?:.*\/)?libs\/([^\/]+)/.exec(dir);
+                            return !!pkgName && pkgName[1] == name;
+                        })
+                        .forEach(docsDir => {
+                            const locdir = path.join(docsDir, "..", "_locales");
                             if (fs.existsSync(locdir))
                                 fs.readdirSync(locdir)
                                     .filter(f => /\.json$/i.test(f))

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -1,12 +1,12 @@
 namespace pxt.crowdin {
     export const KEY_VARIABLE = "CROWDIN_KEY";
     export let testMode = false;
-    export let testPostHandler: (f: string, data: any) => void;
     export const TEST_KEY = "!!!testmode!!!";
+    let testPostHandler: (f: string, data: any) => void;
 
-    export function setTestMode(handler?: (f: string, data: any) => void) {
+    export function setTestMode(postHandler?: (f: string, data: any) => void) {
         pxt.crowdin.testMode = true;
-        testPostHandler = handler;
+        testPostHandler = postHandler;
         pxt.log(`CROWDIN TEST MODE - files will NOT be uploaded`);
     }
 

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -15,10 +15,10 @@ namespace pxt.crowdin {
             const resp = {
                 success: true
             }
-            return Promise.resolve(undefined)
-                .then(() => {
+            return new Promise(resolve => {
                     if (filename && filecontents && testPostHandler)
                         testPostHandler(filename, filecontents)
+                    resolve();
                 })
                 .then(() => ({ statusCode: 200, headers: {}, text: JSON.stringify(resp), json: resp }));
         }

--- a/pxtlib/crowdin.ts
+++ b/pxtlib/crowdin.ts
@@ -1,10 +1,12 @@
 namespace pxt.crowdin {
     export const KEY_VARIABLE = "CROWDIN_KEY";
     export let testMode = false;
+    export let testPostHandler: (f: string, data: any) => void;
     export const TEST_KEY = "!!!testmode!!!";
 
-    export function setTestMode() {
+    export function setTestMode(handler?: (f: string, data: any) => void) {
         pxt.crowdin.testMode = true;
+        testPostHandler = handler;
         pxt.log(`CROWDIN TEST MODE - files will NOT be uploaded`);
     }
 
@@ -13,7 +15,12 @@ namespace pxt.crowdin {
             const resp = {
                 success: true
             }
-            return Promise.resolve({ statusCode: 200, headers: {}, text: JSON.stringify(resp), json: resp })
+            return Promise.resolve(undefined)
+                .then(() => {
+                    if (filename && filecontents && testPostHandler)
+                        testPostHandler(filename, filecontents)
+                })
+                .then(() => ({ statusCode: 200, headers: {}, text: JSON.stringify(resp), json: resp }));
         }
         return Util.multipartPostAsync(uri, data, filename, filecontents);
     }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt/issues/6241

Issue was that it was using the `getBundledPackagesDocs ` in `uploadBundledTranslationsAsync`, when it shouldn't have cared about anything but the dirs explicitly listed in bundleddirs.

Also updates `pxt uploadtrgtranslations --test` to dump the files it would have uploaded into `temp/crowdin` so that it's easier to validate changes; e.g. after this change the contents of [microbit.zip](https://github.com/microsoft/pxt/files/3867396/microbit.zip) would be produced in `temp/crowdin/microbit`.

Starting as draft as I don't see a reason to merge this right away (at least until after figuring out what to do with crowdin) - the only target that seems to be significantly negatively affected by this at the moment seems to be arcade, where very few of the ref pages currently were translatable (e.g. anything from [game/docs](https://github.com/microsoft/pxt-common-packages/tree/master/libs/game/docs) wasn't available before, though it looks like the current state of node_modules is going to persist for the time being [on crowdin](https://crowdin.com/project/kindscript/en#/arcade/node_modules))