### PR TITLE
Dont show completions on commas

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -31,7 +31,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
     constructor(public editor: Editor, public python: boolean) {
     }
 
-    triggerCharacters?: string[] = ["(", ",", "."];
+    triggerCharacters?: string[] = ["(", "."];
 
     kindMap = {}
     private tsKindToMonacoKind(s: pxtc.SymbolKind): monaco.languages.CompletionItemKind {


### PR DESCRIPTION
It's very common to end a line with a comma in TypeScript, and the completion gets committed when you hit enter. Some common examples:

```typescript
let x = [
    1,
    2
];

someFunction(
    "arg1",
    "arg2"
);

let y = {
    a: 0,
    b: 1
}

enum Whatever {
    A,
    B,
}

let a = 0,
b = 1,
c = 2;
```