### PR TITLE
add route to load tutorial locally

### DIFF
--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -56,6 +56,10 @@ You can override the markdown file from the project used for the content of the 
 where MakeCode will load the ``filename.md`` file from the project. Don't forget to add this file in the
 ``files`` list in ``pxt.json``.
 
+### Testing
+
+When looking at the diff of a markdown file (``.md``) in the GitHub view, a ``Preview as Tutorial`` will be avaiable to load through that particular file as a tutorial. Commiting to GitHub is not needed to do the local testing.
+
 ### Localization
 
 Localized copies of the tutorial can be added to a subfolder ``_locales/[isocode]/[filename].md`` 

--- a/theme/github.less
+++ b/theme/github.less
@@ -122,6 +122,11 @@
         .ui.header {
             color: @githubInvertedTextColor !important;
         }
+        .ui.items>.link.item {
+            .meta, .description {
+                color: @githubInvertedTextColor !important;
+            }
+        }
         .diffheader {
             background: @mainMenuInvertedBackground !important;
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3150,8 +3150,9 @@ export class ProjectView
         core.hideDialog();
         core.showLoading("tutorial", lf("starting tutorial..."));
         sounds.initTutorial(); // pre load sounds
-        const scriptId = pxt.Cloud.parseScriptId(tutorialId);
-        const ghid = pxt.github.parseRepoId(tutorialId);
+        const header = workspace.getHeader(tutorialId.split(':')[0]);
+        const scriptId = !header && pxt.Cloud.parseScriptId(tutorialId);
+        const ghid = !header && !scriptId && pxt.github.parseRepoId(tutorialId);
         let reportId: string = undefined;
         let filename: string;
         let autoChooseBoard: boolean = true;
@@ -3202,31 +3203,16 @@ export class ProjectView
                     }
                     return pxt.github.downloadPackageAsync(ghid.fullName, config);
                 })
-                .then(gh => {
-                    const pxtJson = pxt.Package.parseAndValidConfig(gh.files["pxt.json"]);
-                    // if there is any .ts file in the tutorial repo,
-                    // add as a dependency itself
-                    if (pxtJson.files.find(f => /\.ts/.test(f))) {
-                        dependencies = {}
-                        dependencies[ghid.project] = pxt.github.toGithubDependencyPath(ghid);
-                    }
-                    else {// just use dependencies from the tutorial
-                        pxt.Util.jsonMergeFrom(dependencies, pxtJson.dependencies);
-                    }
-                    filename = pxtJson.name || lf("Untitled");
-                    autoChooseBoard = false;
-                    // if non-default language, find localized file if any
-                    const mfn = (ghid.fileName || "README") + ".md";
-                    const lang = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
-                    const md =
-                        (lang && lang[1] && gh.files[`_locales/${lang[0]}-${lang[1]}/${mfn}`])
-                        || (lang && lang[0] && gh.files[`_locales/${lang[0]}/${mfn}`])
-                        || gh.files[mfn];
-                    return processMarkdown(md);
-                }).catch((e) => {
+                .then(gh => loadGitHubTutorial(ghid, gh.files))
+                .catch((e) => {
                     core.errorNotification(tutorialErrorMessage);
                     core.handleNetworkError(e);
                 });
+        } else if (header) {
+            const hghid = pxt.github.parseRepoId(header.githubId);
+            const hfileName = tutorialId.split(':')[1] || "README";
+            p = workspace.getTextAsync(header.id)
+                .then(script => loadGitHubTutorial(hghid, script, hfileName))
         } else {
             p = Promise.resolve(undefined);
         }
@@ -3272,6 +3258,29 @@ export class ProjectView
             pxt.Util.jsonMergeFrom(dependencies, pxt.gallery.parsePackagesFromMarkdown(md));
             features = pxt.gallery.parseFeaturesFromMarkdown(md);
             return md;
+        }
+
+        function loadGitHubTutorial(ghid: pxt.github.ParsedRepo, files: pxt.Map<string>, fileName?: string) {
+            const pxtJson = pxt.Package.parseAndValidConfig(files["pxt.json"]);
+            // if there is any .ts file in the tutorial repo,
+            // add as a dependency itself
+            if (pxtJson.files.find(f => /\.ts/.test(f))) {
+                dependencies = {}
+                dependencies[ghid.project] = pxt.github.toGithubDependencyPath(ghid);
+            }
+            else {// just use dependencies from the tutorial
+                pxt.Util.jsonMergeFrom(dependencies, pxtJson.dependencies);
+            }
+            filename = pxtJson.name || lf("Untitled");
+            autoChooseBoard = false;
+            // if non-default language, find localized file if any
+            const mfn = (fileName || ghid.fileName || "README") + ".md";
+            const lang = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
+            const md =
+                (lang && lang[1] && files[`_locales/${lang[0]}-${lang[1]}/${mfn}`])
+                || (lang && lang[0] && files[`_locales/${lang[0]}/${mfn}`])
+                || files[mfn];
+            return processMarkdown(md);
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3190,6 +3190,7 @@ export class ProjectView
                     core.handleNetworkError(e);
                 });
         } else if (!!ghid && ghid.owner && ghid.project) {
+            pxt.tickEvent("tutorial.github");
             p = pxt.packagesConfigAsync()
                 .then(config => {
                     const status = pxt.github.repoStatus(ghid, config);
@@ -3209,6 +3210,7 @@ export class ProjectView
                     core.handleNetworkError(e);
                 });
         } else if (header) {
+            pxt.tickEvent("tutorial.header");
             const hghid = pxt.github.parseRepoId(header.githubId);
             const hfileName = tutorialId.split(':')[1] || "README";
             p = workspace.getTextAsync(header.id)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3266,7 +3266,7 @@ export class ProjectView
             const pxtJson = pxt.Package.parseAndValidConfig(files["pxt.json"]);
             // if there is any .ts file in the tutorial repo,
             // add as a dependency itself
-            if (pxtJson.files.find(f => /\.ts/.test(f))) {
+            if (pxtJson.files.find(f => /\.ts$/.test(f))) {
                 dependencies = {}
                 dependencies[ghid.project] = pxt.github.toGithubDependencyPath(ghid);
             }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1418,7 +1418,7 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
                         onClick={e => {
                             e.stopPropagation();
                             pxt.tickEvent("github.history.selectday");
-                            this.setState({ selectedDay: selectedDay === day ? undefined : day });
+                            this.setState({ selectedDay: selectedDay === day ? undefined : day, selectedCommit: undefined });
                         }}
                         onKeyDown={sui.fireClickOnEnter}>
                         <div className="content">

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1415,7 +1415,7 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
             </div>}
             {commits && <div className="ui items">
                 {Object.keys(days).map(day =>
-                    <div className="ui link item"
+                    <div role="button" className="ui link item"
                         key={"commitday" + day}
                         onClick={e => {
                             e.stopPropagation();

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -742,7 +742,7 @@ class DiffView extends sui.StatelessUIElement<DiffViewProps> {
                         textClass={"landscape only"} onClick={cache.revert} />}
                     {!!cache.testAction && <sui.Link className="small button" icon="external"
                         ariaLabel={cache.testAction.text} textClass={"landscape only"}
-                        text={cache.testAction.text} href={cache.testAction.url} 
+                        text={cache.testAction.text} href={cache.testAction.url}
                         target="_blank" />}
                     {jsxEls.legendJSX}
                     {showConflicts && !!jsxEls.conflicts && <p>{lf("Merge conflicts found. Resolve them before commiting.")}</p>}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1386,7 +1386,7 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
         const { selectedCommit, expanded } = this.state;
         const inverted = !!pxt.appTarget.appTheme.invertedGitHub;
         const commits = expanded &&
-            this.getData(`gh-commits:${gs.repo}#${gs.commit.sha}`) as pxt.github.CommitInfo[];
+            this.getData(`gh-commits:${githubId.fullName}#${gs.commit.sha}`) as pxt.github.CommitInfo[];
         const loading = expanded && !commits;
 
         return <div className={`ui transparent ${inverted ? 'inverted' : ''} segment`}>

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -29,6 +29,10 @@ interface DiffCache {
     diff: JSX.Element;
     whitespace?: boolean;
     revert?: () => void;
+    testAction?: {
+        text: string;
+        url: string;
+    }
 }
 
 interface GithubProps {
@@ -67,6 +71,11 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         let cache = this.diffCache[cachePrefix + f.name]
         if (!cache || cache.file.file !== f.file) {
             cache = { file: f } as any
+            if (/\.md$/.test(f.name))
+                cache.testAction = {
+                    text: lf("Preview as Tutorial"),
+                    url: `#tutorial:${this.props.parent.state.header.id}:${f.name.replace(/\.[a-z]+$/, '')}`
+                }
             this.diffCache[cachePrefix + f.name] = cache
         }
         return cache;
@@ -731,6 +740,10 @@ class DiffView extends sui.StatelessUIElement<DiffViewProps> {
                     {!!cache.revert && <sui.Button className="small" icon="undo" text={lf("Revert")}
                         ariaLabel={lf("Revert file")} title={lf("Revert file")}
                         textClass={"landscape only"} onClick={cache.revert} />}
+                    {!!cache.testAction && <sui.Link className="small button" icon="external"
+                        ariaLabel={cache.testAction.text} textClass={"landscape only"}
+                        text={cache.testAction.text} href={cache.testAction.url} 
+                        target="_blank" />}
                     {jsxEls.legendJSX}
                     {showConflicts && !!jsxEls.conflicts && <p>{lf("Merge conflicts found. Resolve them before commiting.")}</p>}
                     {!!cache.revert && !!deletedFiles.length &&

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1394,12 +1394,13 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
 
         // group commits by day
         const days: pxt.Map<pxt.github.CommitInfo[]> = {};
-        commits && commits.forEach(commit => {
-            const day = new Date(Date.parse(commit.author.date)).toLocaleDateString();
-            let dcommit = days[day];
-            if (!dcommit) dcommit = days[day] = [];
-            dcommit.push(commit);
-        })
+        if (commits)
+            commits.forEach(commit => {
+                const day = new Date(Date.parse(commit.author.date)).toLocaleDateString();
+                let dcommit = days[day];
+                if (!dcommit) dcommit = days[day] = [];
+                dcommit.push(commit);
+            })
 
         return <div className={`ui transparent ${inverted ? 'inverted' : ''} segment`}>
             <div className="ui header">{lf("History")}</div>

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -71,11 +71,6 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         let cache = this.diffCache[cachePrefix + f.name]
         if (!cache || cache.file.file !== f.file) {
             cache = { file: f } as any
-            if (/\.md$/.test(f.name))
-                cache.testAction = {
-                    text: lf("Preview as Tutorial"),
-                    url: `#tutorial:${this.props.parent.state.header.id}:${f.name.replace(/\.[a-z]+$/, '')}`
-                }
             this.diffCache[cachePrefix + f.name] = cache
         }
         return cache;
@@ -791,8 +786,15 @@ class DiffView extends sui.StatelessUIElement<DiffViewProps> {
         if (virtualF == f.file) virtualF = undefined;
 
         cache.file = f
-        if (this.props.allowRevert)
+        if (this.props.allowRevert) {
             cache.revert = () => this.props.parent.revertFileAsync(f, deletedFiles, addedFiles, virtualF);
+            if (/\.md$/.test(cache.file.name)) {
+                cache.testAction = {
+                    text: lf("Preview as Tutorial"),
+                    url: `#tutorial:${this.props.parent.props.parent.state.header.id}:${cache.file.name.replace(/\.[a-z]+$/, '')}`
+                }
+            }
+        }
         cache.diff = createDiff()
         return cache.diff;
     }


### PR DESCRIPTION
Allows to test github tutorial locally without having to publish to github -- which creates tons of caching issues.

- [x] add route to load local header as a "github tutorial repo"
- [x] add button in github view to load a .md file as a tutorial

![image](https://user-images.githubusercontent.com/4175913/75849635-2b3d3600-5d9a-11ea-89ac-8f7430f755de.png)

- [x] fix inverted rendering of history + grouping by day

![image](https://user-images.githubusercontent.com/4175913/75902362-bf3beb80-5df4-11ea-9df7-63d8fee0f92a.png)
