### PR TITLE
Keymap button in simulator toolbar on wide monitors/full screen

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -177,6 +177,7 @@ declare namespace pxt {
         trustedUrls?: string[]; // URLs that are allowed in simulator modal messages
         invalidatedClass?: string; // CSS class to be applied to the sim iFrame when it needs to be updated (defaults to sepia filter)
         stoppedClass?: string; // CSS class to be applied to the sim iFrame when it isn't running (defaults to grayscale filter)
+        keymap?: boolean; // when non-empty and autoRun is disabled, this code is run upon simulator first start
     }
 
     interface TargetCompileService {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -52,6 +52,7 @@ namespace pxt.editor {
 
         tutorialOptions?: pxt.tutorial.TutorialOptions;
         lightbox?: boolean;
+        keymap?: boolean;
 
         simState?: SimState;
         autoRun?: boolean;
@@ -288,6 +289,8 @@ namespace pxt.editor {
         startTutorial(tutorialId: string, tutorialTitle?: string, recipe?: boolean): void;
         showLightbox(): void;
         hideLightbox(): void;
+        showKeymap(show: boolean): void;
+        toggleKeymap(): void;
 
         showReportAbuse(): void;
         showLanguagePicker(): void;

--- a/theme/keymap.less
+++ b/theme/keymap.less
@@ -1,0 +1,94 @@
+/*******************************
+        Keymap
+*******************************/
+.keymap {
+    position: absolute;
+    display: flex;
+    left: 0;
+    margin: 0 3rem;
+    padding: 1rem;
+    width: calc(~'100% - 6rem');
+    background-color: @simulatorBackground;
+    border-radius: 0.25rem;
+    opacity: 0.95;
+    border: 1px solid @teal;
+}
+
+.keymap .close {
+    position: absolute;
+    right: 1rem;
+    margin: 0;
+    color: @white;
+    cursor: pointer;
+}
+
+.keymap > div {
+    margin-right: 1rem;
+    flex: 1;
+}
+
+.keymap > div:last-child {
+    margin-right: 0;
+}
+
+.keymap-title {
+    display: inline-block;
+    width: 100%;
+    margin: 0 0.25rem 0.25rem;
+    text-transform: capitalize;
+    font-weight: 600;
+}
+
+.keymap-key {
+    display: inline-block;
+    height: 2rem;
+    margin: 0.25rem;
+    padding: 0 0.75rem;
+    line-height: 2rem;
+    border: 1px solid darken(@teal, 10%);
+    border-radius: 0.25rem;
+    background-color: @teal;
+    color: @white;
+    text-transform: uppercase;
+}
+
+.keymap-name {
+    display: inline-block;
+    margin-left: 0.75rem;
+    text-transform: lowercase;
+}
+
+.keymap-name:first-letter {
+    text-transform: uppercase;
+}
+
+
+.keymap.above,
+.fullscreensim .keymap {
+    background-color: @white;
+    top: 2rem;
+
+    .close {
+        color: @teal;
+    }
+}
+
+.fullscreensim .keymap {
+    left: 50%;
+    top: 50%;
+    width: 22rem;
+    margin: 0;
+    transform: translateX(-50%) translateY(-50%);
+}
+
+@media only screen and (max-width: @largestSmallMonitor) {
+    #root:not(.fullscreensim) {
+        .keymap-button {
+            display: none;
+        }
+
+        .mute-button {
+            border-radius: 0.2rem;
+        }
+    }
+}

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -18,6 +18,7 @@
 @import 'functionsdialog';
 @import 'snippet-builder';
 @import 'github';
+@import 'keymap';
 
 @import 'light';
 @import 'accessibility';

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -40,6 +40,7 @@ import * as monacoToolbox from "./monacoSnippets";
 import * as greenscreen from "./greenscreen";
 import * as socketbridge from "./socketbridge";
 import * as webusb from "./webusb";
+import * as keymap from "./keymap";
 
 import * as monaco from "./monaco"
 import * as pxtjson from "./pxtjson"
@@ -158,6 +159,8 @@ export class ProjectView
         this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
         this.cloudSignInComplete = this.cloudSignInComplete.bind(this);
         this.toggleSimulatorCollapse = this.toggleSimulatorCollapse.bind(this);
+        this.showKeymap = this.showKeymap.bind(this);
+        this.toggleKeymap = this.toggleKeymap.bind(this);
         this.initScreenshots();
 
         // add user hint IDs and callback to hint manager
@@ -3353,6 +3356,22 @@ export class ProjectView
     }
 
     ///////////////////////////////////////////////////////////
+    ////////////             Key map              /////////////
+    ///////////////////////////////////////////////////////////
+
+    showKeymap(show: boolean) {
+        this.setState({ keymap: show });
+    }
+
+    toggleKeymap() {
+        if (this.state.keymap) {
+            this.showKeymap(false);
+        } else {
+            this.showKeymap(true);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////
     ////////////         Script Manager           /////////////
     ///////////////////////////////////////////////////////////
 
@@ -3525,6 +3544,7 @@ export class ProjectView
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0}>
                         </div>
                         <simtoolbar.SimulatorToolbar parent={this} />
+                        {this.state.keymap && simOpts.keymap && <keymap.Keymap parent={this} />}
                         <div className="ui item portrait hide hidefullscreen">
                             {pxt.options.debug ? <sui.Button key='hwdebugbtn' className='teal' icon="xicon chip" text={"Dev Debug"} onClick={this.hwDebug} /> : ''}
                         </div>

--- a/webapp/src/keymap.tsx
+++ b/webapp/src/keymap.tsx
@@ -1,0 +1,85 @@
+/// <reference path="../../built/pxtlib.d.ts" />
+
+import * as React from "react";
+import * as data from "./data";
+import * as sui from "./sui";
+
+type ISettingsProps = pxt.editor.ISettingsProps;
+
+interface KeymapState {
+    above?: boolean;
+}
+
+interface KeymapData {
+    title: string;
+    map: { [key: string]: string[] };
+};
+
+const _data: { [key: string]: KeymapData[] } = {
+    "arcade": [ {
+            title: "player 1",
+            map: {
+                "up": ["↑", "W"],
+                "down": ["↓", "S"],
+                "left": ["→", "A"],
+                "right": ["←", "D"],
+                "a": ["Z", "space"],
+                "b": ["X", "enter"]
+            }
+        },
+        {
+            title: "player 2",
+            map: {
+                "up": ["I"],
+                "down": ["K"],
+                "left": ["J"],
+                "right": ["L"],
+                "a": ["U"],
+                "b": ["O"]
+            }
+        } ]
+    }
+export class Keymap extends data.Component<ISettingsProps, KeymapState> {
+    private keymap: KeymapData[];
+    constructor(props: ISettingsProps) {
+        super(props);
+
+        const board = pxt.appTarget && pxt.appTarget.appTheme
+            && pxt.appTarget.appTheme.boardName.toLowerCase();
+        this.keymap = board && _data[board];
+    }
+
+    componentDidMount() {
+        const el = this.refs["keymap"] as HTMLDivElement;
+        if (el.parentElement.clientHeight < el.parentElement.scrollHeight) {
+            this.setState({ above: true });
+        } else {
+            this.setState({ above: false });
+        }
+    }
+
+    hideKeymap = () => {
+        this.props.parent.showKeymap(false);
+    }
+
+    renderCore() {
+        return <div className={`keymap ${this.state.above ? 'above' : ''}`} ref="keymap">
+            <i className="icon large close remove circle" role="presentation" onClick={this.hideKeymap}></i>
+            {this.keymap && this.keymap.map((col, i) => {
+                return <div key={i}>
+                    <span className="keymap-title">{col.title}</span>
+                    {
+                        Object.keys(col.map).map( (el, j) => {
+                            return <div key={j}>
+                                {col.map[el].map( (key, j) => {
+                                    return <div className="keymap-key" key={j}>{key}</div>
+                                })}
+                                <span className="keymap-name">{el}</span>
+                            </div>
+                        })
+                    }
+                </div>
+            })}
+        </div>;
+    }
+}

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -107,6 +107,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const makeTooltip = lf("Open assembly instructions");
         const restartTooltip = lf("Restart the simulator");
         const debugTooltip = lf("Toggle debug mode");
+        const keymapTooltip = lf("View simulator keyboard shortcuts");
         const fullscreenTooltip = isFullscreen ? lf("Exit fullscreen mode") : lf("Launch in fullscreen");
         const muteTooltip = isMuted ? lf("Unmute audio") : lf("Mute audio");
         const screenshotTooltip = targetTheme.simScreenshotKey ? lf("Take Screenshot (shortcut {0})", targetTheme.simScreenshotKey) : lf("Take Screenshot");
@@ -121,6 +122,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
             </div>
             {!isHeadless && <div className={`ui icon tiny buttons computer only`} style={{ padding: "0" }}>
                 {audio && <sui.Button key='mutebtn' className={`mute-button ${isMuted ? 'red' : ''}`} icon={`${isMuted ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={this.toggleMute} />}
+                {simOpts.keymap && <sui.Button key='keymap' className="keymap-button" icon="keyboard" title={keymapTooltip} onClick={this.props.parent.toggleKeymap} />}
             </div>}
             {!isHeadless && <div className={`ui icon tiny buttons computer only`} style={{ padding: "0" }}>
                 {screenshot && <sui.Button disabled={!isRunning} key='screenshotbtn' className={`screenshot-button ${screenshotClass}`} icon={`icon camera left`} title={screenshotTooltip} onClick={this.takeScreenshot} />}


### PR DESCRIPTION
Adds keymap button to simulator toolbar if "keymap" is set to true in pxtarget.

https://arcade.makecode.com/app/132d1e744bf5722d9f36607e688f0dbadeda3518-3ad4bed648

![keymap](https://user-images.githubusercontent.com/34112083/71682293-0f8ac480-2d44-11ea-90c1-c2016fdf3cde.gif)