### PR TITLE
Fix arcade logo on Chrome by ensure it has a height

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -359,6 +359,7 @@ div.simframe > iframe {
     max-height: 1.6rem;
     margin-left: 1rem;
     margin-right: 1rem;
+    height: 100%;
 }
 
 /* Powered by Microsoft logo*/


### PR DESCRIPTION
Arcade logo wasn't rendering because its height was 0 for unclear reasons. This fixes that. There will still be a max-height of 1.6rem enforced by CSS.
Part of: https://github.com/microsoft/pxt-arcade/issues/1500