### PR TITLE
Fix assumption that main.py always exists when switching to python

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -532,18 +532,23 @@ export class ProjectView
     }
 
     openPythonAsync(): Promise<void> {
-        // convert python to typescript, if same as current source, skip decompilation
-        const tssrc = pkg.mainEditorPkg().files["main.ts"].content;
-        return this.textEditor.convertPythonToTypeScriptAsync()
-            .then(pysrc => {
-                if (pysrc == tssrc) {
-                    // decompiled python is same current typescript, go back to python without ts->py conversion
-                    pxt.debug(`ts -> py shortcut`)
-                    this.setFile(pkg.mainEditorPkg().files["main.py"]);
-                    return Promise.resolve();
-                }
-                else return this.convertTypeScriptToPythonAsync();
-            });
+        const pySrcFile = pkg.mainEditorPkg().files["main.py"];
+        if (pySrcFile) { // do we have any python yet?
+            // convert python to typescript, if same as current source, skip decompilation
+            const tsSrc = pkg.mainEditorPkg().files["main.ts"].content;
+            return this.textEditor.convertPythonToTypeScriptAsync()
+                .then(pyAsTsSrc => {
+                    if (pyAsTsSrc == tsSrc) {
+                        // decompiled python is same current typescript, go back to python without ts->py conversion
+                        pxt.debug(`ts -> py shortcut`)
+                        this.setFile(pkg.mainEditorPkg().files["main.py"]);
+                        return Promise.resolve();
+                    }
+                    else return this.convertTypeScriptToPythonAsync();
+                });
+        } else {
+            return this.convertTypeScriptToPythonAsync();
+        }
     }
 
     private convertTypeScriptToPythonAsync() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -541,7 +541,7 @@ export class ProjectView
                     if (pyAsTsSrc == tsSrc) {
                         // decompiled python is same current typescript, go back to python without ts->py conversion
                         pxt.debug(`ts -> py shortcut`)
-                        this.setFile(pkg.mainEditorPkg().files["main.py"]);
+                        this.setFile(pySrcFile);
                         return Promise.resolve();
                     }
                     else return this.convertTypeScriptToPythonAsync();


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-minecraft/issues/1472

When switching to Python, we were assuming that main.py always existed. This was causing crashes.