### PR TITLE
fix animation editor crash when opening right after tilemap edit

### DIFF
--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -75,6 +75,8 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
 
         const { editTileValue, editingTile, alert } = this.state;
 
+        const isAnimationEditor = instanceStore.getState().store.present.kind === "Animation"
+
         return <div className="image-editor-outer">
             <Provider store={instanceStore}>
                 <div className={`image-editor ${editingTile ? "editing-tile" : ""}`}>
@@ -82,13 +84,13 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                     <div className="image-editor-content">
                         <SideBar />
                         <ImageCanvas />
-                        {singleFrame ? undefined : <Timeline />}
+                        {isAnimationEditor && !singleFrame ? <Timeline /> : undefined}
                     </div>
                     <BottomBar singleFrame={singleFrame} onDoneClick={this.onDoneClick} />
                     {alert && alert.title && <Alert title={alert.title} text={alert.text} options={alert.options} />}
                 </div>
             </Provider>
-            { editingTile && <ImageEditor store={tileEditorStore} onDoneClicked={this.onTileEditorFinished} initialValue={editTileValue} singleFrame={true} resizeDisabled={true} /> }
+            {editingTile && <ImageEditor store={tileEditorStore} onDoneClicked={this.onTileEditorFinished} initialValue={editTileValue} singleFrame={true} resizeDisabled={true} />}
         </div>
     }
 

--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -38,6 +38,7 @@ export enum TileDrawingMode {
 
 // State that goes on the undo/redo stack
 export interface AnimationState {
+    kind: "Animation",
     visible: boolean;
     colors: string[];
 
@@ -49,6 +50,7 @@ export interface AnimationState {
 }
 
 export interface TilemapState {
+    kind: "Tilemap"
     tileset: pxt.sprite.TileSet;
     aspectRatioLocked: boolean;
     tilemap: pxt.sprite.ImageState;
@@ -120,7 +122,8 @@ export interface TilemapStore {
     future: TilemapState[];
 }
 
-const initialState: AnimationState =  {
+const initialState: AnimationState = {
+    kind: "Animation",
     visible: true,
     colors: [
         "#000000",
@@ -247,6 +250,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     ...state.store,
                     past: [],
                     present: {
+                        kind: "Animation",
                         visible: true,
                         colors: pxt.appTarget.runtime.palette.slice(),
 
@@ -278,6 +282,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     ...state.store,
                     past: [],
                     present: {
+                        kind: "Tilemap",
                         colors: pxt.appTarget.runtime.palette.slice(),
                         aspectRatioLocked: false,
                         tilemap: {
@@ -404,7 +409,8 @@ const editorReducer = (state: EditorState, action: any): EditorState => {
             tickEvent(`foreground-color-${action.selectedColor}`);
 
             // If the selected tool is the eraser, make sure to switch to pencil
-            return { ...state,
+            return {
+                ...state,
                 selectedColor: action.selectedColor,
                 tool: state.tool === ImageEditorTool.Erase ? ImageEditorTool.Paint : state.tool
             };


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/1562