### PR TITLE
fix python indent errors

### DIFF
--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -702,12 +702,13 @@ namespace pxt.py {
     }
 
     function stmt(): Stmt[] {
-        if (peekToken().type == TokenType.Indent) {
-            error(9573, U.lf("unexpected indent"))
-            shiftToken()
-        }
+        const prevErr = diags.length;
+        const hasIndentationError = peekToken().type == TokenType.Indent;
 
-        let prevErr = diags.length
+        if (hasIndentationError) {
+            shiftToken();
+            error(9573, U.lf("unexpected indent"));
+        }
 
         let decorators: Expr[] = []
         while (currentOp() == "MatMult") {
@@ -746,6 +747,11 @@ namespace pxt.py {
                 if (peekToken().type == TokenType.EOF)
                     break
             }
+
+            if (hasIndentationError && peekToken().type === TokenType.Dedent) {
+                shiftToken();
+            }
+
             inParens = 0
             if (traceParser)
                 pxt.log(traceLev + "skip: " + skp.join(", "))

--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -10,7 +10,7 @@ namespace pxt.py {
     let indentStack: number[]
     let prevToken: Token
     let diags: pxtc.KsDiagnostic[]
-    let traceParser = true
+    let traceParser = false
     let traceLev = ""
 
     type Parse = () => AST

--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -217,7 +217,7 @@ namespace pxt.py {
             shiftToken()
             let rangeStart: Stmt[];
             if (peekToken().type != TokenType.Indent) {
-                error(9554, U.lf("expecting indent"));
+                error(9554, U.lf("expected an indented block"));
                 rangeStart = stmt();
             } else {
                 const level = parseInt(peekToken().value);

--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -215,14 +215,14 @@ namespace pxt.py {
             }
 
             shiftToken()
-            let rangeStart: Stmt[];
+            let outputRange: Stmt[];
             if (peekToken().type != TokenType.Indent) {
                 error(9554, U.lf("expected an indented block"));
-                rangeStart = stmt();
+                outputRange = stmt();
             } else {
                 const level = parseInt(peekToken().value);
                 shiftToken();
-                rangeStart = stmt();
+                outputRange = stmt();
 
                 for (;;) {
                     if (peekToken().type == TokenType.Dedent) {
@@ -231,7 +231,7 @@ namespace pxt.py {
                         if (isFinal)
                             break
                     }
-                    U.pushRange(rangeStart, stmt());
+                    U.pushRange(outputRange, stmt());
                 }
             }
 
@@ -240,7 +240,7 @@ namespace pxt.py {
                 pxt.log(traceLev + "}");
             }
 
-            return rangeStart;
+            return outputRange;
         } else {
             return simple_stmt()
         }

--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -220,17 +220,19 @@ namespace pxt.py {
                 error(9554, U.lf("expecting indent"))
             } else {
                 level = parseInt(peekToken().value)
+                shiftToken()
             }
-            shiftToken()
             let r = stmt()
-            for (; ;) {
-                if (peekToken().type == TokenType.Dedent) {
-                    const isFinal = (isNaN(level) || parseInt(peekToken().value) < level)
-                    shiftToken()
-                    if (isFinal)
-                        break
+            if (!isNaN(level)) {
+                for (; ;) {
+                    if (peekToken().type == TokenType.Dedent) {
+                        const isFinal = parseInt(peekToken().value) < level;
+                        shiftToken()
+                        if (isFinal)
+                            break
+                    }
+                    U.pushRange(r, stmt())
                 }
-                U.pushRange(r, stmt())
             }
             if (traceParser) {
                 traceLev = prevTr


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/1325

Show errors in the correct spots for indentation errors (e.g. on the start of the line that should be indented / unindented, not on the preceding `<nl>`), and don't output spurious errors that stem from the original errors

current:
![2020-01-08 16 14 14](https://user-images.githubusercontent.com/5615930/72026908-01e8a980-3232-11ea-842d-249f00af9a90.gif)

after this:
![2020-01-08 16 16 34](https://user-images.githubusercontent.com/5615930/72027003-4f651680-3232-11ea-9949-af10f91aa581.gif)
