### PR TITLE
Use alias when avaiable in py decompiler

### DIFF
--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -125,6 +125,9 @@ namespace pxt.py {
                 return null
             let tsExp = exp.getText()
             let sym = symbols[tsExp]
+            if (sym && sym.attributes.alias) {
+                return sym.attributes.alias
+            }
             if (sym && sym.pyQName) {
                 return sym.pyQName
             }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -268,7 +268,6 @@ namespace pxt.runner {
                     else {
                         if ($svg) appendJs($svg.parent(), $js, woptions);
                         else appendJs($c, $js, woptions);
-                        $js[0].scrollIntoView();
                     }
                 })
                 $menu.append($jsBtn);
@@ -287,7 +286,6 @@ namespace pxt.runner {
                     else {
                         if ($svg) appendPy($svg.parent(), $py, woptions);
                         else appendPy($c, $py, woptions);
-                        $py[0].scrollIntoView();
                     }
                 })
                 $menu.append($pyBtn);

--- a/tests/decompile-test/baselines/alias.blocks
+++ b/tests/decompile-test/baselines/alias.blocks
@@ -1,0 +1,13 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+<block type="pxt-on-start">
+<statement name="HANDLER">
+<block type="namespaceWithAlias_argsWithAlias">
+<field name="f">EnumWithAlias.Foo</field>
+<next>
+<block type="namespaceWithAlias_functionWithAlias">
+</block>
+</next>
+</block>
+</statement>
+</block>
+</xml>

--- a/tests/decompile-test/cases/alias.ts
+++ b/tests/decompile-test/cases/alias.ts
@@ -1,2 +1,2 @@
-namespaceWithAlias.argsWithAlias(FOO);
+namespaceWithAlias.argsWithAlias(EnumWithAlias.Foo);
 namespaceWithAlias.functionWithAlias();

--- a/tests/decompile-test/cases/alias.ts
+++ b/tests/decompile-test/cases/alias.ts
@@ -1,0 +1,2 @@
+namespaceWithAlias.argsWithAlias(FOO);
+namespaceWithAlias.functionWithAlias();

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -254,3 +254,23 @@ enum EnumWithValueBlock {
     //% block=value2
     testValue2 = 5
 }
+
+enum EnumWithAlias {
+    //% alias=FOO
+    Foo    
+}
+
+const FOO = EnumWithAlias.Foo;
+
+namespace namespaceWithAlias {
+    export function argsWithAlias(f: EnumWithAlias) {
+
+    }
+
+    //% alias=BAR
+    export function functionWithAlias() {
+
+    }
+}
+
+const BAR = namespaceWithAlias.functionWithAlias

--- a/tests/decompile-test/cases/testBlocks/basic.ts
+++ b/tests/decompile-test/cases/testBlocks/basic.ts
@@ -263,11 +263,12 @@ enum EnumWithAlias {
 const FOO = EnumWithAlias.Foo;
 
 namespace namespaceWithAlias {
+    //% block
     export function argsWithAlias(f: EnumWithAlias) {
 
     }
 
-    //% alias=BAR
+    //% alias=BAR block
     export function functionWithAlias() {
 
     }

--- a/tests/pydecompile-test/baselines/alias.py
+++ b/tests/pydecompile-test/baselines/alias.py
@@ -1,0 +1,2 @@
+namespaceWithAlias.argsWithAlias(FOO)
+BAR()


### PR DESCRIPTION
Use "alias" info, e.g. short name if possible when decompiling -- otherwise we end up with ugly code if we come from TS/blocks.

Note: the py decompilation looks trashed. 