### PR TITLE
Tutorial CSS and modal fixes

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -409,6 +409,12 @@ code.lang-filterblocks {
     }
 }
 
+.editorlang-text {
+    #tutorialcard.seemore .tutorialsegment > button {
+        margin-right: 1rem;
+    }
+}
+
 /*******************************
       Tutorial Activity UI
 *******************************/

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -543,7 +543,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                         <div role="button" className={`avatar-image ${hasHint && this.props.pokeUser ? 'shake' : ''}`} onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter}></div>
                         {hasHint && <sui.Button className="ui circular small label blue hintbutton hidelightbox" icon="lightbulb outline" tabIndex={-1} onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter} />}
                         {hasHint && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={hintOnClick} />}
-                        {hasHint && <TutorialHint ref="tutorialhint" parent={this.props.parent} />}
+                        <TutorialHint ref="tutorialhint" parent={this.props.parent} />
                     </div>
                     <div ref="tutorialmessage" className={`tutorialmessage`} role="alert" aria-label={tutorialAriaLabel} tabIndex={hasHint ? 0 : -1}
                         onClick={hasHint ? hintOnClick : undefined} onKeyDown={hasHint ? sui.fireClickOnEnter : undefined}>


### PR DESCRIPTION
- Keep tutorial hint in DOM
- Shift "see more" button to right for text-based tutorials

Fixes https://github.com/microsoft/pxt-minecraft/issues/1648