### PR TITLE
turn on no shadowed variables lint rule

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -135,23 +135,23 @@ namespace pxt {
             }
         }
         export function report() {
-            let report = `performance report:\n`
+            let output = `performance report:\n`
             for (let [msg, time] of stats.milestones) {
                 let pretty = prettyStr(time)
-                report += `\t\t${msg} @ ${pretty}\n`
+                output += `\t\t${msg} @ ${pretty}\n`
             }
-            report += `\n`
+            output += `\n`
             for (let [msg, start, duration] of stats.durations) {
                 if (duration > 50) {
                     let pretty = prettyStr(duration)
-                    report += `\t\t${msg} took ~ ${pretty}`
+                    output += `\t\t${msg} took ~ ${pretty}`
                     if (duration > 1000) {
-                        report += ` (${prettyStr(start)} - ${prettyStr(start + duration)})`
+                        output += ` (${prettyStr(start)} - ${prettyStr(start + duration)})`
                     }
-                    report += `\n`
+                    output += `\n`
                 }
             }
-            console.log(report)
+            console.log(output)
             perfReportLogged = true
         }
         (function () {

--- a/pxteditor/localStorage.ts
+++ b/pxteditor/localStorage.ts
@@ -25,11 +25,11 @@ namespace pxt.storage {
 
     class LocalStorage implements IStorage {
 
-        constructor(private storageId: string) {
+        constructor(private id: string) {
         }
 
         targetKey(key: string): string {
-            return this.storageId + '/' + key;
+            return this.id + '/' + key;
         }
 
         removeItem(key: string) {

--- a/pxtpy/lexer.ts
+++ b/pxtpy/lexer.ts
@@ -99,11 +99,11 @@ namespace pxt.py {
     let source: string
     let pos = 0, pos0 = 0
 
-    export function position(startPos: number, source: string) {
+    export function position(startPos: number, src: string) {
         let lineno = 0
         let lastnl = 0
         for (let i = 0; i < startPos; ++i) {
-            if (source.charCodeAt(i) == 10) {
+            if (src.charCodeAt(i) == 10) {
                 lineno++
                 lastnl = i
             }
@@ -158,15 +158,15 @@ namespace pxt.py {
         }
     }
 
-    export function friendlyTokenToString(t: Token, source: string) {
+    export function friendlyTokenToString(t: Token, src: string) {
         let len = t.endPos - t.startPos
         let s = ""
         if (len == 0) {
             s = tokenToString(t)
         } else if (len > 20) {
-            s = "`" + source.slice(t.startPos, t.startPos + 20) + "`..."
+            s = "`" + src.slice(t.startPos, t.startPos + 20) + "`..."
         } else {
-            s = "`" + source.slice(t.startPos, t.endPos) + "`"
+            s = "`" + src.slice(t.startPos, t.endPos) + "`"
         }
         s = s.replace(/\r/g, "")
             .replace(/\n/g, "\\n")
@@ -455,10 +455,10 @@ namespace pxt.py {
                         pos++
                     }
                     if (num) {
-                        let p = parseInt(num, numBasesRadix[c2])
-                        if (isNaN(p))
+                        const evaluatedNum = parseInt(num, numBasesRadix[c2])
+                        if (isNaN(evaluatedNum))
                             addError(U.lf("invalid number"))
-                        addToken(TokenType.Number, c1 + c2 + num, p)
+                        addToken(TokenType.Number, c1 + c2 + num, evaluatedNum)
                     } else
                         addError(U.lf("expecting numbers to follow 0b, 0o, 0x"))
                     return

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -177,9 +177,9 @@ namespace pxt.py {
         ///
         /// NEWLINES, COMMENTS, and WRAPPERS
         ///
-        function emitFile(file: ts.SourceFile): string {
+        function emitFile(f: ts.SourceFile): string {
             // emit file
-            let outLns = file.getChildren()
+            let outLns = f.getChildren()
                 .map(emitNode)
                 .reduce((p, c) => p.concat(c), [])
 
@@ -436,9 +436,9 @@ namespace pxt.py {
                     ? `for ${name} in range(${toExcl}):`
                     : `for ${name} in range(${fromIncl}, ${toExcl}):`;
 
-                let body = emitBody(s.statement)
+                let rangeBody = emitBody(s.statement)
 
-                return [forStmt].concat(body)
+                return [forStmt].concat(rangeBody)
             }
 
             // general case:
@@ -517,8 +517,8 @@ namespace pxt.py {
 
             if (s.elseStatement) {
                 if (ts.isIfStatement(s.elseStatement)) {
-                    let { supportStmts, ifStmt, rest } = emitIfHelper(s.elseStatement)
-                    let elif = `el${ifStmt}`
+                    let { supportStmts, ifStmt: ifStmtSymb, rest } = emitIfHelper(s.elseStatement)
+                    let elif = `el${ifStmtSymb}`
                     sup = sup.concat(supportStmts)
                     ifRest.push(elif)
                     ifRest = ifRest.concat(rest)
@@ -1072,17 +1072,17 @@ namespace pxt.py {
                 .map(([_, aSup]) => aSup)
                 .reduce((p, c) => p.concat(c), fnSup)
 
+            // TODO sanity check this, should be fine?
+            const args = getCommaSep(argExps.map(([a, _]) => a).reduce((p, c) => p.concat(c), []));
             if (fn.indexOf("_py.py_") === 0) {
                 if (argExps.length <= 0)
                     return throwError(s, 3014, "Unsupported: call expression has no arguments for _py.py_ fn");
                 // The format is _py.py_type_name, so remove the type
                 fn = fn.substr(7).split("_").filter((_, i) => i !== 0).join("_");
                 const recv = argExps.shift()![0];
-                const args = getCommaSep(argExps.map(([a, _]) => a).reduce((p, c) => p.concat(c), []))
                 return [expWrap(`${recv}.${fn}(`, args, ")"), sup]
             }
 
-            let args = getCommaSep(argExps.map(([a, _]) => a).reduce((p, c) => p.concat(c), [])) //getCommaSep(argExps.map(([a, _]) => a));
             return [expWrap(`${fn}(`, args, ")"), sup]
         }
         type ParameterDeclarationExtended = ts.ParameterDeclaration & { altName?: string }
@@ -1163,7 +1163,7 @@ namespace pxt.py {
             let els = s.elements
                 .map(emitExp);
             let sup = els
-                .map(([_, sup]) => sup)
+                .map(([_, unwrappedSup]) => unwrappedSup)
                 .reduce((p, c) => p.concat(c), [])
 
             let inner = getCommaSep(els.map(([e, _]) => e).reduce((p, c) => p.concat(c), []));
@@ -1202,8 +1202,8 @@ namespace pxt.py {
             return asExpRes(name);
         }
         function visitExp(s: ts.Expression, fn: (e: ts.Expression) => boolean): boolean {
-            let visitRecur = (s: ts.Expression) =>
-                visitExp(s, fn)
+            let visitRecur = (exprNode: ts.Expression) =>
+                visitExp(exprNode, fn)
 
             if (ts.isBinaryExpression(s)) {
                 return visitRecur(s.left) && visitRecur(s.right)
@@ -1227,8 +1227,8 @@ namespace pxt.py {
             return fn(s)
         }
         function isConstExp(s: ts.Expression): boolean {
-            let isConst = (s: ts.Expression): boolean => {
-                switch (s.kind) {
+            let isConst = (subS: ts.Expression): boolean => {
+                switch (subS.kind) {
                     case ts.SyntaxKind.PropertyAccessExpression:
                     case ts.SyntaxKind.BinaryExpression:
                     case ts.SyntaxKind.ParenthesizedExpression:
@@ -1251,7 +1251,7 @@ namespace pxt.py {
                         return false
                     case ts.SyntaxKind.PrefixUnaryExpression:
                     case ts.SyntaxKind.PostfixUnaryExpression:
-                        let e = s as ts.PrefixUnaryExpression | ts.PostfixUnaryExpression
+                        let e = subS as ts.PrefixUnaryExpression | ts.PostfixUnaryExpression
                         return e.operator !== ts.SyntaxKind.PlusPlusToken
                             && e.operator !== ts.SyntaxKind.MinusMinusToken
                 }

--- a/pxtpy/varScopes.ts
+++ b/pxtpy/varScopes.ts
@@ -204,7 +204,7 @@ namespace pxt.py {
         const nextGlobals = globals || locals
         const nextNonlocals = globals ? [...nonlocals, locals] : []
         const children = s.children
-            .map(s => computeVarUsage(s, nextGlobals, nextNonlocals))
+            .map(childS => computeVarUsage(childS, nextGlobals, nextNonlocals))
         return {
             globalUsage,
             nonlocalUsage,
@@ -248,7 +248,7 @@ namespace pxt.py {
                 .map(toId)
                 .filter(i => !!i)
                 .map(i => i as ts.Identifier)
-                .reduce((p, n) => p.find(r => r.text === n.text) ? p : [...p, n], [] as ts.Identifier[])
+                .reduce((p, node) => p.find(r => r.text === node.text) ? p : [...p, node], [] as ts.Identifier[])
         }
 
         function walk(s: VarUsages) {
@@ -267,9 +267,9 @@ namespace pxt.py {
         return `${i.kind}:${i.varName}`
     }
     function toStringVarScopes(s: VarScope): string {
-        function internalToStringVarScopes(s: VarScope): string[] {
-            const refs = s.refs.map(toStringVarRef).join(", ")
-            const children = s.children
+        function internalToStringVarScopes(internalScope: VarScope): string[] {
+            const refs = internalScope.refs.map(toStringVarRef).join(", ")
+            const children = internalScope.children
                 .map(internalToStringVarScopes)
                 .map(c => c.map(indent1))
                 .map(c => ["{", ...c, "}"])
@@ -282,12 +282,12 @@ namespace pxt.py {
         return internalToStringVarScopes(s).join("\n")
     }
     function toStringVarUsage(s: VarUsages): string {
-        function internalToStringVarUsage(s: VarUsages): string[] {
-            const gs = s.globalUsage.map(toStringVarRef).join(', ')
-            const ns = s.nonlocalUsage.map(toStringVarRef).join(', ')
-            const ls = s.localUsage.map(toStringVarRef).join(', ')
-            const es = s.environmentUsage.map(toStringVarRef).join(', ')
-            const children = s.children
+        function internalToStringVarUsage(internalScope: VarUsages): string[] {
+            const gs = internalScope.globalUsage.map(toStringVarRef).join(', ')
+            const ns = internalScope.nonlocalUsage.map(toStringVarRef).join(', ')
+            const ls = internalScope.localUsage.map(toStringVarRef).join(', ')
+            const es = internalScope.environmentUsage.map(toStringVarRef).join(', ')
+            const children = internalScope.children
                 .map(internalToStringVarUsage)
                 .map(c => c.map(indent1))
                 .map(c => ["{", ...c, "}"])

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -126,7 +126,7 @@ namespace pxt.runner {
             let nextnext = next.nextSibling; // before we hoist it from the tree
             if (next.nodeType == Node.TEXT_NODE) {
                 text = (next as Text).textContent;
-                const inewline = text.indexOf('\n');
+                inewline = text.indexOf('\n');
                 if (inewline < 0) {
                     span.appendChild(next);
                     next = nextnext;
@@ -353,11 +353,11 @@ namespace pxt.runner {
                     }
 
                     // filter out any blockly definitions from the svg that would be duplicates on the page
-                    r.blocksSvg.querySelectorAll("defs *").forEach(el => {
-                        if (existingFilters[el.id]) {
-                            el.remove();
+                    r.blocksSvg.querySelectorAll("defs *").forEach(svgEl => {
+                        if (existingFilters[svgEl.id]) {
+                            svgEl.remove();
                         } else {
-                            existingFilters[el.id] = true;
+                            existingFilters[svgEl.id] = true;
                         }
                     });
                     render(el, r);
@@ -499,7 +499,7 @@ namespace pxt.runner {
 
     function renderBlocksXmlAsync(opts: ClientRenderOptions): Promise<void> {
         if (!opts.blocksXmlClass) return Promise.resolve();
-        const cls = opts.blocksXmlClass;
+        const { blocksXmlClass } = opts;
         function renderNextXmlAsync(cls: string,
             render: (container: JQuery, r: pxt.runner.DecompileResult) => void,
             options?: pxt.blocks.BlocksRenderOptions): Promise<void> {
@@ -521,7 +521,7 @@ namespace pxt.runner {
                 })
         }
 
-        return renderNextXmlAsync(cls, (c, r) => {
+        return renderNextXmlAsync(blocksXmlClass, (c, r) => {
             const s = r.blocksSvg;
             if (opts.snippetReplaceParent) c = c.parent();
             const segment = $('<div class="ui segment codewidget"/>').append(s);
@@ -531,7 +531,7 @@ namespace pxt.runner {
 
     function renderDiffBlocksXmlAsync(opts: ClientRenderOptions): Promise<void> {
         if (!opts.diffBlocksXmlClass) return Promise.resolve();
-        const cls = opts.diffBlocksXmlClass;
+        const { diffBlocksXmlClass } = opts;
         function renderNextXmlAsync(cls: string,
             render: (container: JQuery, r: pxt.runner.DecompileResult) => void,
             options?: pxt.blocks.BlocksRenderOptions): Promise<void> {
@@ -564,7 +564,7 @@ namespace pxt.runner {
                 })
         }
 
-        return renderNextXmlAsync(cls, (c, r) => {
+        return renderNextXmlAsync(diffBlocksXmlClass, (c, r) => {
             const s = r.blocksSvg;
             if (opts.snippetReplaceParent) c = c.parent();
             const segment = $('<div class="ui segment codewidget"/>').append(s);
@@ -575,7 +575,7 @@ namespace pxt.runner {
 
     function renderDiffAsync(opts: ClientRenderOptions): Promise<void> {
         if (!opts.diffClass) return Promise.resolve();
-        const cls = opts.diffClass;
+        const { diffClass } = opts;
         function renderNextDiffAsync(cls: string): Promise<void> {
             let $el = $("." + cls).first();
             if (!$el[0]) return Promise.resolve();
@@ -602,12 +602,12 @@ namespace pxt.runner {
             return Promise.delay(1, renderNextDiffAsync(cls));
         }
 
-        return renderNextDiffAsync(cls);
+        return renderNextDiffAsync(diffClass);
     }
 
     function renderDiffBlocksAsync(opts: ClientRenderOptions): Promise<void> {
         if (!opts.diffBlocksClass) return Promise.resolve();
-        const cls = opts.diffBlocksClass;
+        const { diffBlocksClass } = opts;
         function renderNextDiffAsync(cls: string): Promise<void> {
             let $el = $("." + cls).first();
             if (!$el[0]) return Promise.resolve();
@@ -662,7 +662,7 @@ namespace pxt.runner {
                 })
         }
 
-        return renderNextDiffAsync(cls);
+        return renderNextDiffAsync(diffBlocksClass);
     }
 
     let decompileApiPromise: Promise<DecompileResult>;
@@ -817,14 +817,14 @@ namespace pxt.runner {
                     const csymbols = symbols.filter(symbol => !!namespaces[symbol.namespace])
                     if (!csymbols.length) return;
 
-                    csymbols.sort((l,r) => {
+                    csymbols.sort((a, b) => {
                         // render cards first
-                        const lcard = !l.attributes.blockHidden && Blockly.Blocks[l.attributes.blockId];
-                        const rcard = !r.attributes.blockHidden && Blockly.Blocks[r.attributes.blockId]
+                        const lcard = !a.attributes.blockHidden && Blockly.Blocks[a.attributes.blockId];
+                        const rcard = !b.attributes.blockHidden && Blockly.Blocks[b.attributes.blockId]
                         if (!!lcard != !!rcard) return -(lcard ? 1 : 0) + (rcard ? 1 : 0);
 
                         // sort alphabetically
-                        return l.name.localeCompare(r.name);
+                        return a.name.localeCompare(b.name);
                     })
 
                     const ul = $('<div />').addClass('ui divided items');

--- a/pxtwinrt/deploy.ts
+++ b/pxtwinrt/deploy.ts
@@ -15,7 +15,7 @@ namespace pxt.winrt {
             return pxt.winrt.promisify(
                 folder.createFileAsync(firmware, Windows.Storage.CreationCollisionOption.replaceExisting)
                     .then(file => Windows.Storage.FileIO.writeTextAsync(file, r))
-            ).then(r => { }).catch(e => {
+            ).then(_ => { }).catch(e => {
                 pxt.debug(`failed to write ${firmware} to ${folder.displayName} - ${e}`)
             })
         }
@@ -26,7 +26,7 @@ namespace pxt.winrt {
                 let pdf = df.map(writeAsync);
                 let all = Promise.join(...pdf)
                 return all;
-            }).then(r => { });
+            }).then(_ => { });
     }
 
     export function browserDownloadAsync(text: string, name: string, contentType: string): Promise<void> {

--- a/pxtwinrt/winrtworkspace.ts
+++ b/pxtwinrt/winrtworkspace.ts
@@ -126,8 +126,8 @@ namespace pxt.winrt.workspace {
                                 return rf;
                             else
                                 return readFileAsync(pathjoin(logicalDirname, fn))
-                                    .then(text => {
-                                        rf.content = text
+                                    .then(content => {
+                                        rf.content = content
                                         return rf;
                                     })
                         }))
@@ -139,9 +139,9 @@ namespace pxt.winrt.workspace {
                             files: files
                         };
                         return readFileAsync(pathjoin(logicalDirname, HEADER_JSON))
-                            .then(text => {
-                                if (text)
-                                    rs.header = JSON.parse(text)
+                            .then(content => {
+                                if (content)
+                                    rs.header = JSON.parse(content)
                             }, e => { })
                             .then(() => rs)
                     })

--- a/tslint.json
+++ b/tslint.json
@@ -46,6 +46,7 @@
             "check-operator",
             "check-type"
         ],
+        "no-shadowed-variable": true,
         /**
          * Security Rules. The following rules should be turned on because they find security issues
          * or are recommended in the Microsoft Secure Development Lifecycle (SDL)


### PR DESCRIPTION
starting as a draft as there are a bunch of minor changes / I'm starting to hit the big folders :)

the bug from https://github.com/microsoft/pxt/pull/6784 was from the data variable being clobbered by the value in the given function; when you start to get nested functions it can lead to VERY subtle bugs.

There's one case I've seen so far where this rule is definitely annoying is with implicit elses; i.e.

```typescript
function fn() {
  if (cond) {
    const a = "edge case a"  // error logged here
    // do some trivial work then bail out
    return a;
  }
  const a = "main case a"
  // do the rest of the work in this implicit else branch
  return a;
}
```

the rule gives an error on the first one because the `a` in the conditional does shadow the `a` outside of it, even if it's obvious looking at it that it's a valid case. That one's definitely annoying, but ¯\\_(ツ)_/¯

Also a minor annoying case with constructor parameter field declarations (don't know the proper name off hand, just look at the `pxteditor/localStorage.ts` change; `storageId` is a function in that file so the parameter name conflicts with that in the scope of the constructor)