### PR TITLE
Larger sidedocs in Monaco, shrink font & no wrap for python

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -399,6 +399,15 @@ namespace pxt.runner {
                 localeLiveRx.test(localeInfo)
             );
         }
+        if (editorLanguageMode == LanguageMode.Blocks) {
+            document.body.classList.remove("editorlang-text");
+            $('link[title="light"]').prop('disabled', false);
+            $('link[title="dark"]').prop('disabled', true);
+        } else {
+            document.body.classList.add("editorlang-text");
+            $('link[title="light"]').prop('disabled', true);
+            $('link[title="dark"]').prop('disabled', false);
+        }
 
         return Promise.resolve();
     }

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -472,3 +472,14 @@
     }
 }
 .replaceDocsAvatar();
+
+#docs.py {
+    pre {
+        overflow-x: scroll;
+        font-size: 0.875em;
+    }
+
+    pre > code {
+        white-space: pre;
+    }
+}

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -371,8 +371,8 @@
         margin: 0;
     }
 
-    /* python sidedocs tutorials */
-    &.py {
+    /* sidedocs tutorials (text-based) */
+    &.editorlang-text {
         pre {
             overflow-x: scroll;
             font-size: 0.875em;

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -370,6 +370,22 @@
     .ui.grid {
         margin: 0;
     }
+
+    /* python sidedocs tutorials */
+    &.py {
+        pre {
+            overflow-x: scroll;
+            font-size: 0.875em;
+        }
+
+        pre > code {
+            white-space: pre;
+        }
+
+        .mainbody .ui.segment {
+            padding: 0;
+        }
+    }
 }
 
 .ui.sidebar.menu.docs {
@@ -472,14 +488,3 @@
     }
 }
 .replaceDocsAvatar();
-
-#docs.py {
-    pre {
-        overflow-x: scroll;
-        font-size: 0.875em;
-    }
-
-    pre > code {
-        white-space: pre;
-    }
-}

--- a/theme/sidedoc.less
+++ b/theme/sidedoc.less
@@ -83,6 +83,29 @@
   font-size: @h3;
 }
 
+/* Sidedocs in Monaco editor */
+.sideDocs.py,
+.sideDocs.js {
+    #sidedocs {
+        width: 50%!important;
+        min-width: 18rem;
+    }
+
+    #sidedocsframe, #sidedocsframe-wrapper {
+        width: 100%!important;
+    }
+
+    #sidedocstoggle {
+        right: calc(~'50% - 0.5rem')!important;
+    }
+
+    @media only screen and (max-width: 36rem) {
+        #sidedocstoggle {
+            right: 17rem!important;
+        }
+    }
+}
+
 /* Large Monitor */
 @media only screen and (min-width: @largeMonitorBreakpoint) {
     .sideDocs #sidedocs, .sideDocs #sidedocsframe, .sideDocs #sidedocsframe-wrapper {

--- a/theme/sidedoc.less
+++ b/theme/sidedoc.less
@@ -84,8 +84,7 @@
 }
 
 /* Sidedocs in Monaco editor */
-.sideDocs.py,
-.sideDocs.js {
+.sideDocs.editorlang-text {
     #sidedocs {
         width: 50%!important;
         min-width: 18rem;

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -82,7 +82,7 @@
 
 <body id="docs">
     <style type="text/css">
-        @import "/blb/highlight.js/styles/vs.css";
+        @import "/blb/highlight.js/styles/vs2015.css";
     </style>
     <div id="sidedocs-back-button" class="ui" style="display: none">
         <i class="ui icon left arrow"></i>
@@ -120,7 +120,10 @@
             if (backLabel)
                 backLabel.textContent = pxt.Util.lf("Go back")
             var editorlang = pxt.Util.getEditorLanguagePref();
-            if (editorlang == "py") document.body.classList.add("py");
+            if (editorlang == "py") {
+                document.body.classList.add("py");
+                document.body.classList.add("inverted");
+            }
 
             var projectid = /projectid=([^&?]+)/i.exec(window.location.href);
             var project = /project=([^&?]+)/i.exec(window.location.href);

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -78,12 +78,11 @@
     </style>
     <link rel="stylesheet" data-rtl="/blb/rtlsemantic.css" href="/blb/semantic.css" type="text/css">
     <link id="blocklycss" rel="stylesheet" data-rtl="/blb/rtlblockly.css" href="/blb/blockly.css" type="text/css">
+    <link rel="stylesheet" title="light" href="/blb/highlight.js/styles/vs.css" type="text/css">
+    <link rel="stylesheet" title="dark" href="/blb/highlight.js/styles/vs2015.css" type="text/css" disabled>
 </head>
 
 <body id="docs">
-    <style type="text/css">
-        @import "/blb/highlight.js/styles/vs2015.css";
-    </style>
     <div id="sidedocs-back-button" class="ui" style="display: none">
         <i class="ui icon left arrow"></i>
         <span id="back-label"></span>
@@ -119,11 +118,6 @@
             var backLabel = document.getElementById('back-label');
             if (backLabel)
                 backLabel.textContent = pxt.Util.lf("Go back")
-            var editorlang = pxt.Util.getEditorLanguagePref();
-            if (editorlang == "py") {
-                document.body.classList.add("py");
-                document.body.classList.add("inverted");
-            }
 
             var projectid = /projectid=([^&?]+)/i.exec(window.location.href);
             var project = /project=([^&?]+)/i.exec(window.location.href);

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -119,6 +119,9 @@
             var backLabel = document.getElementById('back-label');
             if (backLabel)
                 backLabel.textContent = pxt.Util.lf("Go back")
+            var editorlang = pxt.Util.getEditorLanguagePref();
+            if (editorlang == "py") document.body.classList.add("py");
+
             var projectid = /projectid=([^&?]+)/i.exec(window.location.href);
             var project = /project=([^&?]+)/i.exec(window.location.href);
             var code = /code=([^&?]+)/i.exec(window.location.href);

--- a/webapp/public/highlight.js/styles/vs2015.css
+++ b/webapp/public/highlight.js/styles/vs2015.css
@@ -1,0 +1,115 @@
+/*
+ * Visual Studio 2015 dark style
+ * Author: Nicolas LLOBERA <nllobera@gmail.com>
+ */
+
+ .hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #1E1E1E;
+  color: #DCDCDC;
+}
+
+.hljs-keyword,
+.hljs-literal,
+.hljs-symbol,
+.hljs-name {
+  color: #569CD6;
+}
+.hljs-link {
+  color: #569CD6;
+  text-decoration: underline;
+}
+
+.hljs-built_in,
+.hljs-type {
+  color: #4EC9B0;
+}
+
+.hljs-number,
+.hljs-class {
+  color: #B8D7A3;
+}
+
+.hljs-string,
+.hljs-meta-string {
+  color: #D69D85;
+}
+
+.hljs-regexp,
+.hljs-template-tag {
+  color: #9A5334;
+}
+
+.hljs-subst,
+.hljs-function,
+.hljs-title,
+.hljs-params,
+.hljs-formula {
+  color: #DCDCDC;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #57A64A;
+  font-style: italic;
+}
+
+.hljs-doctag {
+  color: #608B4E;
+}
+
+.hljs-meta,
+.hljs-meta-keyword,
+.hljs-tag {
+  color: #9B9B9B;
+}
+
+.hljs-variable,
+.hljs-template-variable {
+  color: #BD63C5;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-builtin-name {
+  color: #9CDCFE;
+}
+
+.hljs-section {
+  color: gold;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+/*.hljs-code {
+  font-family:'Monospace';
+}*/
+
+.hljs-bullet,
+.hljs-selector-tag,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo {
+  color: #D7BA7D;
+}
+
+.hljs-addition {
+  background-color: #144212;
+  display: inline-block;
+  width: 100%;
+}
+
+.hljs-deletion {
+  background-color: #600;
+  display: inline-block;
+  width: 100%;
+}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3514,6 +3514,7 @@ export class ProjectView
             isHeadless ? "headless" : "",
             flyoutOnly ? "flyoutOnly" : "",
             hideTutorialIteration ? "hideIteration" : "",
+            this.editor != this.blocksEditor ? pxt.Util.getEditorLanguagePref() : "",
             'full-abs'
         ];
         const rootClasses = sui.cx(rootClassList);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3514,7 +3514,7 @@ export class ProjectView
             isHeadless ? "headless" : "",
             flyoutOnly ? "flyoutOnly" : "",
             hideTutorialIteration ? "hideIteration" : "",
-            this.editor != this.blocksEditor ? pxt.Util.getEditorLanguagePref() : "",
+            this.editor != this.blocksEditor ? "editorlang-text" : "",
             'full-abs'
         ];
         const rootClasses = sui.cx(rootClassList);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/71857218-8ead2f00-309b-11ea-8df1-4cda4c270be6.png)

Some fixes for https://github.com/microsoft/pxt-minecraft/issues/1521

Sidedocs take up 50% of the screen in text (py/js), unchanged in blocks