### PR TITLE
Small python-related cleanup: var rename & throw->assert

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3720,7 +3720,7 @@ function decompileAsyncWorker(f: string, dependency?: string): Promise<string> {
     });
 }
 
-function testSnippetsAsync(snippets: CodeSnippet[], re?: string, pycheck?: boolean): Promise<void> {
+function testSnippetsAsync(snippets: CodeSnippet[], re?: string, pyStrictSyntaxCheck?: boolean): Promise<void> {
     console.log(`### TESTING ${snippets.length} CodeSnippets`)
     pxt.github.forceProxy = true; // avoid throttling in CI machines
     let filenameMatch: RegExp;
@@ -3887,7 +3887,7 @@ function testSnippetsAsync(snippets: CodeSnippet[], re?: string, pycheck?: boole
                                 .filter(l => l)
                                 .join("")
 
-                        if (pycheck) {
+                        if (pyStrictSyntaxCheck) {
                             let cmp1 = getComparisonString(ts1)
                             let cmp2 = getComparisonString(ts2)
                             let mismatch = cmp1 != cmp2

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2314,8 +2314,7 @@ namespace pxt.py {
         const outfiles: Map<string> = {}
         diagnostics = []
 
-        if (!opts.sourceFiles)
-            throw Error("missing sourceFiles! Cannot convert py to ts")
+        U.assert(!!opts.sourceFiles, "missing sourceFiles! Cannot convert py to ts")
 
         // find .ts files that are copies of / shadowed by the .py files
         let pyFiles = opts.sourceFiles!.filter(fn => U.endsWith(fn, ".py"))
@@ -2328,8 +2327,7 @@ namespace pxt.py {
         let tsShadowFiles = tsFiles
             .filter(fn => removeEnd(fn, ".ts") in pyFilesSet)
 
-        if (!opts.apisInfo)
-            throw Error("missing apisInfo! Cannot convert py to ts")
+        U.assert(!!opts.apisInfo, "missing apisInfo! Cannot convert py to ts")
 
         lastFile = pyFiles[0] // make sure there's some location info for errors from API init
         initApis(opts.apisInfo!, tsShadowFiles)


### PR DESCRIPTION
- Rename "pycheck" to "pyStrictSyntaxCheck" in "pxt checkdocs" CLI command because we DO check python without that flag, we just don't do the full-blown round-trip syntax comparison (which is very brittle)
- Change a throw that's better done as an assert