### PR TITLE
Fix block reflow coming from text issue by checking for blocks being placed exactly on top of eachother

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -254,17 +254,21 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
             needsLayout = needsLayout || (tpX == 10 && tpY == 10);
         });
+        let blockPositions: { left: number, top: number }[] = [];
         (this.editor.getTopBlocks(false) as Blockly.BlockSvg[]).forEach(b => {
-            const tpX = b.getBoundingRectangle().left;
-            const tpY = b.getBoundingRectangle().top;
-            if (minX === undefined || tpX < minX) {
-                minX = tpX;
+            const bounds = b.getBoundingRectangle()
+            if (minX === undefined || bounds.left < minX) {
+                minX = bounds.left;
             }
-            if (minY === undefined || tpY < minY) {
-                minY = tpY;
+            if (minY === undefined || bounds.top < minY) {
+                minY = bounds.top;
             }
 
-            needsLayout = needsLayout || (b.type != ts.pxtc.ON_START_TYPE && tpX == 10 && tpY == 10);
+            const isOverlapping = !!blockPositions.find(b => b.left === bounds.left && b.top === bounds.top)
+
+            needsLayout = needsLayout || isOverlapping;
+
+            blockPositions.push(bounds)
         });
 
         if (needsLayout && !flyoutOnly) {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-minecraft/issues/1664

What happened was that before the default position of blocks seemed to be (10,10) and we were checking if a non-start block was in this default position. Now the default position seems to be (10,-6) so this code never triggered. Instead I'm now checking to see if multiple blocks have the exact same top-left position and if so, do a reflow.