### PR TITLE
no tiny sim view when in sandbox

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1161,7 +1161,7 @@ p.ui.font.small {
         width: 10rem; /* match width of div.simframe */
         height: 9rem;
     }
-    #root:not(.fullscreensim):not(.headless) {
+    #root:not(.fullscreensim):not(.headless):not(.sandbox) {
         #boardview {
             position: absolute;
             left: 4rem;


### PR DESCRIPTION
seems to have been broken for any window size < 1200

fix https://github.com/microsoft/pxt-arcade/issues/1769

don't use the css for the mini sim from the toolbar when in sandbox mode (sim, etc)

![andfixed2](https://user-images.githubusercontent.com/5615930/77124591-87da5b00-6a00-11ea-98e5-8730d77ab105.gif)
