### PR TITLE
Don't rename x, y, and z when decompiling

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -287,12 +287,14 @@ namespace ts.pxtc.decompiler {
 
     export function getNewName(name: string, takenNames: NamesSet, recordNewName = true) {
         // If the variable is a single lower case letter, try and rename it to a different letter (i.e. i -> j)
-        if (name.length === 1) {
+        // DO NOT apply this logic to variables named x, y, or z since those are generally meaningful names
+        if (name.length === 1 && name !== "x" && name !== "y" && name !== "z") {
             const charCode = name.charCodeAt(0);
             if (charCode >= lowerCaseAlphabetStartCode && charCode <= lowerCaseAlphabetEndCode) {
                 const offset = charCode - lowerCaseAlphabetStartCode;
                 for (let i = 1; i < 26; i++) {
                     const newChar = String.fromCharCode(lowerCaseAlphabetStartCode + ((offset + i) % 26));
+                    if (newChar === "x" || newChar === "y" || newChar === "z") continue;
                     if (!takenNames[newChar]) {
                         if (recordNewName)
                             takenNames[newChar] = true;

--- a/tests/decompile-test/baselines/always_decompile_renames_expressions.blocks
+++ b/tests/decompile-test/baselines/always_decompile_renames_expressions.blocks
@@ -10,7 +10,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">2</field>
@@ -25,7 +25,7 @@
 <value name="A">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="typescript_expression">
-<field name="EXPRESSION">&#40;y &#38; 7&#41;</field>
+<field name="EXPRESSION">&#40;x2 &#38; 7&#41;</field>
 </block>
 </value>
 <value name="B">
@@ -37,7 +37,7 @@
 </value>
 <statement name="DO">
 <block type="variables_change">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>

--- a/tests/decompile-test/baselines/always_for_loop_bad_conditional.blocks
+++ b/tests/decompile-test/baselines/always_for_loop_bad_conditional.blocks
@@ -10,19 +10,19 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let x &#61; 0&#59; y &#60;&#61; 5&#59; x&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="left side of for loop conditional must be the variable declared in the initializer" line0="for &#40;let x &#61; 0&#59; y &#60;&#61; 5&#59; x&#43;&#43;&#41; &#123;&#125;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let z &#61; 0&#59; false&#59; z&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loop conditionals must be binary comparison operations" line0="for &#40;let x2 &#61; 0&#59; false&#59; x2&#43;&#43;&#41; &#123;&#125;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let a &#61; 0&#59; a &#61;&#61; 2&#59; a&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loop conditional operator must be either &#60; or &#60;&#61;" line0="for &#40;let x3 &#61; 0&#59; x3 &#61;&#61; 2&#59; x3&#43;&#43;&#41; &#123;&#125;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let b &#61; 0&#59; 2 &#60;&#61; 2&#59; b&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="left side of for loop conditional must be the variable declared in the initializer" line0="for &#40;let x4 &#61; 0&#59; 2 &#60;&#61; 2&#59; x4&#43;&#43;&#41; &#123;&#125;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let c &#61; 0&#59; &#59; c&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loops must have an initializer&#44; incrementor&#44; and condition" line0="for &#40;let x5 &#61; 0&#59; &#59; x5&#43;&#43;&#41; &#123;&#125;" />
 </block>
 </next>
 </block>

--- a/tests/decompile-test/baselines/always_for_loop_bad_incrementor.blocks
+++ b/tests/decompile-test/baselines/always_for_loop_bad_incrementor.blocks
@@ -2,13 +2,13 @@
 <block type="pxt-on-start">
 <statement name="HANDLER">
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let x &#61; 0&#59; x &#60;&#61; 5&#59; x&#43;&#61; 1&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loop incrementors may only increment the variable declared in the initializer" line0="for &#40;let x &#61; 0&#59; x &#60;&#61; 5&#59; x&#43;&#61; 1&#41; &#123;&#125;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let y &#61; 0&#59; y &#60;&#61; 5&#59; y--&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loop incrementors may only increment the variable declared in the initializer" line0="for &#40;let x2 &#61; 0&#59; x2 &#60;&#61; 5&#59; x2--&#41; &#123;&#125;" />
 <next>
 <block type="variables_set">
-<field name="VAR">z</field>
+<field name="VAR">y</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -16,10 +16,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let a &#61; 0&#59; a &#60;&#61; 5&#59; z&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loop incrementors may only increment the variable declared in the initializer" line0="for &#40;let x3 &#61; 0&#59; x3 &#60;&#61; 5&#59; y&#43;&#43;&#41; &#123;&#125;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let b &#61; 0&#59; b &#60;&#61; 5&#59;&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loops must have an initializer&#44; incrementor&#44; and condition" line0="for &#40;let x4 &#61; 0&#59; x4 &#60;&#61; 5&#59;&#41; &#123;&#125;" />
 </block>
 </next>
 </block>

--- a/tests/decompile-test/baselines/always_for_loop_bad_initializer.blocks
+++ b/tests/decompile-test/baselines/always_for_loop_bad_initializer.blocks
@@ -10,7 +10,7 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;1 &#43; 1&#59; x &#60;&#61; 5&#59; x&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="only variable declarations are permitted in for loop initializers" line0="for &#40;1 &#43; 1&#59; x &#60;&#61; 5&#59; x&#43;&#43;&#41; &#123;&#125;" />
 <next>
 <block type="variables_set">
 <field name="VAR">x2</field>
@@ -21,10 +21,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;&#59; x2 &#60;&#61; 5&#59; x2&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loops must have an initializer&#44; incrementor&#44; and condition" line0="for &#40;&#59; x2 &#60;&#61; 5&#59; x2&#43;&#43;&#41; &#123;&#125;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="for &#40;let y &#61; 0&#44; z &#61; 2&#59; y &#60;&#61; 5&#59; y&#43;&#43;&#41; &#123;&#125;" />
+<mutation numlines="1" error="for loop with multiple variables not supported" line0="for &#40;let x3 &#61; 0&#44; y &#61; 2&#59; x3 &#60;&#61; 5&#59; x3&#43;&#43;&#41; &#123;&#125;" />
 </block>
 </next>
 </block>

--- a/tests/decompile-test/baselines/always_null_and_undefined.blocks
+++ b/tests/decompile-test/baselines/always_null_and_undefined.blocks
@@ -2,16 +2,16 @@
 <block type="pxt-on-start">
 <statement name="HANDLER">
 <block type="typescript_statement">
-<mutation declaredvars="y" numlines="1" line0="let y &#61; 0" />
+<mutation declaredvars="x2" numlines="1" line0="let x2 &#61; 0" />
 <next>
 <block type="typescript_statement">
 <mutation declaredvars="x" numlines="1" line0="let x &#61; 0" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="x &#61; null&#59;" />
+<mutation numlines="1" error="Unsupported syntax kind for output expression block&#58; NullKeyword" line0="x &#61; null&#59;" />
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="y &#61; undefined&#59;" />
+<mutation numlines="1" error="Undefined is not supported in blocks" line0="x2 &#61; undefined&#59;" />
 </block>
 </next>
 </block>

--- a/tests/decompile-test/baselines/always_unsupported_operators.blocks
+++ b/tests/decompile-test/baselines/always_unsupported_operators.blocks
@@ -2,25 +2,25 @@
 <block type="pxt-on-start">
 <statement name="HANDLER">
 <block type="typescript_statement">
-<mutation declaredvars="x" numlines="1" line0="let x &#61; 0 &#60;&#60; 1&#59;" />
+<mutation declaredvars="x" numlines="1" error="Could not find operator &#60;&#60;" line0="let x &#61; 0 &#60;&#60; 1&#59;" />
 <next>
 <block type="typescript_statement">
-<mutation declaredvars="y" numlines="1" line0="let y &#61; 0 &#62;&#62; 1&#59;" />
+<mutation declaredvars="x2" numlines="1" error="Could not find operator &#62;&#62;" line0="let x2 &#61; 0 &#62;&#62; 1&#59;" />
 <next>
 <block type="typescript_statement">
-<mutation declaredvars="z" numlines="1" line0="let z &#61; 0 &#62;&#62;&#62; 1&#59;" />
+<mutation declaredvars="x3" numlines="1" error="Could not find operator &#62;&#62;&#62;" line0="let x3 &#61; 0 &#62;&#62;&#62; 1&#59;" />
 <next>
 <block type="typescript_statement">
-<mutation declaredvars="a" numlines="1" line0="let a &#61; 0 &#124; 1&#59;" />
+<mutation declaredvars="x4" numlines="1" error="Could not find operator &#124;" line0="let x4 &#61; 0 &#124; 1&#59;" />
 <next>
 <block type="typescript_statement">
-<mutation declaredvars="b" numlines="1" line0="let b &#61; 0 &#38; 1&#59;" />
+<mutation declaredvars="x5" numlines="1" error="Could not find operator &#38;" line0="let x5 &#61; 0 &#38; 1&#59;" />
 <next>
 <block type="typescript_statement">
-<mutation declaredvars="c" numlines="1" line0="let c &#61; 0 &#94; 1&#59;" />
+<mutation declaredvars="x6" numlines="1" error="Could not find operator &#94;" line0="let x6 &#61; 0 &#94; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">d</field>
+<field name="VAR">x7</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -28,10 +28,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="d &#42;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement AsteriskEqualsToken" line0="x7 &#42;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">e</field>
+<field name="VAR">x8</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -39,10 +39,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="e &#47;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement SlashEqualsToken" line0="x8 &#47;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">f</field>
+<field name="VAR">x9</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -50,10 +50,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="f &#37;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement PercentEqualsToken" line0="x9 &#37;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">g</field>
+<field name="VAR">x10</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -61,10 +61,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="g &#124;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement BarEqualsToken" line0="x10 &#124;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">h</field>
+<field name="VAR">x11</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -72,10 +72,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="h &#38;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement AmpersandEqualsToken" line0="x11 &#38;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">i</field>
+<field name="VAR">x12</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -83,10 +83,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="i &#94;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement LastBinaryOperator" line0="x12 &#94;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">j</field>
+<field name="VAR">x13</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -94,10 +94,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="j &#60;&#60;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement LessThanLessThanEqualsToken" line0="x13 &#60;&#60;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">k</field>
+<field name="VAR">x14</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -105,10 +105,10 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="k &#62;&#62;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement GreaterThanGreaterThanEqualsToken" line0="x14 &#62;&#62;&#61; 1&#59;" />
 <next>
 <block type="variables_set">
-<field name="VAR">l</field>
+<field name="VAR">x15</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -116,7 +116,7 @@
 </value>
 <next>
 <block type="typescript_statement">
-<mutation numlines="1" line0="l &#62;&#62;&#62;&#61; 1&#59;" />
+<mutation numlines="1" error="Unsupported operator token in statement GreaterThanGreaterThanGreaterThanEqualsToken" line0="x15 &#62;&#62;&#62;&#61; 1&#59;" />
 </block>
 </next>
 </block>

--- a/tests/decompile-test/baselines/name_collision_1.blocks
+++ b/tests/decompile-test/baselines/name_collision_1.blocks
@@ -10,7 +10,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -18,7 +18,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -34,7 +34,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">z</field>
+<field name="VAR">x3</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">2</field>
@@ -42,7 +42,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">z</field>
+<field name="VAR">x3</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -76,7 +76,7 @@
 </value>
 <statement name="DO0">
 <block type="variables_set">
-<field name="VAR">a</field>
+<field name="VAR">x4</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">3</field>
@@ -84,7 +84,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">a</field>
+<field name="VAR">x4</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -121,7 +121,7 @@
 </value>
 <statement name="DO">
 <block type="variables_set">
-<field name="VAR">b</field>
+<field name="VAR">x5</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">4</field>
@@ -129,7 +129,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">b</field>
+<field name="VAR">x5</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -149,7 +149,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">c</field>
+<field name="VAR">y</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -157,7 +157,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">c</field>
+<field name="VAR">y</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -165,7 +165,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">d</field>
+<field name="VAR">y2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -173,7 +173,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">d</field>
+<field name="VAR">y2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>

--- a/tests/decompile-test/baselines/name_collision_4.blocks
+++ b/tests/decompile-test/baselines/name_collision_4.blocks
@@ -8,7 +8,7 @@
 </value>
 <statement name="HANDLER">
 <block type="variables_set">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -16,7 +16,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="math_arithmetic">
@@ -24,7 +24,7 @@
 <value name="A">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="variables_get">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 </block>
 </value>
 <value name="B">

--- a/tests/decompile-test/baselines/name_collision_6.blocks
+++ b/tests/decompile-test/baselines/name_collision_6.blocks
@@ -4,9 +4,7 @@
 <block type="variables_set">
 <field name="VAR">x</field>
 <value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">0</field>
-</shadow>
+<shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="test_create_class">
 <value name="x">
 <shadow type="math_number">
@@ -17,7 +15,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -25,7 +23,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -45,7 +43,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">a</field>
+<field name="VAR">y2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">3</field>
@@ -53,7 +51,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">a</field>
+<field name="VAR">y2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -61,11 +59,9 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">z</field>
+<field name="VAR">y</field>
 <value name="VALUE">
-<shadow type="math_number">
-<field name="NUM">0</field>
-</shadow>
+<shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="test_create_class">
 <value name="x">
 <shadow type="math_number">
@@ -78,7 +74,7 @@
 <block type="test_class_method">
 <value name="testClass">
 <block type="variables_get">
-<field name="VAR">z</field>
+<field name="VAR">y</field>
 </block>
 </value>
 <value name="x">

--- a/tests/decompile-test/baselines/name_collision_7.blocks
+++ b/tests/decompile-test/baselines/name_collision_7.blocks
@@ -30,7 +30,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">2</field>
@@ -38,7 +38,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 <value name="VALUE">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="math_arithmetic">
@@ -51,7 +51,7 @@
 <value name="B">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
 <block type="variables_get">
-<field name="VAR">y</field>
+<field name="VAR">x2</field>
 </block>
 </value>
 </block>

--- a/tests/decompile-test/baselines/name_collision_8.blocks
+++ b/tests/decompile-test/baselines/name_collision_8.blocks
@@ -74,7 +74,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">c</field>
+<field name="VAR">z2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -106,7 +106,7 @@
 </value>
 <next>
 <block type="variables_change">
-<field name="VAR">c</field>
+<field name="VAR">z2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -338,7 +338,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">c2</field>
+<field name="VAR">c</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>
@@ -346,7 +346,7 @@
 </value>
 <next>
 <block type="variables_set">
-<field name="VAR">c3</field>
+<field name="VAR">c2</field>
 <value name="VALUE">
 <shadow type="math_number">
 <field name="NUM">1</field>


### PR DESCRIPTION
We do a lot of variable renaming when going from TS to blocks to avoid variable names clashing when they become globals. Part of our renaming algorithm is to switch single letter variables names to the next available single letter. That was to make decompiling for-loops better because it's common to have several variables named `i` throughout the project.

This seemed like a good idea at the time, but I realize now that some single-letter variable names have specific meanings in our targets, like x, y, and z. Are there any others that folks can think of? Should we cut this feature entirely?