### PR TITLE
Use qualified name for handler argument types

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -321,7 +321,7 @@ namespace ts.pxtc {
                             parameters = callbackParameters.map((sym, i) => {
                                 return {
                                     name: sym.getName(),
-                                    type: typechecker.typeToString(typechecker.getTypeOfSymbolAtLocation(sym, p))
+                                    type: typechecker.typeToString(typechecker.getTypeOfSymbolAtLocation(sym, p), undefined, TypeFormatFlags.UseFullyQualifiedType)
                                 };
                             });
                         }

--- a/tests/decompile-test/baselines/draggable_parameters_reporters.blocks
+++ b/tests/decompile-test/baselines/draggable_parameters_reporters.blocks
@@ -17,7 +17,7 @@
 </value>
 <value name="HANDLER_DRAG_PARAM_f">
 <shadow type="argument_reporter_custom">
-<mutation typename="TestClass" />
+<mutation typename="testNamespace.TestClass" />
 <field name="VALUE">f</field>
 </shadow>
 </value>
@@ -43,7 +43,7 @@
 </value>
 <value name="HANDLER_DRAG_PARAM_f">
 <shadow type="argument_reporter_custom">
-<mutation typename="TestClass" />
+<mutation typename="testNamespace.TestClass" />
 <field name="VALUE">doing</field>
 </shadow>
 </value>
@@ -68,7 +68,7 @@
 </value>
 <value name="HANDLER_DRAG_PARAM_f">
 <shadow type="argument_reporter_custom">
-<mutation typename="TestClass" />
+<mutation typename="testNamespace.TestClass" />
 <field name="VALUE">f</field>
 </shadow>
 </value>
@@ -93,7 +93,7 @@
 </value>
 <value name="HANDLER_DRAG_PARAM_f">
 <shadow type="argument_reporter_custom">
-<mutation typename="TestClass" />
+<mutation typename="testNamespace.TestClass" />
 <field name="VALUE">f</field>
 </shadow>
 </value>


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1566