### PR TITLE
encode repo into metadata

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -556,6 +556,7 @@ namespace pxt.github {
     export interface ParsedRepo {
         owner?: string;
         project?: string;
+        // owner/name
         fullName: string;
         tag?: string;
         fileName?: string;

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -148,6 +148,9 @@ export function compileAsync(options: CompileOptions = {}): Promise<pxtc.Compile
                     target: pxt.appTarget.id,
                     targetVersion: pxt.appTarget.versions.target
                 };
+                const gitJson = pkg.mainPkg.readGitJson();
+                if (gitJson)
+                    meta.repo = pxt.github.parseRepoId(gitJson.repo).fullName;
                 resp.outfiles[pxtc.BINARY_JS] =
                     `// meta=${JSON.stringify(meta)}
 ${resp.outfiles[pxtc.BINARY_JS]}`;


### PR DESCRIPTION
When compiling js for github page, encode repo name