### PR TITLE
fix snippet edit button loading correct project

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -103,7 +103,7 @@ namespace pxt.runner {
         const theme = pxt.appTarget.appTheme || {};
         if (woptions.showEdit && !theme.hideDocsEdit && decompileResult) { // edit button
             const pkg = decompileResult.package;
-            pkg.setPreferredEditor(options.showJavaScript ? pxt.JAVASCRIPT_PROJECT_NAME : pxt.BLOCKS_PROJECT_NAME);
+            pkg.setPreferredEditor($svg ? pxt.BLOCKS_PROJECT_NAME : $py ? pxt.PYTHON_PROJECT_NAME : pxt.JAVASCRIPT_PROJECT_NAME);
             const compressed = pkg.compressToFileAsync();
             const $editBtn = snippetBtn(lf("Edit"), "edit icon").click(() => {
                 pxt.tickEvent("docs.btn", { button: "edit" });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -104,21 +104,22 @@ namespace pxt.runner {
 
         const theme = pxt.appTarget.appTheme || {};
         if (woptions.showEdit && !theme.hideDocsEdit && decompileResult) { // edit button
-            const { package: pkg, compileBlocks, compilePython } = decompileResult;
-            const host = pkg.host();
-
-            if ($svg && compileBlocks) {
-                pkg.setPreferredEditor(pxt.BLOCKS_PROJECT_NAME);
-                host.writeFile(pkg, BLOCKS_FILE, compileBlocks.outfiles[BLOCKS_FILE]);
-            } else if ($py && compilePython) {
-                pkg.setPreferredEditor(pxt.PYTHON_PROJECT_NAME);
-                host.writeFile(pkg, PY_FILE, compileBlocks.outfiles[PY_FILE]);
-            }
-
-            const compressed = pkg.compressToFileAsync();
-            const $editBtn = snippetBtn(lf("Edit"), "edit icon").click(() => {
+            const $editBtn = snippetBtn(lf("Edit"), "edit icon");
+            $editBtn.click(() => {
                 pxt.tickEvent("docs.btn", { button: "edit" });
-                compressed.done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'));
+                const { package: pkg, compileBlocks, compilePython } = decompileResult;
+                const host = pkg.host();
+
+                if ($svg && compileBlocks) {
+                    pkg.setPreferredEditor(pxt.BLOCKS_PROJECT_NAME);
+                    host.writeFile(pkg, BLOCKS_FILE, compileBlocks.outfiles[BLOCKS_FILE]);
+                } else if ($py && compilePython) {
+                    pkg.setPreferredEditor(pxt.PYTHON_PROJECT_NAME);
+                    host.writeFile(pkg, PY_FILE, compileBlocks.outfiles[PY_FILE]);
+                }
+
+                pkg.compressToFileAsync()
+                    .done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'));
             });
             $menu.append($editBtn);
         }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -3,7 +3,9 @@
 namespace pxt.runner {
     const JS_ICON = "icon xicon js";
     const PY_ICON = "icon xicon python";
-    const BLOCKS_ICON = "icon xicon blocks"
+    const BLOCKS_ICON = "icon xicon blocks";
+    const PY_FILE = "main.py";
+    const BLOCKS_FILE = "main.blocks";
 
     export interface ClientRenderOptions {
         snippetClass?: string;
@@ -102,8 +104,17 @@ namespace pxt.runner {
 
         const theme = pxt.appTarget.appTheme || {};
         if (woptions.showEdit && !theme.hideDocsEdit && decompileResult) { // edit button
-            const pkg = decompileResult.package;
-            pkg.setPreferredEditor($svg ? pxt.BLOCKS_PROJECT_NAME : $py ? pxt.PYTHON_PROJECT_NAME : pxt.JAVASCRIPT_PROJECT_NAME);
+            const { package: pkg, compileBlocks, compilePython } = decompileResult;
+            const host = pkg.host();
+
+            if ($svg && compileBlocks) {
+                pkg.setPreferredEditor(pxt.BLOCKS_PROJECT_NAME);
+                host.writeFile(pkg, BLOCKS_FILE, compileBlocks.outfiles[BLOCKS_FILE]);
+            } else if ($py && compilePython) {
+                pkg.setPreferredEditor(pxt.PYTHON_PROJECT_NAME);
+                host.writeFile(pkg, PY_FILE, compileBlocks.outfiles[PY_FILE]);
+            }
+
             const compressed = pkg.compressToFileAsync();
             const $editBtn = snippetBtn(lf("Edit"), "edit icon").click(() => {
                 pxt.tickEvent("docs.btn", { button: "edit" });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -119,13 +119,13 @@ namespace pxt.runner {
                 pkg.setPreferredEditor(pxt.JAVASCRIPT_PROJECT_NAME);
             }
 
-            pkg.compressToFileAsync()
-                .done(buf => {
-                    $editBtn.click(() => {
-                        pxt.tickEvent("docs.btn", { button: "edit" });
-                        window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt');
-                    });
+            const compressed = pkg.compressToFileAsync();
+            $editBtn.click(() => {
+                pxt.tickEvent("docs.btn", { button: "edit" });
+                compressed.done(buf => {
+                    window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt');
                 });
+            });
             $menu.append($editBtn);
         }
 

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -105,22 +105,27 @@ namespace pxt.runner {
         const theme = pxt.appTarget.appTheme || {};
         if (woptions.showEdit && !theme.hideDocsEdit && decompileResult) { // edit button
             const $editBtn = snippetBtn(lf("Edit"), "edit icon");
-            $editBtn.click(() => {
-                pxt.tickEvent("docs.btn", { button: "edit" });
-                const { package: pkg, compileBlocks, compilePython } = decompileResult;
-                const host = pkg.host();
 
-                if ($svg && compileBlocks) {
-                    pkg.setPreferredEditor(pxt.BLOCKS_PROJECT_NAME);
-                    host.writeFile(pkg, BLOCKS_FILE, compileBlocks.outfiles[BLOCKS_FILE]);
-                } else if ($py && compilePython) {
-                    pkg.setPreferredEditor(pxt.PYTHON_PROJECT_NAME);
-                    host.writeFile(pkg, PY_FILE, compileBlocks.outfiles[PY_FILE]);
-                }
+            const { package: pkg, compileBlocks, compilePython } = decompileResult;
+            const host = pkg.host();
 
-                pkg.compressToFileAsync()
-                    .done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'));
-            });
+            if ($svg && compileBlocks) {
+                pkg.setPreferredEditor(pxt.BLOCKS_PROJECT_NAME);
+                host.writeFile(pkg, BLOCKS_FILE, compileBlocks.outfiles[BLOCKS_FILE]);
+            } else if ($py && compilePython) {
+                pkg.setPreferredEditor(pxt.PYTHON_PROJECT_NAME);
+                host.writeFile(pkg, PY_FILE, compileBlocks.outfiles[PY_FILE]);
+            } else {
+                pkg.setPreferredEditor(pxt.JAVASCRIPT_PROJECT_NAME);
+            }
+
+            pkg.compressToFileAsync()
+                .done(buf => {
+                    $editBtn.click(() => {
+                        pxt.tickEvent("docs.btn", { button: "edit" });
+                        window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt');
+                    });
+                });
             $menu.append($editBtn);
         }
 

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -102,12 +102,13 @@ namespace pxt.runner {
 
         const theme = pxt.appTarget.appTheme || {};
         if (woptions.showEdit && !theme.hideDocsEdit && decompileResult) { // edit button
+            const pkg = decompileResult.package;
+            pkg.setPreferredEditor(options.showJavaScript ? pxt.JAVASCRIPT_PROJECT_NAME : pxt.BLOCKS_PROJECT_NAME);
+            const compressed = pkg.compressToFileAsync();
             const $editBtn = snippetBtn(lf("Edit"), "edit icon").click(() => {
                 pxt.tickEvent("docs.btn", { button: "edit" });
-                decompileResult.package.setPreferredEditor(options.showJavaScript ? pxt.JAVASCRIPT_PROJECT_NAME : pxt.BLOCKS_PROJECT_NAME)
-                decompileResult.package.compressToFileAsync()
-                    .done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'))
-            })
+                compressed.done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'));
+            });
             $menu.append($editBtn);
         }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -56,7 +56,8 @@ namespace pxt.runner {
         writeFile(module: pxt.Package, filename: string, contents: string): void {
             if (filename == pxt.CONFIG_NAME)
                 return; // ignore config writes
-            throw Util.oops("trying to write " + module + " / " + filename)
+            const epkg = getEditorPkg(module);
+            epkg.files[filename] = contents;
         }
 
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo> {


### PR DESCRIPTION
fix snippet edit button -- fixes https://github.com/microsoft/pxt-arcade/issues/1667, and I'm pretty sure I remember there being at least one other issue for this but I can't find it right away.

![2020-01-06 14 01 57](https://user-images.githubusercontent.com/5615930/71855687-95857300-3096-11ea-8052-14f44aa59cc7.gif)


Looks the ``decompileResult`` is getting mutated / reused for each snippet (https://github.com/microsoft/pxt/blob/master/pxtrunner/runner.ts#L150), so it was always just picking an arbitrary snippet from the page / the last one that gets compiled. I think it would be preferable to avoid doing this, but I haven't taken a look at how large of a task that would be / if it's worth doing at the moment. 