### PR TITLE
scroll python/js snip into view

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -268,6 +268,7 @@ namespace pxt.runner {
                     else {
                         if ($svg) appendJs($svg.parent(), $js, woptions);
                         else appendJs($c, $js, woptions);
+                        $js[0].scrollIntoView();
                     }
                 })
                 $menu.append($jsBtn);
@@ -286,6 +287,7 @@ namespace pxt.runner {
                     else {
                         if ($svg) appendPy($svg.parent(), $py, woptions);
                         else appendPy($c, $py, woptions);
+                        $py[0].scrollIntoView();
                     }
                 })
                 $menu.append($pyBtn);


### PR DESCRIPTION
In docs, when clicking on "python" button, need to scroll the text into view.
![2020-01-16 21 57 43](https://user-images.githubusercontent.com/4175913/72587850-5bdd1500-38ab-11ea-9ecc-5e0f7f86c6ca.gif)
