### PR TITLE
Change position picker theme to reflect new simulator

### DIFF
--- a/theme/fieldeditors.less
+++ b/theme/fieldeditors.less
@@ -248,8 +248,8 @@
     margin: 0.1rem;
     background: #249ca3;
     border: solid 2px #249ca3;
-    border-top-left-radius: 0.5rem;
-    border-top-right-radius: 0.5rem;
+    border-top-left-radius: 1rem;
+    border-top-right-radius: 1rem;
     border-bottom-left-radius: 0;
     border-bottom-left-radius: 0;
 }

--- a/theme/fieldeditors.less
+++ b/theme/fieldeditors.less
@@ -246,8 +246,8 @@
 .blocklyCanvasOverlayOuter {
     padding: 0.5rem;
     margin: 0.1rem;
-    background: #fffae7;
-    border: solid 2px #dedede;
+    background: #249ca3;
+    border: solid 2px #249ca3;
     border-top-left-radius: 0.5rem;
     border-top-right-radius: 0.5rem;
     border-bottom-left-radius: 0;
@@ -260,11 +260,10 @@
     z-index: 10000;
     position: relative;
     overflow: hidden;
-    border: solid 5px;
-    border-left-color: #2f99a1;
-    border-right-color: #2f99a1;
-    border-top-color: #f290c1;
-    border-bottom-color: #f290c1;
+    border: solid 5px #333333;
+
+    clip-path: polygon(0% 4px, 4px 0%, calc(100% - 2px) 0%, 100% 4px,
+    100% calc(100% - 2px), calc(100% - 2px) 100%, 4px 100%, 0 calc(100% - 2px));
 
     .cross-x, .cross-y {
         background-color: #575E75;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/1490

Old:
![image](https://user-images.githubusercontent.com/6453828/70839164-59753000-1dc0-11ea-96c1-e4506e1d2c54.png)

New:
![Screen Shot 2019-12-13 at 3 53 29 PM](https://user-images.githubusercontent.com/6453828/70839264-bd97f400-1dc0-11ea-829e-cfe322780859.png)

New simulator:
![image](https://user-images.githubusercontent.com/6453828/70839207-7b6eb280-1dc0-11ea-96b0-80bf6c85a051.png)
