### PR TITLE
Adding language service tests and improving completions for literals

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -514,6 +514,7 @@ const testpydecomp = testTask("pydecompile-test", "pydecompilerunner.js");
 const testpycomp = testTask("pyconverter-test", "pyconvertrunner.js");
 const testpytraces = testTask("runtime-trace-tests", "tracerunner.js");
 const testtutorials = testTask("tutorial-test", "tutorialrunner.js");
+const testlanguageservice = testTask("language-service", "languageservicerunner.js");
 
 const buildKarmaRunner = () => compileTsProject("tests/blocklycompiler-test", "built/tests/", true);
 const runKarma = () => {
@@ -541,6 +542,7 @@ const testAll = gulp.series(
     testpycomp,
     testpytraces,
     testtutorials,
+    testlanguageservice,
     karma
 )
 
@@ -616,6 +618,7 @@ exports.update = update;
 exports.uglify = runUglify;
 exports.watch = initWatch;
 exports.watchCli = initWatchCli;
+exports.testlanguageservice = testlanguageservice;
 
 console.log(`pxt build how to:`)
 console.log(`run "gulp watch" in pxt folder`)

--- a/tests/language-service/cases/completions_namespace.ts
+++ b/tests/language-service/cases/completions_namespace.ts
@@ -1,0 +1,1 @@
+testNamespace. // testNamespace.someFunction

--- a/tests/language-service/cases/completions_stringliteral.ts
+++ b/tests/language-service/cases/completions_stringliteral.ts
@@ -1,0 +1,1 @@
+"". // String.length; String.compare; String.replace

--- a/tests/language-service/languageservicerunner.ts
+++ b/tests/language-service/languageservicerunner.ts
@@ -1,0 +1,145 @@
+/// <reference path="../../built/pxtcompiler.d.ts"/>
+
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import "mocha";
+import * as chai from "chai";
+
+import * as util from "../common/testUtils";
+
+const casesDir = path.join(process.cwd(), "tests", "language-service", "cases");
+const testPackage = path.relative(process.cwd(), path.join("tests", "language-service", "test-package"));
+
+
+interface CompletionTestCase {
+    fileName: string;
+    fileText: string;
+    isPython: boolean;
+    position: number;
+    wordStartPos: number;
+    wordEndPos: number;
+    expectedSymbols: string[];
+}
+
+function initGlobals() {
+    let g = global as any
+    g.pxt = pxt;
+    g.ts = ts;
+    g.pxtc = pxtc;
+    g.btoa = (str: string) => Buffer.from(str, "binary").toString("base64");
+    g.atob = (str: string) => Buffer.from(str, "base64").toString("binary");
+}
+
+initGlobals();
+pxt.setAppTarget(util.testAppTarget);
+
+describe("language service", () => {
+    const cases = getTestCases();
+
+    for (const testCase of cases) {
+        it("get completions " + testCase.fileName + testCase.position, () => {
+            console.log(JSON.stringify(testCase));
+            return runCompletionTestCaseAsync(testCase);
+        });
+    }
+})
+
+function getTestCases() {
+    const filenames: string[] = [];
+    for (const file of fs.readdirSync(casesDir)) {
+        if (file[0] == ".") {
+            continue;
+        }
+
+        const filename = path.join(casesDir, file);
+        if (file.substr(-3) === ".ts") {
+            filenames.push(filename);
+        }
+    };
+
+    const testCases: CompletionTestCase[] = [];
+
+    for (const fileName of filenames) {
+        const fileText = fs.readFileSync(fileName, { encoding: "utf8" });
+        const isPython = fileName.substr(-3) !== ".ts";
+
+        const lines = fileText.split("\n");
+        let position = 0;
+
+        for (const line of lines) {
+            const commentString = isPython ? "#" : "//";
+            const commentIndex = line.indexOf(commentString);
+            if (commentIndex !== -1) {
+                const comment = line.substr(commentIndex + commentString.length).trim();
+                const expectedSymbols = comment.split(";").map(s => s.trim());
+
+                const dotPosition = position + line.substring(0, commentIndex).lastIndexOf(".");
+
+                testCases.push({
+                    fileName,
+                    fileText,
+                    isPython,
+                    expectedSymbols,
+                    position: dotPosition + 1,
+                    wordStartPos: dotPosition + 1,
+                    wordEndPos: dotPosition + 1,
+                })
+            }
+
+            position += line.length;
+        }
+    }
+
+    return testCases;
+}
+
+function runCompletionTestCaseAsync(testCase: CompletionTestCase) {
+    return getOptionsAsync(testCase.fileText)
+        .then(opts => {
+            setOptionsOp(opts);
+            ensureAPIInfoOp();
+            const result = completionsOp(
+                "main.ts",
+                testCase.position,
+                testCase.wordStartPos,
+                testCase.wordEndPos,
+                testCase.fileText
+            );
+
+            console.log(result.entries.map(e => e.qName).join(", "))
+
+            for (const sym of testCase.expectedSymbols) {
+                chai.assert(result.entries.some(s => (testCase.isPython ? s.pyQName : s.qName) === sym), `Did not receive symbol '${sym}'`);
+            }
+        })
+}
+
+function getOptionsAsync(fileContent: string) {
+    const packageFiles: pxt.Map<string> = {};
+    packageFiles["main.ts"] = fileContent;
+
+    return util.getTestCompileOptsAsync(packageFiles, testPackage, true);
+}
+
+function ensureAPIInfoOp() {
+    pxtc.service.performOperation("apiInfo", {});
+}
+
+function setOptionsOp(opts: pxtc.CompileOptions) {
+    return pxtc.service.performOperation("setOptions", {
+        options: opts
+    });
+}
+
+function completionsOp(fileName: string, position: number, wordStartPos: number, wordEndPos: number, fileContent?: string): pxtc.CompletionInfo {
+    return pxtc.service.performOperation("getCompletions", {
+        fileName,
+        fileContent,
+        position,
+        wordStartPos,
+        wordEndPos,
+        runtime: pxt.appTarget.runtime
+    });
+}

--- a/tests/language-service/test-package/namespaces.ts
+++ b/tests/language-service/test-package/namespaces.ts
@@ -1,0 +1,5 @@
+namespace testNamespace {
+    export function someFunction() {
+
+    }
+}

--- a/tests/language-service/test-package/pxt.json
+++ b/tests/language-service/test-package/pxt.json
@@ -1,0 +1,10 @@
+{
+    "name": "test-package",
+    "description": "Project that defines a variety of APIs for testing the TypeScript and Python language service",
+    "files": [
+        "namespaces.ts"
+    ],
+    "public": true,
+    "dependencies": {},
+    "installedVersion": "file:."
+}

--- a/tests/language-service/tsconfig.json
+++ b/tests/language-service/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "declaration": true,
+        "outDir": "../../built/tests",
+        "newLine": "LF",
+        "module": "commonjs",
+        "types": [
+            "chai",
+            "mocha",
+            "node",
+            "bluebird"
+        ],
+        "sourceMap": false
+    },
+    "files": [
+        "languageservicerunner.ts",
+        "../common/testUtils.ts",
+        "../common/testHost.ts"
+    ]
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2640

The issue wasn't actually overloads, we just completely bail out and return all symbols whenever we can't find the symbol for the left hand side of a property access expression. This adds logic to use the type instead of just the symbol.

Also adds a test suite for the language service. There aren't many tests right now; I'll be adding more as I do fixes. My plan is to expand this to include hover and any other monaco features we implement as well.