### PR TITLE
Don't collapse submenu when clearing toolbox selection

### DIFF
--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -188,7 +188,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     }
 
     clearSelection() {
-        this.setState({ selectedItem: undefined, expandedItem: undefined, focusSearch: false })
+        this.setState({ selectedItem: undefined, focusSearch: false })
     }
 
     clearSearch() {


### PR DESCRIPTION
https://makecode.microbit.org/app/4d050dbac3a24db5fe489aa2c98d8cb491c201bd-e0a8de7603

Leaves toolbox "..." submenu open for last selected category

Fixes https://github.com/microsoft/pxt-microbit/issues/2143