### PR TITLE
Hide simulator on headless share page, CSS tweaks

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -333,6 +333,30 @@ svg {
     display: none;
 }
 
+.docs.footer.inverted a.item {
+    color: rgba(114, 163, 211, 1.0);
+}
+.docs.footer.inverted a.item i.icon {
+    color: rgba(255, 255, 255, .6);
+}
+
+.docs.footer.inverted a.item:hover i.icon,
+.docs.footer.inverted a.item:focus i.icon {
+    color: rgba(255, 255, 255, 0.8);
+}
+.docs.footer.inverted .divider {
+    border-top: 1px solid rgba(255, 255, 255, 0.3);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.docs.footer.inverted .ui.divided.horizontal.list > .item:not(:first-child) {
+    border-left: 1px solid rgba(255, 255, 255, .4);
+}
+
+.docs.footer.inverted span.item {
+    color: rgba(255, 255, 255, .6);
+}
+
 @media only screen and (max-width: 1144px) {
     .hidemobile {
         display: none !important;

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -229,6 +229,7 @@ namespace ts.pxtc.Util {
     }
 
     export function setEditorLanguagePref(lang: string): void {
+        if (lang.match(/prj$/)) lang = lang.replace(/prj$/, "")
         localStorage.setItem("editorlangpref", lang);
     }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -771,21 +771,23 @@ p.ui.font.small {
 
 /* Mobile + Tablet */
 @media only screen and (max-width: @largestTabletScreen) {
-    #root.sandbox .active.item.sim-menuitem ~ .toggle {
-        margin-left: 0 !important;
-        box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
-        background: @editorToggleColor !important;
-    }
-    #root.sandbox .active.item.blocks-menuitem ~ .toggle {
-        margin-left: 40px !important;
-        box-shadow: 2px 0px 0px rgba(0,0,0,0.1), -2px 0px 0px rgba(0,0,0,0.1) !important;
-        background: @editorToggleColor !important;
-    }
-    #root.sandbox .active.item.javascript-menuitem ~ .toggle,
-    #root.sandbox .active.item.python-menuitem ~ .toggle {
-        margin-left: 80px !important;
-        box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
-        background: @editorToggleColor !important;
+    #root.sandbox:not(.headless) {
+        .active.item.sim-menuitem ~ .toggle {
+            margin-left: 0 !important;
+            box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
+            background: @editorToggleColor !important;
+        }
+        .active.item.blocks-menuitem ~ .toggle {
+            margin-left: 40px !important;
+            box-shadow: 2px 0px 0px rgba(0,0,0,0.1), -2px 0px 0px rgba(0,0,0,0.1) !important;
+            background: @editorToggleColor !important;
+        }
+        .active.item.javascript-menuitem ~ .toggle,
+        .active.item.python-menuitem ~ .toggle {
+            margin-left: 80px !important;
+            box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
+            background: @editorToggleColor !important;
+        }
     }
 
     .simView #boardview {
@@ -1501,18 +1503,18 @@ div.simframe.ui.embed {
         bottom: 1.5rem !important;
     }
 
-    .active.item.sim-menuitem ~ .toggle {
+    &:not(.headless) .active.item.sim-menuitem ~ .toggle {
         margin-left: 0 !important;
         box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;
     }
-    .active.item.blocks-menuitem ~ .toggle {
+    &:not(.headless) .active.item.blocks-menuitem ~ .toggle {
         margin-left: 140px !important;
         box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;
     }
-    .active.item.javascript-menuitem ~ .toggle,
-    .active.item.python-menuitem ~ .toggle {
+    &:not(.headless) .active.item.javascript-menuitem ~ .toggle,
+    &:not(.headless) .active.item.python-menuitem ~ .toggle {
         margin-left: 280px !important;
         box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -433,6 +433,7 @@ class SandboxMenuItem extends data.Component<ISettingsProps, {}> {
 interface IEditorSelectorProps extends ISettingsProps {
     python?: boolean;
     sandbox?: boolean;
+    headless?: boolean;
 }
 
 export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
@@ -446,7 +447,7 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
 
         return (<div>
             <div id="editortoggle" className="ui grid padded">
-                {this.props.sandbox && <SandboxMenuItem parent={this.props.parent} />}
+                {this.props.sandbox && !this.props.headless && <SandboxMenuItem parent={this.props.parent} />}
                 <BlocksMenuItem parent={this.props.parent} />
                 {pxt.Util.isPyLangPref() && pythonEnabled ? <PythonMenuItem parent={this.props.parent} /> : <JavascriptMenuItem parent={this.props.parent} />}
                 {pythonEnabled && <sui.DropdownMenu id="editordropdown" role="menuitem" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
@@ -548,6 +549,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const logoWide = !!targetTheme.logoWide;
         const portraitLogoSize = logoWide ? "small" : "mini";
 
+        const simOpts = pxt.appTarget.simulator;
+        const isHeadless = simOpts && simOpts.headless;
+
         const hasCloud = this.hasCloud();
         const user = hasCloud ? this.getUser() : undefined;
         const showCloud = !sandbox && !inTutorial && !debugging && !!user;
@@ -573,7 +577,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                     </span>
                 </div>}
             {!inTutorial && !targetTheme.blocksOnly && !debugging && <div className="ui item link editor-menuitem">
-                <container.EditorSelector parent={this.props.parent} sandbox={sandbox} python={targetTheme.python} />
+                <container.EditorSelector parent={this.props.parent} sandbox={sandbox} python={targetTheme.python} headless={isHeadless} />
             </div>}
             {inTutorial && activityName && <div className="ui item">{activityName}</div>}
             {inTutorial && !hideIteration && <tutorial.TutorialMenu parent={this.props.parent} />}

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -360,8 +360,10 @@ export function installAsync(h0: InstallHeader, text: ScriptText) {
     h.modificationTime = h.recentUse;
 
     const cfg: pxt.PackageConfig = pxt.Package.parseAndValidConfig(text[pxt.CONFIG_NAME]);
-    if (cfg && cfg.preferredEditor)
+    if (cfg && cfg.preferredEditor) {
         h.editor = cfg.preferredEditor
+        pxt.Util.setEditorLanguagePref(cfg.preferredEditor);
+    }
     return importAsync(h, text)
         .then(() => h)
 }


### PR DESCRIPTION
- Hide simulator if "headless" in sandbox mode
- Inverted CSS for share page footer (Minecraft theme)
- Fix toggle CSS
- Set editor language preference (js/py) based on imported project editor state (jsprj/pyprj)