### PR TITLE
add string.replace and string.replaceAll

### DIFF
--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -260,6 +260,16 @@ declare interface String {
     replace(toReplace: string, replacer: string | ((sub: string) => string)): string;
 
     /**
+     * Return the current string with each occurence of toReplace
+     * replaced with the replacer
+     * @param toReplace the substring to replace in the current string
+     * @param replacer either the string that replaces toReplace in the current string,
+     *                or a function that accepts the substring and returns the replacement string.
+     */
+    //% helper=stringReplaceAll
+    replaceAll(toReplace: string, replacer: string | ((sub: string) => string)): string;
+
+    /**
      * Return a substring of the current string.
      * @param start first character index; can be negative from counting from the end, eg:0
      * @param end one-past-last character index

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -82,7 +82,7 @@ interface Array<T> {
       */
     //% helper=arrayJoin weight=40
     join(sep?: string): string;
-    
+
     /**
       * Tests whether at least one element in the array passes the test implemented by the provided function.
       * @param callbackfn A function that accepts up to two arguments. The some method calls the callbackfn function one time for each element in the array.
@@ -96,7 +96,7 @@ interface Array<T> {
       */
     //% helper=arrayEvery weight=40
     every(callbackfn: (value: T, index: number) => boolean): boolean;
-    
+
     /**
       * Sort the elements of an array in place and returns the array. The sort is not necessarily stable.
       * @param specifies a function that defines the sort order. If omitted, the array is sorted according to the prmitive type
@@ -117,7 +117,7 @@ interface Array<T> {
       */
     //% helper=arrayForEach weight=40
     forEach(callbackfn: (value: T, index: number) => void): void;
-    
+
     /**
       * Return the elements of an array that meet the condition specified in a callback function.
       * @param callbackfn A function that accepts up to two arguments. The filter method calls the callbackfn function one time for each element in the array.
@@ -130,10 +130,10 @@ interface Array<T> {
       */
     //% helper=arrayFill weight=39
     fill(value: T, start?: number, end?: number): T[];
-    
+
     /**
      * Returns the value of the first element in the array that satisfies the provided testing function. Otherwise undefined is returned.
-     * @param callbackfn 
+     * @param callbackfn
      */
     //% helper=arrayFind weight=40
     find(callbackfn: (value: T, index: number) => boolean): T;
@@ -250,6 +250,16 @@ declare interface String {
     substr(start: number, length?: number): string;
 
     /**
+     * Return the current string with the first occurence of toReplace
+     * replaced with the replacer
+     * @param toReplace the substring to replace in the current string
+     * @param replacer either the string that replaces toReplace in the current string,
+     *                or a function that accepts the substring and returns the replacement string.
+     */
+    //% helper=stringReplace
+    replace(toReplace: string, replacer: string | ((sub: string) => string)): string;
+
+    /**
      * Return a substring of the current string.
      * @param start first character index; can be negative from counting from the end, eg:0
      * @param end one-past-last character index
@@ -287,8 +297,8 @@ declare interface String {
 
     /**
      * Splits the string according to the separators
-     * @param separator 
-     * @param limit 
+     * @param separator
+     * @param limit
      */
     //% helper=stringSplit
     //% help=text/split

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -265,6 +265,7 @@ namespace helpers {
     }
 
     export function stringReplace(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        toReplace = toReplace + "";
         const ind = s.indexOf(toReplace);
         if (ind == -1)
             return s;
@@ -272,7 +273,7 @@ namespace helpers {
         const begin = s.slice(0, ind);
         const end = s.slice(ind + toReplace.length);
 
-        if (typeof replacer == "string") {
+        if (typeof replacer == "string" || !replacer) {
             return begin + replacer + end;
         } else {
             return begin + replacer(toReplace) + end;
@@ -280,6 +281,7 @@ namespace helpers {
     }
 
     export function stringReplaceAll(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        toReplace = toReplace + "";
         const split = s.split(toReplace);
         const empty = toReplace.isEmpty();
 
@@ -296,8 +298,8 @@ namespace helpers {
         return output;
 
         function applyReplace(r: string, replacer: string | ((sub: string) => string)) {
-            if (typeof replacer == "string") {
-                return r;
+            if (typeof replacer == "string" || !replacer) {
+                return replacer;
             } else {
                 return replacer(r);
             }

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -264,6 +264,21 @@ namespace helpers {
         return res;
     }
 
+    export function stringReplace(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        const ind = s.indexOf(toReplace);
+        if (ind == -1)
+            return s;
+
+        const begin = s.slice(0, ind);
+        const end = s.slice(ind + toReplace.length);
+
+        if (typeof replacer == "string") {
+            return begin + replacer + end;
+        } else {
+            return begin + replacer(toReplace) + end;
+        }
+    }
+
     export function stringSlice(s: string, start: number, end?: number): string {
         const len = s.length;
 
@@ -562,7 +577,7 @@ namespace __internal {
     //% blockId=protractorPicker block="%angle"
     //% shim=TD_ID
     //% angle.fieldEditor=protractor
-    //% angle.fieldOptions.decompileLiterals=1    
+    //% angle.fieldOptions.decompileLiterals=1
     //% colorSecondary="#FFFFFF"
     //% blockHidden=1
     export function __protractor(angle: number) {

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -281,18 +281,29 @@ namespace helpers {
 
     export function stringReplaceAll(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
         const split = s.split(toReplace);
-        let output = split[0];
+        const empty = toReplace.isEmpty();
+
+        let output = (empty ? applyReplace(toReplace, replacer) : "") + split[0];
 
         for (let i = 1; i < split.length; ++i) {
-            if (typeof replacer == "string") {
-                output += replacer + split[i];
-            } else {
-                output += replacer(toReplace) + split[i];
-            }
+            output += applyReplace(toReplace, replacer) + split[i];
+        }
+
+        if (empty) {
+            output += applyReplace(toReplace, replacer);
         }
 
         return output;
+
+        function applyReplace(r: string, replacer: string | ((sub: string) => string)) {
+            if (typeof replacer == "string") {
+                return r;
+            } else {
+                return replacer(r);
+            }
+        }
     }
+
 
     export function stringSlice(s: string, start: number, end?: number): string {
         const len = s.length;

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -285,21 +285,25 @@ namespace helpers {
         const split = s.split(toReplace);
         const empty = toReplace.isEmpty();
 
-        let output = (empty ? applyReplace(toReplace, replacer) : "") + split[0];
+        let output = (empty ? applyReplace(toReplace, replacer) : "");
+
+        if (split.length) {
+            output += split[0];
+        }
 
         for (let i = 1; i < split.length; ++i) {
             output += applyReplace(toReplace, replacer) + split[i];
         }
 
-        if (empty) {
+        if (!s.isEmpty() && empty) {
             output += applyReplace(toReplace, replacer);
         }
 
         return output;
 
-        function applyReplace(r: string, replacer: string | ((sub: string) => string)) {
+        function applyReplace(r: string, replacer: string | ((sub: string) => string)): string {
             if (typeof replacer == "string" || !replacer) {
-                return replacer;
+                return replacer as string;
             } else {
                 return replacer(r);
             }

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -279,6 +279,21 @@ namespace helpers {
         }
     }
 
+    export function stringReplaceAll(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        const split = s.split(toReplace);
+        let output = split[0];
+
+        for (let i = 1; i < split.length; ++i) {
+            if (typeof replacer == "string") {
+                output += replacer + split[i];
+            } else {
+                output += replacer(toReplace) + split[i];
+            }
+        }
+
+        return output;
+    }
+
     export function stringSlice(s: string, start: number, end?: number): string {
         const len = s.length;
 

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -260,6 +260,16 @@ declare interface String {
     replace(toReplace: string, replacer: string | ((sub: string) => string)): string;
 
     /**
+     * Return the current string with each occurence of toReplace
+     * replaced with the replacer
+     * @param toReplace the substring to replace in the current string
+     * @param replacer either the string that replaces toReplace in the current string,
+     *                or a function that accepts the substring and returns the replacement string.
+     */
+    //% helper=stringReplaceAll
+    replaceAll(toReplace: string, replacer: string | ((sub: string) => string)): string;
+
+    /**
      * Return a substring of the current string.
      * @param start first character index; can be negative from counting from the end, eg:0
      * @param end one-past-last character index

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -82,7 +82,7 @@ interface Array<T> {
       */
     //% helper=arrayJoin weight=40
     join(sep?: string): string;
-    
+
     /**
       * Tests whether at least one element in the array passes the test implemented by the provided function.
       * @param callbackfn A function that accepts up to two arguments. The some method calls the callbackfn function one time for each element in the array.
@@ -96,7 +96,7 @@ interface Array<T> {
       */
     //% helper=arrayEvery weight=40
     every(callbackfn: (value: T, index: number) => boolean): boolean;
-    
+
     /**
       * Sort the elements of an array in place and returns the array. The sort is not necessarily stable.
       * @param specifies a function that defines the sort order. If omitted, the array is sorted according to the prmitive type
@@ -117,7 +117,7 @@ interface Array<T> {
       */
     //% helper=arrayForEach weight=40
     forEach(callbackfn: (value: T, index: number) => void): void;
-    
+
     /**
       * Return the elements of an array that meet the condition specified in a callback function.
       * @param callbackfn A function that accepts up to two arguments. The filter method calls the callbackfn function one time for each element in the array.
@@ -130,10 +130,10 @@ interface Array<T> {
       */
     //% helper=arrayFill weight=39
     fill(value: T, start?: number, end?: number): T[];
-    
+
     /**
      * Returns the value of the first element in the array that satisfies the provided testing function. Otherwise undefined is returned.
-     * @param callbackfn 
+     * @param callbackfn
      */
     //% helper=arrayFind weight=40
     find(callbackfn: (value: T, index: number) => boolean): T;
@@ -250,6 +250,16 @@ declare interface String {
     substr(start: number, length?: number): string;
 
     /**
+     * Return the current string with the first occurence of toReplace
+     * replaced with the replacer
+     * @param toReplace the substring to replace in the current string
+     * @param replacer either the string that replaces toReplace in the current string,
+     *                or a function that accepts the substring and returns the replacement string.
+     */
+    //% helper=stringReplace
+    replace(toReplace: string, replacer: string | ((sub: string) => string)): string;
+
+    /**
      * Return a substring of the current string.
      * @param start first character index; can be negative from counting from the end, eg:0
      * @param end one-past-last character index
@@ -287,8 +297,8 @@ declare interface String {
 
     /**
      * Splits the string according to the separators
-     * @param separator 
-     * @param limit 
+     * @param separator
+     * @param limit
      */
     //% helper=stringSplit
     //% help=text/split

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -265,6 +265,7 @@ namespace helpers {
     }
 
     export function stringReplace(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        toReplace = toReplace + "";
         const ind = s.indexOf(toReplace);
         if (ind == -1)
             return s;
@@ -272,7 +273,7 @@ namespace helpers {
         const begin = s.slice(0, ind);
         const end = s.slice(ind + toReplace.length);
 
-        if (typeof replacer == "string") {
+        if (typeof replacer == "string" || !replacer) {
             return begin + replacer + end;
         } else {
             return begin + replacer(toReplace) + end;
@@ -280,6 +281,7 @@ namespace helpers {
     }
 
     export function stringReplaceAll(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        toReplace = toReplace + "";
         const split = s.split(toReplace);
         const empty = toReplace.isEmpty();
 
@@ -296,8 +298,8 @@ namespace helpers {
         return output;
 
         function applyReplace(r: string, replacer: string | ((sub: string) => string)) {
-            if (typeof replacer == "string") {
-                return r;
+            if (typeof replacer == "string" || !replacer) {
+                return replacer;
             } else {
                 return replacer(r);
             }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -264,6 +264,21 @@ namespace helpers {
         return res;
     }
 
+    export function stringReplace(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        const ind = s.indexOf(toReplace);
+        if (ind == -1)
+            return s;
+
+        const begin = s.slice(0, ind);
+        const end = s.slice(ind + toReplace.length);
+
+        if (typeof replacer == "string") {
+            return begin + replacer + end;
+        } else {
+            return begin + replacer(toReplace) + end;
+        }
+    }
+
     export function stringSlice(s: string, start: number, end?: number): string {
         const len = s.length;
 
@@ -562,7 +577,7 @@ namespace __internal {
     //% blockId=protractorPicker block="%angle"
     //% shim=TD_ID
     //% angle.fieldEditor=protractor
-    //% angle.fieldOptions.decompileLiterals=1    
+    //% angle.fieldOptions.decompileLiterals=1
     //% colorSecondary="#FFFFFF"
     //% blockHidden=1
     export function __protractor(angle: number) {

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -281,18 +281,29 @@ namespace helpers {
 
     export function stringReplaceAll(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
         const split = s.split(toReplace);
-        let output = split[0];
+        const empty = toReplace.isEmpty();
+
+        let output = (empty ? applyReplace(toReplace, replacer) : "") + split[0];
 
         for (let i = 1; i < split.length; ++i) {
-            if (typeof replacer == "string") {
-                output += replacer + split[i];
-            } else {
-                output += replacer(toReplace) + split[i];
-            }
+            output += applyReplace(toReplace, replacer) + split[i];
+        }
+
+        if (empty) {
+            output += applyReplace(toReplace, replacer);
         }
 
         return output;
+
+        function applyReplace(r: string, replacer: string | ((sub: string) => string)) {
+            if (typeof replacer == "string") {
+                return r;
+            } else {
+                return replacer(r);
+            }
+        }
     }
+
 
     export function stringSlice(s: string, start: number, end?: number): string {
         const len = s.length;

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -285,21 +285,25 @@ namespace helpers {
         const split = s.split(toReplace);
         const empty = toReplace.isEmpty();
 
-        let output = (empty ? applyReplace(toReplace, replacer) : "") + split[0];
+        let output = (empty ? applyReplace(toReplace, replacer) : "");
+
+        if (split.length) {
+            output += split[0];
+        }
 
         for (let i = 1; i < split.length; ++i) {
             output += applyReplace(toReplace, replacer) + split[i];
         }
 
-        if (empty) {
+        if (!s.isEmpty() && empty) {
             output += applyReplace(toReplace, replacer);
         }
 
         return output;
 
-        function applyReplace(r: string, replacer: string | ((sub: string) => string)) {
+        function applyReplace(r: string, replacer: string | ((sub: string) => string)): string {
             if (typeof replacer == "string" || !replacer) {
-                return replacer;
+                return replacer as string;
             } else {
                 return replacer(r);
             }

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -279,6 +279,21 @@ namespace helpers {
         }
     }
 
+    export function stringReplaceAll(s: string, toReplace: string, replacer: string | ((sub: string) => string)) {
+        const split = s.split(toReplace);
+        let output = split[0];
+
+        for (let i = 1; i < split.length; ++i) {
+            if (typeof replacer == "string") {
+                output += replacer + split[i];
+            } else {
+                output += replacer(toReplace) + split[i];
+            }
+        }
+
+        return output;
+    }
+
     export function stringSlice(s: string, start: number, end?: number): string {
         const len = s.length;
 


### PR DESCRIPTION
noticed we didn't have string.replace in https://github.com/microsoft/pxt-common-packages/pull/1062

`string.prototype.replaceAll` isn't technically part of es yet, but it's stage 3: https://github.com/tc39/proposal-string-replaceall . It's extremely useful for us, though, as we can't use regexes to make string.replace useful for many of the cases you want to use it (as it only replaces the first instance of the input str, unless the input value to replace is a regex with the 'g' flag) -- from the discussions linked on the repo it looks like the main reason it wasn't advanced to stage 4 / accepted was a disagreement on the expected behavior when it was passed a regex without the 'g' flag, and that's been decided on the repo

I ran into a TON of issues with file caching on this PR, seems like it doesn't pick up changes in nested dependencies / .d.ts files or something. I had to `pxt clean` each time I changed any of the files for things to update (and because of that I lost the long list of sample tests I wrote up due to https://github.com/microsoft/pxt/issues/5900 :( )