### PR TITLE
don't put member of emit as constant

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -666,7 +666,8 @@ declare namespace ts.pxtc {
 
         duplicateShadowOnDrag?: boolean; // if true, duplicate the block when its shadow is dragged out (like function arguments)
 
-        alias?: string; // another symbol alias for this member 
+        alias?: string; // another symbol alias for this member
+        pyAlias?: string; // optional python version of the alias
     }
 
     interface ParameterDesc {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -665,6 +665,8 @@ declare namespace ts.pxtc {
         paramFieldEditorOptions?: pxt.Map<pxt.Map<string>>; //.fieldOptions.
 
         duplicateShadowOnDrag?: boolean; // if true, duplicate the block when its shadow is dragged out (like function arguments)
+
+        alias?: string; // another symbol alias for this member 
     }
 
     interface ParameterDesc {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1552,7 +1552,8 @@ namespace ts.pxtc.service {
                                 let pxtSym = apis.byQName[fullName]
                                 if (pxtSym) {
                                     if (pxtSym.attributes.alias)
-                                        return pxtSym.attributes.alias; // prefer alias
+                                        // use pyAlias if python; or default to alias
+                                        return (python && pxtSym.attributes.pyAlias) || pxtSym.attributes.alias; // prefer alias
                                     return python ? pxtSym.pyQName : pxtSym.qName
                                 }
                                 else

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -927,7 +927,9 @@ namespace ts.pxtc.service {
                     /^__/.test(si.name) || // ignore members starting with __
                     /^__/.test(si.namespace) || // ignore namespaces starting with _-
                     si.attributes.hidden ||
-                    si.attributes.deprecated
+                    si.attributes.deprecated ||
+                    // don't emit members of enum marked as "emitAsConstant"
+                    (si.kind == SymbolKind.EnumMember && lastApiInfo.apis.byQName[si.namespace]?.attributes.emitAsConstant)
                 ) continue; // ignore
                 entries[si.qName] = si
                 const n = lastApiInfo.decls[si.qName];

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -928,8 +928,8 @@ namespace ts.pxtc.service {
                     /^__/.test(si.namespace) || // ignore namespaces starting with _-
                     si.attributes.hidden ||
                     si.attributes.deprecated ||
-                    // don't emit members of enum marked as "emitAsConstant"
-                    (si.kind == SymbolKind.EnumMember && lastApiInfo.apis.byQName[si.namespace]?.attributes.emitAsConstant)
+                    // don't emit members with ann alias
+                    si.attributes.alias
                 ) continue; // ignore
                 entries[si.qName] = si
                 const n = lastApiInfo.decls[si.qName];
@@ -1551,6 +1551,8 @@ namespace ts.pxtc.service {
                                 let fullName = checker.getFullyQualifiedName(checker.getSymbolAtLocation(member.name));
                                 let pxtSym = apis.byQName[fullName]
                                 if (pxtSym) {
+                                    if (pxtSym.attributes.alias)
+                                        return pxtSym.attributes.alias; // prefer alias
                                     return python ? pxtSym.pyQName : pxtSym.qName
                                 }
                                 else

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -928,7 +928,7 @@ namespace ts.pxtc.service {
                     /^__/.test(si.namespace) || // ignore namespaces starting with _-
                     si.attributes.hidden ||
                     si.attributes.deprecated ||
-                    // don't emit members with ann alias
+                    // don't members with an alias
                     si.attributes.alias
                 ) continue; // ignore
                 entries[si.qName] = si


### PR DESCRIPTION
Introduces a generic "alias" annotation; emit FORWARD instead of SixDirection.Forward

Before:
![image](https://user-images.githubusercontent.com/4175913/72470154-3bbb3200-3795-11ea-8b2f-18ed7c34c38f.png)

After:
![image](https://user-images.githubusercontent.com/4175913/72470092-2d6d1600-3795-11ea-94e0-ef102929d7ac.png)
