### PR TITLE
support py `for i in "abc"`

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1245,7 +1245,7 @@ namespace pxt.py {
                     stmts(n.body))
             }
 
-            if (currIteration > 0) {
+            if (currIteration > 1) {
                 const typeOfTarget = typeOf(n.target);
                 unifyTypeOf(n.iter, typeOf(n.iter) == tpString ? typeOfTarget : mkArrayType(typeOfTarget));
             }

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1244,9 +1244,17 @@ namespace pxt.py {
                     B.mkText(")"),
                     stmts(n.body))
             }
+
+            let isStringLike = false;
+            if (n.iter.kind == "Name") {
+                const v = lookupVar((n.iter as py.Name).id);
+                isStringLike = !!v && !!v.pyRetType && find(v.pyRetType) == tpString;
+            } else if (n.iter.kind == "Str") {
+                isStringLike = true;
+            }
+
             const typeOfTarget = typeOf(n.target);
-            const outType = n.iter.kind == "Str" ? typeOfTarget : mkArrayType(typeOfTarget);
-            unifyTypeOf(n.iter, outType);
+            unifyTypeOf(n.iter, isStringLike ? typeOfTarget : mkArrayType(typeOfTarget));
             return B.mkStmt(
                 B.mkText("for ("),
                 expr(n.target),

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1245,16 +1245,11 @@ namespace pxt.py {
                     stmts(n.body))
             }
 
-            let isStringLike = false;
-            if (n.iter.kind == "Name") {
-                const v = lookupVar((n.iter as py.Name).id);
-                isStringLike = !!v && !!v.pyRetType && find(v.pyRetType) == tpString;
-            } else if (n.iter.kind == "Str") {
-                isStringLike = true;
+            if (currIteration > 0) {
+                const typeOfTarget = typeOf(n.target);
+                unifyTypeOf(n.iter, typeOf(n.iter) == tpString ? typeOfTarget : mkArrayType(typeOfTarget));
             }
 
-            const typeOfTarget = typeOf(n.target);
-            unifyTypeOf(n.iter, isStringLike ? typeOfTarget : mkArrayType(typeOfTarget));
             return B.mkStmt(
                 B.mkText("for ("),
                 expr(n.target),

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -179,7 +179,7 @@ namespace pxt.py {
         if (tp == "T" || tp == "U") // TODO hack!
             return mkType({ primType: "'" + tp })
 
-        // defined by a symbol, 
+        // defined by a symbol,
         //  either in external (non-py) APIs (like default/common packages)
         //  or in internal (py) APIs (probably main.py)
         let sym = lookupApi(tp + "@type") || lookupApi(tp)
@@ -1244,14 +1244,17 @@ namespace pxt.py {
                     B.mkText(")"),
                     stmts(n.body))
             }
-            unifyTypeOf(n.iter, mkArrayType(typeOf(n.target)))
+            const typeOfTarget = typeOf(n.target);
+            const outType = n.iter.kind == "Str" ? typeOfTarget : mkArrayType(typeOfTarget);
+            unifyTypeOf(n.iter, outType);
             return B.mkStmt(
                 B.mkText("for ("),
                 expr(n.target),
                 B.mkText(" of "),
                 expr(n.iter),
                 B.mkText(")"),
-                stmts(n.body))
+                stmts(n.body)
+            );
         },
         While: (n: py.While) => {
             U.assert(n.orelse.length == 0)

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1247,6 +1247,13 @@ namespace pxt.py {
 
             if (currIteration > 1) {
                 const typeOfTarget = typeOf(n.target);
+                /**
+                 * The type the variable to iterate over must be `string | Iterable<typeof Target>`,
+                 * but we can't model that with the current state of the python type checker.
+                 * If we can identify the type of the value we're iterating over to be a string elsewhere,
+                 * try and allow this by unifying with just the target type;
+                 * otherwise, it is assumed to be an array.
+                 */
                 unifyTypeOf(n.iter, typeOf(n.iter) == tpString ? typeOfTarget : mkArrayType(typeOfTarget));
             }
 

--- a/tests/runtime-trace-tests/cases/for_of_loop.ts
+++ b/tests/runtime-trace-tests/cases/for_of_loop.ts
@@ -1,0 +1,17 @@
+const word = "def";
+
+for (const letter of word) {
+    console.log(letter);
+}
+for (const letter of "abc") {
+    console.log(letter);
+}
+
+const strList = ["Hi", "bye"];
+for (const text of strList) {
+    console.log(text)
+}
+
+for (const num of [1, 2, 3]) {
+    console.log(num)
+}


### PR DESCRIPTION
support string iteration with `for i of "abc"` in python; fixes https://github.com/microsoft/pxt-minecraft/issues/1499

```python
for letter in 'abcdef':
    print(letter)
```

converts to 

```typescript
for (let letter of "abcdef") {
    console.log(letter)
}
```

(and back, of course)

just noticed that that typescript does actually fail to decompile to blocks at the moment, will file an issue for that

sidenote: I did get confused why nothing was changing when I was changing the stmtmap, and it took a few to realize that I was changing the one in cli/pyconv and not pxtpy/converter; is that used for anything at this point?