### PR TITLE
indent snippets correctly and remove superfluous empty lines

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -811,7 +811,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         // determine insert mode
         type InsertMode = "NewLineBefore" | "NewLineAfter" | "Inline"
-        // TODO: allow expressions to be inserted into the middle of the line
         let insertMode: InsertMode;
         if (inline)
             insertMode = "Inline"

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -762,10 +762,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 ev.stopPropagation();
 
                 // if inline snippet, expects dataTransfer in form "inline:1&qName:name" or "inline:1&[snippet]"
-                let inline = insertText.startsWith("inline:1&");
+                let inline = pxtc.U.startsWith(insertText, "inline:1&");
                 if (inline) insertText = insertText.substring("inline:1&".length);
 
-                let p = insertText.startsWith("qName:")
+                let p = pxtc.U.startsWith(insertText, "qName:")
                     ? compiler.snippetAsync(insertText.substring("qName:".length), this.fileType == pxt.editor.FileType.Python)
                     : Promise.resolve(insertText)
                 p.done(snippet => {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -830,7 +830,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const cursorLineContent = model.getLineContent(cursorPos.lineNumber)
         const cursorLineIsEmpty = !cursorLineContent
         if (insertMode === "Inline") {
-            // TODO
         } else {
             if (!cursorLineIsEmpty) {
                 if (insertMode === "NewLineAfter")

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -795,18 +795,22 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         })
     }
 
-    private insertSnippet(position: monaco.Position, insertText: string) {
+    private insertSnippet(cursorPos: monaco.Position, insertText: string) {
         let currPos = this.editor.getPosition();
         let model = this.editor.getModel();
+        let position = cursorPos.clone()
         if (!position) // IE11 fails to locate the mouse
             position = currPos;
 
-        // always insert the text on the next lin
+        // always insert the text on the next line
         insertText += "\n";
         position.lineNumber++;
-        position.column = 1;
+        position.column = 1; // TODO: allow snippets to be inserted at the correct indent level within a block
+
         // check existing content
-        if (position.lineNumber < model.getLineCount() && model.getLineContent(position.lineNumber)) // non-empty line
+        const insertBeyondEnd = position.lineNumber > model.getLineCount()
+        const existingContent = !insertBeyondEnd ? model.getLineContent(position.lineNumber) : ""
+        if (insertBeyondEnd || existingContent) // non-empty line
             insertText = "\n" + insertText;
 
         // update cursor

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -798,9 +798,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private insertSnippet(cursorPos: monaco.Position, insertText: string) {
         let currPos = this.editor.getPosition();
         let model = this.editor.getModel();
+        if (!cursorPos) // IE11 fails to locate the mouse
+            cursorPos = currPos;
         let position = cursorPos.clone()
-        if (!position) // IE11 fails to locate the mouse
-            position = currPos;
 
         // place snippet as if the cursor where at the end of the line
         // TODO: allow expressions to be inserted into the middle of the line

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -808,9 +808,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         position.column = 1; // TODO: allow snippets to be inserted at the correct indent level within a block
 
         // check existing content
-        const insertBeyondEnd = position.lineNumber > model.getLineCount()
-        const existingContent = !insertBeyondEnd ? model.getLineContent(position.lineNumber) : ""
-        if (insertBeyondEnd || existingContent) // non-empty line
+        // Note: if we specify a position beyond the end of the file, Monaco will wrap us to the last line
+        const existingLine = Math.min(position.lineNumber, model.getLineCount())
+        const existingContent = model.getLineContent(existingLine)
+        if (existingContent) // non-empty line
             insertText = "\n" + insertText;
 
         // update cursor

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -800,9 +800,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let model = this.editor.getModel();
         if (!cursorPos) // IE11 fails to locate the mouse
             cursorPos = currPos;
+        if (!cursorPos) {
+            return
+        }
         let position = cursorPos.clone()
-
-        console.dir(cursorPos)
 
         // determine insert mode
         type InsertMode = "NewLineBefore" | "NewLineAfter" | "Inline"


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-minecraft/issues/1671
Fixes: https://github.com/microsoft/pxt-minecraft/issues/1667

![2020-01-27 09 01 18](https://user-images.githubusercontent.com/6453828/73196031-c11eda80-40e3-11ea-83b3-bfdd2ef950ef.gif)
