### PR TITLE
Always emit type annotations for parameter declaration

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -179,7 +179,7 @@ namespace pxt.py {
         if (tp == "T" || tp == "U") // TODO hack!
             return mkType({ primType: "'" + tp })
 
-        // defined by a symbol, 
+        // defined by a symbol,
         //  either in external (non-py) APIs (like default/common packages)
         //  or in internal (py) APIs (probably main.py)
         let sym = lookupApi(tp + "@type") || lookupApi(tp)
@@ -843,6 +843,9 @@ namespace pxt.py {
                 if (sym.pyInstanceType)
                     return sym.pyInstanceType
             }
+            else if (builtInTypes[tpName])
+                return builtInTypes[tpName]
+
             error(e, 9506, U.lf("cannot find type '{0}'", tpName))
         }
 
@@ -892,7 +895,7 @@ namespace pxt.py {
             if (!p.pyType)
                 error(n, 9530, U.lf("parameter '{0}' missing pyType", p.name))
             unify(n, getOrSetSymbolType(v), p.pyType!)
-            let res = [quote(p.name), typeAnnot(p.pyType!)]
+            let res = [quote(p.name), typeAnnot(p.pyType!, true)]
             if (p.default) {
                 res.push(B.mkText(" = " + p.default))
             }
@@ -988,7 +991,7 @@ namespace pxt.py {
         }
     }
 
-    function typeAnnot(t: Type) {
+    function typeAnnot(t: Type, defaultToAny = false) {
         let s = t2s(t)
         if (s[0] == "?") {
             // TODO:
@@ -999,7 +1002,7 @@ namespace pxt.py {
             // work around using any:
             // return B.mkText(": any /** TODO: type **/")
             // but for now we can just omit the type and most of the type it'll be inferable
-            return B.mkText("")
+            return defaultToAny ? B.mkText(": any") : B.mkText("")
         }
         return B.mkText(": " + t2s(t))
     }

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -394,7 +394,7 @@ namespace pxt.py {
             let result_toExcl = toNum
             if (s.condition.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken
                 && isNormalInteger(toNum)) {
-                // Note that we have to be careful here because 
+                // Note that we have to be careful here because
                 // <= 3.5 is not the same as < 4.5
                 // so we only want to handle <= when the toNum is very well behaved
                 result_toExcl = "" + (Number(toNum) + 1)
@@ -771,7 +771,10 @@ namespace pxt.py {
             let typePart = ""
             if (s.type && inclTypesIfAvail) {
                 let typ = pxtc.emitType(s.type)
-                typePart = `: ${typ}`
+
+                if (typ && typ.indexOf("(TODO") === -1) {
+                    typePart = `: ${typ}`
+                }
             }
             let initPart = ""
             if (s.initializer) {

--- a/tests/pyconverter-test/baselines/function_parameters.ts
+++ b/tests/pyconverter-test/baselines/function_parameters.ts
@@ -1,0 +1,8 @@
+function on_chat(num: any) {
+
+}
+
+function on_chat2(num: number) {
+
+}
+

--- a/tests/pyconverter-test/cases/function_parameters.py
+++ b/tests/pyconverter-test/cases/function_parameters.py
@@ -1,0 +1,5 @@
+def on_chat(num):
+    pass
+
+def on_chat2(num: number):
+    pass


### PR DESCRIPTION
In our TS, type annotations are required. This fixes two bugs where they were not being emitted when going from python to TS

1. Type annotations for builtin types (e.g. number) were ignored
1. If we couldn't infer a type for a parameter, we didn't emit any annotation. Now we emit `any`

Because of the second change, I also did a fix to make sure that a parameter declaration with the type `any` is omitted when going from TS to python. Previously it compiled to something like this:

```python
def on_chat5(num: (TODO: Unknown TypeNode kind: 1234)):
    pass
```