### PR TITLE
Langcode bug fix

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2797,19 +2797,19 @@ export class ProjectView
                     title = pxtJson.name || lf("Untitled");
                     autoChooseBoard = false;
                     const mfn = (ghid.fileName || "README") + ".md";
-
-                    let md = gh.files[mfn];
+                    
+                    let md : string = undefined;
                     let [initialLang, baseLang] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
                     if (initialLang && baseLang) {
-                        //Example: normalizeLanguageCode en-IN  will return ["en-IN", "en"] and nb will be returned as ["nb"]
-                        //We need to first search full lang and then the base Lang
-                        md = gh.files[`_locales/${initialLang}/${mfn}`] || gh.files[`_locales/${baseLang}/${mfn}`]
-                    } else if (initialLang) {
-                        // Simple case where there is just one lang code.
-                        md = gh.files[`_locales/${initialLang}/${mfn}`]
+                        //We need to first search base lang and then intial Lang
+                        //Example: normalizeLanguageCode en-IN  will return ["en-IN", "en"] and nb will be returned as ["nb"]                        
+                        md = files[`_locales/${initialLang}/${mfn}`] || files[`_locales/${baseLang}/${mfn}`];
+                    } else {
+                        md = files[`_locales/${initialLang}/${mfn}`];
                     }
-
+                    md = md || files[mfn];
                     return md;
+
                 }).catch((e) => {
                     core.errorNotification(tutorialErrorMessage);
                     core.handleNetworkError(e);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2797,11 +2797,18 @@ export class ProjectView
                     title = pxtJson.name || lf("Untitled");
                     autoChooseBoard = false;
                     const mfn = (ghid.fileName || "README") + ".md";
-                    const lang = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
-                    const md =
-                        (lang && lang[1] && files[`_locales/${lang[0]}-${lang[1]}/${mfn}`])
-                        || (lang && lang[0] && files[`_locales/${lang[0]}/${mfn}`])
-                        || files[mfn];
+
+                    let md = gh.files[mfn];
+                    let [initialLang, baseLang] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
+                    if (initialLang && baseLang) {
+                        //Example: normalizeLanguageCode en-IN  will return ["en-IN", "en"] and nb will be returned as ["nb"]
+                        //We need to first search base lang and then intial Lang
+                        md = gh.files[`_locales/${initialLang}/${mfn}`] || gh.files[`_locales/${baseLang}/${mfn}`]
+                    } else if (initialLang) {
+                        // Simple case where there is just one lang code.
+                        md = gh.files[`_locales/${initialLang}/${mfn}`]
+                    }
+
                     return md;
                 }).catch((e) => {
                     core.errorNotification(tutorialErrorMessage);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2802,7 +2802,7 @@ export class ProjectView
                     let [initialLang, baseLang] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
                     if (initialLang && baseLang) {
                         //Example: normalizeLanguageCode en-IN  will return ["en-IN", "en"] and nb will be returned as ["nb"]
-                        //We need to first search base lang and then intial Lang
+                        //We need to first search full lang and then the base Lang
                         md = gh.files[`_locales/${initialLang}/${mfn}`] || gh.files[`_locales/${baseLang}/${mfn}`]
                     } else if (initialLang) {
                         // Simple case where there is just one lang code.

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2797,9 +2797,9 @@ export class ProjectView
                     title = pxtJson.name || lf("Untitled");
                     autoChooseBoard = false;
                     const mfn = (ghid.fileName || "README") + ".md";
-                    
-                    let md : string = undefined;
-                    let [initialLang, baseLang] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
+
+                    let md: string = undefined;
+                    const [initialLang, baseLang] = pxt.Util.normalizeLanguageCode(pxt.Util.userLanguage());
                     if (initialLang && baseLang) {
                         //We need to first search base lang and then intial Lang
                         //Example: normalizeLanguageCode en-IN  will return ["en-IN", "en"] and nb will be returned as ["nb"]                        


### PR DESCRIPTION
NormalizeLanguageCode en-IN  will return ["en-IN", "en"] and nb will be returned as ["nb"]
We need to search the full lang and then the base lang. 

There search is done for something like en-IN-en and then en-IN. This won't succeed if there is only base lang is specified. 

