### PR TITLE
Python auto-indent after ":"

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -200,6 +200,50 @@ class HoverProvider implements monaco.languages.HoverProvider {
     }
 }
 
+// reference: https://github.com/microsoft/vscode/blob/master/extensions/python/language-configuration.json
+// documentation: https://code.visualstudio.com/api/language-extensions/language-configuration-guide
+const pythonLanguageConfiguration: monaco.languages.LanguageConfiguration = {
+    "comments": {
+        "lineComment": "#",
+        "blockComment": ["\"\"\"", "\"\"\""]
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"", "notIn": ["string"] },
+        { "open": "r\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "R\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "u\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "U\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "f\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "F\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "b\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "B\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "r'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "R'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "u'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "U'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "f'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "F'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "b'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "B'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "`", "close": "`", "notIn": ["string"] }
+    ],
+    "indentationRules": {
+        "increaseIndentPattern": /^.*:\s*$/,
+        "decreaseIndentPattern": /^.*magic.*$/,
+        // "indentNextLinePattern": /^.*:\s*$/,
+        // "unIndentedLinePattern"
+    }
+}
+
 class FormattingProvider implements monaco.languages.DocumentRangeFormattingEditProvider {
     protected isPython: boolean = false;
 
@@ -726,6 +770,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             monaco.languages.registerSignatureHelpProvider("python", new SignatureHelper(this, true));
             monaco.languages.registerHoverProvider("python", new HoverProvider(this, true));
             monaco.languages.registerDocumentRangeFormattingEditProvider("python", new FormattingProvider(this, true));
+            monaco.languages.setLanguageConfiguration("python", pythonLanguageConfiguration)
 
             this.editorViewZones = [];
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -236,12 +236,14 @@ const pythonLanguageConfiguration: monaco.languages.LanguageConfiguration = {
         { "open": "B'", "close": "'", "notIn": ["string", "comment"] },
         { "open": "`", "close": "`", "notIn": ["string"] }
     ],
-    "indentationRules": {
-        "increaseIndentPattern": /^.*:\s*$/,
-        "decreaseIndentPattern": /^.*magic.*$/,
-        // "indentNextLinePattern": /^.*:\s*$/,
-        // "unIndentedLinePattern"
-    }
+    onEnterRules: [
+        {
+            beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async).*?:\s*$/,
+            action: {
+                indentAction: 1/*IndentAction.Indent*/
+            }
+        }
+    ]
 }
 
 class FormattingProvider implements monaco.languages.DocumentRangeFormattingEditProvider {


### PR DESCRIPTION
Before:
![2019-11-27 12 17 54](https://user-images.githubusercontent.com/6453828/69756791-32580680-1110-11ea-8ed7-4365e4d41a67.gif)

After:
![2019-11-27 12 17 06](https://user-images.githubusercontent.com/6453828/69756788-2ff5ac80-1110-11ea-9f4f-3fefa41b0e42.gif)
