### PR TITLE
Limit toolbox animation to once per session, fix issues with advanced…

### DIFF
--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -233,6 +233,14 @@ namespace ts.pxtc.Util {
         localStorage.setItem("editorlangpref", lang);
     }
 
+    export function getToolboxAnimation(): string {
+        return localStorage.getItem("toolboxanimation");
+    }
+
+    export function setToolboxAnimation(): void {
+        localStorage.setItem("toolboxanimation", "1");
+    }
+
     // small deep equals for primitives, objects, arrays. returns error message
     export function deq(a: any, b: any): string {
         if (a === b) return null;

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -204,7 +204,7 @@ div.blocklyTreeIcon span {
       Toolbox Animation
 *******************************/
 #monacoEditorToolbox {
-    .blocklyTreeRoot > div > div > .blocklyTreeRow {
+    .blocklyTreeRoot > div > div > .blocklyTreeAnimate {
         animation: gliss 0.6s ease-in-out;
     }
 }
@@ -308,7 +308,7 @@ div.blocklyTreeIcon span {
         width: @blocklyRowWidthMobile;
     }
     #monacoEditorToolbox {
-        .blocklyTreeRoot > div > div > .blocklyTreeRow {
+        .blocklyTreeRoot > div > div > .blocklyTreeAnimate {
             animation: glisssmall 0.6s ease-in-out;
         }
     }


### PR DESCRIPTION
…, fullscreensim

- Less intrusive animation (stored in localstorage)
- Runs the first time they enter monaco

This might be too infrequent, but it sort of makes sense to me to only show it the first time they enter monaco--if a user is frequently visiting the text editor they probably don't need the toolbox hint anyway.

Fixes https://github.com/microsoft/pxt-microbit/issues/2768
Fixes https://github.com/microsoft/pxt-microbit/issues/2720