### PR TITLE
Youtube card on examplers/tutorials

### DIFF
--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -42,12 +42,6 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
         this.observer = new IntersectionObserver(onIntersection, config);
     }
 
-    protected isYouTubeOnline(): boolean {
-        // check that youtube is reachable
-        return this.props.youTubeId &&
-            this.getData("ping:https://www.youtube.com/favicon.ico");
-    }
-
     componentDidMount() {
         const lazyImage = this.refs.lazyimage as HTMLImageElement;
         if (!lazyImage) return;

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -42,6 +42,12 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
         this.observer = new IntersectionObserver(onIntersection, config);
     }
 
+    protected isYouTubeOnline(): boolean {
+        // check that youtube is reachable
+        return this.props.youTubeId &&
+            this.getData("ping:https://www.youtube.com/favicon.ico");
+    }
+
     componentDidMount() {
         const lazyImage = this.refs.lazyimage as HTMLImageElement;
         if (!lazyImage) return;
@@ -81,8 +87,6 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             card.onClick(e);
         } : undefined;
 
-        // check that youtube is reachable
-        const youTubeOnline = card.youTubeId && this.getData("ping:https://www.youtube.com/favicon.ico");
         const imageUrl = card.imageUrl || (card.youTubeId ? `https://img.youtube.com/vi/${card.youTubeId}/0.jpg` : undefined);
 
         const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`}

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -81,6 +81,8 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             card.onClick(e);
         } : undefined;
 
+        // check that youtube is reachable
+        const youTubeOnline = card.youTubeId && this.getData("ping:https://www.youtube.com/favicon.ico");
         const imageUrl = card.imageUrl || (card.youTubeId ? `https://img.youtube.com/vi/${card.youTubeId}/0.jpg` : undefined);
 
         const cardDiv = <div className={`ui card ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -729,6 +729,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         this.handleDetailClick = this.handleDetailClick.bind(this);
         this.handleOpenForumUrlInEditor = this.handleOpenForumUrlInEditor.bind(this);
+        this.handleOpenYouTube = this.handleOpenYouTube.bind(this);
         this.linkRef = React.createRef<HTMLAnchorElement>();
     }
 
@@ -869,6 +870,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     }
 
     handleOpenForumUrlInEditor() {
+        pxt.tickEvent('projects.actions.forum', undefined, { interactiveConsent: true });
         const { url } = this.props;
         pxt.discourse.extractSharedIdFromPostUrl(url)
             .then(projectId => {
@@ -880,6 +882,19 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                 }
             })
             .catch(core.handleNetworkError)
+    }
+
+    isYouTubeOnline(): boolean {
+        const { youTubeId } = this.props;
+        // check that youtube is reachable
+        return youTubeId &&
+            this.getData("ping:https://www.youtube.com/favicon.ico");
+    }
+
+    handleOpenYouTube() {
+        pxt.tickEvent('projects.actions.youtube', undefined, { interactiveConsent: true });
+        const { youTubeId } = this.props;
+        window.open(`https://youtu.be/${youTubeId}`, `_blank`);
     }
 
     componentDidMount() {
@@ -934,6 +949,9 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                         // TODO (shakao) migrate forumurl to otherAction json in md
                         this.getActionCard(lf("Open in Editor"), "example", this.handleOpenForumUrlInEditor)
                     }
+                    {youTubeId && this.isYouTubeOnline() &&
+                        // show youtube card
+                        this.getActionCard(lf("YouTube"), "", this.handleOpenYouTube)}
                 </div>
             </div>
         </div>;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -729,7 +729,6 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
 
         this.handleDetailClick = this.handleDetailClick.bind(this);
         this.handleOpenForumUrlInEditor = this.handleOpenForumUrlInEditor.bind(this);
-        this.handleOpenYouTube = this.handleOpenYouTube.bind(this);
         this.linkRef = React.createRef<HTMLAnchorElement>();
     }
 
@@ -833,8 +832,8 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
     }
 
     protected getActionCard(text: string, type: string, onClick: any, autoFocus?: boolean, action?: pxt.CodeCardAction, key?: string): JSX.Element {
-        let editor = this.getActionEditor(type, action);
-        let title = this.getActionTitle(editor);
+        const editor = this.getActionEditor(type, action);
+        const title = this.getActionTitle(editor);
         return <div className={`card-action ui items ${editor || ""}`} key={key}>
             {this.getActionIcon(onClick, type, editor)}
             {title && <div className="card-action-title">{title}</div>}
@@ -891,12 +890,6 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             this.getData("ping:https://www.youtube.com/favicon.ico");
     }
 
-    handleOpenYouTube() {
-        pxt.tickEvent('projects.actions.youtube', undefined, { interactiveConsent: true });
-        const { youTubeId } = this.props;
-        window.open(`https://youtu.be/${youTubeId}`, `_blank`);
-    }
-
     componentDidMount() {
         // autofocus on linked action
         if (this.linkRef && this.linkRef.current) {
@@ -951,7 +944,18 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                     }
                     {youTubeId && this.isYouTubeOnline() &&
                         // show youtube card
-                        this.getActionCard(lf("YouTube"), "", this.handleOpenYouTube)}
+                        <div className="card-action ui items youtube">
+                            <sui.Link role="button" className="link button attached" icon="youtube" href={`https://youtu.be/${youTubeId}`} target="_blank" tabIndex={-1} />
+                            <div className="card-action-title">YouTube</div>
+                            <sui.Link
+                                href={`https://youtu.be/${youTubeId}`}
+                                refCallback={this.linkRef}
+                                target="_blank"
+                                text={lf("Play")}
+                                className={`button attached approve large`}
+                                title={lf("Open YouTube video in new window")}
+                            />
+                        </div>}
                 </div>
             </div>
         </div>;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -951,7 +951,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                                 href={`https://youtu.be/${youTubeId}`}
                                 refCallback={this.linkRef}
                                 target="_blank"
-                                text={lf("Play")}
+                                text={lf("Play Video")}
                                 className={`button attached approve large`}
                                 title={lf("Open YouTube video in new window")}
                             />


### PR DESCRIPTION
When a tutorial/example card has a youTubeId entry, display an additional action card to start stream. This allows to surface videos "near" the tutorial.

- [x] detect that youtube is reachable: the card is not displayed if youtube is not reachable.
- [x] display additional action card with video stream

This change is backward compatible: it will be ignored by older makecode instances.

![image](https://user-images.githubusercontent.com/4175913/77189355-aab64f00-6a94-11ea-863e-06986b2249a5.png)
