### PR TITLE
split findblock to by line and by pos; fix error ranges, debugger

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1813,7 +1813,7 @@ namespace pxt.blocks {
         diagnostics: BlockDiagnostic[];
     }
 
-    export function findBlockId(sourceMap: BlockSourceInterval[], loc: { start: number; length: number; }): string {
+    export function findBlockIdByPosition(sourceMap: BlockSourceInterval[], loc: { start: number; length: number; }): string {
         if (!loc) return undefined;
         let bestChunk: BlockSourceInterval;
         let bestChunkLength: number;
@@ -1821,10 +1821,30 @@ namespace pxt.blocks {
         for (let i = 0; i < sourceMap.length; ++i) {
             let chunk = sourceMap[i];
             if (chunk.startPos <= loc.start
-                && chunk.endPos >= loc.start + loc.length
-                && (!bestChunk || bestChunkLength > chunk.endPos - chunk.startPos)) {
+                    && chunk.endPos >= loc.start + loc.length
+                    && (!bestChunk || bestChunkLength > chunk.endPos - chunk.startPos)) {
                 bestChunk = chunk;
                 bestChunkLength = chunk.endPos - chunk.startPos;
+            }
+        }
+        if (bestChunk) {
+            return bestChunk.id;
+        }
+        return undefined;
+    }
+
+    export function findBlockIdByLine(sourceMap: BlockSourceInterval[], loc: { start: number; length: number; }): string {
+        if (!loc) return undefined;
+        let bestChunk: BlockSourceInterval;
+        let bestChunkLength: number;
+        // look for smallest chunk containing the block
+        for (let i = 0; i < sourceMap.length; ++i) {
+            let chunk = sourceMap[i];
+            if (chunk.startLine <= loc.start
+                    && chunk.endLine > loc.start + loc.length
+                    && (!bestChunk || bestChunkLength > chunk.endLine - chunk.startLine)) {
+                bestChunk = chunk;
+                bestChunkLength = chunk.endLine - chunk.startLine;
             }
         }
         if (bestChunk) {

--- a/pxtblocks/blocklydiff.ts
+++ b/pxtblocks/blocklydiff.ts
@@ -487,12 +487,12 @@ namespace pxt.blocks {
                         lineLength -= lwl;
                     }
                     // find block ids mapped to the ranges
-                    const newid = pxt.blocks.findBlockId(newResp.blockSourceMap, {
+                    const newid = pxt.blocks.findBlockIdByPosition(newResp.blockSourceMap, {
                         start: newLineStart,
                         length: lineLength
                     });
                     if (newid && !newids[newid]) {
-                        const oldid = pxt.blocks.findBlockId(oldResp.blockSourceMap, {
+                        const oldid = pxt.blocks.findBlockIdByPosition(oldResp.blockSourceMap, {
                             start: oldLineStart,
                             length: lineLength
                         });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -41,7 +41,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let map: pxt.Map<number> = {};
         if (!breakpoints || !this.compilationResult) return;
         breakpoints.forEach(breakpoint => {
-            let blockId = pxt.blocks.findBlockId(this.compilationResult.sourceMap, { start: breakpoint.line, length: breakpoint.endLine - breakpoint.line });
+            let blockId = pxt.blocks.findBlockIdByLine(this.compilationResult.sourceMap, { start: breakpoint.line, length: breakpoint.endLine - breakpoint.line });
             if (blockId) map[blockId] = breakpoint.id;
         });
         this.breakpointsByBlock = map;
@@ -837,7 +837,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         let sourceMap = this.compilationResult.sourceMap;
 
         diags.filter(diag => diag.category == ts.pxtc.DiagnosticCategory.Error).forEach(diag => {
-            let bid = pxt.blocks.findBlockId(sourceMap, { start: diag.line, length: 0 });
+            let bid = pxt.blocks.findBlockIdByLine(sourceMap, { start: diag.line, length: 0 });
             if (bid) {
                 let b = this.editor.getBlockById(bid) as Blockly.BlockSvg;
                 if (b) {
@@ -864,7 +864,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             return false;
         this.updateDebuggerVariables(brk);
         if (stmt) {
-            let bid = pxt.blocks.findBlockId(this.compilationResult.sourceMap, { start: stmt.line, length: stmt.endLine - stmt.line });
+            let bid = pxt.blocks.findBlockIdByLine(this.compilationResult.sourceMap, { start: stmt.line, length: stmt.endLine - stmt.line });
             if (bid) {
                 this.editor.highlightBlock(bid);
                 if (brk) {


### PR DESCRIPTION
the blocksdiff stuff is based off of char position, where many of the other ranges are based no line positions; fixes  breakpoints in debugger and error ranges in blocks.

fixes https://github.com/microsoft/pxt-minecraft/issues/1740, and also debugger that I just noticed was broken while fixing this:

![2020-02-11 14 37 07](https://user-images.githubusercontent.com/5615930/74286260-3e4d7080-4cdc-11ea-9133-207008b933ac.gif)
