### PR TITLE
Python gray blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1455,7 +1455,7 @@ namespace pxt.blocks {
     }
 
     function compileTypescriptBlock(e: Environment, b: Blockly.Block) {
-        return ((b as GrayBlockStatement).getLines() as string[]).map(line => mkText(line + "\n"));
+        return (b as GrayBlockStatement).getLines().map(line => mkText(line + "\n"));
     }
 
     function compileDebuggeStatementBlock(e: Environment, b: Blockly.Block) {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1455,22 +1455,7 @@ namespace pxt.blocks {
     }
 
     function compileTypescriptBlock(e: Environment, b: Blockly.Block) {
-        let res: JsNode[] = [];
-        let i = 0;
-
-        while (true) {
-            const value = b.getFieldValue("LINE" + i);
-            i++;
-
-            if (value !== null) {
-                res.push(mkText(value + "\n"));
-            }
-            else {
-                break;
-            }
-        }
-
-        return res;
+        return ((b as any).getLines() as string[]).map(line => mkText(line + "\n"));
     }
 
     function compileDebuggeStatementBlock(e: Environment, b: Blockly.Block) {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1455,7 +1455,7 @@ namespace pxt.blocks {
     }
 
     function compileTypescriptBlock(e: Environment, b: Blockly.Block) {
-        return ((b as any).getLines() as string[]).map(line => mkText(line + "\n"));
+        return ((b as GrayBlockStatement).getLines() as string[]).map(line => mkText(line + "\n"));
     }
 
     function compileDebuggeStatementBlock(e: Environment, b: Blockly.Block) {
@@ -2232,7 +2232,7 @@ namespace pxt.blocks {
                 currentScope.referencedVars.push(info.id);
             }
             else if (block.type === pxtc.TS_STATEMENT_TYPE) {
-                const declaredVars: string = (block as any).declaredVariables
+                const declaredVars: string = (block as GrayBlockStatement).declaredVariables
                 if (declaredVars) {
                     const varNames = declaredVars.split(",");
                     varNames.forEach(vName => {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1659,11 +1659,13 @@ namespace pxt.blocks {
                         // need to have the same fields as the real block, and this field will
                         // always be created by domToMutation regardless of TS or Python mode
                         that.appendDummyInput().appendField(Util.lf("<python code>"), "LINE0")
+                        that.setTooltip(lf("A Python statement that could not be converted to blocks"));
                     }
                     else {
                         lines.forEach((line, index) => {
                             that.appendDummyInput().appendField(line, "LINE" + index);
                         });
+                        that.setTooltip(lf("A JavaScript statement that could not be converted to blocks"));
                     }
                 }
 
@@ -1694,6 +1696,13 @@ namespace pxt.blocks {
 
                 that.setPythonEnabled = (enabled: boolean) => {
                     (that.getField("EXPRESSION") as pxtblockly.FieldTsExpression).setPythonEnabled(enabled);
+
+                    if (enabled) {
+                        that.setTooltip(lf("A Python expression that could not be converted to blocks"));
+                    }
+                    else {
+                        that.setTooltip(lf("A JavaScript expression that could not be converted to blocks"));
+                    }
                 }
 
                 setHelpResources(that,

--- a/pxtblocks/fields/field_tsexpression.ts
+++ b/pxtblocks/fields/field_tsexpression.ts
@@ -44,7 +44,7 @@ namespace pxtblockly {
         }
 
         protected setPythonText() {
-            this.setText(pxt.Util.lf("<python expression>"))
+            this.setText(pxt.Util.lf("<python code>"))
         }
     }
 }

--- a/pxtblocks/fields/field_tsexpression.ts
+++ b/pxtblocks/fields/field_tsexpression.ts
@@ -3,6 +3,7 @@
 namespace pxtblockly {
     export class FieldTsExpression extends Blockly.FieldTextInput implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
+        protected pythonMode = false;
 
         /**
          * Same as parent, but adds a different class to text when disabled
@@ -10,17 +11,40 @@ namespace pxtblockly {
         public updateEditable() {
             let group = this.fieldGroup_;
             if (!this.EDITABLE || !group) {
-              return;
+                return;
             }
             if (this.sourceBlock_.isEditable()) {
-              pxt.BrowserUtils.addClass(group, 'blocklyEditableText');
-              pxt.BrowserUtils.removeClass(group, 'blocklyGreyExpressionBlockText');
-              (this.fieldGroup_ as any).style.cursor = this.CURSOR;
+                pxt.BrowserUtils.addClass(group, 'blocklyEditableText');
+                pxt.BrowserUtils.removeClass(group, 'blocklyGreyExpressionBlockText');
+                (this.fieldGroup_ as any).style.cursor = this.CURSOR;
             } else {
-              pxt.BrowserUtils.addClass(group, 'blocklyGreyExpressionBlockText');
-              pxt.BrowserUtils.removeClass(group, 'blocklyEditableText');
-              (this.fieldGroup_ as any).style.cursor = '';
+                pxt.BrowserUtils.addClass(group, 'blocklyGreyExpressionBlockText');
+                pxt.BrowserUtils.removeClass(group, 'blocklyEditableText');
+                (this.fieldGroup_ as any).style.cursor = '';
             }
+        }
+
+        doValueUpdate_(newValue: string) {
+            super.doValueUpdate_(newValue);
+
+            if (this.pythonMode) this.setPythonText();
+        }
+
+        public setPythonEnabled(enabled: boolean) {
+            if (enabled === this.pythonMode) return;
+
+            this.pythonMode = enabled;
+
+            if (enabled) {
+                this.setPythonText();
+            }
+            else {
+                this.setText(this.getValue());
+            }
+        }
+
+        protected setPythonText() {
+            this.setText(pxt.Util.lf("<python expression>"))
         }
     }
 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -220,6 +220,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.initLayout();
             this.editor.clearUndo();
             this.reportDeprecatedBlocks();
+            this.updateGrayBlocks();
 
             this.typeScriptSaveable = true;
         } catch (e) {
@@ -456,6 +457,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 if (blockId == "variables_set") {
                     // Need to bump suffix in flyout
                     this.clearFlyoutCaches();
+                }
+                if (blockId === pxtc.TS_STATEMENT_TYPE || blockId === pxtc.TS_OUTPUT_TYPE) {
+                    this.updateGrayBlocks();
                 }
                 pxt.tickEvent("blocks.create", { "block": blockId });
                 if (ev.xml.tagName == 'SHADOW')
@@ -1470,6 +1474,17 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         })
         this.showFlyoutInternal_(xmlList);
         this.parent.forceUpdate();
+    }
+
+    protected updateGrayBlocks() {
+        if (this.editor) {
+            const pythonEnabled = pxt.Util.isPyLangPref();
+            this.editor.getAllBlocks(false).forEach(b => {
+                if (b.type === pxtc.TS_STATEMENT_TYPE || b.type === pxtc.TS_OUTPUT_TYPE) {
+                    (b as pxt.blocks.GrayBlock).setPythonEnabled(pythonEnabled);
+                }
+            })
+        }
     }
 
     ///////////////////////////////////////////////////////////


### PR DESCRIPTION
If Python is set as your editor language preference, don't render TypeScript code in gray blocks. Instead, we render `<python code>` for statements and `<python expression>` for expressions. This is more of a placeholder until we have time to do something more comparable to TS.

Here is a GIF that loops perfectly:

![2020-01-13 17 05 27](https://user-images.githubusercontent.com/13754588/72305993-748ac800-362a-11ea-8722-57c411072656.gif)
