### PR TITLE
Home screen, tutorial UI fixes

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -249,7 +249,8 @@ div.simframe > iframe {
 /* Menu */
 // The classname .menubar is also used by monaco. This rule just negates the clashing
 // values
-#root > .menubar {
+#root > .menubar,
+#homescreen > .home > .menubar {
     height: unset;
     overflow: unset;
 }

--- a/theme/home.less
+++ b/theme/home.less
@@ -169,6 +169,7 @@
         transition: height 0.5s;
         z-index: @homeDetailViewZIndex;
         position: relative;
+        overflow: hidden;
         .ui.grid {
             background: @homeDetailViewBackground;
         }
@@ -211,7 +212,7 @@
             color: @homeDetailViewColor;
         }
         .actions {
-            padding: 2rem 0;
+            padding-right: 4rem !important;
             position: absolute;
             bottom: 0;
             text-align: right;
@@ -239,10 +240,12 @@
                 .button.attached i {
                     display: block;
                     margin: auto!important;
-                    font-size: 5rem;
-                    line-height: 8rem;
                     opacity: 0.1;
                     color: @homeCardHeaderColor;
+                }
+                .button.attached .icon:not(.xicon) {
+                    font-size: 5rem;
+                    line-height: 8rem;
                 }
 
                 .button.approve {
@@ -253,9 +256,6 @@
                 }
                 &:first-child .button.approve {
                     background-color: @green;
-                }
-                &:last-child {
-                    margin-right: 6rem;
                 }
             }
             .card-action-title {
@@ -422,7 +422,6 @@
 /* Inverted */
 .inverted-theme {
     .projectsdialog .detailview .actions {
-        height: 9rem;
         .card-action {
             > .item, > .icon {
                 background: @homeInvertedDetailCardActionBackground;
@@ -469,12 +468,25 @@
             }
         }
         .detailview {
+            .actions .card-action {
+                max-width: 10rem;
+                .button.attached .icon:not(.xicon) {
+                    line-height: 6rem;
+                }
+            }
             .actions .card-action > .item,
             .actions .card-action > .icon {
                 height: 6rem;
+                max-width: 10rem;
+                background-size: 60%;
+            }
+            .actions .segment {
+                margin-top: 4rem;
+                margin-right: 2rem;
             }
             .ui.button.approve {
                 font-size: 1rem!important;
+                padding: 0.7rem 1rem;
             }
         }
     }
@@ -608,15 +620,20 @@
             }
             .actions {
                 height: 9rem;
+                padding-right: 4rem !important;
                 .card-action {
                     > .item, > .icon {
                         height: 2rem;
                     }
                     .xicon {
-                        background-image: none;
+                        background-image: none!important;
                     }
                     .button.approve {
                         padding: .35em 1em .5em;
+                    }
+                    .button.attached .icon:not(.xicon) {
+                        font-size: 2rem;
+                        line-height: 2rem;
                     }
                     &:first-child {
                         margin-left: 0;

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -148,7 +148,7 @@ default semantic
 @jsIconUrl: "../docs/static/icons/js.svg";
 @jsIcon: data-uri(@jsIconUrl);
 
-@logoFilter: saturate(0%);
+@logoFilter: invert(23%) sepia(91%) saturate(1957%) hue-rotate(290deg) brightness(83%) contrast(94%);
 
 /*-------------------
    Menu

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -20,7 +20,6 @@
         background-size: contain;
         background-image: @blocksIcon;
         filter: @logoFilter;
-        opacity: 0.8;
     }
     .content {
         margin-left: 4rem;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3344,7 +3344,12 @@ export class ProjectView
         if (flyoutOnly) {
             margin += 2;
         }
-        return tc ? { 'top': "calc(min(" + tc.getCardHeight() + "px, 18rem) + " + margin + "em)" } : null;
+        if (tc) {
+            // maxium offset of 18rem
+            let maxOffset = Math.min(tc.getCardHeight(), parseFloat(getComputedStyle(document.documentElement).fontSize) * 18);
+            return { 'top': "calc(" + maxOffset + "px + " + margin + "em)" };
+        }
+        return null;
     }
 
     ///////////////////////////////////////////////////////////


### PR DESCRIPTION
- Fix horizontal scroll for details view with three cards
- Fix homescreen gradient menubar height
- Fix card alignment on Safari
- Fix tutorial card overlapping workspace
- Purple icons


Fixes https://github.com/microsoft/pxt-minecraft/issues/1738
Fixes https://github.com/microsoft/pxt-minecraft/issues/1727
Fixes https://github.com/microsoft/pxt-minecraft/issues/1719
Fixes https://github.com/microsoft/pxt-minecraft/issues/1716