### PR TITLE
clear crowdin translation annotations from blocks

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -472,13 +472,7 @@ namespace ts.pxtc {
         if (pxtc.Util.userLanguage() == "en") {
             // remove crowdin annotations from blocks
             return Promise.all(
-                Util.values(apis.byQName).map(fn => {
-                    const attrs = fn.attributes;
-                    if (attrs.block) {
-                        attrs.block = removeCrowdinAnnotations(attrs.block);
-                        updateBlockDef(attrs);
-                    }
-                })
+                Util.values(apis.byQName).map(fn => removeCrowdinAnnotations(fn.attributes))
             ).then(() => apis);
         }
 
@@ -543,10 +537,7 @@ namespace ts.pxtc {
                             }
                         }
                     }
-                    if (fn.attributes.block) {
-                        // remove any remaining annotations from untranslated blocks
-                        fn.attributes.block = removeCrowdinAnnotations(fn.attributes.block);
-                    }
+                    removeCrowdinAnnotations(fn.attributes);
                     updateBlockDef(fn.attributes);
                 })
             })))
@@ -556,8 +547,10 @@ namespace ts.pxtc {
                     pxt.reportError(`loc.errors`, `invalid translation`, errors);
             })
 
-        function removeCrowdinAnnotations(blockText: string) {
-            return blockText.replace(/{.+:.+}/, "");
+        function removeCrowdinAnnotations(attrs: CommentAttrs) {
+            if (attrs.block) {
+                attrs.block = attrs.block.replace(/{.+:.+}/, "");
+            }
         }
     }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -549,7 +549,7 @@ namespace ts.pxtc {
 
         function removeCrowdinAnnotations(attrs: CommentAttrs) {
             if (attrs.block) {
-                attrs.block = attrs.block.replace(/{.+:.+}/, "");
+                attrs.block = attrs.block.replace(/{[^}]+:[^}]+}/, "");
             }
         }
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1458

Issue was that the block text never directly goes the `rlf`, which typically handles the removal of these annotations; the annotations that are added (like the namespace) are only used to lookup the translations, and are not part of the comment attributes. This just clears any annotations from the blocks when handling localizations. 

(also, I'm out on vacation next week so probably won't be able to update this PR before this needs to be fixed, so anyone can feel free to take this over / fix it in a better way if this is the wrong way to handle it)

re: https://github.com/microsoft/pxt-common-packages/pull/986, https://github.com/microsoft/pxt-common-packages/pull/1020