### PR TITLE
Handle diff of reconstructed blockly xml payloads

### DIFF
--- a/pxtblocks/blocklydiff.ts
+++ b/pxtblocks/blocklydiff.ts
@@ -22,13 +22,13 @@ namespace pxt.blocks {
             return false;
         // collect all ids
         const oldids: pxt.Map<boolean> = {};
-        oldXml.replace(/id="([^]+)"/g, (m, id) => { oldids[id] = true; return ""; });
+        oldXml.replace(/id="([^"]+)"/g, (m, id) => { oldids[id] = true; return ""; });
         if (!Object.keys(oldids).length)
             return false;
         // test if any newid exists in old
         let total = 0;
         let found = 0;
-        newXml.replace(/id="([^]+)"/g, (m, id) => {
+        newXml.replace(/id="([^"]+)"/g, (m, id) => {
             total++;
             if (oldids[id])
                 found++;

--- a/pxtblocks/blocklydiff.ts
+++ b/pxtblocks/blocklydiff.ts
@@ -16,6 +16,27 @@ namespace pxt.blocks {
         modified: number;
     }
 
+    // sniff ids to see if the xml was completly reconstructed
+    export function needsDecompiledDiff(oldXml: string, newXml: string): boolean {
+        if (!oldXml || !newXml)
+            return false;
+        // collect all ids
+        const oldids: pxt.Map<boolean> = {};
+        oldXml.replace(/id="([^]+)"/g, (m, id) => { oldids[id] = true; return ""; });
+        if (!Object.keys(oldids).length)
+            return false;
+        // test if any newid exists in old
+        let total = 0;
+        let found = 0;
+        newXml.replace(/id="([^]+)"/g, (m, id) => {
+            total++;
+            if (oldids[id])
+                found++;
+            return "";
+        });
+        return total > 0 && found == 0;
+    }
+
     export function diffXml(oldXml: string, newXml: string, options?: DiffOptions): DiffResult {
         const oldWs = pxt.blocks.loadWorkspaceXml(oldXml, true);
         const newWs = pxt.blocks.loadWorkspaceXml(newXml, true);

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -71,9 +71,12 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
             this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[code]);
         } else {
             renderer(code)
-                .done(renderedCode => {
+                .then(renderedCode => {
                     MarkedContent.blockSnippetCache[code] = renderedCode;
                     this.finishRenderLangSnippet(wrapperDiv, MarkedContent.blockSnippetCache[code]);
+                }).catch(e => {
+                    pxt.reportException(e);
+                    this.finishRenderLangSnippet(wrapperDiv, lf("Something changed."))
                 })
         }
     }


### PR DESCRIPTION
When we try to diff blocks that were roundtripped, use text-based diff instead since all ids have been trashed.