### PR TITLE
Demote "trying to access outdated session" to a warning

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -305,6 +305,10 @@ namespace pxt {
         ? (msg) => {
             console.log(msg);
         } : () => { };
+    export let warn: (msg: any) => void = typeof console !== "undefined" && !!console.log
+        ? (msg) => {
+            console.warn(msg);
+        } : () => { };
 
     export let reportException: (err: any, data?: Map<string | number>) => void = function (e, d) {
         if (console) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -165,7 +165,7 @@ export function isSessionOutdated() {
 }
 function checkSession() {
     if (isSessionOutdated()) {
-        pxt.Util.assert(false, "trying to access outdated session")
+        pxt.warn("trying to access outdated session")
     }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6453828/69978756-d8758900-14e1-11ea-8348-d8ae342c54f3.png)

We've been living with this bug for probably over a year. We should fix it: https://github.com/microsoft/pxt/issues/6276

but given that we're not fixing it right now, we shouldn't keep throwing devs into the debugger so I demoted this to a warning.
