### PR TITLE
Give proper error on super() when no parent ctor

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -247,7 +247,7 @@ namespace ts.pxtc {
         console.log(stringKind(n))
     }
 
-    // next free error 9280
+    // next free error 9281
     function userError(code: number, msg: string, secondary = false): Error {
         let e = new Error(msg);
         (<any>e).ksEmitterUserError = true;
@@ -2298,7 +2298,10 @@ ${lbl}: .short 0xffff
             // special case call to super
             if (funcExpr.kind == SK.SuperKeyword) {
                 let baseCtor = proc.classInfo.baseClassInfo.ctor
-                assert(!bin.finalPass || !!baseCtor, "!bin.finalPass || !!baseCtor")
+                for (let p = proc.classInfo.baseClassInfo; p && !baseCtor; p = p.baseClassInfo)
+                    baseCtor = p.ctor
+                if (!baseCtor && bin.finalPass)
+                    throw userError(9280, lf("super() call requires an explicit constructor in base class"))
                 let ctorArgs = args.map((x) => emitExpr(x))
                 ctorArgs.unshift(emitThis(funcExpr))
                 return mkProcCallCore(baseCtor, ctorArgs)


### PR DESCRIPTION
fixes #6154 