### PR TITLE
use more space of the card to display script title

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -668,6 +668,7 @@
         .ui.card, .ui.cards>.card {
             width: 15rem;
             height: 9rem;
+            white-space: nowrap;
         }
         .ui.card.buttoncard {
             .content {

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -26,9 +26,9 @@
         min-width: 5rem;
         height: 8rem;
         .header {
-            word-wrap: break-word;
+            word-break: break-all;
             overflow: hidden;
-            white-space: nowrap;
+            height: 6.5rem;
             text-overflow: ellipsis;
         }
     }
@@ -256,6 +256,7 @@ a.ui.card:focus,
         .content .header {
             font-size: 80%;
             font-weight: normal;
+            white-space: nowrap;
         }
     }
 }


### PR DESCRIPTION
Mobile view not modified otherwise, should title over multiple lines. Btw, we don't have any limitation of size on the title...
![image](https://user-images.githubusercontent.com/4175913/74963772-24401c00-53c7-11ea-8535-a91c32680e7f.png)
