### PR TITLE
Force redirect to /browsers from IE11 regardless of pxtarget

### DIFF
--- a/docfiles/pxtweb/browserRedirect.ts
+++ b/docfiles/pxtweb/browserRedirect.ts
@@ -1,0 +1,9 @@
+// redirect for IE11 (unsupported)
+(function _() {
+    if (typeof navigator !== "undefined" && /Trident/i.test(navigator.userAgent)
+        && !/skipbrowsercheck=1/i.exec(window.location.href)
+        && !/\/browsers/i.exec(window.location.href)) {
+        window.location.href = "/browsers";
+        return;
+    }
+})();

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -34,10 +34,5 @@
         "hideDocsEdit": true,
         "hideDocsSimulator": true
     },
-    "unsupportedBrowsers": [
-        {
-            "id": "ie"
-        }
-    ],
     "uploadDocs": true
 }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -209,6 +209,7 @@ namespace pxt.BrowserUtils {
 
     let hasLoggedBrowser = false
 
+    // Note that IE11 is no longer supported in any target. Redirect handled in docfiles/pxtweb/browserRedirect.ts
     export function isBrowserSupported(): boolean {
         if (!navigator) {
             return true; //All browsers define this, but we can't make any predictions if it isn't defined, so assume the best
@@ -219,7 +220,7 @@ namespace pxt.BrowserUtils {
             return true;
 
         // Check target theme to see if this browser is supported
-        let unsupportedBrowsers = pxt.appTarget?.unsupportedBrowsers
+        const unsupportedBrowsers = pxt.appTarget?.unsupportedBrowsers
             || (window as any).pxtTargetBundle?.unsupportedBrowsers as BrowserOptions[];
         if (unsupportedBrowsers?.some(b => b.id == browser())) {
             return false
@@ -234,8 +235,7 @@ namespace pxt.BrowserUtils {
         const isRecentEdge = isEdge();
         const isRecentSafari = isSafari() && v >= 9;
         const isRecentOpera = (isOpera() && isChrome()) && v >= 21;
-        const isRecentIE = isIE() && v >= 11;
-        const isModernBrowser = isRecentChrome || isRecentFirefox || isRecentEdge || isRecentSafari || isRecentOpera || isRecentIE
+        const isModernBrowser = isRecentChrome || isRecentFirefox || isRecentEdge || isRecentSafari || isRecentOpera
 
         //In the future this should check for the availability of features, such
         //as web workers

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4,14 +4,6 @@
 /// <reference path="../../built/pxtsim.d.ts"/>
 /// <reference path="../../built/pxtwinrt.d.ts"/>
 
-// redirect for unsupported browsers (IE11) before loading
-(function _() {
-    if (!pxt.BrowserUtils.isBrowserSupported() && !/skipbrowsercheck=1/i.exec(window.location.href)) {
-        window.location.href = "/browsers";
-        return;
-    }
-})();
-
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as workspace from "./workspace";
@@ -4116,6 +4108,13 @@ document.addEventListener("DOMContentLoaded", () => {
     pxt.setBundledApiInfo((window as any).pxtTargetBundle.apiInfo);
 
     enableAnalytics()
+
+    if (!pxt.BrowserUtils.isBrowserSupported() && !/skipbrowsercheck=1/i.exec(window.location.href)) {
+        pxt.tickEvent("unsupported");
+        window.location.href = "/browsers";
+        core.showLoading("browsernotsupported", lf("Sorry, this browser is not supported."));
+        return;
+    }
 
     initLogin();
     hash = parseHash();


### PR DESCRIPTION
Hardcoded IE redirect in separate script, restore previous redirect behavior (message in loading dimmer) for all other unsupported browsers.