### PR TITLE
Fix confusing method snippets by adding my_ prefix

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1691,7 +1691,13 @@ namespace ts.pxtc.service {
                 else if (element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Property) {
                     const params = pxt.blocks.compileInfo(element);
                     if (params.thisParameter) {
-                        snippetPrefix = params.thisParameter.defaultValue || params.thisParameter.definitionName;
+                        let varName: string = undefined
+                        if (params.thisParameter.definitionName) {
+                            varName = params.thisParameter.definitionName
+                            varName = varName[0].toUpperCase() + varName.substring(1)
+                            varName = `my${varName}`
+                        }
+                        snippetPrefix = params.thisParameter.defaultValue || varName;
                         if (python && snippetPrefix)
                             snippetPrefix = snakify(snippetPrefix);
                     }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-minecraft/issues/1708
pt 2
![2020-02-06 17 13 51](https://user-images.githubusercontent.com/6453828/73992455-15a43000-4904-11ea-8efb-d2bf9b21e781.gif)
