### PR TITLE
unify parsing of "tutorial", "example", "recipe" routes

### DIFF
--- a/docs/targets/home-screen.md
+++ b/docs/targets/home-screen.md
@@ -43,7 +43,7 @@ Shuffle values:
 ```
     "galleries": {
         "Classics": {
-            "url": "classics",
+            "url": "/classics",
             "shuffle": "daily"
         },
         ...

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -47,6 +47,10 @@ If you plan to update your tutorial over time, we recommend storing your project
 
     https://[editor url]/#tutorial:[GitHub repository url]
 
+For example,
+
+    https://makecode.microbit.org/#tutorial:https://github.com/myorg/myrepo
+
 ### Multiple tutorials per repository
 
 You can override the markdown file from the project used for the content of the tutorial (default is ``README.md``) by adding the path to the query argument (``.md`` not needed)
@@ -55,6 +59,10 @@ You can override the markdown file from the project used for the content of the 
 
 where MakeCode will load the ``filename.md`` file from the project. Don't forget to add this file in the
 ``files`` list in ``pxt.json``.
+
+For example,
+
+    https://makecode.microbit.org/#tutorial:https://github.com/myorg/myrepo/mytutorial
 
 ### Testing
 

--- a/docs/writing-docs/user-tutorials.md
+++ b/docs/writing-docs/user-tutorials.md
@@ -64,6 +64,12 @@ For example,
 
     https://makecode.microbit.org/#tutorial:https://github.com/myorg/myrepo/mytutorial
 
+### Examples
+
+You can also use the ``#example`` route similarly to ``#tutorial`` to load a markdown example into the editor.
+
+    https://[editor url]/#example:[GitHub repository url]/[filename]
+
 ### Testing
 
 Click on the ``external link`` icon in the **Explorer** view to open any markdown file (``.md``)

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -166,6 +166,8 @@ namespace pxt.editor {
         photo?: string;
     }
 
+    export type Activity = "tutorial" | "recipe" | "example";
+
     export interface IProjectView {
         state: IAppState;
         setState(st: IAppState): void;
@@ -290,7 +292,7 @@ namespace pxt.editor {
 
         editor: IEditor;
 
-        startTutorial(tutorialId: string, tutorialTitle?: string, recipe?: boolean, editor?: string): void;
+        startActivity(activitity: Activity, path: string, title?: string, editor?: string): void;
         showLightbox(): void;
         hideLightbox(): void;
         showKeymap(show: boolean): void;

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -41,7 +41,7 @@ namespace pxt.gallery {
     export function parseExampleMarkdown(name: string, md: string): GalleryProject {
         if (!md) return undefined;
 
-        const m = /```(blocks?|typescript|python|spy)\s+((.|\s)+?)\s*```/i.exec(md);
+        const m = /```(blocks?|typescript|python|spy|sim)\s+((.|\s)+?)\s*```/i.exec(md);
         if (!m) return undefined;
 
         const dependencies = parsePackagesFromMarkdown(md);

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -115,9 +115,4 @@ namespace pxt.gallery {
         return pxt.Cloud.markdownAsync(name)
             .then(md => parseGalleryMardown(md))
     }
-
-    export function loadExampleAsync(name: string, path: string): Promise<GalleryProject> {
-        return pxt.Cloud.markdownAsync(path)
-            .then(md => parseExampleMarkdown(name, md))
-    }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2067,7 +2067,7 @@ export class ProjectView
         return this.loadActivityFromMarkdownAsync(path, name.toLowerCase(), preferredEditor)
             .then(r => {
                 const { filename, md, features, autoChooseBoard: autoChooseBoardMeta } = (r || {});
-                const autoChooseBoard = !prj && autoChooseBoardMeta ;
+                const autoChooseBoard = !prj && autoChooseBoardMeta;
                 const example = !!md && pxt.gallery.parseExampleMarkdown(filename, md);
                 if (!example)
                     throw new Error(lf("Example not found or invalid format"))
@@ -2105,10 +2105,10 @@ export class ProjectView
                                         }
                                     })
                                     .then(() => autoChooseBoard && this.autoChooseBoardAsync(features));
-                                }
+                            }
                             return Promise.resolve();
                         })
-                    }
+                }
             })
 
             .finally(() => core.hideLoading("changingcode"))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3222,6 +3222,9 @@ export class ProjectView
                 temporary,
                 md
             };
+        }).catch(e => {
+            core.handleNetworkError(e);
+            core.errorNotification(lf("Oops, we could not load this activity."))
         });
 
         function processMarkdown(md: string) {
@@ -3277,7 +3280,7 @@ export class ProjectView
 
         return this.loadActivityFromMarkdownAsync(tutorialId, tutorialTitle, editorProjectName)
             .then(r => {
-                const { filename, dependencies, temporary, reportId, autoChooseBoard, features, md } = r;
+                const { filename, dependencies, temporary, reportId, autoChooseBoard, features, md } = (r || {});
                 if (!md)
                     throw new Error(lf("Tutorial not found"));
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3313,7 +3313,7 @@ export class ProjectView
 
     startActivity(activity: pxt.editor.Activity, path: string, title?: string, editorProjectName?: string) {
         pxt.tickEvent(activity + ".start", { editor: editorProjectName });
-        switch(activity) {
+        switch (activity) {
             case "tutorial":
                 this.startTutorialAsync(path, title, false, editorProjectName); break;
             case "recipe":
@@ -3910,7 +3910,7 @@ function handleHash(hash: { cmd: string; arg: string }, loading: boolean): boole
         }
         // shortcut to a tutorial. eg: #tutorial:tutorials/getting-started
         // or #tutorial:py:tutorials/getting-started
-        case "tutorial": 
+        case "tutorial":
         case "example":
         case "recipe": {
             pxt.tickEvent("hash." + hash.cmd)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2066,7 +2066,8 @@ export class ProjectView
         core.showLoading("changingcode", lf("loading..."));
         return this.loadActivityFromMarkdownAsync(path, name.toLowerCase(), preferredEditor)
             .then(r => {
-                const { filename, md, features, autoChooseBoard } = (r || {});
+                const { filename, md, features, autoChooseBoard: autoChooseBoardMeta } = (r || {});
+                const autoChooseBoard = !prj && autoChooseBoardMeta ;
                 const example = !!md && pxt.gallery.parseExampleMarkdown(filename, md);
                 if (!example)
                     throw new Error(lf("Example not found or invalid format"))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3191,7 +3191,7 @@ export class ProjectView
                     const status = pxt.github.repoStatus(ghid, config);
                     switch (status) {
                         case pxt.github.GitRepoStatus.Banned:
-                            throw lf("This tutorial has been banned.");
+                            throw lf("This GitHub repository has been banned.");
                         case pxt.github.GitRepoStatus.Approved:
                             reportId = undefined;
                             break;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -26,7 +26,7 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 
 function openTutorial(parent: pxt.editor.IProjectView, path: string) {
     pxt.tickEvent(`docs`, { path }, { interactiveConsent: true });
-    parent.startTutorial(path);
+    parent.startActivity("tutorial", path);
 }
 
 function openDocs(parent: pxt.editor.IProjectView, path: string) {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -115,11 +115,11 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 this.props.parent.newEmptyProject(scr.name, url);
                 break;
             case "tutorial":
-                this.props.parent.startTutorial(url, scr.name, false, editorPref);
+                this.props.parent.startActivity("tutorial", url, scr.name, false, editorPref);
                 break;
             default:
                 const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(url); // Tutorial
-                if (m) this.props.parent.startTutorial(m[1]);
+                if (m) this.props.parent.startActivity("tutorial", m[1]);
                 else {
                     if (scr.youTubeId && !url) // Youtube video
                         return; // Handled by href

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -115,7 +115,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 this.props.parent.newEmptyProject(scr.name, url);
                 break;
             case "tutorial":
-                this.props.parent.startActivity("tutorial", url, scr.name, false, editorPref);
+                this.props.parent.startActivity("tutorial", url, scr.name, editorPref);
                 break;
             default:
                 const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(url); // Tutorial

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -136,8 +136,8 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         }
     }
 
-    chgCode(name: string, path: string, loadBlocks: boolean, preferredEditor?: string, prj?: pxt.ProjectTemplate) {
-        return this.props.parent.importExampleAsync({ name, path, loadBlocks, preferredEditor, prj });
+    chgCode(name: string, path: string, loadBlocks: boolean, preferredEditor?: string, template?: pxt.ProjectTemplate) {
+        return this.props.parent.importExampleAsync({ name, path, loadBlocks, preferredEditor, prj: template });
     }
 
     importProject() {


### PR DESCRIPTION
- [x] refactor loading code for "tutorial", "example", "recipe" routes
- [x] use common loading code in all instances of loading
- [x] support for loading example from github repo
- [x] support for template route