### PR TITLE
clean up language options settings

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -841,7 +841,7 @@ function readMdAsync(pathname: string, lang: string): Promise<string> {
     } else {
         // ask makecode cloud for translations
         const mdpath = pathname.replace(/^\//, '');
-        return pxt.Cloud.markdownAsync(mdpath, lang, true);
+        return pxt.Cloud.markdownAsync(mdpath, lang);
     }
 }
 

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -35,8 +35,9 @@ namespace pxt.Cloud {
     }
 
     export function cdnApiUrl(url: string) {
+        url = url.replace(/^\//, '');
         if (!useCdnApi())
-            return apiRoot + url
+            return apiRoot + url;
 
         const d = new Date()
         const timestamp = d.getUTCFullYear() + ("0" + (d.getUTCMonth() + 1)).slice(-2) + ("0" + d.getUTCDate()).slice(-2)

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -114,7 +114,9 @@ namespace pxt.Cloud {
 
     // 1h check on markdown content if not on development server
     const MARKDOWN_EXPIRATION = pxt.BrowserUtils.isLocalHostDev() ? 1 : 1 * 60 * 60 * 1000;
-    export function markdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
+    export function markdownAsync(docid: string, locale?: string): Promise<string> {
+        locale = locale || pxt.Util.userLanguage();
+        const live = pxt.Util.localizeLive;
         const branch = "";
         return pxt.BrowserUtils.translationDbAsync()
             .then(db => db.getAsync(locale, docid, "")

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -92,12 +92,12 @@ namespace pxt.gallery {
     }
 
     export function loadGalleryAsync(name: string): Promise<Gallery[]> {
-        return pxt.Cloud.markdownAsync(name, pxt.Util.userLanguage(), pxt.Util.localizeLive)
+        return pxt.Cloud.markdownAsync(name)
             .then(md => parseGalleryMardown(md))
     }
 
     export function loadExampleAsync(name: string, path: string): Promise<GalleryProject> {
-        return pxt.Cloud.markdownAsync(path, pxt.Util.userLanguage(), pxt.Util.localizeLive)
+        return pxt.Cloud.markdownAsync(path)
             .then(md => parseExampleMarkdown(name, md))
     }
 }

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -384,20 +384,18 @@ namespace pxt.runner {
     }
 
     export let editorLanguageMode = LanguageMode.Blocks;
-    export let editorLocale = "en";
 
-    export function setEditorContextAsync(mode: LanguageMode, locale: string) {
+    export function setEditorContextAsync(mode: LanguageMode, localeInfo: string) {
         editorLanguageMode = mode;
-        if (locale != editorLocale) {
+        if (localeInfo != pxt.Util.localeInfo()) {
             const localeLiveRx = /^live-/;
-            editorLocale = locale;
             return pxt.Util.updateLocalizationAsync(
                 pxt.appTarget.id,
                 pxt.webConfig.commitCdnUrl,
-                editorLocale.replace(localeLiveRx, ''),
+                localeInfo.replace(localeLiveRx, ''),
                 pxt.appTarget.versions.pxtCrowdinBranch,
                 pxt.appTarget.versions.targetCrowdinBranch,
-                localeLiveRx.test(editorLocale)
+                localeLiveRx.test(localeInfo)
             );
         }
 
@@ -699,7 +697,7 @@ ${linkString}
 
     function renderDocAsync(content: HTMLElement, docid: string): Promise<void> {
         docid = docid.replace(/^\//, "");
-        return pxt.Cloud.markdownAsync(docid, editorLocale, pxt.Util.localizeLive)
+        return pxt.Cloud.markdownAsync(docid)
             .then(md => renderMarkdownAsync(content, md, { path: docid }))
     }
 
@@ -715,7 +713,7 @@ ${linkString}
         // start the work
         let toc: TOCMenuEntry[];
         return Promise.delay(100)
-            .then(() => pxt.Cloud.markdownAsync(summaryid, editorLocale, pxt.Util.localizeLive))
+            .then(() => pxt.Cloud.markdownAsync(summaryid))
             .then(summary => {
                 toc = pxt.docs.buildTOC(summary);
                 pxt.log(`TOC: ${JSON.stringify(toc, null, 2)}`)
@@ -723,7 +721,7 @@ ${linkString}
                 pxt.docs.visitTOC(toc, entry => {
                     if (!/^\//.test(entry.path) || /^\/pkg\//.test(entry.path)) return;
                     tocsp.push(
-                        pxt.Cloud.markdownAsync(entry.path, editorLocale, pxt.Util.localizeLive)
+                        pxt.Cloud.markdownAsync(entry.path)
                             .then(md => {
                                 entry.markdown = md;
                             }, e => {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -47,7 +47,8 @@ namespace pxsim {
     export interface SimulatorFileLoadedMessage extends SimulatorMessage {
         type: "fileloaded";
         name: string;
-        locale: string;
+        // localeInfo NOT userLanguage
+        locale: string; 
         content?: string;
     }
 

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -48,7 +48,7 @@ namespace pxsim {
         type: "fileloaded";
         name: string;
         // localeInfo NOT userLanguage
-        locale: string; 
+        locale: string;
         content?: string;
     }
 
@@ -275,10 +275,10 @@ namespace pxsim {
                     let simData = data as SimulatorCommandMessage;
                     switch (simData.command) {
                         case "focus":
-                            tickEvent("simulator.focus", {timestamp: simData.timestamp});
+                            tickEvent("simulator.focus", { timestamp: simData.timestamp });
                             break;
                         case "blur":
-                            tickEvent("simulator.blur", {timestamp: simData.timestamp});
+                            tickEvent("simulator.blur", { timestamp: simData.timestamp });
                             break;
                     }
                 default: queue(data); break;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3087,7 +3087,7 @@ export class ProjectView
 
         if (/^\//.test(tutorialId)) {
             filename = tutorialTitle || tutorialId.split('/').reverse()[0].replace('-', ' '); // drop any kind of sub-paths
-            p = pxt.Cloud.markdownAsync(tutorialId, pxt.Util.userLanguage(), pxt.Util.localizeLive)
+            p = pxt.Cloud.markdownAsync(tutorialId)
                 .then(md => {
                     if (md) {
                         dependencies = pxt.gallery.parsePackagesFromMarkdown(md);


### PR DESCRIPTION
Consistently use userLanguage() and localeLive to pick up the correct locale in the editor.
Fix for https://github.com/microsoft/pxt-arcade/issues/1507