### PR TITLE
Fixing monaco sprite editor after tile map refactor

### DIFF
--- a/pxteditor/monaco-fields/field_react.ts
+++ b/pxteditor/monaco-fields/field_react.ts
@@ -52,8 +52,8 @@ namespace pxt.editor {
             this.onClosed();
         }
 
-        protected textToValue(text: string): any {
-            return text
+        protected textToValue(text: string): U {
+            return null
         }
 
         protected resultToText(result: U): string {

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -5,7 +5,7 @@ namespace pxt.editor {
     const fieldEditorId = "image-editor";
 
     export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.sprite.Bitmap> {
-        protected textToValue(text: string): any {
+        protected textToValue(text: string): pxt.sprite.Bitmap {
             return pxt.sprite.imageLiteralToBitmap(text);
         }
 

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -6,7 +6,7 @@ namespace pxt.editor {
 
     export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.sprite.Bitmap> {
         protected textToValue(text: string): any {
-            return text;
+            return pxt.sprite.imageLiteralToBitmap(text);
         }
 
         protected resultToText(result: pxt.sprite.Bitmap): string {


### PR DESCRIPTION
As the name suggests, I refactored the interface for the react field editors in the tilemap pr but forgot to do this one.

Fixes https://github.com/microsoft/pxt-arcade/issues/1523