### PR TITLE
Break long API calls, don't wrap dragged block

### DIFF
--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -168,6 +168,7 @@
             span {
                 display: inline-block;
                 width: calc(~'100% - 1.75rem');
+                word-wrap: break-word;
             }
 
             .blockHelp {
@@ -286,6 +287,7 @@
     pointer-events: none;
     touch-action: none;
     font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+    white-space: nowrap;
 }
 
 /* Limit color interferences with semantic anchor element */
@@ -335,6 +337,7 @@
 #monacoEditorInner {
     position: relative !important;
     display: inline-block;
+    overflow: hidden;
 }
 
 /*******************************

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -109,6 +109,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
             this.dragging = true;
             if (!dragBlock) {
                 const parent = document.getElementById("root");
+                parent.style.overflow = "hidden";
                 dragBlock = document.createElement("div");
                 dragBlock.id = "monacoDraggingBlock";
                 dragBlock.textContent = block.snippetOnly
@@ -139,6 +140,8 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
         this.props.setInsertionSnippet(undefined);
         const block = document.getElementById("monacoDraggingBlock");
         if (block) block.remove();
+        const parent = document.getElementById("root");
+        parent.style.overflow = "";
     }
 
     protected getKeyDownHandler = (block?: toolbox.BlockDefinition, snippet?: string, isPython?: boolean) => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1758
Fixes https://github.com/microsoft/pxt-minecraft/issues/1759

Also fixes issue with drag handle overflow when it's scrolled out of the toolbox