### PR TITLE
Store pyQName in compressed API info if differing from qName

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1996,6 +1996,7 @@ function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
         if (isEmpty(attrs))
             attrs = undefined
         const kind = sym.snippet !== undefined ? -sym.kind : sym.kind
+        const pyQName = sym.pyQName !== sym.qName ? sym.pyQName : undefined
         return {
             kind: kind == 7 ? undefined : kind,
             retType: sym.retType == "void" ? undefined : sym.retType,
@@ -2013,6 +2014,7 @@ function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
             })) : undefined,
             isInstance: sym.isInstance || undefined,
             isReadOnly: sym.isReadOnly || undefined,
+            pyQName: pyQName
         } as any
     }
 

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -58,6 +58,7 @@ namespace pxt {
             for (const apiName of Object.keys(byQName)) {
                 const sym = byQName[apiName]
                 const lastDot = apiName.lastIndexOf(".")
+                const pyQName = sym.pyQName;
                 // re-create the object - this will hint the JIT that these are objects of the same type
                 // and the same hidden class should be used
                 const newsym = byQName[apiName] = {
@@ -65,6 +66,8 @@ namespace pxt {
                     qName: apiName,
                     namespace: apiName.slice(0, lastDot < 0 ? 0 : lastDot),
                     name: apiName.slice(lastDot + 1),
+                    pyQName: pyQName,
+                    pyName: pyQName ? pyQName.slice(pyQName.lastIndexOf(".") + 1) : undefined,
                     fileName: "",
                     attributes: sym.attributes || ({} as any),
                     retType: sym.retType || "void",


### PR DESCRIPTION
Display correct API names in Python toolbox (on_player_chat vs onPlayerChat)

Fixes https://github.com/microsoft/pxt-minecraft/issues/1657
