### PR TITLE
Tutorialparsefix

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5346,7 +5346,7 @@ export interface SnippetInfo {
 
 export function getSnippets(source: string): SnippetInfo[] {
     let snippets: SnippetInfo[] = []
-    let re = /^`{3}\s*([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm;
+    let re = /^`{3} *([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm;
     let index = 0
     source.replace(re, (match, type, code) => {
         snippets.push({

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5346,7 +5346,7 @@ export interface SnippetInfo {
 
 export function getSnippets(source: string): SnippetInfo[] {
     let snippets: SnippetInfo[] = []
-    let re = /^`{3}([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm;
+    let re = /^`{3}\s*([\S]+)?\s*\n([\s\S]+?)\n`{3}\s*?$/gm;
     let index = 0
     source.replace(re, (match, type, code) => {
         snippets.push({

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -39,7 +39,7 @@ namespace pxt.tutorial {
     function computeBodyMetadata(body: string) {
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /```(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /```\s*(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
         let code = '';
         let templateCode: string;
         let language: string;

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -39,7 +39,7 @@ namespace pxt.tutorial {
     function computeBodyMetadata(body: string) {
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /```\s*(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
         let code = '';
         let templateCode: string;
         let language: string;


### PR DESCRIPTION
It turns out that markdown is merciful and eats white. spaces between back tick and the fence code session name eg. If the user makes this mistake our tutorial parsing completely breaks.

     ```      python
     x = 1
     ```
is valid.

Test both:
```python
while True:
    pass
```

with space
``` python
while True:
    pass
```