### PR TITLE
Clear caches on header load

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1174,6 +1174,8 @@ export class ProjectView
             simulator.driver.preload(pxt.appTarget.simulator.aspectRatio);
         this.clearSerial()
         this.firstRun = true
+        // clear caches in all editors
+        this.allEditors.forEach(editor => editor.clearCaches())
         // always start simulator once at least if autoRun is enabled
         // always disable tracing
         this.setState({

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1175,6 +1175,7 @@ export class ProjectView
         this.clearSerial()
         this.firstRun = true
         // clear caches in all editors
+        compiler.clearCaches();
         this.allEditors.forEach(editor => editor.clearCaches())
         // always start simulator once at least if autoRun is enabled
         // always disable tracing

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -113,11 +113,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
-    updateBlocksInfo(bi: pxtc.BlocksInfo) {
-        this.blockInfo = bi;
-        this.refreshToolbox();
-    }
-
     domUpdate() {
         if (this.delayLoadXml) {
             if (this.loadingXml) return

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1101,7 +1101,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     ////////////         Toolbox methods          /////////////
     ///////////////////////////////////////////////////////////
 
-    protected clearCaches() {
+    clearCaches() {
         super.clearCaches();
         this.clearFlyoutCaches();
         snippets.clearBuiltinBlockCache();

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1486,7 +1486,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     ////////////         Toolbox methods          /////////////
     ///////////////////////////////////////////////////////////
 
-    protected clearCaches() {
+    clearCaches() {
         super.clearCaches();
         snippets.clearBuiltinBlockCache();
     }

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -85,7 +85,7 @@ export class Editor implements pxt.editor.IEditor {
     setScale(scale: number) { }
 
     closeFlyout() { }
-
+    clearCaches() { }
     /*******************************
      loadFile
     *******************************/

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -6,7 +6,7 @@ import * as compiler from "./compiler";
 export abstract class ToolboxEditor extends srceditor.Editor {
 
     protected blockInfo: pxtc.BlocksInfo;
-    protected blockGroups: pxt.Map<toolbox.GroupDefinition[]>;
+    protected blockGroupsCache: pxt.Map<toolbox.GroupDefinition[]>;
     protected blockIdMap: pxt.Map<string>;
 
     private searchSubset: pxt.Map<boolean | string>;
@@ -102,6 +102,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
     clearCaches() {
         super.clearCaches();
         this.searchSubset = undefined;
+        this.blockGroupsCache = undefined;
     }
 
     abstract getBuiltinCategory(ns: string): toolbox.ToolboxCategory;
@@ -304,8 +305,8 @@ export abstract class ToolboxEditor extends srceditor.Editor {
 
     getBlockGroups(treeRow: toolbox.ToolboxCategory): toolbox.GroupDefinition[] {
         const ns = treeRow.nameid + (treeRow.subns || "");
-        if (!this.blockGroups) this.blockGroups = {}
-        if (!this.blockGroups[ns]) {
+        if (!this.blockGroupsCache) this.blockGroupsCache = {}
+        if (!this.blockGroupsCache[ns]) {
             const {groups, groupIcons, groupHelp, blocks } = treeRow;
 
             // Parse full list of groups from block attributes
@@ -339,12 +340,12 @@ export abstract class ToolboxEditor extends srceditor.Editor {
             }
             // Only cache if there are no filters
             if (!this.parent.state?.editorState?.filters) {
-                this.blockGroups[ns] = blockGroups;
+                this.blockGroupsCache[ns] = blockGroups;
             } else {
                 return blockGroups;
             }
         }
 
-        return this.blockGroups[ns];
+        return this.blockGroupsCache[ns];
     }
 }

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -99,7 +99,8 @@ export abstract class ToolboxEditor extends srceditor.Editor {
             });
     }
 
-    protected clearCaches() {
+    clearCaches() {
+        super.clearCaches();
         this.searchSubset = undefined;
     }
 


### PR DESCRIPTION
Attempt to extensively clear caches in the editors and compiler between header reload to avoid unexpected caching bugs (hard to find and repro). I probably missed caches that could be flushed. The goal is to make the editor more deterministic because there is a an entire space of bugs that requires loading/unloading various programs to be triggered.