### PR TITLE
Wrap Python tutorial snippets in a function to reduce scoping issues

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -43,6 +43,7 @@ namespace pxt.tutorial {
         let code = '';
         let templateCode: string;
         let language: string;
+        let idx = 0;
         // Concatenate all blocks in separate code blocks and decompile so we can detect what blocks are used (for the toolbox)
         body
             .replace(/((?!.)\s)+/g, "\n")
@@ -72,7 +73,10 @@ namespace pxt.tutorial {
                         templateCode = m2;
                         break;
                 }
-                code += `\n${m1 == "python" ? m2 : "{\n" + m2 + "\n}"}\n`;
+                code += `\n${m1 == "python"
+                    ? "def __wrapper_" + idx + "():\n" + m2.replace(/^/gm, "    ")
+                    : "{\n" + m2 + "\n}"}\n`;
+                idx++
                 return "";
             });
         // default to blocks

--- a/tests/tutorial-test/baselines/python.json
+++ b/tests/tutorial-test/baselines/python.json
@@ -15,7 +15,7 @@
         }
     ],
     "activities": null,
-    "code": "\nbasic.show_string(\"Hello\")\n\nbasic.forever(function() {\n    basic.show_leds(`\n        . # . # .\n        # # # # #\n        # # # # #\n        . # # # .\n        . . # . .`);\n})\n",
+    "code": "\ndef __wrapper_0():\n    basic.show_string(\"Hello\")\n\ndef __wrapper_1():\n    basic.forever(function() {\n        basic.show_leds(`\n            . # . # .\n            # # # # #\n            # # # # #\n            . # # # .\n            . . # . .`);\n    })\n",
     "metadata": {
         "noDiffs": true
     },

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -17,7 +17,7 @@ interface BlockDragInfo {
 
 export interface MonacoFlyoutProps extends pxt.editor.ISettingsProps {
     fileType?: pxt.editor.FileType;
-    blockIdMap?: pxt.Map<string>;
+    blockIdMap?: pxt.Map<string[]>;
     moveFocusToParent?: () => void;
     insertSnippet?: (position: monaco.Position, insertText: string, inline?: boolean) => void;
     setInsertionSnippet?: (snippet: string) => void;
@@ -281,13 +281,13 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
         const { ns } = this.state;
         const filters = this.props.parent.state.editorState ? this.props.parent.state.editorState.filters : undefined;
         const categoryState = filters ? (filters.namespaces && filters.namespaces[ns] != undefined ? filters.namespaces[ns] : filters.defaultState) : undefined;
-        const mappedId = this.props.blockIdMap && this.props.blockIdMap[block.attributes.blockId];
+        const mappedIds = this.props.blockIdMap && this.props.blockIdMap[block.attributes.blockId];
 
         let fnState = filters ? filters.defaultState : pxt.editor.FilterState.Visible;
         if (filters && filters.fns && filters.fns[block.name] !== undefined) {
             fnState = filters.fns[block.name];
         } else if (filters && filters.blocks && block.attributes.blockId &&
-            (filters.blocks[block.attributes.blockId] !== undefined || filters.blocks[mappedId] !== undefined)) {
+            (filters.blocks[block.attributes.blockId] !== undefined || mappedIds?.some(id => filters.blocks[id]))) {
             fnState = filters.blocks[block.attributes.blockId];
         } else if (categoryState !== undefined) {
             fnState = categoryState;

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -603,11 +603,12 @@ export function getPauseUntil() {
 
 // Map of defined snippets to blockIds, for when multiple
 // blocks (eg "for index" and "repeat") map to the same snippet
-let _blockIdMap: pxt.Map<string>;
+let _blockIdMap: pxt.Map<string[]>;
 export function blockIdMap() {
     if (!_blockIdMap) {
         _blockIdMap = {
-            "pxt_controls_for": "controls_repeat_ext"
+            "pxt_controls_for": ["controls_repeat_ext"],
+            "minecraftAgentTurn": ["agentturnleft", "agentturnright"],
         }
     }
     return _blockIdMap;

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -7,7 +7,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
 
     protected blockInfo: pxtc.BlocksInfo;
     protected blockGroupsCache: pxt.Map<toolbox.GroupDefinition[]>;
-    protected blockIdMap: pxt.Map<string>;
+    protected blockIdMap: pxt.Map<string[]>;
 
     private searchSubset: pxt.Map<boolean | string>;
 
@@ -20,7 +20,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
         const filters = this.parent.state.editorState && this.parent.state.editorState.filters;
         if (filters) {
             // block-level filters should not apply to shadow blocks (nested)
-            const blockFilter = filters.blocks && (filters.blocks[blockId] || (this.blockIdMap && filters.blocks[this.blockIdMap[blockId]]));
+            const blockFilter = filters.blocks && (filters.blocks[blockId] || (this.blockIdMap && this.blockIdMap[blockId]?.some(id => filters.blocks[id])));
             const categoryFilter = filters.namespaces && filters.namespaces[ns];
             // First try block filters
             if (blockFilter != undefined && blockFilter == pxt.editor.FilterState.Hidden && !shadow) return false;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1789
Fixes https://github.com/microsoft/pxt-minecraft/issues/1787

Removing the on chat wrappers means we have code that looks like this:

```
for i in range(4):
    mobs.spawn(CHICKEN, pos(0,0,0))

for i in range(2):
    mobs.spawn(COW, pos(0,0,0))
```

which decompiles (correctly) with the `i` hoisted:
```
let i: number;
for (i = 0; i < 4; i++) {
    mobs.spawn(CHICKEN, pos(0, 0, 0))
}
for (i = 0; i < 2; i++) {
    mobs.spawn(COW, pos(0, 0, 0))
}
```

which does not decompile to blocks.

For tutorials, I've wrapped each snippet in a function to isolate the scopes (I think this is safer behavior anyways, since even the event handlers had the same name at each step, resulting in multiple `on_chat` definitions in the tutorial code blob). This doesn't fix the underlying issue with two python for loops that use the same index variable, which I think we should still be able to convert to blocks.

(+ this PR also adds the turn left/right APIs to the Monaco snippet map, so those blocks show up correctly in the toolbox)