### PR TITLE
add `back` translate to ja

### DIFF
--- a/webapp/public/locales/ja/strings.json
+++ b/webapp/public/locales/ja/strings.json
@@ -24,6 +24,7 @@
   "Approve": "承認",
   "Assigns a value to a variable": "変数に値を設定します",
   "B": "シ",
+  "Back": "戻る",
   "Bad HTTP status code: {0} at {1}; message: {2}": "期待と異なるHTTPステータスコード：{1}で{0}、メッセージ「{2}」",
   "Beta": "ベータ",
   "Blocks": "ブロック",


### PR DESCRIPTION
The value corresponding to Japanese of `back` was not registered