### PR TITLE
Ellipsis truncation for toolbox header in flyoutOnly mode

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -467,6 +467,9 @@ span.highlight-line {
 
     #flyoutHeader {
         box-sizing: content-box;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 
     div {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/72566585-f405da80-3868-11ea-92cb-01a38d43c7c6.png)

Handle long text in flyoutOnly headers, for https://github.com/microsoft/pxt-minecraft/issues/1453