### PR TITLE
Match interface name to example in "Interface" page

### DIFF
--- a/common-docs/javascript/interfaces.md
+++ b/common-docs/javascript/interfaces.md
@@ -169,9 +169,9 @@ mySearch = function (src: string, i: number): string {
 ```
 
 Function parameters are checked one at a time, with the type in each corresponding parameter position checked against each other.
-If you do not want to specify types at all, TypeScript's contextual typing can infer the argument types since the function value is assigned directly to a variable of type `SearchFunc`.
+If you do not want to specify types at all, TypeScript's contextual typing can infer the argument types since the function value is assigned directly to a variable of type `SubstrFunc`.
 Here, also, the return type of our function expression is implied by the values it returns (here `false` and `true`).
-Had the function expression returned numbers or strings, the type-checker would have warned us that return type doesn't match the return type described in the `SearchFunc` interface.
+Had the function expression returned numbers or strings, the type-checker would have warned us that return type doesn't match the return type described in the `SubstrFunc` interface.
 
 ```ts
 let mySearch: SubstrFunc;


### PR DESCRIPTION
Name to example mismatch. Found by a Crowdin translator.

RE: https://crowdin.com/translate/kindscript/1390/en-tr#55145
