### PR TITLE
Always show diffs between steps when auto-diffing; remove exception for if all lines change

### DIFF
--- a/pxtlib/diff.ts
+++ b/pxtlib/diff.ts
@@ -342,11 +342,6 @@ namespace pxt.diff {
             "+": "diff-added",
             "-": "diff-removed",
         }
-        // check if all lines have been changed and we are hiding removeed files
-        if (options.hideRemoved && !diffLines.some(l => /^ {2}/.test(l))) {
-            // render added lines as unchanged since everything changed
-            diffClasses["+"] = "diff-unchanged";
-        }
 
         let lnA = 0, lnB = 0
         let lastMark = ""


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/6453828/74550918-15f58a00-4f07-11ea-922d-a70362b541b2.gif)
After:
![2020-02-14 10 11 00](https://user-images.githubusercontent.com/6453828/74556186-573f6700-4f12-11ea-80e8-28100b0c7b86.gif)
