### PR TITLE
Fix auto-complete of certain global shortcuts like pos and world

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1617,7 +1617,7 @@ namespace ts.pxtc.service {
             .filter(param => !param.initializer && !param.questionToken)
             .map(getParameterDefault) : [];
 
-        let snippetPrefix = (fn.attributes.blockNamespace || fn.namespace);
+        let snippetPrefix = fn.namespace;
         let isInstance = false;
         let addNamespace = false;
         let namespaceToUse = "";


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-minecraft/issues/1706