### PR TITLE
Dual tutorials

### DIFF
--- a/docs/writing-docs/tutorials.md
+++ b/docs/writing-docs/tutorials.md
@@ -405,7 +405,11 @@ player.onChat("blockleft", function () {
 
 ## Using Python
 
-If the target supports Python, snippets can be written directly in Python by using "python" after the triple tick like this:
+If the target supports Python, snippets can be written in JavaScript or Python directly.
+
+## Python snippets
+
+Using ``python`` after the triple tick like this:
 ````
 ```python
 for i in range(100):
@@ -413,7 +417,20 @@ for i in range(100):
 ```
 ````
 
-Note that if the target supports python then snippets written in the usuall way like:
+## Spy snippets (JavaScript to Python)
+
+Snippets can also be written in JavaScript and automatically converted to Python
+at display time. Use the ``spy`` section:
+
+````
+```spy
+basic.showString("Hello!")
+```
+````
+
+## Other languages
+
+Note that if the target supports python then snippets written in the usual way like:
 ````
 ```typescript
 basic.showString("Hello!")
@@ -424,6 +441,33 @@ basic.showString("Hello!")
 ```
 ````
 users will have the option of clicking the Python icon to see the snippet in Python just like they can with Blocks and Javascript/Typescript.
+
+## JavaScript and Python tutorial ("Spy tutorials")
+
+If you author tutorials using ``JavaScript`` or ``spy``, MakeCode is able to automatically
+render them in JavaScript or Python. Overriding the default language is done in the
+``tutorials.md`` page, in the cards section by specifying the ``editor`` field.
+
+If you are able to author your tutorial in a language agnostic way, 
+you will be able to have a single source for both JavaScript and Python.
+
+````
+```codecard
+[{
+    "name": "Chicken Rain",
+    ...
+    "otherActions": [{
+        "url": "/tutorials/spy/chicken-rain",
+        "editor": "py",
+        "cardType": "tutorial"
+    }, {
+        "url": "/tutorials/spy/chicken-rain",
+        "editor": "js",
+        "cardType": "tutorial"
+    }]
+}]
+```
+````
 
 ## Testing
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -287,7 +287,7 @@ namespace pxt.editor {
 
         editor: IEditor;
 
-        startTutorial(tutorialId: string, tutorialTitle?: string, recipe?: boolean): void;
+        startTutorial(tutorialId: string, tutorialTitle?: string, recipe?: boolean, editor?: string): void;
         showLightbox(): void;
         hideLightbox(): void;
         showKeymap(show: boolean): void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3081,12 +3081,12 @@ export class ProjectView
 
     private hintManager: HintManager = new HintManager();
 
-    startTutorial(tutorialId: string, tutorialTitle?: string, recipe?: boolean) {
-        pxt.tickEvent("tutorial.start");
-        this.startTutorialAsync(tutorialId, tutorialTitle, recipe);
+    startTutorial(tutorialId: string, tutorialTitle?: string, recipe?: boolean, editor?: string) {
+        pxt.tickEvent("tutorial.start", { editor });
+        this.startTutorialAsync(tutorialId, tutorialTitle, recipe, editor);
     }
 
-    startTutorialAsync(tutorialId: string, tutorialTitle?: string, recipe?: boolean): Promise<void> {
+    startTutorialAsync(tutorialId: string, tutorialTitle?: string, recipe?: boolean, editorHint?: string): Promise<void> {
         core.hideDialog();
         core.showLoading("tutorial", lf("starting tutorial..."));
         sounds.initTutorial(); // pre load sounds
@@ -3187,7 +3187,10 @@ export class ProjectView
             if (!md)
                 throw new Error(lf("Tutorial not found"));
 
-            const { options, editor } = pxt.tutorial.getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
+            const { options, editor: parsedEditor } = pxt.tutorial.getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
+
+            // pick tutorial editor
+            const editor = editorHint || parsedEditor;
 
             // start a tutorial within the context of an existing program
             if (recipe) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3086,7 +3086,7 @@ export class ProjectView
         this.startTutorialAsync(tutorialId, tutorialTitle, recipe, editor);
     }
 
-    startTutorialAsync(tutorialId: string, tutorialTitle?: string, recipe?: boolean, editorHint?: string): Promise<void> {
+    startTutorialAsync(tutorialId: string, tutorialTitle?: string, recipe?: boolean, editorProjectName?: string): Promise<void> {
         core.hideDialog();
         core.showLoading("tutorial", lf("starting tutorial..."));
         sounds.initTutorial(); // pre load sounds
@@ -3178,7 +3178,7 @@ export class ProjectView
             const { options, editor: parsedEditor } = pxt.tutorial.getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
 
             // pick tutorial editor
-            const editor = editorHint || parsedEditor;
+            const editor = editorProjectName || parsedEditor;
 
             // start a tutorial within the context of an existing program
             if (recipe) {
@@ -3203,10 +3203,10 @@ export class ProjectView
         function processMarkdown(md: string) {
             if (!md) return md;
 
-            if (editorHint == "js") { // spy => typescript
-                md = md.replace(/^```spy\b/gm, "```typescript");
-            } else if (editorHint == "py") { // typescript => spy
-                md = md.replace(/^```typescript\b/gm, "```spy");
+            if (editorProjectName == pxt.JAVASCRIPT_PROJECT_NAME) { // spy => typescript
+                md = md.replace(/^```(blocks|block|spy)\b/gm, "```typescript");
+            } else if (editorProjectName == pxt.PYTHON_PROJECT_NAME) { // typescript => spy
+                md = md.replace(/^```(blocks|block|typescript)\b/gm, "```spy");
             }
 
             pxt.Util.jsonMergeFrom(dependencies, pxt.gallery.parsePackagesFromMarkdown(md));

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -25,7 +25,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     name: "loops_for",
                     snippetName: "for",
                     snippet: `for(let i = 0; i < 5; i++) {\n\n}`,
-                    pySnippet: `for i in range(0, 4):\n  pass`,
+                    pySnippet: `for i in range(4):\n  pass`,
                     attributes: {
                         blockId: 'pxt_controls_for',
                         weight: 47,

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -100,10 +100,11 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     }
 
     chgGallery(scr: pxt.CodeCard, action?: pxt.CodeCardAction) {
-        pxt.tickEvent("projects.gallery", { name: scr.name });
-        let url = action ? action.url : scr.url;
-        let editor = action ? action.editor : "blocks";
-        let editorPref = editor + "prj";
+        let editor: string = (action && action.editor) || "blocks";
+        if (editor == "js") editor = "ts";
+        pxt.tickEvent("projects.gallery", { name: scr.name, cardType: scr.cardType, editor });
+        const url = action ? action.url : scr.url;
+        const editorPref = editor + "prj";
         switch (scr.cardType) {
             case "template":
                 const prj = pxt.Util.clone(pxt.appTarget.blocksprj);
@@ -115,7 +116,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 this.props.parent.newEmptyProject(scr.name, url);
                 break;
             case "tutorial":
-                this.props.parent.startTutorial(url, scr.name);
+                this.props.parent.startTutorial(url, scr.name, false, editorPref);
                 break;
             default:
                 const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(url); // Tutorial


### PR DESCRIPTION
Support for loading tutorials in typescript or python. The approach is simple: if the preferred editor is speficied, regex/replace "```spy" into "```typescript" and vice-versa; then push through tutorial engine.

Allows to use same markdown in python or javascript.

Note: Direct python tutorials not supported for this feature.
