### PR TITLE
setup lang picker in right space so it works on core docs

### DIFF
--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -247,7 +247,6 @@ function setupBlocklyAsync() {
                 })
         })
     }
-    setupLangPicker();
     return promise;
 }
 
@@ -375,4 +374,5 @@ $(document).ready(function () {
     setupSidebar();
     setupSemantic();
     renderSnippets();
+    setupLangPicker();
 });


### PR DESCRIPTION
render snippets exits if 'probably in pxt docs', and I had this at the end of render snippets for some reason..

Better to initiate with the other set up code anyways

should fix lang picker on makecode.com/blog (well, it will remove it as it langs not selectable in pxtarget right now, needs the flag and a few langs if you want it there: https://github.com/microsoft/pxt/blob/master/pxtarget.json)
