### PR TITLE
Fix while loops py decompile (missing colon regression)

### DIFF
--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -339,7 +339,7 @@ namespace pxt.py {
         function emitWhileStmt(s: ts.WhileStatement): string[] {
             let [cond, condSup] = emitExp(s.expression)
             let body = emitBody(s.statement)
-            let whileStmt = expWrap("while ", cond);
+            let whileStmt = expWrap("while ", cond, ":");
             return condSup.concat(whileStmt).concat(body)
         }
         type RangeItr = {

--- a/tests/runtime-trace-tests/cases/while_loop.ts
+++ b/tests/runtime-trace-tests/cases/while_loop.ts
@@ -1,0 +1,4 @@
+while (true) {
+    console.log("hi")
+    break
+}


### PR DESCRIPTION
Accidental regression from: https://github.com/microsoft/pxt/pull/6426/files
I checked for other regressions but didn't see any. Might be worth another look @shakao 