### PR TITLE
Fix sourcemap for python when debugging/tracing

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -799,6 +799,7 @@ declare namespace ts.pxtc {
         skipPxtModulesEmit?: boolean; // skip re-emit of pxt_modules/*
 
         syntaxInfo?: SyntaxInfo;
+        forceTranspile?: boolean;
 
         // decompiler only
         alwaysDecompileOnStart?: boolean;

--- a/pxtcompiler/emitter/transpile.ts
+++ b/pxtcompiler/emitter/transpile.ts
@@ -77,8 +77,8 @@ namespace ts.pxtc.transpile {
         }
     }
 
-    // @param force: forces a live transpile, and does not cache the result
-    function transpileInternal(from: CodeLang, fromTxt: string, to: CodeLang, doRealTranspile: () => TranspileResult, force?: boolean): TranspileResult {
+    // @param force: forces a live transpile, and does not cache the result (unless forceOverwrite is true)
+    function transpileInternal(from: CodeLang, fromTxt: string, to: CodeLang, doRealTranspile: () => TranspileResult, force?: boolean, forceOverwrite?: boolean): TranspileResult {
         let equiv = tryGetCachedTranspile(from, fromTxt)
         if (equiv && equiv.outfiles[mainName(to)] && !force) {
             // return from cache
@@ -89,7 +89,7 @@ namespace ts.pxtc.transpile {
         // not found in cache, do the compile
         let res = doRealTranspile()
 
-        if (res.success && !force) {
+        if (res.success && (!force || forceOverwrite)) {
             // store the result
             let toTxt = res.outfiles[mainName(to)] || ""
             cacheTranspile(from, fromTxt, to, toTxt, res.sourceMap)
@@ -106,7 +106,7 @@ namespace ts.pxtc.transpile {
         if (fromTxt === undefined || fromTxt === null)
             fromTxt = ""; // don't crash if main.ts is missing, just create new file
 
-        return transpileInternal("py", fromTxt, "ts", doRealTranspile, !!options.syntaxInfo)
+        return transpileInternal("py", fromTxt, "ts", doRealTranspile, !!(options.syntaxInfo || options.forceTranspile), !!options.forceTranspile)
     }
 
     export function tsToPy(program: ts.Program, filename: string = mainName("ts")): TranspileResult {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -387,6 +387,8 @@ export class ProjectView
     openPython(giveFocusOnLoading = true) {
         if (this.updatingEditorFile) return; // already transitioning
 
+        this.setState({ tracing: false });
+
         if (this.isPythonActive()) {
             if (this.state.embedSimView) {
                 this.setState({ embedSimView: false });

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -213,12 +213,14 @@ function compileCoreAsync(opts: pxtc.CompileOptions): Promise<pxtc.CompileResult
     return workerOpAsync("compile", { options: opts })
 }
 
-export function py2tsAsync(): Promise<pxtc.transpile.TranspileResult> {
+export function py2tsAsync(force = false): Promise<pxtc.transpile.TranspileResult> {
     let trg = pkg.mainPkg.getTargetOptions()
     return waitForFirstTypecheckAsync()
         .then(() => pkg.mainPkg.getCompileOptionsAsync(trg))
         .then(opts => {
             opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME
+            if (force) opts.forceTranspile = true;
+
             return workerOpAsync("py2ts", { options: opts })
         })
 }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1421,6 +1421,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
 
         if (brk && this.breakpoints?.getLoadedBreakpoint(brk.breakpointId)) stmt = this.breakpoints.getLoadedBreakpoint(brk.breakpointId);
+        else if (this.currFile.getExtension() === "py" && this.pythonSourceMap) stmt = this.pythonSourceMap.ts.locToLoc(stmt);
 
         if (this.currFile.getTextFileName() !== stmt.fileName && this.isDebugging() && lookupFile(stmt.fileName)) {
             this.parent.setFile(lookupFile(stmt.fileName))


### PR DESCRIPTION
This fixes the scenario where you go from a non-python language to python and start debugging or tracing. I added a flag to the compile options to force-update the transpile cache. We should still do something about the transpile cache, but this is a hold-over fix.