### PR TITLE
enable ```python code directive and clarify how highlighting & decompilation works

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1623,6 +1623,10 @@ function processLf(filename: string, translationStrings: pxt.Map<string>): void 
         })
 }
 
+function getGalleryUrl(props: pxt.GalleryProps | string): string {
+    return typeof props === "string" ? props : props.url
+}
+
 function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boolean) {
     cfg.appTheme.id = cfg.id
     cfg.appTheme.title = cfg.title
@@ -1691,9 +1695,10 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
 `;
             Object.keys(targetConfig.galleries).forEach(k => {
                 targetStrings[k] = k;
-                const gallerymd = nodeutil.resolveMd(docsRoot, targetConfig.galleries[k]);
+                const galleryUrl = getGalleryUrl(targetConfig.galleries[k])
+                const gallerymd = nodeutil.resolveMd(docsRoot, galleryUrl);
                 const gallery = pxt.gallery.parseGalleryMardown(gallerymd);
-                const gurl = `/${targetConfig.galleries[k].replace(/^\//, '')}`;
+                const gurl = `/${galleryUrl.replace(/^\//, '')}`;
                 tocmd +=
                     `* [${k}](${gurl})
 `;
@@ -5026,7 +5031,11 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
     if (fs.existsSync("targetconfig.json")) {
         const targeConfig = nodeutil.readJson("targetconfig.json") as pxt.TargetConfig;
         if (targeConfig.galleries)
-            Object.keys(targeConfig.galleries).forEach(gallery => todo.push(targeConfig.galleries[gallery]));
+            Object.keys(targeConfig.galleries)
+                .forEach(gallery => {
+                    const url = getGalleryUrl(targeConfig.galleries[gallery])
+                    todo.push(url)
+                });
     }
 
     // push files from targetconfig checkdocsdirs
@@ -5090,7 +5099,8 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
         if (targetConfig && targetConfig.galleries) {
             Object.keys(targetConfig.galleries).forEach(k => {
                 pxt.log(`gallery ${k}`);
-                let gallerymd = nodeutil.resolveMd(docsRoot, targetConfig.galleries[k]);
+                const galleryUrl = getGalleryUrl(targetConfig.galleries[k])
+                let gallerymd = nodeutil.resolveMd(docsRoot, galleryUrl);
                 let gallery = pxt.gallery.parseGalleryMardown(gallerymd);
                 pxt.debug(`found ${gallery.length} galleries`);
                 gallery.forEach(gal => gal.cards.forEach((card, cardIndex) => {

--- a/docs/writing-docs/tutorials.md
+++ b/docs/writing-docs/tutorials.md
@@ -403,6 +403,28 @@ player.onChat("blockleft", function () {
 ```
 ````
 
+## Using Python
+
+If the target supports Python, snippets can be written directly in Python by using "python" after the triple tick like this:
+````
+```python
+for i in range(100):
+    mobs.spawn(AnimalMob.CHICKEN, positions.create(0, 10, 0))
+```
+````
+
+Note that if the target supports python then snippets written in the usuall way like:
+````
+```typescript
+basic.showString("Hello!")
+```
+or
+```blocks
+basic.showString("Hello!")
+```
+````
+users will have the option of clicking the Python icon to see the snippet in Python just like they can with Blocks and Javascript/Typescript.
+
 ## Testing
 
 When developing your new tutorials, it is easiest to first render and view them as a markdown documentation page until all steps look OK to you. Going through all the steps several times using the tutorial runner might become quite tedious while developing the tutorial.

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -5,10 +5,14 @@
 
 declare namespace pxt {
     // targetconfig.json
+    interface GalleryProps {
+        url: string,
+        experimentName?: string
+    }
     interface TargetConfig {
         packages?: PackagesConfig;
         // common galleries
-        galleries?: pxt.Map<string>;
+        galleries?: pxt.Map<string | GalleryProps>;
         // localized galleries
         localizedGalleries?: pxt.Map<pxt.Map<string>>;
         windowsStoreLink?: string;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -451,7 +451,7 @@ namespace pxt.runner {
             options.splitSvg = false; // don't split when requesting rendered images
             pxt.tickEvent("renderer.job")
             jobPromise = pxt.BrowserUtils.loadBlocklyAsync()
-                .then(() => runner.decompileToBlocksAsync(msg.code, msg.options))
+                .then(() => runner.decompileSnippetAsync(msg.code, msg.options))
                 .then(result => {
                     const blocksSvg = result.blocksSvg as SVGSVGElement;
                     return blocksSvg ? pxt.blocks.layout.blocklyToSvgAsync(blocksSvg, 0, 0, blocksSvg.viewBox.baseVal.width, blocksSvg.viewBox.baseVal.height) : undefined;
@@ -886,7 +886,7 @@ ${linkString}
 
     let programCache: ts.Program;
 
-    export function decompileToBlocksAsync(code: string, options?: blocks.BlocksRenderOptions): Promise<DecompileResult> {
+    export function decompileSnippetAsync(code: string, options?: blocks.BlocksRenderOptions): Promise<DecompileResult> {
         // code may be undefined or empty!!!
         const packageid = options && options.packageId ? "pub:" + options.packageId :
             options && options.package ? "docs:" + options.package
@@ -909,6 +909,7 @@ ${linkString}
                 }
                 programCache = program;
 
+                // decompile to python
                 let compilePython: pxtc.transpile.TranspileResult = undefined;
                 if (pxt.appTarget.appTheme.python) {
                     compilePython = ts.pxtc.transpile.tsToPy(program, "main.ts");

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -157,7 +157,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         const targetConfig = this.getData("target-config:") as pxt.TargetConfig;
         const lang = pxt.Util.userLanguage();
         // collect localized and unlocalized galleries
-        let galleries: pxt.Map<string> = {};
+        let galleries: pxt.Map<string | pxt.GalleryProps> = {};
         if (targetConfig && targetConfig.localizedGalleries && targetConfig.localizedGalleries[lang])
             pxt.Util.jsonCopyFrom(galleries, targetConfig.localizedGalleries[lang]);
         if (targetConfig && targetConfig.galleries)
@@ -198,15 +198,26 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                     <ProjectsCarousel key={`mystuff_carousel`} parent={this.props.parent} name={'recent'} onClick={this.chgHeader} />
                 </div>
             </div>
-            {Object.keys(galleries).map(galleryName =>
-                <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment" role="region" aria-label={pxt.Util.rlf(galleryName)}>
-                    <h2 className="ui header heading">{pxt.Util.rlf(galleryName)} </h2>
-                    <div className="content">
-                        <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`} key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={galleries[galleryName]}
-                            onClick={this.chgGallery} setSelected={this.setSelected} selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined} />
+            {Object.keys(galleries)
+                .filter(galleryName => {
+                    let galProps = galleries[galleryName] as pxt.GalleryProps | string
+                    if (typeof galProps === "string")
+                        return true
+                    let exp = galProps.experimentName
+                    return !exp || !!(pxt.appTarget.appTheme as any)[exp]
+                })
+                .map(galleryName => {
+                    let galProps = galleries[galleryName] as pxt.GalleryProps | string
+                    let url = typeof galProps === "string" ? galProps : galProps.url
+                    return <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment" role="region" aria-label={pxt.Util.rlf(galleryName)}>
+                        <h2 className="ui header heading">{pxt.Util.rlf(galleryName)} </h2>
+                        <div className="content">
+                            <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`} key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={url}
+                                onClick={this.chgGallery} setSelected={this.setSelected} selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined} />
+                        </div>
                     </div>
-                </div>
-            )}
+                }
+                )}
             {targetTheme.organizationUrl || targetTheme.organizationUrl || targetTheme.privacyUrl || targetTheme.copyrightText ? <div className="ui horizontal small divided link list homefooter">
                 {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" rel="noopener noreferrer" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
                 {targetTheme.selectLanguage ? <sui.Link className="item" icon="xicon globe" text={lf("Language")} onClick={this.showLanguagePicker} onKeyDown={sui.fireClickOnEnter} /> : undefined}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -200,6 +200,8 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             </div>
             {Object.keys(galleries)
                 .filter(galleryName => {
+                    // hide galleries that are part of an experiment and that experiment is
+                    // not enabled
                     let galProps = galleries[galleryName] as pxt.GalleryProps | string
                     if (typeof galProps === "string")
                         return true


### PR DESCRIPTION
See also: https://github.com/microsoft/pxt-minecraft/pull/1518
Part of: https://github.com/microsoft/pxt-minecraft/issues/1461
This is needed to unblock writing Python content.

TODO:
- [x] Only show the "Python" homepage row if the Python experiment is enabled
- [x] Update checkdocs to check direct python snippets

Enables the ```python tag for writting Python-specific tutorials.

We only show the "Python" carousel if the Python experiment is enabled.
Without experiment:
<img width="402" alt="Screen Shot 2019-12-30 at 3 01 15 PM" src="https://user-images.githubusercontent.com/6453828/71604247-afaed680-2b15-11ea-886a-25221ca3ad08.png">

With experiment:
<img width="337" alt="Screen Shot 2019-12-30 at 3 01 35 PM" src="https://user-images.githubusercontent.com/6453828/71604244-ac1b4f80-2b15-11ea-8295-6eb739d55d6b.png">

This lets us iterate on Python content work without impacting our users.