### PR TITLE
Don't rebuild the API info for each snippet in docs

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -953,8 +953,6 @@ ${linkString}
     function getApiInfo(program: ts.Program, opts: pxtc.CompileOptions) {
         if (!apiCache) apiCache = {};
 
-        // FIXME: If some page theoretically included two different verions of the same package, this might fail.
-        // It's very unlikely
         const key = Object.keys(opts.fileSystem).sort().join(";");
 
         if (!apiCache[key]) apiCache[key] = pxtc.getApiInfo(program, opts.jres);

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -885,6 +885,7 @@ ${linkString}
     }
 
     let programCache: ts.Program;
+    let apiCache: pxt.Map<pxtc.ApisInfo>;
 
     export function decompileToBlocksAsync(code: string, options?: blocks.BlocksRenderOptions): Promise<DecompileResult> {
         // code may be undefined or empty!!!
@@ -915,7 +916,7 @@ ${linkString}
                 }
 
                 // decompile to blocks
-                let apis = pxtc.getApiInfo(program, opts.jres);
+                let apis = getApiInfo(program, opts);
                 return ts.pxtc.localizeApisAsync(apis, mainPkg)
                     .then(() => {
                         let blocksInfo = pxtc.getBlocksInfo(apis);
@@ -949,6 +950,18 @@ ${linkString}
             });
     }
 
+    function getApiInfo(program: ts.Program, opts: pxtc.CompileOptions) {
+        if (!apiCache) apiCache = {};
+
+        // FIXME: If some page theoretically included two different verions of the same package, this might fail.
+        // It's very unlikely
+        const key = Object.keys(opts.fileSystem).sort().join(";");
+
+        if (!apiCache[key]) apiCache[key] = pxtc.getApiInfo(program, opts.jres);
+
+        return apiCache[key];
+    }
+
     export function compileBlocksAsync(code: string, options?: blocks.BlocksRenderOptions): Promise<DecompileResult> {
         const packageid = options && options.packageId ? "pub:" + options.packageId :
             options && options.package ? "docs:" + options.package
@@ -958,7 +971,7 @@ ${linkString}
             .then(opts => {
                 opts.ast = true
                 const resp = pxtc.compile(opts)
-                const apis = pxtc.getApiInfo(resp.ast, opts.jres);
+                const apis = getApiInfo(resp.ast, opts);
                 return ts.pxtc.localizeApisAsync(apis, mainPkg)
                     .then(() => {
                         const blocksInfo = pxtc.getBlocksInfo(apis);


### PR DESCRIPTION
This speeds up the load time of docs pages with a lot of snippets. I used this page for testing: https://arcade.makecode.com/concepts/star-field

On my local machine it took ~6 seconds to fire the onLoad event before my changes and ~3.7 seconds after my changes.

We could improve this even more by using the same API info that the editor stores in the indexed db, but I didn't think it was worth duplicating all of that code in the embed frame. I might try to refactor it out later.