### PR TITLE
disable Python toolbox but add an experiment to re-enable

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -183,7 +183,7 @@ declare namespace pxt {
         yottaCorePackage?: string; // pxt-microbit-core
         yottaConfig?: any; // additional config
         yottaConfigCompatibility?: boolean; // enforce emitting backward compatible yotta config entries (YOTTA_CFG_)
-        
+
         platformioIni?: string[];
 
         codalTarget?: string | {
@@ -358,6 +358,7 @@ declare namespace pxt {
         shareFinishedTutorials?: boolean; // always pop a share dialog once the tutorial is finished
         leanShare?: boolean; // use leanscript.html instead of script.html for sharing pages
         nameProjectFirst?: boolean;
+        pythonToolbox?: boolean; // Code toolbox for Python
     }
 
     interface SocialOptions {

--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -85,6 +85,12 @@ namespace pxt.editor.experiments {
                 feedbackUrl: "https://github.com/microsoft/pxt/issues/5390"
             },
             {
+                id: "pythonToolbox",
+                name: lf("Toolbox for Static Python"),
+                description: lf("Use the code toolbox in Static Python"),
+                feedbackUrl: "https://github.com/microsoft/pxt/issues/6291"
+            },
+            {
                 id: "simGif",
                 name: lf("Simulator Gifs"),
                 description: lf("Download gifs of the simulator"),

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1017,7 +1017,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         return pxt.appTarget.appTheme.monacoToolbox
             && !readOnly
             && ((this.fileType == "typescript" && this.currFile.name == "main.ts")
-                || (this.fileType == "python" && this.currFile.name == "main.py"));
+                || (pxt.appTarget.appTheme.pythonToolbox && this.fileType == "python" && this.currFile.name == "main.py"));
     }
 
     loadFileAsync(file: pkg.File, hc?: boolean): Promise<void> {


### PR DESCRIPTION
Puts the toolbox behind an experiment flag. 

Fixes: https://github.com/microsoft/pxt-minecraft/issues/1476