### PR TITLE
Fix a couple places where we trash the undo/redo stack in Monaco

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -701,7 +701,7 @@ namespace ts.pxtc.service {
 
         getScriptSnapshot(fileName: string): IScriptSnapshot {
             let f = this.opts.fileSystem[fileName]
-            if (f)
+            if (f != null)
                 return ScriptSnapshot.fromString(f)
             else
                 return null

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1185,9 +1185,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                             this.editor.setValue(this.editor.getValue().replace(/\u{201c}|\u{201d}/gu, `"`).replace(/\u{2018}|\u{2019}/gu, `'`));
                         }
 
-                        if (!e.isRedoing && !e.isUndoing && !this.editor.getValue()) {
-                            this.editor.setValue(" ");
-                        }
                         this.updateDiagnostics();
                         this.changeCallback();
                         this.updateFieldEditors();

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1179,10 +1179,21 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         });
                         this.editorViewZones = [];
 
+                        const bannedCharactersRegex = /[\u{201c}\u{201d}\u{2018}\u{2019}]/u;
+
                         // Test for left and right quotes because ios safari will sometimes insert
                         // them automatically for the user. Convert them to normal quotes
-                        if (e.changes.some(change => /[\u{201c}\u{201d}\u{2018}\u{2019}]/u.test(change.text))) {
-                            this.editor.setValue(this.editor.getValue().replace(/\u{201c}|\u{201d}/gu, `"`).replace(/\u{2018}|\u{2019}/gu, `'`));
+                        if (e.changes.some(change => bannedCharactersRegex.test(change.text))) {
+                            const edits: monaco.editor.IIdentifiedSingleEditOperation[] = e.changes.filter(e => bannedCharactersRegex.test(e.text)).map(e => {
+                                const start = model.getPositionAt(e.rangeOffset);
+                                const end = model.getPositionAt(e.rangeOffset + e.text.length);
+                                return {
+                                    range: new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column),
+                                    text: e.text.replace(/\u{201c}|\u{201d}/gu, `"`).replace(/\u{2018}|\u{2019}/gu, `'`)
+                                }
+                            });
+
+                            this.editor.executeEdits("pxt", edits);
                         }
 
                         this.updateDiagnostics();


### PR DESCRIPTION
Calling `editor.setValue()` trashes the undo stack in monaco. We had a very annoying hack to handle empty files where we replaced the contents of main.ts with a single space if there was no text. I tracked down the real bug which was a truthiness check in the language service compiler host.

I also fixed the logic that replaces special quotes (the ones macOS and iOS like to insert for you) to not call `setValue` directly. Now the evil quotes will show up on your undo/redo stack but that's better than trashing the whole thing.

Fixes https://github.com/microsoft/pxt-microbit/issues/2648
Fixes https://github.com/microsoft/pxt-minecraft/issues/988