### PR TITLE
Add compiler hooks common to CLI, cloud and web

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1319,6 +1319,8 @@ export function internalBuildTargetAsync(options: BuildTargetOptions = {}): Prom
 
     return initPromise
         .then(() => { copyCommonSim(); return simshimAsync() })
+        .then(() => buildFolderAsync('compiler', true, 'compiler'))
+        .then(() => fillInCompilerExtension(pxt.appTarget))
         .then(() => options.rebundle ? buildTargetCoreAsync({ quick: true }) : buildTargetCoreAsync(options))
         .then(() => buildSimAsync())
         .then(() => buildFolderAsync('cmds', true))
@@ -2179,6 +2181,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                 targetCrowdinBranch: targetCrowdinBranch()
             }
             saveThemeJson(cfg, options.localDir, options.packaged)
+            fillInCompilerExtension(cfg);
 
             const webmanifest = buildWebManifest(cfg)
             const targetjson = nodeutil.stringify(cfg)
@@ -2190,6 +2193,8 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
             delete targetlight.bundledpkgs;
             delete targetlight.appTheme;
             delete targetlight.apiInfo;
+            if (targetlight.compile)
+                delete targetlight.compile.compilerExtension;
             const targetlightjson = nodeutil.stringify(targetlight);
             nodeutil.writeFileSync("built/targetlight.json", targetlightjson)
             nodeutil.writeFileSync("built/sim.webmanifest", nodeutil.stringify(webmanifest))
@@ -2197,6 +2202,15 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
         .then(() => {
             console.log("target.json built.")
         })
+}
+
+function fillInCompilerExtension(cfg: pxt.TargetBundle) {
+    const compPath = path.join(nodeutil.targetDir, "built/compiler.js")
+    if (fs.existsSync(compPath)) {
+        const src = fs.readFileSync(compPath, "utf8");
+        // remove top-level namespace declarations, so it evals() correctly
+        cfg.compile.compilerExtension = src.replace(/^var \w+;$/gm, "");
+    }
 }
 
 function deleteRedundantSymbols(core: pxt.Map<pxtc.SymbolInfo | pxt.JRes>, trg: pxt.Map<pxtc.SymbolInfo | pxt.JRes>) {
@@ -6140,6 +6154,7 @@ export function mainCli(targetDir: string, args: string[] = process.argv.slice(2
     nodeutil.setTargetDir(targetDir);
 
     let trg = nodeutil.getPxtTarget()
+    fillInCompilerExtension(trg)
     pxt.setAppTarget(trg)
 
     pxt.setCompileSwitches(process.env["PXT_COMPILE_SWITCHES"])

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -479,6 +479,7 @@ declare namespace ts.pxtc {
         imageRefTag?: number;
         keepCppFiles?: boolean;
         debugMode?: boolean; // set dynamically, not in config
+        compilerExtension?: string; // JavaScript code to load in compiler
     }
 
     type BlockContentPart = BlockLabel | BlockParameter | BlockImage;

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -205,6 +205,8 @@ namespace ts.pxtc {
         if (!compilerHooks) {
             // run the extension at most once
             compilerHooks = {}
+
+            // The extension JavaScript code comes from target.json. It is generated from compiler/*.ts in target by 'pxt buildtarget'
             if (opts.target.compilerExtension)
                 // tslint:disable-next-line
                 eval(opts.target.compilerExtension)

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -194,7 +194,25 @@ namespace ts.pxtc {
         return U.startsWith(filename, "pxt_modules/")
     }
 
+    export interface CompilerHooks {
+        init?(opts: CompileOptions, service?: LanguageService): void;
+        preBinary?(program: Program, opts: CompileOptions, res: CompileResult): void;
+        postBinary?(program: Program, opts: CompileOptions, res: CompileResult): void;
+    }
+    export let compilerHooks: CompilerHooks
+
     export function compile(opts: CompileOptions, service?: LanguageService) {
+        if (!compilerHooks) {
+            // run the extension at most once
+            compilerHooks = {}
+            if (opts.target.compilerExtension)
+                // tslint:disable-next-line
+                eval(opts.target.compilerExtension)
+        }
+
+        if (compilerHooks.init)
+            compilerHooks.init(opts, service)
+
         let startTime = U.cpuUs()
         let res = mkCompileResult()
 

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -933,6 +933,10 @@ namespace ts.pxtc {
         opts: CompileOptions,
         res: CompileResult,
         entryPoint: string): EmitResult {
+
+        if (compilerHooks.preBinary)
+            compilerHooks.preBinary(program, opts, res)
+
         target = opts.target
         compileOptions = opts
         target.debugMode = !!opts.breakpoints
@@ -1087,6 +1091,9 @@ namespace ts.pxtc {
 
         if (resDiags.length == 0)
             resDiags = diagnostics.getDiagnostics()
+
+        if (compilerHooks.postBinary)
+            compilerHooks.postBinary(program, opts, res)
 
         return {
             diagnostics: resDiags,


### PR DESCRIPTION
Example extension, tsconfig.json and foobar.ts in compiler/ folder in a target.

```json
{
    "compilerOptions": {
        "target": "es5",
        "noImplicitAny": true,
        "noImplicitReturns": true,
        "noImplicitThis": true,
        "declaration": true,
        "out": "../built/compiler.js",
        "newLine": "LF",
        "sourceMap": false
    }
}
```

```typescript
/// <reference path="../node_modules/pxt-core/built/pxtcompiler.d.ts"/>

namespace ts.pxtc.extension {
    pxtc.compilerHooks.preBinary = (program: Program, opts: CompileOptions, res: CompileResult) => {
        pxt.log("pre binary")
    }
    pxtc.compilerHooks.postBinary = (program: Program, opts: CompileOptions, res: CompileResult) => {
        pxt.log("post binary")
    }
}
```