### PR TITLE
Debugger variable view improvements

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -178,6 +178,9 @@
         font-size: 90%;
         margin-left: 0.5rem;
     }
+    .exception {
+        font-style: italic;
+    }
 }
 
 .debugging .ui.segment.debugvariables {

--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -112,6 +112,13 @@
         font-size: larger;
         color: black;
     }
+    .ui.variableTablePlaceholder {
+        padding: 1rem;
+        border: none;
+        font-family: @pageFont;
+        font-size: larger;
+        color: rgba(40, 40, 40, .3);
+    }
 }
 .ui.segment.debugvariables {
     width: 100%;

--- a/webapp/src/debuggerTable.tsx
+++ b/webapp/src/debuggerTable.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export interface DebuggerTableProps {
     header: string;
-    frozen?: boolean;
+    placeholderText?: string;
 }
 
 export class DebuggerTable extends React.Component<DebuggerTableProps> {
@@ -11,7 +11,12 @@ export class DebuggerTable extends React.Component<DebuggerTableProps> {
             <div className="ui variableTableHeader">
                 {this.props.header}
             </div>
-            <div className={`ui segment debugvariables ${this.props.frozen ? "frozen" : ""} ui collapsing basic striped table`}>
+            { this.props.placeholderText &&
+                <div className="ui variableTablePlaceholder">
+                    { this.props.placeholderText }
+                </div>
+            }
+            <div className={`ui segment debugvariables collapsing basic striped table`}>
                 {this.props.children}
             </div>
         </div>

--- a/webapp/src/debuggerVariables.tsx
+++ b/webapp/src/debuggerVariables.tsx
@@ -86,8 +86,17 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             variables = stackFrames[this.props.activeFrame].variables.concat(variables);
         }
 
-        return <DebuggerTable header={variableTableHeader} frozen={frozen}>
-            {this.renderVars(variables)}
+        let placeholderText: string;
+
+        if (frozen) {
+            placeholderText = lf("Code is running...");
+        }
+        else if (!variables.length) {
+            placeholderText = lf("No variables to show");
+        }
+
+        return <DebuggerTable header={variableTableHeader} placeholderText={placeholderText}>
+            { !placeholderText && this.renderVars(variables) }
         </DebuggerTable>
     }
 

--- a/webapp/src/debuggerVariables.tsx
+++ b/webapp/src/debuggerVariables.tsx
@@ -77,13 +77,14 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
 
     renderCore() {
         const { globalFrame, stackFrames, frozen } = this.state;
+        const { activeFrame, breakpoint } = this.props;
         const variableTableHeader = lf("Variables");
         let variables = globalFrame.variables;
 
         // Add in the local variables.
         // TODO: Handle callstack
-        if (stackFrames && stackFrames.length && this.props.activeFrame !== undefined) {
-            variables = stackFrames[this.props.activeFrame].variables.concat(variables);
+        if (stackFrames && stackFrames.length && activeFrame !== undefined) {
+            variables = stackFrames[activeFrame].variables.concat(variables);
         }
 
         let placeholderText: string;
@@ -91,12 +92,23 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
         if (frozen) {
             placeholderText = lf("Code is running...");
         }
-        else if (!variables.length) {
+        else if (!variables.length && !breakpoint?.exceptionMessage) {
             placeholderText = lf("No variables to show");
         }
 
+        const tableRows = placeholderText ? [] : this.renderVars(variables);
+
+        if (breakpoint?.exceptionMessage && !frozen) {
+            tableRows.unshift(<DebuggerTableRow
+                leftText={lf("Exception:")}
+                leftClass="exception"
+                rightText={truncateLength(breakpoint.exceptionMessage)}
+                rightTitle={breakpoint.exceptionMessage}
+            />);
+        }
+
         return <DebuggerTable header={variableTableHeader} placeholderText={placeholderText}>
-            { !placeholderText && this.renderVars(variables) }
+            { tableRows }
         </DebuggerTable>
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2777
Fixes https://github.com/microsoft/pxt-microbit/issues/2738

This PR contains three changes

1. If the code is running, we now show a message instead of the variables from the last stack frame
2. If there are no variables visible at the current breakpoint, we now show a message instead of an empty toolbox
3. Exception messages are now displayed at the top of the variable pane when paused on an exception

And here's a GIF showing all of that off:

![2020-04-06 16 25 40](https://user-images.githubusercontent.com/13754588/78614432-67ddd080-7823-11ea-9eea-0d1f576f1a4c.gif)

Probably needs a UI review
