### PR TITLE
Bump pxt-blockly to 2.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "monaco-editor": "0.10.0",
     "pxt-monaco-typescript": "2.3.6",
-    "pxt-blockly": "2.1.12",
+    "pxt-blockly": "2.1.13",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1482