### PR TITLE
Image Editor: keybindings for colors, suppress delete key

### DIFF
--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -1,15 +1,17 @@
 import { ImageEditorTool } from './store/imageReducer';
-import { dispatchChangeZoom, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchChangeImageTool, dispatchSwapBackgroundForeground } from './actions/dispatch';
+import { dispatchChangeZoom, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchChangeImageTool, dispatchSwapBackgroundForeground, dispatchChangeSelectedColor} from './actions/dispatch';
 import store from './store/imageStore';
 
 export function addKeyListener() {
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keydown", handleUndoRedo, true);
+    document.addEventListener("keydown", overrideBlocklyShortcuts, true);
 }
 
 export function removeKeyListener() {
     document.removeEventListener("keydown", handleKeyDown);
     document.removeEventListener("keydown", handleUndoRedo, true);
+    document.removeEventListener("keydown", overrideBlocklyShortcuts, true);
 }
 
 function handleUndoRedo(event: KeyboardEvent) {
@@ -20,6 +22,13 @@ function handleUndoRedo(event: KeyboardEvent) {
         event.stopPropagation();
     } else if (event.key === "Redo" || (controlOrMeta && event.key === "y")) {
         redo();
+        event.preventDefault();
+        event.stopPropagation();
+    }
+}
+
+function overrideBlocklyShortcuts(event: KeyboardEvent) {
+    if (event.key === "Backspace" || event.key === "Delete") {
         event.preventDefault();
         event.stopPropagation();
     }
@@ -59,6 +68,12 @@ function handleKeyDown(event: KeyboardEvent) {
             swapForegroundBackground();
             break;
     }
+
+    if (/Digit\d/.test(event.code)) {
+        const keyAsNum = +event.code.slice(-1);
+        const color = keyAsNum + (event.shiftKey ? 9 : 0);
+        setColor(color);
+    }
 }
 
 function undo() {
@@ -71,6 +86,10 @@ function redo() {
 
 function setTool(tool: ImageEditorTool) {
     dispatchAction(dispatchChangeImageTool(tool));
+}
+
+function setColor(selectedColor: number) {
+    dispatchAction(dispatchChangeSelectedColor(selectedColor))
 }
 
 function zoom(delta: number) {

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -69,7 +69,7 @@ function handleKeyDown(event: KeyboardEvent) {
             break;
     }
 
-    if (/Digit\d/.test(event.code)) {
+    if (/^Digit\d$/.test(event.code)) {
         const keyAsNum = +event.code.slice(-1);
         const color = keyAsNum + (event.shiftKey ? 9 : 0);
         setColor(color);

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -74,7 +74,10 @@ function handleKeyDown(event: KeyboardEvent) {
     if (!editorState.isTilemap && /^Digit\d$/.test(event.code)) {
         const keyAsNum = +event.code.slice(-1);
         const color = keyAsNum + (event.shiftKey ? 9 : 0);
-        setColor(color);
+        // TODO: if we need to generalize for different numbers of colors,
+        // will need to fix the magic 16 here
+        if (color >= 0 && color < 16)
+            setColor(color);
     }
 }
 

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -69,7 +69,9 @@ function handleKeyDown(event: KeyboardEvent) {
             break;
     }
 
-    if (/^Digit\d$/.test(event.code)) {
+    const editorState = store.getState().editor;
+
+    if (!editorState.isTilemap && /^Digit\d$/.test(event.code)) {
         const keyAsNum = +event.code.slice(-1);
         const color = keyAsNum + (event.shiftKey ? 9 : 0);
         setColor(color);

--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -410,10 +410,6 @@ const editorReducer = (state: EditorState, action: any): EditorState => {
             return { ...state, cursorSize: action.cursorSize };
         case actions.CHANGE_SELECTED_COLOR:
             tickEvent(`foreground-color-${action.selectedColor}`);
-            // TODO: if we need to generalize for different numbers of colors,
-            // will need to fix the magic 16 here
-            if (action.selectedColor < 0 || action.selectedColor >= 16)
-                return state;
 
             // If the selected tool is the eraser, make sure to switch to pencil
             return {
@@ -425,8 +421,6 @@ const editorReducer = (state: EditorState, action: any): EditorState => {
             return { ...state, cursorLocation: action.cursorLocation };
         case actions.CHANGE_BACKGROUND_COLOR:
             tickEvent(`background-color-${action.backgroundColor}`);
-            if (action.selectedColor < 0 || action.selectedColor >= 16)
-                return state;
             return { ...state, backgroundColor: action.backgroundColor };
         case actions.SWAP_FOREGROUND_BACKGROUND:
             tickEvent(`swap-foreground-background`);

--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -410,6 +410,10 @@ const editorReducer = (state: EditorState, action: any): EditorState => {
             return { ...state, cursorSize: action.cursorSize };
         case actions.CHANGE_SELECTED_COLOR:
             tickEvent(`foreground-color-${action.selectedColor}`);
+            // TODO: if we need to generalize for different numbers of colors,
+            // will need to fix the magic 16 here
+            if (action.selectedColor < 0 || action.selectedColor >= 16)
+                return state;
 
             // If the selected tool is the eraser, make sure to switch to pencil
             return {
@@ -421,6 +425,8 @@ const editorReducer = (state: EditorState, action: any): EditorState => {
             return { ...state, cursorLocation: action.cursorLocation };
         case actions.CHANGE_BACKGROUND_COLOR:
             tickEvent(`background-color-${action.backgroundColor}`);
+            if (action.selectedColor < 0 || action.selectedColor >= 16)
+                return state;
             return { ...state, backgroundColor: action.backgroundColor };
         case actions.SWAP_FOREGROUND_BACKGROUND:
             tickEvent(`swap-foreground-background`);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1777 (unless there are other blockly shortcuts to prevent, but I couldn't think of any right away) and fix https://github.com/microsoft/pxt-arcade/issues/1778

had the shortcuts for colors already in the old editor (https://github.com/microsoft/pxt/pull/5549), but never used them as much so I never noticed they were gone in the new one