### PR TITLE
Add "hot" rollover for resources links

### DIFF
--- a/docs/static/online-learning/online-learning.css
+++ b/docs/static/online-learning/online-learning.css
@@ -211,11 +211,18 @@ h1 {
 .banners > div > a {
     display: flex;
     flex-direction: row;
-    margin-bottom: 4rem;
+    margin-bottom: 2rem;
     color: #000;
-    height: 12rem;
+    height: 14rem;
+    padding: 1rem;
 }
 
+.banners > div > a:hover {
+    background-color: #fcf6fb;
+    border: 0.1rem solid #eee;
+    border-radius: 0.5rem;
+    padding: 0.9rem;
+}
 .banners > div:nth-child(even) a {
     flex-direction: row-reverse;
 }

--- a/docs/static/online-learning/online-learning.css
+++ b/docs/static/online-learning/online-learning.css
@@ -114,6 +114,10 @@ h1 {
 .lesson {
     display: flex;
     margin: 1rem 0;
+    background-color: #fafafa;
+    border-top: 1px solid #eee;
+    border-right: 1px solid #eee;
+    border-bottom: 1px solid #eee;
 }
 
 .lesson .imgWrapper {


### PR DESCRIPTION
Style resource links with a rollover to jazz them up...


![rollover](https://user-images.githubusercontent.com/27789908/77488925-e71adf80-6df3-11ea-88d9-74c1c3efd522.gif)
