### PR TITLE
add block ids before exporting to github

### DIFF
--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1079,7 +1079,7 @@ class ReleaseZone extends sui.StatelessUIElement<GitHubViewProps> {
                     <sui.Link className="basic button"
                         href={pages.html_url}
                         loading={pagesBuilding}
-                        text={lf("Open Pages")} 
+                        text={lf("Open Pages")}
                         target="_blank" />
                     <span className="inline-help">
                         {pagesBuilding ? lf("Pages building, it may take a few minutes.")

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1079,7 +1079,8 @@ class ReleaseZone extends sui.StatelessUIElement<GitHubViewProps> {
                     <sui.Link className="basic button"
                         href={pages.html_url}
                         loading={pagesBuilding}
-                        text={lf("Open Pages")} />
+                        text={lf("Open Pages")} 
+                        target="_blank" />
                     <span className="inline-help">
                         {pagesBuilding ? lf("Pages building, it may take a few minutes.")
                             : compiledJs ? lf("Commit & create release to update Pages.")

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -845,6 +845,18 @@ export async function exportToGithubAsync(hd: Header, repoid: string) {
         repo: repoid,
         commit
     })
+
+    // assign ids to blockly blocks
+    const mainBlocks = files["main.blocks"];
+    if (mainBlocks) {
+        const ws = pxt.blocks.loadWorkspaceXml(mainBlocks, true);
+        if (ws) {
+            const mainBlocksWithIds = pxt.blocks.saveWorkspaceXml(ws, true);
+            if (mainBlocksWithIds)
+                files["main.blocks"] = mainBlocksWithIds;
+        }
+    }
+    // save updated files
     await saveAsync(hd, files);
     await initializeGithubRepoAsync(hd, repoid, false, true);
     // race condition, don't pull right away


### PR DESCRIPTION
To avoid the first empty commit, add block ids as we are exporting to github.