### PR TITLE
unbox snippets when rendering in tip

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -9,6 +9,8 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 interface MarkedContentProps extends ISettingsProps {
     markdown: string;
     className?: string;
+    // do not emit segment around snippets
+    unboxSnippets?: boolean;
     onDidRender?: () => void;
 }
 
@@ -42,11 +44,12 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     }
 
     private startRenderLangSnippet(langBlock: HTMLElement): HTMLDivElement {
+        const { unboxSnippets } = this.props;
         const preBlock = langBlock.parentElement as HTMLPreElement; // pre parent of the code
         const parentBlock = preBlock.parentElement as HTMLDivElement; // parent containing all text
 
         const wrapperDiv = document.createElement('div');
-        wrapperDiv.className = 'ui segment raised loading codewidget';
+        wrapperDiv.className = `ui ${unboxSnippets ? "": "segment raised " }loading codewidget`;
         parentBlock.insertBefore(wrapperDiv, preBlock);
         parentBlock.removeChild(preBlock);
 
@@ -84,7 +87,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     }
 
     private renderSnippets(content: HTMLElement) {
-        const { parent, onDidRender } = this.props;
+        const { parent, unboxSnippets, onDidRender } = this.props;
 
         let promises: Promise<void>[] = [];
 
@@ -162,7 +165,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
                 const wrapperDiv = document.createElement('div');
                 pxsim.U.clear(langBlock);
                 langBlock.appendChild(wrapperDiv);
-                wrapperDiv.className = 'ui segment raised loading';
+                wrapperDiv.className = `ui ${unboxSnippets ? "" : "segment raised "} loading`;
                 if (MarkedContent.blockSnippetCache[code]) {
                     // Use cache
                     const doc = Blockly.utils.xml.textToDomDocument(pxt.blocks.layout.serializeSvgString(MarkedContent.blockSnippetCache[code] as string));

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -49,7 +49,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         const parentBlock = preBlock.parentElement as HTMLDivElement; // parent containing all text
 
         const wrapperDiv = document.createElement('div');
-        wrapperDiv.className = `ui ${unboxSnippets ? "": "segment raised " }loading codewidget`;
+        wrapperDiv.className = `ui ${unboxSnippets ? "" : "segment raised "}loading codewidget`;
         parentBlock.insertBefore(wrapperDiv, preBlock);
         parentBlock.removeChild(preBlock);
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -244,7 +244,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
             if (!tutorialHint) return <div />;
 
             return <div className={`tutorialhint ${!visible ? 'hidden' : ''}`} ref={this.setRef}>
-                <md.MarkedContent markdown={this.state.showFullText ? fullText : tutorialHint} parent={this.props.parent} />
+                <md.MarkedContent markdown={this.state.showFullText ? fullText : tutorialHint} unboxSnippets={true} parent={this.props.parent} />
             </div>
         } else {
             let onClick = tutorialStep < tutorialStepInfo.length - 1 ? this.next : this.closeHint;


### PR DESCRIPTION
Hints only contain a single code snippets (they could have more but they shouldn't). We waste space by wrapping the snippet in a segment that adds padding. Don't wrap snippets when rendering tutorial hint.
before:
![image](https://user-images.githubusercontent.com/4175913/74745026-1a2beb00-5218-11ea-977f-d7945d888e3a.png)
after:
![image](https://user-images.githubusercontent.com/4175913/74745068-29129d80-5218-11ea-9ba4-2330d1d03d0e.png)
