### PR TITLE
Set no-select for monaco toolbox icons (old Edge fix)

### DIFF
--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -20,7 +20,9 @@
     transition-timing-function: ease-in;
 }
 
-.blocklyToolboxDiv text, .monacoToolboxDiv text {
+.blocklyToolboxDiv text,
+.monacoToolboxDiv text,
+span.blocklyTreeIcon {
     user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
@@ -185,7 +187,6 @@ span.blocklyTreeIcon {
     height: 100%;
     display: none;
     vertical-align: middle;
-    user-select: none;
 }
 
 div.blocklyTreeIcon span {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2718