### PR TITLE
Clear last argument after shifting lambda parameters

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1351,6 +1351,7 @@ namespace pxsim {
                     const sa = s as any
                     for (let i = 1; i < numShift; ++i)
                         sa["arg" + (i - 1)] = sa["arg" + i]
+                    delete sa["arg" + (numShift - 1)]
                 }
                 if (a instanceof RefAction) {
                     s.fn = a.func

--- a/tests/compile-test/lang-test0/35lambdaparameters.ts
+++ b/tests/compile-test/lang-test0/35lambdaparameters.ts
@@ -6,3 +6,20 @@ function testLambdasWithMoreParams() {
 }
 
 testLambdasWithMoreParams()
+
+namespace Arcade1617 {
+    class Foo {
+        public handlerxx: () => void;
+        run() {
+            this.handlerxx()
+        }
+    }
+
+    function end(win?: boolean) {
+        assert(win === undefined, "lp1")
+    }
+
+    const f = new Foo()
+    f.handlerxx = end
+    f.run()
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1617

For release