### PR TITLE
Return Travis info for Azure pipelines (Minecraft) build as well

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1492,9 +1492,11 @@ interface CiBuildInfo {
 function ciBuildInfo(): CiBuildInfo {
     const isTravis = (process.env.TRAVIS === "true");
     const isGithubAction = (!!process.env.GITHUB_ACTIONS);
+    const isAzurePipelines = (process.env.TF_BUILD === "True");
 
     if (isTravis) return travisInfo();
     else if (isGithubAction) return githubActionInfo();
+    else if (isAzurePipelines) return travisInfo(); // azure pipelines uses same info
     else {
         // local build
         return {


### PR DESCRIPTION
`TF_BUILD` environment variable from https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml