### PR TITLE
Removing extra newlines in comments and fixing transpiler bug

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1710,7 +1710,7 @@ namespace pxt.blocks {
                     });
                 }
                 if (b.type == ts.pxtc.ON_START_TYPE)
-                    append(stmtsMain, compileStartEvent(e, b).children);
+                    append(stmtsMain, compileStatementBlock(e, b));
                 else {
                     const compiled = mkBlock(compileStatementBlock(e, b));
                     if (compiled.type == NT.Block)
@@ -1973,40 +1973,10 @@ namespace pxt.blocks {
 
     function addCommentNodes(comments: string[], r: JsNode[]) {
         const commentNodes: JsNode[] = []
-        const paragraphs: string[] = []
 
         for (const comment of comments) {
-            for (const paragraph of comment.split("\n")) {
-                paragraphs.push(paragraph)
-            }
-        }
-
-        for (let i = 0; i < paragraphs.length; i++) {
-            // Wrap paragraph lines
-            const words = paragraphs[i].split(/\s/)
-            let currentLine: string;
-            for (const word of words) {
-                if (!currentLine) {
-                    currentLine = word
-                }
-                else if (currentLine.length + word.length > MAX_COMMENT_LINE_LENGTH) {
-                    commentNodes.push(mkText(`// ${currentLine}`))
-                    commentNodes.push(mkNewLine())
-                    currentLine = word
-                }
-                else {
-                    currentLine += " " + word
-                }
-            }
-
-            if (currentLine) {
-                commentNodes.push(mkText(`// ${currentLine}`))
-                commentNodes.push(mkNewLine())
-            }
-
-            // The decompiler expects an empty comment line between paragraphs
-            if (i !== paragraphs.length - 1) {
-                commentNodes.push(mkText(`//`))
+            for (const line of comment.split("\n")) {
+                commentNodes.push(mkText(`// ${line}`))
                 commentNodes.push(mkNewLine())
             }
         }

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -3730,10 +3730,6 @@ ${output}</xml>`;
                     out += line.trim() + "\n";
                 }
             }
-
-            if (comment.hasTrailingNewline) {
-                out += "\n";
-            }
         }
 
         return out.trim();

--- a/pxtcompiler/emitter/transpile.ts
+++ b/pxtcompiler/emitter/transpile.ts
@@ -115,7 +115,7 @@ namespace ts.pxtc.transpile {
         }
         let tsSrc = program.getSourceFile(filename)
         U.assert(tsSrc !== undefined && tsSrc !== null, `Missing file "${filename}" when converting from ts->py`)
-        let fromTxt = tsSrc.getText()
+        let fromTxt = tsSrc.getFullText()
 
         return transpileInternal("ts", fromTxt, "py", doRealTranspile)
     }

--- a/tests/decompile-test/baselines/comments.blocks
+++ b/tests/decompile-test/baselines/comments.blocks
@@ -93,7 +93,7 @@
 <comment pinned="false">Comment</comment>
 </block>
 </next>
-<comment pinned="false">Paragraphs from&#10;&#10;&#10;&#10;single-line comments</comment>
+<comment pinned="false">Paragraphs from&#10;&#10;single-line comments</comment>
 </block>
 </next>
 <comment pinned="false">Whitespace between comments and statement</comment>
@@ -117,7 +117,7 @@
 <comment pinned="false">Multi line with&#10;no asterisks on body</comment>
 </block>
 </next>
-<comment pinned="false">Multiple&#10;&#10;Single-line&#10;&#10;Comments</comment>
+<comment pinned="false">Multiple&#10;Single-line&#10;Comments</comment>
 </block>
 </next>
 <comment pinned="false">Single-line comment</comment>


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2723

This is a few tiny bugs:
1. Decompiler was adding extra newlines to comments
2. BlocklyCompiler was still using the old comment logic that also added extra newlines
3. The transpiler was calling getText() instead of getFullText() when going from python to typescript which strips leading comments