### PR TITLE
MarkedContent update

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -376,6 +376,7 @@ declare namespace pxt {
         hideHomeDetailsVideo?: boolean; // hide video/large image from details card
         tutorialBlocksDiff?: boolean; // automatically display diffs in tutorials
         openProjectNewTab?: boolean; // allow opening project in a new tab
+        tutorialExplicitHints?: boolean; // allow use explicit hints
     }
 
     interface SocialOptions {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -275,8 +275,13 @@ ${code}
 
             return "";
         });
+        const metadata = (m as TutorialMetadata);
+        if (metadata.explicitHints !== undefined 
+            && pxt.appTarget.appTheme 
+            && pxt.appTarget.appTheme.tutorialExplicitHints)
+            metadata.explicitHints = true;
 
-        return { metadata: (m as TutorialMetadata), body };
+        return { metadata, body };
     }
 
     export function highlight(pre: HTMLElement): void {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -276,8 +276,8 @@ ${code}
             return "";
         });
         const metadata = (m as TutorialMetadata);
-        if (metadata.explicitHints !== undefined 
-            && pxt.appTarget.appTheme 
+        if (metadata.explicitHints !== undefined
+            && pxt.appTarget.appTheme
             && pxt.appTarget.appTheme.tutorialExplicitHints)
             metadata.explicitHints = true;
 

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -87,6 +87,15 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         const { parent, onDidRender } = this.props;
 
         let promises: Promise<void>[] = [];
+
+        pxt.Util.toArray(content.querySelectorAll(`img`))
+            .forEach((imgBlock: HTMLImageElement) => {
+                promises.push(new Promise<void>((resolve, reject) => {
+                    imgBlock.addEventListener("load", () => resolve(), false); 
+                    imgBlock.addEventListener("error", () => resolve(), false); 
+                }))
+            });
+
         pxt.Util.toArray(content.querySelectorAll(`code.lang-typescript,code.lang-python`))
             .forEach((langBlock: HTMLElement) => {
                 const code = langBlock.textContent;
@@ -305,6 +314,8 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         /* tslint:disable:no-inner-html (marked content is already sanitized) */
         content.innerHTML = marked(markdown);
         /* tslint:enable:no-inner-html */
+
+        // 
 
         // We'll go through a series of adjustments here, rendering inline blocks, blocks and snippets as needed
         this.renderInlineBlocks(content);

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -91,8 +91,8 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         pxt.Util.toArray(content.querySelectorAll(`img`))
             .forEach((imgBlock: HTMLImageElement) => {
                 promises.push(new Promise<void>((resolve, reject) => {
-                    imgBlock.addEventListener("load", () => resolve(), false); 
-                    imgBlock.addEventListener("error", () => resolve(), false); 
+                    imgBlock.addEventListener("load", () => resolve(), false);
+                    imgBlock.addEventListener("error", () => resolve(), false);
                 }))
             });
 

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -9,6 +9,7 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 interface MarkedContentProps extends ISettingsProps {
     markdown: string;
     className?: string;
+    onDidRender?: () => void;
 }
 
 interface MarkedContentState {
@@ -83,7 +84,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     }
 
     private renderSnippets(content: HTMLElement) {
-        const { parent } = this.props;
+        const { parent, onDidRender } = this.props;
 
         let promises: Promise<void>[] = [];
         pxt.Util.toArray(content.querySelectorAll(`code.lang-typescript,code.lang-python`))
@@ -224,10 +225,11 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
             });
 
         promises = promises.filter(p => !!p);
-        if (promises.length)
+        if (promises.length && onDidRender)
             Promise.all(promises)
                 .then(() => {
-                    this.forceUpdate()
+                    pxt.log(`markdowcontent: forcing update after async rendering`)
+                    onDidRender();
                 });
 
         function wrapBlockDiff(diff: pxt.blocks.DiffResult): HTMLElement {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -300,6 +300,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.nextTutorialStep = this.nextTutorialStep.bind(this);
         this.finishTutorial = this.finishTutorial.bind(this);
         this.toggleExpanded = this.toggleExpanded.bind(this);
+        this.onMarkdownDidRender = this.onMarkdownDidRender.bind(this);
 
     }
 
@@ -395,6 +396,10 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     componentDidMount() {
+        this.setShowSeeMore(this.props.parent.state.tutorialOptions.autoexpandStep);
+    }
+
+    onMarkdownDidRender() {
         this.setShowSeeMore(this.props.parent.state.tutorialOptions.autoexpandStep);
     }
 
@@ -551,7 +556,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                     <div ref="tutorialmessage" className={`tutorialmessage`} role="alert" aria-label={tutorialAriaLabel} tabIndex={hasHint ? 0 : -1}
                         onClick={hasHint ? hintOnClick : undefined} onKeyDown={hasHint ? sui.fireClickOnEnter : undefined}>
                         <div className="content">
-                            {!unplugged && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} />}
+                            {!unplugged && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
                         </div>
                     </div>
                     {this.state.showSeeMore && !tutorialStepExpanded && <sui.Button className="fluid compact lightgrey" icon="chevron down" tabIndex={0} text={lf("More...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} />}


### PR DESCRIPTION
The content displayed in the tutorial changes sizes as it gets resized. This change notifies the tutorial engine to run the computation again when it is done.
- [x] track loading of code snippets and handle image loading.
- [x] target flag to use explicithints 

![2020-02-11 19 43 39](https://user-images.githubusercontent.com/4175913/74301116-da8c6d00-4d06-11ea-959d-080a3dbb80d1.gif)

Not the cleanest React way to do this, suggestions welcome.