### PR TITLE
non-greedy whitespace eating in tutorial parsing

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -39,7 +39,7 @@ namespace pxt.tutorial {
     function computeBodyMetadata(body: string) {
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /```(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /```(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*?\n([\s\S]*?)\n```/gmi;
         let code = '';
         let templateCode: string;
         let language: string;


### PR DESCRIPTION
Right now it's eating up all the whitespace, this makes it so you can put in empty macros to:

````
```template

```
````

Not perfect, as it will still fail on 

````
```template
```
````

but I'm having trouble reasoning through a full fix for that when this part is needed for minecraft  hour of code tuts