### PR TITLE
add empty front-matter and ignore homepage update fails

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -711,11 +711,17 @@ namespace pxt.github {
         if (url) {
             // check if the repo already has a web site
             const rep = await ghGetJsonAsync(`https://api.github.com/repos/${repo}`);
-            if (rep && !rep.homepage)
-                await ghPostAsync(`https://api.github.com/repos/${repo}`,
-                    {
-                        "homepage": url
-                    }, undefined, "PATCH");
+            if (rep && !rep.homepage) {
+                try {
+                    await ghPostAsync(`https://api.github.com/repos/${repo}`,
+                        {
+                            "homepage": url
+                        }, undefined, "PATCH");
+                } catch (e) {
+                    // just ignore if fail to update the homepage
+                    pxt.tickEvent("github.homepage.error");
+                }
+            }
         }
     }
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -713,10 +713,7 @@ namespace pxt.github {
             const rep = await ghGetJsonAsync(`https://api.github.com/repos/${repo}`);
             if (rep && !rep.homepage) {
                 try {
-                    await ghPostAsync(`https://api.github.com/repos/${repo}`,
-                        {
-                            "homepage": url
-                        }, undefined, "PATCH");
+                    await ghPostAsync(`https://api.github.com/repos/${repo}`, { "homepage": url }, undefined, "PATCH");
                 } catch (e) {
                     // just ignore if fail to update the homepage
                     pxt.tickEvent("github.homepage.error");

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -36,14 +36,13 @@ test:
 `,
             "Gemfile": `source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins`,
-            "README.md":
-                `
+            "README.md": `
 ---
 
 ---                
                 > ${lf("Open this page at {0}",
-                    "[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
-                )}
+                "[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
+            )}
 
 ## ${lf("Use this extension")}
 

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -39,7 +39,7 @@ gem 'github-pages', group: :jekyll_plugins`,
             "README.md": `
 ---
 
----                
+---
                 > ${lf("Open this page at {0}",
                 "[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
             )}

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -37,7 +37,11 @@ test:
             "Gemfile": `source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins`,
             "README.md":
-                `> ${lf("Open this page at {0}",
+                `
+---
+
+---                
+                > ${lf("Open this page at {0}",
                     "[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
                 )}
 


### PR DESCRIPTION
Front matter ensures jekyll renders the page in github pages + don't fail on updating homepage of repo.

This change allows to use the README.md as the "manual" page for a game automaitcally. Otherwise, jekyll does not render it. Also, only admins have the right to update the homepage of a project so we should not be failing on updating homepage.