### PR TITLE
Adding gulp watch task

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * [Try out the editors in your browser...](https://makecode.com)
 
-[![Build Status](https://travis-ci.org/microsoft/pxt.svg?branch=master)](https://travis-ci.org/microsoft/pxt) 
+[![Build Status](https://travis-ci.org/microsoft/pxt.svg?branch=master)](https://travis-ci.org/microsoft/pxt)
 [![Community Discord](https://img.shields.io/discord/448979533891371018.svg)](https://aka.ms/makecodecommunity)
 
 Microsoft MakeCode is based on the open source project [Microsoft Programming Experience Toolkit (PXT)](https://github.com/microsoft/pxt). ``Microsoft MakeCode`` is the name in the user-facing editors, ``PXT`` is used in all the GitHub sources.
@@ -58,7 +58,7 @@ If you run `npm i` afterwards (in either the target or pxt), you might need to r
 
 ## Build
 
-First, install [Node](https://nodejs.org/en/): minimum version 8. 
+First, install [Node](https://nodejs.org/en/): minimum version 8.
 
 To build the PXT command line tools:
 
@@ -77,6 +77,9 @@ After this you can run `pxt` from anywhere within the build tree.
 
 To start the local web server, run `pxt serve` from within the root
 of an app target (e.g. pxt-microbit). PXT will open the editor in your default web browser.
+
+If you are developing against pxt, you can run `gulp watch` from within the root of the
+pxt repository to watch for changes and rebuild.
 
 ### Icons
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1470,24 +1470,6 @@ function buildFolderAndBrowserifyAsync(p: string, optional?: boolean, outputName
     })
 }
 
-function buildPxtAsync(includeSourceMaps = false): Promise<string[]> {
-    let ksd = fs.realpathSync("node_modules/pxt-core");
-    if (!fs.existsSync(ksd + "/pxtlib/main.ts")) return Promise.resolve([]);
-
-    console.log(`building ${ksd}...`);
-    return nodeutil.spawnAsync({
-        cmd: nodeutil.addCmd("npm"),
-        args: includeSourceMaps ? ["run", "build", "sourceMaps=true"] : ["run", "build"],
-        cwd: ksd
-    }).then(() => {
-        console.log("local pxt-core built.")
-        return [ksd]
-    }, e => {
-        buildFailed("local pxt-core build FAILED", e)
-        return [ksd]
-    });
-}
-
 let dirsToWatch: string[] = []
 
 interface CiBuildInfo {
@@ -2329,12 +2311,12 @@ function buildAndWatchTargetAsync(includeSourceMaps: boolean, rebundle: boolean)
         simDirectories = simDirectories.filter(fn => fs.existsSync(fn));
     }
 
-    return buildAndWatchAsync(() => buildPxtAsync(includeSourceMaps)
-        .then(buildCommonSimAsync, e => buildFailed("common sim build failed: " + e.message, e))
+    return buildAndWatchAsync(() => buildCommonSimAsync()
+        .catch(e => buildFailed("common sim build failed: " + e.message, e))
         .then(() => internalBuildTargetAsync({ localDir: true, rebundle }))
         .catch(e => buildFailed("target build failed: " + e.message, e))
         .then(() => {
-            let toWatch = [path.resolve("node_modules/pxt-core")].concat(dirsToWatch)
+            let toWatch = dirsToWatch.slice();
             if (hasCommonPackages) {
                 toWatch = toWatch.concat(simDirectories);
             }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -107,6 +107,47 @@ const pxtdts = () => gulp.src("built/cli.d.ts")
     .pipe(gulp.dest("built"));
 
 
+function initWatch() {
+    gulp.watch("./docfiles/pxtweb/**/*", pxtweb);
+
+    const tasks = [
+        pxtlib,
+        gulp.parallel(pxtcompiler, pxtsim, backendutils),
+        gulp.parallel(pxtpy, gulp.series(copyBlockly, pxtblocks, pxtblockly)),
+        pxteditor,
+        gulp.parallel(pxtrunner, pxtwinrt, cli, pxtcommon),
+        updatestrings,
+        gulp.parallel(pxtjs, pxtdts, pxtapp, pxtworker, pxtembed),
+        targetjs,
+        webapp,
+        browserifyWebapp
+    ];
+
+
+    gulp.watch("./pxtlib/**/*", gulp.series(...tasks));
+
+    gulp.watch("./pxtcompiler/**/*", gulp.series(pxtcompiler, ...tasks.slice(2)));
+    gulp.watch("./pxtsim/**/*", gulp.series(pxtsim, ...tasks.slice(2)));
+    gulp.watch("./backendutils/**/*", gulp.series(backendutils, ...tasks.slice(2)));
+
+    gulp.watch("./pxtpy/**/*", gulp.series(pxtpy, ...tasks.slice(3)));
+    gulp.watch("./pxtblockly/**/*", gulp.series(gulp.series(copyBlockly, pxtblocks, pxtblockly), ...tasks.slice(3)));
+
+    gulp.watch("./pxteditor/**/*", gulp.series(pxteditor, ...tasks.slice(4)));
+
+    gulp.watch("./pxtrunner/**/*", gulp.series(pxtrunner, ...tasks.slice(5)));
+    gulp.watch("./pxtwinrt/**/*", gulp.series(pxtwinrt, ...tasks.slice(5)));
+    gulp.watch("./cli/**/*", gulp.series(cli, ...tasks.slice(5)));
+
+    gulp.watch("./webapp/src/**/*", gulp.series(webapp, browserifyWebapp));
+
+    gulp.watch(["./theme/**/*.less", "./theme/**/*.overrides", "./theme/**/*.variables", "./svgicons/**/*.svg"], gulp.parallel(buildcss, buildSVGIcons))
+
+    buildAll();
+}
+
+
+
 const targetjs = () => exec("node built/pxt.js buildtarget", true);
 
 const buildcss = () => exec("node built/pxt.js buildcss", true);
@@ -558,3 +599,4 @@ exports.travis = travis;
 exports.karma = karma;
 exports.update = update;
 exports.uglify = runUglify;
+exports.watch = initWatch;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,7 +139,7 @@ function initWatch() {
     gulp.watch("./pxtwinrt/**/*", gulp.series(pxtwinrt, ...tasks.slice(5)));
     gulp.watch("./cli/**/*", gulp.series(cli, ...tasks.slice(5)));
 
-    gulp.watch("./webapp/src/**/*", gulp.series(webapp, browserifyWebapp));
+    gulp.watch("./webapp/src/**/*", gulp.series(updatestrings, webapp, browserifyWebapp));
 
     gulp.watch(["./theme/**/*.less", "./theme/**/*.overrides", "./theme/**/*.variables", "./svgicons/**/*.svg"], gulp.parallel(buildcss, buildSVGIcons))
 


### PR DESCRIPTION
Adding a "gulp watch" task to the gulpfile and removing that functionality from `pxt serve`.

The new workflow for developing PXT is to run `gulp watch` in one terminal and `pxt serve` in another. Serve watches for changes to the target and gulp watches for changes to core. This has a number of improvements over the old way:

1. Incremental compilation! No more full rebuilds on changes!
2. Better file watching! No more rebuilds triggered by running `git status` in pxt!
3. Faster `pxt serve`! No more waiting for pxt to build when you only made changes in the target!

Note that `pxt serve` no longer builds pxt core *at all*, so make sure you run gulp before starting the server.