### PR TITLE
fix share page in one-language & headless mode

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1535,8 +1535,14 @@ div.simframe.ui.embed {
     }
 
     .one-language {
-        &:not(.headless) .active.item.javascript-menuitem ~ .toggle,
-        &:not(.headless) .active.item.python-menuitem ~ .toggle {
+        .active.item.javascript-menuitem ~ .toggle,
+        .active.item.python-menuitem ~ .toggle {
+            margin-left: 0px !important;
+        }
+    }
+    &:not(.headless) .one-language {
+        .active.item.javascript-menuitem ~ .toggle,
+        .active.item.python-menuitem ~ .toggle {
             margin-left: 140px !important;
         }
     }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/1780

(I had the not headless selecting on the wrong element, but it didn't matter too much as the styling would have still been broken :))

<img width="1208" alt="Screen Shot 2020-02-18 at 1 59 04 PM" src="https://user-images.githubusercontent.com/5615930/74781740-e7edae00-5256-11ea-9a26-1662fd260b81.png">

add a rule for headless mode, and maintain the current rule for !headless mode