### PR TITLE
multi-target support for testDepencies

### DIFF
--- a/docs/extensions/pxt-json.md
+++ b/docs/extensions/pxt-json.md
@@ -106,7 +106,8 @@ the online editor.
 They usually contain unit tests for extension.
 
 Similarly, dependencies from `testDependencies` are only included when compiled
-as top-level.
+as top-level. The ``testDependencies`` can be added for multiple targets
+and will only be added if they can be resolved.
 
 ## C++ dependencies
 

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -509,7 +509,7 @@ namespace pxt {
             // add test dependencies if nedeed
             if (this.level == 0 && this.config.testDependencies) {
                 // only add testDepdencies that can be resolved
-                Util.iterMap(this.config.dependencies, (k, v) => {
+                Util.iterMap(this.config.testDependencies, (k, v) => {
                     if (v != "*" || pxt.appTarget.bundledpkgs[k])
                         dependencies[k] = v;
                 })

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -508,7 +508,11 @@ namespace pxt {
             const dependencies = Util.clone(this.config.dependencies || {});
             // add test dependencies if nedeed
             if (this.level == 0 && this.config.testDependencies) {
-                Util.jsonMergeFrom(dependencies, this.config.testDependencies);
+                // only add testDepdencies that can be resolved
+                Util.iterMap(this.config.dependencies, (k, v) => {
+                    if (v != "*" || pxt.appTarget.bundledpkgs[k])
+                        dependencies[k] = v;
+                })
             }
             if (includeCpp && this.config.cppDependencies) {
                 Util.jsonMergeFrom(dependencies, this.config.cppDependencies);


### PR DESCRIPTION
When authoring an extension, we need the testDepencies to load the appropriate project (e.g. "circui-playground" in adafruit). Those can be different in editor so ignoring testDependencies that can't be resolved.