### PR TITLE
fix approved repos in extensions page

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -312,7 +312,7 @@ namespace pxt.github {
     export interface CreateCommitReq {
         message: string;
         parents: string[]; // shas
-        tree: string; // sha		
+        tree: string; // sha
     }
 
     function ghPostAsync(path: string, data: any, headers?: any, method?: string) {
@@ -659,7 +659,7 @@ namespace pxt.github {
                     node.default_branch = node.defaultBranchRef.name;
                     const pxtJson = pxt.Package.parseAndValidConfig(node.pxtjson && node.pxtjson.text);
                     const readme = node.readme && node.readme.text;
-                    // needs to have a valid pxt.json file                    
+                    // needs to have a valid pxt.json file
                     if (!pxtJson) return false;
                     // new style of supported annontation
                     if (pxtJson.supportedTargets)
@@ -802,7 +802,7 @@ namespace pxt.github {
         // always try proxy first
         if (hasProxy()) {
             try {
-                return await proxyRepoAsync(rid, config);
+                return await proxyRepoAsync(rid, status);
             } catch (e) {
                 ghProxyHandleException(e);
             }
@@ -812,7 +812,7 @@ namespace pxt.github {
         return mkRepo(r, config, rid.tag);
     }
 
-    function proxyRepoAsync(rid: ParsedRepo, config: pxt.PackagesConfig): Promise<GitRepo> {
+    function proxyRepoAsync(rid: ParsedRepo, status: GitRepoStatus): Promise<GitRepo> {
         // always use proxy
         return ghProxyJsonAsync(`${rid.fullName}`)
             .then(meta => {
@@ -986,7 +986,7 @@ namespace pxt.github {
 
     /**
      * Executes a GraphQL query against GitHub v4 api
-     * @param query 
+     * @param query
      */
     export function ghGraphQLQueryAsync(query: string): Promise<any> {
         const payload = JSON.stringify({
@@ -1003,8 +1003,8 @@ namespace pxt.github {
 
     /**
      * Finds the first PR associated with a branch
-     * @param reponame 
-     * @param headName 
+     * @param reponame
+     * @param headName
      */
     export function findPRNumberforBranchAsync(reponame: string, headName: string): Promise<PullRequest> {
         const repoId = parseRepoId(reponame);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2715

the helper function created in https://github.com/microsoft/pxt/pull/6760 (`proxyRepoAsync`) was using the status created at the beginning of `repoAsync`. This wouldn't have ever made it through the compiler, except for the fact that that `window.*` properties are unpacked into globals; so there's a global `parent` variable, and in this case, a global `status` variable (that was evaluating to "")

bug came from https://github.com/microsoft/pxt/pull/6760, but I'm going to instead choose to blame javascript as a whole. ~There's gotta be a compiler flag or linter rule to prevent using those, right? Haven't checked but will. I can't imagine a case where I would ever intentionally use `parent` over `window.parent`.~ I forgot that's just how top level `var`s works, but I'll still take a look for a flag to not allow use of those) no compiler flag at the moment, and workaround is gross (explicitly setting all built in libs and creating our own dom.d.ts: https://github.com/microsoft/TypeScript/issues/14306)