### PR TITLE
Small CSS cleanup for tutorial circle

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -40,6 +40,8 @@
 .menubar .ui.menu .item.tutorial-menuitem > .step-label {
     margin-left: 0.4em;
     margin-right: 0.4em;
+    min-width: 2.1rem;
+    max-width: 2.1rem;
 }
 .menubar .ui.menu .item.tutorial-menuitem > .label {
     background: white;
@@ -439,10 +441,10 @@ code.lang-filterblocks {
 *******************************/
 .progresscircle {
     position: absolute;
-    width: 2.4em;
-    height: 2.4em;
-    margin-top: -0.345em;
-    margin-left: -0.2em;
+    width: 2.3em;
+    height: 2.3em;
+    margin-top: -.3em;
+    margin-left: -.15em;
 }
 
 .progresscircle path {


### PR DESCRIPTION
Adjusting to remove space between number label and progress circle

![image](https://user-images.githubusercontent.com/34112083/73580109-53531580-4439-11ea-8a80-fe6d2fb7e28b.png)
