### PR TITLE
list user repoes using graphql

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -613,11 +613,11 @@ namespace pxt.github {
                 })
                 .map((node: any) => <pxt.github.GitRepo>{
                     name: node.name,
-                    fullName: node.nameWithOwner,
+                    fullName: node.fullName,
                     owner: node.owner.login,
                     description: node.description,
                     defaultBranch: node.defaultBranchRef.name,
-                    updatedAt: new Date(node.updatedAt).getTime(),
+                    updatedAt: new Date(node.updatedAt).getMilliseconds(),
                     private: node.private,
                     fork: node.fork
                 })

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -583,12 +583,12 @@ namespace pxt.github {
       nodes {
         name
         description
-        fullName: nameWithOwner
+        full_name: nameWithOwner
         private: isPrivate
         fork: isFork
-        updatedAt
+        updated_at: updatedAt
         owner {
-            login
+          login
         }
         defaultBranchRef {
           name
@@ -606,21 +606,13 @@ namespace pxt.github {
             .then(res => (<any[]>res.data.viewer.repositories.nodes)
                 .filter((node: any) => node.object)
                 .filter((node: any) => {
+                    node.default_branch = node.defaultBranchRef.name;
                     const pxtJson = pxt.Package.parseAndValidConfig(node.object.text);
                     return pxtJson
                         && pxtJson.supportedTargets
                         && pxtJson.supportedTargets.indexOf(pxt.appTarget.id) > -1;
                 })
-                .map((node: any) => <pxt.github.GitRepo>{
-                    name: node.name,
-                    fullName: node.fullName,
-                    owner: node.owner.login,
-                    description: node.description,
-                    defaultBranch: node.defaultBranchRef.name,
-                    updatedAt: new Date(node.updatedAt).getMilliseconds(),
-                    private: node.private,
-                    fork: node.fork
-                })
+                .map((node: any) => mkRepo(node, null))
             );
     }
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -603,13 +603,13 @@ namespace pxt.github {
   }
 }`
         return ghGraphQLQueryAsync(q)
-            .then(res => res.data.viewer.repositories.nodes
+            .then(res => (<any[]>res.data.viewer.repositories.nodes)
                 .filter((node: any) => node.object)
-                .filer((node: any) => {
+                .filter((node: any) => {
                     const pxtJson = pxt.Package.parseAndValidConfig(node.object.text);
                     return pxtJson
                         && pxtJson.supportedTargets
-                        && pxtJson.supportedTargets.indexOf(pxt.appTarget.id) > 0;
+                        && pxtJson.supportedTargets.indexOf(pxt.appTarget.id) > -1;
                 })
                 .map((node: any) => <pxt.github.GitRepo>{
                     name: node.name,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2835,7 +2835,8 @@ export class ProjectView
     }
 
     importProjectDialog() {
-        this.importDialog.show();
+        cloudsync.ensureGitHubTokenAsync()
+            .then(() => this.importDialog.show());
     }
 
     renderPythonAsync(req: pxt.editor.EditorMessageRenderPythonRequest): Promise<pxt.editor.EditorMessageRenderPythonResponse> {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2835,8 +2835,7 @@ export class ProjectView
     }
 
     importProjectDialog() {
-        cloudsync.ensureGitHubTokenAsync()
-            .then(() => this.importDialog.show());
+        this.importDialog.show();
     }
 
     renderPythonAsync(req: pxt.editor.EditorMessageRenderPythonRequest): Promise<pxt.editor.EditorMessageRenderPythonResponse> {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -534,6 +534,8 @@ export function showImportGithubDialogAsync() {
         .then(repos => core.confirmAsync({
             header: lf("Clone or create your own GitHub repo"),
             hideAgree: true,
+            hideCancel: true,
+            hasCloseIcon: true,
             /* tslint:disable:react-a11y-anchors */
             jsx: <div className="ui form">
                 <div className="ui relaxed divided list" role="menu">

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -521,9 +521,7 @@ export function showImportGithubDialogAsync() {
     return pxt.github.listUserReposAsync()
         .finally(() => core.hideLoading("githublist"))
         .then(repos => {
-            let isPXT = (r: pxt.github.GitRepo) => /pxt|makecode/.test(r.name)
-            return repos.filter(isPXT).concat(repos.filter(r => !isPXT(r)))
-                .map(r => ({
+            return repos.map(r => ({
                     name: r.fullName,
                     description: r.description,
                     updatedAt: r.updatedAt,

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -982,7 +982,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                         /> : undefined}
                     {pxt.appTarget.cloud
                         && pxt.appTarget.cloud.cloudProviders
-                        && pxt.appTarget.cloud.cloudProviders ?
+                        && pxt.appTarget.cloud.cloudProviders.github ?
                         <codecard.CodeCardView
                             ariaLabel={lf("Clone or create your own GitHub repository")}
                             role="button"


### PR DESCRIPTION
GraphQL query also returns pxt.json from reopes which allows to parse the supported target precisely. No more loading microbit repoes in arcade editor...