### PR TITLE
Record & console log performance metrics

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -70,14 +70,11 @@ namespace pxt {
     let eventLogger: TelemetryQueue<string, Map<string>, Map<number>>;
     let exceptionLogger: TelemetryQueue<any, string, Map<string>>;
 
-    // performance measuring
+    // performance measuring, added here because this is amongst the first (typescript) code ever executed
     export namespace perf {
-        export let startTimeMs: number = Date.now()
-        export function reset() {
-            startTimeMs = Date.now()
-        }
+        export let startTimeMs: number;
         export function splitMs(): number {
-            return Date.now() - startTimeMs
+            return Math.round(performance.now() - startTimeMs)
         }
         export function splitStr(): string {
             let ms = splitMs()
@@ -97,7 +94,18 @@ namespace pxt {
         export function logSplit(msg: string) {
             console.log(`[PERF] ${msg} @ ${splitStr()}`)
         }
-        console.log("[PERF MEASURE STARTED]")
+        export function reset() {
+            startTimeMs = performance.now()
+        }
+        export function initFromNavStart() {
+            performance.measure("measure from the start of navigation to now")
+            let navStartMeasure = performance.getEntriesByType("measure")[0]
+            startTimeMs = navStartMeasure.startTime
+        }
+        (function () {
+            initFromNavStart()
+            logSplit("pxt.perf interpreted")
+        })()
     }
 
     export function initAnalyticsAsync() {

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -70,6 +70,36 @@ namespace pxt {
     let eventLogger: TelemetryQueue<string, Map<string>, Map<number>>;
     let exceptionLogger: TelemetryQueue<any, string, Map<string>>;
 
+    // performance measuring
+    export namespace perf {
+        export let startTimeMs: number = Date.now()
+        export function reset() {
+            startTimeMs = Date.now()
+        }
+        export function splitMs(): number {
+            return Date.now() - startTimeMs
+        }
+        export function splitStr(): string {
+            let ms = splitMs()
+            let r_ms = ms % 1000
+            let s = Math.floor(ms / 1000)
+            let r_s = s % 60
+            let m = Math.floor(s / 60)
+            if (m > 0)
+                return `${m}m${r_s}s`
+            else if (s > 5)
+                return `${s}s`
+            else if (s > 0)
+                return `${s}s${r_ms}ms`
+            else
+                return `${ms}ms`
+        }
+        export function logSplit(msg: string) {
+            console.log(`[PERF] ${msg} @ ${splitStr()}`)
+        }
+        console.log("[PERF MEASURE STARTED]")
+    }
+
     export function initAnalyticsAsync() {
         if (isNativeApp() || shouldHideCookieBanner()) {
             initializeAppInsightsInternal(true);

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -107,9 +107,6 @@ namespace pxt {
 
         export function recordMilestone(msg: string, time: number = splitMs()) {
             stats.milestones.push([msg, time])
-            if (time > 5000 && !perfReportLogged) {
-                console.log(`[perf alert] ${msg} @ ${prettyStr(time)}`)
-            }
         }
         export function init() {
             performance.measure("measure from the start of navigation to now")
@@ -128,9 +125,6 @@ namespace pxt {
                 if (e && e.length === 1) {
                     let measure = e[0]
                     let durMs = measure.duration
-                    if (durMs > 1000) {
-                        console.log(`[perf alert] ${name} took ~ ${prettyStr(durMs)}`)
-                    }
                     if (durMs > 10) {
                         stats.durations.push([name, measure.startTime, durMs])
                     }

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -8,9 +8,7 @@ namespace pxt {
 
 namespace pxt.perf {
     // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
-    export declare function reset(): void;
-    export declare function splitMs(): number;
-    export declare function splitStr(): string;
+    export declare function report(): void;
     export declare function recordMilestone(msg: string, time?: number): void;
     export declare function measureStart(name: string): void;
     export declare function measureEnd(name: string): void;

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -6,14 +6,6 @@ namespace pxt {
     export declare function aiTrackException(err: any, kind: string, props: any): void;
 }
 
-namespace pxt.perf {
-    // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
-    export declare function report(): void;
-    export declare function recordMilestone(msg: string, time?: number): void;
-    export declare function measureStart(name: string): void;
-    export declare function measureEnd(name: string): void;
-}
-
 namespace pxt.analytics {
     const defaultProps: Map<string> = {};
     const defaultMeasures: Map<number> = {};

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -4,6 +4,13 @@ namespace pxt {
     // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
     export declare function aiTrackEvent(id: string, data?: any, measures?: any): void;
     export declare function aiTrackException(err: any, kind: string, props: any): void;
+
+    export declare namespace perf {
+        export function reset(): void;
+        export function splitMs(): number;
+        export function splitStr(): string;
+        export function logSplit(msg: string): void;
+    }
 }
 
 namespace pxt.analytics {

--- a/pxtlib/analytics.ts
+++ b/pxtlib/analytics.ts
@@ -4,13 +4,16 @@ namespace pxt {
     // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
     export declare function aiTrackEvent(id: string, data?: any, measures?: any): void;
     export declare function aiTrackException(err: any, kind: string, props: any): void;
+}
 
-    export declare namespace perf {
-        export function reset(): void;
-        export function splitMs(): number;
-        export function splitStr(): string;
-        export function logSplit(msg: string): void;
-    }
+namespace pxt.perf {
+    // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
+    export declare function reset(): void;
+    export declare function splitMs(): number;
+    export declare function splitStr(): string;
+    export declare function recordMilestone(msg: string, time?: number): void;
+    export declare function measureStart(name: string): void;
+    export declare function measureEnd(name: string): void;
 }
 
 namespace pxt.analytics {

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -6,6 +6,26 @@
 /// <reference path="apptarget.ts"/>
 /// <reference path="tickEvent.ts"/>
 
+namespace pxt.perf {
+    // These functions are defined in docfiles/pxtweb/cookieCompliance.ts
+    export declare function report(): void;
+    export declare function recordMilestone(msg: string, time?: number): void;
+    export declare function measureStart(name: string): void;
+    export declare function measureEnd(name: string): void;
+}
+(function () {
+    // Sometimes these aren't initialized, for example in tests. We only care about them
+    // doing anything in the browser.
+    if (!pxt.perf.report)
+        pxt.perf.report = () => { }
+    if (!pxt.perf.recordMilestone)
+        pxt.perf.recordMilestone = () => { }
+    if (!pxt.perf.measureStart)
+        pxt.perf.measureStart = () => { }
+    if (!pxt.perf.measureEnd)
+        pxt.perf.measureEnd = () => { }
+})()
+
 namespace pxt {
     export import U = pxtc.Util;
     export import Util = pxtc.Util;

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -210,6 +210,7 @@ namespace pxt {
     }
 
     export function reloadAppTargetVariant() {
+        pxt.perf.measureStart("reloadAppTargetVariant")
         const curr = JSON.stringify(appTarget);
         appTarget = U.clone(savedAppTarget)
         if (appTargetVariant) {
@@ -223,6 +224,7 @@ namespace pxt {
         // check if apptarget changed
         if (onAppTargetChanged && curr != JSON.stringify(appTarget))
             onAppTargetChanged();
+        pxt.perf.measureEnd("reloadAppTargetVariant")
     }
 
     // this is set by compileServiceVariant in pxt.json

--- a/pxtlib/workeriface.ts
+++ b/pxtlib/workeriface.ts
@@ -61,7 +61,9 @@ namespace pxt.worker {
         let worker = new Worker(workerFile)
         let iface = wrap(v => worker.postMessage(v))
         worker.onmessage = ev => {
+            pxt.perf.measureStart("webworker recvHandler")
             iface.recvHandler(ev.data)
+            pxt.perf.measureEnd("webworker recvHandler")
         }
         return iface
     }

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -9,6 +9,7 @@ namespace pxsim {
         onTraceMessage?: (msg: TraceMessage) => void;
         onDebuggerResume?: () => void;
         onStateChanged?: (state: SimulatorState) => void;
+        onSimulatorReady?: () => void;
         onSimulatorCommand?: (msg: pxsim.SimulatorCommandMessage) => void;
         onTopLevelCodeEnd?: () => void;
         simUrl?: string;
@@ -520,6 +521,8 @@ namespace pxsim {
                         if (this.options.revealElement)
                             this.options.revealElement(frame);
                     }
+                    if (this.options.onSimulatorReady)
+                        this.options.onSimulatorReady();
                     break;
                 }
                 case 'status': {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3917,6 +3917,7 @@ function initExtensionsAsync(): Promise<void> {
 
 pxt.winrt.captureInitialActivation();
 document.addEventListener("DOMContentLoaded", () => {
+    pxt.perf.logSplit(`DOM loaded`)
     pxt.setupWebConfig((window as any).pxtConfig);
     const config = pxt.webConfig
     pxt.options.debug = /dbg=1/i.test(window.location.href);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -589,6 +589,7 @@ export class ProjectView
     }
 
     private maybeShowPackageErrors(force = false) {
+        pxt.perf.measureStart("maybeShowPackageErrors")
         // Only show in blocks or main.ts
         if (this.state.currFile) {
             const fn = this.state.currFile;
@@ -620,9 +621,11 @@ export class ProjectView
                             this.openHome();
                         }
                     });
+                pxt.perf.measureEnd("maybeShowPackageErrors")
                 return true;
             }
         }
+        pxt.perf.measureEnd("maybeShowPackageErrors")
         return false;
     }
 
@@ -759,6 +762,8 @@ export class ProjectView
                         this.setState({ simState: pxt.editor.SimState.Running });
                         break;
                 }
+            },
+            onSimulatorReady: () => {
             },
             setState: (k, v) => {
                 pkg.mainEditorPkg().setSimState(k, v)
@@ -1258,6 +1263,8 @@ export class ProjectView
         if (!header || !header.tutorial || !header.tutorial.tutorialMd)
             return Promise.resolve();
 
+        pxt.perf.measureStart("loadTutorial loadBlockly")
+
         const t = header.tutorial;
         return this.loadBlocklyAsync()
             .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode))
@@ -1285,6 +1292,9 @@ export class ProjectView
                 core.errorNotification(lf("Oops, an error occured as we were loading the tutorial."));
                 // Reset state (delete the current project and exit the tutorial)
                 this.exitTutorial(true);
+            })
+            .finally(() => {
+                pxt.perf.measureEnd("loadTutorial loadBlockly")
             });
     }
 
@@ -1932,6 +1942,7 @@ export class ProjectView
     }
 
     createProjectAsync(options: ProjectCreationOptions): Promise<void> {
+        pxt.perf.measureStart("createProjectAsync")
         this.setSideDoc(undefined);
         if (!options.prj) options.prj = pxt.appTarget.blocksprj;
         let cfg = pxt.U.clone(options.prj.config);
@@ -1986,7 +1997,8 @@ export class ProjectView
             tutorial: options.tutorial,
             extensionUnderTest: options.extensionUnderTest
         }, files)
-            .then(hd => this.loadHeaderAsync(hd, { filters: options.filters }));
+            .then(hd => this.loadHeaderAsync(hd, { filters: options.filters }))
+            .then(() => pxt.perf.measureEnd("createProjectAsync"))
     }
 
     // in multiboard targets, allow use to pick a different board
@@ -2193,7 +2205,7 @@ export class ProjectView
                     this.checkForHwVariant()
                 }, pairAsync)
                 .then(() => {
-                    pxt.perf.logSplit("HID bridge init finished")
+                    pxt.perf.recordMilestone("HID bridge init finished")
                 })
             return true
         }
@@ -2566,6 +2578,7 @@ export class ProjectView
     }
 
     stopSimulator(unload?: boolean, opts?: pxt.editor.SimulatorStartOptions) {
+        pxt.perf.measureStart("stopSimulator")
         pxt.tickEvent('simulator.stop')
         const clickTrigger = opts && opts.clickTrigger;
         pxt.debug(`sim: stop (autorun ${this.state.autoRun})`)
@@ -2576,6 +2589,7 @@ export class ProjectView
         simulator.stop(unload);
         const autoRun = this.state.autoRun && !clickTrigger; // if user pressed stop, don't restart
         this.setState({ simState: pxt.editor.SimState.Stopped, autoRun: autoRun });
+        pxt.perf.measureEnd("stopSimulator")
     }
 
     suspendSimulator() {
@@ -3920,7 +3934,7 @@ function initExtensionsAsync(): Promise<void> {
 
 pxt.winrt.captureInitialActivation();
 document.addEventListener("DOMContentLoaded", () => {
-    pxt.perf.logSplit(`DOM loaded`)
+    pxt.perf.recordMilestone(`DOM loaded`)
     pxt.setupWebConfig((window as any).pxtConfig);
     const config = pxt.webConfig
     pxt.options.debug = /dbg=1/i.test(window.location.href);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2192,6 +2192,9 @@ export class ProjectView
                     this.checkWebUSBVariant = false
                     this.checkForHwVariant()
                 }, pairAsync)
+                .then(() => {
+                    pxt.perf.logSplit("HID bridge init finished")
+                })
             return true
         }
         this.showChooseHwDialog()

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -122,6 +122,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (this.delayLoadXml) {
             if (this.loadingXml) return
             pxt.debug(`loading blockly`)
+            pxt.perf.measureStart("domUpdate loadBlockly")
             this.loadingXml = true
 
             const loadingDimmer = document.createElement("div");
@@ -158,6 +159,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         // It's possible Blockly reloads and the loading dimmer is no longer a child of the editorDiv
                         editorDiv.removeChild(loadingDimmer);
                     } catch { }
+                    pxt.perf.measureEnd("domUpdate loadBlockly")
                 });
 
             this.loadingXmlPromise.done();
@@ -430,6 +432,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private prepareBlockly(forceHasCategories?: boolean) {
+        pxt.perf.measureStart("prepareBlockly")
         let blocklyDiv = document.getElementById('blocksEditor');
         pxsim.U.clear(blocklyDiv);
         this.editor = Blockly.inject(blocklyDiv, this.getBlocklyOptions(forceHasCategories)) as Blockly.WorkspaceSvg;
@@ -511,6 +514,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.initBlocklyToolbox();
         this.initWorkspaceSounds();
         this.resize();
+        pxt.perf.measureEnd("prepareBlockly")
     }
 
     resize(e?: Event) {
@@ -658,6 +662,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const container = document.getElementById('debuggerToolbox');
         if (!container) return;
 
+        pxt.perf.measureStart("updateToolbox")
         const debugging = !!this.parent.state.debugging;
         let debuggerToolbox = debugging ? <DebuggerToolbox ref={this.handleDebuggerToolboxRef} parent={this.parent} apis={this.blockInfo.apis.byQName} /> : <div />;
 
@@ -668,6 +673,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.toolbox.show();
         }
         ReactDOM.render(debuggerToolbox, container);
+        pxt.perf.measureEnd("updateToolbox")
     }
 
     showPackageDialog() {
@@ -721,7 +727,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private _loadBlocklyPromise: Promise<void>;
     loadBlocklyAsync() {
-        if (!this._loadBlocklyPromise)
+        if (!this._loadBlocklyPromise) {
+            pxt.perf.measureStart("loadBlockly")
             this._loadBlocklyPromise = pxt.BrowserUtils.loadBlocklyAsync()
                 .then(() => {
                     // Initialize the "Make a function" button
@@ -755,6 +762,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     this.prepareBlockly();
                 })
                 .then(() => pxt.editor.initEditorExtensionsAsync())
+                .then(() => pxt.perf.measureStart("loadBlockly"))
+        }
         return this._loadBlocklyPromise;
     }
 
@@ -971,6 +980,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private refreshToolbox() {
         if (!this.blockInfo) return;
+        pxt.perf.measureStart("refreshToolbox")
         // no toolbox when readonly
         if (pxt.shell.isReadOnly()) return;
 
@@ -1015,6 +1025,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.renderToolbox(true);
             }
         }
+        pxt.perf.measureEnd("refreshToolbox")
     }
 
     filterToolbox(showCategories?: boolean) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -762,7 +762,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     this.prepareBlockly();
                 })
                 .then(() => pxt.editor.initEditorExtensionsAsync())
-                .then(() => pxt.perf.measureStart("loadBlockly"))
+                .then(() => pxt.perf.measureEnd("loadBlockly"))
         }
         return this._loadBlocklyPromise;
     }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -841,6 +841,7 @@ class ApiInfoIndexedDb {
     }
 
     setAsync(pack: pkg.EditorPackage, apis: pxt.PackageApiInfo): Promise<void> {
+        pxt.perf.measureStart("compiler db setAsync")
         const key = getPackageKey(pack);
         const hash = getPackageHash(pack);
 
@@ -850,6 +851,9 @@ class ApiInfoIndexedDb {
             apis
         };
 
-        return this.db.setAsync(ApiInfoIndexedDb.TABLE, entry);
+        return this.db.setAsync(ApiInfoIndexedDb.TABLE, entry)
+            .then(() => {
+                pxt.perf.measureEnd("compiler db setAsync")
+            })
     }
 }

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -29,6 +29,7 @@ export function isLoading() {
 
 export function hideLoading(id: string) {
     pxt.debug("hideloading: " + id);
+    pxt.perf.logSplit(`loading done #${id}`)
     if (loadingQueueMsg[id] != undefined) {
         // loading exists, remove from queue
         const index = loadingQueue.indexOf(id);
@@ -62,6 +63,7 @@ export function killLoadingQueue() {
 export function showLoading(id: string, msg: string) {
     pxt.debug("showloading: " + id);
     if (loadingQueueMsg[id]) return; // already loading?
+    pxt.perf.logSplit(`loading started #${id}`)
     initializeDimmer();
     loadingDimmer.show(lf("Please wait"));
     loadingQueue.push(id);

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -29,7 +29,7 @@ export function isLoading() {
 
 export function hideLoading(id: string) {
     pxt.debug("hideloading: " + id);
-    pxt.perf.logSplit(`loading done #${id}`)
+    pxt.perf.recordMilestone(`loading done #${id}`)
     if (loadingQueueMsg[id] != undefined) {
         // loading exists, remove from queue
         const index = loadingQueue.indexOf(id);
@@ -63,7 +63,7 @@ export function killLoadingQueue() {
 export function showLoading(id: string, msg: string) {
     pxt.debug("showloading: " + id);
     if (loadingQueueMsg[id]) return; // already loading?
-    pxt.perf.logSplit(`loading started #${id}`)
+    pxt.perf.recordMilestone(`loading started #${id}`)
     initializeDimmer();
     loadingDimmer.show(lf("Please wait"));
     loadingQueue.push(id);

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -11,6 +11,7 @@ interface SimulatorConfig {
     highlightStatement(stmt: pxtc.LocationInfo, brk?: pxsim.DebuggerBreakpointMessage): boolean;
     restartSimulator(): void;
     onStateChanged(state: pxsim.SimulatorState): void;
+    onSimulatorReady(): void;
     setState(key: string, value: any): void;
     editor: string;
 }
@@ -160,6 +161,9 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
                 this.onDebuggerResume();
             }
             cfg.onStateChanged(state);
+        },
+        onSimulatorReady: function () {
+            pxt.perf.logSplit("simulator ready")
         },
         onSimulatorCommand: (msg: pxsim.SimulatorCommandMessage): void => {
             switch (msg.command) {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -163,7 +163,8 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
             cfg.onStateChanged(state);
         },
         onSimulatorReady: function () {
-            pxt.perf.logSplit("simulator ready")
+            pxt.perf.recordMilestone("simulator ready")
+            pxt.perf.report()
         },
         onSimulatorCommand: (msg: pxsim.SimulatorCommandMessage): void => {
             switch (msg.command) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -180,7 +180,10 @@ export function initAsync() {
     allScripts = []
 
     return syncAsync()
-        .then(state => cleanupBackupsAsync().then(() => state));
+        .then(state => cleanupBackupsAsync().then(() => state))
+        .then(() => {
+            pxt.perf.logSplit("workspace init finished")
+        })
 }
 
 export function getTextAsync(id: string): Promise<ScriptText> {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -181,8 +181,9 @@ export function initAsync() {
 
     return syncAsync()
         .then(state => cleanupBackupsAsync().then(() => state))
-        .then(() => {
-            pxt.perf.logSplit("workspace init finished")
+        .then(_ => {
+            pxt.perf.recordMilestone("workspace init finished")
+            return _
         })
 }
 


### PR DESCRIPTION
Record & report (to the console for now) key performance metrics including:
- how long it took to reach certain milestones (from browser nav start; like: DOM loaded, tutorial load done, simulator ready, ...)
- the duration of certain long functions like: loadBlockly, createProjectAsync, refreshToolbox

The point of this isn't for us as developers to analyze performance (use Chrome devtools for that), it's to have something easy that users can send us from wherever they are (e.g. China schools) so we can see what they're experiencing (instead of just "it loads really slow").

Here's an example report (Macbook w/ 6x CPU throttle):
```
performance report:
		first JS running @ 941ms
		DOM loaded @ 3s203ms
		workspace init finished @ 3s738ms
		loading started #tutorial @ 4s905ms
		loading done #updateeditorfile @ 7s
		loading done #tutorial @ 9s
		simulator ready @ 13s

		reloadAppTargetVariant took ~ 190ms
		prepareBlockly took ~ 193ms
		loadBlockly took ~ 1s513ms (4s49ms - 5s563ms)
		stopSimulator took ~ 148ms
		webworker recvHandler took ~ 201ms
		stopSimulator took ~ 75ms
		webworker recvHandler took ~ 106ms
		refreshToolbox took ~ 164ms
		domUpdate loadBlockly took ~ 1s183ms (7s - 9s)
		maybeShowPackageErrors took ~ 67ms
		updateToolbox took ~ 63ms
		webworker recvHandler took ~ 130ms
		prepareBlockly took ~ 87ms
		refreshToolbox took ~ 117ms
		loadTutorial loadBlockly took ~ 1s956ms (7s - 9s)
		createProjectAsync took ~ 4s271ms (5s676ms - 9s)
		webworker recvHandler took ~ 104ms
		refreshToolbox took ~ 114ms
		domUpdate loadBlockly took ~ 872ms
```
The report is logged once the "simulator ready" event happens, which appears to consistently be the latest milestone.

Any function that takes longer than 1 second will also be logged immediately:
```
[perf alert] createProjectAsync took ~ 4s271ms
```