### PR TITLE
use css variables for glow animation

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -271,15 +271,20 @@ code.lang-filterblocks {
     border-radius: 50%;
     transform-style: preserve-3d;
 
+    --bubble-pulse-color: @blue;
+    --bubble-pulse-size: 30px;
+
     &.flash {
         border: 2px solid fade(white, 70%) !important;
+
         &:before {
             content: "";
             position: absolute;
             top: 50%;
             left: 50%;
             border-radius: 50%;
-            animation-name: large-bubble-pulse-animation;
+
+            animation-name: bubble-pulse-animation;
             animation-direction: alternate;
             animation-iteration-count: infinite;
             animation-duration: .5s;
@@ -288,19 +293,14 @@ code.lang-filterblocks {
     }
 }
 
-// TODO jwunderl: before merging, with ie dropped should be able to change this to just use a pair of
-// css vars for color, so the color can be customized at runtime for the glow without
-// duping the keyframes all over the place (for high contrast, hour of code, etc)
-.bubble-pulse-animation (@name, @size, @color) {
-    @keyframes @name {
-        0% { }
-        20% { box-shadow: 0 0 0 0px fade(@color, 100%); }
-        100% { box-shadow: 0 0 calc(3 * @size / 4 ) @size fade(@color, 90%); }
-    }
+// use two css variables to customize as needed:
+// * --bubble-pulse-color, the color to use for the pulse; default: @blue
+// * --bubble-pulse-radius, the radius for the pulse; default: 30
+@keyframes bubble-pulse-animation {
+    0% { }
+    20% { box-shadow: 0 0 0 0 var(--bubble-pulse-color, @blue); }
+    100% { box-shadow: 0 0  ~'calc(var(--bubble-pulse-size, 30) * 3 / 4)' var(--bubble-pulse-size, 30) var(--bubble-pulse-color, @blue); }
 }
-
-.bubble-pulse-animation(large-bubble-pulse-animation, 30px, @blue);
-.bubble-pulse-animation(small-bubble-pulse-animation, 16px, @blue);
 
 /*******************************
         Tutorial Hint
@@ -541,10 +541,7 @@ code.lang-filterblocks {
     #tutorialcard .ui.button.hintbutton {
         font-size: 12.5px !important;
         top: 20%;
-
-        &.flash:before {
-            animation-name: small-bubble-pulse-animation;
-        }
+        --bubble-pulse-size: 16px;
     }
 
     .tutorial #tutorialcard .tutorialmessage {


### PR DESCRIPTION
Meant to include this in https://github.com/microsoft/pxt/pull/6611, but I must have fallen asleep without committing it and didn't notice till today. Makes it so you can customize the glow at runtime instead of being stuck adjusting less vars