### PR TITLE
Adding a field option to disable resizing of sprite editor

### DIFF
--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -14,6 +14,8 @@ namespace pxtblockly {
         initWidth: string;
         initHeight: string;
 
+        disableResize: string;
+
         filter?: string;
     }
 
@@ -21,6 +23,7 @@ namespace pxtblockly {
         initColor: number;
         initWidth: number;
         initHeight: number;
+        disableResize: boolean;
         filter?: string;
     }
 
@@ -167,6 +170,7 @@ namespace pxtblockly {
             initColor: 1,
             initWidth: 16,
             initHeight: 16,
+            disableResize: false,
         };
 
         if (!opts) {
@@ -205,6 +209,10 @@ namespace pxtblockly {
 
         if (opts.filter) {
             parsed.filter = opts.filter;
+        }
+
+        if (opts.disableResize) {
+            parsed.disableResize = opts.disableResize.toLowerCase() === "true" || opts.disableResize === "1";
         }
 
         parsed.initColor = withDefault(opts.initColor, parsed.initColor);

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -53,7 +53,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
         }
 
         if (this.props.resizeDisabled) {
-            this.dispatchOnStore(dispatchDisableResize());
+            this.disableResize();
         }
 
         this.unsubscribeChangeListener = this.getStore().subscribe(this.onStoreChange);
@@ -151,6 +151,10 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
 
     setCurrentFrame(bitmap: pxt.sprite.Bitmap) {
         this.dispatchOnStore(dispatchImageEdit({ bitmap: bitmap.data() }))
+    }
+
+    disableResize() {
+        this.dispatchOnStore(dispatchDisableResize());
     }
 
     protected getStore() {

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -19,6 +19,7 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
     protected blocksInfo: pxtc.BlocksInfo;
     protected ref: ImageEditor;
     protected closeEditor: () => void;
+    protected options: any;
 
     constructor(props: ImageFieldEditorProps) {
         super(props);
@@ -64,6 +65,7 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
 
     init(value: U, close: () => void, options?: any) {
         this.closeEditor = close;
+        this.options = options;
         if (this.props.singleFrame) {
             let bitmap = value as pxt.sprite.Bitmap;
             if (bitmap.height == 0 || bitmap.width == 0) {
@@ -105,6 +107,10 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
     restorePersistentData(oldValue: any) {
         if (this.ref) {
             this.ref.restorePersistentData(oldValue);
+
+            if (this.options && this.options.disableResize) {
+                this.ref.disableResize();
+            }
         }
     }
 
@@ -115,9 +121,11 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
     }
 
     protected initSingleFrame(value: pxt.sprite.Bitmap, options?: any) {
-
-
         this.ref.initSingleFrame(value);
+
+        if (options.disableResize) {
+            this.ref.disableResize();
+        }
     }
 
     protected initAnimation(value: pxt.sprite.AnimationData, options?: any) {
@@ -129,6 +137,10 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
         }
 
         this.ref.initAnimation(value.frames.map(b => pxt.sprite.Bitmap.fromData(b)), value.interval);
+
+        if (options.disableResize) {
+            this.ref.disableResize();
+        }
     }
 
     protected toggleGallery = () => {


### PR DESCRIPTION
So that you can have a fixed width and height for an API. I already added this functionality for the tilemap editor and am just surfacing it now.