### PR TITLE
remove the pythonToolbox flag

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -370,7 +370,6 @@ declare namespace pxt {
         leanShare?: boolean; // use leanscript.html instead of script.html for sharing pages
         nameProjectFirst?: boolean; // prompt user to name project when creating new one
         chooseLanguageRestrictionOnNewProject?: boolean; // include 'options' menu when creating a new project
-        pythonToolbox?: boolean; // Code toolbox for Python
         githubEditor?: boolean; // allow editing github repositories from the editor
         githubCompiledJs?: boolean; // commit binary.js in commit when creating a github release,
         blocksCollapsing?: boolean; // collapse/uncollapse functions/event in blocks

--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -85,12 +85,6 @@ namespace pxt.editor.experiments {
                 feedbackUrl: "https://github.com/microsoft/pxt/issues/5390"
             },
             {
-                id: "pythonToolbox",
-                name: lf("Toolbox for Static Python"),
-                description: lf("Use the code toolbox in Static Python"),
-                feedbackUrl: "https://github.com/microsoft/pxt/issues/6291"
-            },
-            {
                 id: "simGif",
                 name: lf("Simulator Gifs"),
                 description: lf("Download gifs of the simulator"),

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1096,7 +1096,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         return pxt.appTarget.appTheme.monacoToolbox
             && !readOnly
             && ((this.fileType == "typescript" && this.currFile.name == "main.ts")
-                || (pxt.appTarget.appTheme.pythonToolbox && this.fileType == "python" && this.currFile.name == "main.py"));
+                || (this.fileType == "python" && this.currFile.name == "main.py"));
     }
 
     loadFileAsync(file: pkg.File, hc?: boolean): Promise<void> {


### PR DESCRIPTION
The python toolbox is stable and should be always enabled (1 less flag!)