### PR TITLE
Make sig macro match editor tooltip, and show py

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -443,15 +443,16 @@ namespace pxt.runner {
             const symbolInfo = r.apiInfo.byQName[info.qName];
             if (!symbolInfo) return;
             let block = Blockly.Blocks[symbolInfo.attributes.blockId];
-            let xml = block && block.codeCard ? block.codeCard.blocksXml : undefined;
+            let xml = block?.codeCard?.blocksXml ?? undefined;
 
-            const blocksHtml = xml ? pxt.blocks.render(xml) : r.compileBlocks && r.compileBlocks.success ? r.blocksSvg : undefined;
+            const blocksHtml = xml ? pxt.blocks.render(xml) : r.compileBlocks?.success ? r.blocksSvg : undefined;
             const s = blocksHtml ? $(blocksHtml as HTMLElement) : undefined
             let sig = info.decl.getText().replace(/^export/, '');
             sig = sig.slice(0, sig.indexOf('{')).trim() + ';';
             const js = $('<code class="lang-typescript highlight"/>').text(sig);
-            // TODO python
-            const py: JQuery = undefined;// $('<code class="lang-python highlight"/>').text(sig);
+
+            const pySig = pxt.appTarget?.appTheme?.python && sig.slice(0, -1).replace(/^function /, "def ").replace(/\?/g, "").replace(/void$/, "None");
+            const py: JQuery = pySig && $('<code class="lang-python highlight"/>').text(pySig);
             if (options.snippetReplaceParent) c = c.parent();
             // add an html widge that allows to translate the block
             if (pxt.Util.isTranslationMode()) {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -443,15 +443,15 @@ namespace pxt.runner {
             const symbolInfo = r.apiInfo.byQName[info.qName];
             if (!symbolInfo) return;
             let block = Blockly.Blocks[symbolInfo.attributes.blockId];
-            let xml = block?.codeCard?.blocksXml ?? undefined;
+            let xml = block?.codeCard?.blocksXml || undefined;
 
             const blocksHtml = xml ? pxt.blocks.render(xml) : r.compileBlocks?.success ? r.blocksSvg : undefined;
             const s = blocksHtml ? $(blocksHtml as HTMLElement) : undefined
-            let sig = info.decl.getText().replace(/^export/, '');
-            sig = sig.slice(0, sig.indexOf('{')).trim() + ';';
-            const js = $('<code class="lang-typescript highlight"/>').text(sig);
+            let jsSig = ts.pxtc.service.displayStringForSymbol(symbolInfo, /** python **/ false, r.apiInfo)
+                .split("\n")[1] + ";";
+            const js = $('<code class="lang-typescript highlight"/>').text(jsSig);
 
-            const pySig = pxt.appTarget?.appTheme?.python && sig.slice(0, -1).replace(/^function /, "def ").replace(/\?/g, "").replace(/void$/, "None");
+            const pySig = pxt.appTarget?.appTheme?.python && ts.pxtc.service.displayStringForSymbol(symbolInfo, /** python **/ true, r.apiInfo).split("\n")[1];
             const py: JQuery = pySig && $('<code class="lang-python highlight"/>').text(pySig);
             if (options.snippetReplaceParent) c = c.parent();
             // add an html widge that allows to translate the block


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5615930/77130029-80707d00-6a13-11ea-88d7-6f41f31c0376.png)

use the same signatures that are shown in tooltips for the `sig` in docs, and show python sig as well. Notably this adds the namespace to the signature (instead of just the fn / method name)

saw an email that this was missing; this matches the format shown for the tooltip in the editor. A bit redundant with the js, but it's only ever a single line of code per snippet; either way we'd eventually need the format with a language selector in docs / etc

also would close https://github.com/microsoft/pxt-arcade/issues/301 by making the displayed name actually map to what needs to be typed in