### PR TITLE
when view is very tiny, bump down toggle closed view

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1159,6 +1159,7 @@ p.ui.font.small {
         left: 4rem; /* match left pos of #boardview */
         bottom: -3rem;
         width: 10rem; /* match width of div.simframe */
+        max-width: 35vw;
         height: 9rem;
     }
     #root:not(.fullscreensim):not(.headless) {
@@ -1166,6 +1167,7 @@ p.ui.font.small {
             position: absolute;
             left: 4rem;
             width: 10rem;
+            max-width: 35vw;
         }
         #filelist .simtoolbar {
             margin: 0.5em 0;
@@ -1236,6 +1238,7 @@ p.ui.font.small {
     div.simframe {
         display:inline-block;
         width: 10rem;
+        max-width: 35rem;
         margin-right:0.5rem;
         padding-bottom: 81.96% !important;
     }
@@ -1315,6 +1318,14 @@ p.ui.font.small {
     }
     #root #editordropdown .menu .item .text {
         display: inline-block!important;
+    }
+}
+
+/* Thin view, likely zoomed in; toggles need  */
+@media only screen and (max-height: 450px) {
+    #mobiletogglesim.collapse-button.toggle-hide {
+        z-index: @editorToolsZIndex + 1;
+        bottom: 0 !important;
     }
 }
 

--- a/theme/common.less
+++ b/theme/common.less
@@ -1318,7 +1318,7 @@ p.ui.font.small {
     }
 }
 
-/* Thin view, likely zoomed in; toggles need  */
+/* Thin view, likely zoomed in; view toggle needs to drop to the bottom to make sure it's accessible  */
 @media only screen and (max-height: 450px) {
     #mobiletogglesim.collapse-button.toggle-hide {
         z-index: @editorToolsZIndex + 1;

--- a/theme/common.less
+++ b/theme/common.less
@@ -1159,7 +1159,6 @@ p.ui.font.small {
         left: 4rem; /* match left pos of #boardview */
         bottom: -3rem;
         width: 10rem; /* match width of div.simframe */
-        max-width: 35vw;
         height: 9rem;
     }
     #root:not(.fullscreensim):not(.headless) {
@@ -1167,7 +1166,6 @@ p.ui.font.small {
             position: absolute;
             left: 4rem;
             width: 10rem;
-            max-width: 35vw;
         }
         #filelist .simtoolbar {
             margin: 0.5em 0;
@@ -1238,7 +1236,6 @@ p.ui.font.small {
     div.simframe {
         display:inline-block;
         width: 10rem;
-        max-width: 35rem;
         margin-right:0.5rem;
         padding-bottom: 81.96% !important;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3638,7 +3638,7 @@ export class ProjectView
                 </div>
                 <div id="maineditor" className={(sandbox ? "sandbox" : "") + (inDebugMode ? "debugging" : "")} role="main" aria-hidden={inHome}>
                     {showCollapseButton && <sui.Button id='computertogglesim' className={`computer only collapse-button large`} icon={`inverted chevron ${showRightChevron ? 'right' : 'left'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
-                    {showCollapseButton && <sui.Button id='mobiletogglesim' className={`mobile tablet only collapse-button large`} icon={`inverted chevron ${this.state.collapseEditorTools ? 'up' : 'down'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
+                    {showCollapseButton && <sui.Button id='mobiletogglesim' className={`mobile tablet only collapse-button large ${!this.state.collapseEditorTools ? "toggle-hide" : ""}`} icon={`inverted chevron ${this.state.collapseEditorTools ? 'up' : 'down'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
                     {this.allEditors.map(e => e.displayOuter(expandedStyle))}
                 </div>
                 {inHome ? <div id="homescreen" className="full-abs">

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -150,7 +150,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     protected getCompileButton(view: View, collapsed?: boolean): JSX.Element[] {
         const targetTheme = pxt.appTarget.appTheme;
         const { compiling, isSaving } = this.props.parent.state;
-        const compileLoading = !!compiling;
         const compileTooltip = lf("Download your code to the {0}", targetTheme.boardName);
         const downloadIcon = targetTheme.downloadIcon || "download";
         const downloadText = targetTheme.useUploadMessage ? lf("Upload") : lf("Download");
@@ -161,9 +160,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         let displayRight = false;
         if (isSaving) {
             downloadButtonClasses += "disabled ";
-        } else if (compileLoading) {
+        } else if (compiling) {
             downloadButtonClasses += "loading disabled ";
         }
+
         switch (view) {
             case View.Mobile:
                 downloadButtonClasses += "download-button-full";


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2377 for now

When the view is very very tiny (e.g. zoomed in 400% +), the toggle gets knocked out of view as the expanded toolbar fills the screen. This drops the 'hide' button to the bottom of the screen when in a thin view to make it so you can get out. (the 450px is fairly arbitrary, but does correspond to the default phones in chrome debugger showing the toggle on top in portrait mode (current behavor) and at the bottom in landscape)

![2020-03-03 16 38 53](https://user-images.githubusercontent.com/5615930/75833802-02ec1200-5d6f-11ea-9930-4d368a6b1991.gif)

mobile views
![2020-03-03 16 53 37](https://user-images.githubusercontent.com/5615930/75834007-aa694480-5d6f-11ea-9907-e1b432577137.gif)

