### PR TITLE
Use ignore snippets in Python lang docs

### DIFF
--- a/common-docs/python/classes.md
+++ b/common-docs/python/classes.md
@@ -4,7 +4,7 @@ Classes in Python follow a definition format similar to other object-oriented la
 
 Let's take a look at a simple class-based example:
 
-```python
+```python-ignore
 class Greeter:
     greeting = ""
     def __init__(self, message):

--- a/common-docs/python/functions.md
+++ b/common-docs/python/functions.md
@@ -3,7 +3,7 @@
 Functions are the fundamental building block of programs. Here is the simplest
 way to make a function that adds two numbers:
 
-```python
+```python-ignore
 // Named function
 def add(x, y):
     return x + y
@@ -14,7 +14,7 @@ sum = add(1, 2)
 Functions can refer to variables outside of the function body.
 When they do so, they're said to `capture` these variables.
 
-```python
+```python-ignore
 z = 100
 
 def addToZ(x, y):
@@ -76,14 +76,14 @@ result4 = buildName("Bob", "Adams")         # ah, just right
 Default-initialized parameters that come after all required parameters are treated as optional, and just like optional parameters, can be omitted when calling their respective function.
 This means optional parameters and trailing default parameters will share commonality in their types, so both
 
-```python
+```python-ignore
 def buildName(firstName, lastName = None):
     # ...
 ```
 
 and
 
-```python
+```python-ignore
 def buildName(firstName, lastName = "Smith"):
     # ...
 ```
@@ -98,7 +98,7 @@ it at a later time. When an event happens, like a new input value or an elapsed 
 
 As an example, the `Thermal` class will check for changes in temperature and run a registered handler when the temperature drops to a set thershold:
 
-```python
+```python-ignore
 # the handler function when it's cold...
 def whenCold():
     print("It's cold!")
@@ -126,7 +126,7 @@ thermal.checkCold()
 
 Lamda functions serve as a kind of shortcut to return a result of an expression. A lamda is often saved to a variable and then used like a function to return the expression result:
 
-```python
+```python-ignore
 def square(x):
     return x * x
 
@@ -141,6 +141,6 @@ volume2 = cube(area(4, 3), 10)
 
 A lambda can also be used anonymously to directly return a result.
 
-```python
+```python-ignore
 print("area = " + str((lambda x, y: x * y)(3, 4)))
 ```

--- a/common-docs/python/sequence.md
+++ b/common-docs/python/sequence.md
@@ -12,7 +12,7 @@ doAnotherThing()
 In Python, there is the concept of an *empty statement*, which is the keyword `pass` in the context where a statement is expected. The `pass` statement serves as a convenient _placeholder_ for a statement or statements
 that the programmer will fill in later to complete some functionality.
 
-```python
+```python-ignore
 def myUnfinished():
     # Fill in code later to complete this function!
     pass

--- a/common-docs/python/variables.md
+++ b/common-docs/python/variables.md
@@ -2,7 +2,7 @@
 
 Declaring a variable is simply a matter of just assigning a value to a variable identifier:
 
-```python
+```python-ignore
 a = 10
 ```
 
@@ -11,7 +11,7 @@ a = 10
 When a variable is declared with an assignment, it uses what some call *lexical-scoping* or *block-scoping*.
 Block-scoped variables are not visible outside of their nearest containing block or `for`-loop.
 
-```python
+```python-ignore
 def f(inp):
     a = 100
 


### PR DESCRIPTION
Not all illustrative, general language examples will compile properly. Sacrifice syntax highlighting and set snippets to `python-ignore`.

Closes #6720