### PR TITLE
View all button instead of > to get to script manager

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -71,6 +71,7 @@
         box-shadow: none;
         padding: 0rem;
         margin: 0;
+
         .ui.header {
             margin: 0;
             padding-left: @carouselArrowSize;
@@ -91,14 +92,13 @@
                 }
             }
         }
-        .ui.padded.grid.heading, .heading {
+        .heading {
+            display: flex;
+            align-items: flex-end;
+            justify-content: space-between;
+
             margin-bottom: -1rem !important;
             margin-top: 1rem !important;
-        }
-        .ui.padded.grid.heading .ui.header {
-            bottom: 0;
-            position: absolute;
-            vertical-align: bottom;
         }
         .column {
             padding: 0 !important;

--- a/theme/home.less
+++ b/theme/home.less
@@ -82,6 +82,13 @@
                 &:focus, &:hover {
                     color: fade(@homeHeaderColor, 80%);
                 }
+
+                > .view-all-button {
+                    padding-left: 0.5em;
+                    color: @linkColor;
+                    font-size: 16px;
+                    font-weight: 500;
+                }
             }
         }
         .ui.padded.grid.heading, .heading {
@@ -161,7 +168,7 @@
             border-top-color: @homeSelectedCardBorderColor;
             border-width: 17px;
             margin-left: -17px;
-        }            
+        }
     }
 
     .detailview {
@@ -710,22 +717,22 @@
                 top: 2rem;
                 left: 1rem;
                 width: 2rem;
-                height: 1.5rem;                
+                height: 1.5rem;
             }
-        }        
+        }
         .detailview.visible {
-            .column, 
-            .imagewrapper .image        
+            .column,
+            .imagewrapper .image
             {
                 height: 220px;
-            }        
+            }
         }
         .getting-started-segment {
             margin-top: -3.1rem!important;
             margin-bottom: 0rem!important;
             height: 168px;
         }
-    }    
+    }
 }
 
 

--- a/theme/home.less
+++ b/theme/home.less
@@ -607,15 +607,6 @@
                 font-size: 30px;
             }
         }
-        .gallerysegment {
-            .ui.padded.grid.heading, .heading {
-                margin-bottom: -1rem !important;
-                margin-top: 0rem !important;
-            }
-            .ui.padded.grid.heading .ui.header {
-                font-size: 18px;
-            }
-        }
         .carouselcontainer {
             padding: 1.5rem @carouselArrowSizeMobile !important;
         }

--- a/theme/home.less
+++ b/theme/home.less
@@ -85,7 +85,7 @@
 
                 > .view-all-button {
                     padding-left: 0.5em;
-                    color: @linkColor;
+                    color: @primaryColor;
                     font-size: 16px;
                     font-weight: 500;
                 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -190,7 +190,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                             onClick={this.showScriptManager} onKeyDown={sui.fireClickOnEnter}>
                             {lf("My Projects")}
                             <span className="view-all-button">
-                                {lf("View all")}
+                                {lf("View All")}
                             </span>
                         </h2> : <h2 className="ui header">{lf("My Projects")}</h2>}
                     </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -184,17 +184,17 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             {showHeroBanner ?
                 <div className="ui segment getting-started-segment" style={{ backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` }} /> : undefined}
             <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment" role="region" aria-label={lf("My Projects")}>
-                <div className="ui grid padded heading">
-                    <div className="column twelve wide" style={{ zIndex: 1 }}>
+                <div className="ui heading">
+                    <div className="column " style={{ zIndex: 1 }}>
                         {targetTheme.scriptManager ? <h2 role="button" className="ui header myproject-header" title={lf("View all projects")} tabIndex={0}
                             onClick={this.showScriptManager} onKeyDown={sui.fireClickOnEnter}>
                             {lf("My Projects")}
                             <span className="view-all-button">
                                 {lf("View all")}
                             </span>
-                        </h2> : <h2 className="ui header twelve wide">{lf("My Projects")}</h2>}
+                        </h2> : <h2 className="ui header">{lf("My Projects")}</h2>}
                     </div>
-                    <div className="column four wide right aligned" style={{ zIndex: 1 }}>
+                    <div className="column right aligned" style={{ zIndex: 1 }}>
                         {pxt.appTarget.compile || (pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing) ?
                             <sui.Button key="import" icon="upload" className="import-dialog-btn" textClass="landscape only" text={lf("Import")} title={lf("Import a project")} onClick={this.importProject} /> : undefined}
                     </div>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -185,7 +185,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                 <div className="ui segment getting-started-segment" style={{ backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` }} /> : undefined}
             <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment" role="region" aria-label={lf("My Projects")}>
                 <div className="ui heading">
-                    <div className="column " style={{ zIndex: 1 }}>
+                    <div className="column" style={{ zIndex: 1 }}>
                         {targetTheme.scriptManager ? <h2 role="button" className="ui header myproject-header" title={lf("View all projects")} tabIndex={0}
                             onClick={this.showScriptManager} onKeyDown={sui.fireClickOnEnter}>
                             {lf("My Projects")}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -184,17 +184,17 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
             {showHeroBanner ?
                 <div className="ui segment getting-started-segment" style={{ backgroundImage: `url(${encodeURI(targetTheme.homeScreenHero)})` }} /> : undefined}
             <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment" role="region" aria-label={lf("My Projects")}>
-                <div className="ui grid equal width padded heading">
-                    <div className="column" style={{ zIndex: 1 }}>
-                        {targetTheme.scriptManager ? <h2 role="button" className="ui header myproject-header" title={lf("See all projects")} tabIndex={0}
+                <div className="ui grid padded heading">
+                    <div className="column twelve wide" style={{ zIndex: 1 }}>
+                        {targetTheme.scriptManager ? <h2 role="button" className="ui header myproject-header" title={lf("View all projects")} tabIndex={0}
                             onClick={this.showScriptManager} onKeyDown={sui.fireClickOnEnter}>
                             {lf("My Projects")}
-                            <span className="ui grid-dialog-btn">
-                                <sui.Icon icon="angle right" />
+                            <span className="view-all-button">
+                                {lf("View all")}
                             </span>
-                        </h2> : <h2 className="ui header">{lf("My Projects")}</h2>}
+                        </h2> : <h2 className="ui header twelve wide">{lf("My Projects")}</h2>}
                     </div>
-                    <div className="column right aligned" style={{ zIndex: 1 }}>
+                    <div className="column four wide right aligned" style={{ zIndex: 1 }}>
                         {pxt.appTarget.compile || (pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing) ?
                             <sui.Button key="import" icon="upload" className="import-dialog-btn" textClass="landscape only" text={lf("Import")} title={lf("Import a project")} onClick={this.importProject} /> : undefined}
                     </div>


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2418 (well, not remembering home page, but that would be a feature that comes with identity)

![image](https://user-images.githubusercontent.com/5615930/77604068-dee3a280-6ece-11ea-9138-23a1c2009eb3.png)


Went with the primary color to start, as the link blue has issues against the background (it's mostly used against pure white backgrounds like the lang picker, where microbit's home page has a slight blue tint that would make it < 4.5); should be as accessible as the rest of the home page, and it feels like it matches the the projects that way to me.

changed from the sui grid layout for the headers to flexbox as grid wasn't working for small screen sizes (bumping out to new lines unnecessarily, etc) and flexbox handles that properly.

![view all button](https://user-images.githubusercontent.com/5615930/77603360-1ea98a80-6ecd-11ea-95d1-0c00e77e0ca3.gif)
