### PR TITLE
cleanup locs identifier

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -544,8 +544,8 @@ namespace ts.pxtc {
 
     function cleanLocalizations(apis: ApisInfo) {
         Util.values(apis.byQName)
-        .filter(fb => fb.attributes.block && /^{id:[^}]+}/.test(fb.attributes.block))
-        .forEach(fn => { fn.attributes.block = fn.attributes.block.replace(/^{id:[^}]+}/, ''); });
+        .filter(fb => fb.attributes.block && /^{[^:]+:[^}]+}/.test(fb.attributes.block))
+        .forEach(fn => { fn.attributes.block = fn.attributes.block.replace(/^{[^:]+:[^}]+}/, ''); });
         return apis;
     }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -469,7 +469,7 @@ namespace ts.pxtc {
 
     export function localizeApisAsync(apis: pxtc.ApisInfo, mainPkg: pxt.MainPackage): Promise<pxtc.ApisInfo> {
         const lang = pxtc.Util.userLanguage();
-        if (pxtc.Util.userLanguage() == "en") return Promise.resolve(apis);
+        if (pxtc.Util.userLanguage() == "en") return Promise.resolve(cleanLocalizations(apis));
 
         const errors: pxt.Map<number> = {};
         const langLower = lang.toLowerCase();
@@ -535,11 +535,18 @@ namespace ts.pxtc {
                     updateBlockDef(fn.attributes);
                 })
             })))
-            .then(() => apis)
+            .then(() => cleanLocalizations(apis))
             .finally(() => {
                 if (Object.keys(errors).length)
                     pxt.reportError(`loc.errors`, `invalid translation`, errors);
             })
+    }
+
+    function cleanLocalizations(apis: ApisInfo) {
+        Util.values(apis.byQName)
+        .filter(fb => fb.attributes.block && /^{id:[^}]+}/.test(fb.attributes.block))
+        .forEach(fn => { fn.attributes.block = fn.attributes.block.replace(/^{id:[^}]+}/, ''); });
+        return apis;
     }
 
     export function emptyExtInfo(): ExtensionInfo {


### PR DESCRIPTION
Make sure {id:...} are gone from translations. Fix for https://github.com/microsoft/pxt-arcade/issues/1458
Duplicate PR of https://github.com/microsoft/pxt/pull/6303