### PR TITLE
Only upload ide strings to crowdin if on tagged release on master

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -356,6 +356,27 @@ function semverCmp(a: string, b: string) {
     return parse(a) - parse(b)
 }
 
+function checkIfTaggedCommitAsync() {
+    let currentCommit: string;
+
+    return nodeutil.gitInfoAsync(["rev-parse", "HEAD"])
+        .then(info => {
+            currentCommit = info.trim();
+            return nodeutil.gitInfoAsync(["ls-remote", "--tags"])
+        })
+        .then(info => {
+            const tagCommits = info.split("\n")
+                .map(line => {
+                    const match = /^([a-fA-F0-9]+)\s+refs\/tags\/v\d+\.\d+\.\d+\^\{\}$/.exec(line);
+                    return match && match[1]
+                });
+
+            console.log(tagCommits.filter(t => !!t).join("\n"))
+
+            return tagCommits.some(t => t === currentCommit)
+        });
+}
+
 let readJson = nodeutil.readJson;
 
 function ciAsync() {
@@ -406,16 +427,19 @@ function ciAsync() {
     let pkg = readJson("package.json")
     if (pkg["name"] == "pxt-core") {
         pxt.log("pxt-core build");
-        let p = npmPublishAsync();
-        if (uploadDocs)
-            p = p
-                .then(() => buildWebStringsAsync())
-                .then(() => crowdin.execCrowdinAsync("upload", "built/webstrings.json"));
-        if (uploadApiStrings)
-            p = p.then(() => crowdin.execCrowdinAsync("upload", "built/strings.json"))
-        if (uploadDocs || uploadApiStrings)
-            p = p.then(() => crowdin.internalUploadTargetTranslationsAsync(uploadApiStrings, uploadDocs));
-        return p;
+        return checkIfTaggedCommitAsync()
+            .then(isTaggedCommit => {
+                let p = npmPublishAsync();
+                if (uploadDocs && branch === "master" && isTaggedCommit)
+                    p = p
+                        .then(() => buildWebStringsAsync())
+                        .then(() => crowdin.execCrowdinAsync("upload", "built/webstrings.json"));
+                if (uploadApiStrings)
+                    p = p.then(() => crowdin.execCrowdinAsync("upload", "built/strings.json"))
+                if (uploadDocs || uploadApiStrings)
+                    p = p.then(() => crowdin.internalUploadTargetTranslationsAsync(uploadApiStrings, uploadDocs));
+                return p;
+            });
     } else {
         pxt.log("target build");
         return internalBuildTargetAsync()

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -371,8 +371,6 @@ function checkIfTaggedCommitAsync() {
                     return match && match[1]
                 });
 
-            console.log(tagCommits.filter(t => !!t).join("\n"))
-
             return tagCommits.some(t => t === currentCommit)
         });
 }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -362,7 +362,7 @@ function checkIfTaggedCommitAsync() {
     return nodeutil.gitInfoAsync(["rev-parse", "HEAD"])
         .then(info => {
             currentCommit = info.trim();
-            return nodeutil.gitInfoAsync(["ls-remote", "--tags"])
+            return nodeutil.gitInfoAsync(["ls-remote", "--tags"], undefined, true)
         })
         .then(info => {
             const tagCommits = info.split("\n")

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -429,6 +429,7 @@ function ciAsync() {
         pxt.log("pxt-core build");
         return checkIfTaggedCommitAsync()
             .then(isTaggedCommit => {
+                pxt.log(`is tagged commit: ${isTaggedCommit}`);
                 let p = npmPublishAsync();
                 if (uploadDocs && branch === "master" && isTaggedCommit)
                     p = p


### PR DESCRIPTION
Right now we upload the ide strings for any tagged release and any commit on master. This tweaks that logic so that we now only upload on tagged commits that are on master (and not untagged commits).

We run two builds for every `pxt bump`; one on master and one on the tag that's created. This will only upload strings on the former, the tagged release will skip that step.

I tested my `checkIfTaggedCommitAsync()` locally but can't really test the full scenario. Should be safe to merge and then test out.