### PR TITLE
render video or large image if available

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -370,6 +370,7 @@ declare namespace pxt {
         githubEditor?: boolean; // allow editing github repositories from the editor
         githubCompiledJs?: boolean; // commit binary.js in commit when creating a github release,
         blocksCollapsing?: boolean; // collapse/uncollapse functions/event in blocks
+        hideHomeDetailsVideo?: boolean; // hide video/large image from details card
     }
 
     interface SocialOptions {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -852,8 +852,9 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         const tagColors: pxt.Map<string> = pxt.appTarget.appTheme.tagColors || {};
         const descriptions = description && description.split("\n");
-        const image = largeImageUrl || imageUrl || (youTubeId && `https://img.youtube.com/vi/${youTubeId}/0.jpg`);
+        const image = largeImageUrl || (youTubeId && `https://img.youtube.com/vi/${youTubeId}/0.jpg`);
         const video = !pxt.BrowserUtils.isElectron() && videoUrl;
+        const showVideoOrImage = !pxt.appTarget.appTheme.hideHomeDetailsVideo;
 
         let clickLabel: string;
         if (buttonLabel)
@@ -862,7 +863,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             clickLabel = this.getClickLabel(cardType);
 
         return <div className="ui grid stackable padded">
-            {false && (video || image) && <div className="imagewrapper">
+            {showVideoOrImage && (video || image) && <div className="imagewrapper">
                 {video ? <video className="video" src={video} autoPlay={true} controls={false} loop={true} playsInline={true} />
                     : <div className="image" style={{ backgroundImage: `url("${image}")` }} />}
             </div>}


### PR DESCRIPTION
Reenable rendering background videos/large image on details page + flag to disable this behavior. Note that the "imageUrl" data is not used anymore so a user can decide to hide the video/image by simply not populating the largeImageUrl/videoUrl flags. IMO, this is a more flexible setting and allows content author to control the video inclusion behavior.