### PR TITLE
Slightly better support for screen reader modals

### DIFF
--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -319,10 +319,31 @@ function buildLangPicker() {
             localesContainer.appendChild(card);
         });
 
+        /**
+         * In addition to normal focus trap, need to explicitly hide these
+         * elements when the modal is open so screen readers do not allow user
+         * to escape modal while in scan mode.
+         *
+         * Ideally, aria-modal && role="dialog" should make the screen reader
+         * handle this (https://www.w3.org/TR/wai-aria-1.1/#aria-modal)
+         * but none seem to :)
+         **/
+        var identifiersToHide = [
+            "#docs",
+            "#top-bar",
+            "#side-menu"
+        ];
+
         modalContainer.className += `  ${appTheme.availableLocales.length > 4 ? "large" : "small"}`;
 
         $(modalContainer).modal({
             onShow: function() {
+                for (var id of identifiersToHide) {
+                    var divToHide = document.querySelector(id);
+                    if (divToHide)
+                        divToHide.setAttribute("aria-hidden", "true");
+                }
+
                 $(document).off("focusin.focusJail");
                 $(document).on("focusin.focusJail", function(event) {
                     if (event.target !== modalContainer && !$.contains(modalContainer, event.target)) {
@@ -331,6 +352,12 @@ function buildLangPicker() {
                 });
             },
             onHide: function() {
+                for (var id of identifiersToHide) {
+                    var divToHide = document.querySelector(id);
+                    if (divToHide)
+                        divToHide.removeAttribute("aria-hidden");
+                }
+
                 $(document).off("focusin.focusJail");
             }
         });

--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -26,7 +26,7 @@
             <a class="item" href="https://makecode.com/privacy" target="_blank" rel="noopener">Privacy &amp; Cookies</a>
             <a class="item" href="https://makecode.com/termsofuse" target="_blank" rel="noopener">Terms Of Use</a>
             <a class="item" href="https://makecode.com/trademarks" target="_blank" rel="noopener">Trademarks</a>
-            <span class="item">© 2019 Microsoft</span>
+            <span class="item">© 2020 Microsoft</span>
         </div>
         <div class="ui container horizontal small link list poweredBy">
             <span class="item">Powered by</span>

--- a/docfiles/tocheader.html
+++ b/docfiles/tocheader.html
@@ -1,4 +1,4 @@
-<div class="ui fixed accent borderless @tocclass@ main menu hideprint docs" role="menubar">
+<div id="top-bar" class="ui fixed accent borderless @tocclass@ main menu hideprint docs" role="menubar">
     <div>
         @sidebarToggle@
         <div class="item" role="menuitem">
@@ -24,7 +24,7 @@
     </div>
 </div>
 
-<div class="ui vertical accent @tocclass@ sidebar menu left hideprint docs" role="menubar">
+<div id="side-menu" class="ui vertical accent @tocclass@ sidebar menu left hideprint docs" role="menubar">
     <!-- TOC Menu (tocheader.html) -->
     <div class="menuContainer" role="menu">
         @TOC@

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1394,6 +1394,7 @@ export class Dimmer extends UIElement<DimmerProps, DimmerState> {
             shouldCloseOnOverlayClick={closable}
             onRequestClose={onClose}
             overlayClassName={portalClasses}
+            role="dialog"
             {...rest}>
             {children}
         </ReactModal>

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1262,8 +1262,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
         ])
         const aria = {
             labelledby: header ? this.id + 'title' : undefined,
-            describedby: (!isFullscreen && description) ? this.id + 'description' : this.id + 'desc',
-            modal: 'true'
+            describedby: (!isFullscreen && description) ? this.id + 'description' : this.id + 'desc'
         }
         const customStyles = {
             content: {
@@ -1280,6 +1279,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             overlayClassName={`ui page modals dimmer transition ${overlayClassName} ${isOpen ? 'visible active' : ''}`}
             className={classes}
             style={customStyles}
+            role="dialog"
             aria={aria} {...rest}>
             {header || showBack || helpUrl ? <div id={this.id + 'title'} className={"header " + (headerClass || "")}>
                 <span className="header-title" style={{ margin: `0 ${helpUrl ? '-20rem' : '0'} 0 ${showBack ? '-20rem' : '0'}` }}>{header}</span>


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/2370

makes the modals work a bit better with narrator in scan mode in latest firefox, chrome; docs seems to work properly, but some of the dialogs (in the editor itself) still end up escaping to background / do not properly refocus while in scan mode. Looks like https://github.com/OfficeDev/office-ui-fabric-react/pull/6884 has the same basic problem, with the same attempt at a solution and the rest being left to future narrator updates (also nice write up on the associated issue: https://github.com/OfficeDev/office-ui-fabric-react/issues/6422#issuecomment-430331471).

does not currently work as well in latest (chromium) edge, which seems... weird as it should be consistent with chrome - but the behavior is similar to what I saw in chrome last year, so maybe a fix will propagate. Also noticed https://github.com/microsoft/pxt-microbit/issues/2652, which is another bug not present in other browsers