### PR TITLE
Adding emitAsConstant for emitting enums as constants

### DIFF
--- a/docs/defining-blocks.md
+++ b/docs/defining-blocks.md
@@ -394,6 +394,52 @@ export function readUntil(del: string) : string {
 }
 ```
 
+
+### Tip: using dropdowns for constants
+
+Enums in TypeScript can be verbose, so sometimes it is desirable to compile a dropdown to a constant
+variable rather than an enum member (for example, `Item.Shovel` could instead be `SHOVEL`).
+
+To achieve this behavior, set `emitAsConstant` to true on an enum
+
+```typescript
+//% emitAsConstant
+enum Item {
+    //% block="Iron"
+    Iron = 1
+}
+```
+
+and then declare a constant for that enum member like so:
+
+```typescript
+//% enumIdentity="Item.Iron"
+const IRON = Item.Iron;
+```
+
+If the enum has a shim function, you can also set `blockIdentity` just like you can for enum members. This
+will make the decompiler will convert any instance of that constant into the block for that enum.
+
+```typescript
+//% emitAsConstant
+enum Item {
+    //% block="Iron"
+    //% blockIdentity="blocks.item"
+    Iron = 1
+}
+
+namespace blocks {
+    //% shim=TD_ID
+    //% blockId=minecraftItem
+    //% block="item %item"
+    function item(item: Item): number;
+}
+
+//% enumIdentity="Item.Iron"
+//% blockIdentity="blocks.item"
+const IRON = Item.Iron;
+```
+
 ### Tip: implicit conversion for string parameters
 
 If you have an API that takes a string as an argument it is possible to bypass the usual

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -570,6 +570,8 @@ declare namespace ts.pxtc {
         advanced?: boolean;
         deprecated?: boolean;
         useEnumVal?: boolean; // for conversion from typescript to blocks with enumVal
+        emitAsConstant?: boolean; // used by the blocklycompiler to indicate that an enum should be compiled to a constant with the enumIdentity attribute set
+        enumIdentity?: string; // used by the decompiler to map constants to enum dropdown values
         callInDebugger?: boolean; // for getters, they will be invoked by the debugger.
         py2tsOverride?: string; // used to map functions in python that have an equivalent (but differently named) ts function
         pyHelper?: string; // used to specify functions on the _py namespace that provide implementations. Should be of the form py_class_methname

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1154,6 +1154,19 @@ namespace pxt.blocks {
             if (b.getField(p.definitionName) instanceof pxtblockly.FieldTextInput) {
                 return H.mkStringLiteral(f);
             }
+
+            // For some enums in pxt-minecraft, we emit the members as constants that are defined in
+            // libs/core. For example, Blocks.GoldBlock is emitted as GOLD_BLOCK
+            const type = e.blocksInfo.apis.byQName[p.type];
+            if (type && type.attributes.emitAsConstant) {
+                for (const symbolName of Object.keys(e.blocksInfo.apis.byQName)) {
+                    const symbol = e.blocksInfo.apis.byQName[symbolName];
+                    if (symbol && symbol.attributes && symbol.attributes.enumIdentity === f) {
+                        return mkText(symbolName);
+                    }
+                }
+            }
+
             return mkText(f);
         }
         else {

--- a/pxtcompiler/emitter/annotate.ts
+++ b/pxtcompiler/emitter/annotate.ts
@@ -41,7 +41,11 @@ namespace ts.pxtc {
                     case SyntaxKind.Identifier:
                         const decl: Declaration = getDecl(child);
                         if (decl && decl.getSourceFile().fileName !== "main.ts" && decl.kind == SyntaxKind.VariableDeclaration) {
-                            pxtInfo(child).flags |= PxtNodeFlags.IsGlobalIdentifier;
+                            const info = pxtInfo(child);
+                            info.flags |= PxtNodeFlags.IsGlobalIdentifier;
+                            if (!info.commentAttrs) {
+                                info.commentAttrs = parseComments(decl);
+                            }
                         }
                         break;
 

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -926,6 +926,12 @@ ${output}</xml>`;
         }
 
         function getIdentifier(identifier: Identifier): ExpressionNode {
+            if (isDeclaredElsewhere(identifier)) {
+                const info = pxtInfo(identifier);
+
+                const id = blocksInfo.apis.byQName[info.commentAttrs.blockIdentity];
+                return getEnumFieldBlock(id, info.commentAttrs.enumIdentity);
+            }
             const name = getVariableName(identifier);
             const oldName = identifier.text;
             let localReporterArg: PropertyDesc = null;
@@ -1086,14 +1092,18 @@ ${output}</xml>`;
             }
 
             let idfn = attributes.blockIdentity ? blocksInfo.apis.byQName[attributes.blockIdentity] : blocksInfo.blocksById[blockId];
-            let f = /%([a-zA-Z0-9_]+)/.exec(idfn.attributes.block);
+            return getEnumFieldBlock(idfn, value);
+        }
+
+        function getEnumFieldBlock(idfn: SymbolInfo, value: string) {
+            let f = /(?:%|\$)([a-zA-Z0-9_]+)/.exec(idfn.attributes.block);
             const r = mkExpr(U.htmlEscape(idfn.attributes.blockId));
             r.fields = [{
                 kind: "field",
                 name: U.htmlEscape(f[1]),
                 value
             }];
-            return r
+            return r;
         }
 
         function getArrayLiteralExpression(n: ts.ArrayLiteralExpression): ExpressionNode {
@@ -1866,6 +1876,11 @@ ${output}</xml>`;
                     if (shimAttrs && shimAttrs.shim === "TD_ID" && paramInfo.isEnum) {
                         e = unwrapNode(shimCall.args[0]) as ts.Expression;
                     }
+                }
+
+                if (param && paramInfo && paramInfo.isEnum && e.kind === SK.Identifier) {
+                    addField(getField(U.htmlEscape(param.definitionName), pxtInfo(e).commentAttrs.enumIdentity));
+                    return;
                 }
 
                 if (param && param.fieldOptions && param.fieldOptions[DecompileParamKeys.DecompileArgumentAsString]) {
@@ -2668,6 +2683,10 @@ ${output}</xml>`;
                             }
                         }
                     }
+                    else if (e.kind === SK.Identifier) {
+                        const attributes = pxtInfo(e).commentAttrs;
+                        if (attributes && attributes.enumIdentity) return undefined;
+                    }
                     return Util.lf("Enum arguments may only be literal property access expressions");
                 }
                 else if (isLiteralNode(e) && (param.fieldEditor || param.shadowBlockId)) {
@@ -3096,9 +3115,10 @@ ${output}</xml>`;
             case SK.NoSubstitutionTemplateLiteral:
                 return checkStringLiteral(n as ts.StringLiteral);
             case SK.Identifier:
+                const pInfo = pxtInfo(n);
                 if (isUndefined(n)) {
                     return Util.lf("Undefined is not supported in blocks");
-                } else if (isDeclaredElsewhere(n as Identifier)) {
+                } else if (isDeclaredElsewhere(n as Identifier) && !(pInfo.commentAttrs && pInfo.commentAttrs.blockIdentity && pInfo.commentAttrs.enumIdentity)) {
                     return Util.lf("Variable is declared in another file");
                 } else {
                     return undefined;

--- a/tests/blocklycompiler-test/baselines/enum_constants.ts
+++ b/tests/blocklycompiler-test/baselines/enum_constants.ts
@@ -1,0 +1,3 @@
+agent.destroy(BACK)
+agent.collect(IRON_PICKAXE)
+let x = IRON_SHOVEL

--- a/tests/blocklycompiler-test/cases/enum_constants.blocks
+++ b/tests/blocklycompiler-test/cases/enum_constants.blocks
@@ -1,0 +1,34 @@
+<xml xmlns="https://developers.google.com/blockly/xml">
+<variables>
+<variable id="wF{4tW}3~-4X5{YhKnU0">x</variable>
+</variables>
+<block type="pxt-on-start" x="230" y="175">
+<statement name="HANDLER">
+<block type="minecraftAgentCommandDestroy">
+<field name="direction">SixDirection.Back</field>
+<next>
+<block type="minecraftAgentCollect">
+<value name="block">
+<shadow type="minecraftItem">
+<field name="item">Item.IronPickaxe</field>
+</shadow>
+</value>
+<next>
+<block type="variables_set">
+<field name="VAR" id="wF{4tW}3~-4X5{YhKnU0">x</field>
+<value name="VALUE">
+<shadow type="math_number">
+<field name="NUM">0</field>
+</shadow>
+<block type="minecraftItem">
+<field name="item">Item.IronShovel</field>
+</block>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/blocklycompiler-test/test-library/enums.ts
+++ b/tests/blocklycompiler-test/test-library/enums.ts
@@ -43,3 +43,75 @@ namespace userEnums {
         return arg;
     }
 }
+
+
+//% emitAsConstant
+declare const enum Item {
+    //% blockIdentity="blocks.item" enumval=256 block="Iron Shovel"
+    //% jres
+    IronShovel = 256,
+    //% blockIdentity="blocks.item" enumval=257 block="Iron Pickaxe"
+    //% jres
+    IronPickaxe = 257
+}
+
+//% blockIdentity="blocks.item" enumIdentity="Item.IronShovel"
+const IRON_SHOVEL = Item.IronShovel;
+//% blockIdentity="blocks.item" enumIdentity="Item.IronPickaxe"
+const IRON_PICKAXE = Item.IronPickaxe;
+
+//% emitAsConstant
+declare const enum SixDirection {
+    //% block=forward
+    Forward,
+    //% block=back
+    Back
+}
+
+//% enumIdentity="SixDirection.Forward"
+const FORWARD = SixDirection.Forward;
+//% enumIdentity="SixDirection.Back"
+const BACK = SixDirection.Back;
+
+declare namespace agent {
+    /**
+     * Commands the agent to destroy a block in the given direction
+     * @param direction the direction in which the agent will destroy a block, eg: SixDirection.Forward
+     */
+    //% help=agent/destroy
+    //% promise
+    //% group="Actions" weight=260
+    //% blockId=minecraftAgentCommandDestroy block="agent destroy|%direction"
+    //% shim=agent::destroyAsync promise
+    function destroy(direction: SixDirection): void;
+
+
+    /**
+     * Commands the agent to Collect a block or item of the specified type
+     * @param block the type of the block or item to collect
+     */
+    //% help=agent/collect
+    //% promise
+    //% group="Actions" weight=220
+    //% blockId=minecraftAgentCollect block="agent collect %block=minecraftItem"
+    //% block.shadow=minecraftItem
+    //% shim=agent::collectAsync promise
+    function collect(block: number): void;
+}
+
+declare namespace blocks {
+    /**
+     * Represents an item from the game
+     * @param item the item
+     */
+    //% help=blocks/item
+    //% weight=320
+    //% shim=TD_ID blockId=minecraftItem block="item %item"
+    //% item.fieldEditor="gridpicker"
+    //% item.fieldOptions.width=340 item.fieldOptions.columns=8 item.fieldOptions.tooltips=true
+    //% item.fieldOptions.tooltipsXOffset="20" item.fieldOptions.tooltipsYOffset="-20"
+    //% item.fieldOptions.maxRows="8"
+    //% item.fieldOptions.hasSearchBar=true
+    //% item.fieldOptions.hideRect=true
+    function item(item: Item): number;
+}

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -437,6 +437,10 @@ describe("blockly compiler", function () {
         it("should set the right check for primitive draggable parameters in blockly loader", done => {
             blockTestAsync("draggable_primitive_reporter").then(done, done);
         });
+
+        it("should convert enums to constants when emitAsConstant is set", done => {
+            blockTestAsync("enum_constants").then(done, done);
+        });
     });
 
     describe("compiling expandable blocks", () => {

--- a/tests/decompile-test/baselines/enum_constants.blocks
+++ b/tests/decompile-test/baselines/enum_constants.blocks
@@ -1,0 +1,29 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="minecraftAgentCommandDestroy">
+<field name="direction">SixDirection.Forward</field>
+<next>
+<block type="variables_set">
+<field name="VAR">x</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="minecraftItem">
+<field name="item">Item.IronPickaxe</field>
+</block>
+</value>
+<next>
+<block type="minecraftAgentCollect">
+<value name="block">
+<shadow type="minecraftItem">
+<field name="item">Item.IronShovel</field>
+</shadow>
+</value>
+</block>
+</next>
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/enum_constants.ts
+++ b/tests/decompile-test/cases/enum_constants.ts
@@ -1,0 +1,3 @@
+agent.destroy(FORWARD);
+let x = IRON_PICKAXE;
+agent.collect(IRON_SHOVEL);

--- a/tests/decompile-test/cases/testBlocks/constantShim.ts
+++ b/tests/decompile-test/cases/testBlocks/constantShim.ts
@@ -18,3 +18,75 @@ namespace constant {
         return constant;
     }
 }
+
+
+//% emitAsConstant
+declare const enum Item {
+    //% blockIdentity="blocks.item" enumval=256 block="Iron Shovel"
+    //% jres
+    IronShovel = 256,
+    //% blockIdentity="blocks.item" enumval=257 block="Iron Pickaxe"
+    //% jres
+    IronPickaxe = 257
+}
+
+//% blockIdentity="blocks.item" enumIdentity="Item.IronShovel"
+const IRON_SHOVEL = Item.IronShovel;
+//% blockIdentity="blocks.item" enumIdentity="Item.IronPickaxe"
+const IRON_PICKAXE = Item.IronPickaxe;
+
+//% emitAsConstant
+declare const enum SixDirection {
+    //% block=forward
+    Forward,
+    //% block=back
+    Back
+}
+
+//% enumIdentity="SixDirection.Forward"
+const FORWARD = SixDirection.Forward;
+//% enumIdentity="SixDirection.Back"
+const BACK = SixDirection.Back;
+
+declare namespace agent {
+    /**
+     * Commands the agent to destroy a block in the given direction
+     * @param direction the direction in which the agent will destroy a block, eg: SixDirection.Forward
+     */
+    //% help=agent/destroy
+    //% promise
+    //% group="Actions" weight=260
+    //% blockId=minecraftAgentCommandDestroy block="agent destroy|%direction"
+    //% shim=agent::destroyAsync promise
+    function destroy(direction: SixDirection): void;
+
+
+    /**
+     * Commands the agent to Collect a block or item of the specified type
+     * @param block the type of the block or item to collect
+     */
+    //% help=agent/collect
+    //% promise
+    //% group="Actions" weight=220
+    //% blockId=minecraftAgentCollect block="agent collect %block=minecraftItem"
+    //% block.shadow=minecraftItem
+    //% shim=agent::collectAsync promise
+    function collect(block: number): void;
+}
+
+declare namespace blocks {
+    /**
+     * Represents an item from the game
+     * @param item the item
+     */
+    //% help=blocks/item
+    //% weight=320
+    //% shim=TD_ID blockId=minecraftItem block="item %item"
+    //% item.fieldEditor="gridpicker"
+    //% item.fieldOptions.width=340 item.fieldOptions.columns=8 item.fieldOptions.tooltips=true
+    //% item.fieldOptions.tooltipsXOffset="20" item.fieldOptions.tooltipsYOffset="-20"
+    //% item.fieldOptions.maxRows="8"
+    //% item.fieldOptions.hasSearchBar=true
+    //% item.fieldOptions.hideRect=true
+    function item(item: Item): number;
+}


### PR DESCRIPTION
This is adding a feature to have some enums compile to constants when the `emitAsConstant` attribute is set. To use this feature:

On the enum, set `emitAsConstant` to true:

```typescript
//% emitAsConstant
enum Item {
    //% block="Iron"
    Iron = 1
}
```

and then declare a constant for that enum member like so:

```typescript
//% enumIdentity="Item.Iron"
const IRON = Item.Iron;
```

If the enum has a shim function, you can also set `blockIdentity` just like you can for enum members:

```typescript
//% emitAsConstant
enum Item {
    //% block="Iron" blockIdentity="blocks.item"
    Iron = 1
}

namespace blocks {
    //% shim=TD_ID
    //% blockId=minecraftItem 
    //% block="item %item"
    function item(item: Item): number;
}

//% enumIdentity="Item.Iron" blockIdentity="blocks.item"
const IRON = Item.Iron;
```

and the decompiler will convert any instance of that constant into the block for that enum.
