### PR TITLE
 Line breaks in long lists and function calls for Python

### DIFF
--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -1031,7 +1031,7 @@ namespace pxt.py {
                 return exps.map((el, i) => {
                     if (i == 0) {
                         return el + ",";
-                    } else if (i == exps.length -1) {
+                    } else if (i == exps.length - 1) {
                         return indent1(el);
                     } else {
                         return indent1(el + ",");

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -1029,12 +1029,13 @@ namespace pxt.py {
             let res = exps.join(", ");
             if (res.length > 60) {
                 return exps.map((el, i) => {
+                    let sep = el.charAt(el.length - 1) == "," ? "" : ",";
                     if (i == 0) {
-                        return el + ",";
+                        return el + sep;
                     } else if (i == exps.length - 1) {
                         return indent1(el);
                     } else {
-                        return indent1(el + ",");
+                        return indent1(el + sep);
                     }
                 })
             }

--- a/tests/runtime-trace-tests/cases/for_of_loop.ts
+++ b/tests/runtime-trace-tests/cases/for_of_loop.ts
@@ -1,0 +1,3 @@
+for (let animal of ["alligator", "hippopotamus", "lionfish", "coelacanth"]) {
+    console.log(animal)
+}


### PR DESCRIPTION
Extends ExpRes to have an array of expressions, breaks up long array literals and function calls.

![fix_indent](https://user-images.githubusercontent.com/34112083/71942930-b40d6c00-3173-11ea-8f25-38fc82297081.gif)

Fixes https://github.com/microsoft/pxt-minecraft/issues/915
Fixes https://github.com/microsoft/pxt-minecraft/issues/1523