### PR TITLE
Fix decompilation of `for ( ... of "abc")`

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -516,7 +516,8 @@ namespace pxt.blocks {
             c.parentType = p;
         }
 
-        p.isArrayType = true;
+        if (isArrayType(p.type))
+            p.isArrayType = true;
     }
 
     function getConcreteType(point: Point, found: Point[] = []) {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -527,7 +527,11 @@ namespace pxt.blocks {
                 if (t.parentType) {
                     const parent = getConcreteType(t.parentType, found);
                     if (parent.type && parent.type !== "Array") {
-                        t.type = parent.type.substr(0, parent.type.length - 2);
+                        if (isArrayType(parent.type)) {
+                            t.type = parent.type.substr(0, parent.type.length - 2);
+                        } else {
+                            t.type = parent.type;
+                        }
                         return t;
                     }
                 }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1715,7 +1715,7 @@ namespace pxt.blocks {
                         {
                             "type": "input_value",
                             "name": "LIST",
-                            "check": "Array"
+                            "check": ["Array", "String"]
                         }
                     ],
                     "previousStatement": null,

--- a/tests/blocklycompiler-test/baselines/for_each_string.ts
+++ b/tests/blocklycompiler-test/baselines/for_each_string.ts
@@ -1,0 +1,4 @@
+let b = ""
+for (let i of "helloooo") {
+    b = i
+}

--- a/tests/blocklycompiler-test/cases/for_each_string.blocks
+++ b/tests/blocklycompiler-test/cases/for_each_string.blocks
@@ -1,0 +1,35 @@
+<xml xmlns="https://developers.google.com/blockly/xml">
+    <variables>
+        <variable id="0bxnSP$mv}T_i3PB!WjI">i</variable>
+        <variable id="banrJ*WEJJ8s!{P.@D(E">b</variable>
+    </variables>
+    <block type="pxt-on-start" x="0" y="0">
+        <statement name="HANDLER">
+            <block type="pxt_controls_for_of">
+                <value name="VAR">
+                    <shadow type="variables_get_reporter">
+                        <field name="VAR" id="0bxnSP$mv}T_i3PB!WjI">i</field>
+                    </shadow>
+                </value>
+                <value name="LIST">
+                    <shadow type="text">
+                        <field name="TEXT">helloooo</field>
+                    </shadow>
+                </value>
+                <statement name="DO">
+                    <block type="variables_set">
+                        <field name="VAR" id="banrJ*WEJJ8s!{P.@D(E">b</field>
+                        <value name="VALUE">
+                            <shadow type="math_number">
+                                <field name="NUM">0</field>
+                            </shadow>
+                            <block type="variables_get">
+                                <field name="VAR" id="0bxnSP$mv}T_i3PB!WjI">i</field>
+                            </block>
+                        </value>
+                    </block>
+                </statement>
+            </block>
+        </statement>
+    </block>
+</xml>

--- a/tests/blocklycompiler-test/test.spec.ts
+++ b/tests/blocklycompiler-test/test.spec.ts
@@ -280,6 +280,10 @@ describe("blockly compiler", function () {
             blockTestAsync("lists_length_with_for_of").then(done, done);
         });
 
+        it("should not declare strings as stris when using for each string block", (done: () => void) => {
+            blockTestAsync("for_each_string").then(done, done);
+        });
+
         it("should handle empty array blocks", (done: () => void) => {
             blockTestAsync("lists_empty_arrays").then(done, done);
         });

--- a/tests/decompile-test/baselines/array_for_of_string.blocks
+++ b/tests/decompile-test/baselines/array_for_of_string.blocks
@@ -1,0 +1,29 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="pxt_controls_for_of">
+<value name="LIST">
+<shadow type="text">
+<field name="TEXT">hello</field>
+</shadow>
+</value>
+<value name="VAR">
+<shadow type="variables_get_reporter">
+<field name="VAR">i</field>
+</shadow>
+</value>
+<statement name="DO">
+<block type="variables_set">
+<field name="VAR">b</field>
+<value name="VALUE">
+<shadow type="math_number"><field name="NUM">0</field></shadow>
+<block type="variables_get">
+<field name="VAR">i</field>
+</block>
+</value>
+</block>
+</statement>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/array_for_of_string.ts
+++ b/tests/decompile-test/cases/array_for_of_string.ts
@@ -1,0 +1,3 @@
+for (let i of "hello") {
+    let b = i
+}


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/1553 by allowing strings in for each statements, so

```typescript
for (let i of "hello") {
    console.log(i)
}
```

goes to

<img width="390" alt="Screen Shot 2020-01-10 at 2 02 37 PM" src="https://user-images.githubusercontent.com/5615930/72189534-e3a9b780-33b1-11ea-9141-4806ee1e038a.png">

(and you can make that in blocks too, of course)

The issue itself is really minor (as far as I can tell, it's been there since arrays in blocks were first implemented and no one's noticed), and this does touch the array type inference code in blocklycompiler to fix two issues that came up due to the change, so it doesn't seem like a thing to rush to get in / probably better to let in bake in a /beta for a bit? Mainly just did this while thinking about how to structure things in an unrelated change

changes in blocklycompiler:

* in some cases ``getConcreteType`` would emit the type minus the last two letters if it hadn't inferred the type already for the given point -- e.g. ``stri`` instead of ``string``
* in generic link it set the type to be an array without checking that the type was actually an array, as it always had been up to this point -- causing random other tests to fail when the top level `string` constant would end up unioned with `undefined[]` depending on ordering. I think I had run into this one before when writing an extension and trying to have a block take `string|string[]` and just assumed it was a completely unsupported case