### PR TITLE
Do not emit workspace comments that are empty

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -829,16 +829,18 @@ ${output}</xml>`;
         function emitWorkspaceComment(comment: WorkspaceComment) {
             let maxLineLength = 0;
             const text = formatCommentsForBlocks(comment.comment);
-            const lines = text.split("\n");
-            lines.forEach(line => maxLineLength = Math.max(maxLineLength, line.length));
+            if (text.trim()) {
+                const lines = text.split("\n");
+                lines.forEach(line => maxLineLength = Math.max(maxLineLength, line.length));
 
-            // These are just approximations but they are the best we can do outside the DOM
-            const width = Math.max(Math.min(maxLineLength * 10, maxCommentWidth), minCommentWidth);
-            const height = Math.max(Math.min(lines.length * 40, maxCommentHeight), minCommentHeight);
+                // These are just approximations but they are the best we can do outside the DOM
+                const width = Math.max(Math.min(maxLineLength * 10, maxCommentWidth), minCommentWidth);
+                const height = Math.max(Math.min(lines.length * 40, maxCommentHeight), minCommentHeight);
 
-            write(`<comment h="${height}" w="${width}" data="${U.htmlEscape(comment.refId)}">`)
-            write(U.htmlEscape(text))
-            write(`</comment>`);
+                write(`<comment h="${height}" w="${width}" data="${U.htmlEscape(comment.refId)}">`)
+                write(U.htmlEscape(text))
+                write(`</comment>`);
+            }
         }
 
         function getOutputBlock(n: ts.Node): OutputNode {


### PR DESCRIPTION
Before:
![2020-02-14 15 06 51](https://user-images.githubusercontent.com/6453828/74575421-b665a180-4f3b-11ea-9114-439736c7df15.gif)

After:
![2020-02-14 15 07 09](https://user-images.githubusercontent.com/6453828/74575423-b82f6500-4f3b-11ea-9a06-9a0d1bdcd378.gif)
