### PR TITLE
Fix signature help overlapping the user  text

### DIFF
--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -135,6 +135,7 @@ namespace pxt.vs {
             minimap: {
                 enabled: false
             },
+            fixedOverflowWidgets: true,
             autoIndent: "full",
             useTabStops: true,
             dragAndDrop: true,


### PR DESCRIPTION
Fixes:  https://github.com/microsoft/pxt-minecraft/issues/1721

For whatever reason I never quite got to the bottom of, Monaco computes the height and placement of the signature help incorrectly. This is a workaround that tells it to use a different algorithm that works a lot better.