### PR TITLE
fix color for player namespace

### DIFF
--- a/tests/pyconverter-test/testlib/cp.ts
+++ b/tests/pyconverter-test/testlib/cp.ts
@@ -1729,7 +1729,7 @@ declare namespace mobs {
 /**
  * Give commands, communicate, and respond to events that happen in the game
  */
-//% color=#0078D7 weight=100 icon="\uf007"
+//% color=#B09EFF weight=100 icon="\uf007"
 namespace player {
     export class ChatCommandArguments {
         public number: number;


### PR DESCRIPTION
Uses the color from arcade
Fixes: https://github.com/microsoft/pxt-arcade/issues/1489
Sister PR: https://github.com/microsoft/pxt-common-packages/pull/1029