### PR TITLE
Support routing back to create repository from oauth flow

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3788,7 +3788,7 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
         case "reload": // need to reload last project - handled later in the load process
             if (loading) pxt.BrowserUtils.changeHash("");
             return false;
-        case "github": { // follows a github OAuth rountrip
+        case "github": { // follows a github OAuth roundtrip
             const [hid, ghCmd] = hash.arg.split(':', 2);
             const hd = workspace.getHeader(hid);
             if (hd) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3827,6 +3827,7 @@ function isProjectRelatedHash(hash: { cmd: string; arg: string }): boolean {
         case "edit":
         case "sandboxproject":
         case "project":
+        case "github":
             return true;
         default:
             return false;

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -699,19 +699,6 @@ export function loginCheck() {
         impl.loginCheck();
 }
 
-export function githubLogin() {
-    core.showLoading("ghlogin", lf("Logging you in to GitHub..."))
-    const self = window.location.href.replace(/#.*/, "")
-    const state = ts.pxtc.Util.guidGen();
-    pxt.storage.setLocal(OAUTH_STATE, state)
-    pxt.storage.setLocal(OAUTH_TYPE, "github")
-    const login = pxt.Cloud.getServiceUrl() +
-        "/oauth/login?state=" + state +
-        "&response_type=token&client_id=gh-token&redirect_uri=" +
-        encodeURIComponent(self)
-    window.location.href = login
-}
-
 export function saveToCloudAsync(h: Header) {
     if (!currentProvider || !currentProvider.hasSync())
         return Promise.resolve();

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -208,7 +208,7 @@ export class ProviderBase {
 
     protected loginInner() {
         const ns = this.name
-        core.showLoading(ns + "login", lf("Logging you in to {0}...", this.friendlyName))
+        core.showLoading(ns + "login", lf("Signing you in to {0}...", this.friendlyName))
         const state = setOauth(ns);
 
         const providerDef = pxt.appTarget.cloud && pxt.appTarget.cloud.cloudProviders && pxt.appTarget.cloud.cloudProviders[this.name];

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -249,7 +249,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
     }
 
     signOutGithub() {
-        pxt.tickEvent("home.github.signout");
+        pxt.tickEvent("menu.github.signout");
         const githubProvider = cloudsync.githubProvider();
         if (githubProvider) {
             githubProvider.logout();

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -110,11 +110,11 @@ export class GithubProvider extends cloudsync.ProviderBase {
     }
 
     private oauthRedirectAsync(): Promise<void> {
-        core.showLoading("ghlogin", lf("Logging you in to GitHub..."))
+        core.showLoading("ghlogin", lf("Signing you in to GitHub..."))
         const self = window.location.href.replace(/#.*/, "")
         const state = ts.pxtc.Util.guidGen();
-        pxt.storage.setLocal("oauthState", state)
-        pxt.storage.setLocal("oauthType", this.name)
+        pxt.storage.setLocal(cloudsync.OAUTH_STATE, state)
+        pxt.storage.setLocal(cloudsync.OAUTH_TYPE, this.name)
         const login = pxt.Cloud.getServiceUrl() +
             "/oauth/login?state=" + state +
             "&response_type=token&client_id=gh-token&redirect_uri=" +

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -112,9 +112,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
     private oauthRedirectAsync(): Promise<void> {
         core.showLoading("ghlogin", lf("Signing you in to GitHub..."))
         const self = window.location.href.replace(/#.*/, "")
-        const state = ts.pxtc.Util.guidGen();
-        pxt.storage.setLocal(cloudsync.OAUTH_STATE, state)
-        pxt.storage.setLocal(cloudsync.OAUTH_TYPE, this.name)
+        const state = cloudsync.setOauth(this.name);
         const login = pxt.Cloud.getServiceUrl() +
             "/oauth/login?state=" + state +
             "&response_type=token&client_id=gh-token&redirect_uri=" +

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -111,8 +111,8 @@ export class GithubProvider extends cloudsync.ProviderBase {
 
     private oauthRedirectAsync(): Promise<void> {
         core.showLoading("ghlogin", lf("Signing you in to GitHub..."))
-        const self = window.location.href.replace(/#.*/, "")
         const state = cloudsync.setOauth(this.name);
+        const self = window.location.href.replace(/#.*/, "")
         const login = pxt.Cloud.getServiceUrl() +
             "/oauth/login?state=" + state +
             "&response_type=token&client_id=gh-token&redirect_uri=" +

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -72,6 +72,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
     }
 
     private async newBranchAsync() {
+        await cloudsync.ensureGitHubTokenAsync();
         const gid = this.parsedRepoId()
         const initialBranchName = await pxt.github.getNewBranchNameAsync(gid.fullName, "patch-")
         const branchName = await core.promptAsync({

--- a/webapp/src/onedrive.ts
+++ b/webapp/src/onedrive.ts
@@ -129,7 +129,7 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
             let expiresInSeconds = qs["expires_in"];
 
             if (accessToken) {
-                let ex = pxt.storage.getLocal("oauthState");
+                let ex = pxt.storage.getLocal(cloudsync.OAUTH_STATE);
                 if (!ex) {
                     reportError("OAuth not started");
                     return;
@@ -138,8 +138,8 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
                     reportError("OAuth state mismatch");
                     return;
                 }
-                pxt.storage.removeLocal("oauthState");
-                pxt.storage.setLocal("oauthHash", frameHash);
+                pxt.storage.removeLocal(cloudsync.OAUTH_STATE);
+                pxt.storage.setLocal(cloudsync.OAUTH_HASH, frameHash);
             } else {
                 reportError("access_token not in #");
                 return;
@@ -173,7 +173,7 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
 
         // Pop out
         const popupCallback = () => {
-            const qs = core.parseQueryString(pxt.storage.getLocal("oauthHash") || "")
+            const qs = core.parseQueryString(pxt.storage.getLocal(cloudsync.OAUTH_HASH) || "")
             const accessToken = qs["access_token"];
             const expiresInSeconds = parseInt(qs["expires_in"]);
 
@@ -248,7 +248,7 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
                 let expiresInSeconds = qs["expires_in"];
 
                 if (accessToken) {
-                    let ex = pxt.storage.getLocal("oauthState");
+                    let ex = pxt.storage.getLocal(cloudsync.OAUTH_STATE);
                     if (!ex) {
                         pxt.debug("OAuth not started")
                         retryLogin();
@@ -259,8 +259,8 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
                         retryLogin();
                         return;
                     }
-                    pxt.storage.removeLocal("oauthState");
-                    pxt.storage.setLocal("oauthHash", frameHash);
+                    pxt.storage.removeLocal(cloudsync.OAUTH_STATE);
+                    pxt.storage.setLocal(cloudsync.OAUTH_HASH, frameHash);
                 } else {
                     pxt.debug("access_token not in #")
                     retryLogin();

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -269,8 +269,11 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
     signOutGithub() {
         pxt.tickEvent("home.github.signout");
         const githubProvider = cloudsync.githubProvider();
-        if (githubProvider)
+        if (githubProvider) {
             githubProvider.logout();
+            this.props.parent.forceUpdate();
+            core.infoNotification(lf("Signed out from GitHub"))
+        }
     }
 
     renderCore() {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -786,19 +786,6 @@ export interface ImportDialogState {
     visible?: boolean;
 }
 
-function githubLogin() {
-    core.showLoading("ghlogin", lf("Logging you in to GitHub..."))
-    const self = window.location.href.replace(/#.*/, "")
-    const state = ts.pxtc.Util.guidGen();
-    pxt.storage.setLocal("oauthState", state)
-    pxt.storage.setLocal("oauthType", "github")
-    const login = pxt.Cloud.getServiceUrl() +
-        "/oauth/login?state=" + state +
-        "&response_type=token&client_id=gh-token&redirect_uri=" +
-        encodeURIComponent(self)
-    window.location.href = login
-}
-
 export class ImportDialog extends data.Component<ISettingsProps, ImportDialogState> {
     constructor(props: ISettingsProps) {
         super(props);
@@ -892,7 +879,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                 {pxt.github.token || true ? undefined :
                     <p>
                         <br /><br />
-                        <a className="small" href="#github" role="button" onClick={githubLogin}
+                        <a className="small" href="#github" role="button" onClick={cloudsync.githubLogin}
                             aria-label={lf("GitHub login")}>{lf("GitHub login")}</a>
                     </p>}
             </sui.Modal>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -879,12 +879,6 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                             onClick={this.cloneGithub}
                         /> : undefined}
                 </div>
-                {pxt.github.token || true ? undefined :
-                    <p>
-                        <br /><br />
-                        <a className="small" href="#github" role="button" onClick={cloudsync.githubLogin}
-                            aria-label={lf("GitHub login")}>{lf("GitHub login")}</a>
-                    </p>}
             </sui.Modal>
         )
     }


### PR DESCRIPTION
Scenario: GitHub button -> create repo -> OAuth sign in -> reload script -> create repository -> success
- [x] clean up use of "oath*" local variables
- [x] removed legacy GitHub sign in button in extensions
- [x] support for coming back in editor when signing in
- [x] support for coming back into "create repository" dialog after oath