### PR TITLE
reenable .mp4 in safari

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -718,7 +718,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
         const tagColors: pxt.Map<string> = pxt.appTarget.appTheme.tagColors || {};
         const descriptions = description && description.split("\n");
         const image = largeImageUrl || imageUrl || (youTubeId && `https://img.youtube.com/vi/${youTubeId}/0.jpg`);
-        const video = !pxt.BrowserUtils.isElectron() && !pxt.BrowserUtils.isSafari() && videoUrl;
+        const video = !pxt.BrowserUtils.isElectron() && videoUrl;
 
         let clickLabel = lf("Show Instructions");
         if (buttonLabel)


### PR DESCRIPTION
Following the fix for .mp4 in CDN, it works in Safari.