### PR TITLE
Revert "add flag to control api string upload branch (#6500)"

### DIFF
--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -30,14 +30,13 @@ function crowdinCredentialsAsync(): Promise<CrowdinCredentials> {
 
 export function uploadTargetTranslationsAsync(parsed?: commandParser.ParsedCommand) {
     const uploadDocs = parsed && !!parsed.flags["docs"];
-    const uploadApiStrings = parsed && !!parsed.flags["apis"]
     if (parsed && !!parsed.flags["test"])
         pxt.crowdin.setTestMode();
-    return internalUploadTargetTranslationsAsync(uploadApiStrings, uploadDocs);
+    return internalUploadTargetTranslationsAsync(uploadDocs);
 }
 
-export function internalUploadTargetTranslationsAsync(uploadApiStrings: boolean, uploadDocs: boolean) {
-    pxt.log(`uploading translations (apis ${uploadApiStrings ? "yes" : "no"}, docs ${uploadDocs ? "yes" : "no"})...`);
+export function internalUploadTargetTranslationsAsync(uploadDocs: boolean) {
+    pxt.log("retrieving Crowdin credentials...");
     return crowdinCredentialsAsync()
         .then(cred => {
             if (!cred) return Promise.resolve();
@@ -48,30 +47,31 @@ export function internalUploadTargetTranslationsAsync(uploadApiStrings: boolean,
                     pxt.log('missing --docs flag, skipping')
                     return Promise.resolve();
                 }
+                pxt.log("uploading core translations...");
                 return uploadDocsTranslationsAsync("docs", crowdinDir, cred.branch, cred.prj, cred.key)
                     .then(() => uploadDocsTranslationsAsync("common-docs", crowdinDir, cred.branch, cred.prj, cred.key))
             } else {
-                let p = Promise.resolve();
-                if (uploadApiStrings)
-                    p = p.then(() => execCrowdinAsync("upload", "built/target-strings.json", crowdinDir))
-                        .then(() => fs.existsSync("built/sim-strings.json") ? execCrowdinAsync("upload", "built/sim-strings.json", crowdinDir) : Promise.resolve())
-                        .then(() => uploadBundledTranslationsAsync(crowdinDir, cred.branch, cred.prj, cred.key));
-                else
-                    p = p.then(() => pxt.log(`translations: skipping api strings upload`));
-                if (uploadDocs)
-                    p = p.then(() => uploadDocsTranslationsAsync("docs", crowdinDir, cred.branch, cred.prj, cred.key))
-                        // scan for docs in bundled packages
-                        .then(() => Promise.all(pxt.appTarget.bundleddirs
-                            // there must be a folder under .../docs
-                            .filter(pkgDir => nodeutil.existsDirSync(path.join(pkgDir, "docs")))
-                            // upload to crowdin
-                            .map(pkgDir => uploadDocsTranslationsAsync(path.join(pkgDir, "docs"), crowdinDir, cred.branch, cred.prj, cred.key)
-                            )).then(() => {
-                                pxt.log("docs uploaded");
-                            }));
-                else
-                    p = p.then(() => pxt.log(`translations: skipping docs upload`));
-                return p;
+                pxt.log("uploading target translations...");
+                return execCrowdinAsync("upload", "built/target-strings.json", crowdinDir)
+                    .then(() => fs.existsSync("built/sim-strings.json") ? execCrowdinAsync("upload", "built/sim-strings.json", crowdinDir) : Promise.resolve())
+                    .then(() => uploadBundledTranslationsAsync(crowdinDir, cred.branch, cred.prj, cred.key))
+                    .then(() => {
+                        if (uploadDocs) {
+                            pxt.log("uploading docs...");
+                            return uploadDocsTranslationsAsync("docs", crowdinDir, cred.branch, cred.prj, cred.key)
+                                // scan for docs in bundled packages
+                                .then(() => Promise.all(pxt.appTarget.bundleddirs
+                                    // there must be a folder under .../docs
+                                    .filter(pkgDir => nodeutil.existsDirSync(path.join(pkgDir, "docs")))
+                                    // upload to crowdin
+                                    .map(pkgDir => uploadDocsTranslationsAsync(path.join(pkgDir, "docs"), crowdinDir, cred.branch, cred.prj, cred.key)
+                                    )).then(() => {
+                                        pxt.log("docs uploaded");
+                                    }))
+                        }
+                        pxt.log("skipping docs upload (not a release)");
+                        return Promise.resolve();
+                    });
             }
         });
 }

--- a/docs/targets/pxtarget.md
+++ b/docs/targets/pxtarget.md
@@ -283,15 +283,6 @@ PXT expects to find the C/C++ sources on github.
     }
 ```
 
-### ``uploadDocs`` and ``uploadApiStringsBranchRx``
-
-The ``uploadDocs`` flag determins if the API strings and docs have to be uploaded
-to crowdin when a build occurs on master or release branches.
-
-The ``uploadApiStringsBranchRx`` flag provide a custom regex
-for matching the branch where api strings should be uploaded.
-From a stable branch, this would be ``^stable\d+\.\d+$``
-
 ## Additional settings
 
 ### template project

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -51,7 +51,6 @@ declare namespace pxt {
         appTheme: AppTheme;
         compileService?: TargetCompileService;
         ignoreDocsErrors?: boolean;
-        uploadApiStringsBranchRx?: string; // regular expression to match branches that should upload api strings
         uploadDocs?: boolean; // enable uploading to crowdin on master or v* builds
         variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
         multiVariants?: string[];


### PR DESCRIPTION
This reverts commit 0163ee4de8190c59817eb203b554d3fb52c30656.

After thinking about the problem of translations, i don't think this is a good fix. We should sniff what is the version in index-ref.json and only upload if the branch name matches ``stableMAJOR.MINOR``

- [x] handle case where crowdin reports ``500`` while payload says it uploaded succesfully