### PR TITLE
iOS 13 iPad recognition

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -25,7 +25,9 @@ namespace pxt.BrowserUtils {
     }
 
     export function isIOS(): boolean {
-        return hasNavigator() && /iPad|iPhone|iPod/.test(navigator.userAgent);
+        return (hasNavigator() && /iPad|iPhone|iPod/.test(navigator.userAgent)) || 
+        (/iPad|iPhone|iPod/.test(navigator.platform) ||
+        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream; //works for iPad OS 13 which now identifies itself as "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko)"
     }
 
     //MacIntel on modern Macs
@@ -85,7 +87,8 @@ namespace pxt.BrowserUtils {
     export function isSafari(): boolean {
         //Could also check isMac but I don't want to risk excluding iOS
         //Checking for iPhone, iPod or iPad as well as Safari in order to detect home screen browsers on iOS
-        return !isChrome() && !isEdge() && !!navigator && /(Macintosh|Safari|iPod|iPhone|iPad)/i.test(navigator.userAgent);
+        return !isChrome() && !isEdge() && !!navigator && /(Macintosh|Safari|iPod|iPhone|iPad)/i.test(navigator.userAgent) ||
+                (((navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream); // iPad  > iOS13
     }
 
     //Safari and WebKit lie about being Firefox

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -26,8 +26,8 @@ namespace pxt.BrowserUtils {
 
     export function isIOS(): boolean {
         return (hasNavigator() && /iPad|iPhone|iPod/.test(navigator.userAgent))
-            || (/iPad|iPhone|iPod/.test(navigator.platform)
-                || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream; //works for iPad OS 13 which now identifies itself as "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko)"
+            || (/iPad|iPhone|iPod/.test(navigator.platform) // fails on iPad iOS13 webview
+                || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.hasOwnProperty('MSStream'); // therefore we check for MacIntel platform with multiple touch and make sure its not an IE.
     }
 
     //MacIntel on modern Macs
@@ -88,7 +88,7 @@ namespace pxt.BrowserUtils {
         //Could also check isMac but I don't want to risk excluding iOS
         //Checking for iPhone, iPod or iPad as well as Safari in order to detect home screen browsers on iOS
         return !isChrome() && !isEdge() && !!navigator && /(Macintosh|Safari|iPod|iPhone|iPad)/i.test(navigator.userAgent)
-            || (((navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream); // iPad  > iOS13
+            || (((navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.hasOwnProperty('MSStream')); // iPad  with IOS > 13
     }
 
     //Safari and WebKit lie about being Firefox

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -25,9 +25,9 @@ namespace pxt.BrowserUtils {
     }
 
     export function isIOS(): boolean {
-        return (hasNavigator() && /iPad|iPhone|iPod/.test(navigator.userAgent)) || 
-        (/iPad|iPhone|iPod/.test(navigator.platform) ||
-        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream; //works for iPad OS 13 which now identifies itself as "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko)"
+        return (hasNavigator() && /iPad|iPhone|iPod/.test(navigator.userAgent))
+            || (/iPad|iPhone|iPod/.test(navigator.platform)
+                || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream; //works for iPad OS 13 which now identifies itself as "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko)"
     }
 
     //MacIntel on modern Macs
@@ -87,8 +87,8 @@ namespace pxt.BrowserUtils {
     export function isSafari(): boolean {
         //Could also check isMac but I don't want to risk excluding iOS
         //Checking for iPhone, iPod or iPad as well as Safari in order to detect home screen browsers on iOS
-        return !isChrome() && !isEdge() && !!navigator && /(Macintosh|Safari|iPod|iPhone|iPad)/i.test(navigator.userAgent) ||
-                (((navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream); // iPad  > iOS13
+        return !isChrome() && !isEdge() && !!navigator && /(Macintosh|Safari|iPod|iPhone|iPad)/i.test(navigator.userAgent)
+            || (((navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.MSStream); // iPad  > iOS13
     }
 
     //Safari and WebKit lie about being Firefox


### PR DESCRIPTION
On iOS 13 the user agent for safari got changed and therefore the browser identification stopped working in the WebView on iPads running > iOS 13.

"iPad OS 13 now identifies itself as "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko)", which is detected neither as mobile nor desktop."
[https://stackoverflow.com/questions/58019463/how-to-detect-device-name-in-safari-on-ios-13-while-it-doesnt-show-the-correct](https://stackoverflow.com/questions/58019463/how-to-detect-device-name-in-safari-on-ios-13-while-it-doesnt-show-the-correct)

I cant test it on an actual device, so the changes should be tested by someone who can. I just got that Issue report and used google for finding a possible solution.