### PR TITLE
Support for adding localized versions of markdown files

### DIFF
--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -113,8 +113,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             // we keep this disabled, until implemented for cloud syncing
             // makse no sense for local saves - the star just blinks for half second after every change
             const showStar = false // !meta.isSaved
-            const isTutorialMd = topPkg 
-                && !!header && !!header.githubId 
+            const isTutorialMd = topPkg
+                && !!header && !!header.githubId
                 && /\.md$/.test(file.name)
                 && !/^_locales\//.test(file.name)
             const openUrl = isTutorialMd
@@ -122,7 +122,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             const lang = pxt.Util.userLanguage();
             const localized = `_locales/${lang}/${file.name}`;
             const addLocale = pxt.Util.userLanguage() !== (pxt.appTarget.appTheme.defaultLocale || "en")
-                && isTutorialMd 
+                && isTutorialMd
                 && !/^_locales\//.test(file.name)
                 && !files.some(f => f.name == localized);
 

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -366,6 +366,7 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
         this.handleRemove = this.handleRemove.bind(this);
         this.handleButtonKeydown = this.handleButtonKeydown.bind(this);
         this.handleOpen = this.handleOpen.bind(this);
+        this.handleAddLocale = this.handleAddLocale.bind(this);
     }
 
     handleClick(e: React.MouseEvent<HTMLElement>) {

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -120,7 +120,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             const localized = `_locales/${lang}/${file.name}`;
             const addLocale = pxt.Util.userLanguage() !== (pxt.appTarget.appTheme.defaultLocale || "en")
                 && isTutorialMd 
-                && !/^_locale\//.test(file.name)
+                && !/^_locales\//.test(file.name)
                 && !files.some(f => f.name == localized);
 
             return (

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -423,11 +423,11 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
                 onClick={this.handleRemove}
                 onKeyDown={this.handleButtonKeydown} />}
             {meta && meta.numErrors ? <span className='ui label red button' role="button" title={lf("Go to error")}>{meta.numErrors}</span> : undefined}
+            {openUrl && <sui.Button className="button primary label" icon="external" title={lf("Preview")} onClick={this.handleOpen} onKeyDown={sui.fireClickOnEnter} />}
             {!!addLocalizedFile && <sui.Button className="primary label" icon="xicon globe"
                 title={lf("Add localized file")}
                 onClick={this.handleAddLocale}
                 onKeyDown={this.handleButtonKeydown} />}
-            {openUrl && <sui.Button className="button primary label" icon="external" title={lf("Preview")} onClick={this.handleOpen} onKeyDown={sui.fireClickOnEnter} />}
         </a>
     }
 }

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -113,7 +113,10 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             // we keep this disabled, until implemented for cloud syncing
             // makse no sense for local saves - the star just blinks for half second after every change
             const showStar = false // !meta.isSaved
-            const isTutorialMd = topPkg && !!header && !!header.githubId && /\.md$/.test(file.name);
+            const isTutorialMd = topPkg 
+                && !!header && !!header.githubId 
+                && /\.md$/.test(file.name)
+                && !/^_locales\//.test(file.name)
             const openUrl = isTutorialMd
                 && `#tutorial:${header.id}:${file.name.replace(/\.[a-z]+$/, '')}`;
             const lang = pxt.Util.userLanguage();

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -121,9 +121,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && `#tutorial:${header.id}:${file.name.replace(/\.[a-z]+$/, '')}`;
             const lang = pxt.Util.userLanguage();
             const localized = `_locales/${lang}/${file.name}`;
-            const addLocale = pxt.Util.userLanguage() !== (pxt.appTarget.appTheme.defaultLocale || "en")
-                && isTutorialMd
-                && !/^_locales\//.test(file.name)
+            const addLocale = isTutorialMd
+                && pxt.Util.userLanguage() !== (pxt.appTarget.appTheme.defaultLocale || "en")
                 && !files.some(f => f.name == localized);
 
             return (

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -108,7 +108,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             // we keep this disabled, until implemented for cloud syncing
             // makse no sense for local saves - the star just blinks for half second after every change
             const showStar = false // !meta.isSaved
-            const openUrl = topPkg && !!header && !!header.githubId && /\.md$/.test(file.name)
+            const isTutorialMd = topPkg && !!header && !!header.githubId && /\.md$/.test(file.name);
+            const openUrl = isTutorialMd
                 && `#tutorial:${header.id}:${file.name.replace(/\.[a-z]+$/, '')}`
 
             return (
@@ -121,6 +122,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                     isActive={currentFile == file}
                     hasDelete={deleteFiles && !/^(main\.ts|pxt\.json)$/.test(file.name)}
                     openUrl={openUrl}
+                    addLocale={isTutorialMd && !/^_locale\//.test(file.name)}
                     className={(currentFile == file ? "active " : "") + (pkg.isTopLevel() ? "" : "nested ") + "item"}
                 >
                     {file.name}
@@ -340,6 +342,7 @@ interface FileTreeItemProps extends React.DetailedHTMLProps<React.AnchorHTMLAttr
     isActive: boolean;
     hasDelete?: boolean;
     openUrl?: string;
+    addLocale?: boolean;
 }
 
 class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
@@ -371,8 +374,14 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
     }
 
     handleOpen(e: React.MouseEvent<HTMLElement>) {
-        e.stopPropagation();
+        pxt.tickEvent("explorer.file.open");
         window.open(this.props.openUrl, "_blank");
+        e.stopPropagation();
+    }
+
+    handleAddLocale(e: React.MouseEvent<HTMLElement>) {
+        pxt.tickEvent("explorer.file.addlocale");
+
         e.stopPropagation();
     }
 
@@ -382,7 +391,7 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
 
     renderCore() {
         const { onClick, onItemClick, onItemRemove, onErrorClick, // keep these to avoid warnings with ...rest
-            isActive, hasDelete, file, meta, openUrl, ...rest } = this.props;
+            isActive, hasDelete, file, meta, openUrl, addLocale, ...rest } = this.props;
 
         return <a
             onClick={this.handleClick}
@@ -398,6 +407,10 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
                 onClick={this.handleRemove}
                 onKeyDown={this.handleButtonKeydown} />}
             {meta && meta.numErrors ? <span className='ui label red button' role="button" title={lf("Go to error")}>{meta.numErrors}</span> : undefined}
+            {addLocale && <sui.Button className="primary label" icon="xicon globe"
+                title={lf("Add localized file")}
+                onClick={this.handleAddLocale}
+                onKeyDown={this.handleButtonKeydown} />}
             {openUrl && <sui.Button className="button primary label" icon="external" title={lf("Preview")} onClick={this.handleOpen} onKeyDown={sui.fireClickOnEnter} />}
         </a>
     }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1354,7 +1354,7 @@ class CommitView extends sui.UIElement<CommitViewProps, CommitViewState> {
                     <span>{date.toLocaleTimeString()}</span>
                 </div>
                 <div className="description">{commit.message}</div>
-                {expanded && diffFiles && <div className="extra">{lf("Comparing selected commit with local files")}</div>}
+                {expanded && diffFiles && <div className="ui inverted segment">{lf("Comparing selected commit with local files")}</div>}
                 {expanded && diffFiles && <DiffView parent={parent} blocksMode={false} diffFiles={diffFiles} cacheKey={commit.sha} />}
             </div>
         </div>

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -72,6 +72,8 @@ export class File implements pxt.editor.IFile {
     weight() {
         if (/^main\./.test(this.name))
             return 5;
+        if (/^_locales\//.test(this.name))
+            return 500;
         if (extWeight.hasOwnProperty(this.getExtension()))
             return extWeight[this.getExtension()]
         return 60;


### PR DESCRIPTION
When the user is in a different locale than the default locale, the explorer view contains a button to add a localized version of markdown files (language icon)

In the example below, README.md does not have a fr files, so the icon is visible; test.md already have a fr version so the icon is not visible and _locales/fr/test.md does not have the locale or preview button.

![image](https://user-images.githubusercontent.com/4175913/75951604-4fb01580-5e61-11ea-8679-967c07830951.png)
