### PR TITLE
Add CSS class field to docs menu items in pxtarget

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -394,6 +394,7 @@ declare namespace pxt {
         popout?: boolean;
         tutorial?: boolean;
         subitems?: DocMenuEntry[];
+        className?: string; // optional class name used in editor help menu rendering
     }
 
     interface TOCMenuEntry {

--- a/theme/common.less
+++ b/theme/common.less
@@ -336,6 +336,25 @@ div.simframe > iframe {
     }
 }
 
+/* Help dropdown */
+#root {
+    .docsmenu-py, .docsmenu-js {
+        display: none;
+    }
+    &.editorlang-py,  &.editorlang-js {
+        .docsmenu-blocks {
+            display: none;
+        }
+    }
+
+    &.editorlang-py .docsmenu-py {
+        display: block;
+    }
+    &.editorlang-js .docsmenu-js {
+        display: block;
+    }
+}
+
 /* Help card */
 #helpcard {
     position: absolute;

--- a/theme/sidedoc.less
+++ b/theme/sidedoc.less
@@ -84,7 +84,8 @@
 }
 
 /* Sidedocs in Monaco editor */
-.sideDocs.editorlang-text {
+.sideDocs.editorlang-js,
+.sideDocs.editorlang-py {
     #sidedocs {
         width: 50%!important;
         min-width: 18rem;

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -411,7 +411,7 @@ code.lang-filterblocks {
     }
 }
 
-.editorlang-text {
+.editorlang-js, .editorlang-py {
     #tutorialcard.seemore .tutorialsegment > button {
         margin-right: 1rem;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3552,7 +3552,8 @@ export class ProjectView
             isHeadless ? "headless" : "",
             flyoutOnly ? "flyoutOnly" : "",
             hideTutorialIteration ? "hideIteration" : "",
-            this.editor != this.blocksEditor ? "editorlang-text" : "",
+            this.isPythonActive() ? "editorlang-py" : "",
+            this.isJavaScriptActive() ? "editorlang-js" : "",
             'full-abs'
         ];
         const rootClasses = sui.cx(rootClassList);

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -38,7 +38,7 @@ function renderDocItems(parent: pxt.editor.IProjectView, elements: pxt.DocMenuEn
     return elements.map(m =>
         m.tutorial ? <DocsMenuItem key={"docsmenututorial" + m.path} role="menuitem" ariaLabel={pxt.Util.rlf(m.name)} text={pxt.Util.rlf(m.name)} className={"ui " + cls} parent={parent} path={m.path} onItemClick={openTutorial} />
             : !/^\//.test(m.path) ? <a key={"docsmenulink" + m.path} role="menuitem" aria-label={m.name} title={m.name} className={`ui item link ${cls}`} href={m.path} target="docs">{pxt.Util.rlf(m.name)}</a>
-                : <DocsMenuItem key={"docsmenu" + m.path} role="menuitem" ariaLabel={pxt.Util.rlf(m.name)} text={pxt.Util.rlf(m.name)} className={"ui " + cls} parent={parent} path={m.path} onItemClick={openDocs} />
+                : <DocsMenuItem key={"docsmenu" + m.path} role="menuitem" ariaLabel={pxt.Util.rlf(m.name)} text={pxt.Util.rlf(m.name)} className={`ui ${cls} ${m.className || ""}`} parent={parent} path={m.path} onItemClick={openDocs} />
     );
 }
 


### PR DESCRIPTION
Hide/show menu items based on specified CSS classes (for https://github.com/microsoft/pxt-minecraft/issues/1463)