### PR TITLE
Disable keyboard command for accessibility if experiment off, small c…

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -138,7 +138,7 @@ namespace pxt.blocks.layout {
 
     export function setCollapsedAll(ws: Blockly.WorkspaceSvg, collapsed: boolean) {
         ws.getTopBlocks(false)
-            .forEach(b => b.setCollapsed(collapsed));
+            .forEach(b => { if (b.isEnabled()) b.setCollapsed(collapsed) });
     }
 
     export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -138,7 +138,8 @@ namespace pxt.blocks.layout {
 
     export function setCollapsedAll(ws: Blockly.WorkspaceSvg, collapsed: boolean) {
         ws.getTopBlocks(false)
-            .forEach(b => { if (b.isEnabled()) b.setCollapsed(collapsed) });
+            .filter(b => b.isEnabled())
+            .forEach(b => b.setCollapsed(collapsed));
     }
 
     export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -414,7 +414,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const onBlocklyAction = Blockly.navigation.onBlocklyAction;
         Blockly.navigation.onBlocklyAction = function (action) {
             if (pxt.appTarget.appTheme?.accessibleBlocks) {
-                if (!(Blockly.getMainWorkspace() as any).keyboardAccessibilityMode &&
+                if (!self.editor.keyboardAccessibilityMode &&
                     (action as any).name === Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
                     self.parent.setState({ accessibleBlocks: true });
                 }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -410,6 +410,18 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             document.querySelector("#blocksEditor").addEventListener("keydown", this.handleKeyDown)
         }
 
+        const self = this;
+        const onBlocklyAction = Blockly.navigation.onBlocklyAction;
+        Blockly.navigation.onBlocklyAction = function (action) {
+            if (pxt.appTarget.appTheme?.accessibleBlocks) {
+                if (!(Blockly.getMainWorkspace() as any).keyboardAccessibilityMode &&
+                    (action as any).name === Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
+                    self.parent.setState({ accessibleBlocks: true });
+                }
+                return onBlocklyAction(action);
+            }
+            return false;
+        };
     }
 
     private reportDeprecatedBlocks() {


### PR DESCRIPTION
…ollapse all fix

- Only allow ctrl+shift+k shortcut if accessibility experiment is turned on
- Collapse all should only collapse blocks that are enabled (event handlers)