### PR TITLE
Toolbox visibility: animate drawers, hover effect on flyout

### DIFF
--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -222,6 +222,18 @@
             .signature {
                 display: block;
             }
+
+            .blockHandle {
+                border-color: @white;
+                border-width: 4px 4px 4px 0px;
+                border-style: solid;
+            }
+        }
+        &.hover {
+            cursor: grab;
+            .blockHandle {
+                display: block;
+            }
         }
 
         .blockHandle {
@@ -230,9 +242,6 @@
             width: 2rem;
             right: -0.9rem;
             border-radius: 0 1rem 1rem 0;
-            border-color: @white;
-            border-width: 4px 4px 4px 0px;
-            border-style: solid;
             background: @monacoFlyoutColor;
 
             i.bars {

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -200,6 +200,23 @@ div.blocklyTreeIcon span {
 }
 
 /*******************************
+      Toolbox Animation
+*******************************/
+#monacoEditorToolbox {
+    .blocklyTreeRoot > div > div > .blocklyTreeRow {
+        animation: gliss 0.6s ease-in-out;
+    }
+}
+@keyframes gliss {
+    50% { border-left-width: 1.5rem; }
+}
+@keyframes glisssmall {
+    0% { width: 50px; }
+    50% { border-left-width: 1rem; }
+    100% { width: 50px; }
+}
+
+/*******************************
     Blockly Accessibility
 *******************************/
 
@@ -288,6 +305,11 @@ div.blocklyTreeIcon span {
     }
     #root:not(.flyoutOnly) #blocklyTrashIcon {
         width: @blocklyRowWidthMobile;
+    }
+    #monacoEditorToolbox {
+        .blocklyTreeRoot > div > div > .blocklyTreeRow {
+            animation: glisssmall 0.6s ease-in-out;
+        }
     }
 }
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -77,13 +77,17 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
     }
 
     protected getBlockClickHandler = (name: string) => {
-        pxt.tickEvent("monaco.toolbox.itemclick", undefined, { interactiveConsent: true });
-        return () => { this.setState({ selectedBlock: name != this.state.selectedBlock ? name : undefined }) };
+        return () => {
+            pxt.tickEvent("monaco.toolbox.itemclick", undefined, { interactiveConsent: true });
+            this.setState({ selectedBlock: name != this.state.selectedBlock ? name : undefined });
+        };
     }
 
     protected getBlockMouseOver = (name: string) => {
-        pxt.tickEvent("monaco.toolbox.itemmouseover", undefined, { interactiveConsent: true });
-        return () => { this.setState({ hoverBlock: name != this.state.hoverBlock ? name : undefined }) };
+        return () => {
+            pxt.tickEvent("monaco.toolbox.itemmouseover");
+            this.setState({ hoverBlock: name != this.state.hoverBlock ? name : undefined});
+        };
     }
 
     protected getBlockMouseOut = (name: string) => {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -430,6 +430,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         ])
 
         let index = 0;
+        let topRowIndex = 0; // index of top-level rows for animation
         return <div ref={this.handleRootElementRef} className={classes} id={`${editorname}EditorToolbox`}>
             <ToolboxStyle categories={this.items} />
             {showSearchBox ? <ToolboxSearch ref="searchbox" parent={parent} toolbox={this} editorname={editorname} /> : undefined}
@@ -438,14 +439,14 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                     {hasSearch ? <CategoryItem key={"search"} toolbox={this} index={index++} selected={selectedItem == "search"} treeRow={searchTreeRow} onCategoryClick={this.setSelection} /> : undefined}
                     {hasTopBlocks ? <CategoryItem key={"topblocks"} toolbox={this} selected={selectedItem == "topblocks"} treeRow={topBlocksTreeRow} onCategoryClick={this.setSelection} /> : undefined}
                     {nonAdvancedCategories.map((treeRow) => (
-                        <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection}>
+                        <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection} topRowIndex={topRowIndex++}>
                             {treeRow.subcategories ? treeRow.subcategories.map((subTreeRow) => (
                                 <CategoryItem key={subTreeRow.nameid + subTreeRow.subns} index={index++} toolbox={this} selected={selectedItem == (subTreeRow.nameid + subTreeRow.subns)} treeRow={subTreeRow} onCategoryClick={this.setSelection} />
                             )) : undefined}
                         </CategoryItem>
                     ))}
                     {hasAdvanced ? <TreeSeparator key="advancedseparator" /> : undefined}
-                    {hasAdvanced ? <CategoryItem toolbox={this} treeRow={{ nameid: "", name: pxt.toolbox.advancedTitle(), color: pxt.toolbox.getNamespaceColor('advanced'), icon: pxt.toolbox.getNamespaceIcon(showAdvanced ? 'advancedexpanded' : 'advancedcollapsed') }} onCategoryClick={this.advancedClicked} /> : undefined}
+                    {hasAdvanced ? <CategoryItem toolbox={this} treeRow={{ nameid: "", name: pxt.toolbox.advancedTitle(), color: pxt.toolbox.getNamespaceColor('advanced'), icon: pxt.toolbox.getNamespaceIcon(showAdvanced ? 'advancedexpanded' : 'advancedcollapsed') }} onCategoryClick={this.advancedClicked} topRowIndex={topRowIndex++} /> : undefined}
                     {showAdvanced ? advancedCategories.map((treeRow) => (
                         <CategoryItem key={treeRow.nameid} toolbox={this} index={index++} selected={selectedItem == treeRow.nameid} childrenVisible={expandedItem == treeRow.nameid} treeRow={treeRow} onCategoryClick={this.setSelection}>
                             {treeRow.subcategories ? treeRow.subcategories.map((subTreeRow) => (
@@ -464,6 +465,7 @@ export interface CategoryItemProps extends TreeRowProps {
     childrenVisible?: boolean;
     onCategoryClick?: (treeRow: ToolboxCategory, index: number) => void;
     index?: number;
+    topRowIndex?: number;
 }
 
 export interface CategoryItemState {
@@ -604,11 +606,13 @@ export interface TreeRowProps {
     onKeyDown?: (e: React.KeyboardEvent<any>) => void;
     selected?: boolean;
     isRtl?: boolean;
+    topRowIndex?: number;
 }
 
 export class TreeRow extends data.Component<TreeRowProps, {}> {
 
     private treeRow: HTMLElement;
+    private animationDelay: number = 0.25;
 
     constructor(props: TreeRowProps) {
         super(props);
@@ -658,7 +662,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
     }
 
     renderCore() {
-        const { selected, onClick, onKeyDown, isRtl } = this.props;
+        const { selected, onClick, onKeyDown, isRtl, topRowIndex } = this.props;
         const { nameid, subns, name, icon } = this.props.treeRow;
         const appTheme = pxt.appTarget.appTheme;
         const metaColor = this.getMetaColor();
@@ -685,6 +689,9 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
                 treeRowStyle.borderRight = border;
             } else {
                 treeRowStyle.borderLeft = border;
+            }
+            if (topRowIndex) {
+                treeRowStyle.animationDelay = `${topRowIndex * this.animationDelay}s`;
             }
         }
 


### PR DESCRIPTION
- Small animation on toolbox drawers when entering monaco
- Display handle on flyout hover to indicate draggable elements

![toolbox-gliss](https://user-images.githubusercontent.com/34112083/77711724-faae7d80-6f8e-11ea-9a10-0c05775d1b88.gif)

Build: https://makecode.microbit.org/app/dd487eba2ea31ef83f2e2d03e651a5bb200f24d2-1a20e6fcd0