### PR TITLE
Submit on enter for import url dialog

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -352,8 +352,11 @@ export function showPRDialogAsync(repo: string, prURL: string): Promise<void> {
 export function showImportUrlDialogAsync() {
     let input: HTMLInputElement;
     const shareUrl = pxt.appTarget.appTheme.shareUrl || "https://makecode.com/";
+
     return core.confirmAsync({
         header: lf("Open project URL"),
+        hasCloseIcon: true,
+        hideCancel: true,
         onLoaded: (el) => {
             input = el.querySelector('input');
             input.onkeydown = ev => {
@@ -599,6 +602,8 @@ export function showImportFileDialogAsync(options?: pxt.editor.ImportFileOptions
     }
     return core.confirmAsync({
         header: lf("Open {0} file", exts.join(lf(" or "))),
+        hasCloseIcon: true,
+        hideCancel: true,
         onLoaded: (el) => {
             input = el.querySelectorAll('input')[0] as HTMLInputElement;
         },

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -355,7 +355,13 @@ export function showImportUrlDialogAsync() {
     return core.confirmAsync({
         header: lf("Open project URL"),
         onLoaded: (el) => {
-            input = el.querySelectorAll('input')[0] as HTMLInputElement;
+            input = el.querySelector('input');
+            input.onkeydown = ev => {
+                if (ev.key === "Enter") {
+                    const confirm = el.querySelector('.button.approve') as HTMLButtonElement;
+                    confirm?.click();
+                }
+            }
         },
         jsx: <div className="ui form">
             <div className="ui icon violet message">


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2106

also noticed this and the import file both still had cancel instead of the close button; changed that here as I believe we're moving over all but a few special cases to use the close button? can change back if needed.