### PR TITLE
Bump pxt-blockly to 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.5",
+    "pxt-blockly": "3.0.6",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
- Only draw accessibility cursor if mode is enabled (https://github.com/microsoft/pxt-blockly/pull/283)
- Adding go to definition and removing edit function from calls (https://github.com/microsoft/pxt-blockly/pull/282)
- Fixing exception on disabled breakpoints (https://github.com/microsoft/pxt-blockly/pull/281)
- Add EDGE_OR_IE useragent for flyout button (https://github.com/microsoft/pxt-blockly/pull/280)