### PR TITLE
[stable5.30] fix snippet edit button loading correct project 

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -3,7 +3,9 @@
 namespace pxt.runner {
     const JS_ICON = "icon xicon js";
     const PY_ICON = "icon xicon python";
-    const BLOCKS_ICON = "icon xicon blocks"
+    const BLOCKS_ICON = "icon xicon blocks";
+    const PY_FILE = "main.py";
+    const BLOCKS_FILE = "main.blocks";
 
     export interface ClientRenderOptions {
         snippetClass?: string;
@@ -102,12 +104,28 @@ namespace pxt.runner {
 
         const theme = pxt.appTarget.appTheme || {};
         if (woptions.showEdit && !theme.hideDocsEdit && decompileResult) { // edit button
-            const $editBtn = snippetBtn(lf("Edit"), "edit icon").click(() => {
+            const $editBtn = snippetBtn(lf("Edit"), "edit icon");
+
+            const { package: pkg, compileBlocks, compilePython } = decompileResult;
+            const host = pkg.host();
+
+            if ($svg && compileBlocks) {
+                pkg.setPreferredEditor(pxt.BLOCKS_PROJECT_NAME);
+                host.writeFile(pkg, BLOCKS_FILE, compileBlocks.outfiles[BLOCKS_FILE]);
+            } else if ($py && compilePython) {
+                pkg.setPreferredEditor(pxt.PYTHON_PROJECT_NAME);
+                host.writeFile(pkg, PY_FILE, compileBlocks.outfiles[PY_FILE]);
+            } else {
+                pkg.setPreferredEditor(pxt.JAVASCRIPT_PROJECT_NAME);
+            }
+
+            const compressed = pkg.compressToFileAsync();
+            $editBtn.click(() => {
                 pxt.tickEvent("docs.btn", { button: "edit" });
-                decompileResult.package.setPreferredEditor(options.showJavaScript ? pxt.JAVASCRIPT_PROJECT_NAME : pxt.BLOCKS_PROJECT_NAME)
-                decompileResult.package.compressToFileAsync()
-                    .done(buf => window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt'))
-            })
+                compressed.done(buf => {
+                    window.open(`${getEditUrl(options)}/#project:${ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf))}`, 'pxt');
+                });
+            });
             $menu.append($editBtn);
         }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -56,7 +56,8 @@ namespace pxt.runner {
         writeFile(module: pxt.Package, filename: string, contents: string): void {
             if (filename == pxt.CONFIG_NAME)
                 return; // ignore config writes
-            throw Util.oops("trying to write " + module + " / " + filename)
+            const epkg = getEditorPkg(module);
+            epkg.files[filename] = contents;
         }
 
         getHexInfoAsync(extInfo: pxtc.ExtensionInfo): Promise<pxtc.HexInfo> {


### PR DESCRIPTION
cherry pick #6410 for arcade; make edit button load right snippet from page, and open in correct editor (typically blocks)