### PR TITLE
Allow renaming of project for github

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -54,6 +54,13 @@ function parseBuildInfo(parsed?: commandParser.ParsedCommand) {
     }
 
     if (hwvariant) {
+        // map known variants
+        const knowVariants: pxt.Map<string> = {
+            "f4": "stm32f401",
+            "d5": "samd51",
+            "p0": "rpi"
+        }
+        hwvariant = knowVariants[hwvariant.toLowerCase()] || hwvariant;
         if (!/^hw---/.test(hwvariant)) hwvariant = 'hw---' + hwvariant;
         pxt.debug(`setting hardware variant to ${hwvariant}`);
         pxt.setHwVariant(hwvariant)

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -46,7 +46,7 @@ function parseHwVariant(parsed: commandParser.ParsedCommand) {
             "p0": "rpi"
         }
         hwvariant = knowVariants[hwvariant.toLowerCase()] || hwvariant;
-        if (!/^hw---/.test(hwvariant)) hwvariant = 'hw---' + hwvariant;    
+        if (!/^hw---/.test(hwvariant)) hwvariant = 'hw---' + hwvariant;
     }
     return hwvariant;
 }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -36,10 +36,25 @@ let forceBuild = false; // don't use cache
 
 Error.stackTraceLimit = 100;
 
+function parseHwVariant(parsed: commandParser.ParsedCommand) {
+    let hwvariant = parsed && parsed.flags["hwvariant"] as string;
+    if (hwvariant) {
+        // map known variants
+        const knowVariants: pxt.Map<string> = {
+            "f4": "stm32f401",
+            "d5": "samd51",
+            "p0": "rpi"
+        }
+        hwvariant = knowVariants[hwvariant.toLowerCase()] || hwvariant;
+        if (!/^hw---/.test(hwvariant)) hwvariant = 'hw---' + hwvariant;    
+    }
+    return hwvariant;
+}
+
 function parseBuildInfo(parsed?: commandParser.ParsedCommand) {
     const cloud = parsed && parsed.flags["cloudbuild"];
     const local = parsed && parsed.flags["localbuild"];
-    let hwvariant = parsed && parsed.flags["hwvariant"] as string;
+    const hwvariant = parseHwVariant(parsed);
     forceBuild = parsed && !!parsed.flags["force"];
     if (cloud && local)
         U.userError("cannot specify local-build and cloud-build together");
@@ -54,15 +69,7 @@ function parseBuildInfo(parsed?: commandParser.ParsedCommand) {
     }
 
     if (hwvariant) {
-        // map known variants
-        const knowVariants: pxt.Map<string> = {
-            "f4": "stm32f401",
-            "d5": "samd51",
-            "p0": "rpi"
-        }
-        hwvariant = knowVariants[hwvariant.toLowerCase()] || hwvariant;
-        if (!/^hw---/.test(hwvariant)) hwvariant = 'hw---' + hwvariant;
-        pxt.debug(`setting hardware variant to ${hwvariant}`);
+        pxt.log(`setting hardware variant to ${hwvariant}`);
         pxt.setHwVariant(hwvariant)
     }
 }
@@ -2856,10 +2863,7 @@ export function installAsync(parsed?: commandParser.ParsedCommand): Promise<void
     pxt.log("installing dependencies...");
     ensurePkgDir();
     const packageName = parsed && parsed.args.length ? parsed.args[0] : undefined;
-    let hwvariant = parsed && parsed.flags["hwvariant"] as string;
-    if (hwvariant && !/^hw---/.test(hwvariant))
-        hwvariant = 'hw---' + hwvariant;
-
+    const hwvariant = parseHwVariant(parsed);
     return installPackageNameAsync(packageName)
         .then(() => addDepsAsync())
         .then(() => mainPkg.installAllAsync())

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -283,9 +283,10 @@ namespace pxt {
                 U.userError("Missing dependencies in config of: " + this.id)
             if (!Array.isArray(this.config.files))
                 U.userError("Missing files in config of: " + this.id)
-            if (typeof this.config.name != "string" || !this.config.name ||
-                (this.config.public && !/^[a-z][a-z0-9\-_]+$/i.test(this.config.name)))
-                U.userError("Invalid extension name: " + this.config.name)
+            if (typeof this.config.name != "string" || !this.config.name)
+                this.config.name = lf("Untitled");
+            // don't be so uptight about project names,
+            // handle invalid names downstream
             if (this.config.targetVersions
                 && this.config.targetVersions.target
                 && semver.majorCmp(this.config.targetVersions.target, appTarget.versions.target) > 0)

--- a/theme/diff.less
+++ b/theme/diff.less
@@ -11,7 +11,7 @@ table.diffview {
     }
 
     .change code {
-        white-space: pre;
+        white-space: pre-wrap;
     }
 
     .diff-added {

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -217,13 +217,14 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         if (!isEditor) return <div />;
 
         const disableFileAccessinMaciOs = targetTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
-        const hasRepository = header && !!header.githubId;
+        const ghid = header && pxt.github.parseRepoId(header.githubId);
+        const hasRepository = !!ghid;
         const showSave = !readOnly && !isController && !targetTheme.saveInMenu
             && !tutorial && !debugging && !disableFileAccessinMaciOs
             && !hasRepository;
         const showProjectRename = !tutorial && !readOnly && !isController
             && !targetTheme.hideProjectRename && !debugging;
-        const showProjectRenameReadonly = hasRepository;
+        const showProjectRenameReadonly = hasRepository && /^pxt-/.test(ghid.project); // allow renaming of name with github
         const compile = pxt.appTarget.compile;
         const compileBtn = compile.hasHex || compile.saveAsPNG || compile.useUF2;
         const compileTooltip = lf("Download your code to the {0}", targetTheme.boardName);

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -586,11 +586,12 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                         scr.tutorial ? scr.tutorial.tutorialStepInfo.length
                             : scr.tutorialCompleted ? scr.tutorialCompleted.steps
                                 : undefined;
+                    const ghid = pxt.github.parseRepoId(scr.githubId);
                     return <ProjectsCodeCard
                         key={'local' + scr.id + scr.recentUse}
                         // ref={(view) => { if (index === 1) this.latestProject = view }}
                         cardType="file"
-                        name={scr.name}
+                        name={(ghid && ghid.project) || scr.name}
                         time={scr.recentUse}
                         url={scr.pubId && scr.pubCurrent ? "/" + scr.pubId : ""}
                         scr={scr} index={index}

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -972,8 +972,9 @@ export async function recomputeHeaderFlagsAsync(h: Header, files: ScriptText) {
     }
 
     // automatically update project name with github name
+    // if it start with pxt-
     const ghid = pxt.github.parseRepoId(h.githubId);
-    if (ghid.project) {
+    if (ghid.project && /^pxt-/.test(ghid.project)) {
         const ghname = ghid.project.replace(/^pxt-/, '').replace(/-+/g, ' ')
         if (ghname != h.name) {
             const cfg = pxt.Package.parseAndValidConfig(files[pxt.CONFIG_NAME]);


### PR DESCRIPTION
Required to create a project called ".menu".

Don't enforce naming unless project starts with ``pxt-``, we assume it is an extension and we keep that name in sync with the repo. Otherwise, allow any names.
- [x] don't crash when validating names
- [x] don't sync name when non extension
- [x] allow renaming for non-extensions
- [x] cleanup hwvariant and allow "--hw f4", "--hw d5" "--hw p0"