### PR TITLE
add selected language restriction to tick for new project dialog

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1170,11 +1170,16 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
     }
 
     onExpandedMenuHide = () => {
+        pxt.tickEvent('newprojectdialog.codeoptions.hide');
         // reset language restrictions when user closes the options menu;
         // it's an 'advanced' feature that we want an easy escape hatch for.
         this.setState({
             languageRestriction: pxt.editor.LanguageRestriction.Standard
         });
+    }
+
+    onExpandedMenuShow = () => {
+        pxt.tickEvent('newprojectdialog.codeoptions.show');
     }
 
     renderCore() {
@@ -1223,7 +1228,7 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
             </div>
             {chooseLanguageRestrictionOnNewProject && <div>
                 <br />
-                <sui.ExpandableMenu title={lf("Code options")} onHide={this.onExpandedMenuHide}>
+                <sui.ExpandableMenu title={lf("Code options")} onShow={this.onExpandedMenuShow} onHide={this.onExpandedMenuHide}>
                     <sui.Select options={langOpts} onChange={this.handleLanguageChange} aria-label={lf("Select Language")} />
                 </sui.ExpandableMenu>
             </div>}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1161,7 +1161,11 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
             });
         }
 
-        pxt.tickEvent('newprojectdialog.projectcreate', undefined, { interactiveConsent: true });
+        pxt.tickEvent(
+            'newprojectdialog.projectcreate',
+            { language: languageRestriction },
+            { interactiveConsent: true }
+        );
         this.createProjectCb = null;
     }
 


### PR DESCRIPTION
add the selected language restriction to the tick for new projects. Currently that will be `"" | "python-only" | "javascript-only" | "no-blocks"`