### PR TITLE
GitHub Oauth confirmation dialog

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1529,3 +1529,14 @@ img.pixelart {
 a.ui.link {
     cursor: pointer;
 }
+
+p > a.ui.link {
+    margin-left: 0.5rem;
+}
+
+p.ui.tiny {
+    font-size: 80%;
+}
+p.ui.small {
+    font-size: 90%;
+}

--- a/theme/common.less
+++ b/theme/common.less
@@ -1525,3 +1525,7 @@ img.pixelart {
     z-index: @blocklyWidgetDivZIndex;
     background-color: rgba(0, 0, 0, 0.4)
 }
+
+a.ui.link {
+    cursor: pointer;
+}

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -191,6 +191,10 @@ export function hideDialog() {
     coretsx.hideDialog();
 }
 
+export function forceUpdate() {
+    coretsx.forceUpdate();
+}
+
 export function confirmAsync(options: ConfirmOptions): Promise<number> {
     options.type = 'confirm';
     if (!options.buttons) options.buttons = []

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -33,18 +33,70 @@ export class GithubProvider extends cloudsync.ProviderBase {
         this.loginCheck()
         let p = Promise.resolve();
         if (!this.token()) {
-            // auth flow
-            const cl = pxt.appTarget && pxt.appTarget.cloud && pxt.appTarget.cloud.cloudProviders && pxt.appTarget.cloud.cloudProviders[this.name];
-            if (cl)
-                p = p.then(() => this.oauthLoginAsync());
-            else
-                p = p.then(() => this.showGithubLoginAsync());
+            // auth flow if github provider is prsent
+            const useOAuth = pxt.appTarget
+                && pxt.appTarget.cloud
+                && pxt.appTarget.cloud.cloudProviders
+                && !!pxt.appTarget.cloud.cloudProviders[this.name];
+            p = p.then(() => this.showLoginAsync(useOAuth));
         }
         return p.then(() => { return { accessToken: this.token() } as cloudsync.ProviderLoginResponse; });
 
     }
 
-    private oauthLoginAsync(): Promise<void> {
+    private showLoginAsync(useOAuth: boolean): Promise<void> {
+        pxt.tickEvent("github.login.dialog");
+        const useToken = !useOAuth;
+        let input: HTMLInputElement;
+        return core.confirmAsync({
+            header: lf("Sign in with GitHub"),
+            hideCancel: true,
+            hasCloseIcon: true,
+            helpUrl: "/github",
+            agreeLbl: lf("Sign in"),
+            onLoaded: (el) => {
+                input = el.querySelectorAll('input')[0] as HTMLInputElement;
+            },
+            jsx: <div className="ui form">
+                <p>{lf("Host your code on GitHub and work together with friends on projects.")}</p>
+                {useToken && <ol>
+                    <li>
+                        {lf("Navigate to: ")}
+                        <a href="https://github.com/settings/tokens/new" target="_blank" rel="noopener noreferrer">
+                            {lf("GitHub token generation page")}
+                        </a>
+                    </li>
+                    <li>
+                        {lf("Put something like 'MakeCode {0}' in description", pxt.appTarget.name)}
+                    </li>
+                    <li>
+                        {lf("Select either '{0}' or '{1}' scope, depending which repos you want to edit from here", "repo", "public_repo")}
+                    </li>
+                    <li>
+                        {lf("Click generate token, copy it, and paste it below.")}
+                    </li>
+                </ol>}
+                {useToken && <div className="ui field">
+                    <label id="selectUrlToOpenLabel">{lf("Paste GitHub token here:")}</label>
+                    <input type="url" tabIndex={0} autoFocus aria-labelledby="selectUrlToOpenLabel" placeholder="0123abcd..." className="ui blue fluid"></input>
+                </div>}
+            </div>,
+        }).then(res => {
+            if (!res) {
+                pxt.tickEvent("github.login.cancel");
+                return Promise.resolve()
+            } else {
+                if (useOAuth)
+                    return this.oauthRedirectAsync();
+                else {
+                    const hextoken = input.value.trim();
+                    return this.saveAndValidateTokenAsync(hextoken);
+                }
+            }
+        })
+    }
+
+    private oauthRedirectAsync(): Promise<void> {
         core.showLoading("ghlogin", lf("Logging you in to GitHub..."))
         const self = window.location.href.replace(/#.*/, "")
         const state = ts.pxtc.Util.guidGen();
@@ -82,54 +134,6 @@ export class GithubProvider extends cloudsync.ProviderBase {
     setNewToken(token: string) {
         super.setNewToken(token);
         pxt.github.token = token;
-    }
-
-    private showGithubLoginAsync() {
-        pxt.tickEvent("github.token.dialog");
-        let input: HTMLInputElement;
-        return core.confirmAsync({
-            header: lf("Sign in to GitHub"),
-            hideCancel: true,
-            hasCloseIcon: true,
-            helpUrl: "/github/token",
-            onLoaded: (el) => {
-                input = el.querySelectorAll('input')[0] as HTMLInputElement;
-            },
-            jsx: <div className="ui form">
-                <p>{lf("Host your code on GitHub and work together with friends on projects.")}
-                    {sui.helpIconLink("/github", lf("Learn more about GitHub"))}</p>
-                <p>{lf("You will need a GitHub token:")}</p>
-                <ol>
-                    <li>
-                        {lf("Navigate to: ")}
-                        <a href="https://github.com/settings/tokens/new" target="_blank" rel="noopener noreferrer">
-                            {lf("GitHub token generation page")}
-                        </a>
-                    </li>
-                    <li>
-                        {lf("Put something like 'MakeCode {0}' in description", pxt.appTarget.name)}
-                    </li>
-                    <li>
-                        {lf("Select either '{0}' or '{1}' scope, depending which repos you want to edit from here", "repo", "public_repo")}
-                    </li>
-                    <li>
-                        {lf("Click generate token, copy it, and paste it below.")}
-                    </li>
-                </ol>
-                <div className="ui field">
-                    <label id="selectUrlToOpenLabel">{lf("Paste GitHub token here:")}</label>
-                    <input type="url" tabIndex={0} autoFocus aria-labelledby="selectUrlToOpenLabel" placeholder="0123abcd..." className="ui blue fluid"></input>
-                </div>
-            </div>,
-        }).then(res => {
-            if (!res) {
-                pxt.tickEvent("github.token.cancel");
-                return Promise.resolve()
-            } else {
-                const hextoken = input.value.trim();
-                return this.saveAndValidateTokenAsync(hextoken);
-            }
-        })
     }
 
     private saveAndValidateTokenAsync(hextoken: string): Promise<void> {

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -61,9 +61,9 @@ export class GithubProvider extends cloudsync.ProviderBase {
             jsxd: () => <div className="ui form">
                 <p>{lf("You need to sign in with GitHub to use this feature.")}</p>
                 <p>{lf("You can host your code on GitHub and collaborate with friends on projects.")}</p>
-                {!useToken && <p className="small">
+                {!useToken && <p className="ui small">
                     {lf("Looking to use a Developer token instead?")}
-                    <sui.Link text={lf("Click here")} onClick={showToken} />
+                    <sui.Link className="link" text={lf("Click here")} onClick={showToken} />
                 </p>}
                 {useToken && <ol>
                     <li>

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -58,7 +58,8 @@ export class GithubProvider extends cloudsync.ProviderBase {
                 input = el.querySelectorAll('input')[0] as HTMLInputElement;
             },
             jsx: <div className="ui form">
-                <p>{lf("Host your code on GitHub and work together with friends on projects.")}</p>
+                <p>{lf("You need to sign in with GitHub to use this feature.")}</p>
+                <p>{lf("You can host your code on GitHub and collaborate with friends on projects.")}</p>
                 {useToken && <ol>
                     <li>
                         {lf("Navigate to: ")}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -845,27 +845,10 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
         this.handleSignInClick = this.handleSignInClick.bind(this);
     }
 
-    private handleSignInClick(e: React.MouseEvent<HTMLElement>) {
-        pxt.tickEvent("github.signin");
-        e.stopPropagation();
-        cloudsync.githubProvider().loginAsync()
-            .done(() => this.props.parent.forceUpdate());
-    }
-
     renderCore() {
         const { needsCommitMessage } = this.props.parent.state;
-        const targetTheme = pxt.appTarget.appTheme;
-        const needsToken = !pxt.github.token;
 
-        if (needsToken)
-            return <div className={`ui ${targetTheme.invertedMenu ? 'inverted' : ''} info message join`}>
-                <p>{lf("Host your code on GitHub and work together with friends on projects.")}
-                    {sui.helpIconLink("/github", lf("Learn more about GitHub"))}
-                </p>
-                <sui.Button className="tiny green" text={lf("Sign in")} onClick={this.handleSignInClick} />
-            </div>;
-
-        if (!needsToken && needsCommitMessage)
+        if (needsCommitMessage)
             return <div className="ui warning message">
                 <div className="content">
                     {lf("You need to commit your changes before you can pull from GitHub.")}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -842,7 +842,6 @@ interface GitHubViewProps {
 class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
     constructor(props: GitHubViewProps) {
         super(props)
-        this.handleSignInClick = this.handleSignInClick.bind(this);
     }
 
     renderCore() {


### PR DESCRIPTION
Confirm that the user wants to sign in with github before redirecting to the oauth page. Unifies sign in dialog for token/oauth scenarios.
- [x] display dialog before sending user to github (less jaring)
- [x] don't display sign in banner in git view
- [x] ability to still use dev token

![repro](https://user-images.githubusercontent.com/4175913/69304514-c4728300-0bd5-11ea-8a38-415025dffd32.gif)
