### PR TITLE
display beta editor card

### DIFF
--- a/docs/targets/pxtarget.md
+++ b/docs/targets/pxtarget.md
@@ -140,7 +140,6 @@ Here is the appTheme from pxt-sample with some comments:
         "homeUrl": "https://microsoft.github.io/pxt-sample/",
         "privacyUrl": "https://go.microsoft.com/fwlink/?LinkId=521839",
         "termsOfUseUrl": "https://go.microsoft.com/fwlink/?LinkID=206977",
-        "betaUrl": "https://makecode.com/",
         // populating the (?) menu
         "docMenu": [
             {

--- a/docs/targets/theming.md
+++ b/docs/targets/theming.md
@@ -73,7 +73,6 @@ interface AppTheme {
         homeUrl?: string;
         shareUrl?: string;
         embedUrl?: string;
-        betaUrl?: string;   // beta tag and URL
         privacyUrl?: string;
         termsOfUseUrl?: string;
         contactUrl?: string;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -238,7 +238,7 @@ declare namespace pxt {
         homeUrl?: string;
         shareUrl?: string;
         embedUrl?: string;
-        betaUrl?: string;
+        // betaUrl?: string; deprecated, beta button automatically shows up in experiments dialog
         docMenu?: DocMenuEntry[];
         TOC?: TOCMenuEntry[];
         hideSideDocs?: boolean;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -520,7 +520,6 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                         {portraitLogo ? (<img className={`ui ${portraitLogoSize} image portrait only`} src={portraitLogo} alt={lf("{0} Logo", targetTheme.boardName)} />) : null}
                     </a>
                 }
-                {(!lockedEditor && targetTheme.betaUrl) && <a href={`${targetTheme.betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta")}</a>}
                 {!inTutorial && homeEnabled ? <sui.Item className="icon openproject" role="menuitem" textClass="landscape only" icon="home large" ariaLabel={lf("Home screen")} text={lf("Home")} onClick={this.goHome} /> : null}
                 {showShare ? <sui.Item className="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project")} text={lf("Share")} icon="share alternate large" onClick={this.showShareDialog} /> : null}
                 {inTutorial && <sui.Item className="tutorialname" tabIndex={-1} textClass="landscape only" text={tutorialOptions.tutorialName} />}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -379,7 +379,6 @@ export class ProjectsMenu extends data.Component<ISettingsProps, {}> {
                     {targetTheme.organizationLogo ? (<img className='ui mini image portrait only' src={targetTheme.organizationLogo} alt={lf("{0} Logo", targetTheme.organization)} />) : null}
                 </a>
             </div>
-            {targetTheme.betaUrl ? <a href={`${targetTheme.betaUrl}`} className="ui red mini corner top left attached label betalabel" role="menuitem">{lf("Beta")}</a> : undefined}
         </div>;
     }
 }

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -359,7 +359,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             && !searchFor;
         // inject beta at end of / or /#
         // also excludes http://localhost:port/index.html
-        const betaUrl = window.location.href.replace(/\/(#|$)/, "/beta$1")
+        const betaUrl = window.location.href.replace(/\/(#|$|\?)/, "/beta$1")
         const showOpenBeta = mode == ScriptSearchMode.Experiments
             && betaUrl != window.location.href; // don't show beta button in beta
 

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -9,7 +9,6 @@ import * as core from "./core";
 import * as codecard from "./codecard";
 import * as electron from "./electron";
 import * as workspace from "./workspace";
-import * as dialogs from "./dialogs";
 import { SearchInput } from "./components/searchInput";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
@@ -358,8 +357,11 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             && pxt.appTarget.appTheme.importExtensionFiles
             && !disableFileAccessinMaciOs
             && !searchFor;
+        // inject beta at end of / or /#
+        // also excludes http://localhost:port/index.html
+        const betaUrl = window.location.href.replace(/\/(#|$)/, "/beta$1")
         const showOpenBeta = mode == ScriptSearchMode.Experiments
-            && pxt.appTarget.appTheme.betaUrl;
+            && betaUrl != window.location.href; // don't show beta button in beta
 
         const compareConfig = (a: pxt.PackageConfig, b: pxt.PackageConfig) => {
             // core first
@@ -529,7 +531,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                 label={lf("Beta")}
                                 labelClass="red right ribbon"
                                 description={lf("Open the next version of the editor")}
-                                url={pxt.appTarget.appTheme.betaUrl}
+                                url={betaUrl}
                             />}
                         </div>
                     }

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -358,6 +358,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             && pxt.appTarget.appTheme.importExtensionFiles
             && !disableFileAccessinMaciOs
             && !searchFor;
+        const showOpenBeta = mode == ScriptSearchMode.Experiments
+            && pxt.appTarget.appTheme.betaUrl;
 
         const compareConfig = (a: pxt.PackageConfig, b: pxt.PackageConfig) => {
             // core first
@@ -507,7 +509,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                     feedbackUrl={experiment.feedbackUrl}
                                 />
                             )}
-                            {showImportFile ? <codecard.CodeCardView
+                            {showImportFile && <codecard.CodeCardView
                                 ariaLabel={lf("Open files from your computer")}
                                 role="button"
                                 key={'import'}
@@ -516,7 +518,19 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
                                 name={lf("Import File...")}
                                 description={lf("Open files from your computer")}
                                 onClick={this.importExtensionFile}
-                            /> : undefined}
+                            />}
+                            {showOpenBeta && <codecard.CodeCardView
+                                ariaLabel={lf("Open the next version of the editor")}
+                                role="button"
+                                key={'beta'}
+                                icon="lab ui cardimage"
+                                iconColor="secondary"
+                                name={lf("Beta Editor")}
+                                label={lf("Beta")}
+                                labelClass="red right ribbon"
+                                description={lf("Open the next version of the editor")}
+                                url={pxt.appTarget.appTheme.betaUrl}
+                            />}
                         </div>
                     }
                     {isEmpty() ?


### PR DESCRIPTION
- [x] display "Beta Editor" card in experiments, based on current URL (query and hash carried over)
- [x] deprecated "betaUrl" entry in pxtarget.json (ignored)