### PR TITLE
Github route

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3903,6 +3903,8 @@ async function importGithubProject(repoid: string, requireSignin?: boolean) {
         }
         if (hd)
             await theEditor.loadHeaderAsync(hd, null)
+        else
+            theEditor.openHome();
     } catch (e) {
         core.handleNetworkError(e)
         theEditor.openHome();

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -30,19 +30,19 @@ export class GithubProvider extends cloudsync.ProviderBase {
     }
 
     loginAsync(redirect?: boolean, silent?: boolean): Promise<cloudsync.ProviderLoginResponse> {
-        return this.routedLoginAsync(undefined, undefined);
+        return this.routedLoginAsync(undefined);
     }
 
-    private routedLoginAsync(header: pxt.workspace.Header, route: string) {
+    routedLoginAsync(route: string) {
         this.loginCheck()
         let p = Promise.resolve();
         if (!this.token()) {
-            p = p.then(() => this.showLoginAsync(header, route));
+            p = p.then(() => this.showLoginAsync(route));
         }
         return p.then(() => { return { accessToken: this.token() } as cloudsync.ProviderLoginResponse; });
     }
 
-    private showLoginAsync(header: pxt.workspace.Header, route: string): Promise<void> {
+    private showLoginAsync(route: string): Promise<void> {
         pxt.tickEvent("github.login.dialog");
         // auth flow if github provider is prsent
         const oAuthSupported = pxt.appTarget
@@ -101,7 +101,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
                     return this.saveAndValidateTokenAsync(hextoken);
                 }
                 else {
-                    return this.oauthRedirectAsync(header, route);
+                    return this.oauthRedirectAsync(route);
                 }
             }
         })
@@ -112,9 +112,9 @@ export class GithubProvider extends cloudsync.ProviderBase {
         }
     }
 
-    private oauthRedirectAsync(header: pxt.workspace.Header, route: string): Promise<void> {
-        core.showLoading("ghlogin", lf("Signing you in to GitHub..."))
-        const state = cloudsync.setOauth(this.name, header && route ? `#github:${header.id}:${route}` : undefined);
+    private oauthRedirectAsync(route: string): Promise<void> {
+        core.showLoading("ghlogin", lf("Signing you into GitHub..."))
+        const state = cloudsync.setOauth(this.name, route ? `#github:${route}` : undefined);
         const self = window.location.href.replace(/#.*/, "")
         const login = pxt.Cloud.getServiceUrl() +
             "/oauth/login?state=" + state +
@@ -190,7 +190,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
 
     async createRepositoryAsync(projectName: string, header: pxt.workspace.Header): Promise<boolean> {
         pxt.tickEvent("github.filelist.create.start");
-        await this.routedLoginAsync(header, "create-repository")
+        await this.routedLoginAsync(`create-repository:${header.id}`)
         if (!this.token()) {
             pxt.tickEvent("github.filelist.create.notoken");
             return false;

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -12,7 +12,6 @@ import * as iframeworkspace from "./iframeworkspace"
 import * as cloudsync from "./cloudsync"
 import * as indexedDBWorkspace from "./idbworkspace";
 import * as compiler from "./compiler"
-import * as dialogs from "./dialogs"
 
 import U = pxt.Util;
 import Cloud = pxt.Cloud;
@@ -847,7 +846,7 @@ export async function exportToGithubAsync(hd: Header, repoid: string) {
         commit
     })
     await saveAsync(hd, files);
-    await initializeGithubRepoAsync(hd, repoid, false);
+    await initializeGithubRepoAsync(hd, repoid, false, true);
     // race condition, don't pull right away
     // await pullAsync(hd);
 }
@@ -969,7 +968,7 @@ export function prepareConfigForGithub(content: string, createTag?: boolean): st
     }
 }
 
-export async function initializeGithubRepoAsync(hd: Header, repoid: string, forceTemplateFiles: boolean) {
+export async function initializeGithubRepoAsync(hd: Header, repoid: string, forceTemplateFiles: boolean, binaryJs: boolean) {
     await cloudsync.ensureGitHubTokenAsync();
 
     let parsed = pxt.github.parseRepoId(repoid)
@@ -1027,7 +1026,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
     await commitAsync(hd, {
         message: lf("Initial files for MakeCode project"),
         filenamesToCommit: Object.keys(currFiles),
-        binaryJs: true
+        binaryJs
     })
 
     // remove files not in the package (only in git)
@@ -1103,7 +1102,7 @@ export async function importGithubAsync(id: string): Promise<Header> {
         files: {}
     })
     if (hd && isEmpty)
-        await initializeGithubRepoAsync(hd, repoid, forceTemplateFiles);
+        await initializeGithubRepoAsync(hd, repoid, forceTemplateFiles, false);
     return hd
 }
 


### PR DESCRIPTION
Support for GitHub classroom routing:

``#github:owner/repo`` imports the repo into MakeCode, **requires sign in**.
``#github:create-repository:headerid`` exports a project into GitHub repo

