### PR TITLE
Fix patching of @PXT@ in hex files

### DIFF
--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -452,13 +452,18 @@ namespace ts.pxtc {
         function applyHexPatches(myhex: string[]) {
             const marker = "40505854" // @PXT
             for (let i = 0; i < myhex.length; ++i) {
-                let idx = myhex[i].indexOf(marker)
-                if (idx > 0) {
-                    let off = (idx - 9) >> 1
-                    let bytes = readHex(myhex, i, off, 200)
-                    let patch = patchString(bytes)
-                    if (patch)
-                        writeHex(myhex, i, off, patch)
+                // There could be a few such hex strings per line
+                for (let k = 0; k < 4; ++k) {
+                    let idx = myhex[i].indexOf(marker)
+                    if (idx > 0) {
+                        let off = (idx - 9) >> 1
+                        let bytes = readHex(myhex, i, off, 200)
+                        let patch = patchString(bytes)
+                        if (patch)
+                            writeHex(myhex, i, off, patch)
+                    } else {
+                        break
+                    }
                 }
             }
         }


### PR DESCRIPTION
This just does the patching up to 4 times per hex line.

This bug only triggers with particular binary layouts, essentially due to "randomness" in object binary layout