### PR TITLE
Tileset field editor

### DIFF
--- a/pxtblocks/blocklycustomeditor.ts
+++ b/pxtblocks/blocklycustomeditor.ts
@@ -43,6 +43,7 @@ namespace pxt.blocks {
         registerFieldEditor('sprite', pxtblockly.FieldSpriteEditor);
         registerFieldEditor('animation', pxtblockly.FieldAnimationEditor);
         registerFieldEditor('tilemap', pxtblockly.FieldTilemap);
+        registerFieldEditor('tileset', pxtblockly.FieldTileset);
         registerFieldEditor('speed', pxtblockly.FieldSpeed);
         registerFieldEditor('turnratio', pxtblockly.FieldTurnRatio);
         registerFieldEditor('protractor', pxtblockly.FieldProtractor);

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -85,6 +85,10 @@ namespace pxtblockly {
         constructor(text: string, options: FieldImageDropdownOptions, validator?: Function) {
             super(text, options, validator);
             this.blocksInfo = options.blocksInfo;
+
+            if (!text) {
+                this.setValue(this.getOptions()[0][1]);
+            }
         }
 
         menuGenerator_ = () => {

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -1,0 +1,109 @@
+/// <reference path="../../built/pxtlib.d.ts" />
+
+namespace pxtblockly {
+    export interface ImageJSON {
+        src: string;
+        alt: string;
+        width: number;
+        height: number;
+    }
+
+    export type TilesetDropdownOption = [ImageJSON, string];
+
+    export class FieldTileset extends FieldImages implements Blockly.FieldCustom {
+        private static tileCache: pxt.Map<string>;
+        private static galleryTiles: TilesetDropdownOption[];
+
+        public static rebuildTileCache(ws: Blockly.Workspace, blocksInfo: pxtc.BlocksInfo) {
+            const tiles = getAllTilesetTiles(ws);
+
+            if (!FieldTileset.tileCache) FieldTileset.tileCache = {};
+
+            for (const t of tiles) {
+                const key = FieldTileset.getTileKey(t);
+
+                if (key) {
+                    FieldTileset.tileCache[key] = bitmapToImageURI(pxt.sprite.Bitmap.fromData(t.data), 16, false);
+                }
+            }
+
+            FieldTileset.galleryTiles = [];
+
+            if (!blocksInfo) return;
+
+            const tilemaps = getAllBlocksWithTilemaps(ws);
+            for (const t of tilemaps) {
+                const ts = t.ref.getTileset();
+
+                for (const tile of ts.tiles) {
+                    if (tile.qualifiedName) {
+                        if (!FieldTileset.tileCache[tile.qualifiedName]) {
+                            FieldTileset.tileCache[tile.qualifiedName] = bitmapToImageURI(pxt.sprite.getBitmap(blocksInfo, tile.qualifiedName), ts.tileWidth, false);
+                        }
+                        if (!FieldTileset.galleryTiles.some(([, qname]) => qname === tile.qualifiedName)) {
+                            FieldTileset.galleryTiles.push([FieldTileset.getTileImageJSON(tile, ws, blocksInfo), tile.qualifiedName]);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static getTileKey(t: pxt.sprite.TileInfo) {
+            if (t.qualifiedName) return t.qualifiedName;
+            if (t.projectId !== undefined) return `${pxt.sprite.TILE_NAMESPACE}.${pxt.sprite.TILE_PREFIX}${t.projectId}`;
+
+            return undefined;
+        }
+
+        public static getTileImage(t: pxt.sprite.TileInfo, ws: Blockly.Workspace, blocksInfo: pxtc.BlocksInfo) {
+            if (!FieldTileset.tileCache) {
+                FieldTileset.rebuildTileCache(ws, blocksInfo);
+            }
+
+            return FieldTileset.tileCache[FieldTileset.getTileKey(t)];
+        }
+
+        public static getTileImageJSON(t: pxt.sprite.TileInfo, ws: Blockly.Workspace, blocksInfo: pxtc.BlocksInfo) {
+            const uri = FieldTileset.getTileImage(t, ws, blocksInfo);
+
+            return {
+                src: uri,
+                width: 50,
+                height: 50,
+                alt: FieldTileset.getTileKey(t).split(".").pop()
+            }
+        }
+
+        public static getGalleryTiles(): TilesetDropdownOption[] {
+            return FieldTileset.galleryTiles;
+        }
+
+        public isFieldCustom_ = true;
+        protected selected: pxt.sprite.TileInfo;
+        protected blocksInfo: pxtc.BlocksInfo;
+
+        constructor(text: string, options: FieldImageDropdownOptions, validator?: Function) {
+            super(text, options, validator);
+            this.blocksInfo = options.blocksInfo;
+        }
+
+        menuGenerator_ = () => {
+            let options: any[][] = [[{
+                    src: bitmapToImageURI(new pxt.sprite.Bitmap(16, 16), 16, false),
+                    width: 50,
+                    height: 50,
+                    alt: "transparency"
+                }, "null"
+            ]];
+
+            if (this.sourceBlock_) {
+                // projectId 0 is reserved for transparency, which is always included
+                const projectTiles = getAllTilesetTiles(this.sourceBlock_.workspace).filter(t => t.projectId !== 0);
+                options.push(...projectTiles.map(info => [FieldTileset.getTileImageJSON(info, this.sourceBlock_.workspace, this.blocksInfo), FieldTileset.getTileKey(info)]).filter(([, b]) => !!b));
+                options.push(...FieldTileset.getGalleryTiles());
+            }
+
+            return options;
+        }
+    }
+}

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -191,6 +191,10 @@ namespace pxt.sprite {
 
     export class TilemapData {
         nextId = 0;
+
+        // Used to make sure the user doesn't delete a tile used elsewhere in their project
+        projectReferences: number[];
+
         constructor(public tilemap: Tilemap, public tileset: TileSet, public layers: BitmapData) {}
     }
 

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -100,7 +100,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
     }
 
     initTilemap(data: pxt.sprite.TilemapData, gallery: GalleryTile[]) {
-        this.getStore().dispatch(dispatchSetInitialTilemap(data.tilemap.data(), data.tileset, gallery, [data.layers], data.nextId));
+        this.getStore().dispatch(dispatchSetInitialTilemap(data.tilemap.data(), data.tileset, gallery, [data.layers], data.nextId, data.projectReferences));
     }
 
     onResize() {

--- a/webapp/src/components/ImageEditor/actions/dispatch.ts
+++ b/webapp/src/components/ImageEditor/actions/dispatch.ts
@@ -29,7 +29,7 @@ export const dispatchSwapBackgroundForeground = () => ({ type: actions.SWAP_FORE
 export const dispatchChangeBackgroundColor = (backgroundColor: number) => ({ type: actions.CHANGE_BACKGROUND_COLOR, backgroundColor })
 export const dispatchSetInitialFrames = (frames: pxt.sprite.ImageState[], interval: number) => ({ type: actions.SET_INITIAL_FRAMES, frames, interval });
 export const dispatchSetInitialState = (state: EditorState, past: AnimationState[]) => ({ type: actions.SET_INITIAL_STATE, state, past });
-export const dispatchSetInitialTilemap = (tilemap: pxt.sprite.BitmapData, tileset: pxt.sprite.TileSet, gallery: GalleryTile[], layers: pxt.sprite.BitmapData[], nextId: number) => ({ type: actions.SET_INITIAL_TILEMAP, tilemap, tileset, layers, gallery, nextId });
+export const dispatchSetInitialTilemap = (tilemap: pxt.sprite.BitmapData, tileset: pxt.sprite.TileSet, gallery: GalleryTile[], layers: pxt.sprite.BitmapData[], nextId: number, referencedTiles: number[]) => ({ type: actions.SET_INITIAL_TILEMAP, tilemap, tileset, layers, gallery, nextId, referencedTiles });
 export const dispatchChangeTilePaletteCategory = (category: TileCategory) => ({ type: actions.CHANGE_TILE_PALETTE_CATEGORY, category });
 export const dispatchChangeTilePalettePage = (page: number) => ({ type: actions.CHANGE_TILE_PALETTE_PAGE, page });
 export const dispatchChangeDrawingMode = (drawingMode: TileDrawingMode) => ({ type: actions.CHANGE_DRAWING_MODE, drawingMode });

--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -64,6 +64,7 @@ export interface EditorState {
     tileGalleryOpen?: boolean;
 
     isTilemap: boolean;
+    referencedTiles?: number[];
 
     // The state below this comment is not persisted between editor reloads
     previewAnimating: boolean;
@@ -194,7 +195,8 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     tilemapPalette: restored.tilemapPalette,
                     tileGalleryOpen: restored.tileGalleryOpen,
                     tileGallery: restored.tileGallery,
-                    isTilemap: restored.isTilemap
+                    isTilemap: restored.isTilemap,
+                    referencedTiles: state.editor.referencedTiles
                 },
                 store: {
                     ...state.store,
@@ -263,7 +265,8 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     },
                     drawingMode: TileDrawingMode.Default,
                     overlayEnabled: true,
-                    tileGallery: action.gallery
+                    tileGallery: action.gallery,
+                    referencedTiles: action.referencedTiles
                 },
                 store: {
                     ...state.store,

--- a/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
+++ b/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
@@ -13,6 +13,8 @@ export interface TilePaletteProps {
     selected: number;
     backgroundColor: number;
 
+    referencedTiles: number[];
+
     category: TileCategory;
     page: number;
 
@@ -285,9 +287,15 @@ class TilePaletteImpl extends React.Component<TilePaletteProps,{}> {
     }
 
     protected tileDeleteHandler = () => {
-        const { tileset, selected, dispatchDeleteTile } = this.props;
+        const { tileset, selected, dispatchDeleteTile, referencedTiles } = this.props;
 
-        if (!tileset.tiles[selected] || tileset.tiles[selected].qualifiedName || selected === 0) return;
+        const info = tileset.tiles[selected];
+
+        if (!selected || !info || info.qualifiedName) return;
+
+        if (referencedTiles && referencedTiles.indexOf(info.projectId) !== -1) {
+            return;
+        }
 
         dispatchDeleteTile(selected);
     }
@@ -412,7 +420,8 @@ function mapStateToProps({ store: { present }, editor }: ImageEditorStore, ownPr
         colors: state.colors,
         drawingMode: editor.drawingMode,
         gallery: editor.tileGallery,
-        galleryOpen: editor.tileGalleryOpen
+        galleryOpen: editor.tileGalleryOpen,
+        referencedTiles: editor.referencedTiles
     };
 }
 


### PR DESCRIPTION
![2019-12-09 16 34 37](https://user-images.githubusercontent.com/13754588/70486890-4dc7f780-1aa8-11ea-9063-9ccb725f6b68.gif)

This is the field editor for referencing tiles; it's based on the image dropdown and contains all tiles that are referenced in your current project.

In order to prevent students from breaking their own code, you can't delete any tile from your tilemap that is referenced by one of these field editors. Right now it just silently refuses to do it; I'll be adding an actual warning message in a different PR.