### PR TITLE
Support for multi-language examples

### DIFF
--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -7,6 +7,8 @@ namespace pxt.gallery {
 
     export interface GalleryProject {
         name: string;
+        snippetType: string;
+        source: string;
         filesOverride: pxt.Map<string>;
         dependencies: pxt.Map<string>;
         features?: string[];
@@ -39,21 +41,25 @@ namespace pxt.gallery {
     export function parseExampleMarkdown(name: string, md: string): GalleryProject {
         if (!md) return undefined;
 
-        const m = /```(blocks?|typescript|python)\s+((.|\s)+?)\s*```/i.exec(md);
+        const m = /```(blocks?|typescript|python|spy)\s+((.|\s)+?)\s*```/i.exec(md);
         if (!m) return undefined;
 
         const dependencies = parsePackagesFromMarkdown(md);
-        let src = m[2];
+        const snippetType = m[1];
+        const source = m[2];
         const features = parseFeaturesFromMarkdown(md);
-        return {
+        const prj = {
             name,
             filesOverride: {
                 "main.blocks": `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>`,
-                [m[1] === "python" ? "main.py" : "main.ts"]: src
+                [m[1] === "python" ? "main.py" : "main.ts"]: source
             },
             dependencies,
-            features
+            features,
+            snippetType,
+            source
         };
+        return prj;
     }
 
     export function parseGalleryMardown(md: string): Gallery[] {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1599,7 +1599,7 @@ export class ProjectView
             });
         }
         catch (e) {
-            Util.userError("Could not import tutorial");
+            Util.userError(lf("Could not import tutorial"));
             return Promise.reject(e);
         }
     }
@@ -2055,7 +2055,20 @@ export class ProjectView
                     opts.tsOnly = !loadBlocks;
                     opts.preferredEditor = preferredEditor;
                     return this.createProjectAsync(opts)
-                        .then(() => Promise.delay(500));
+                        .then(() => {
+                            // convert js to py as needed
+                            if (preferredEditor == pxt.PYTHON_PROJECT_NAME && example.snippetType !== "python") {
+                                return compiler.getApisInfoAsync() // ensure compiled
+                                    .then(() => compiler.pyDecompileAsync("main.ts"))
+                                    .then(resp => {
+                                        pxt.debug(`example decompilation: ${resp.success}`)
+                                        if (resp.success) {
+                                            this.overrideTypescriptFile(resp.outfiles["main.py"])
+                                        }
+                                    })
+                            }
+                            return Promise.resolve();
+                        })
                 }
             })
             .then(() => this.autoChooseBoardAsync(features))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2038,7 +2038,7 @@ export class ProjectView
                 const opts: pxt.editor.ProjectCreationOptions = example;
                 if (prj) opts.prj = prj;
                 features = example.features;
-                if (loadBlocks && preferredEditor == "blocksprj") {
+                if (loadBlocks && preferredEditor == pxt.BLOCKS_PROJECT_NAME) {
                     return this.createProjectAsync(opts)
                         .then(() => {
                             return this.loadBlocklyAsync()


### PR DESCRIPTION
Ability to load an example in Blocks/TS/Python from the same markdown.