### PR TITLE
support for rendering xml directly

### DIFF
--- a/common-docs/blocks-embed.md
+++ b/common-docs/blocks-embed.md
@@ -88,7 +88,7 @@ export interface RenderBlocksRequestMessage extends SimulatorMessage {
 ```
 
 * ``id``: The identifer of the snippet element. This is used to match the document element of the snippet with the rendered blocks returned later.
-* ``code``: The text of the code snippet to send, compile, and render.
+* ``code``: The text of the code snippet to send, compile, and render. The snippet may be JavaScript or the Blockly XML payload.
 * ``packageId``: the identifier of a project shared in the editor (without the ``https://makecode.com/`` prefix)
 
 #### Render Blocks Response message

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -460,8 +460,10 @@ namespace pxt.runner {
             const options = (msg.options || {}) as pxt.blocks.BlocksRenderOptions;
             options.splitSvg = false; // don't split when requesting rendered images
             pxt.tickEvent("renderer.job")
+            const isXml = /^\s*<xml/.test(msg.code);
+
             jobPromise = pxt.BrowserUtils.loadBlocklyAsync()
-                .then(() => runner.decompileSnippetAsync(msg.code, msg.options))
+                .then(() => isXml ? pxt.runner.compileBlocksAsync(msg.code, options) : runner.decompileSnippetAsync(msg.code, msg.options))
                 .then(result => {
                     const blocksSvg = result.blocksSvg as SVGSVGElement;
                     return blocksSvg ? pxt.blocks.layout.blocklyToSvgAsync(blocksSvg, 0, 0, blocksSvg.viewBox.baseVal.width, blocksSvg.viewBox.baseVal.height) : undefined;

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -2,12 +2,20 @@
 
 <body>
     <pre id="mycode">
-    basic.showString("hello!")
+    <code>basic.showString("hello!")</code>
     </pre>
     <pre id="mycode2">
             basic.showIcon(IconNames.Heart)                    
             </pre>
-    <div id="status"></div>
+            <pre id="mycode3">
+                <code>
+                    &lt;xml xmlns="http://www.w3.org/1999/xhtml"&gt;
+                        &lt;block type="device_forever"&gt;&lt;/block&gt;
+                      &lt;/xml&gt;    
+                </code>
+                </pre>
+            
+            <div id="status"></div>
     <div id="blocks"></div>
 
     <script>
@@ -38,8 +46,9 @@
 
             switch (msg.type) {
                 case "renderready":
-                    makeCodeRenderPre(document.getElementById("mycode"))
-                    makeCodeRenderPre(document.getElementById("mycode2"))
+                 //   makeCodeRenderPre(document.getElementById("mycode"))
+                   // makeCodeRenderPre(document.getElementById("mycode2"))
+                    makeCodeRenderPre(document.getElementById("mycode3"))
                     break;
                 case "renderblocks":
                     console.log(msg);


### PR DESCRIPTION
Detect that renderblocks is sending XML, and render as blockly xml payload instead of decompiling.
Required for microbit.org support.
@abchatra this will need to be integrated in the microbit branch and deployed.