### PR TITLE
make docs at least take up full window, footer stays at bottom

### DIFF
--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -191,6 +191,7 @@ svg {
     position: absolute;
     /* match with menu bar height */
     top: 3.5em;
+    min-height: calc(100vh - 3.5em);
     -webkit-box-flex: 1;
 
     -webkit-flex: 1 1 auto;


### PR DESCRIPTION
Don't think there was a bug yet, but for example https://arcade.makecode.com/courses; if you have a tallish window footer won't be stuck to the bottom. (or if you zoom out a bunch)

big zoom out pictures:

current:
![image](https://user-images.githubusercontent.com/5615930/78207397-65136200-7456-11ea-82dd-05cfa8326280.png)


with this:
![image](https://user-images.githubusercontent.com/5615930/78207377-575ddc80-7456-11ea-9fa0-b3e365b27280.png)
