### PR TITLE
Set path of language cookie to prevent multiple cookie from docs

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1039,7 +1039,7 @@ namespace pxt.BrowserUtils {
             pxt.tickEvent(`menu.lang.setcookielang`, { lang: langId, docs: `${docs}` });
             const expiration = new Date();
             expiration.setTime(expiration.getTime() + (pxt.Util.langCookieExpirationDays * 24 * 60 * 60 * 1000));
-            document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}`;
+            document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}; path=/`;
         }
     }
 }


### PR DESCRIPTION
Fixes issue where setting lang in a nested docs page (/courses/csintro) would set a cookie with path `/courses` that would not be respected in the homepage/editor