### PR TITLE
Fixing draw cursor bug

### DIFF
--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -538,7 +538,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
                     if (!tileImage) {
                         // invalid tileset index
-                        return;
+                        continue;
                     }
 
                     context.drawImage(tileImage,  (x + x0) * this.cellWidth,  (y + y0) * this.cellWidth);

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -505,6 +505,9 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
     }
 
     protected generateTile(index: number, tileset: pxt.sprite.TileSet) {
+        if (!tileset.tiles[index]) {
+            return null;
+        }
         const tileImage = document.createElement("canvas");
         tileImage.width = tileset.tileWidth * TILE_SCALE;
         tileImage.height = tileset.tileWidth * TILE_SCALE;
@@ -533,6 +536,11 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
                         tileImage = this.generateTile(index, tileset);
                     }
 
+                    if (!tileImage) {
+                        // invalid tileset index
+                        return;
+                    }
+
                     context.drawImage(tileImage,  (x + x0) * this.cellWidth,  (y + y0) * this.cellWidth);
                 }
                 else {
@@ -554,6 +562,12 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
                 if (!tileImage) {
                     tileImage = this.generateTile(color, this.props.tilemapState.tileset);
                 }
+
+                if (!tileImage) {
+                    // invalid tileset index
+                    return;
+                }
+
                 for (let x = 0; x < width; x++) {
                     for (let y = 0; y < width; y++) {
                         context.drawImage(tileImage,  (left + x) * this.cellWidth,  (top + y) * this.cellWidth);


### PR DESCRIPTION
I'm not sure if this was introduced by my cursor PR or something else, but this fixes an exception in the image canvas that I just noticed while testing.

The bug repros if you create a tilemap in a project with no tiles and click on the canvas.