### PR TITLE
tut / docs diffs ignore whitespace, show fileB content on no-diff

### DIFF
--- a/pxtlib/diff.ts
+++ b/pxtlib/diff.ts
@@ -105,7 +105,7 @@ namespace pxt.diff {
             let y = x - k
             const snakeLen = V[MAX + k] - x
             for (let i = snakeLen - 1; i >= 0; --i)
-                diff.push("  " + a[x + i])
+                diff.push("  " + b[y + i])
 
             if (nextK == k - 1) {
                 diff.push("- " + a[x - 1])

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -585,7 +585,8 @@ namespace pxt.runner {
                     hideMarkerLine: true,
                     hideMarker: true,
                     hideRemoved: true,
-                    update: true
+                    update: true,
+                    ignoreWhitespace: true,
                 });
                 if (opts.snippetReplaceParent) $el = $el.parent();
                 const segment = $('<div class="ui segment codewidget"/>').append(diffEl);
@@ -626,7 +627,8 @@ namespace pxt.runner {
                             hideMarkerLine: true,
                             hideMarker: true,
                             hideRemoved: true,
-                            update: true
+                            update: true,
+                            ignoreWhitespace: true
                         })
                         let diffPy: HTMLElement;
                         const [oldPy, newPy] = resps.map(resp =>
@@ -639,7 +641,8 @@ namespace pxt.runner {
                                 hideMarkerLine: true,
                                 hideMarker: true,
                                 hideRemoved: true,
-                                update: true
+                                update: true,
+                                ignoreWhitespace: true
                             })
                         }
                         fillWithWidget(opts, $el.parent(), $(diffJs), diffPy && $(diffPy), $(diffBlocks.svg as HTMLElement), undefined, {

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -116,7 +116,8 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                                 hideMarkerLine: true,
                                 hideMarker: true,
                                 hideRemoved: true,
-                                update: true
+                                update: true,
+                                ignoreWhitespace: true
                             });
                             return el;
                         });
@@ -132,7 +133,8 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                         hideMarkerLine: true,
                         hideMarker: true,
                         hideRemoved: true,
-                        update: true
+                        update: true,
+                        ignoreWhitespace: true
                     });
                     return Promise.resolve(el);
                 })


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-minecraft/issues/1744, the diffs renderer wasn't passing in `ignoreWhitespace`

see comment about seemingly minor diff algorithm change \\/

didn't look at the issue about it not rendering diffspy in the docs page, but it looks like that's just https://github.com/Microsoft/pxt/blob/master/pxtrunner/renderer.ts not having handling for  spydiffs  like /marked.tsx does?