### PR TITLE
Add default locale for cookie banner request

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -233,7 +233,7 @@ namespace pxt {
         // Warning: app.tsx overwrites the hash after reading the language so this needs
         // to be called before that happens
         const mlang = /(live)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
-        return mlang ? mlang[2] : ((navigator as any).userLanguage || navigator.language);
+        return (mlang ? mlang[2] : ((navigator as any).userLanguage || navigator.language)) || "en";
     }
 
     function getCookieBannerAsync(domain: string, locale: string, cb: Callback<CookieBannerInfo>) {


### PR DESCRIPTION
We were getting errors in the backend where the locale was being passed the empty string so adding a default of "en"