### PR TITLE
Enable GitHub pages on github project

### DIFF
--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -16,7 +16,22 @@ A quick solution is take screenshots of the snippets but that approach can quick
 
 The MakeCode approach to solving this issue is to render the **JavaScript** code snippets on the client using the same block rendering engine as the editor. Under the hood, an ``iframe`` from the MakeCode editor will render the blocks for you.
 
-## Plugins
+## GitHub pages
+
+You can use [GitHub pages](https://help.github.com/en/github/working-with-github-pages) to render your README.md file as a web site.
+
+* enable [GitHub pages](https://help.github.com/en/github/working-with-github-pages/creating-a-github-pages-site#creating-your-site) on your repository
+* add the following entry in the ``_config.yml``
+```
+makecode:
+  home_url: @homeurl@
+```
+* copy the following text at the bottom of your ``README.md`` file
+```
+<script src="https://makecode.com/gh-pages-embed.js"></script><script>makeCodeRender("{{ site.makecode.home_url }}", "{{ site.github.owner_name }}/{{ site.github.repository_name }}");</script>
+```
+
+## Other Plugins
 
 Here is an integration sample:
 
@@ -30,7 +45,7 @@ To render blocks in your own HTML documents or to make plugins for a document pl
 
 ### ~ hint
 
-Try this [fiddle](https://jsfiddle.net/L8msdjpu/2/) to see an embedded blocks rendering example.
+Try this [fiddle](https://jsfiddle.net/nq0hyz97/) to see an embedded blocks rendering example.
 
 ### ~
 

--- a/docs/blocks-embed.md
+++ b/docs/blocks-embed.md
@@ -15,7 +15,22 @@ Unlike text based programming languages, block-based snippets aren't easily rend
 
 The MakeCode approach in solving this problem is to render the **JavaScript** code snippets on a client using the same block rendering engine as the editor. Under the hood, an IFrame from the MakeCode editor will render the blocks for you.
 
-## Plugins
+## GitHub pages
+
+You can use [GitHub pages](https://help.github.com/en/github/working-with-github-pages) to render your README.md file as a web site.
+
+* enable [GitHub pages](https://help.github.com/en/github/working-with-github-pages/creating-a-github-pages-site#creating-your-site) on your repository
+* add the url of the editor in ``_config.yml`` (including trailing /)
+```
+makecode:
+  home_url: https://makecode.microbit.org/
+```
+* copy the following text at the bottom of your ``README.md`` file
+```
+<script src="https://makecode.com/gh-pages-embed.js"></script><script>makeCodeRender("{{ site.makecode.home_url }}", "{{ site.github.owner_name }}/{{ site.github.repository_name }}");</script>
+```
+
+## Other Plugins
 
 Here are some sample integrations for various documentation/blogging engines.
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -272,10 +272,11 @@ namespace pxt.github {
         tree: string; // sha		
     }
 
-    function ghPostAsync(path: string, data: any) {
+    function ghPostAsync(path: string, data: any, headers?: any, method?: string) {
         return ghRequestAsync({
             url: /^https:/.test(path) ? path : "https://api.github.com/repos/" + path,
-            method: "POST",
+            headers,
+            method: method || "POST",
             allowHttpErrors: true,
             data: data
         }).then(resp => {
@@ -581,6 +582,25 @@ namespace pxt.github {
             has_wiki: false,
             allow_rebase_merge: false
         }).then(v => mkRepo(v, null))
+    }
+
+    export function enablePagesAsync(repo: string) {
+        // https://developer.github.com/v3/repos/pages/#enable-a-pages-site
+        return ghPostAsync(`https://api.github.com/repos/${repo}/pages`, {
+            source: {
+                branch: "master",
+                path: ""
+          }
+        }, {
+            "Accept": "application/vnd.github.switcheroo-preview+json"
+        }).then(r => {
+            const url = r.html_url;
+            // update repo home page
+            return ghPostAsync(`https://api.github.com/repos/${repo}`,
+            {
+                "homepage": url
+            }, undefined, "PATCH");
+        });
     }
 
     export function repoIconUrl(repo: GitRepo): string {

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -39,7 +39,7 @@ ${lf("This repository can be added as an **extension** in MakeCode.")}
 * ${lf("open [@HOMEURL@](@HOMEURL@)")}
 * ${lf("click on **New Project**")}
 * ${lf("click on **Extensions** under the gearwheel menu")}
-* ${lf("search for the URL of this repository and import")}
+* ${lf("search for **https://github.com/@REPO@** and import")}
 
 ## ${lf("Edit this extension")}
 
@@ -47,7 +47,7 @@ ${lf("To edit this repository in MakeCode.")}
 
 * ${lf("open [@HOMEURL@](@HOMEURL@)")}
 * ${lf("click on **Import** then click on **Import URL**")}
-* ${lf("paste the repository URL and click import")}
+* ${lf("paste **https://github.com/@REPO@** and click import")}
 
 ## ${lf("Blocks preview")}
 

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -36,7 +36,7 @@ test:
 
             "README.md": 
 `> ${lf("Open this page at {0}", 
-"[https://@REPO_OWNER@.github.io/@REPO_NAME@/](https://@REPO_OWNER@.github.io/@REPO_NAME@/)"
+"[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
 )}
 
 @DESCRIPTION@

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -15,7 +15,13 @@ namespace pxt.template {
 
             "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}
 `,
-            "_config.yml": "theme: jekyll-theme-primer",
+            "_config.yml": 
+`
+makecode:
+  target: @TARGET@
+  platform: @PLATFORM@
+  home_url: @HOMEURL@
+theme: jekyll-theme-slate`,
             "Makefile": `all: deploy
 
 build:
@@ -28,7 +34,10 @@ test:
 \tpxt test
 `,
 
-            "README.md": `# @NAME@ ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
+            "README.md": 
+`> ${lf("Open this page at {0}", 
+"[https://@REPO_OWNER@.github.io/@REPO_NAME@/](https://@REPO_OWNER@.github.io/@REPO_NAME@/)"
+)}
 
 @DESCRIPTION@
 
@@ -41,7 +50,7 @@ ${lf("This repository can be added as an **extension** in MakeCode.")}
 * ${lf("click on **Extensions** under the gearwheel menu")}
 * ${lf("search for **https://github.com/@REPO@** and import")}
 
-## ${lf("Edit this extension")}
+## ${lf("Edit this extension")} ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
 
 ${lf("To edit this repository in MakeCode.")}
 

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -38,8 +38,6 @@ test:
                     "[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
                 )}
 
-@DESCRIPTION@
-
 ## ${lf("Use this extension")}
 
 ${lf("This repository can be added as an **extension** in MakeCode.")}

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -28,7 +28,7 @@ test:
 \tpxt test
 `,
 
-            "README.md": `# @NAME@ ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
+            "README.md": `# [@NAME@](https://@REPO_OWNER@.github.io/@REPO_NAME@/) ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
 
 @DESCRIPTION@
 

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -161,12 +161,6 @@ jobs:
         "command": "pxt clean",
         "group": "test",
         "problemMatcher": [ "$tsc" ]
-    }, {
-        "label": "pxt serial",
-        "type": "shell",
-        "command": "pxt serial",
-        "group": "test",
-        "problemMatcher": [ "$tsc" ]
     }]
 }
 `

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -15,7 +15,7 @@ namespace pxt.template {
 
             "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}
 `,
-
+            "_config.yml": "theme: jekyll-theme-cayman",
             "Makefile": `all: deploy
 
 build:
@@ -36,7 +36,7 @@ test:
 
 ${lf("This repository can be added as an **extension** in MakeCode.")}
 
-* ${lf("open @HOMEURL@")}
+* ${lf("open [@HOMEURL@](@HOMEURL@)")}
 * ${lf("click on **New Project**")}
 * ${lf("click on **Extensions** under the gearwheel menu")}
 * ${lf("search for the URL of this repository and import")}
@@ -45,7 +45,7 @@ ${lf("This repository can be added as an **extension** in MakeCode.")}
 
 ${lf("To edit this repository in MakeCode.")}
 
-* ${lf("open @HOMEURL@")}
+* ${lf("open [@HOMEURL@](@HOMEURL@)")}
 * ${lf("click on **Import** then click on **Import URL**")}
 * ${lf("paste the repository URL and click import")}
 
@@ -56,12 +56,11 @@ ${lf("This image may take a few minutes to refresh.")}
 
 ![${lf("A rendered view of the blocks")}](https://github.com/@REPO@/raw/master/.github/makecode/blocks.png)
 
-## ${lf("Supported targets")}
+### ${lf("Metadata (used for search, rendering)")}
 
 * for PXT/@TARGET@
-* for PXT/@PLATFORM@
-${lf("(The metadata above is needed for package search.)")}
-
+<script src="https://makecode.com/gh-pages-embed.js"></script>
+<script>makeCodeRender("@HOMEURL@", "@REPO@");</script>
 `,
 
             ".gitignore":

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -15,8 +15,8 @@ namespace pxt.template {
 
             "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}
 `,
-            "_config.yml": 
-`
+            "_config.yml":
+                `
 makecode:
   target: @TARGET@
   platform: @PLATFORM@
@@ -34,10 +34,10 @@ test:
 \tpxt test
 `,
 
-            "README.md": 
-`> ${lf("Open this page at {0}", 
-"[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
-)}
+            "README.md":
+                `> ${lf("Open this page at {0}",
+                    "[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
+                )}
 
 @DESCRIPTION@
 
@@ -136,7 +136,7 @@ jobs:
         env:
           CI: true
 `,
-        ".vscode/tasks.json":
+            ".vscode/tasks.json":
                 `
 // A task runner that calls the MakeCode (PXT) compiler
 {

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -16,8 +16,7 @@ namespace pxt.template {
             "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}
 `,
             "_config.yml":
-                `
-makecode:
+                `makecode:
   target: @TARGET@
   platform: @PLATFORM@
   home_url: @HOMEURL@

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -65,11 +65,10 @@ ${lf("This image may take a few minutes to refresh.")}
 
 ![${lf("A rendered view of the blocks")}](https://github.com/@REPO@/raw/master/.github/makecode/blocks.png)
 
-### ${lf("Metadata (used for search, rendering)")}
+#### ${lf("Metadata (used for search, rendering)")}
 
 * for PXT/@TARGET@
-<script src="https://makecode.com/gh-pages-embed.js"></script>
-<script>makeCodeRender("@HOMEURL@", "@REPO@");</script>
+<script src="https://makecode.com/gh-pages-embed.js"></script><script>makeCodeRender("{{ site.makecode.home_url }}", "{{ site.github.owner_name }}/{{ site.github.repository_name }}");</script>
 `,
 
             ".gitignore":

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -15,7 +15,7 @@ namespace pxt.template {
 
             "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}
 `,
-            "_config.yml": "theme: jekyll-theme-cayman",
+            "_config.yml": "theme: jekyll-theme-primer",
             "Makefile": `all: deploy
 
 build:
@@ -28,7 +28,7 @@ test:
 \tpxt test
 `,
 
-            "README.md": `# [@NAME@](https://@REPO_OWNER@.github.io/@REPO_NAME@/) ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
+            "README.md": `# @NAME@ ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
 
 @DESCRIPTION@
 

--- a/theme/home.less
+++ b/theme/home.less
@@ -524,6 +524,12 @@
             .meta {
                 padding: 0.5rem;
             }
+            .fileimage {
+                top: 2rem;
+                left: 1rem;
+                width: 2rem;
+                height: 1.5rem;                
+            }
         }        
         .detailview.visible {
             .column, 

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -485,6 +485,7 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
             pxt.tickEvent("github.create.cancel");
         else {
             if (!repoNameError()) {
+                repoDescription = repoDescription || lf("A MakeCode project")
                 core.showLoading("creategithub", lf("creating {0} repository...", repoName))
                 return pxt.github.createRepoAsync(repoName, repoDescription.trim(), !repoPublic)
                     .finally(() => core.hideLoading("creategithub"))

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -953,7 +953,10 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 
     const templateFiles = pxt.template.packageFiles(name);
     pxt.template.packageFilesFixup(templateFiles, {
-        repo: parsed.fullName
+        repo: parsed.fullName,
+        repo_owner: parsed.owner,
+        repo_name: parsed.project,
+        repo_tag: parsed.tag
     });
 
     if (forceTemplateFiles) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -954,9 +954,9 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
     const templateFiles = pxt.template.packageFiles(name);
     pxt.template.packageFilesFixup(templateFiles, {
         repo: parsed.fullName,
-        repo_owner: parsed.owner,
-        repo_name: parsed.project,
-        repo_tag: parsed.tag
+        repoowner: parsed.owner,
+        reponame: parsed.project,
+        repotag: parsed.tag
     });
 
     if (forceTemplateFiles) {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1013,6 +1013,9 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 
     await saveAsync(hd, currFiles)
 
+    // enable github pages
+    await pxt.github.enablePagesAsync(parsed.fullName);
+
     return hd
 }
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1013,7 +1013,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
 
     await saveAsync(hd, currFiles)
 
-    // enable github pages
+    // try enable github pages
     await pxt.github.enablePagesAsync(parsed.fullName);
 
     return hd

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -468,7 +468,7 @@ export async function pullAsync(hd: Header, checkOnly = false) {
     let gitjson = JSON.parse(gitjsontext) as GitJson
     let parsed = pxt.github.parseRepoId(gitjson.repo)
     const sha = await pxt.github.getRefAsync(parsed.fullName, parsed.tag)
-    if  (!sha) {
+    if (!sha) {
         // 404: branch does not exist, repo is gone or no rights to access repo
         // try to get the list of heads to see if we can access the project
         const heads = await pxt.github.listRefsAsync(parsed.fullName, "heads");
@@ -1014,7 +1014,11 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
     await saveAsync(hd, currFiles)
 
     // try enable github pages
-    await pxt.github.enablePagesAsync(parsed.fullName);
+    try {
+        await pxt.github.enablePagesAsync(parsed.fullName);
+    } catch (e) {
+        pxt.reportException(e);
+    }
 
     return hd
 }


### PR DESCRIPTION
GitHub pages allow to have blocks rendered on the repository homage in a user friendly way.
- [x] enable github pages on repo creation
- [x] set repo homepage as github page rendered web site
- [x] updated readme template to link to pages link
- [x] inject rendering javascript at bottom of readme