### PR TITLE
Hoist for variables when required

### DIFF
--- a/pxtpy/ast.ts
+++ b/pxtpy/ast.ts
@@ -44,9 +44,11 @@ namespace pxt.py {
         isParam?: boolean;
         isImport?: SymbolInfo;
         modifier?: VarModifier;
+        forVariableEndPos?: number;
 
         /* usage information */
         firstRefPos?: number;
+        lastRefPos?: number;
         firstAssignPos?: number;
         firstAssignDepth?: number;
     }
@@ -69,6 +71,7 @@ namespace pxt.py {
         tsType?: Type;
         symbolInfo?: SymbolInfo;
         inCalledPosition?: boolean; // it's an f in f(...)
+        forTargetEndPos?: number; // it's X in "for X in ..." and this is the position of the end of that for
         _exprBrand: void;
     }
 

--- a/tests/pyconverter-test/baselines/for_hoisting.ts
+++ b/tests/pyconverter-test/baselines/for_hoisting.ts
@@ -1,0 +1,16 @@
+let i: number;
+let z: number;
+let k: number;
+for (i = 0; i < 2; i++) {
+    
+}
+for (i = 0; i < 2; i++) {
+    
+}
+for (let j = 0; j < 2; j++) {
+    z = j
+}
+for (k = 0; k < 2; k++) {
+    
+}
+let q = k

--- a/tests/pyconverter-test/cases/for_hoisting.py
+++ b/tests/pyconverter-test/cases/for_hoisting.py
@@ -1,0 +1,9 @@
+for i in range(0, 2):
+    pass
+for i in range(0, 2):
+    pass
+for j in range(0, 2):
+    z = j
+for k in range(0, 2):
+    pass
+q = k


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/1557

Loop variables in python are function scope (like all other variables). With this PR we scope them to the for loop if they are only ever used inside that for loop.
