### PR TITLE
add update available state to indicate electron app will try to download update in bkgd

### DIFF
--- a/localtypings/pxtelectron.d.ts
+++ b/localtypings/pxtelectron.d.ts
@@ -11,6 +11,7 @@ declare namespace pxt.electron {
     export const enum UpdateStatus {
         UpdatingCritical = "updating-critical",
         BannedWithoutUpdate = "banned-without-update",
+        UpdateAvailable = "update-available",
         Ok = "ok"
     }
 

--- a/webapp/src/electron.ts
+++ b/webapp/src/electron.ts
@@ -51,6 +51,8 @@ export function initElectron(projectView: ProjectView): void {
         }
 
         switch (status) {
+            case pxt.electron.UpdateStatus.UpdateAvailable:
+                // Downloading update in background; nothing to do
             case pxt.electron.UpdateStatus.Ok:
                 // No update available; nothing to do
                 return;


### PR DESCRIPTION
currently the electron app sends the same state for 'no update is available and everything is fine' as it does for 'downloading non-mandatory update' (`Ok`) , which is a bit misleading

No functional difference currently (the default also just returns), but clears up a misleading comment (`No update available; nothing to do` while downloading update) / can maybe add a 'downloading update' toast. More useful for now in that keeping the states separate helps dedup some info in the update logic of the electron app.