### PR TITLE
Add max size to gallery items and allow more columns on large screens

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -183,6 +183,7 @@
     flex-direction: row;
     flex-wrap: wrap;
     align-items: stretch;
+    justify-content: center;
 
     visibility: hidden;
 }
@@ -196,6 +197,7 @@
     margin: 1px;
     border-radius: 0px;
     width: ~"calc(20% - 2px)";
+    max-width: 120px;
 }
 
 .ui.button.image-editor-confirm {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/1480

Gallery items are limited to 120px wide.
There will always be a minimum of 5 rows/columns, but as screen space allows the number of columns will grow endlessly.

Example after this fix:
<img width="1142" alt="Screen Shot 2019-12-12 at 10 54 50 AM" src="https://user-images.githubusercontent.com/6453828/70740525-323e3600-1cce-11ea-93b5-b4bbe07a1f6e.png">
