### PR TITLE
ping a url before loading a gallery

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -11,6 +11,10 @@ declare namespace pxt {
         experimentName?: string;
         locales?: string[];
         shuffle?: GalleryShuffle;
+        // pings this url to determine if the gallery is available
+        // value @random@ will be expanded to a random string
+        // looks for 200, 403 error codes
+        testUrl?: string;
     }
     interface TargetConfig {
         packages?: PackagesConfig;

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -765,7 +765,7 @@ function pingApiHandlerAsync(p: string): Promise<any> {
         url: data.stripProtocol(p),
         method: "GET",
         allowHttpErrors: true
-    }).then(r => r.statusCode === 200 || r.statusCode == 403)
+    }).then(r => r.statusCode === 200 || r.statusCode == 403 || r.statusCode == 400)
     .catch(e => false)
 }
 

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -761,8 +761,20 @@ function githubApiHandler(p: string) {
 }
 
 function pingApiHandlerAsync(p: string): Promise<any> {
+    const url = data.stripProtocol(p);
+    // special case favicon.ico
+    if (/\.ico$/.test(p)) {
+        const imgUrl = `${url}?v=${Math.random()}&origin=${encodeURIComponent(window.location.origin)}`;
+        const img = document.createElement("img")
+        return new Promise<boolean>((resolve, reject) => {
+            img.onload = () => resolve(true);
+            img.onerror = () => resolve(false);
+            img.src = imgUrl;
+        });
+    }
+    // other request
     return pxt.Util.requestAsync({
-        url: data.stripProtocol(p),
+        url,
         method: "GET",
         allowHttpErrors: true
     }).then(r => r.statusCode === 200 || r.statusCode == 403 || r.statusCode == 400)

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -778,13 +778,13 @@ function pingApiHandlerAsync(p: string): Promise<any> {
         method: "GET",
         allowHttpErrors: true
     }).then(r => r.statusCode === 200 || r.statusCode == 403 || r.statusCode == 400)
-    .catch(e => false)
+        .catch(e => false)
 }
 
 data.mountVirtualApi("sync", { getSync: syncApiHandler })
 data.mountVirtualApi("github", { getSync: githubApiHandler })
-data.mountVirtualApi("ping", { 
-    getAsync: pingApiHandlerAsync, 
+data.mountVirtualApi("ping", {
+    getAsync: pingApiHandlerAsync,
     expirationTime: p => 24 * 3600 * 1000,
     isOffline: () => !pxt.Cloud.isOnline()
 })

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -760,8 +760,22 @@ function githubApiHandler(p: string) {
     return null
 }
 
+function pingApiHandlerAsync(p: string): Promise<any> {
+    return pxt.Util.requestAsync({
+        url: data.stripProtocol(p),
+        method: "GET",
+        allowHttpErrors: true
+    }).then(r => r.statusCode === 200 || r.statusCode == 403)
+    .catch(e => false)
+}
+
 data.mountVirtualApi("sync", { getSync: syncApiHandler })
 data.mountVirtualApi("github", { getSync: githubApiHandler })
+data.mountVirtualApi("ping", { 
+    getAsync: pingApiHandlerAsync, 
+    expirationTime: p => 24 * 3600 * 1000,
+    isOffline: () => !pxt.Cloud.isOnline()
+})
 
 function invalidateData() {
     data.invalidate("sync:status")

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -217,6 +217,14 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                     const locales = galProps.locales;
                     if (locales && locales.indexOf(pxt.Util.userLanguage()) < 0)
                         return false; // locale not supported
+                    // test if blocked
+                    const testUrl = galProps.testUrl;
+                    if (testUrl) {
+                        const ping = this.getData(`ping:${testUrl.replace('@random@', Math.random().toString())}`);
+                        if (ping !== true) // still loading or can't ping
+                            return false;
+                    }
+                    // show the gallery
                     return true;
                 })
                 .map(galleryName => {


### PR DESCRIPTION
Before displaying a category, test that a particular domain is reachable. e.g. try to download the youtube favicon.ico file before showing a row of videos.
```
        "Tutorials": {
            "url": "tutorials",
            "testUrl": "https://www.google.com/favicon.ico"
        }
```