### PR TITLE
Don't cache filtered snippet groups

### DIFF
--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -297,7 +297,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
                     }
                     // Add group blocks
                     if (g.blocks) {
-                        group = group.concat(g.blocks.map((b, j) => {
+                        let blocks = g.blocks.map((b, j) => {
                             // Check if the block is built in, ignore it as it's already defined in snippets
                             if (b.attributes.blockBuiltin) {
                                 pxt.log("ignoring built in block: " + b.attributes.blockId);
@@ -305,7 +305,12 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
                             } else {
                                 return this.getMonacoBlock(b, j, rgb);
                             }
-                        }));
+                        }).filter(b => b !== undefined);
+                        if (blocks && blocks.length > 0) {
+                            group = group.concat(blocks);
+                        } else {
+                            return null;
+                        }
                     }
                    return group;
                })}

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -336,7 +336,12 @@ export abstract class ToolboxEditor extends srceditor.Editor {
                     }
                 }
             }
-            this.blockGroups[ns] = blockGroups;
+            // Only cache if there are no filters
+            if (!this.parent.state?.editorState?.filters) {
+                this.blockGroups[ns] = blockGroups;
+            } else {
+                return blockGroups;
+            }
         }
 
         return this.blockGroups[ns];


### PR DESCRIPTION
\+ don't render group headers if all blocks are filtered out

Fixes https://github.com/microsoft/pxt-minecraft/issues/1728