### PR TITLE
escape script tags in marked.tsx before markdown rendering

### DIFF
--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -326,6 +326,10 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
             sanitize: true
         })
 
+        // preemptively remove script tags, although they'll be escaped anyway
+        // prevents ugly <script ...> rendering in docs
+        markdown = markdown.replace(/<\s*script[^>]*>.*<\/\s*script\s*>/g, '');
+
         // Render the markdown and add it to the content div
         /* tslint:disable:no-inner-html (marked content is already sanitized) */
         content.innerHTML = marked(markdown);


### PR DESCRIPTION
This change removes script tag before rendering markdown for tutorials. this is purely cosmetic. The markdown engine still runs with ``sanitize: true``.

It takes care of the javascript we add to markdown pages to render blocks in GitHub Pages.