### PR TITLE
Rename experiment to Accessible Blocks, default to off, add info dialog

### DIFF
--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -160,8 +160,8 @@ namespace pxt.editor.experiments {
             },
             {
                 id: "accessibleBlocks",
-                name: lf("Block Keyboard Accessibility"),
-                description: lf("Use keyboard controls to move and modify blocks.")
+                name: lf("Accessible Blocks"),
+                description: lf("Use the WASD keys to move and modify blocks.")
             }
         ].filter(experiment => ids.indexOf(experiment.id) > -1);
     }

--- a/webapp/src/accessibleblocks.tsx
+++ b/webapp/src/accessibleblocks.tsx
@@ -41,7 +41,6 @@ export class AccessibleBlocksInfo extends data.Component<{}, AccessibleBlocksInf
                     {lf("See the official Blockly Documentation for additional detail")}
                 </a></strong>
             </div>
-            
         </sui.Modal>
     }
 }

--- a/webapp/src/accessibleblocks.tsx
+++ b/webapp/src/accessibleblocks.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import * as data from "./data";
+import * as sui from "./sui";
+
+export interface AccessibleBlocksInfoState {
+    shown?: boolean;
+}
+
+export class AccessibleBlocksInfo extends data.Component<{}, AccessibleBlocksInfoState> {
+    constructor(props: {}) {
+        super(props);
+        this.state = { shown: false }
+        this.handleOnClose = this.handleOnClose.bind(this);
+    }
+
+    handleOnClose() {
+        this.setState({ shown: true })
+    }
+
+    render() {
+        const shown = this.state.shown;
+        if (shown) return <div />;
+        return <sui.Modal isOpen={!this.state.shown} onClose={this.handleOnClose} closeIcon={true}
+            dimmer={true} header={lf("Move, edit, and insert blocks using your keyboard")}>
+            <div className="ui equal width grid">
+                <div className="column">
+                    <h3>{lf("Navigate")}</h3>
+                    <span className="ui small">{lf("Use the WASD keys to move between blocks. Hold shift to move on the workspace.")}</span>
+                </div>
+                <div className="column">
+                    <h3>{lf("Modify")}</h3>
+                    <span className="ui small">{lf("Press Enter to 'mark' a block, then X to disconnect, I to reconnect.")}</span>
+                </div>
+                <div className="column">
+                    <h3>{lf("Insert")}</h3>
+                    <span className="ui small">{lf("Use T to open the toolbox. Inside the toolbox, use WASD to navigate, and Enter to insert.")}</span>
+                </div>
+            </div>
+            <div className="ui grid">
+                <strong><a href="https://developers.google.com/blockly/guides/configure/web/keyboard-nav">
+                    {lf("See the official Blockly Documentation for additional detail")}
+                </a></strong>
+            </div>
+            
+        </sui.Modal>
+    }
+}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -38,6 +38,7 @@ import * as make from "./make";
 import * as blocklyToolbox from "./blocksSnippets";
 import * as monacoToolbox from "./monacoSnippets";
 import * as greenscreen from "./greenscreen";
+import * as accessibleblocks from "./accessibleblocks";
 import * as socketbridge from "./socketbridge";
 import * as webusb from "./webusb";
 import * as keymap from "./keymap";
@@ -3614,7 +3615,7 @@ export class ProjectView
         const inDebugMode = this.state.debugging;
         const inHome = this.state.home && !sandbox;
         const inEditor = !!this.state.header && !inHome;
-        const { lightbox, greenScreen } = this.state;
+        const { lightbox, greenScreen, accessibleBlocks } = this.state;
         const flyoutOnly = this.state.editorState && this.state.editorState.hasCategories === false;
 
         const { hideEditorToolbar, transparentEditorToolbar } = targetTheme;
@@ -3687,6 +3688,7 @@ export class ProjectView
         return (
             <div id='root' className={rootClasses}>
                 {greenScreen ? <greenscreen.WebCam close={this.toggleGreenScreen} /> : undefined}
+                {accessibleBlocks && <accessibleblocks.AccessibleBlocksInfo />}
                 {hideMenuBar || inHome ? undefined :
                     <header className="menubar" role="banner">
                         {inEditor ? <accessibility.EditorAccessibilityMenu parent={this} highContrast={this.state.highContrast} /> : undefined}

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -405,7 +405,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private initAccessibleBlocks() {
         const enabled = pxt.appTarget.appTheme?.accessibleBlocks;
-        this.parent.setAccessibleBlocks(enabled);
         // Append listener to open toolbox on 'T' key if accessible blocks is enabled
         if (enabled) {
             document.querySelector("#blocksEditor").addEventListener("keydown", this.handleKeyDown)

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -286,6 +286,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             <div className="ui divider"></div>
             {targetTheme.selectLanguage ? <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} /> : undefined}
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
+            {targetTheme.accessibleBlocks ? <sui.Item role="menuitem" text={accessibleBlocks ? lf("Accessible Blocks Off") : lf("Accessible Blocks On")} onClick={this.toggleAccessibleBlocks} /> : undefined}
             {showGreenScreen ? <sui.Item role="menuitem" text={greenScreen ? lf("Green Screen Off") : lf("Green Screen On")} onClick={this.toggleGreenScreen} /> : undefined}
             {docItems && renderDocItems(this.props.parent, docItems, "ui mobile only inherit")}
             {githubUser ? <div className="ui divider"></div> : undefined}


### PR DESCRIPTION
- Rename experiment to 'Accessible Blocks' for consistency
- Change behavior so experiment enables settings menu item (Accessible Blocks On) which defaults to off
- Add information dialog when toggling accessible blocks on, to explain keyboard commands

Fixes https://github.com/microsoft/pxt-microbit/issues/2779