### PR TITLE
Fix script manager duplicate renaming

### DIFF
--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -493,7 +493,7 @@ function cloudSyncAsync(): Promise<void> {
     async function resolveConflictAsync(header: Header, cloudHeader: FileInfo) {
         // rename current script
         let text = await ws.getTextAsync(header.id)
-        let newHd = await ws.duplicateAsync(header, text, true)
+        let newHd = await ws.duplicateAsync(header, text, ws.createDuplicateName(header))
         header.blobId = null
         header.blobVersion = null
         header.blobCurrent = false

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -493,7 +493,7 @@ function cloudSyncAsync(): Promise<void> {
     async function resolveConflictAsync(header: Header, cloudHeader: FileInfo) {
         // rename current script
         let text = await ws.getTextAsync(header.id)
-        let newHd = await ws.duplicateAsync(header, text, ws.createDuplicateName(header))
+        let newHd = await ws.duplicateAsync(header, text)
         header.blobId = null
         header.blobVersion = null
         header.blobCurrent = false

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -179,29 +179,21 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
         };
         return core.promptAsync(opts).then(res => {
             if (res === null) return Promise.resolve(false); // null means cancelled, empty string means ok (but no value entered)
-            let files: pxt.Map<string>;
             return workspace.getTextAsync(header.id)
                 .then(text => {
-                    files = text;
                     // Duplicate the existing header
-                    return workspace.duplicateAsync(header, text, false);
+                    return workspace.duplicateAsync(header, text, res);
                 })
-                .then((clonedHeader) => {
+                .then(clonedHeader => {
                     // If we're cloud synced, update the cloudSync flag
                     if (this.props.parent.cloudSync()) clonedHeader.cloudSync = true;
 
-                    // Update the name of the new header
-                    clonedHeader.name = res;
                     delete clonedHeader.blobId
                     delete clonedHeader.blobVersion
                     delete clonedHeader.blobCurrent
-                    // Set the name in the pxt.json (config)
-                    let cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig
-                    cfg.name = clonedHeader.name
-                    files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
-                    return clonedHeader;
+
+                    return workspace.saveAsync(clonedHeader);
                 })
-                .then((clonedHeader) => workspace.saveAsync(clonedHeader, files))
                 .then(() => {
                     data.invalidate("headers:");
                     data.invalidate(`headers:${this.state.searchFor}`);

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -178,7 +178,8 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
             size: "tiny"
         };
         return core.promptAsync(opts).then(res => {
-            if (res === null) return Promise.resolve(false); // null means cancelled
+            if (res === null)
+                return false; // null means cancelled
             return workspace.getTextAsync(header.id)
                 .then(text => workspace.duplicateAsync(header, text, res))
                 .then(clonedHeader => {

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -178,12 +178,9 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
             size: "tiny"
         };
         return core.promptAsync(opts).then(res => {
-            if (res === null) return Promise.resolve(false); // null means cancelled, empty string means ok (but no value entered)
+            if (res === null) return Promise.resolve(false); // null means cancelled
             return workspace.getTextAsync(header.id)
-                .then(text => {
-                    // Duplicate the existing header
-                    return workspace.duplicateAsync(header, text, res);
-                })
+                .then(text => workspace.duplicateAsync(header, text, res))
                 .then(clonedHeader => {
                     // If we're cloud synced, update the cloudSync flag
                     if (this.props.parent.cloudSync()) clonedHeader.cloudSync = true;

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -412,25 +412,28 @@ export function renameAsync(h: Header, newName: string) {
     return cloudsync.renameAsync(h, newName);
 }
 
-export function duplicateAsync(h: Header, text: ScriptText, rename?: boolean): Promise<Header> {
+export function duplicateAsync(h: Header, text: ScriptText, newName?: string): Promise<Header> {
     const e = lookup(h.id)
     U.assert(e.header === h)
     const h2 = U.flatClone(h)
     e.header = h2
 
     h.id = U.guidGen()
-    if (rename) {
-        h.name = createDuplicateName(h);
+    let dupText = text;
+    if (newName) {
+        dupText = U.flatClone(text);
+        h.name = newName;
         const cfg = JSON.parse(text[pxt.CONFIG_NAME]) as pxt.PackageConfig
         cfg.name = h.name
-        text[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
+        dupText[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
     delete h._rev
     delete (h as any)._id
     delete h.githubCurrent
     delete h.githubId
     delete h.githubTag
-    return importAsync(h, text)
+
+    return importAsync(h, dupText)
         .then(() => h)
 }
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -413,20 +413,19 @@ export function renameAsync(h: Header, newName: string) {
 }
 
 export function duplicateAsync(h: Header, text: ScriptText, newName?: string): Promise<Header> {
+    if (!newName)
+        newName = createDuplicateName(h);
     const e = lookup(h.id)
     U.assert(e.header === h)
     const h2 = U.flatClone(h)
     e.header = h2
 
+    const dupText = U.flatClone(text);
     h.id = U.guidGen()
-    let dupText = text;
-    if (newName) {
-        dupText = U.flatClone(text);
-        h.name = newName;
-        const cfg = JSON.parse(text[pxt.CONFIG_NAME]) as pxt.PackageConfig;
-        cfg.name = h.name;
-        dupText[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
-    }
+    h.name = newName;
+    const cfg = JSON.parse(text[pxt.CONFIG_NAME]) as pxt.PackageConfig;
+    cfg.name = h.name;
+    dupText[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
 
     delete h._rev;
     delete (h as any)._id;

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -423,15 +423,16 @@ export function duplicateAsync(h: Header, text: ScriptText, newName?: string): P
     if (newName) {
         dupText = U.flatClone(text);
         h.name = newName;
-        const cfg = JSON.parse(text[pxt.CONFIG_NAME]) as pxt.PackageConfig
-        cfg.name = h.name
+        const cfg = JSON.parse(text[pxt.CONFIG_NAME]) as pxt.PackageConfig;
+        cfg.name = h.name;
         dupText[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
-    delete h._rev
-    delete (h as any)._id
-    delete h.githubCurrent
-    delete h.githubId
-    delete h.githubTag
+
+    delete h._rev;
+    delete (h as any)._id;
+    delete h.githubCurrent;
+    delete h.githubId;
+    delete h.githubTag;
 
     return importAsync(h, dupText)
         .then(() => h)


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2450

the cfg for the original file was being mutated - `getTextAsync` returns the actual object in memory, not a clone, which feels not ideal as it will arbitrarily persist or not depending on if the page gets refreshed or some other save gets applied first? It's not used a ton so can look at making it readonly if we want so we don't accidentally bypass save paths?

 Anyway it looked okay till you loaded it up without refreshing & the `header.name` got overrided by `pxt.json`'s config. that is stored in memory and not invalidated