### PR TITLE
Fixing tile editor and blurriness in Microsoft Edge

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -217,6 +217,12 @@
     background-color: darken(#4b7bec, 10%);
 }
 
+.image-editor.editing-tile {
+    .image-editor-content, .image-editor-topbar, .image-editor-bottombar {
+        display: none;
+    }
+}
+
 :root {
     --editor-height: 31rem;
 }

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -34,11 +34,10 @@ export interface ImageCanvasProps {
 
 /**
  * This is a scaling factor for all of the pixels in the canvas. Scaling is not needed for browsers
- * that support "image-rendering: pixelated," so only scale for Microsoft Edge and Chrome on MacOS.
- *
- * Chrome on MacOS should be fixed in the next release: https://bugs.chromium.org/p/chromium/issues/detail?id=134040
+ * that support "image-rendering: pixelated," so only scale for Microsoft Edge.
  */
 const SCALE = pxt.BrowserUtils.isEdge() ? 25 : 1;
+const TILE_SCALE = pxt.BrowserUtils.isEdge() ? 2 : 1;
 
 /**
  * Color for the walls
@@ -92,7 +91,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
     }
 
     componentDidMount() {
-        this.cellWidth = this.props.isTilemap ? this.props.tilemapState.tileset.tileWidth : SCALE;
+        this.cellWidth = this.props.isTilemap ? this.props.tilemapState.tileset.tileWidth * TILE_SCALE : SCALE;
         this.canvas = this.refs["paint-surface"] as HTMLCanvasElement;
         this.background = this.refs["paint-surface-bg"] as HTMLCanvasElement;
         this.floatingLayer = this.refs["floating-layer-border"] as HTMLDivElement;
@@ -132,7 +131,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
             this.editState = getEditState(imageState, this.props.isTilemap, this.props.drawingMode);
         }
 
-        this.cellWidth = this.props.isTilemap ? SCALE * this.props.tilemapState.tileset.tileWidth : SCALE;
+        this.cellWidth = this.props.isTilemap ? this.props.tilemapState.tileset.tileWidth * TILE_SCALE : SCALE;
 
         if (this.props.zoomDelta || this.props.zoomDelta === 0) {
             // This is a total hack. Ideally, the zoom should be part of the global state but because
@@ -504,9 +503,9 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
     protected generateTile(index: number, tileset: pxt.sprite.TileSet) {
         const tileImage = document.createElement("canvas");
-        tileImage.width = tileset.tileWidth;
-        tileImage.height = tileset.tileWidth;
-        this.drawBitmap(pxt.sprite.Bitmap.fromData(tileset.tiles[index].data), 0, 0, true, 1, tileImage);
+        tileImage.width = tileset.tileWidth * TILE_SCALE;
+        tileImage.height = tileset.tileWidth * TILE_SCALE;
+        this.drawBitmap(pxt.sprite.Bitmap.fromData(tileset.tiles[index].data), 0, 0, true, TILE_SCALE, tileImage);
         this.tileCache[index] = tileImage;
         return tileImage;
     }

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -70,7 +70,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
 
         return <div className="image-editor-outer">
             <Provider store={instanceStore}>
-                <div className="image-editor">
+                <div className={`image-editor ${editingTile ? "editing-tile" : ""}`}>
                     <TopBar singleFrame={singleFrame} />
                     <div className="image-editor-content">
                         <SideBar />

--- a/webapp/src/components/ImageEditor/tilemap/Minimap.tsx
+++ b/webapp/src/components/ImageEditor/tilemap/Minimap.tsx
@@ -8,6 +8,7 @@ export interface MinimapProps {
     tilemap: pxt.sprite.ImageState;
 }
 
+const SCALE = pxt.BrowserUtils.isEdge() ? 25 : 1;
 
 class MinimapImpl extends React.Component<MinimapProps, {}> {
     protected tileColors: string[] = [];
@@ -36,8 +37,8 @@ class MinimapImpl extends React.Component<MinimapProps, {}> {
         const image = pxt.sprite.Tilemap.fromData(bitmap);
         const floatingImage = floating && floating.bitmap ? pxt.sprite.Tilemap.fromData(floating.bitmap) : null;
 
-        this.canvas.width = image.width;
-        this.canvas.height = image.height;
+        this.canvas.width = image.width * SCALE;
+        this.canvas.height = image.height * SCALE;
         this.tileColors = [];
 
         for (let x = 0; x < image.width; x++) {
@@ -46,13 +47,13 @@ class MinimapImpl extends React.Component<MinimapProps, {}> {
                 const index = image.get(x, y);
                 if (float) {
                     context.fillStyle = this.getColor(float);
-                    context.fillRect(x, y, 1, 1);
+                    context.fillRect(x * SCALE, y * SCALE, SCALE, SCALE);
                 } else if (index) {
                     context.fillStyle = this.getColor(index);
-                    context.fillRect(x, y, 1, 1);
+                    context.fillRect(x * SCALE, y * SCALE, SCALE, SCALE);
                 }
                 else {
-                    context.clearRect(x, y, 1, 1);
+                    context.clearRect(x * SCALE, y * SCALE, SCALE, SCALE);
                 }
             }
         }


### PR DESCRIPTION
Fixing the tilemap editor in Edge. This fixes three bugs:

1. The minmap was very blurry
2. The tilemap canvas was drawing the tiles at native resolution while scaling the canvas size so the tiles were too small to actually see
3. The tile editor (for creating new tiles, not the field editor) was not rendering correctly when overlaying the tilemap editor