### PR TITLE
Bump pxt-blockly to 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.4",
+    "pxt-blockly": "3.0.5",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
Fixes last "P1" bug from https://github.com/microsoft/pxt-microbit/issues/2678
Fixes https://github.com/microsoft/pxt-microbit/issues/1565
Fixes https://github.com/microsoft/pxt-microbit/issues/2726