### PR TITLE
lang restriction picker: reset state on hide

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1162,6 +1162,14 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
         this.createProjectCb = null;
     }
 
+    onExpandedMenuHide = () => {
+        // reset language restrictions when user closes the options menu;
+        // it's an 'advanced' feature that we want an easy escape hatch for.
+        this.setState({
+            languageRestriction: pxt.editor.LanguageRestriction.Standard
+        });
+    }
+
     renderCore() {
         const { visible, name, emoji } = this.state;
         const { python, chooseLanguageRestrictionOnNewProject } = pxt.appTarget.appTheme;
@@ -1208,7 +1216,7 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
             </div>
             {chooseLanguageRestrictionOnNewProject && <div>
                 <br />
-                <sui.ExpandableMenu title={lf("Code options")}>
+                <sui.ExpandableMenu title={lf("Code options")} onHide={this.onExpandedMenuHide}>
                     <sui.Select options={langOpts} onChange={this.handleLanguageChange} aria-label={lf("Select Language")} />
                 </sui.ExpandableMenu>
             </div>}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -368,6 +368,8 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
 
 export interface ExpandableMenuProps {
     title?: string;
+    onShow?: () => void;
+    onHide?: () => void;
 }
 
 export interface ExpandableMenuState {
@@ -375,10 +377,28 @@ export interface ExpandableMenuState {
 }
 
 export class ExpandableMenu extends UIElement<ExpandableMenuProps, ExpandableMenuState> {
+    hide = () => {
+        this.setState({ expanded: false });
+        const { onHide } = this.props;
+        if (onHide)
+            onHide();
+    }
+
+    show = () => {
+        this.setState({ expanded: true });
+        const { onShow } = this.props;
+        if (onShow)
+            onShow();
+    }
+
     toggleExpanded = () => {
-        this.setState({
-            expanded: !this.state.expanded
-        });
+        const { expanded } = this.state;
+
+        if (expanded) {
+            this.hide();
+        } else {
+            this.show();
+        }
     }
 
     render() {


### PR DESCRIPTION
when hiding the code options section, reset the language restriction; make it an escape hatch if you select the wrong option and randomly click to try to 'get out'

fixes https://github.com/microsoft/pxt-minecraft/issues/1689

![2020-01-30 11 02 44](https://user-images.githubusercontent.com/5615930/73481489-c5036480-4350-11ea-9380-3cdce6f5e90d.gif)

![2020-01-30 11 11 35](https://user-images.githubusercontent.com/5615930/73481776-5d99e480-4351-11ea-917f-93c31fff9a05.gif)

(wow my gif tool made the colors awful there..)

