### PR TITLE
Allow delete main.ts in GitHub mode

### DIFF
--- a/pxtcompiler/emitter/transpile.ts
+++ b/pxtcompiler/emitter/transpile.ts
@@ -102,8 +102,9 @@ namespace ts.pxtc.transpile {
             return (pxt as any).py.py2ts(options) as TranspileResult
         }
 
-        let fromTxt = options.fileSystem[filename]
-        U.assert(fromTxt !== undefined && fromTxt !== null, `Missing file "${filename}" when converting from py->ts`)
+        let fromTxt = options.fileSystem[filename];
+        if (fromTxt === undefined || fromTxt === null)
+            fromTxt = ""; // don't crash if main.ts is missing, just create new file
 
         return transpileInternal("py", fromTxt, "ts", doRealTranspile, !!options.syntaxInfo)
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -411,9 +411,10 @@ export class ProjectView
             // make sure there's .py file
             const mpkg = pkg.mainEditorPkg();
             const mainpy = mpkg.files["main.py"];
-            const p = mainpy ? Promise.resolve()
-                : this.updateFileAsync("main.py", "# ...", open);
-            p.done(() => this.setFile(pkg.mainEditorPkg().files["main.py"]))
+            if (!mainpy)
+                this.updateFileAsync("main.py", "# ...", true);
+            else
+                this.setFile(mainpy);
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -400,6 +400,8 @@ export class ProjectView
             this.textEditor.giveFocusOnLoading = giveFocusOnLoading;
         }
 
+        // update language pref
+        pxt.Util.setEditorLanguagePref("py");
         // switch
         if (this.isBlocksActive()) {
             this.blocksEditor.openPython();
@@ -409,12 +411,10 @@ export class ProjectView
             // make sure there's .py file
             const mpkg = pkg.mainEditorPkg();
             const mainpy = mpkg.files["main.py"];
-            if (!mainpy)
-                mpkg.setFile("main.py", "# ...");
-            this.setFile(pkg.mainEditorPkg().files["main.py"])
+            const p = mainpy ? Promise.resolve()
+                : this.updateFileAsync("main.py", "# ...", open);
+            p.done(() => this.setFile(pkg.mainEditorPkg().files["main.py"]))
         }
-
-        pxt.Util.setEditorLanguagePref("py");
     }
 
     openJavaScript(giveFocusOnLoading = true) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -400,8 +400,6 @@ export class ProjectView
             this.textEditor.giveFocusOnLoading = giveFocusOnLoading;
         }
 
-        // update language pref
-        pxt.Util.setEditorLanguagePref("py");
         // switch
         if (this.isBlocksActive()) {
             this.blocksEditor.openPython();
@@ -412,10 +410,12 @@ export class ProjectView
             const mpkg = pkg.mainEditorPkg();
             const mainpy = mpkg.files["main.py"];
             if (!mainpy)
-                this.updateFileAsync("main.py", "# ...", true);
+                this.updateFileAsync("main.py", "# ...", false);
             else
                 this.setFile(mainpy);
         }
+        // update language pref
+        pxt.Util.setEditorLanguagePref("py");
     }
 
     openJavaScript(giveFocusOnLoading = true) {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -517,7 +517,7 @@ export function showImportGithubDialogAsync() {
         res = "NEW"
         core.hideDialog()
     }
-    core.showLoading("githublist", lf("Getting repo list..."))
+    core.showLoading("githublist", lf("searching GitHub repositories..."))
     return pxt.github.listUserReposAsync()
         .finally(() => core.hideLoading("githublist"))
         .then(repos => {

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -130,7 +130,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && (usesGitHub || file.name != "main.ts");
 
             return (
-                <FileTreeItem key={file.getName()}
+                <FileTreeItem key={"file" + file.getName()}
                     file={file}
                     meta={meta}
                     onItemClick={this.setFile}
@@ -401,7 +401,9 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
 
     handleAddLocale(e: React.MouseEvent<HTMLElement>) {
         pxt.tickEvent("explorer.file.addlocale");
-        this.props.onItemLocalize(this.props.file, this.props.addLocalizedFile);
+        const { addLocalizedFile, onItemLocalize } = this.props;
+        if (onItemLocalize && addLocalizedFile)
+            onItemLocalize(this.props.file, addLocalizedFile);
         e.stopPropagation();
     }
 

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -351,7 +351,7 @@ namespace custom {
     }
 }
 
-interface FileTreeItemProps extends React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
+interface FileTreeItemProps {
     file: pkg.File;
     meta: pkg.FileMeta;
     onItemClick: (fn: pkg.File) => void;
@@ -362,6 +362,7 @@ interface FileTreeItemProps extends React.DetailedHTMLProps<React.AnchorHTMLAttr
     hasDelete?: boolean;
     openUrl?: string;
     addLocalizedFile?: string;
+    className?: string;
 }
 
 class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
@@ -412,8 +413,7 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
     }
 
     renderCore() {
-        const { onClick, onItemClick, onItemRemove, onErrorClick, // keep these to avoid warnings with ...rest
-            isActive, hasDelete, file, meta, openUrl, addLocalizedFile, ...rest } = this.props;
+        const { isActive, hasDelete, file, meta, openUrl, addLocalizedFile, className } = this.props;
 
         return <a
             onClick={this.handleClick}
@@ -422,7 +422,7 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
             aria-selected={isActive}
             aria-label={isActive ? lf("{0}, it is the current opened file in the JavaScript editor", file.name) : file.name}
             onKeyDown={sui.fireClickOnEnter}
-            {...rest}>
+            className={className}>
             {this.props.children}
             {hasDelete && <sui.Button className="primary label" icon="trash"
                 title={lf("Delete file {0}", file.name)}

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -113,8 +113,9 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             // we keep this disabled, until implemented for cloud syncing
             // makse no sense for local saves - the star just blinks for half second after every change
             const showStar = false // !meta.isSaved
+            const usesGitHub = !!header && !!header.githubId;
             const isTutorialMd = topPkg
-                && !!header && !!header.githubId
+                && usesGitHub
                 && /\.md$/.test(file.name)
                 && !/^_locales\//.test(file.name)
             const openUrl = isTutorialMd
@@ -124,6 +125,9 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             const addLocale = isTutorialMd
                 && pxt.Util.userLanguage() !== (pxt.appTarget.appTheme.defaultLocale || "en")
                 && !files.some(f => f.name == localized);
+            const hasDelete = deleteFiles
+                && file.name != pxt.CONFIG_NAME
+                && (usesGitHub || file.name != "main.ts");
 
             return (
                 <FileTreeItem key={file.getName()}
@@ -134,7 +138,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                     onErrorClick={this.navigateToError}
                     onItemLocalize={this.addLocalizedFile}
                     isActive={currentFile == file}
-                    hasDelete={deleteFiles && !/^(main\.ts|pxt\.json)$/.test(file.name)}
+                    hasDelete={hasDelete}
                     openUrl={openUrl}
                     addLocalizedFile={addLocale && localized}
                     className={(currentFile == file ? "active " : "") + (pkg.isTopLevel() ? "" : "nested ") + "item"}

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -841,8 +841,8 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
     const oldCfg = pxt.Package.parseAndValidConfig(files[pxt.CONFIG_NAME])
     const cfgText = await downloadAsync(pxt.CONFIG_NAME)
     let cfg = pxt.Package.parseAndValidConfig(cfgText);
-    // invalid cfg or no TypeScript files
-    if (!cfg || !cfg.files.find(f => /\.ts$/.test(f))) {
+    // invalid cfg
+    if (!cfg) {
         if (hd) // not importing
             U.userError(lf("Invalid pxt.json file."));
         pxt.debug(`github: reconstructing pxt.json`)


### PR DESCRIPTION
Tutorial repos should be able to delete all code.

- [x] allow deleteing main.ts in github projects
- [x] automatically create missing .ts file from python compilation (instead of recursively crashing)
- [x] ensure that main.py is added to pxt.json when created
- [x] fix onItemLocalize warning
