### PR TITLE
iOS/TouchEvent fixes for the Monaco flyout

### DIFF
--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -49,6 +49,11 @@
     color: #FFB900 !important;
 }
 
+/* Monaco Editor Rename Widget: default positioning causes scroll with transparent editor toolbar, so we reposition */
+.monaco-editor .rename-box {
+    bottom: 3rem;
+}
+
 /* The view lines in the monaco editor sometimes ignore the editor width and cause a scrollbar to appear */
 .monaco-editor.vs {
     overflow: hidden;
@@ -247,6 +252,7 @@
     overflow-x: visible;
     overflow-y: auto;
     height: 100%;
+    -webkit-overflow-scrolling: touch;
 
     & > div {
         padding: 1rem;

--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -187,7 +187,7 @@
             font-weight: 600;
             background: rgba(0,0,0,0.3);
             color: #fff;
-            padding: 0.1rem .5rem;
+            padding: 0 .5rem;
             display: inline-block;
             border-radius: 0.8rem;
             line-height: 1.75rem;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -766,7 +766,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 monacoEditorInner.onmousemove = this.onPointerMove;
                 monacoEditorInner.onmouseup = this.onPointerUp;
                 if (pxt.BrowserUtils.isTouchEnabled()) {
-                    monacoEditorInner.ontouchmove = this.onPointerMove;
+                    // For devices without PointerEvents (iOS < 13.0), use state to
+                    // hide the flyout rather than focusing the editor (onPointerMove)
                     monacoEditorInner.ontouchend = this.onPointerUp;
                 }
             }
@@ -1622,6 +1623,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.flyout.setState({
                 name: name || Util.capitalize(subns || ns),
                 selectedBlock: undefined,
+                hide: false,
                 ns, color, icon, groups
             })
         }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -759,7 +759,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             })
 
             const monacoEditorInner = document.getElementById('monacoEditorInner');
-            if ((window as any).PointerEvent) {
+            if (pxt.BrowserUtils.hasPointerEvents()) {
                 monacoEditorInner.onpointermove = this.onPointerMove;
                 monacoEditorInner.onpointerup = this.onPointerUp;
             } else {

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -43,7 +43,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
     }
 
     componentDidMount() {
-        if ((window as any).PointerEvent) {
+        if (pxt.BrowserUtils.hasPointerEvents()) {
             document.addEventListener("pointermove", this.blockDragHandler);
             document.addEventListener("pointerup", this.blockDragEndHandler);
         } else {
@@ -57,7 +57,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
     }
 
     componentWillUnmount() {
-        if ((window as any).PointerEvent) {
+        if (pxt.BrowserUtils.hasPointerEvents()) {
             document.removeEventListener("pointermove", this.blockDragHandler);
             document.removeEventListener("pointerup", this.blockDragEndHandler);
         } else {
@@ -204,7 +204,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
     }
 
     protected getSelectedStyle = () => {
-        return { touchAction: (window as any).PointerEvent ? "pan-y"  : undefined };
+        return { touchAction: pxt.BrowserUtils.hasPointerEvents() ? "pan-y"  : undefined };
     }
 
     protected getBlockStyle = (color: string) => {
@@ -303,7 +303,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
         const qName =  this.getQName(block) || this.getSnippetName(block);
         const selected = qName == this.state.selectedBlock;
 
-        const hasPointer = (window as any).PointerEvent;
+        const hasPointer = pxt.BrowserUtils.hasPointerEvents();
         const hasTouch = pxt.BrowserUtils.isTouchEnabled();
         const dragStartHandler = this.getBlockDragStartHandler(block, snippet, blockColor);
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -216,7 +216,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
     }
 
     protected getQName(block: toolbox.BlockDefinition): string {
-        return this.props.fileType == pxt.editor.FileType.Python ? block.pyQName : block.qName;
+        return this.props.fileType == pxt.editor.FileType.Python && block.pyQName ? block.pyQName : block.qName;
     }
 
     protected getSnippetName(block: toolbox.BlockDefinition): string {
@@ -250,7 +250,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
             })
         } else {
             // if no blockdef found, use the snippet name
-            description.push(<span>{block.snippetName || block.name}</span>)
+            description.push(<span key={name}>{block.snippetName || block.name}</span>)
         }
 
         // imitates block behavior in adding "run code" before any handler
@@ -310,7 +310,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
         return <div className={`monacoBlock ${disabled ? "monacoDisabledBlock" : ""} ${selected ? "expand" : ""}`}
                     style={this.getSelectedStyle()}
                     title={block.attributes.jsDoc}
-                    key={`block_${qName}`} tabIndex={0} role="listitem"
+                    key={`block_${qName}_${index}`} tabIndex={0} role="listitem"
                     onClick={this.getBlockClickHandler(qName)}
                     onKeyDown={this.getKeyDownHandler(block, snippet, isPython)}
                     onPointerDown={hasPointer ? dragStartHandler : undefined}

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -23,6 +23,7 @@ export const enum CategoryNameID {
 export interface BlockDefinition {
     qName?: string;
     name: string;
+    pyQName?: string;
     pyName?: string;
     namespace?: string;
     type?: string;


### PR DESCRIPTION
- Fixes TouchEvent event listeners (when PointerEvents are not present)
- Fixes flyout scroll on iOS
- Fixes React warnings for toolbox
- Fixes small vertical scroll on page for inGame Monaco view
- Displays Python qName in expanded toolbox and dragged API snippet

https://minecraft.makecode.com/app/cf78239e71f67f95ce966e2060ab408ec83adf40-f94313c5bc

Fixes https://github.com/microsoft/pxt-minecraft/issues/1735
Fixes https://github.com/microsoft/pxt-minecraft/issues/1457