### PR TITLE
handle defaults with param.shadow=text

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -141,6 +141,7 @@ namespace pxt.blocks {
         }
 
         const isVariable = shadowId == "variables_get";
+        const isText = shadowId == "text";
 
         const value = document.createElement("value");
         value.setAttribute("name", p.definitionName);
@@ -212,6 +213,10 @@ namespace pxt.blocks {
 
             if (isVariable) {
                 field.setAttribute("name", "VAR");
+                shadow.appendChild(field);
+            }
+            else if (isText) {
+                field.setAttribute("name", "TEXT");
                 shadow.appendChild(field);
             }
             else if (shadowId) {


### PR DESCRIPTION
currently, adding a default value for https://github.com/microsoft/pxt-common-packages/blob/master/libs/base/console.ts#L57 (or in my case making ``player.say`` allow `any` in minecraft) will just get dropped and show up as the empty string, because it doesn't convert the field name from 'text' to 'TEXT' and the value is silently ignored.

This is annoying when using it to give a default for `any` or complex types (e.g. union types involving strings), for example adding an ``e.g.`` default for https://github.com/microsoft/pxt-common-packages/blob/master/libs/base/console.ts#L57 (or in my case making ``player.say`` allow `any` in minecraft) doesn't work currently.