### PR TITLE
Display language type in card icon on home screen

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -289,7 +289,7 @@
                 background-blend-mode: color-burn;
                 font-size: 6.5rem!important;
             }
-            .card-action .xicon.python { background-image: @pyIcon; }
+            .card-action .xicon.py { background-image: @pyIcon; }
             .card-action .xicon.js { background-image: @jsIcon; }
 
             /* unset semantic properties */

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -148,7 +148,6 @@ default semantic
 @jsIconUrl: "../docs/static/icons/js.svg";
 @jsIcon: data-uri(@jsIconUrl);
 
-@logoColor: #a7268b;
 @logoFilter: invert(22%) sepia(54%) saturate(2744%) hue-rotate(288deg) brightness(95%) contrast(97%);
 
 /*-------------------

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -148,6 +148,9 @@ default semantic
 @jsIconUrl: "../docs/static/icons/js.svg";
 @jsIcon: data-uri(@jsIconUrl);
 
+@logoColor: #a7268b;
+@logoFilter: invert(22%) sepia(54%) saturate(2744%) hue-rotate(288deg) brightness(95%) contrast(97%);
+
 /*-------------------
    Menu
 --------------------*/

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -56,6 +56,40 @@
     }
 }
 
+.ui.card.file.blocksprj {
+    .fileimage {
+        background-size: 85%;
+        background-position-y: 50%;
+    }
+}
+
+.ui.card.file.pyprj {
+    .fileimage {
+        background-image: @pyIcon;
+        filter: @logoFilter;
+    }
+}
+
+.ui.card.file.tsprj {
+    .fileimage {
+        height: 2.5rem;
+        width: 2.5rem;
+        padding: .3rem;
+        margin: .25rem;
+        text-align: right;
+        background-color: @logoColor;
+        background-image: none;
+    }
+    .fileimage:after {
+        content: "js";
+        color: @white;
+        font-weight: 600;
+        font-family: sans-serif;
+        text-transform: uppercase;
+        line-height: 3rem;
+    }
+}
+
 .ui.card.file.positive, .ui.card.file.positive:focus {
     border-color: @green;
 }

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -72,21 +72,10 @@
 
 .ui.card.file.tsprj {
     .fileimage {
-        height: 2.5rem;
-        width: 2.5rem;
-        padding: .3rem;
-        margin: .25rem;
-        text-align: right;
-        background-color: @logoColor;
-        background-image: none;
-    }
-    .fileimage:after {
-        content: "js";
-        color: @white;
-        font-weight: 600;
-        font-family: sans-serif;
-        text-transform: uppercase;
-        line-height: 3rem;
+        background-image: @jsIcon;
+        filter: @logoFilter;
+        background-size: 65%;
+        background-position-y: 50%;
     }
 }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -647,11 +647,12 @@ export class ProjectsCodeCard extends sui.StatelessUIElement<ProjectsCodeCardPro
             else if (scr.board) {
                 className = 'file board ' + className;
                 imageUrl = pxt.bundledSvg(scr.board)
+            } else if (scr.editor) {
+                className = 'file ' + scr.editor;
             }
             else
                 className = 'file ' + className;
         }
-
         return <codecard.CodeCardView className={className} imageUrl={imageUrl} cardType={cardType} {...rest} onClick={this.handleClick}
             onLabelClicked={onLabelClick ? this.handleLabelClick : undefined} />
     }
@@ -757,10 +758,10 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             case "tutorial":
             case "example":
                 icon = "xicon blocks"
-                if (editor) icon = (editor == "py") ? "xicon python" : "xicon " + editor;
+                if (editor) icon = `xicon ${editor}`;
                 break;
             case "codeExample":
-                icon = (editor == "py") ? "xicon python" : "xicon js";
+                icon = `xicon ${editor || "js"}`;
                 break;
             case "forumUrl":
                 icon = "comments"


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1627

Other icon changes (Github, board, etc) take precedence, otherwise display language.

![image](https://user-images.githubusercontent.com/34112083/73577335-6f52b900-4431-11ea-9bc4-395f72f90a17.png)
![image](https://user-images.githubusercontent.com/34112083/73577330-6bbf3200-4431-11ea-9e1d-98af3b079b9b.png)
