### PR TITLE
Shuffle gallery

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -5,9 +5,12 @@
 
 declare namespace pxt {
     // targetconfig.json
+    type GalleryShuffle = "daily";
     interface GalleryProps {
-        url: string,
-        experimentName?: string
+        url: string;
+        experimentName?: string;
+        locales?: string[];
+        shuffled?: GalleryShuffle;
     }
     interface TargetConfig {
         packages?: PackagesConfig;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -789,9 +789,9 @@ declare namespace ts.pxtc {
         syntaxInfo?: SyntaxInfo;
 
         // decompiler only
-        alwaysDecompileOnStart?: boolean; 
+        alwaysDecompileOnStart?: boolean;
         // decompiler-only; the types allowed for user-defined function arguments in blocks (unlisted types will cause grey blocks)
-        allowedArgumentTypes?: string[]; 
+        allowedArgumentTypes?: string[];
         // decompiler only
         snippetMode?: boolean;
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -10,7 +10,7 @@ declare namespace pxt {
         url: string;
         experimentName?: string;
         locales?: string[];
-        shuffled?: GalleryShuffle;
+        shuffle?: GalleryShuffle;
     }
     interface TargetConfig {
         packages?: PackagesConfig;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -448,7 +448,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                     // keep last one
                     const last = this.prevGalleries.pop();
                     // shuffle array
-                    const now = new Date(Date.now());
+                    const now = new Date();
                     const seed = now.toDateString();
                     this.prevGalleries.sort((l, r) =>
                         ts.pxtc.Util.codalHash16(l.name + seed)

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -222,7 +222,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 .map(galleryName => {
                     const galProps = galleries[galleryName] as pxt.GalleryProps | string
                     const url = typeof galProps === "string" ? galProps : galProps.url
-                    const shuffle : pxt.GalleryShuffle = typeof galProps === "string" ? undefined : galProps.shuffled;
+                    const shuffle : pxt.GalleryShuffle = typeof galProps === "string" ? undefined : galProps.shuffle;
                     return <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment" role="region" aria-label={pxt.Util.rlf(galleryName)}>
                         <h2 className="ui header heading">{pxt.Util.rlf(galleryName)} </h2>
                         <div className="content">

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -207,20 +207,32 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 .filter(galleryName => {
                     // hide galleries that are part of an experiment and that experiment is
                     // not enabled
-                    let galProps = galleries[galleryName] as pxt.GalleryProps | string
+                    const galProps = galleries[galleryName] as pxt.GalleryProps | string
                     if (typeof galProps === "string")
                         return true
-                    let exp = galProps.experimentName
-                    return !exp || !!(pxt.appTarget.appTheme as any)[exp]
+                    // filter categories by experiment
+                    const exp = galProps.experimentName;
+                    if (exp && !(pxt.appTarget.appTheme as any)[exp])
+                        return false; // experiment not enabled
+                    const locales = galProps.locales;
+                    if (locales && locales.indexOf(pxt.Util.userLanguage()) < 0)
+                        return false; // locale not supported
+                    return true;
                 })
                 .map(galleryName => {
-                    let galProps = galleries[galleryName] as pxt.GalleryProps | string
-                    let url = typeof galProps === "string" ? galProps : galProps.url
+                    const galProps = galleries[galleryName] as pxt.GalleryProps | string
+                    const url = typeof galProps === "string" ? galProps : galProps.url
+                    const shuffle : pxt.GalleryShuffle = typeof galProps === "string" ? undefined : galProps.shuffled;
                     return <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment" role="region" aria-label={pxt.Util.rlf(galleryName)}>
                         <h2 className="ui header heading">{pxt.Util.rlf(galleryName)} </h2>
                         <div className="content">
-                            <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`} key={`${galleryName}_carousel`} parent={this.props.parent} name={galleryName} path={url}
-                                onClick={this.chgGallery} setSelected={this.setSelected} selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined} />
+                            <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`} 
+                                key={`${galleryName}_carousel`} parent={this.props.parent} 
+                                name={galleryName} 
+                                path={url}
+                                onClick={this.chgGallery} setSelected={this.setSelected}
+                                shuffle={shuffle}
+                                selectedIndex={selectedCategory == galleryName ? selectedIndex : undefined} />
                         </div>
                     </div>
                 }
@@ -390,6 +402,7 @@ interface ProjectsCarouselProps extends ISettingsProps {
     onClick: (src: any, action?: pxt.CodeCardAction) => void;
     selectedIndex?: number;
     setSelected?: (name: string, index: number) => void;
+    shuffle?: pxt.GalleryShuffle;
 }
 
 interface ProjectsCarouselState {
@@ -430,6 +443,21 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                 this.hasFetchErrors = true;
             } else {
                 this.prevGalleries = pxt.Util.concat(res.map(g => g.cards));
+                const shuffle = this.props.shuffle
+                if (shuffle) {
+                    // keep last one
+                    const last = this.prevGalleries.pop();
+                    // shuffle array
+                    const now = new Date(Date.now());
+                    const seed = now.toDateString();
+                    this.prevGalleries.sort((l, r) => 
+                        ts.pxtc.Util.codalHash16(l.name + seed) 
+                        - ts.pxtc.Util.codalHash16(r.name + seed)
+                    );
+                    // add last back
+                    if (last)
+                        this.prevGalleries.push(last);
+                }
             }
         }
         return this.prevGalleries || [];

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -222,13 +222,13 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 .map(galleryName => {
                     const galProps = galleries[galleryName] as pxt.GalleryProps | string
                     const url = typeof galProps === "string" ? galProps : galProps.url
-                    const shuffle : pxt.GalleryShuffle = typeof galProps === "string" ? undefined : galProps.shuffle;
+                    const shuffle: pxt.GalleryShuffle = typeof galProps === "string" ? undefined : galProps.shuffle;
                     return <div key={`${galleryName}_gallerysegment`} className="ui segment gallerysegment" role="region" aria-label={pxt.Util.rlf(galleryName)}>
                         <h2 className="ui header heading">{pxt.Util.rlf(galleryName)} </h2>
                         <div className="content">
-                            <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`} 
-                                key={`${galleryName}_carousel`} parent={this.props.parent} 
-                                name={galleryName} 
+                            <ProjectsCarousel ref={`${selectedCategory == galleryName ? 'activeCarousel' : ''}`}
+                                key={`${galleryName}_carousel`} parent={this.props.parent}
+                                name={galleryName}
                                 path={url}
                                 onClick={this.chgGallery} setSelected={this.setSelected}
                                 shuffle={shuffle}
@@ -450,8 +450,8 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                     // shuffle array
                     const now = new Date(Date.now());
                     const seed = now.toDateString();
-                    this.prevGalleries.sort((l, r) => 
-                        ts.pxtc.Util.codalHash16(l.name + seed) 
+                    this.prevGalleries.sort((l, r) =>
+                        ts.pxtc.Util.codalHash16(l.name + seed)
                         - ts.pxtc.Util.codalHash16(r.name + seed)
                     );
                     // add last back


### PR DESCRIPTION
- [x] Ability to specify that a gallery should be shuffled. It provides a stable shuffled based on the day (more options can be added later)
```
        "Community Games": {
            "url": "community",
            "shuffle": "daily"
        },
```
- [x] allow to filter a gallery by locales too