### PR TITLE
don't lower case block names

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -99,9 +99,6 @@ namespace pxt.blocks {
         // remove spaces before after pipe
         nb = nb.replace(/\s*\|\s*/g, '|');
 
-        // lower case first character
-        nb = nb.replace(/^[A-Z]/, (m) => m.toLowerCase());
-
         return nb;
     }
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-arcade/issues/1691