### PR TITLE
Allow for unary operators on any type, including enums

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3082,39 +3082,33 @@ ${lbl}: .short 0xffff
             if (folded)
                 return emitLit(folded.val)
 
-            let tp = typeOf(node.operand)
-            if (node.operator == SK.ExclamationToken) {
-                return fromBool(ir.rtcall("Boolean_::bang", [emitCondition(node.operand)]))
-            }
-
-            if (isNumberType(tp)) {
-                switch (node.operator) {
-                    case SK.PlusPlusToken:
-                        return emitIncrement(node.operand, "numops::adds", false)
-                    case SK.MinusMinusToken:
-                        return emitIncrement(node.operand, "numops::subs", false)
-                    case SK.MinusToken: {
-                        let inner = emitExpr(node.operand)
-                        let v = valueToInt(inner)
-                        if (v != null)
-                            return emitLit(-v)
-                        return emitIntOp("numops::subs", emitLit(0), inner)
-                    }
-                    case SK.PlusToken:
-                        return emitExpr(node.operand) // no-op
-                    case SK.TildeToken: {
-                        let inner = emitExpr(node.operand)
-                        let v = valueToInt(inner)
-                        if (v != null)
-                            return emitLit(~v)
-                        return rtcallMaskDirect(mapIntOpName("numops::bnot"), [inner]);
-                    }
-                    default:
-                        break
+            switch (node.operator) {
+                case SK.ExclamationToken:
+                    return fromBool(ir.rtcall("Boolean_::bang", [emitCondition(node.operand)]))
+                case SK.PlusPlusToken:
+                    return emitIncrement(node.operand, "numops::adds", false)
+                case SK.MinusMinusToken:
+                    return emitIncrement(node.operand, "numops::subs", false)
+                case SK.MinusToken: {
+                    let inner = emitExpr(node.operand)
+                    let v = valueToInt(inner)
+                    if (v != null)
+                        return emitLit(-v)
+                    return emitIntOp("numops::subs", emitLit(0), inner)
                 }
+                case SK.PlusToken:
+                    return emitExpr(node.operand) // no-op
+                case SK.TildeToken: {
+                    let inner = emitExpr(node.operand)
+                    let v = valueToInt(inner)
+                    if (v != null)
+                        return emitLit(~v)
+                    return rtcallMaskDirect(mapIntOpName("numops::bnot"), [inner]);
+                }
+                default:
+                    throw unhandled(node, lf("unsupported prefix unary operation"), 9245)
             }
 
-            throw unhandled(node, lf("unsupported prefix unary operation"), 9245)
         }
 
         function doNothing() { }

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3089,15 +3089,18 @@ ${lbl}: .short 0xffff
                     return emitIncrement(node.operand, "numops::adds", false)
                 case SK.MinusMinusToken:
                     return emitIncrement(node.operand, "numops::subs", false)
+                case SK.PlusToken:
                 case SK.MinusToken: {
                     let inner = emitExpr(node.operand)
                     let v = valueToInt(inner)
                     if (v != null)
                         return emitLit(-v)
-                    return emitIntOp("numops::subs", emitLit(0), inner)
+                    if (node.operator == SK.MinusToken)
+                        return emitIntOp("numops::subs", emitLit(0), inner)
+                    else
+                        // force conversion to number
+                        return emitIntOp("numops::subs", inner, emitLit(0))
                 }
-                case SK.PlusToken:
-                    return emitExpr(node.operand) // no-op
                 case SK.TildeToken: {
                     let inner = emitExpr(node.operand)
                     let v = valueToInt(inner)

--- a/tests/compile-test/lang-test0/02numbers.ts
+++ b/tests/compile-test/lang-test0/02numbers.ts
@@ -192,7 +192,33 @@ function testNaN() {
     assert(1 / inf == 0)
 }
 
-testComma();
+function testUnaryPlus() {
+    function testOne(v: any) {
+        assert(+v + 1 == 2, "t1")
+    }
+    function testZero(v: any) {
+        msg("v:" + v)
+        assert(+v + 1 == 1, "t0")
+    }
+    function test35(v: any) {
+        assert(+v + 1 == 4.5, "t35")
+    }
+    testOne(1)
+    testOne("1")
+    testOne(" 1 ")
+    testOne(true)
+    testZero(0)
+    testZero(" 0")
+    testZero("0")
+    testZero(null)
+    testZero(false)
+    test35(3.5)
+    test35("3.5")
+    let qq: any = undefined
+    assert(isNaN(+qq))
+}
 
+testComma();
 testNums();
 testNaN();
+testUnaryPlus();

--- a/tests/compile-test/lang-test0/18enums.ts
+++ b/tests/compile-test/lang-test0/18enums.ts
@@ -56,6 +56,11 @@ function testEnums() {
     if (kk & En2.D2) {
         assert(false, "e&")
     }
+
+    // https://github.com/microsoft/pxt-arcade/issues/774
+    let bar = Foo.B;  // inferred to type Foo
+    bar |= Foo.A;
+    bar = ~(~bar | Foo.B);
 }
 
 
@@ -79,6 +84,11 @@ function switchB(e: En) {
         default: return 17;
     }
     return r;
+}
+
+enum Foo {
+    A = 1 << 0,
+    B = 1 << 1
 }
 
 testEnums()

--- a/tests/compile-test/lang-test0/18enums.ts
+++ b/tests/compile-test/lang-test0/18enums.ts
@@ -1,94 +1,96 @@
-enum En {
-    A,
-    B,
-    C,
-    D = 4200,
-    E,
-}
-
-enum En2 {
-    D0 = En.D,
-    D1,
-    D2 = 1,
-}
-
-
-function testEnums() {
-    msg("enums")
-
-    let k = En.C as number
-    assert(k == 2, "e0")
-    k = En.D as number
-    assert(k == 4200, "e1")
-    k = En.E as number
-    assert(k == 4201, "e43")
-
-    k = En2.D0 as number
-    assert(k == 4200, "eX0")
-    k = En2.D1 as number
-    assert(k == 4201, "eX1")
-
-    msg("enums0")
-    assert(switchA(En.A) == 7, "s1")
-    assert(switchA(En.B) == 7, "s2")
-    let two = 2
-    assert(switchA((3 - two) as En) == 7, "s2")
-    assert(switchA(En.C) == 12, "s3")
-    assert(switchA(En.D) == 13, "s4")
-    assert(switchA(En.E) == 12, "s5")
-    assert(switchA(-3 as En) == 12, "s6")
-
-    msg("enums1")
-    assert(switchB(En.A) == 7, "x1")
-    assert(switchB(En.B) == 7, "x2")
-    assert(switchB(En.C) == 17, "x3")
-    assert(switchB(En.D) == 13, "x4")
-    assert(switchB(En.E) == 14, "x5")
-
-    pause(3)
-
-    let kk = 1
-    if (kk & En2.D2) {
-    } else {
-        assert(false, "e&")
-    }
-    kk = 2
-    if (kk & En2.D2) {
-        assert(false, "e&")
+namespace EnumsTest {
+    enum En {
+        A,
+        B,
+        C,
+        D = 4200,
+        E,
     }
 
-    // https://github.com/microsoft/pxt-arcade/issues/774
-    let bar = Foo.B;  // inferred to type Foo
-    bar |= Foo.A;
-    bar = ~(~bar | Foo.B);
-}
-
-
-function switchA(e: En) {
-    let r = 12;
-    switch (e) {
-        case En.A:
-        case En.B: return 7;
-        case En.D: r = 13; break;
+    enum En2 {
+        D0 = En.D,
+        D1,
+        D2 = 1,
     }
-    return r
-}
 
-function switchB(e: En) {
-    let r = 33;
-    switch (e) {
-        case En.A:
-        case En.B: return 7;
-        case En.D: r = 13; break;
-        case En.E: r = 14; break;
-        default: return 17;
+
+    function testEnums() {
+        msg("enums")
+
+        let k = En.C as number
+        assert(k == 2, "e0")
+        k = En.D as number
+        assert(k == 4200, "e1")
+        k = En.E as number
+        assert(k == 4201, "e43")
+
+        k = En2.D0 as number
+        assert(k == 4200, "eX0")
+        k = En2.D1 as number
+        assert(k == 4201, "eX1")
+
+        msg("enums0")
+        assert(switchA(En.A) == 7, "s1")
+        assert(switchA(En.B) == 7, "s2")
+        let two = 2
+        assert(switchA((3 - two) as En) == 7, "s2")
+        assert(switchA(En.C) == 12, "s3")
+        assert(switchA(En.D) == 13, "s4")
+        assert(switchA(En.E) == 12, "s5")
+        assert(switchA(-3 as En) == 12, "s6")
+
+        msg("enums1")
+        assert(switchB(En.A) == 7, "x1")
+        assert(switchB(En.B) == 7, "x2")
+        assert(switchB(En.C) == 17, "x3")
+        assert(switchB(En.D) == 13, "x4")
+        assert(switchB(En.E) == 14, "x5")
+
+        pause(3)
+
+        let kk = 1
+        if (kk & En2.D2) {
+        } else {
+            assert(false, "e&")
+        }
+        kk = 2
+        if (kk & En2.D2) {
+            assert(false, "e&")
+        }
+
+        // https://github.com/microsoft/pxt-arcade/issues/774
+        let bar = Foo.B;  // inferred to type Foo
+        bar |= Foo.A;
+        bar = ~(~bar | Foo.B);
     }
-    return r;
-}
 
-enum Foo {
-    A = 1 << 0,
-    B = 1 << 1
-}
 
-testEnums()
+    function switchA(e: En) {
+        let r = 12;
+        switch (e) {
+            case En.A:
+            case En.B: return 7;
+            case En.D: r = 13; break;
+        }
+        return r
+    }
+
+    function switchB(e: En) {
+        let r = 33;
+        switch (e) {
+            case En.A:
+            case En.B: return 7;
+            case En.D: r = 13; break;
+            case En.E: r = 14; break;
+            default: return 17;
+        }
+        return r;
+    }
+
+    enum Foo {
+        A = 1 << 0,
+        B = 1 << 1
+    }
+
+    testEnums()
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/774
