### PR TITLE
Use config name instead of id when checking for localization files

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -685,7 +685,7 @@ namespace pxt {
          */
         packageLocalizationStringsAsync(lang: string): Promise<Map<string>> {
             const targetId = pxt.appTarget.id;
-            const filenames = [this.id + "-jsdoc", this.id];
+            const filenames = [this.config.name + "-jsdoc", this.config.name];
             const r: Map<string> = {};
             const theme = pxt.appTarget.appTheme || {};
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2251

The id of the package is the id it was assigned inside of the parent package's pxt.json. I think this bug went undiscovered because it usually always matches but technically we don't require them to match.