### PR TITLE
Track source mappings through PY->TS

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1808,20 +1808,20 @@ namespace pxt.blocks {
 
     export interface BlockCompilationResult {
         source: string;
-        sourceMap: SourceInterval[];
+        sourceMap: SourceIntervalToId[];
         stats: pxt.Map<number>;
         diagnostics: BlockDiagnostic[];
     }
 
-    export function findBlockId(sourceMap: SourceInterval[], loc: { start: number; length: number; }): string {
+    export function findBlockId(sourceMap: SourceIntervalToId[], loc: { start: number; length: number; }): string {
         if (!loc) return undefined;
-        let bestChunk: SourceInterval;
+        let bestChunk: SourceIntervalToId;
         let bestChunkLength: number;
         for (let i = 0; i < sourceMap.length; ++i) {
             let chunk = sourceMap[i];
-            if (chunk.start <= loc.start && chunk.end > loc.start + loc.length && (!bestChunk || bestChunkLength > chunk.end - chunk.start)) {
+            if (chunk.startLine <= loc.start && chunk.endLine > loc.start + loc.length && (!bestChunk || bestChunkLength > chunk.endLine - chunk.startLine)) {
                 bestChunk = chunk;
-                bestChunkLength = chunk.end - chunk.start;
+                bestChunkLength = chunk.endLine - chunk.startLine;
             }
         }
         if (bestChunk) {

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1808,14 +1808,14 @@ namespace pxt.blocks {
 
     export interface BlockCompilationResult {
         source: string;
-        sourceMap: SourceIntervalToId[];
+        sourceMap: BlockSourceInterval[];
         stats: pxt.Map<number>;
         diagnostics: BlockDiagnostic[];
     }
 
-    export function findBlockId(sourceMap: SourceIntervalToId[], loc: { start: number; length: number; }): string {
+    export function findBlockId(sourceMap: BlockSourceInterval[], loc: { start: number; length: number; }): string {
         if (!loc) return undefined;
-        let bestChunk: SourceIntervalToId;
+        let bestChunk: BlockSourceInterval;
         let bestChunkLength: number;
         for (let i = 0; i < sourceMap.length; ++i) {
             let chunk = sourceMap[i];

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -89,12 +89,12 @@ namespace ts.pxtc {
         })
     }
 
-    export function py2tsIfNecessary(opts: CompileOptions): pxtc.KsDiagnostic[] {
+    export function py2tsIfNecessary(opts: CompileOptions): transpile.TranspileResult | undefined {
         if (opts.target.preferredEditor == pxt.PYTHON_PROJECT_NAME) {
             let res = pxtc.transpile.pyToTs(opts)
-            return res.diagnostics
+            return res
         }
-        return []
+        return undefined
     }
 
     function mkCompileResult(): CompileResult {
@@ -112,12 +112,17 @@ namespace ts.pxtc {
             res.outfiles[f] = opts.fileSystem[f]
     }
 
-    export function runConversionsAndStoreResults(opts: CompileOptions, res?: CompileResult) {
+    export function runConversionsAndStoreResults(opts: CompileOptions, res?: CompileResult): CompileResult {
         const startTime = U.cpuUs()
-        if (!res) res = mkCompileResult()
-        const convDiag = py2tsIfNecessary(opts)
+        if (!res) {
+            res = mkCompileResult();
+        }
+        const convRes = py2tsIfNecessary(opts)
+        if (convRes) {
+            res = { ...res, diagnostics: convRes.diagnostics, sourceMap: convRes.sourceMap }
+        }
+
         storeGeneratedFiles(opts, res)
-        res.diagnostics = convDiag
 
         if (!opts.sourceFiles)
             opts.sourceFiles = Object.keys(opts.fileSystem)

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1009,7 +1009,7 @@ namespace ts.pxtc.service {
             timesToMs(res);
             if (host.opts.target.switches.time)
                 console.log("DIAG-TIME", res.times)
-            return res.diagnostics
+            return res
         },
 
         format: v => {
@@ -1206,7 +1206,7 @@ namespace ts.pxtc.service {
         }
     }
 
-    function runConversionsAndCompileUsingService() {
+    function runConversionsAndCompileUsingService(): CompileResult {
         addApiInfo(host.opts)
         const prevFS = U.flatClone(host.opts.fileSystem);
         let res = runConversionsAndStoreResults(host.opts);
@@ -1228,12 +1228,14 @@ namespace ts.pxtc.service {
                 else if (host.pxtModulesOK == "js" && (!host.opts.breakpoints || host.opts.justMyCode))
                     host.opts.skipPxtModulesEmit = true
             }
-            res = compile(host.opts, service);
+            let ts2asm = compile(host.opts, service)
+            res = { sourceMap: res.sourceMap, ...ts2asm }
             if (res.needsFullRecompile) {
                 pxt.log("trigering full recompile")
                 pxt.tickEvent("compile.fullrecompile")
                 host.opts.skipPxtModulesEmit = false
-                res = compile(host.opts, service);
+                ts2asm = compile(host.opts, service);
+                res = { sourceMap: res.sourceMap, ...ts2asm }
             }
             if (res.diagnostics.every(d => !isPxtModulesFilename(d.fileName)))
                 host.pxtModulesOK = currKey

--- a/pxtcompiler/emitter/transpile.ts
+++ b/pxtcompiler/emitter/transpile.ts
@@ -10,7 +10,7 @@ namespace ts.pxtc.transpile {
     export interface TranspileResult {
         diagnostics: pxtc.KsDiagnostic[],
         success: boolean,
-        outfiles: { [key: string]: string },
+        outfiles: pxt.Map<string>,
         sourceMap: SourceInterval[],
     }
 
@@ -69,7 +69,7 @@ namespace ts.pxtc.transpile {
         }
     }
     function makeSuccess(l: CodeLang, txt: string, sourceMap: SourceInterval[]): TranspileResult {
-        let outfiles: { [key: string]: string } = {}
+        let outfiles: pxt.Map<string> = {}
         outfiles[mainName(l)] = txt
         return {
             diagnostics: [],

--- a/pxtcompiler/emitter/transpile.ts
+++ b/pxtcompiler/emitter/transpile.ts
@@ -11,7 +11,7 @@ namespace ts.pxtc.transpile {
         diagnostics: pxtc.KsDiagnostic[],
         success: boolean,
         outfiles: { [key: string]: string },
-        sourceMap: SourceInterval[]
+        sourceMap: SourceInterval[],
     }
 
     const mainName = (l: CodeLang) => `main.${l}`

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -270,17 +270,17 @@ namespace pxt.blocks {
         ".": 18,
     }
 
-    export interface SourceInterval {
+    export interface SourceIntervalToId {
         id: string;
-        start: number;
-        startPos: number;
-        end: number;
+        startLine: number; // 0-indexed
+        startPos: number; // 0-indexed from start of file including newlines
+        endLine: number;
         endPos: number;
     }
 
     export function flattenNode(app: JsNode[]) {
-        let sourceMap: SourceInterval[] = [];
-        let sourceMapById: pxt.Map<SourceInterval> = {};
+        let sourceMap: SourceIntervalToId[] = [];
+        let sourceMapById: pxt.Map<SourceIntervalToId> = {};
         let output = ""
         let indent = ""
         let variables: Map<string>[] = [{}];
@@ -389,15 +389,15 @@ namespace pxt.blocks {
             if (n.id) {
                 if (sourceMapById[n.id]) {
                     const node = sourceMapById[n.id];
-                    node.start = Math.min(node.start, start);
-                    node.end = Math.max(node.end, end);
+                    node.startLine = Math.min(node.startLine, start);
+                    node.endLine = Math.max(node.endLine, end);
                     node.startPos = Math.min(node.startPos, startPos);
                     node.endPos = Math.max(node.endPos, endPos);
                 }
                 else {
-                    const interval: SourceInterval = {
+                    const interval: SourceIntervalToId = {
                         id: n.id,
-                        start, startPos, end, endPos
+                        startLine: start, startPos, endLine: end, endPos
                     }
                     sourceMapById[n.id] = interval;
                     sourceMap.push(interval)

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -273,7 +273,9 @@ namespace pxt.blocks {
     export interface SourceInterval {
         id: string;
         start: number;
+        startPos: number;
         end: number;
+        endPos: number;
     }
 
     export function flattenNode(app: JsNode[]) {
@@ -351,6 +353,7 @@ namespace pxt.blocks {
             }
 
             let start = getCurrentLine();
+            let startPos = output.length;
 
             switch (n.type) {
                 case NT.Infix:
@@ -381,15 +384,21 @@ namespace pxt.blocks {
             }
 
             let end = getCurrentLine();
+            let endPos = output.length;
 
             if (n.id) {
                 if (sourceMapById[n.id]) {
                     const node = sourceMapById[n.id];
                     node.start = Math.min(node.start, start);
                     node.end = Math.max(node.end, end);
+                    node.startPos = Math.min(node.startPos, startPos);
+                    node.endPos = Math.max(node.endPos, endPos);
                 }
                 else {
-                    const interval = { id: n.id, start: start, end: end }
+                    const interval: SourceInterval = {
+                        id: n.id,
+                        start, startPos, end, endPos
+                    }
                     sourceMapById[n.id] = interval;
                     sourceMap.push(interval)
                 }

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -272,7 +272,7 @@ namespace pxt.blocks {
 
     export interface BlockSourceInterval {
         id: string;
-        startLine: number; // 0-indexed
+        startLine: number; // 0-indexed of the line itself
         startPos: number; // 0-indexed from start of file including newlines
         endLine: number;
         endPos: number;

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -270,7 +270,7 @@ namespace pxt.blocks {
         ".": 18,
     }
 
-    export interface SourceIntervalToId {
+    export interface BlockSourceInterval {
         id: string;
         startLine: number; // 0-indexed
         startPos: number; // 0-indexed from start of file including newlines
@@ -279,8 +279,8 @@ namespace pxt.blocks {
     }
 
     export function flattenNode(app: JsNode[]) {
-        let sourceMap: SourceIntervalToId[] = [];
-        let sourceMapById: pxt.Map<SourceIntervalToId> = {};
+        let sourceMap: BlockSourceInterval[] = [];
+        let sourceMapById: pxt.Map<BlockSourceInterval> = {};
         let output = ""
         let indent = ""
         let variables: Map<string>[] = [{}];
@@ -395,7 +395,7 @@ namespace pxt.blocks {
                     node.endPos = Math.max(node.endPos, endPos);
                 }
                 else {
-                    const interval: SourceIntervalToId = {
+                    const interval: BlockSourceInterval = {
                         id: n.id,
                         startLine: start, startPos, endLine: end, endPos
                     }

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -352,7 +352,7 @@ namespace pxt.blocks {
                 }
             }
 
-            let start = getCurrentLine();
+            let startLine = getCurrentLine();
             let startPos = output.length;
 
             switch (n.type) {
@@ -383,21 +383,21 @@ namespace pxt.blocks {
                     break
             }
 
-            let end = getCurrentLine();
+            let endLine = getCurrentLine();
             let endPos = Math.max(output.length - 1, 0);
 
             if (n.id) {
                 if (sourceMapById[n.id]) {
                     const node = sourceMapById[n.id];
-                    node.startLine = Math.min(node.startLine, start);
-                    node.endLine = Math.max(node.endLine, end);
+                    node.startLine = Math.min(node.startLine, startLine);
+                    node.endLine = Math.max(node.endLine, endLine);
                     node.startPos = Math.min(node.startPos, startPos);
                     node.endPos = Math.max(node.endPos, endPos);
                 }
                 else {
                     const interval: BlockSourceInterval = {
                         id: n.id,
-                        startLine: start, startPos, endLine: end, endPos
+                        startLine: startLine, startPos, endLine: endLine, endPos
                     }
                     sourceMapById[n.id] = interval;
                     sourceMap.push(interval)

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -384,7 +384,7 @@ namespace pxt.blocks {
             }
 
             let end = getCurrentLine();
-            let endPos = output.length;
+            let endPos = Math.max(output.length - 1, 0);
 
             if (n.id) {
                 if (sourceMapById[n.id]) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -98,6 +98,14 @@ namespace ts.pxtc {
         value: number;
     }
 
+    export type CodeLang = "py" | "blocks" | "ts"
+    export type SourceInterval = {
+        [key in CodeLang]: {
+            start: number,
+            end: number
+        } | undefined
+    }
+
     export interface CompileResult {
         outfiles: pxt.Map<string>;
         diagnostics: KsDiagnostic[];
@@ -117,6 +125,7 @@ namespace ts.pxtc {
         headerId?: string;
         confirmAsync?: (confirmOptions: {}) => Promise<number>;
         configData?: ConfigEntry[];
+        sourceMap?: SourceInterval;
     }
 
     export interface Breakpoint extends LocationInfo {
@@ -544,8 +553,8 @@ namespace ts.pxtc {
 
     function cleanLocalizations(apis: ApisInfo) {
         Util.values(apis.byQName)
-        .filter(fb => fb.attributes.block && /^{[^:]+:[^}]+}/.test(fb.attributes.block))
-        .forEach(fn => { fn.attributes.block = fn.attributes.block.replace(/^{[^:]+:[^}]+}/, ''); });
+            .filter(fb => fb.attributes.block && /^{[^:]+:[^}]+}/.test(fb.attributes.block))
+            .forEach(fn => { fn.attributes.block = fn.attributes.block.replace(/^{[^:]+:[^}]+}/, ''); });
         return apis;
     }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -125,7 +125,7 @@ namespace ts.pxtc {
         headerId?: string;
         confirmAsync?: (confirmOptions: {}) => Promise<number>;
         configData?: ConfigEntry[];
-        sourceMap?: SourceInterval;
+        sourceMap?: SourceInterval[];
     }
 
     export interface Breakpoint extends LocationInfo {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -100,10 +100,10 @@ namespace ts.pxtc {
 
     export type CodeLang = "py" | "blocks" | "ts"
     export type SourceInterval = {
-        [key in CodeLang]: {
+        [key in CodeLang]?: {
             start: number,
             end: number
-        } | undefined
+        }
     }
 
     export interface CompileResult {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -101,12 +101,12 @@ namespace ts.pxtc {
     export type CodeLang = "py" | "blocks" | "ts"
     export interface SourceInterval {
         ts: {
-            start: number;
-            end: number;
+            startPos: number;
+            endPos: number;
         };
         py: {
-            start: number;
-            end: number;
+            startPos: number;
+            endPos: number;
         };
     }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -99,11 +99,15 @@ namespace ts.pxtc {
     }
 
     export type CodeLang = "py" | "blocks" | "ts"
-    export type SourceInterval = {
-        [key in CodeLang]?: {
-            start: number,
-            end: number
-        }
+    export interface SourceInterval {
+        ts: {
+            start: number;
+            end: number;
+        };
+        py: {
+            start: number;
+            end: number;
+        };
     }
 
     export interface CompileResult {

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2473,19 +2473,19 @@ namespace pxt.py {
                 opts.fileSystem[m.tsFilename] = res.output
                 outfiles[m.tsFilename] = res.output
                 let rawSrcMap = res.sourceMap
-                function unpackInterval(i: B.SourceIntervalToId): pxtc.SourceInterval | undefined {
+                function unpackInterval(i: B.BlockSourceInterval): pxtc.SourceInterval | undefined {
                     let splits = i.id.split(":")
                     if (splits.length != 2)
                         return undefined
                     let py = splits.map(i => parseInt(i))
                     return {
                         py: {
-                            start: py[0],
-                            end: py[1]
+                            startPos: py[0],
+                            endPos: py[1]
                         },
                         ts: {
-                            start: i.startPos,
-                            end: i.endPos
+                            startPos: i.startPos,
+                            endPos: i.endPos
                         }
                     }
                 }

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2484,8 +2484,8 @@ namespace pxt.py {
                             end: py[1]
                         },
                         ts: {
-                            start: i.start,
-                            end: i.end
+                            start: i.startPos,
+                            end: i.endPos
                         }
                     }
                 }

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2473,7 +2473,7 @@ namespace pxt.py {
                 opts.fileSystem[m.tsFilename] = res.output
                 outfiles[m.tsFilename] = res.output
                 let rawSrcMap = res.sourceMap
-                function unpackInterval(i: B.SourceInterval): pxtc.SourceInterval | undefined {
+                function unpackInterval(i: B.SourceIntervalToId): pxtc.SourceInterval | undefined {
                     let splits = i.id.split(":")
                     if (splits.length != 2)
                         return undefined

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -4,7 +4,7 @@ import * as workspace from "./workspace";
 
 import U = pxt.Util;
 
-function setDiagnostics(diagnostics: pxtc.KsDiagnostic[]) {
+function setDiagnostics(diagnostics: pxtc.KsDiagnostic[], sourceMap?: pxtc.SourceInterval[]) {
     let mainPkg = pkg.mainEditorPkg();
 
     mainPkg.forEachFile(f => f.diagnostics = [])
@@ -387,8 +387,8 @@ export function typecheckAsync() {
             opts.testMode = true // show errors in all top-level code
             return workerOpAsync("setOptions", { options: opts })
         })
-        .then(() => workerOpAsync("allDiags", {}))
-        .then(setDiagnostics)
+        .then(() => workerOpAsync("allDiags", {}) as Promise<pxtc.CompileResult>)
+        .then(r => setDiagnostics(r.diagnostics, r.sourceMap))
         .then(ensureApisInfoAsync)
         .catch(catchUserErrorAndSetDiags(null))
     if (!firstTypecheck) firstTypecheck = p;

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -11,6 +11,8 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[], sourceMap?: pxtc.Sourc
 
     let output = "";
 
+    // TODO: if a source map is present, map errors into the main language file
+
     for (let diagnostic of diagnostics) {
         if (diagnostic.fileName) {
             output += `${diagnostic.category == ts.pxtc.DiagnosticCategory.Error ? lf("error") : diagnostic.category == ts.pxtc.DiagnosticCategory.Warning ? lf("warning") : lf("message")}: ${diagnostic.fileName}(${diagnostic.line + 1},${diagnostic.column + 1}): `;

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -11,14 +11,88 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[], sourceMap?: pxtc.Sourc
 
     let output = "";
 
-    // TODO: if a source map is present, map errors into the main language file
+    // If we have source map information, then prepare a function for converting
+    //  TS errors to PY
+    let tsErrToPyLoc: (err: pxtc.KsDiagnostic) => pxtc.LocationInfo = undefined;
+    let errStart = performance.now()
+    if (diagnostics.length > 0
+        && mainPkg.filterFiles(f => f.name === "main.ts" || f.name === "main.py").length === 2
+        && sourceMap) {
+        const tsFile = mainPkg.files["main.ts"].content
+        const pyFile = mainPkg.files["main.py"].content
+
+        // Notes:
+        //  lines are 0-indexed (Monaco they are 1-indexed)
+        //  columns are 0-indexed (0th is first character)
+        //  positions are 0-indexed, as if getting the index of a character in a file as a giant string (incl. new lines)
+        //  line summation is the length of that line plus its newline plus all the lines before it; aka the position of the next line's first character
+        //  end positions are zero-index but not inclusive, same behavior as substring
+        type LineColToPos = (line: number, col: number) => number
+        type PosToLineCol = (pos: number) => [number, number]
+        const makeLineColPosConverters = (file: string): [PosToLineCol, LineColToPos] => {
+            const lines = file.split("\n")
+            const lineLengths = lines
+                .map(l => l.length)
+            const lineLenSums = lineLengths
+                .reduce(({ lens, sum }, n) =>
+                    ({ lens: [...lens, sum + n + 1], sum: sum + n + 1 }),
+                    { lens: [] as number[], sum: 0 })
+                .lens
+            const lineColToPos = (line: number, col: number) => {
+                let pos = (lineLenSums[line - 1] || 0) + col
+                return pos
+            }
+            const posToLineCol = (pos: number) => {
+                const line = lineLenSums
+                    .reduce((curr, nextLen, i) => pos < nextLen ? curr : i + 1, 0)
+                const col = lineLengths[line] - (lineLenSums[line] - pos) + 1
+                return [line, col] as [number, number]
+            }
+            return [posToLineCol, lineColToPos]
+        }
+
+        const [tsPosToLineCol, tsLineColToPos] = makeLineColPosConverters(tsFile)
+        const [pyPosToLineCol, pyLineColToPos] = makeLineColPosConverters(pyFile)
+
+        const tsErrToPosAndLen = (err: pxtc.KsDiagnostic) => [tsLineColToPos(err.line, err.column), err.length] as [number, number]
+
+        tsErrToPyLoc = (err: pxtc.KsDiagnostic) => {
+            const [tsPos, tsLen] = tsErrToPosAndLen(err)
+            const overlaps = sourceMap
+                .filter(i => {
+                    // O(n), can we and should we do better?
+                    return i.ts.start <= tsPos && tsPos + tsLen - 1 <= i.ts.end
+                })
+            const intLen = (i: { start: number, end: number }) => i.end - i.start
+            const bestOverlap = overlaps.reduce((p, n) => intLen(n.ts) < intLen(p.ts) ? n : p, overlaps[0])
+            const [startLine, startCol] = pyPosToLineCol(bestOverlap.py.start)
+            const pyLoc = {
+                fileName: "main.py",
+                start: bestOverlap.py.start,
+                length: intLen(bestOverlap.py),
+                line: startLine,
+                column: startCol
+            }
+            return pyLoc
+        }
+    }
+
+    let errElapsed = performance.now() - errStart
 
     for (let diagnostic of diagnostics) {
         if (diagnostic.fileName) {
             output += `${diagnostic.category == ts.pxtc.DiagnosticCategory.Error ? lf("error") : diagnostic.category == ts.pxtc.DiagnosticCategory.Warning ? lf("warning") : lf("message")}: ${diagnostic.fileName}(${diagnostic.line + 1},${diagnostic.column + 1}): `;
             let f = mainPkg.filterFiles(f => f.getTypeScriptName() == diagnostic.fileName)[0]
-            if (f)
+            if (f) {
                 f.diagnostics.push(diagnostic)
+
+                if (tsErrToPyLoc && diagnostic.fileName === "main.ts") {
+                    let pyLoc = tsErrToPyLoc(diagnostic)
+                    let pyError = { ...diagnostic, ...pyLoc }
+                    let pyFile = mainPkg.files["main.py"]
+                    pyFile.diagnostics.push(pyError)
+                }
+            }
         }
 
         const category = ts.pxtc.DiagnosticCategory[diagnostic.category].toLowerCase();


### PR DESCRIPTION
Needed for correct error messages, future debugger support, and possibly better intellisense.

Fixes: https://github.com/microsoft/pxt-minecraft/issues/1614
Related: https://github.com/microsoft/pxt-minecraft/issues/1673

TODO:
- [x] in `setDiagnostics`, use the source map to show TS errors in PY

Now:
<img width="701" alt="Screen Shot 2020-01-28 at 6 31 10 PM" src="https://user-images.githubusercontent.com/6453828/73323997-426a9000-41fe-11ea-8c99-935113a218bf.png">

Whereas before we saw no error. (Note that the TurnDirection vs SixDirection confusion is still very confusing)

https://minecraft.makecode.com/app/c16ae7fa3eeabd09f4440341c0da58afc2f1a1e1-f4abc06a71