### PR TITLE
include packages when compiling tutorial steps in checkdocs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5113,11 +5113,14 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
                                 tutorial.steps
                                     .filter(step => !!step.contentMd)
                                     .forEach((step, stepIndex) => getCodeSnippets(`${gal.name}-${stepIndex}`, step.contentMd)
-                                        .forEach((snippet, snippetIndex) => addSnippet(
-                                            snippet,
-                                            "tutorial" + `${gal.name}-${stepIndex}-${snippetIndex}`,
-                                            cardIndex)
-                                        )
+                                        .forEach((snippet, snippetIndex) => {
+                                            snippet.packages = pkgs;
+                                            addSnippet(
+                                                snippet,
+                                                "tutorial" + `${gal.name}-${stepIndex}-${snippetIndex}`,
+                                                cardIndex
+                                            )
+                                        })
                                     );
                             }
                             else {


### PR DESCRIPTION
currently failing like this: https://travis-ci.org/microsoft/pxt-arcade/builds/627920185#L515 when a tutorial a) uses an extension and b) has a tilemap