### PR TITLE
Allow for ?compile=rawELF to skip UF2 on RPi

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -438,6 +438,7 @@ declare namespace ts.pxtc {
         noPeepHole?: boolean;
         time?: boolean;
         noIncr?: boolean;
+        rawELF?: boolean;
     }
 
     interface CompileTarget {

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -551,7 +551,7 @@ namespace ts.pxtc {
                 for (let i = 0; i < hd.length; ++i)
                     pxt.HF2.write16(resbuf, i * 2 + jmpStartAddr, hd[i])
                 applyPatches(null, resbuf)
-                if (uf2) {
+                if (uf2 && !bin.target.switches.rawELF) {
                     let bn = bin.options.name || "pxt"
                     bn = bn.replace(/[^a-zA-Z0-9\-\.]+/g, "_")
                     uf2.filename = "Projects/" + bn + ".elf"

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -465,7 +465,7 @@ namespace pxt {
 
         if (trg.nativeType == ts.pxtc.NATIVE_TYPE_VM)
             return ts.pxtc.BINARY_PXT64
-        else if (trg.useUF2)
+        else if (trg.useUF2 && !trg.switches.rawELF)
             return ts.pxtc.BINARY_UF2
         else if (trg.useELF)
             return ts.pxtc.BINARY_ELF


### PR DESCRIPTION
This is useful when you want to compile something and place it directly on the SD card, or when you want to scp it to a Linux box (eg Pocket Beagle)