### PR TITLE
Set PXT_ENV to production when minify is set in StaticPkg

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4119,6 +4119,9 @@ export function staticpkgAsync(parsed: commandParser.ParsedCommand) {
     const disableAppCache = !!parsed.flags["no-appcache"];
     const locs = !!parsed.flags["locs"];
     if (parsed.flags["cloud"]) forceCloudBuild = true;
+    if (minify && process.env["PXT_ENV"] === undefined) {
+        process.env["PXT_ENV"] = "production";
+    }
 
     pxt.log(`packaging editor to ${builtPackaged}`)
 


### PR DESCRIPTION
So that StaticPkg can have the benefit introduced in #6244 automatically, unless `PXT_ENV` is already set.