### PR TITLE
Add PXT_IGNORE_BMP flag

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5687,6 +5687,7 @@ PXT_RUNTIME_DEV  - always rebuild the C++ runtime, allowing for modification
                    in the lower level runtime if any
 PXT_ASMDEBUG     - embed additional information in generated binary.asm file
 PXT_ACCESS_TOKEN - pxt access token
+PXT_IGNORE_BMP   - don't search for Black Magic Probe debugger
 GITHUB_ACCESS_TOKEN/GITHUB_TOKEN - github access token
 ${pxt.crowdin.KEY_VARIABLE} - crowdin key
 `)

--- a/cli/gdb.ts
+++ b/cli/gdb.ts
@@ -18,6 +18,8 @@ let bmpMode = false
 const execAsync: (cmd: string, options?: { cwd?: string }) => Promise<Buffer | string> = Promise.promisify(child_process.exec)
 
 function getBMPSerialPortsAsync(): Promise<string[]> {
+    if (process.env["PXT_IGNORE_BMP"])
+        return Promise.resolve([])
     if (process.platform == "win32") {
         return execAsync("wmic PATH Win32_SerialPort get DeviceID, PNPDeviceID")
             .then((buf: Buffer) => {


### PR DESCRIPTION
This is useful if you have both BMP and CMSIS-DAP connected and want to talk to CMSIS-DAP (eg BMP is used to program non-makecode jacdac device and CMSIS-DAP talks to a makecode device)