### PR TITLE
Pull status as cached data

### DIFF
--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -280,6 +280,11 @@ export function invalidate(prefix: string) {
     })
 }
 
+export function invalidateHeader(prefix: string, hd: pxt.workspace.Header) {
+    if (hd)
+        invalidate(prefix + ':' + hd.id);
+}
+
 export function getAsync(path: string) {
     let ce = lookup(path)
 

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as sui from "./sui";
 import * as pkg from "./package";
 import * as cloudsync from "./cloudsync";
+import * as workspace from "./workspace";
 
 interface GithubButtonProps extends pxt.editor.ISettingsProps {
     className?: string;
@@ -60,6 +61,7 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
 
         // existing repo
         const meta: pkg.PackageGitStatus = this.getData("pkg-git-status:" + header.id);
+        const haspull = meta && this.getData("pkg-git-pull-status:" + header.id) == workspace.PullStatus.GotChanges;
         const modified = meta && !!meta.modified;
         const repoName = ghid.project && ghid.tag ? `${ghid.project}${ghid.tag == "master" ? "" : `#${ghid.tag}`}` : ghid.fullName;
         const title = lf("Review and commit changes for {0}", repoName);
@@ -67,7 +69,7 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
         return <div key="githubeditorbtn" role="button" className={`${defaultCls} ${this.props.className || ""}`}
             title={title} onClick={this.handleClick}>
             <i className="github icon" />
-            <i className={`ui long ${modified ? "arrow alternate up" : "check"} icon mobile hide`} />
+            <i className={`ui long ${haspull ? "arrow alternate down" : modified ? "arrow alternate up" : "check"} icon mobile hide`} />
         </div>;
     }
 }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -331,7 +331,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         pkg.mainEditorPkg().setFiles(files);
         // check if we need to reload header
         const newKey = this.pkgConfigKey(files[pxt.CONFIG_NAME])
-        _package.invalidatePullStatus();        
+        _package.invalidatePullStatus(header);        
         if (newKey != this.state.previousCfgKey) {
             await this.setStateAsync({ previousCfgKey: newKey });
             await this.props.parent.reloadHeaderAsync();
@@ -340,6 +340,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
 
     private async pullAsync() {
         this.showLoading("github.pull", false, lf("pulling changes from GitHub..."));
+        const { header } = this.props.parent.state;
         try {
             const status = await workspace.pullAsync(this.props.parent.state.header)
                 .catch(this.handleGithubError)
@@ -357,7 +358,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         } catch (e) {
             this.handleGithubError(e);
         } finally {
-            _package.invalidatePullStatus();
+            _package.invalidatePullStatus(header);
             this.hideLoading();
         }
     }
@@ -743,15 +744,12 @@ ${content}
         }
     }
 
-    private refreshPull() {
-        data.invalidate("pkg-git-pull-status:" + this.props.parent.state.header.id)
-    }
-
     setVisible(b: boolean) {
         if (b === this.state.isVisible) return;
 
-        _package.invalidatePullStatus();        
+        const { header} = this.props.parent.state        
         if (b) {
+            _package.invalidatePullStatus(header);        
             this.setState({
                 previousCfgKey: this.pkgConfigKey(pkg.mainEditorPkg().files[pxt.CONFIG_NAME].content)
             });

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -331,7 +331,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         pkg.mainEditorPkg().setFiles(files);
         // check if we need to reload header
         const newKey = this.pkgConfigKey(files[pxt.CONFIG_NAME])
-        _package.invalidatePullStatus(header);        
+        _package.invalidatePullStatus(header);
         if (newKey != this.state.previousCfgKey) {
             await this.setStateAsync({ previousCfgKey: newKey });
             await this.props.parent.reloadHeaderAsync();
@@ -747,9 +747,9 @@ ${content}
     setVisible(b: boolean) {
         if (b === this.state.isVisible) return;
 
-        const { header} = this.props.parent.state        
+        const { header } = this.props.parent.state
         if (b) {
-            _package.invalidatePullStatus(header);        
+            _package.invalidatePullStatus(header);
             this.setState({
                 previousCfgKey: this.pkgConfigKey(pkg.mainEditorPkg().files[pxt.CONFIG_NAME].content)
             });

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -10,6 +10,7 @@ import * as data from "./data";
 import * as markedui from "./marked";
 import * as compiler from "./compiler";
 import * as cloudsync from "./cloudsync";
+import * as _package from "./package";
 
 const MAX_COMMIT_DESCRIPTION_LENGTH = 70;
 
@@ -35,7 +36,6 @@ interface GithubState {
     isVisible?: boolean;
     description?: string;
     needsCommitMessage?: boolean;
-    needsPull?: boolean;
     triedFork?: boolean;
     previousCfgKey?: string;
     loadingMessage?: string;
@@ -331,11 +331,9 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         pkg.mainEditorPkg().setFiles(files);
         // check if we need to reload header
         const newKey = this.pkgConfigKey(files[pxt.CONFIG_NAME])
-        if (newKey == this.state.previousCfgKey) {
-            // refresh pull status
-            await this.refreshPullAsync();
-        } else {
-            await this.setStateAsync({ needsPull: undefined, previousCfgKey: newKey });
+        _package.invalidatePullStatus();        
+        if (newKey != this.state.previousCfgKey) {
+            await this.setStateAsync({ previousCfgKey: newKey });
             await this.props.parent.reloadHeaderAsync();
         }
     }
@@ -343,17 +341,14 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
     private async pullAsync() {
         this.showLoading("github.pull", false, lf("pulling changes from GitHub..."));
         try {
-            this.setState({ needsPull: undefined });
             const status = await workspace.pullAsync(this.props.parent.state.header)
                 .catch(this.handleGithubError)
             switch (status) {
                 case workspace.PullStatus.NoSourceControl:
                 case workspace.PullStatus.UpToDate:
-                    this.setState({ needsPull: false });
                     break
                 case workspace.PullStatus.NeedsCommit:
                     this.setState({ needsCommitMessage: true });
-                    await this.refreshPullAsync();
                     break
                 case workspace.PullStatus.GotChanges:
                     await this.maybeReloadAsync();
@@ -362,6 +357,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         } catch (e) {
             this.handleGithubError(e);
         } finally {
+            _package.invalidatePullStatus();
             this.hideLoading();
         }
     }
@@ -747,34 +743,22 @@ ${content}
         }
     }
 
-    private refreshPullAsync() {
-        return this.setStateAsync({ needsPull: undefined })
-            .then(() => workspace.hasPullAsync(this.props.parent.state.header))
-            .then(v => this.setStateAsync({ needsPull: v }))
-            .catch(e => {
-                const statusCode = parseInt(e.statusCode);
-                if (e.isOffline || statusCode === 0) {
-                    // don't report offline on this one
-                    this.setState({ needsPull: undefined });
-                    return;
-                }
-                this.handleGithubError(e);
-            });
+    private refreshPull() {
+        data.invalidate("pkg-git-pull-status:" + this.props.parent.state.header.id)
     }
 
     setVisible(b: boolean) {
         if (b === this.state.isVisible) return;
 
+        _package.invalidatePullStatus();        
         if (b) {
             this.setState({
                 previousCfgKey: this.pkgConfigKey(pkg.mainEditorPkg().files[pxt.CONFIG_NAME].content)
             });
-            this.refreshPullAsync().done();
         } else {
             this.clearCache();
             this.setState({
                 needsCommitMessage: false,
-                needsPull: undefined
             });
         }
     }
@@ -803,7 +787,8 @@ ${content}
         const needsCommit = diffFiles.length > 0;
         const displayDiffFiles = isBlocksMode && !pxt.options.debug ? diffFiles.filter(f => /\.blocks$/.test(f.name)) : diffFiles;
 
-        const { needsPull } = this.state;
+        const pullStatus: workspace.PullStatus = this.getData("pkg-git-pull-status:" + this.props.parent.state.header.id);
+        const needsPull = pullStatus === workspace.PullStatus.GotChanges;
         const githubId = this.parsedRepoId()
         const master = githubId.tag == "master";
         const user = this.getData("github:user");

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -703,8 +703,7 @@ data.mountVirtualApi("pkg-git-status", {
 })
 
 export function invalidatePullStatus(hd: pxt.workspace.Header) {
-    if (hd)
-        data.invalidate("pkg-git-pull-status:" + hd.id)
+    data.invalidateHeader("pkg-git-pull-status:", hd)
 }
 
 data.mountVirtualApi("pkg-git-pull-status", {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -703,7 +703,7 @@ data.mountVirtualApi("pkg-git-status", {
 })
 
 export function invalidatePullStatus(hd: pxt.workspace.Header) {
-    data.invalidateHeader("pkg-git-pull-status:", hd)
+    data.invalidateHeader("pkg-git-pull-status", hd)
 }
 
 data.mountVirtualApi("pkg-git-pull-status", {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -702,6 +702,23 @@ data.mountVirtualApi("pkg-git-status", {
     }
 })
 
+export function invalidatePullStatus(hd: pxt.workspace.Header) {
+    if (hd)
+        data.invalidate("pkg-git-pull-status:" + hd.id)
+}
+
+data.mountVirtualApi("pkg-git-pull-status", {
+    getAsync: p => {
+        p = data.stripProtocol(p)
+        const f = allEditorPkgs().find(pkg => pkg.header && pkg.header.id == p);
+        const ghid = f.getPkgId() == "this" && f.header && f.header.githubId;
+        if (!ghid) return Promise.resolve(workspace.PullStatus.NoSourceControl)
+        return workspace.pullAsync(f.header, true)
+            .catch(e => workspace.PullStatus.NoSourceControl);
+    },
+    expirationTime: p => 3600 * 1000
+})
+
 // pkg-status:<guid>
 data.mountVirtualApi("pkg-status", {
     getSync: p => {


### PR DESCRIPTION
- [x] Use mounted service to store and cache pull status of a repository
- [x] display pull status in button as well
