### PR TITLE
Fix compilation with disabled blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1602,6 +1602,7 @@ namespace pxt.blocks {
             // update disable blocks
             updateDisabledBlocks(e, allBlocks, topblocks);
             // drop disabled blocks
+            allBlocks = allBlocks.filter(b => !b.disabled);
             topblocks = topblocks.filter(b => !b.disabled);
             // reorder remaining events by names
             topblocks = topblocks.sort((a, b) => {


### PR DESCRIPTION
It turns out that we treat disabled blocks as events and sort them in the compiler. To create a call key for the block we compile each variable which blows up because the context has not been set.

> This change modifies the blocky compiler to sort events **after** disabled blocks have been filtered out. The only impact I can see here is that the decision to disable a bloc is now dependent on their positions rather than their naming -- **which might be a breaking change**.

Fixed. It uses the previous sorting.

@riknoll @abchatra careful review here

Fix for https://github.com/microsoft/pxt-arcade/issues/1485