### PR TITLE
Porting over minify and jres fixes to stable

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -75,7 +75,7 @@ function runKarma(that, flags) {
     cmdIn(that, "node_modules/.bin", command);
 }
 
-task('default', ['updatestrings', 'built/pxt.js', 'built/pxt.d.ts', 'built/pxtrunner.js', 'built/backendutils.js', 'built/target.js', 'wapp', 'monaco-editor', 'built/web/pxtweb.js', 'built/tests/blocksrunner.js'], { parallelLimit: 10 })
+task('default', ['updatestrings', 'built/pxt.js', 'built/pxt.d.ts', 'built/pxtrunner.js', 'built/backendutils.js', 'built/target.js', 'wapp', 'monaco-editor', 'built/web/pxtweb.js', 'built/tests/blocksrunner.js', 'uglify'], { parallelLimit: 10 })
 
 task('test', ['default', 'testfmt', 'testerr', 'testdecompiler', 'testpy', 'testlang', 'testtutorials', 'karma'])
 
@@ -599,4 +599,29 @@ ju.catFiles("built/web/semantic.js",
 file('docs/playground.html', ['built/web/pxtworker.js', 'built/web/pxtblockly.js', 'built/web/semantic.css'], function () {
     jake.cpR("libs/pxt-common/pxt-core.d.ts", "docs/static/playground/pxt-common/pxt-core.d.js");
     jake.cpR("libs/pxt-common/pxt-helpers.ts", "docs/static/playground/pxt-common/pxt-helpers.js");
+})
+
+task("uglify", ['updatestrings', 'built/pxt.js', 'built/pxt.d.ts', 'built/pxtrunner.js', 'built/backendutils.js', 'built/target.js', 'wapp', 'monaco-editor', 'built/web/pxtweb.js', 'built/tests/blocksrunner.js'], () => {
+    if (process.env.PXT_ENV == 'production') {
+        console.log("Minifying built/web...")
+
+        const uglify = require("uglify-js");
+
+        expand("built/web", ".js").forEach(fn => {
+            console.log("Minifying " + fn)
+
+            const content = fs.readFileSync(fn, "utf-8")
+            const res = uglify.minify(content);
+
+            if (!res.error) {
+                fs.writeFileSync(fn, res.code, { encoding: "utf8" })
+            }
+            else {
+                console.log("Could not minify " + fn);
+            }
+        });
+    }
+    else {
+        console.log("Skipping minification for non-production build")
+    }
 })

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1970,6 +1970,8 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                     }
 
                     if (options && api) {
+                        // JRES is already included in the target bundle
+                        api.jres = undefined;
                         builtInfo[dirname] = {
                             apis: api,
                             sha: packageSha
@@ -2009,8 +2011,18 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
 
                 Object.keys(builtInfo).filter(k => k !== corepkg).map(k => builtInfo[k]).forEach(info => {
                     deleteRedundantSymbols(coreInfo.apis.byQName, info.apis.byQName)
-                    deleteRedundantSymbols(coreInfo.apis.jres, info.apis.jres)
                 });
+
+                for (const pkgName of Object.keys(builtInfo)) {
+                    const byQName = builtInfo[pkgName].apis.byQName
+                    for (const apiName of Object.keys(byQName)) {
+                        const symbol = byQName[apiName];
+
+                        if (symbol && symbol.attributes && symbol.attributes.iconURL && symbol.attributes.jres) {
+                            delete symbol.attributes.iconURL;
+                        }
+                    }
+                }
             }
 
             cfg.apiInfo = builtInfo;

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -489,6 +489,24 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
         if (used.apis.jres) pxt.Util.jsonCopyFrom(result.jres, used.apis.jres);
     }
 
+    const jres = pkg.mainPkg.getJRes();
+
+    for (const qName of Object.keys(result.byQName)) {
+        let si = result.byQName[qName]
+
+        let jrname = si.attributes.jres
+        if (jrname) {
+            if (jrname == "true") jrname = qName
+            let jr = U.lookup(jres || {}, jrname)
+            if (jr && jr.icon && !si.attributes.iconURL) {
+                si.attributes.iconURL = jr.icon
+            }
+            if (jr && jr.data && !si.attributes.jresURL) {
+                si.attributes.jresURL = "data:" + jr.mimeType + ";base64," + jr.data
+            }
+        }
+    }
+
     return result;
 }
 


### PR DESCRIPTION
Porting over the code minification and JRES de-duplication to stable 5.26. This is not a cherry pick because we didn't want to take the compress API info change.