### PR TITLE
use close icon instead of cancel

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -343,7 +343,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 header: message,
                 initialValue: defaultValue,
                 agreeLbl: lf("Ok"),
-                disagreeLbl: lf("Cancel"),
+                hideCancel: true,
+                hasCloseIcon: true,
                 size: "tiny"
             }).then(value => {
                 callback(value);


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-arcade/issues/1481. This impacts **all** blockly prompts: new variable, etc...
![image](https://user-images.githubusercontent.com/4175913/70730586-1d57a780-1cba-11ea-8788-06f57f4784c2.png)
