### PR TITLE
account for top bar height in anchor links

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -213,6 +213,19 @@ svg {
     justify-content: space-between;
     align-items: center;
 }
+
+#docs h1:before, #docs h2:before,
+#docs h3:before, #docs h4:before,
+#docs h5:before, #docs h6:before {
+    content: '';
+    display: block;
+    /* keep this aligned with top bar menu height */
+    height: 3.5em;
+    margin-top: -3.5em;
+    visibility: hidden;
+}
+
+
 /* first children are left & right div wrappers */
 .fixed.menu div {
     display:flex;


### PR DESCRIPTION
looking at https://github.com/microsoft/pxt/issues/6715 and wanted to use relative links to make things fit into the table easier, but the top bar offsets them annoyingly and makes it hard to follow. This makes the link account for the header bar by offsetting the 'beginning' of the anchor on the page. (I saw the approach on stack overflow a while ago and remembered it, can find it again I'm sure if we want to link it for reference)

e.g., make https://makecode.com/blog/online-learning#09-00am-est-monday-arcade-by-steve-isaacs-https-twitter-com-mr_isaacs- position properly:

current:

![liveoffset](https://user-images.githubusercontent.com/5615930/76908119-36e22f80-6865-11ea-8903-6b9991f1b680.gif)

with change:

![newoffset](https://user-images.githubusercontent.com/5615930/76908309-9b9d8a00-6865-11ea-8957-9cdcb2adc5d9.gif)
