### PR TITLE
don't emit function marked as TD_ID

### DIFF
--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -120,6 +120,12 @@ namespace pxt.py {
                 'type', 'vars', 'zip']
             return reservedNames;
         }
+        function tryGetSymbol(exp: ts.Node) {
+            if (!exp.getSourceFile())
+                return null
+            let tsExp = exp.getText()
+            return symbols[tsExp] || null;
+        }
         function tryGetPyName(exp: ts.BindingPattern | ts.PropertyName | ts.EntityName | ts.PropertyAccessExpression): string | null {
             if (!exp.getSourceFile())
                 return null
@@ -1086,6 +1092,13 @@ namespace pxt.py {
                     pxt.tickEvent("depython.todo", { kind: s.kind })
                     return throwError(s, 3010, "TODO: Unsupported call site where caller the arguments outnumber the callee parameters: " + s.getText());
                 }
+            }
+
+            // special case TD_ID function, don't emit them
+            const sym = tryGetSymbol(s.expression);
+            if (s.arguments && sym && sym.attributes.shim == "TD_ID") {
+                // this function is a no-op and should not be emitted
+                return emitExp(s.arguments[0])
             }
 
             // TODO inspect type info to rewrite things like console.log, Math.max, etc.


### PR DESCRIPTION
We use many "invisible" helper function, marked as "shim=TD_ID" that should not be emitted when doing JS->Py.