### PR TITLE
Better auto-complete for Python and refactor necessary for TS lang service change

### DIFF
--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -230,9 +230,11 @@ namespace ts.pxtc {
         let program: Program
 
         if (service) {
+            console.log("driver:233")
             storeGeneratedFiles(opts, res)
             program = service.getProgram()
         } else {
+            console.log("driver:237")
             runConversionsAndStoreResults(opts, res)
             if (res.diagnostics.length > 0)
                 return res;

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -230,11 +230,9 @@ namespace ts.pxtc {
         let program: Program
 
         if (service) {
-            console.log("driver:233")
             storeGeneratedFiles(opts, res)
             program = service.getProgram()
         } else {
-            console.log("driver:237")
             runConversionsAndStoreResults(opts, res)
             if (res.diagnostics.length > 0)
                 return res;

--- a/pxtcompiler/emitter/transpile.ts
+++ b/pxtcompiler/emitter/transpile.ts
@@ -7,19 +7,20 @@
 // so that we can cache results for better performance and user
 // experience (since compile -> decompile round-trips are lossy)
 namespace ts.pxtc.transpile {
-    export interface TranspileResult {
-        diagnostics: pxtc.KsDiagnostic[],
-        success: boolean,
+    export interface TranspileCodeResult {
         outfiles: pxt.Map<string>,
         sourceMap: SourceInterval[],
+        syntaxInfo?: SyntaxInfo,
+    }
+    export interface TranspileResult extends TranspileCodeResult {
+        diagnostics: pxtc.KsDiagnostic[],
+        success: boolean,
     }
 
     const mainName = (l: CodeLang) => `main.${l}`
 
-    export interface LangEquivSet {
-        comparable: { [key in CodeLang]: string },
-        code: { [key in CodeLang]: string },
-        sourceMap: SourceInterval[]
+    export interface LangEquivSet extends TranspileCodeResult {
+        comparable: { [key in CodeLang]: string }
     }
     // a circular buffer of size MAX_CODE_EQUIVS that stores
     // sets of equivalent code files so that when we translate
@@ -50,16 +51,12 @@ namespace ts.pxtc.transpile {
                 "blocks": undefined,
                 "py": undefined
             },
-            code: {
-                "ts": undefined,
-                "blocks": undefined,
-                "py": undefined
-            },
+            outfiles: {},
             sourceMap
         }
-        equiv.code[lang1] = lang1Txt
+        equiv.outfiles[mainName(lang1)] = lang1Txt
         equiv.comparable[lang1] = toComparable(lang1Txt)
-        equiv.code[lang2] = lang2Txt
+        equiv.outfiles[mainName(lang2)] = lang2Txt
         equiv.comparable[lang2] = toComparable(lang2Txt)
 
         codeEquivalences.unshift(equiv)
@@ -68,23 +65,21 @@ namespace ts.pxtc.transpile {
             codeEquivalences.pop()
         }
     }
-    function makeSuccess(l: CodeLang, txt: string, sourceMap: SourceInterval[]): TranspileResult {
-        let outfiles: pxt.Map<string> = {}
-        outfiles[mainName(l)] = txt
+    function makeSuccess(equiv: LangEquivSet): TranspileResult {
         return {
             diagnostics: [],
             success: true,
-            outfiles,
-            sourceMap
+            outfiles: equiv.outfiles,
+            sourceMap: equiv.sourceMap,
+            syntaxInfo: equiv.syntaxInfo
         }
     }
 
     function transpileInternal(from: CodeLang, fromTxt: string, to: CodeLang, doRealTranspile: () => TranspileResult): TranspileResult {
         let equiv = tryGetCachedTranspile(from, fromTxt)
-        if (equiv && equiv.code[to]) {
+        if (equiv && equiv.outfiles[mainName(to)]) {
             // return from cache
-            let toTxt = equiv.code[to]
-            let res = makeSuccess(to, toTxt, equiv.sourceMap)
+            let res = makeSuccess(equiv)
             return res
         }
 

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -384,7 +384,8 @@ namespace pxt.blocks {
             }
 
             let endLine = getCurrentLine();
-            let endPos = Math.max(output.length - 1, 0);
+            // end position is non-inclusive
+            let endPos = Math.max(output.length, 1);
 
             if (n.id) {
                 if (sourceMapById[n.id]) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1514,6 +1514,8 @@ namespace ts.pxtc.service {
         fileContent?: string;
         infoType?: InfoType;
         position?: number;
+        wordStartPos?: number;
+        wordEndPos?: number;
         options?: CompileOptions;
         search?: SearchOptions;
         format?: FormatOptions;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -99,15 +99,136 @@ namespace ts.pxtc {
     }
 
     export type CodeLang = "py" | "blocks" | "ts"
+    export type PosSpan = {
+        startPos: number;
+        endPos: number;
+    }
     export interface SourceInterval {
+        ts: PosSpan;
+        py: PosSpan;
+    }
+
+    export type LineColToPos = (line: number, col: number) => number
+    export type PosToLineCol = (pos: number) => [number, number]
+    export interface SourceMapHelpers {
         ts: {
-            startPos: number;
-            endPos: number;
-        };
+            posToLineCol: PosToLineCol,
+            lineColToPos: LineColToPos,
+            allOverlaps: (i: PosSpan) => SourceInterval[],
+            smallestOverlap: (i: PosSpan) => SourceInterval | undefined
+            locToLoc: (thisLoc: pxtc.LocationInfo) => pxtc.LocationInfo,
+            getText: (i: PosSpan) => string,
+        },
         py: {
-            startPos: number;
-            endPos: number;
-        };
+            posToLineCol: PosToLineCol,
+            lineColToPos: LineColToPos,
+            allOverlaps: (i: PosSpan) => SourceInterval[],
+            smallestOverlap: (i: PosSpan) => SourceInterval | undefined,
+            locToLoc: (thisLoc: pxtc.LocationInfo) => pxtc.LocationInfo,
+            getText: (i: PosSpan) => string,
+        },
+    }
+
+    export function BuildSourceMapHelpers(sourceMap: SourceInterval[], tsFile: string, pyFile: string): SourceMapHelpers {
+        // Notes:
+        //  lines are 0-indexed (Monaco they are 1-indexed)
+        //  columns are 0-indexed (0th is first character)
+        //  positions are 0-indexed, as if getting the index of a character in a file as a giant string (incl. new lines)
+        //  line summation is the length of that line plus its newline plus all the lines before it; aka the position of the next line's first character
+        //  end positions are zero-index but not inclusive, same behavior as substring
+        const makeLineColPosConverters = (file: string): { posToLineCol: PosToLineCol, lineColToPos: LineColToPos } => {
+            const lines = file.split("\n")
+            const lineLengths = lines
+                .map(l => l.length)
+            const lineLenSums = lineLengths
+                .reduce(({ lens, sum }, n) =>
+                    ({ lens: [...lens, sum + n + 1], sum: sum + n + 1 }),
+                    { lens: [] as number[], sum: 0 })
+                .lens
+            const lineColToPos = (line: number, col: number) => {
+                let pos = (lineLenSums[line - 1] || 0) + col
+                return pos
+            }
+            const posToLineCol = (pos: number) => {
+                const line = lineLenSums
+                    .reduce((curr, nextLen, i) => pos < nextLen ? curr : i + 1, 0)
+                const col = lineLengths[line] - (lineLenSums[line] - pos) + 1
+                return [line, col] as [number, number]
+            }
+            return { posToLineCol, lineColToPos }
+        }
+
+        const lcp = {
+            ts: makeLineColPosConverters(tsFile),
+            py: makeLineColPosConverters(pyFile)
+        }
+
+        const intLen = (i: PosSpan) => i.endPos - i.startPos
+        const allOverlaps = (i: PosSpan, lang: "ts" | "py") => {
+            const { startPos, endPos } = i
+            return sourceMap
+                .filter(i => {
+                    // O(n), can we and should we do better?
+                    return i[lang].startPos <= startPos && endPos <= i[lang].endPos
+                })
+        }
+        const smallestOverlap = (i: PosSpan, lang: "ts" | "py"): SourceInterval | undefined => {
+            const overlaps = allOverlaps(i, lang)
+            return overlaps.reduce((p, n) => intLen(n[lang]) < intLen(p[lang]) ? n : p, overlaps[0])
+        }
+
+        const os = {
+            ts: {
+                allOverlaps: (i: PosSpan) => allOverlaps(i, "ts"),
+                smallestOverlap: (i: PosSpan) => smallestOverlap(i, "ts"),
+            },
+            py: {
+                allOverlaps: (i: PosSpan) => allOverlaps(i, "py"),
+                smallestOverlap: (i: PosSpan) => smallestOverlap(i, "py"),
+            }
+        }
+
+        const makeLocToLoc = (inLang: "ts" | "py", outLang: "ts" | "py") => {
+            const inLocToPosAndLen = (inLoc: pxtc.LocationInfo) => [lcp[inLang].lineColToPos(inLoc.line, inLoc.column), inLoc.length] as [number, number]
+            const locToLoc = (inLoc: pxtc.LocationInfo): pxtc.LocationInfo | undefined => {
+                const [inStartPos, inLen] = inLocToPosAndLen(inLoc)
+                const inEndPos = inStartPos + inLen
+                const bestOverlap = smallestOverlap({ startPos: inStartPos, endPos: inEndPos }, inLang)
+                if (!bestOverlap)
+                    return undefined
+                const [outStartLine, outStartCol] = lcp[outLang].posToLineCol(bestOverlap[outLang].startPos)
+                const outLoc = {
+                    fileName: `main.${outLang}`,
+                    start: bestOverlap[outLang].startPos,
+                    length: intLen(bestOverlap[outLang]),
+                    line: outStartLine,
+                    column: outStartCol
+                }
+                return outLoc
+            }
+            return locToLoc
+        }
+
+        const tsLocToPyLoc = makeLocToLoc("ts", "py")
+        const pyLocToTsLoc = makeLocToLoc("py", "ts")
+
+        const tsGetText = (i: PosSpan) => tsFile.substring(i.startPos, i.endPos)
+        const pyGetText = (i: PosSpan) => pyFile.substring(i.startPos, i.endPos)
+
+        return {
+            ts: {
+                ...lcp.ts,
+                ...os.ts,
+                locToLoc: tsLocToPyLoc,
+                getText: tsGetText
+            },
+            py: {
+                ...lcp.py,
+                ...os.py,
+                locToLoc: pyLocToTsLoc,
+                getText: pyGetText
+            },
+        }
     }
 
     export interface CompileResult {

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -223,11 +223,13 @@ export function py2tsAsync(): Promise<pxtc.transpile.TranspileResult> {
         })
 }
 
-export function completionsAsync(fileName: string, position: number, fileContent?: string): Promise<pxtc.CompletionInfo> {
+export function completionsAsync(fileName: string, position: number, wordStartPos: number, wordEndPos: number, fileContent?: string): Promise<pxtc.CompletionInfo> {
     return workerOpAsync("getCompletions", {
         fileName,
         fileContent,
         position,
+        wordStartPos,
+        wordEndPos,
         runtime: pxt.appTarget.runtime
     });
 }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -44,7 +44,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
     constructor(public editor: Editor, public python: boolean) {
     }
 
-    triggerCharacters?: string[] = ["."];
+    triggerCharacters?: string[] = ["(", ",", "."];
 
     kindMap = {}
     private tsKindToMonacoKind(s: pxtc.SymbolKind): monaco.languages.CompletionItemKind {
@@ -780,6 +780,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 this.hideFlyout();
             })
 
+            // TODO: typescript
             monaco.languages.registerCompletionItemProvider("python", new CompletionProvider(this, true));
             monaco.languages.registerSignatureHelpProvider("python", new SignatureHelper(this, true));
             monaco.languages.registerHoverProvider("python", new HoverProvider(this, true));

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -70,7 +70,12 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
         const offset = model.getOffsetAt(position);
         const source = model.getValue();
         const fileName = this.editor.currFile.name;
-        return compiler.completionsAsync(fileName, offset, source)
+
+        const word = model.getWordUntilPosition(position);
+        const wordStartOffset = model.getOffsetAt({ lineNumber: position.lineNumber, column: word.startColumn })
+        const wordEndOffset = model.getOffsetAt({ lineNumber: position.lineNumber, column: word.endColumn })
+
+        return compiler.completionsAsync(fileName, offset, wordStartOffset, wordEndOffset, source)
             .then(completions => {
                 const items = (completions.entries || []).map((si, i) => {
                     let insertSnippet = this.python ? si.pySnippet : si.snippet;


### PR DESCRIPTION
Hopefully much better auto-complete for parameters of functions, especially enums.

Before:
![2020-02-03 09 50 59](https://user-images.githubusercontent.com/6453828/73677283-c0012680-466a-11ea-9409-37f9f4c57e6b.gif)

After:
![2020-02-03 09 43 20](https://user-images.githubusercontent.com/6453828/73677299-c55e7100-466a-11ea-9971-c9b0734a33b8.gif)

Fixes: https://github.com/microsoft/pxt-minecraft/issues/1673

Also a lot of refactoring was done in this PR that is necessary for: https://github.com/microsoft/pxt-minecraft/issues/1699
but that issue is not yet solved. Needs another PR.

Additionally, a number of improvements were made to the TS<->PY source map infrastructure to make working with the source mapping much easier from many places.

This doesn't fix everything with auto-complete/intellisense. For example:
- Statement level auto-complete is still pretty bad (too many options, not what the user wants)
- No auto-complete for loops
- Expressions other than function args (or args that are themselves nested expressions) do not auto-complete well
- Probably a lot more if we kick the tires a bit 