### PR TITLE
Use language service to fetch help info

### DIFF
--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -450,6 +450,7 @@ declare namespace Math {
      * @param x An angle in radians
      */
     //% shim=Math_::sin
+    //% help=math/trigonometry
     function sin(x: number): number;
 
     /**
@@ -457,6 +458,7 @@ declare namespace Math {
      * @param x An angle in radians
      */
     //% shim=Math_::cos
+    //% help=math/trigonometry
     function cos(x: number): number;
 
     /**
@@ -507,6 +509,7 @@ declare namespace Math {
      * @param x A numeric expression.
      */
     //% shim=Math_::ceil
+      //% help=math
     function ceil(x: number): number;
 
     /**
@@ -514,6 +517,7 @@ declare namespace Math {
       * @param x A numeric expression.
       */
     //% shim=Math_::floor
+      //% help=math
     function floor(x: number): number;
 
     /**
@@ -521,6 +525,7 @@ declare namespace Math {
       * @param x A numeric expression.
       */
     //% shim=Math_::trunc
+    //% help=math
     function trunc(x: number): number;
 
     /**
@@ -528,6 +533,7 @@ declare namespace Math {
       * @param x The value to be rounded to the nearest number.
       */
     //% shim=Math_::round
+    //% help=math
     function round(x: number): number;
 
     /**

--- a/docs/static/playground/pxt-common/pxt-helpers.js
+++ b/docs/static/playground/pxt-common/pxt-helpers.js
@@ -417,6 +417,7 @@ namespace Math {
       * For example, the absolute value of -5 is the same as the absolute value of 5.
       * @param x A numeric expression for which the absolute value is needed.
       */
+    //% help=math/abs
     export function abs(x: number): number {
         return x < 0 ? -x : x;
     }
@@ -434,6 +435,7 @@ namespace Math {
     /**
       * Returns the larger of two supplied numeric expressions.
       */
+    //% help=math/max
     export function max(a: number, b: number): number {
         if (a >= b) return a;
         return b;
@@ -442,6 +444,7 @@ namespace Math {
     /**
       * Returns the smaller of two supplied numeric expressions.
       */
+    //% help=math/min
     export function min(a: number, b: number): number {
         if (a <= b) return a;
         return b;

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -450,6 +450,7 @@ declare namespace Math {
      * @param x An angle in radians
      */
     //% shim=Math_::sin
+    //% help=math/trigonometry
     function sin(x: number): number;
 
     /**
@@ -457,6 +458,7 @@ declare namespace Math {
      * @param x An angle in radians
      */
     //% shim=Math_::cos
+    //% help=math/trigonometry
     function cos(x: number): number;
 
     /**
@@ -507,6 +509,7 @@ declare namespace Math {
      * @param x A numeric expression.
      */
     //% shim=Math_::ceil
+      //% help=math
     function ceil(x: number): number;
 
     /**
@@ -514,6 +517,7 @@ declare namespace Math {
       * @param x A numeric expression.
       */
     //% shim=Math_::floor
+      //% help=math
     function floor(x: number): number;
 
     /**
@@ -521,6 +525,7 @@ declare namespace Math {
       * @param x A numeric expression.
       */
     //% shim=Math_::trunc
+    //% help=math
     function trunc(x: number): number;
 
     /**
@@ -528,6 +533,7 @@ declare namespace Math {
       * @param x The value to be rounded to the nearest number.
       */
     //% shim=Math_::round
+    //% help=math
     function round(x: number): number;
 
     /**

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -417,6 +417,7 @@ namespace Math {
       * For example, the absolute value of -5 is the same as the absolute value of 5.
       * @param x A numeric expression for which the absolute value is needed.
       */
+    //% help=math/abs
     export function abs(x: number): number {
         return x < 0 ? -x : x;
     }
@@ -434,6 +435,7 @@ namespace Math {
     /**
       * Returns the larger of two supplied numeric expressions.
       */
+    //% help=math/max
     export function max(a: number, b: number): number {
         if (a >= b) return a;
         return b;
@@ -442,6 +444,7 @@ namespace Math {
     /**
       * Returns the smaller of two supplied numeric expressions.
       */
+    //% help=math/min
     export function min(a: number, b: number): number {
         if (a <= b) return a;
         return b;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1007,7 +1007,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     }
                 }
 
-                core.warningNotification(Util.lf("Help resource  not found"))
+                core.warningNotification(Util.lf("Help resource not found"))
             });
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1006,6 +1006,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         }
                     }
                 }
+
+                core.warningNotification(Util.lf("Help resource  not found"))
             });
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -991,18 +991,22 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private loadReference() {
         Util.assert(this.editor != undefined); // Guarded
-        let currentPosition = this.editor.getPosition();
-        let wordInfo = this.editor.getModel().getWordAtPosition(currentPosition);
-        if (!wordInfo) return;
-        let prevWordInfo = this.editor.getModel().getWordUntilPosition(new monaco.Position(currentPosition.lineNumber, wordInfo.startColumn - 1));
-        if (prevWordInfo && wordInfo) {
-            let namespaceName = prevWordInfo.word.replace(/([A-Z]+)/g, "-$1");
-            let methodName = wordInfo.word.replace(/([A-Z]+)/g, "-$1");
-            this.parent.setSideDoc(`/reference/${namespaceName}/${methodName}`, false);
-        } else if (wordInfo) {
-            let methodName = wordInfo.word.replace(/([A-Z]+)/g, "-$1");
-            this.parent.setSideDoc(`/reference/${methodName}`, false);
-        }
+
+        const model = this.editor.getModel();
+        const offset = model.getOffsetAt(this.editor.getPosition());
+        const source = model.getValue();
+        const fileName = this.currFile.name;
+        compiler.syntaxInfoAsync("symbol", fileName, offset, source)
+            .then(info => {
+                if (info?.symbols) {
+                    for (const s of info.symbols) {
+                        if (s.attributes.help) {
+                            this.parent.setSideDoc('/reference/' + s.attributes.help.replace(/^\//, ''));
+                            return;
+                        }
+                    }
+                }
+            });
     }
 
     private setupFieldEditors() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2676
Fixes https://github.com/microsoft/pxt-microbit/issues/2797

Switching the help command in monaco to use the language service instead of constructing a help URL from whatever happens to be in the editor. Also adding the help URLs for the builtin math functions. @ganicke you might want to do a pass on the APIs in `libs/pxt-common`, I just added the ones I saw pages for.