### PR TITLE
support advanced python operators & throw error instead of returning comment

### DIFF
--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -869,9 +869,17 @@ namespace pxt.py {
                     return throwError(node, 3009, "Unsupported operator: >>>");
                 case ts.SyntaxKind.AsteriskAsteriskToken:
                     return "**"
+                case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
+                    return "**="
+                case ts.SyntaxKind.PercentEqualsToken:
+                    return "%="
+                case ts.SyntaxKind.AsteriskEqualsToken:
+                    return "*="
+                case ts.SyntaxKind.SlashEqualsToken:
+                    return "/="
                 default:
                     pxt.tickEvent("depython.todo", { op: s })
-                    return "# TODO unknown op: " + s
+                    return throwError(node, 3008, `Unsupported Python operator (code: ${s})`);
             }
         }
         function emitBinExp(s: ts.BinaryExpression): ExpRes {

--- a/tests/runtime-trace-tests/cases/adv_operators.ts
+++ b/tests/runtime-trace-tests/cases/adv_operators.ts
@@ -1,0 +1,10 @@
+
+let c = 7.0
+let a = 5.1
+
+c %= a
+c **= a
+c *= a
+c /= a
+
+console.log(c)


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-minecraft/issues/1031