### PR TITLE
When a shared project is too big, suggest github

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -321,6 +321,7 @@ namespace pxt.editor {
         popScreenshotHandler(): void;
 
         openDependentEditor(header: pxt.workspace.Header): void;
+        createGitHubRepositoryAsync(): Promise<void>;
     }
 
     export interface IHexFileImporter {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2926,10 +2926,6 @@ export class ProjectView
             }).finally(() => {
                 this.setState({ publishing: false })
             })
-            .catch(e => {
-                core.errorNotification(e.message)
-                throw e;
-            })
     }
 
     private debouncedSaveProjectName: () => void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2775,6 +2775,13 @@ export class ProjectView
             simulator.driver.registerDependentEditor(w);
         }
     }
+
+    createGitHubRepositoryAsync(): Promise<void> {
+        const { projectName, header } = this.state;
+        return cloudsync.githubProvider().createRepositoryAsync(projectName, header)
+            .then(r => r && this.reloadHeaderAsync());
+    }
+
     ///////////////////////////////////////////////////////////
     ////////////             Debugging            /////////////
     ///////////////////////////////////////////////////////////

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -27,9 +27,7 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
 
     private createRepository(e: React.MouseEvent<HTMLElement>) {
         pxt.tickEvent("github.button.create", undefined, { interactiveConsent: true });
-        const { projectName, header } = this.props.parent.state;
-        cloudsync.githubProvider().createRepositoryAsync(projectName, header)
-            .done(r => r && this.props.parent.reloadHeaderAsync());
+        this.props.parent.createGitHubRepositoryAsync().done();
     }
 
     private handleClick(e: React.MouseEvent<HTMLElement>) {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -951,6 +951,10 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
     renderCore() {
         const { visible } = this.state;
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
+        const showImport = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
+        const showCreateGithubRepo = pxt.appTarget.cloud
+            && pxt.appTarget.cloud.cloudProviders
+            && pxt.appTarget.cloud.cloudProviders.github;
         /* tslint:disable:react-a11y-anchors */
         return (
             <sui.Modal isOpen={visible} className="importdialog" size="small"
@@ -970,7 +974,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                             description={lf("Open files from your computer")}
                             onClick={this.importHex}
                         /> : undefined}
-                    {pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing ?
+                    {showImport &&
                         <codecard.CodeCardView
                             ariaLabel={lf("Open a shared project URL or GitHub repo")}
                             role="button"
@@ -980,10 +984,8 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                             name={lf("Import URL...")}
                             description={lf("Open a shared project URL or GitHub repo")}
                             onClick={this.importUrl}
-                        /> : undefined}
-                    {pxt.appTarget.cloud
-                        && pxt.appTarget.cloud.cloudProviders
-                        && pxt.appTarget.cloud.cloudProviders.github ?
+                        />}
+                    {showCreateGithubRepo &&
                         <codecard.CodeCardView
                             ariaLabel={lf("Clone or create your own GitHub repository")}
                             role="button"
@@ -993,7 +995,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
                             name={lf("Your GitHub Repo...")}
                             description={lf("Clone or create your own GitHub repository")}
                             onClick={this.cloneGithub}
-                        /> : undefined}
+                        />}
                 </div>
             </sui.Modal>
         )
@@ -1088,7 +1090,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                         <sui.Input ref="filenameinput" id={"projectNameInput"}
                             ariaLabel={lf("Type a name for your project")} autoComplete={false}
                             value={projectName || ''} onChange={this.handleChange} onEnter={this.save}
-                            selectOnMount={!mobile} autoFocus={!mobile}/>
+                            selectOnMount={!mobile} autoFocus={!mobile} />
                     </div>
                 </div>
             </sui.Modal>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -952,7 +952,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
         const { visible } = this.state;
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const showImport = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
-        const showCreateGithubRepo = pxt.appTarget.cloud
+        const showCreateGithubRepo = pxt.appTarget?.cloud?.cloudProviders?.github
             && pxt.appTarget.cloud.cloudProviders
             && pxt.appTarget.cloud.cloudProviders.github;
         /* tslint:disable:react-a11y-anchors */
@@ -1382,4 +1382,3 @@ export class ChooseHwDialog extends data.Component<ISettingsProps, ChooseHwDialo
         )
     }
 }
-

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -952,9 +952,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
         const { visible } = this.state;
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const showImport = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
-        const showCreateGithubRepo = pxt.appTarget?.cloud?.cloudProviders?.github
-            && pxt.appTarget.cloud.cloudProviders
-            && pxt.appTarget.cloud.cloudProviders.github;
+        const showCreateGithubRepo = pxt.appTarget?.cloud?.cloudProviders?.github;
         /* tslint:disable:react-a11y-anchors */
         return (
             <sui.Modal isOpen={visible} className="importdialog" size="small"

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -362,6 +362,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                     this.forceUpdate();
                 })
                 .catch((e: Error) => {
+                    pxt.tickEvent("menu.embed.error", { code: (e as any).statusCode })
                     this.setState({
                         pubId: undefined,
                         sharingError: e,

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -65,6 +65,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         this.handleRecordClick = this.handleRecordClick.bind(this);
         this.handleScreenshotClick = this.handleScreenshotClick.bind(this);
         this.handleScreenshotMessage = this.handleScreenshotMessage.bind(this);
+        this.handleCreateGitHubRepository = this.handleCreateGitHubRepository.bind(this);
     }
 
     hide() {
@@ -300,6 +301,12 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             });
     }
 
+    handleCreateGitHubRepository() {
+        pxt.tickEvent("share.github.create", undefined, { interactiveConsent: true });
+        this.hide();
+        this.props.parent.createGitHubRepositoryAsync().done();
+    }
+
     renderCore() {
         const { visible, projectName: newProjectName, loading, recordingState, screenshotUri, thumbnails, recordError, pubId, qrCodeUri, title, sharingError } = this.state;
         const targetTheme = pxt.appTarget.appTheme;
@@ -461,7 +468,9 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         </div>
                     </div> : undefined}
                     {action && !this.loanedSimulator ? <p className="ui tiny message info">{disclaimer}</p> : undefined}
-                    {tooBigErrorSuggestGitHub && <p className="ui orange inverted segment">{lf("Oops! Your project is too big. You can create a GitHub repository to share it.")}</p>}
+                    {tooBigErrorSuggestGitHub && <p className="ui orange inverted segment">{lf("Oops! Your project is too big. You can create a GitHub repository to share it.")}
+                        <sui.Button className="inverted basic" text={lf("Create")} icon="github" onClick={this.handleCreateGitHubRepository} />
+                    </p>}
                     {unknownError && <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>}
                     {url && ready ? <div>
                         <p>{lf("Your project is ready! Use the address below to share your projects.")}</p>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -418,7 +418,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 : isGifRendering ? lf("Rendering gif...")
                     : undefined;
         const screenshotMessageClass = recordError ? "warning" : "";
-        const tooBigErrorSuggestGitHub = sharingError 
+        const tooBigErrorSuggestGitHub = sharingError
             && (sharingError as any).statusCode === 413
             && pxt.appTarget.cloud && pxt.appTarget.cloud.cloudProviders && pxt.appTarget.cloud.cloudProviders.github;
         const unknownError = sharingError && !tooBigErrorSuggestGitHub;

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -420,7 +420,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         const screenshotMessageClass = recordError ? "warning" : "";
         const tooBigErrorSuggestGitHub = sharingError
             && (sharingError as any).statusCode === 413
-            && pxt.appTarget.cloud && pxt.appTarget.cloud.cloudProviders && pxt.appTarget.cloud.cloudProviders.github;
+            && pxt.appTarget?.cloud?.cloudProviders?.github;
         const unknownError = sharingError && !tooBigErrorSuggestGitHub;
 
         return (


### PR DESCRIPTION
When someone fails to share a game, we can suggest to use github instead. Instead of an arcane error.

- [x] specialized message for 413
- [x] "create" button to create a new github repo

![image](https://user-images.githubusercontent.com/4175913/74970817-e8f81a00-53d3-11ea-85fe-49fce6d7c8e7.png)

