### PR TITLE
don't restart when opening console editor

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -648,6 +648,10 @@ export class ProjectView
                 pxt.debug(`sim: skip blocks auto, field editor is open`);
                 return;
             }
+            if (this.editor === this.serialEditor) {
+                pxt.debug(`sim: don't restart when entering console view`)
+                return;
+            }
             this.runSimulator({ debug: !!this.state.debugging, background: true });
         },
         1000, true);


### PR DESCRIPTION
Just ignore the request to restart (because we change the current editor) when opening the console view.
Fix for https://github.com/microsoft/pxt-arcade/issues/1509