### PR TITLE
handle variables matching top level constants, namespaces

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2015,7 +2015,7 @@ function compressApiInfo(inf: Map<pxt.PackageApiInfo>) {
             isInstance: sym.isInstance || undefined,
             isReadOnly: sym.isReadOnly || undefined,
             pyQName: pyQName
-        } as any
+        } as pxtc.SymbolInfo;
     }
 
     inf = U.clone(inf)
@@ -2126,6 +2126,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         // JRES is already included in the target bundle
                         api.jres = undefined;
                         builtInfo[dirname] = {
+                            name: dirname,
                             apis: api,
                             sha: packageSha
                         };

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2126,7 +2126,6 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                         // JRES is already included in the target bundle
                         api.jres = undefined;
                         builtInfo[dirname] = {
-                            name: dirname,
                             apis: api,
                             sha: packageSha
                         };

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -413,6 +413,7 @@ declare namespace pxt {
     interface PackageApiInfo {
         sha: string;
         apis: ts.pxtc.ApisInfo;
+        name: string;
     }
 }
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -413,7 +413,6 @@ declare namespace pxt {
     interface PackageApiInfo {
         sha: string;
         apis: ts.pxtc.ApisInfo;
-        name: string;
     }
 }
 

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1515,7 +1515,7 @@ namespace pxt.blocks {
                 // Otherwise, after the first compile the function will be renamed because it conflicts
                 // with itself. You can still get collisions if you attempt to define a function with
                 // the same name as a function defined in another file in the user's project (e.g. custom.ts)
-                if (info.pkg && (info.kind === pxtc.SymbolKind.Enum || info.kind === pxtc.SymbolKind.Function || info.kind === pxtc.SymbolKind.Module)) {
+                if (info.pkg && (info.kind === pxtc.SymbolKind.Enum || info.kind === pxtc.SymbolKind.Function || info.kind === pxtc.SymbolKind.Module || info.kind === pxtc.SymbolKind.Variable)) {
                     e.renames.takenNames[info.qName] = true;
                 }
             });

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -565,14 +565,17 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
     };
 
     for (const used of usedPackageInfo) {
-        const { info, dirname } = used;
         if (!used) continue;
-        pxt.Util.jsonCopyFrom(result.byQName, info.apis.byQName);
+        const { info, dirname } = used;
+
+        // reinclude the pkg the api originates from, which is trimmed during compression
         for (const api of Object.keys(info.apis.byQName)) {
-            result.byQName[api].pkg = dirname;
+            info.apis.byQName[api].pkg = dirname;
         }
 
-        if (info.apis.jres) pxt.Util.jsonCopyFrom(result.jres, info.apis.jres);
+        pxt.Util.jsonCopyFrom(result.byQName, info.apis.byQName);
+        if (info.apis.jres)
+            pxt.Util.jsonCopyFrom(result.jres, info.apis.jres);
     }
 
     const jres = pkg.mainPkg.getJRes();

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -553,6 +553,9 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
     for (const used of usedInfo) {
         if (!used) continue;
         pxt.Util.jsonCopyFrom(result.byQName, used.apis.byQName);
+        for (const api of Object.keys(used.apis.byQName)) {
+            result.byQName[api].pkg = used.name;
+        }
 
         if (used.apis.jres) pxt.Util.jsonCopyFrom(result.jres, used.apis.jres);
     }
@@ -587,12 +590,13 @@ async function cacheApiInfoAsync(project: pkg.EditorPackage, info: pxtc.ApisInfo
         const db = await ApiInfoIndexedDb.createAsync();
 
         for (const dep of externalPackages) {
+            const name = dep.getKsPkg().config.name;
             const entry: pxt.PackageApiInfo = {
+                name: name,
                 sha: null,
                 apis: { byQName: {} }
             }
 
-            const name = dep.getKsPkg().config.name;
 
             for (const api of apiList) {
                 if (info.byQName[api].pkg === name) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/1663 (variables conflicting with the new shorthand / alias constants in minecraft, like `LEFT`), as well as other variable conflicts (e.g. namespaces: `console`) that were broken due to the pkg being dropped from the cached api info.

![2020-02-10 16 41 56](https://user-images.githubusercontent.com/5615930/74203820-bf95fc00-4c25-11ea-807e-088318e4c67b.gif)