### PR TITLE
Don't clobber r1 register in clearStack()

### DIFF
--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -458,6 +458,7 @@ ${baseLabel}_nochk:
             if (!fast) {
                 let toClear = this.exprStack.filter(e => e.currUses == e.totalUses && e.irCurrUses != -1)
                 if (toClear.length > 0) {
+                    // use r7 as temp; r0-r3 might be used as arguments to functions
                     this.write(this.t.reg_gets_imm("r7", 0))
                     for (let a of toClear) {
                         a.irCurrUses = -1

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -458,10 +458,10 @@ ${baseLabel}_nochk:
             if (!fast) {
                 let toClear = this.exprStack.filter(e => e.currUses == e.totalUses && e.irCurrUses != -1)
                 if (toClear.length > 0) {
-                    this.write(this.t.reg_gets_imm("r1", 0))
+                    this.write(this.t.reg_gets_imm("r7", 0))
                     for (let a of toClear) {
                         a.irCurrUses = -1
-                        this.write(this.loadFromExprStack("r1", a, 0, true))
+                        this.write(this.loadFromExprStack("r7", a, 0, true))
                     }
                 }
             }

--- a/tests/compile-test/lang-test0/29lazyreferences.ts
+++ b/tests/compile-test/lang-test0/29lazyreferences.ts
@@ -33,3 +33,35 @@ function testLazyRef() {
     assert(qq == null, "&r")
 }
 testLazyRef()
+
+// https://github.com/microsoft/pxt-arcade/issues/1519
+namespace InlinePlusCond {
+    interface MFX {
+        _dummy: any;
+    }
+    
+    const zero = 0 as any as MFX
+    const one = 1 as any as MFX
+    function sub(a:MFX, b:MFX) {
+        return ((a as any as number) - (b as any as number)) as any as MFX
+    }
+    class Foobar {
+        constructor(public x: MFX, public y: MFX) {}
+    }
+    
+    function testIt() {
+        let s = new Foobar(zero, one)
+        let right = true
+    
+        let vv = zero
+    
+        s.x = sub(
+            right ? vv : vv,
+            s.y
+        );
+
+        assert(s.x as any as number == -1, "mfx")
+    }
+
+    testIt()
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1519
