### PR TITLE
Custom template files

### DIFF
--- a/docs/targets/pxtarget.md
+++ b/docs/targets/pxtarget.md
@@ -283,3 +283,10 @@ PXT expects to find the C/C++ sources on github.
         serviceId: string;
     }
 ```
+
+## Additional settings
+
+### template project
+
+You can add or modify the default files created with a new project by adding
+a library called ``template`` (make it ``hidden``).

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -10,7 +10,7 @@ namespace pxt.template {
 }
 `;
     export function defaultFiles(): Map<string> {
-        const files : Map<string> = {
+        const files: Map<string> = {
             "tsconfig.json": TS_CONFIG,
 
             "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -9,7 +9,7 @@ namespace pxt.template {
     "exclude": ["pxt_modules/**/*test.ts"]
 }
 `;
-    function defaultFiles(): Map<string> {
+    export function defaultFiles(): Map<string> {
         const files : Map<string> = {
             "tsconfig.json": TS_CONFIG,
 
@@ -168,8 +168,11 @@ jobs:
 
         // override files from target
         const overrides = pxt.appTarget.bundledpkgs["template"];
-        if (overrides)
-            Util.jsonCopyFrom(files, overrides);
+        if (overrides) {
+            Object.keys(overrides)
+                .filter(k => k != pxt.CONFIG_NAME)
+                .forEach(k => files[k] = overrides[k]);
+        }
 
         return files;
     }

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -167,7 +167,7 @@ jobs:
         };
 
         // override files from target
-        const overrides = pxt.appTarget.bundledpkgs["template"];
+        const overrides = pxt.appTarget.bundledpkgs[pxt.template.TEMPLATE_PRJ];
         if (overrides) {
             Object.keys(overrides)
                 .filter(k => k != pxt.CONFIG_NAME)

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -10,7 +10,7 @@ namespace pxt.template {
 }
 `;
     function defaultFiles(): Map<string> {
-        return {
+        const files : Map<string> = {
             "tsconfig.json": TS_CONFIG,
 
             "test.ts": `// ${lf("tests go here; this will not be compiled when this package is used as an extension.")}
@@ -164,8 +164,17 @@ jobs:
     }]
 }
 `
-        }
+        };
+
+        // override files from target
+        const overrides = pxt.appTarget.bundledpkgs["template"];
+        if (overrides)
+            Util.jsonCopyFrom(files, overrides);
+
+        return files;
     }
+
+    export const TEMPLATE_PRJ = "template";
 
     export function packageFiles(name: string): pxt.Map<string> {
         const prj = pxt.appTarget.blocksprj || pxt.appTarget.tsprj;


### PR DESCRIPTION
Allows target to redefine built-in template files (to be used by arcade to provide full screen simulator support in github pages web site)