### PR TITLE
Reapply extension command overrides after app init

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -126,12 +126,12 @@ namespace pxt.BrowserUtils {
         return isPxtElectron() || isIpcRenderer();
     }
 
-    export function isLocalHost(): boolean {
+    export function isLocalHost(ignoreFlags?: boolean): boolean {
         try {
             return typeof window !== "undefined"
                 && /^http:\/\/(localhost|127\.0\.0\.1):\d+\//.test(window.location.href)
-                && !/nolocalhost=1/.test(window.location.href)
-                && !(pxt.webConfig && pxt.webConfig.isStatic);
+                && (ignoreFlags || !/nolocalhost=1/.test(window.location.href))
+                && !(pxt?.webConfig?.isStatic);
         } catch (e) { return false; }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4136,7 +4136,7 @@ function initExtensionsAsync(): Promise<void> {
                     monacoToolbox.overrideToolbox(res.toolboxOptions.monacoToolbox);
                 }
             }
-            pxt.commands.setExtensionResult(res);
+            cmds.setExtensionResult(res);
         });
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4125,26 +4125,6 @@ function initExtensionsAsync(): Promise<void> {
                     theEditor.resourceImporters.push(fi);
                 });
             }
-            if (res.deployAsync) {
-                pxt.debug(`\tadded custom deploy core async`);
-                pxt.commands.deployCoreAsync = res.deployAsync;
-            }
-            if (res.saveOnlyAsync) {
-                pxt.debug(`\tadded custom save only async`);
-                pxt.commands.saveOnlyAsync = res.saveOnlyAsync;
-            }
-            if (res.saveProjectAsync) {
-                pxt.debug(`\tadded custom save project async`);
-                pxt.commands.saveProjectAsync = res.saveProjectAsync;
-            }
-            if (res.showUploadInstructionsAsync) {
-                pxt.debug(`\tadded custom upload instructions async`);
-                pxt.commands.showUploadInstructionsAsync = res.showUploadInstructionsAsync;
-            }
-            if (res.patchCompileResultAsync) {
-                pxt.debug(`\tadded build patch`);
-                pxt.commands.patchCompileResultAsync = res.patchCompileResultAsync;
-            }
             if (res.beforeCompile) {
                 theEditor.beforeCompile = res.beforeCompile;
             }
@@ -4156,15 +4136,7 @@ function initExtensionsAsync(): Promise<void> {
                     monacoToolbox.overrideToolbox(res.toolboxOptions.monacoToolbox);
                 }
             }
-            if (res.blocklyPatch) {
-                pxt.blocks.extensionBlocklyPatch = res.blocklyPatch;
-            }
-            if (res.webUsbPairDialogAsync) {
-                pxt.commands.webUsbPairDialogAsync = res.webUsbPairDialogAsync;
-            }
-            if (res.onTutorialCompleted) {
-                pxt.commands.onTutorialCompleted = res.onTutorialCompleted;
-            }
+            pxt.commands.setExtensionResult(res);
         });
 }
 

--- a/webapp/src/appcache.ts
+++ b/webapp/src/appcache.ts
@@ -1,7 +1,9 @@
 import * as core from "./core";
 
 export function init(updated: () => void) {
-    if ("serviceWorker" in navigator && !pxt.webConfig.isStatic && !pxt.BrowserUtils.isLocalHost()) {
+    if ("serviceWorker" in navigator
+        && !pxt.webConfig.isStatic
+        && !pxt.BrowserUtils.isLocalHost(true)) {
         window.addEventListener("load", function () {
             const ref = pxt.webConfig.relprefix.replace("---", "").replace(/^\//, "");
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -7,6 +7,7 @@ import * as webusb from "./webusb";
 import * as compiler from "./compiler";
 import Cloud = pxt.Cloud;
 
+let extensionResult: pxt.editor.ExtensionResult;
 let tryPairedDevice = false;
 
 function browserDownloadAsync(text: string, name: string, contentType: string): Promise<void> {
@@ -217,6 +218,49 @@ function localhostDeployCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     return deploy()
 }
 
+export function setExtensionResult(res: pxt.editor.ExtensionResult) {
+    extensionResult = res;
+    applyExtensionResult();
+}
+
+function applyExtensionResult() {
+    const res = extensionResult;
+    if (!res) return;
+
+    if (res.deployAsync) {
+        pxt.debug(`\tadded custom deploy core async`);
+        pxt.commands.deployCoreAsync = res.deployAsync;
+    }
+    if (res.saveOnlyAsync) {
+        pxt.debug(`\tadded custom save only async`);
+        pxt.commands.saveOnlyAsync = res.saveOnlyAsync;
+    }
+    if (res.saveProjectAsync) {
+        pxt.debug(`\tadded custom save project async`);
+        pxt.commands.saveProjectAsync = res.saveProjectAsync;
+    }
+    if (res.showUploadInstructionsAsync) {
+        pxt.debug(`\tadded custom upload instructions async`);
+        pxt.commands.showUploadInstructionsAsync = res.showUploadInstructionsAsync;
+    }
+    if (res.patchCompileResultAsync) {
+        pxt.debug(`\tadded build patch`);
+        pxt.commands.patchCompileResultAsync = res.patchCompileResultAsync;
+    }
+    if (res.blocklyPatch) {
+        pxt.debug(`\tadded blockly patch`);
+        pxt.blocks.extensionBlocklyPatch = res.blocklyPatch;
+    }
+    if (res.webUsbPairDialogAsync) {
+        pxt.debug(`\tadded webusb pair dialog`);
+        pxt.commands.webUsbPairDialogAsync = res.webUsbPairDialogAsync;
+    }
+    if (res.onTutorialCompleted) {
+        pxt.debug(`\tadded tutorial completed`);
+        pxt.commands.onTutorialCompleted = res.onTutorialCompleted;
+    }
+}
+
 export function init(): void {
     pxt.onAppTargetChanged = () => {
         pxt.debug('app target changed')
@@ -285,6 +329,8 @@ export function init(): void {
         pxt.debug(`deploy: browser`);
         pxt.commands.deployFallbackAsync = shouldUseWebUSB ? checkWebUSBThenDownloadAsync : browserDownloadDeployCoreAsync;
     }
+
+    applyExtensionResult();
 }
 
 export function setWebUSBPaired(enabled: boolean) {


### PR DESCRIPTION
App init is called after loading a variant and forgets about the editor extension command overrides.
In maker, we loose the custom "download dialog".
- [x] no service worker on localhost
- [x] record extension load result and reapply to commands after loading a variant