### PR TITLE
Support for python/ts step-by-step tutorials

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -880,6 +880,7 @@ declare namespace pxt.tutorial {
         templateCode?: string;
         autoexpandStep?: boolean; // autoexpand tutorial card if instruction text overflows
         metadata?: TutorialMetadata; // metadata about the tutorial parsed from the markdown
+        inlineHints?: boolean; // always show hint as part of the main card
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -880,7 +880,6 @@ declare namespace pxt.tutorial {
         templateCode?: string;
         autoexpandStep?: boolean; // autoexpand tutorial card if instruction text overflows
         metadata?: TutorialMetadata; // metadata about the tutorial parsed from the markdown
-        inlineHints?: boolean; // always show hint as part of the main card
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -26,7 +26,8 @@ declare namespace pxt {
 
     interface CodeCardAction {
         url: string,
-        editor?: CodeCardEditorType
+        editor?: CodeCardEditorType;
+        cardType?: CodeCardType;
     }
 
     /**

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -214,7 +214,7 @@ namespace pxt.tutorial {
                     pre.appendChild(span);
                 }
             } else {
-                pre.appendChild(document.createTextNode(line + '\n'));
+                pre.appendChild(document.createTextNode(line + ((i < lines.length - 1) ? '\n' : '')));
             }
         }
     }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -190,7 +190,7 @@ namespace pxt.tutorial {
         return { metadata: (m as TutorialMetadata), body};
     }
 
-    export function highlight(pre: HTMLPreElement): void {
+    export function highlight(pre: HTMLElement): void {
         let text = pre.textContent;
         if (!/@highlight/.test(text)) // shortcut, nothing to do
             return;

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -18,6 +18,7 @@ namespace pxt.tutorial {
         body
             .replace(/((?!.)\s)+/g, "\n")
             .replace(regex, function (m0, m1, m2) {
+                let addCode = true;
                 switch (m1) {
                     case "block":
                     case "blocks":
@@ -29,6 +30,8 @@ namespace pxt.tutorial {
                     case "python":
                         if (!checkTutorialEditor(pxt.PYTHON_PROJECT_NAME))
                             return undefined;
+                        if (m1 == "python")
+                            addCode = false;
                         break;
                     case "typescript":
                     case "ts":
@@ -41,7 +44,8 @@ namespace pxt.tutorial {
                         templateCode = m2;
                         break;
                 }
-                code += "\n { \n " + m2 + "\n } \n";
+                if (addCode) // TODO: support python
+                    code += "\n { \n " + m2 + "\n } \n";
                 return "";
             });
 

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -203,7 +203,7 @@ namespace pxt.tutorial {
         pre.textContent = ""; // clear up and rebuild
         const lines = text.split('\n');
         for (let i = 0; i < lines.length; ++i) {
-            if (i < lines.length)
+            if (i > 0 && i < lines.length)
                 pre.appendChild(document.createTextNode("\n"))
             let line = lines[i];
             if (/@highlight/.test(line)) {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -18,7 +18,6 @@ namespace pxt.tutorial {
         body
             .replace(/((?!.)\s)+/g, "\n")
             .replace(regex, function (m0, m1, m2) {
-                let addCode = true;
                 switch (m1) {
                     case "block":
                     case "blocks":
@@ -31,7 +30,7 @@ namespace pxt.tutorial {
                         if (!checkTutorialEditor(pxt.PYTHON_PROJECT_NAME))
                             return undefined;
                         if (m1 == "python")
-                            addCode = false;
+                            return undefined; // TODO: support for those?
                         break;
                     case "typescript":
                     case "ts":
@@ -44,8 +43,7 @@ namespace pxt.tutorial {
                         templateCode = m2;
                         break;
                 }
-                if (addCode) // TODO: support python
-                    code += "\n { \n " + m2 + "\n } \n";
+                code += "\n { \n " + m2 + "\n } \n";
                 return "";
             });
 

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -26,6 +26,7 @@ namespace pxt.tutorial {
                             return undefined;
                         break;
                     case "spy":
+                    case "python":
                         if (!checkTutorialEditor(pxt.PYTHON_PROJECT_NAME))
                             return undefined;
                         break;

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -240,8 +240,7 @@ namespace pxt.tutorial {
             tutorialRecipe: !!recipe,
             templateCode: tutorialInfo.templateCode,
             autoexpandStep: true,
-            metadata: tutorialInfo.metadata,
-            inlineHints: tutorialInfo.editor != pxt.BLOCKS_PROJECT_NAME
+            metadata: tutorialInfo.metadata
         };
 
         return { options: tutorialOptions, editor: tutorialInfo.editor };

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -218,4 +218,31 @@ namespace pxt.tutorial {
             }
         }
     }
+
+    export function getTutorialOptions(md: string, tutorialId: string, filename: string, reportId: string, recipe: boolean): { options: pxt.tutorial.TutorialOptions, editor: string } {
+        const tutorialInfo = pxt.tutorial.parseTutorial(md);
+        if (!tutorialInfo)
+            throw new Error(lf("Invalid tutorial format"));
+
+        const tutorialOptions: pxt.tutorial.TutorialOptions = {
+            tutorial: tutorialId,
+            tutorialName: tutorialInfo.title || filename,
+            tutorialReportId: reportId,
+            tutorialStep: 0,
+            tutorialReady: true,
+            tutorialHintCounter: 0,
+            tutorialStepInfo: tutorialInfo.steps,
+            tutorialActivityInfo: tutorialInfo.activities,
+            tutorialMd: md,
+            tutorialCode: tutorialInfo.code,
+            tutorialRecipe: !!recipe,
+            templateCode: tutorialInfo.templateCode,
+            autoexpandStep: true,
+            metadata: tutorialInfo.metadata,
+            inlineHints: tutorialInfo.editor != pxt.BLOCKS_PROJECT_NAME
+        };
+
+        return { options: tutorialOptions, editor: tutorialInfo.editor };
+    }
+
 }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -11,7 +11,7 @@ namespace pxt.tutorial {
 
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /```(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template)?\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /```(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
         let code = '';
         let templateCode: string;
         // Concatenate all blocks in separate code blocks and decompile so we can detect what blocks are used (for the toolbox)

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -203,6 +203,8 @@ namespace pxt.tutorial {
         pre.textContent = ""; // clear up and rebuild
         const lines = text.split('\n');
         for (let i = 0; i < lines.length; ++i) {
+            if (i < lines.length)
+                pre.appendChild(document.createTextNode("\n"))
             let line = lines[i];
             if (/@highlight/.test(line)) {
                 // highlight next line
@@ -214,7 +216,7 @@ namespace pxt.tutorial {
                     pre.appendChild(span);
                 }
             } else {
-                pre.appendChild(document.createTextNode(line + ((i < lines.length - 1) ? '\n' : '')));
+                pre.appendChild(document.createTextNode(line));
             }
         }
     }

--- a/theme/code.less
+++ b/theme/code.less
@@ -1,0 +1,30 @@
+/**
+* All things related to coloring text-based tokens
+**/
+
+code.hjls {
+    padding: 0 !important;
+
+    span.highlight-line {
+        font-weight: bold;
+        white-space: pre-wrap;
+        background: @highlightLineBackground;
+        display: inline-block;
+        padding: 0.5rem;
+        margin-left: -0.5rem;
+        color: @highlightLineColor;
+
+        .hljs-string, .hljs-meta-string {
+            color: @highlightLineStringColor;
+        }
+        .hljs-class {
+            color: @highlightLineClassColor;
+        }
+        .hljs-number {
+            color: @highlightLineNumberColor;
+        }
+        .hljs-keyword {
+            color: @highlightLineKeywordColor;
+        }
+    }
+}

--- a/theme/code.less
+++ b/theme/code.less
@@ -1,8 +1,8 @@
 /**
 * All things related to coloring text-based tokens
 **/
-
-code.hjls {
+code.hljs {
+    white-space: pre-wrap;
     padding: 0 !important;
 
     span.highlight-line {
@@ -27,4 +27,9 @@ code.hjls {
             color: @highlightLineKeywordColor;
         }
     }
+}
+
+// don't double pad
+.ui.segment.codewidget > code.hjls {
+    margin: 0;
 }

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -5,6 +5,7 @@
 
 @import 'common';
 @import 'monaco';
+@import 'code';
 @import 'tutorial';
 @import 'sidedoc';
 @import 'home';

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -251,29 +251,6 @@ code.lang-filterblocks {
     display: none;
 }
 
-span.highlight-line {
-    font-weight: bold;
-    white-space: pre-wrap;
-    background: @highlightLineBackground;
-    display: inline-block;
-    padding: 0.5rem;
-    margin-left: -0.5rem;
-    color: @highlightLineColor;
-
-    .hljs-string, .hljs-meta-string {
-        color: @highlightLineStringColor;
-    }
-    .hljs-class {
-        color: @highlightLineClassColor;
-    }
-    .hljs-number {
-        color: @highlightLineNumberColor;
-    }
-    .hljs-keyword {
-        color: @highlightLineKeywordColor;
-    }
-}
-
 #tutorialcard .prevbutton,
 #tutorialcard .nextbutton {
     background: @tutorialSegmentBackground;

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -22,17 +22,14 @@
 /*******************************
       Tutorial mode
 *******************************/
-.tutorial #maineditor .full-abs {
+.tutorial #maineditor > .full-abs {
     top: @tutorialCardHeight;
 }
 
-.tutorial.flyoutOnly #maineditor .full-abs {
+.tutorial.flyoutOnly #maineditor > .full-abs {
     top: calc(@tutorialCardHeight + @workspaceHeaderHeight);
 }
 
-.tutorial #maineditor #monacoEditor {
-    top: 0rem;
-}
 /* Tutorial Mode */
 .menubar .ui.menu .item.tutorial-menuitem {
     background: rgba(27, 28, 29, 0.3) !important;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1588,7 +1588,7 @@ export class ProjectView
 
     importTutorialAsync(md: string) {
         try {
-            const { options, editor } = getTutorialOptions(md, "untitled", "untitled", "", false);
+            const { options, editor } = pxt.tutorial.getTutorialOptions(md, "untitled", "untitled", "", false);
             const dependencies = pxt.gallery.parsePackagesFromMarkdown(md);
 
             return this.createProjectAsync({
@@ -3187,7 +3187,7 @@ export class ProjectView
             if (!md)
                 throw new Error(lf("Tutorial not found"));
 
-            const { options, editor } = getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
+            const { options, editor } = pxt.tutorial.getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
 
             // start a tutorial within the context of an existing program
             if (recipe) {
@@ -4247,29 +4247,3 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }, false);
 })
-
-
-function getTutorialOptions(md: string, tutorialId: string, filename: string, reportId: string, recipe: boolean): { options: pxt.tutorial.TutorialOptions, editor: string } {
-    const tutorialInfo = pxt.tutorial.parseTutorial(md);
-    if (!tutorialInfo)
-        throw new Error(lf("Invalid tutorial format"));
-
-    const tutorialOptions: pxt.tutorial.TutorialOptions = {
-        tutorial: tutorialId,
-        tutorialName: tutorialInfo.title || filename,
-        tutorialReportId: reportId,
-        tutorialStep: 0,
-        tutorialReady: true,
-        tutorialHintCounter: 0,
-        tutorialStepInfo: tutorialInfo.steps,
-        tutorialActivityInfo: tutorialInfo.activities,
-        tutorialMd: md,
-        tutorialCode: tutorialInfo.code,
-        tutorialRecipe: !!recipe,
-        templateCode: tutorialInfo.templateCode,
-        autoexpandStep: true,
-        metadata: tutorialInfo.metadata
-    };
-
-    return { options: tutorialOptions, editor: tutorialInfo.editor };
-}

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -54,8 +54,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
     private finishRenderLangSnippet(wrapperDiv: HTMLDivElement, code: string) {
         const preDiv = document.createElement('pre') as HTMLPreElement;
-        preDiv.textContent = code;
-        pxt.tutorial.highlight(preDiv);
+        const codeDiv = document.createElement('code') as HTMLElement
+        preDiv.className = "hljs"
+        preDiv.appendChild(codeDiv);
+        codeDiv.textContent = code;
+        pxt.tutorial.highlight(codeDiv);
         wrapperDiv.appendChild(preDiv);
         pxsim.U.removeClass(wrapperDiv, 'loading');
     }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -45,7 +45,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         const parentBlock = preBlock.parentElement as HTMLDivElement; // parent containing all text
 
         const wrapperDiv = document.createElement('div');
-        wrapperDiv.className = 'ui segment raised loading';
+        wrapperDiv.className = 'ui segment raised loading codewidget';
         parentBlock.insertBefore(wrapperDiv, preBlock);
         parentBlock.removeChild(preBlock);
 
@@ -53,13 +53,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     }
 
     private finishRenderLangSnippet(wrapperDiv: HTMLDivElement, code: string) {
-        const preDiv = document.createElement('pre') as HTMLPreElement;
         const codeDiv = document.createElement('code') as HTMLElement
-        preDiv.className = "hljs"
-        preDiv.appendChild(codeDiv);
+        codeDiv.className = "hljs"
         codeDiv.textContent = code;
         pxt.tutorial.highlight(codeDiv);
-        wrapperDiv.appendChild(preDiv);
+        wrapperDiv.appendChild(codeDiv);
         pxsim.U.removeClass(wrapperDiv, 'loading');
     }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -115,12 +115,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 this.props.parent.newEmptyProject(scr.name, url);
                 break;
             case "tutorial":
-                if (editor != "blocks") {
-                    pxt.Util.setEditorLanguagePref(editor);
-                    this.props.parent.newEmptyProject(scr.name, url, editorPref);
-                } else {
-                    this.props.parent.startTutorial(url, scr.name);
-                }
+                this.props.parent.startTutorial(url, scr.name);
                 break;
             default:
                 const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(url); // Tutorial

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -786,7 +786,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             case "js":
                 return "JavaScript";
             case "blocks":
-                return "Blocks";
+                return lf("Blocks");
             default:
                 return null;
         }
@@ -888,7 +888,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                     {this.getActionCard(clickLabel, cardType, this.handleDetailClick, true)}
                     {otherActions && otherActions.map( (el, i) => {
                         let onClick = this.handleActionClick(el);
-                        return this.getActionCard(clickLabel, cardType, onClick, false, el, `action${i}`);
+                        return this.getActionCard(clickLabel, el.cardType || cardType, onClick, false, el, `action${i}`);
                     })}
                     {cardType === "forumUrl" &&
                         // TODO (shakao) migrate forumurl to otherAction json in md

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -424,7 +424,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const options = this.props.parent.state.tutorialOptions;
         const { tutorialReady, tutorialStepInfo, tutorialStep } = options;
         if (!tutorialReady) return false;
-        return (!options.inlineHints && tutorialStepInfo[tutorialStep].hasHint)
+        return tutorialStepInfo[tutorialStep].hasHint
             || tutorialStepInfo[tutorialStep].unplugged;
     }
 
@@ -517,9 +517,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const hasNext = tutorialReady && currentStep != maxSteps - 1 && !hideIteration;
         const hasFinish = !lockedEditor && currentStep == maxSteps - 1 && !hideIteration;
         const hasHint = this.hasHint();
-        let tutorialCardContent = stepInfo.headerContentMd;
-        if (!hasHint && stepInfo.hintContentMd && options.inlineHints)
-            tutorialCardContent += "\n" + stepInfo.hintContentMd
+        const tutorialCardContent = stepInfo.headerContentMd;
         const unplugged = stepInfo.unplugged;
 
         let tutorialAriaLabel = '',

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -424,7 +424,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const options = this.props.parent.state.tutorialOptions;
         const { tutorialReady, tutorialStepInfo, tutorialStep } = options;
         if (!tutorialReady) return false;
-        return tutorialStepInfo[tutorialStep].hasHint || tutorialStepInfo[tutorialStep].unplugged;
+        return (!options.inlineHints && tutorialStepInfo[tutorialStep].hasHint)
+            || tutorialStepInfo[tutorialStep].unplugged;
     }
 
     private hintOnClick(evt?: any) {
@@ -506,7 +507,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const options = this.props.parent.state.tutorialOptions;
         const { tutorialReady, tutorialStepInfo, tutorialStep, tutorialStepExpanded, metadata } = options;
         if (!tutorialReady) return <div />
-        const tutorialCardContent = tutorialStepInfo[tutorialStep].headerContentMd;
+        const stepInfo = tutorialStepInfo[tutorialStep];
 
         const lockedEditor = !!pxt.appTarget.appTheme.lockedEditor;
         const currentStep = tutorialStep;
@@ -516,7 +517,10 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const hasNext = tutorialReady && currentStep != maxSteps - 1 && !hideIteration;
         const hasFinish = !lockedEditor && currentStep == maxSteps - 1 && !hideIteration;
         const hasHint = this.hasHint();
-        const unplugged = tutorialStepInfo[tutorialStep].unplugged;
+        let tutorialCardContent = stepInfo.headerContentMd;
+        if (!hasHint && stepInfo.hintContentMd && options.inlineHints)
+            tutorialCardContent += "\n" + stepInfo.hintContentMd
+        const unplugged = stepInfo.unplugged;
 
         let tutorialAriaLabel = '',
             tutorialHintTooltip = '';

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -56,7 +56,7 @@ export class TutorialMenu extends data.Component<ISettingsProps, {}> {
         this.hasActivities = tutorialOptions && tutorialOptions.tutorialActivityInfo && tutorialOptions.tutorialActivityInfo.length > 1;
     }
 
-    renderCore () {
+    renderCore() {
         let tutorialOptions = this.props.parent.state.tutorialOptions;
         if (this.hasActivities) {
             return <TutorialStepCircle parent={this.props.parent} />;
@@ -155,12 +155,12 @@ export class TutorialStepCircle extends data.Component<ITutorialMenuProps, {}> {
 
     handleNextClick = () => {
         let options = this.props.parent.state.tutorialOptions;
-        this.openTutorialStep( options.tutorialStep + 1);
+        this.openTutorialStep(options.tutorialStep + 1);
     }
 
     handlePrevClick = () => {
         let options = this.props.parent.state.tutorialOptions;
-        this.openTutorialStep( options.tutorialStep - 1);
+        this.openTutorialStep(options.tutorialStep - 1);
     }
 
     openTutorialStep(step: number) {
@@ -387,7 +387,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             this.prevStep = step;
 
             // on "new step", sync tutorial card state. used when exiting the modal, since that bypasses the react lifecycle
-            this.setState({showHint: options.tutorialStepInfo[step].unplugged || options.tutorialStepInfo[step].fullscreen})
+            this.setState({ showHint: options.tutorialStepInfo[step].unplugged || options.tutorialStepInfo[step].fullscreen })
         }
     }
 
@@ -467,7 +467,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     getExpandedCardStyle(prop: string) {
-        return { [prop] : `calc(${this.getCardHeight()}px + 2rem)` }
+        return { [prop]: `calc(${this.getCardHeight()}px + 2rem)` }
     }
 
     toggleHint(showFullText?: boolean) {
@@ -677,8 +677,8 @@ export class WorkspaceHeader extends data.Component<any, {}> {
 
     renderCore() {
         return <div id="headers">
-                    <div id="flyoutHeader" style={this.headerStyle()}>{this.flyoutTitle}</div>
-                    <div id="workspaceHeader">{this.workspaceTitle}</div>
-               </div>;
+            <div id="flyoutHeader" style={this.headerStyle()}>{this.flyoutTitle}</div>
+            <div id="workspaceHeader">{this.workspaceTitle}</div>
+        </div>;
     }
 }


### PR DESCRIPTION
- [x] auto-detect preferred editor based on language of snippets
- [x] ~~always inline snippets for non-blocks programs (no hint)~~ use @expliticitHint in content
- [x] refactor code css
- [x] open py/ts tutorial in step-by-step mode if specified so
- [x] allow to override cardType in otherActions to specific side-docs
![2020-01-17 09 02 58](https://user-images.githubusercontent.com/4175913/72630919-39c5b000-3908-11ea-9267-0ef2153e03d4.gif)
