### PR TITLE
fix pxsim.d.ts typescript errors

### DIFF
--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -524,7 +524,7 @@ namespace pxsim {
          */
         getVariables(variablesReference: number): DebugProtocol.Variable[] {
             const lz = this._vars[variablesReference];
-            return (lz && lz.value) || [];
+            return (lz && lz.value()) || [];
         }
 
         private getVariableValues(v: Variables): util.Lazy<DebugProtocol.Variable[]> {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -288,7 +288,7 @@ namespace pxsim {
             this.messageListeners.push(listener);
         }
 
-        get storedState(): Map<any> {
+        storedState(): Map<any> {
             if (!this.runOptions) return {}
             if (!this.runOptions.storedState)
                 this.runOptions.storedState = {}
@@ -300,9 +300,9 @@ namespace pxsim {
         }
         public setStoredState(k: string, value: any) {
             if (value == null)
-                delete this.storedState[k]
+                delete this.storedState()[k]
             else
-                this.storedState[k] = value
+                this.storedState()[k] = value
             Runtime.postMessage({
                 type: "simulator",
                 command: "setstate",
@@ -441,7 +441,7 @@ namespace pxsim {
                     aws.forEach(aw => aw());
                 }
             }
-            if (this.handlers.length == 0 || this.events.length > this.max)
+            if (this._handlers.length == 0 || this.events.length > this.max)
                 return Promise.resolve()
 
             this.events.push(e)
@@ -460,7 +460,7 @@ namespace pxsim {
             this.events = []
             // in order semantics for events and handlers
             return Promise.each(events, (value) => {
-                return Promise.each(this.handlers, (handler) => {
+                return Promise.each(this._handlers, (handler) => {
                     return this.runtime.runFiberAsync(handler, ...(this.valueToArgs ? this.valueToArgs(value) : [value]))
                 })
             }).then(() => {
@@ -481,7 +481,7 @@ namespace pxsim {
             })
         }
 
-        get handlers() {
+        handlers() {
             return this._handlers;
         }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -164,7 +164,7 @@ namespace pxsim {
                 case SimulatorState.Suspended:
                     pxsim.U.addClass(frame,
                         (this.state == SimulatorState.Stopped || (this._runOptions && this._runOptions.autoRun))
-                            ? this.stoppedClass : this.invalidatedClass);
+                            ? this.stoppedClass() : this.invalidatedClass());
                     if (!this._runOptions || !this._runOptions.autoRun) {
                         icon.style.display = '';
                         icon.className = 'videoplay xicon icon';
@@ -174,8 +174,8 @@ namespace pxsim {
                     this.scheduleFrameCleanup();
                     break;
                 default:
-                    pxsim.U.removeClass(frame, this.stoppedClass);
-                    pxsim.U.removeClass(frame, this.invalidatedClass);
+                    pxsim.U.removeClass(frame, this.stoppedClass());
+                    pxsim.U.removeClass(frame, this.invalidatedClass());
                     icon.style.display = 'none';
                     loader.style.display = 'none';
                     break;
@@ -709,11 +709,11 @@ namespace pxsim {
             return this.nextFrameId++ + (Math.random() + '' + Math.random()).replace(/[^\d]/, '')
         }
 
-        private get stoppedClass() {
+        private stoppedClass() {
             return (this.options && this.options.stoppedClass) || "grayscale";
         }
 
-        private get invalidatedClass() {
+        private invalidatedClass() {
             return (this.options && this.options.invalidatedClass) || "sepia";
         }
     }

--- a/pxtsim/utils.ts
+++ b/pxtsim/utils.ts
@@ -250,7 +250,7 @@ namespace pxsim.util {
 
         constructor(private _func: () => T) { }
 
-        get value(): T {
+        value(): T {
             if (!this._evaluated) {
                 this._value = this._func();
                 this._evaluated = true;


### PR DESCRIPTION
The sim fails to build in microbit:
```
[run] cd sim; node ../node_modules/typescript/bin/tsc
../node_modules/pxt-core/built/pxtsim.d.ts(255,13): error TS1086: An accessor cannot be declared in an ambient context.
../node_modules/pxt-core/built/pxtsim.d.ts(1006,13): error TS1086: An accessor cannot be declared in an ambient context.
../node_modules/pxt-core/built/pxtsim.d.ts(1045,13): error TS1086: An accessor cannot be declared in an ambient context.
../node_modules/pxt-core/built/pxtsim.d.ts(1284,21): error TS1086: An accessor cannot be declared in an ambient context.
../node_modules/pxt-core/built/pxtsim.d.ts(1284,21): error TS7033: Property 'stoppedClass' implicitly has type 'any', because its get accessor lacks a return type annotation.
../node_modules/pxt-core/built/pxtsim.d.ts(1285,21): error TS1086: An accessor cannot be declared in an ambient context.
../node_modules/pxt-core/built/pxtsim.d.ts(1285,21): error TS7033: Property 'invalidatedClass' implicitly has type 'any', because its get accessor lacks a return type annotation.
INTERNAL ERROR: Error: Exit code: 2 from cd sim; node ../node_modules/typescript/bin/tsc
    at ChildProcess.<anonymous> (/Users/jonathandehalleux/Documents/GitHub/pxt/built/nodeutil.js:85:24)
```