### PR TITLE
Only show menu divider if items above it are present

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -281,7 +281,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
                 </div>
                 {lf("Sign out")}
             </div> : undefined}
-            <div className="ui divider"></div>
+            {(targetTheme.selectLanguage || targetTheme.highContrast || showGreenScreen || githubUser) && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             {!isController ? <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} /> : undefined}
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -260,6 +260,8 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         const githubUser = !readOnly && !isController && this.getData("github:user") as pxt.editor.UserInfo;
         const showPairDevice = pxt.usb.isEnabled && !pxt.BrowserUtils.isElectron();
 
+        const showCenterDivider = targetTheme.selectLanguage || targetTheme.highContrast || showGreenScreen || githubUser;
+
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             {showProjectSettings ? <sui.Item role="menuitem" icon="options" text={lf("Project Settings")} onClick={this.openSettings} /> : undefined}
             {packages ? <sui.Item role="menuitem" icon="disk outline" text={lf("Extensions")} onClick={this.showPackageDialog} /> : undefined}
@@ -281,7 +283,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
                 </div>
                 {lf("Sign out")}
             </div> : undefined}
-            {(targetTheme.selectLanguage || targetTheme.highContrast || showGreenScreen || githubUser) && <div className="ui divider"></div>}
+            {showCenterDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             {!isController ? <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} /> : undefined}
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -321,7 +321,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
                 </div>
                 {lf("Sign out")}
             </div>}
-            <div className="ui divider"></div>
+            {(targetTheme.selectLanguage || targetTheme.highContrast || githubUser) && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -309,6 +309,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
         const targetTheme = pxt.appTarget.appTheme;
         const githubUser = this.getData("github:user") as pxt.editor.UserInfo;
         const reportAbuse = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
+        const showDivider = targetTheme.selectLanguage || targetTheme.highContrast || githubUser;
 
         // tslint:disable react-a11y-anchors
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
@@ -321,7 +322,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
                 </div>
                 {lf("Sign out")}
             </div>}
-            {(targetTheme.selectLanguage || targetTheme.highContrast || githubUser) && <div className="ui divider"></div>}
+            {showDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />
             <sui.Item role="menuitem" text={lf("About...")} onClick={this.showAboutDialog} />


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1765 as well as editor settings menu, in Minecraft case (no language menu option)