### PR TITLE
Make the function names for python snippets match the pydeompiler

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1625,7 +1625,7 @@ namespace ts.pxtc.service {
         }
 
         const includedParameters = decl.parameters ? decl.parameters
-        .filter(param => !param.initializer && !param.questionToken) : []
+            .filter(param => !param.initializer && !param.questionToken) : []
 
         const args = includedParameters.map(getParameterDefault)
 

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -967,9 +967,8 @@ namespace pxt.py {
                     break
                 allWords = newWords
             }
-            // 3. if there is only one word, add "on_" prefix
-            if (allWords.length == 1)
-                allWords = ["on", allWords[0]]
+            // 3. add an "on_" prefix
+            allWords = ["on", ...allWords]
 
             return allWords.join("_")
             function dedupWords(words: string[]): string[] {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2701

I wanted to unite the code paths entirely, but it's really tough to factor out the name hint function from the pydecompiler. Instead I tweaked both of them so that they match. The following changed:

1. Snippets from the toolbox now have enum arguments appended to the end
2. Snippets from the pydecompiler now always begin with `on_`