### PR TITLE
Fill default values into blockdef for search, add param jsdoc

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1209,20 +1209,32 @@ namespace ts.pxtc.service {
 
             // Fill default parameters in block string
             const computeBlockString = (symbol: SymbolInfo): string => {
-                let block = symbol.attributes.block;
-                if (symbol.attributes?.paramDefl) {
-                    const paramDefl = symbol.attributes.paramDefl;
-                    for (let param in paramDefl) {
-                        if (block.indexOf(`%${param}`) >= 0) {
-                            block = block.replace(`%${param}`, paramDefl[param]);
-                        } else if (!parseInt(paramDefl[param])) {
-                            // If default param name is not found, and value is not a number
-                            // append to the end of the block string
-                            block = block + " " + paramDefl[param];
+                if (symbol.attributes?.paramDefl && symbol.attributes?._def) {
+                    let block = [];
+                    const blockDef = symbol.attributes._def;
+                    const paramDefl = Object.assign({}, symbol.attributes.paramDefl);
+
+                    // Construct block string from parsed blockdef
+                    for (let part of blockDef.parts) {
+                        switch (part.kind) {
+                            case "label":
+                                block.push(part.text);
+                                break;
+                            case "param":
+                                block.push(paramDefl[part.name] || part.name);
+                                delete paramDefl[part.name];
+                                break;
                         }
                     }
+
+                    // Append values we don't find to the end of the string
+                    for (let param in paramDefl) {
+                        block.push(paramDefl[param]);
+                    }
+
+                    return block.join(" ");
                 }
-                return block;
+                return symbol.attributes.block;
             }
 
             // Join parameter jsdoc into a string

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1209,10 +1209,10 @@ namespace ts.pxtc.service {
 
             // Fill default parameters in block string
             const computeBlockString = (symbol: SymbolInfo): string => {
-                if (symbol.attributes?.paramDefl && symbol.attributes?._def) {
+                if (symbol.attributes?._def) {
                     let block = [];
                     const blockDef = symbol.attributes._def;
-                    const paramDefl = Object.assign({}, symbol.attributes.paramDefl);
+                    const compileInfo = pxt.blocks.compileInfo(symbol);
 
                     // Construct block string from parsed blockdef
                     for (let part of blockDef.parts) {
@@ -1221,15 +1221,14 @@ namespace ts.pxtc.service {
                                 block.push(part.text);
                                 break;
                             case "param":
-                                block.push(paramDefl[part.name] || part.name);
-                                delete paramDefl[part.name];
+                                // In order, preference default value, var name, param name, blockdef param name
+                                let actualParam = compileInfo.definitionNameToParam[part.name];
+                                block.push(actualParam?.defaultValue
+                                    || part.varName
+                                    || actualParam?.actualName
+                                    || part.name);
                                 break;
                         }
-                    }
-
-                    // Append values we don't find to the end of the string
-                    for (let param in paramDefl) {
-                        block.push(paramDefl[param]);
                     }
 
                     return block.join(" ");

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1555,6 +1555,7 @@ namespace ts.pxtc.service {
         field?: [string, string];
         localizedCategory?: string;
         builtinBlock?: boolean;
+        params?: string;
     }
 
     export interface ProjectSearchOptions {


### PR DESCRIPTION
The user reads the default parameter values when they scan the block in the toolbox so it makes sense to add them to the block string for search. Also adds a field for param jsdoc, but weighted much lighter.

Fixes https://github.com/microsoft/pxt-microbit/issues/2467