### PR TITLE
Remove "debugger;" statements as there is no easy way to turn these off; instead devs can opt-in to setting breakpoints where they want

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1113,7 +1113,7 @@ namespace ts.pxtc {
 
         function unhandled(n: Node, info?: string, code: number = 9202) {
             // if we hit this, and are in debugger, we probably want to look at the node
-            debugger
+            // debugger
 
             // If we have info then we may as well present that instead
             if (info) {

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -10,7 +10,6 @@ import pxtc = ts.pxtc
 namespace ts.pxtc.Util {
     export function assert(cond: boolean, msg = "Assertion failed") {
         if (!cond) {
-            debugger
             throw new Error(msg)
         }
     }

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -205,7 +205,7 @@ namespace ts.pxtc.Util {
     }
 
     export function oops(msg = "OOPS"): Error {
-        debugger
+
         throw new Error(msg)
     }
 

--- a/pxtsim/langsupport.ts
+++ b/pxtsim/langsupport.ts
@@ -5,7 +5,6 @@ namespace pxsim {
 
     export function check(cond: boolean, msg: string = "sim: check failed") {
         if (!cond) {
-            debugger
             throw new Error(msg)
         }
     }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -68,7 +68,6 @@ namespace pxsim {
 
         export function assert(cond: boolean, msg = "Assertion failed") {
             if (!cond) {
-                debugger
                 throw new Error(msg)
             }
         }

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -113,7 +113,6 @@ function showNotificationMsg(kind: string, msg: string) {
 
 export function errorNotification(msg: string) {
     pxt.tickEvent("notification.error", { message: msg })
-    debugger // trigger a breakpoint when a debugger is connected, like in U.oops()
     showNotificationMsg("err", msg)
 }
 


### PR DESCRIPTION
Removes "debugger;" statements from our asserts.

I've heard support for this in the office, but want to see if there's support from everyone:
@mmoskal @pelikhan @abchatra @shakao @riknoll 

The problem is that the debugger statement is hard to opt-out of. Manually set breakpoints can be toggled on-off in the Chrome debugger or VSCode. If there's a failed assert, we'll see it in the console and it's trivial to set a breakpoint then.

We have some occasional assert fails (especially when working with multiple tabs) that for better or worse haven't been fixed for many months. I don't see us taking the stance that we must fix every assert failure always, so let's not pretend every dev will jump in the debugger and derail their other work.