### PR TITLE
high contrast accessible monaco toolbox

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -61,14 +61,6 @@
         }
     }
 
-    #monacoEditor .monacoDraggableBlock {
-        background: none !important;
-
-        span.argName {
-            border: 1px solid rgba(255, 255, 255, .7);
-        }
-    }
-
     p {
         color: @HCtextColor !important;
     }
@@ -108,7 +100,7 @@
         }
     }
 
-    /* Blockly toolbox */
+    /* Toolbox */
     .pxtToolbox:not(.invertedToolbox) {
         span.blocklyTreeLabel {
             color: @HCblocklyTreeLabelColor;
@@ -119,6 +111,14 @@
         .blocklyTreeRow:not(.blocklyTreeSelected):hover,
         .blocklyTreeRow:not(.blocklyTreeSelected):focus {
             background-color: lighten(@HCblocklyToolboxColor, 25.0);
+        }
+    }
+
+    #monacoEditor .monacoDraggableBlock {
+        background: none !important;
+
+        span.argName {
+            border: 1px solid rgba(255, 255, 255, .7);
         }
     }
 

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -61,6 +61,14 @@
         }
     }
 
+    #monacoEditor .monacoDraggableBlock {
+        background: none !important;
+
+        span.argName {
+            border: 1px solid rgba(255, 255, 255, .7);
+        }
+    }
+
     p {
         color: @HCtextColor !important;
     }

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -213,6 +213,7 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
     protected getBlockStyle = (color: string) => {
         return {
             backgroundColor: color,
+            border: this.props.parent.state.highContrast ? `2px solid ${color}` : "none",
             fontSize: `${this.props.parent.settings.editorFontSize}px`,
             lineHeight: `${this.props.parent.settings.editorFontSize + 16}px`
         };


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2271

The namespace colors on the text portion is fixed for now due to new monaco dropping that form of highlighting; this change just makes the toolbox snippets themselves meet color guidelines in high contrast mode by changing the background to be a border:

![2020-02-27 15 24 08](https://user-images.githubusercontent.com/5615930/75496353-c470e480-5975-11ea-8ba0-0d80749d882d.gif)
 