### PR TITLE
Alternate links in Online Learning page

### DIFF
--- a/docs/online-learning.html
+++ b/docs/online-learning.html
@@ -45,6 +45,8 @@
 				video streams daily to walk students through different MakeCode tutorials and 
 				projects.  All streams will be recorded and available for viewing in the 
 				MakeCode YouTube Channel.
+				All videos will be live streamed on <a href="https://mixer.com/MakeCode">Mixer</a>
+				and available for viewing later in the <a href="https://youtube.com/microsoftmakecode">MakeCode YouTube Channel</a>.
 			</p>
 			<div id="schedule"></div>
 			<div id="lessons"></div>

--- a/docs/static/online-learning/schedule.ts
+++ b/docs/static/online-learning/schedule.ts
@@ -52,7 +52,7 @@ const lessons: Lesson[] = [
     {
         "title": "MakeCode in the Kitchen",
         "description": "Join Jacqueline, a MakeCode team member as she crafts and codes projects with the Adafruit Circuit Playground Express in her kitchen!",
-        "url": "https://aka.ms/makecodeadafruitstream",
+        "url": "https://aka.ms/makecodecpxstream",
         "img": "/static/online-learning/img/cpx-stream.png",
         "time": 14,
         "days": [Day.Friday]
@@ -60,7 +60,7 @@ const lessons: Lesson[] = [
     {
         "title": "Arcade with Steve Isaacs",
         "description": "Learn MakeCode Arcade game development with Mr. Isaacs, an ISTE outstanding teacher and PBS Lead Digital Innovator.",
-        "url": "https://aka.ms/makecodearcadestreamcommunity",
+        "url": "https://www.twitch.tv/mr_isaacs/",
         "img": "/static/online-learning/img/arcade-2-stream.png",
         "time": 6,
         "days": [Day.Monday]
@@ -135,7 +135,10 @@ function makeLessons() {
 
         const description = document.createElement("div");
         const title = document.createElement("h4");
-        title.innerText = l.title;
+        const linkUrl = document.createElement("a");
+        linkUrl.innerText = l.title;
+        linkUrl.href = l.url;
+        title.appendChild(linkUrl);
         const time = document.createElement("div");
         time.innerText = formatTime(l.time);
         time.className = "time";


### PR DESCRIPTION
Fixes for @Jaqster 's #6749.

- [x] Links for "Streaming" header
- [x] Alternate individual stream links
- [x] Make stream titles into links - someone needs to check that change.

Still need an on hover CSS class for the stream and resource text links.