### PR TITLE
make docs tables scrollable iff too wide

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -163,6 +163,11 @@ svg {
     padding-bottom: 3em;
 }
 
+#docs .mainbody table {
+    display: block;
+    overflow-x: auto;
+}
+
 #accessibleMenu .ui.item.link {
     position: absolute;
     height: 4em;


### PR DESCRIPTION
re: table issue in https://github.com/microsoft/pxt/pull/6717

make tables scrollable if too wide to fit on screen; better than scrolling the entire page.

![scrollabletables](https://user-images.githubusercontent.com/5615930/76910938-9b54bd00-686c-11ea-99db-7eeb018ec2a0.gif)

