### PR TITLE
collapse all option

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -134,7 +134,12 @@ namespace pxt.blocks.layout {
             y += block.getHeightWidth().height
             y += emPixels; //buffer
         })
-    };
+    }
+
+    export function collapseAll(ws: Blockly.WorkspaceSvg) {
+        ws.getTopBlocks(false)
+            .forEach(b => b.setCollapsed(true));
+    }
 
     export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {
         if (opts) {

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -136,9 +136,9 @@ namespace pxt.blocks.layout {
         })
     }
 
-    export function collapseAll(ws: Blockly.WorkspaceSvg) {
+    export function setCollapsedAll(ws: Blockly.WorkspaceSvg, collapsed: boolean) {
         ws.getTopBlocks(false)
-            .forEach(b => b.setCollapsed(true));
+            .forEach(b => b.setCollapsed(collapsed));
     }
 
     export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1550,7 +1550,7 @@ namespace pxt.blocks {
 
             if (pxt.appTarget.appTheme.blocksCollapsing) {
                 const collapseAllOption = {
-                    text: lf("Collapse All"),
+                    text: lf("Collapse Blocks"),
                     enabled: true,
                     callback: () => {
                         pxt.tickEvent("blocks.context.collapse", undefined, { interactiveConsent: true });
@@ -1561,7 +1561,7 @@ namespace pxt.blocks {
                 options.push(collapseAllOption);
 
                 const expandAllOption = {
-                    text: lf("Expand All"),
+                    text: lf("Expand Blocks"),
                     enabled: true,
                     callback: () => {
                         pxt.tickEvent("blocks.context.expand", undefined, { interactiveConsent: true });

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1554,11 +1554,22 @@ namespace pxt.blocks {
                     enabled: true,
                     callback: () => {
                         pxt.tickEvent("blocks.context.collapse", undefined, { interactiveConsent: true });
-                        pxt.blocks.layout.collapseAll(this);
+                        pxt.blocks.layout.setCollapsedAll(this, true);
                         pxt.blocks.layout.flow(this, { useViewWidth: true });
                     }
                 }
                 options.push(collapseAllOption);
+
+                const expandAllOption = {
+                    text: lf("Expand All"),
+                    enabled: true,
+                    callback: () => {
+                        pxt.tickEvent("blocks.context.expand", undefined, { interactiveConsent: true });
+                        pxt.blocks.layout.setCollapsedAll(this, false);
+                        pxt.blocks.layout.flow(this, { useViewWidth: true });
+                    }
+                }
+                options.push(expandAllOption);
             }
 
             if (pxt.blocks.layout.screenshotEnabled()) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1548,6 +1548,19 @@ namespace pxt.blocks {
             }
             options.push(formatCodeOption);
 
+            if (pxt.appTarget.appTheme.blocksCollapsing) {
+                const collapseAllOption = {
+                    text: lf("Collapse All"),
+                    enabled: true,
+                    callback: () => {
+                        pxt.tickEvent("blocks.context.collapse", undefined, { interactiveConsent: true });
+                        pxt.blocks.layout.collapseAll(this);
+                        pxt.blocks.layout.flow(this, { useViewWidth: true });
+                    }
+                }
+                options.push(collapseAllOption);
+            }
+
             if (pxt.blocks.layout.screenshotEnabled()) {
                 const screenshotOption = {
                     text: lf("Snapshot"),
@@ -2382,7 +2395,7 @@ namespace pxt.blocks {
 
         const functionReturnId = "function_return";
         Blockly.Blocks[functionReturnId] = {
-            init: function() {
+            init: function () {
                 initReturnStatement(this);
             },
             onchange: function (event) {


### PR DESCRIPTION
In my arcade streams, the size of the blocks quickly becomes unbearable. A collapse all and format options just shrinks everything and make it easier to scale large programs.
![2020-04-02 22 09 33](https://user-images.githubusercontent.com/4175913/78326467-58af0800-752f-11ea-8952-b517935b0978.gif)
