### PR TITLE
Fixes for hardware menu, select D5/F4/Pi0, CSS

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1023,7 +1023,8 @@ p.ui.font.small {
         }
     }
     .ui.button.hw-button > .icon.ellipsis {
-        left: -3px;
+        left: -1px;
+        position: relative;
     }
     .collapsedEditorTools .hw-button:hover:after {
         transform: translateX(0%)!important;
@@ -1081,8 +1082,9 @@ p.ui.font.small {
     }
 
     .ui.button.hw-button > .icon.ellipsis {
-        left: -3px;
-        top: 2px;
+        left: -1px;
+        top: 4px;
+        position: relative;
     }
 }
 

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -210,11 +210,11 @@
 }
 
 .image-editor-confirm:hover {
-    background-color: darken(#4b7bec, 5%);
+    background-color: darken(@green, 5%);
 }
 
 .image-editor-confirm:active {
-    background-color: darken(#4b7bec, 10%);
+    background-color: darken(@green, 10%);
 }
 
 .image-editor.editing-tile {

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -140,6 +140,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         this.props.parent.showChooseHwDialog(true);
     }
 
+    protected onHwDownloadClick = () => {
+        this.compile();
+    }
+
     protected getCompileButton(view: View, collapsed?: boolean): JSX.Element[] {
         const targetTheme = pxt.appTarget.appTheme;
         const { compiling, isSaving } = this.props.parent.state;
@@ -151,12 +155,11 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
 
         let downloadButtonClasses = boards ? "left attached " : "";
         let hwIconClasses = "";
-        let hwMenuClasses = ""
         let displayRight = false;
         if (isSaving) {
-            downloadButtonClasses = "disabled ";
+            downloadButtonClasses += "disabled ";
         } else if (compileLoading) {
-            downloadButtonClasses = "loading disabled ";
+            downloadButtonClasses += "loading disabled ";
         }
         switch (view) {
             case View.Mobile:
@@ -165,28 +168,29 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                 break;
             case View.Tablet:
                 downloadButtonClasses += `download-button-full ${!collapsed ? 'large fluid' : ''}`;
-                hwMenuClasses = !collapsed ? "large" : "";
                 hwIconClasses = !collapsed ? "large" : "";
                 displayRight = collapsed;
                 break;
             case View.Computer:
             default:
                 downloadButtonClasses += "huge fluid";
-                hwMenuClasses = "large";
                 hwIconClasses = "large";
         }
 
         let el = [];
         el.push(<EditorToolbarButton key="downloadbutton" role="menuitem" icon={downloadIcon} className={`primary download-button ${downloadButtonClasses}`} text={view != View.Mobile ? downloadText : undefined} title={compileTooltip} onButtonClick={this.compile} view='computer' />)
 
-        let deviceName = pxt.hwName || lf("device");
-        let tooltip = pxt.hwName || lf("Click to select hardware")
+        const deviceName = pxt.hwName || lf("device");
+        const tooltip = pxt.hwName || lf("Click to select hardware")
+
+        const hardwareMenuText = view == View.Mobile ? lf("Hardware") : lf("Choose hardware");
+        const downloadMenuText = view == View.Mobile ? (pxt.hwName || lf("Download")) : lf("Download to {0}", deviceName);
 
         if (boards) {
             el.push(
-                <sui.DropdownMenu key="downloadmenu" role="menuitem" icon={`ellipsis horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwMenuClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight}>
-                    <sui.Item role="menuitem" icon="microchip" text={lf("Choose hardware")} tabIndex={-1} onClick={this.onHwItemClick} />
-                    <sui.Item role="menuitem" icon="download" text={lf("Download to {0}", deviceName)} tabIndex={-1} onClick={this.compile} />
+                <sui.DropdownMenu key="downloadmenu" role="menuitem" icon={`ellipsis horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight}>
+                    <sui.Item role="menuitem" icon="microchip" text={hardwareMenuText} tabIndex={-1} onClick={this.onHwItemClick} />
+                    <sui.Item role="menuitem" icon="download" text={downloadMenuText} tabIndex={-1} onClick={this.onHwDownloadClick} />
                 </sui.DropdownMenu>
             )
         }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1108,7 +1108,7 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
         }, { interactiveConsent: true });
         this.hide()
 
-        pxt.setHwVariant(cfg.name, card.name)
+        pxt.setHwVariant(cfg.name, card ? card.name : (cfg.description || cfg.name))
         let editor = this.props.parent
         editor.reloadHeaderAsync()
             .then(() => !this.state.skipDownload && editor.compile())


### PR DESCRIPTION
Fix:
- Hardware menu "Download to device"
- D5, F4, Pi0 options in hardware menu
- Shorten strings for mobile HW dropdown to reduce overlap (partial fix)
- CSS for tilemap done button hover, download button "loading"

Fixes https://github.com/microsoft/pxt-arcade/issues/1587
Fixes https://github.com/microsoft/pxt-arcade/issues/1589