### PR TITLE
Fix backspace in image editor text fields

### DIFF
--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -29,7 +29,6 @@ function handleUndoRedo(event: KeyboardEvent) {
 
 function overrideBlocklyShortcuts(event: KeyboardEvent) {
     if (event.key === "Backspace" || event.key === "Delete") {
-        event.preventDefault();
         event.stopPropagation();
     }
 }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1834

I thought the event ordering would have handled this but I was mistaken; we don't need the prevent default anyways as stopPropagation is enough to prevent the event from bubbling to blockly.