### PR TITLE
auto-populate other actions

### DIFF
--- a/docs/writing-docs/tutorials.md
+++ b/docs/writing-docs/tutorials.md
@@ -455,6 +455,8 @@ you will be able to have a single source for both JavaScript and Python.
 ```codecard
 [{
     "name": "Chicken Rain",
+    "cardType": "tutorial",
+    "url": "/tutorials/spy/chicken-rain",
     ...
     "otherActions": [{
         "url": "/tutorials/spy/chicken-rain",
@@ -468,6 +470,21 @@ you will be able to have a single source for both JavaScript and Python.
 }]
 ```
 ````
+
+Leave ``otherActions`` empty, to automatically populate it.
+
+````
+```codecard
+[{
+    "name": "Chicken Rain",
+    "cardType": "tutorial",
+    "url": "/tutorials/spy/chicken-rain",
+    ...
+    "otherActions": []
+}]
+```
+````
+
 
 ## Testing
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -88,6 +88,17 @@ namespace pxt.gallery {
             } else if (incard)
                 cards += line + '\n';
         })
+        // apply transformations
+        galleries.forEach(gallery => gallery.cards.forEach(card => {
+            if (card.cardType == "tutorial" && card.otherActions && !card.otherActions.length) {
+                card.otherActions = ["py", "js"].map((editor: CodeCardEditorType) => ({
+                        url: card.url,
+                        cardType: "tutorial",
+                        editor
+                }));
+            }
+        }))
+
         return galleries;
     }
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -90,12 +90,13 @@ namespace pxt.gallery {
         })
         // apply transformations
         galleries.forEach(gallery => gallery.cards.forEach(card => {
-            if (card.cardType == "tutorial" && card.otherActions && !card.otherActions.length) {
+            if (card.otherActions && !card.otherActions.length
+                && (card.cardType == "tutorial" || card.cardType == "example")) {
                 const editors = ["js"];
                 if (pxt.appTarget.appTheme.python) editors.unshift("py");
                 card.otherActions = editors.map((editor: CodeCardEditorType) => (<CodeCardAction>{
                     url: card.url,
-                    cardType: "tutorial",
+                    cardType: card.cardType,
                     editor
                 }));
             }

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -94,9 +94,9 @@ namespace pxt.gallery {
                 const editors = ["js"];
                 if (pxt.appTarget.appTheme.python) editors.unshift("py");
                 card.otherActions = ["py", "js"].map((editor: CodeCardEditorType) => ({
-                        url: card.url,
-                        cardType: "tutorial",
-                        editor
+                    url: card.url,
+                    cardType: "tutorial",
+                    editor
                 }));
             }
         }))

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -93,7 +93,7 @@ namespace pxt.gallery {
             if (card.cardType == "tutorial" && card.otherActions && !card.otherActions.length) {
                 const editors = ["js"];
                 if (pxt.appTarget.appTheme.python) editors.unshift("py");
-                card.otherActions = ["py", "js"].map((editor: CodeCardEditorType) => ({
+                card.otherActions = editors.map((editor: CodeCardEditorType) => (<CodeCardAction>{
                     url: card.url,
                     cardType: "tutorial",
                     editor

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -91,6 +91,8 @@ namespace pxt.gallery {
         // apply transformations
         galleries.forEach(gallery => gallery.cards.forEach(card => {
             if (card.cardType == "tutorial" && card.otherActions && !card.otherActions.length) {
+                const editors = ["js"];
+                if (pxt.appTarget.appTheme.python) editors.unshift("py");
                 card.otherActions = ["py", "js"].map((editor: CodeCardEditorType) => ({
                         url: card.url,
                         cardType: "tutorial",


### PR DESCRIPTION
Short hand to auto-populate otherActions: empty array means populate otherActions as best as can.

Allows to avoid copy-pasting tons of markdown and URL path errors.

This currently applies to tutorials only but next step will be support for auto multi-editor examples. See https://github.com/microsoft/pxt-maker/pull/276