### PR TITLE
make Code, Editor embeds match version

### DIFF
--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -326,9 +326,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         if (!/\/$/.test(shareUrl)) shareUrl += '/';
         let rootUrl = pxt.appTarget.appTheme.embedUrl
         if (!/\/$/.test(rootUrl)) rootUrl += '/';
-        const verPrefix = pxt.webConfig.verprefix
-                || pxt.webConfig.relprefix?.replace(/^\//, "").replace(/---$/, "")
-                || '';
+        const verPrefix = pxt.webConfig.verprefix || '';
 
         if (header) {
             if (ready) {
@@ -346,7 +344,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         let padding = '81.97%';
                         // TODO: parts aspect ratio
                         if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio).toPrecision(4) + '%';
-                        const runUrl = rootUrl + (pxt.webConfig.runUrl || `${verPrefix}---run`).replace(/^\//, '');
+                        const runUrl = rootUrl + `${verPrefix}---run`.replace(/^\//, '');
                         embed = pxt.docs.runUrl(runUrl, padding, pubId);
                         break;
                     case ShareMode.Url:

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -326,12 +326,15 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         if (!/\/$/.test(shareUrl)) shareUrl += '/';
         let rootUrl = pxt.appTarget.appTheme.embedUrl
         if (!/\/$/.test(rootUrl)) rootUrl += '/';
-        const verPrefix = pxt.webConfig.verprefix || '';
+        const verPrefix = pxt.webConfig.verprefix
+                || pxt.webConfig.relprefix?.replace(/^\//, "").replace(/---$/, "")
+                || '';
 
         if (header) {
             if (ready) {
                 url = `${shareUrl}${pubId}`;
-                let editUrl = `${rootUrl}${verPrefix}#pub:${pubId}`;
+                const editUrl = `${rootUrl}${verPrefix}#pub:${pubId}`;
+
                 switch (mode) {
                     case ShareMode.Code:
                         embed = pxt.docs.codeEmbedUrl(`${rootUrl}${verPrefix}`, pubId);
@@ -343,7 +346,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         let padding = '81.97%';
                         // TODO: parts aspect ratio
                         if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio).toPrecision(4) + '%';
-                        const runUrl = rootUrl + (pxt.webConfig.runUrl || `${verPrefix}--run`).replace(/^\//, '');
+                        const runUrl = rootUrl + (pxt.webConfig.runUrl || `${verPrefix}---run`).replace(/^\//, '');
                         embed = pxt.docs.runUrl(runUrl, padding, pubId);
                         break;
                     case ShareMode.Url:


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2154

the backend is serving effectively the same string with "---run" at the end as `pxt.webconfig.runUrl` in `serveAppAsync`, which is why that one was working

Potentially better fixed in the backend? Could just make the verprefix also return the tag / versioned release the same as relprefix does, instead of just leaving verprefix solely for 'v0' / 'v1' / etc -- this is the only place that one seems to be used. Figured fixing in frontend when it's easy enough will typically be preferred though