### PR TITLE
CSS updates for details view cards

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -333,7 +333,25 @@
                 background-color: @HCbackground;
             }
             .header {
-                color: @HCbackground;
+                color: @HCtextColor;
+            }
+            .ui.grid {
+                background-color: @HChomeScreenBackground;
+                border-width: 2px 0;
+                border-color: @HCtextColor;
+                border-style: solid;
+            }
+            .actions {
+                .card-action {
+                    border: 2px solid @HCtextColor;
+                    .button.attached i {
+                        opacity: 1;
+                        color: @HCtextColor;
+                    }
+                }
+                .card-action-title {
+                    color: @HCtextColor;
+                }
             }
         }
     }

--- a/theme/home.less
+++ b/theme/home.less
@@ -246,6 +246,7 @@
                 }
 
                 .button.approve {
+                    width: 100%;
                     color: @homeCardHeaderColor;
                     background-color: @orange;
                     transition-duration: 0s;
@@ -418,6 +419,26 @@
     right: 0rem;
 }
 
+/* Inverted */
+.inverted-theme {
+    .projectsdialog .detailview .actions {
+        height: 9rem;
+        .card-action {
+            > .item, > .icon {
+                background: @homeInvertedDetailCardActionBackground;
+            }
+
+            .button.approve {
+                color: @invertedLightTextColor;
+            }
+
+            i.xicon {
+                filter: invert(1);
+            }
+        }
+    }
+}
+
 /* <= Tablet (Mobile + Tablet) */
 
 @media only screen and (max-width: @largestTabletScreen) {
@@ -500,6 +521,12 @@
             }
             .ui.header {
                 padding-left: @carouselArrowSizeMobile;
+            }
+        }
+        .carouselitem.selected {
+            .ui.card {
+                margin-top: -8px;
+                border-width: 5px!important;
             }
         }
     }

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -311,6 +311,7 @@ default semantic
 @homeDetailCloseColor: white;
 @homeDetailCloseBackground: @grey;
 @homeDetailCardActionBackground: darken(@homeDetailViewBackground, 10%);
+@homeInvertedDetailCardActionBackground: lighten(@homeScreenBackground, 10%);
 
 /*-------------------
    Tutorial

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -161,8 +161,10 @@ a.ui.card:focus,
 .setExampleCardFullHeight() when (@exampleCardFullHeight) {
     .projectsdialog {
         .ui.card.example {
-            .ui.image, .ui.cardimage {
-                height: 12rem !important;
+            height: 12rem;
+
+            .ui.image, .ui.imagewrapper, .ui.cardimage {
+                height: 100% !important;
             }
             .ui.image ~ .content {
                 background: @exampleCardFullHeightBackground;
@@ -178,6 +180,8 @@ a.ui.card:focus,
     @media only screen and (max-width: @largestMobileScreen) {
         .projectsdialog {
             .ui.card.example {
+                height: 9rem;
+
                 .ui.image, .ui.cardimage {
                     height: 8.4rem !important;
                 }


### PR DESCRIPTION
Fixes:
- High contrast details banner
- Dark theme details banner
- Preview card should not overlap details banner (Chrome on Mac)
- Green action button sizing for shorter text

high contrast:
![image](https://user-images.githubusercontent.com/34112083/72843216-eb3d4c00-3c4e-11ea-9b08-09d8d9ef49f9.png)

dark theme:
![image](https://user-images.githubusercontent.com/34112083/72843225-f1332d00-3c4e-11ea-884a-e40a17ab6ce8.png)

Fixes https://github.com/microsoft/pxt-minecraft/issues/1607
Fixes https://github.com/microsoft/pxt-minecraft/issues/1620
Fixes https://github.com/microsoft/pxt-minecraft/issues/1619
Fixes https://github.com/microsoft/pxt-arcade/issues/1712