### PR TITLE
Add basic hover to the TS language service

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -202,8 +202,17 @@ class HoverProvider implements monaco.languages.HoverProvider {
                 let sym = r.symbols ? r.symbols[0] : null
                 if (!sym) return null;
                 const documentation = pxt.Util.rlf(sym.attributes.jsDoc);
+
+                let contents: string[];
+                if (this.python) {
+                    contents = [`**${sym.pyQName}**${sym.retType ? `: ${sym.retType}` : ''}`, documentation]
+                }
+                else {
+                    contents = [`**${sym.qName}**${sym.retType ? `: ${sym.retType}` : ''}`, documentation]
+                }
+
                 const res: monaco.languages.Hover = {
-                    contents: [`**${sym.pyQName}**${sym.retType ? `: ${sym.retType}` : ''}`, documentation].map(toMarkdownString),
+                    contents: contents.map(toMarkdownString),
                     range: monaco.Range.fromPositions(model.getPositionAt(r.beginPos), model.getPositionAt(r.endPos))
                 }
                 return res


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1808

Provides hovers for symbols in TypeScript. Not as good as the old TS language service which also gives signature help, but better than nothing!

![2020-03-03 15 53 53](https://user-images.githubusercontent.com/13754588/75831075-6a9e5f00-5d67-11ea-980e-3b152a9aec5d.gif)