### PR TITLE
CSS/style fixes for blockly, toolbox animation

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -62,7 +62,7 @@ namespace pxt.blocks.layout {
             return svg;
 
         const div = document.createElement("div") as HTMLDivElement;
-        div.className = "blocks-svg-list"
+        div.className = `blocks-svg-list ${ws.getInjectionDiv().className}`
 
         function extract(
             parentClass: string,

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1468,7 +1468,7 @@ namespace pxt.blocks {
         msg.HELP = lf("Help");
 
         // inject hook to handle openings docs
-        (<any>Blockly).BlockSvg.prototype.showHelp_ = function () {
+        (<any>Blockly).BlockSvg.prototype.showHelp = function () {
             const url = goog.isFunction(this.helpUrl) ? this.helpUrl() : this.helpUrl;
             if (url) (pxt.blocks.openHelpUrl || window.open)(url);
         };

--- a/theme/light.less
+++ b/theme/light.less
@@ -34,3 +34,6 @@
 .light .blocklyMainBackground {
     fill: @blocklySvgColor !important;
 }
+.light #monacoEditorToolbox .blocklyTreeRow {
+    animation: none !important;
+}

--- a/theme/print.less
+++ b/theme/print.less
@@ -102,46 +102,48 @@
     }
 
     /** blockly **/
-    .blocklyPath {
-        stroke-width: 3px !important;
-        stroke: black !important;
-        fill: white !important;
-    }
-    .blocklyBlockBackground, .blocklyLedOff {
-        stroke-width: 2px !important;
-        stroke: black !important;
-        fill: white !important;        
-    }
-    .blocklyText, .blocklyDropdownText {
-        fill: black !important;
-    }
-    .blocklyLedOn {
-        stroke-width: 2px !important;
-        stroke: black !important;
-        fill: black !important;
-    }
-    .blocklyOutlinePath,
-    .blocklyFieldRect.blocklyDropdownRect {
-        stroke-width: 2px !important;
-        stroke: black !important;
-        fill: transparent !important;
-    }
-    /* comments */
-    .blocklyCommentRect {
-        fill: white !important;
-        stroke: black !important;
-    }
-    .blocklyCommentTextarea {
-        overflow: hidden !important;
-    }
-    .blocklyCommentTarget, .blocklyCommentHandleTarget, .blocklyResizeSE {
-        display: none !important;
-    }
-    .blocklyToggleRect {
-        fill: white !important;
-    }
-    .blocklyText.blocklyToggleText {
-        fill: black !important;
+    svg, .pxt-renderer {
+        .blocklyPath {
+            stroke-width: 3px !important;
+            stroke: black !important;
+            fill: white !important;
+        }
+        .blocklyBlockBackground, .blocklyLedOff {
+            stroke-width: 2px !important;
+            stroke: black !important;
+            fill: white !important;
+        }
+        .blocklyText, .blocklyDropdownText {
+            fill: black !important;
+        }
+        .blocklyLedOn {
+            stroke-width: 2px !important;
+            stroke: black !important;
+            fill: black !important;
+        }
+        .blocklyOutlinePath,
+        .blocklyFieldRect.blocklyDropdownRect {
+            stroke-width: 2px !important;
+            stroke: black !important;
+            fill: transparent !important;
+        }
+        /* comments */
+        .blocklyCommentRect {
+            fill: white !important;
+            stroke: black !important;
+        }
+        .blocklyCommentTextarea {
+            overflow: hidden !important;
+        }
+        .blocklyCommentTarget, .blocklyCommentHandleTarget, .blocklyResizeSE {
+            display: none !important;
+        }
+        .blocklyToggleRect {
+            fill: white !important;
+        }
+        .blocklyText.blocklyToggleText {
+            fill: black !important;
+        }
     }
 
     .codesnippet {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -612,7 +612,7 @@ export interface TreeRowProps {
 export class TreeRow extends data.Component<TreeRowProps, {}> {
 
     private treeRow: HTMLElement;
-    private animationDelay: number = 0.25;
+    private animationDelay: number = 0.15;
 
     constructor(props: TreeRowProps) {
         super(props);


### PR DESCRIPTION
- Right-click context menu opens sidedocs
- Fix printing bugs (black text field in function/colored fields)
- Faster toolbox animation
- Turn off animation in light mode

Fixes https://github.com/microsoft/pxt-minecraft/issues/1855
Fixes for https://github.com/microsoft/pxt-microbit/issues/2678