### PR TITLE
Unifiying dialogs for webusb/download

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -23,8 +23,6 @@ declare namespace pxt {
         // localized galleries
         localizedGalleries?: pxt.Map<pxt.Map<string>>;
         windowsStoreLink?: string;
-        // link to the latest firmware urls (boardid -> url)
-        firmwareUrls?: pxt.Map<string>;
         // release manifest for the electron app
         electronManifest?: pxt.electron.ElectronManifest;
     }

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -83,6 +83,7 @@ declare namespace pxt {
         experimentalHw?: boolean;
         requiredCategories?: string[]; // ensure that those block categories are visible
         supportedTargets?: string[]; // a hint about targets in which this extension is supported
+        firmwareUrl?: string; // link to documentation page about upgrading firmware
     }
 
     interface PackageExtension {

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -317,7 +317,8 @@ namespace pxt.editor {
         showPackageDialog(): void;
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
-        pairAsync(autoConnect: boolean): Promise<void>;
+        pairAsync(): Promise<void>;
+        connectAsync(): Promise<void>;
         disconnectAsync(): Promise<void>;
 
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;
@@ -375,6 +376,7 @@ namespace pxt.editor {
         deployAsync?: (r: pxtc.CompileResult) => Promise<void>;
         saveOnlyAsync?: (r: ts.pxtc.CompileResult) => Promise<void>;
         saveProjectAsync?: (project: pxt.cpp.HexFile) => Promise<void>;
+        renderBrowserDownloadInstructions?: () => any /* JSX.Element */;
         showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void>;
         toolboxOptions?: IToolboxOptions;
         blocklyPatch?: (pkgTargetVersion: string, dom: Element) => void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -377,11 +377,11 @@ namespace pxt.editor {
         saveOnlyAsync?: (r: ts.pxtc.CompileResult) => Promise<void>;
         saveProjectAsync?: (project: pxt.cpp.HexFile) => Promise<void>;
         renderBrowserDownloadInstructions?: () => any /* JSX.Element */;
-        renderUsbPairDialog?: () => any /* JSX.Element */;
+        renderUsbPairDialog?: (firmwareUrl?: string) => any /* JSX.Element */;
         showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void>;
         toolboxOptions?: IToolboxOptions;
         blocklyPatch?: (pkgTargetVersion: string, dom: Element) => void;
-        webUsbPairDialogAsync?: (confirmAsync: (options: any) => Promise<number>) => Promise<number>;
+        webUsbPairDialogAsync?: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number>;
         mkPacketIOWrapper?: (io: pxt.packetio.PacketIO) => pxt.packetio.PacketIOWrapper;
 
         // Used with the @tutorialCompleted macro. See docs/writing-docs/tutorials.md for more info

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -377,6 +377,7 @@ namespace pxt.editor {
         saveOnlyAsync?: (r: ts.pxtc.CompileResult) => Promise<void>;
         saveProjectAsync?: (project: pxt.cpp.HexFile) => Promise<void>;
         renderBrowserDownloadInstructions?: () => any /* JSX.Element */;
+        renderUsbPairDialog?: () => any /* JSX.Element */;
         showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void>;
         toolboxOptions?: IToolboxOptions;
         blocklyPatch?: (pkgTargetVersion: string, dom: Element) => void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -377,7 +377,7 @@ namespace pxt.editor {
         saveOnlyAsync?: (r: ts.pxtc.CompileResult) => Promise<void>;
         saveProjectAsync?: (project: pxt.cpp.HexFile) => Promise<void>;
         renderBrowserDownloadInstructions?: () => any /* JSX.Element */;
-        renderUsbPairDialog?: (firmwareUrl?: string) => any /* JSX.Element */;
+        renderUsbPairDialog?: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */;
         showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void>;
         toolboxOptions?: IToolboxOptions;
         blocklyPatch?: (pkgTargetVersion: string, dom: Element) => void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -403,12 +403,10 @@ namespace pxt.editor {
                                         .then(() => projectView.printCode());
                                 }
                                 case "pair": {
-                                    return Promise.resolve()
-                                        .then(() => projectView.pairAsync(false));
+                                    return projectView.pairAsync();
                                 }
                                 case "connect": {
-                                    return Promise.resolve()
-                                        .then(() => projectView.pairAsync(true));
+                                    return projectView.connectAsync();
                                 }
                                 case "info": {
                                     return Promise.resolve()

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -17,10 +17,10 @@ namespace pxt.commands {
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
     export let renderBrowserDownloadInstructions: () => any /* JSX.Element */ = undefined;
-    export let renderUsbPairDialog: () => any /* JSX.Element */ = undefined;
+    export let renderUsbPairDialog: (firmwareUrl?: string) => any /* JSX.Element */ = undefined;
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void> = undefined;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
-    export let webUsbPairDialogAsync: (confirmAsync: (options: any) => Promise<number>) => Promise<number> = undefined;
+    export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number> = undefined;
     export let onTutorialCompleted: () => void = undefined;
 }

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -16,6 +16,7 @@ namespace pxt.commands {
     export let patchCompileResultAsync: (r: pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
+    export let renderBrowserDownloadInstructions: () => any /* JSX.Element */ = undefined;
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void> = undefined;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -17,7 +17,7 @@ namespace pxt.commands {
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
     export let renderBrowserDownloadInstructions: () => any /* JSX.Element */ = undefined;
-    export let renderUsbPairDialog: (firmwareUrl?: string) => any /* JSX.Element */ = undefined;
+    export let renderUsbPairDialog: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */ = undefined;
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void> = undefined;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -17,6 +17,7 @@ namespace pxt.commands {
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
     export let renderBrowserDownloadInstructions: () => any /* JSX.Element */ = undefined;
+    export let renderUsbPairDialog: () => any /* JSX.Element */ = undefined;
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void> = undefined;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -398,13 +398,10 @@ namespace pxt.usb {
         }
     }
 
-    export function pairAsync(): Promise<void> {
+    export function pairAsync(): Promise<boolean> {
         return ((navigator as any).usb.requestDevice({
             filters: filters
-        }) as Promise<USBDevice>).then(dev => {
-            // try connecting to it
-            return pxt.usb.mkPacketIOAsync()
-        }).then(io => io.reconnectAsync())
+        }) as Promise<USBDevice>).then(dev => !!dev)
     }
 
     export function isPairedAsync(): Promise<boolean> {

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -401,7 +401,14 @@ namespace pxt.usb {
     export function pairAsync(): Promise<boolean> {
         return ((navigator as any).usb.requestDevice({
             filters: filters
-        }) as Promise<USBDevice>).then(dev => !!dev)
+        }) as Promise<USBDevice>)
+            .then(dev => !!dev)
+            .catch(e => {
+                // user cancelled
+                if (e.name == "NotFoundError")
+                    return undefined;
+                throw e;
+            })
     }
 
     export function isPairedAsync(): Promise<boolean> {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2190,38 +2190,16 @@ export class ProjectView
             );
     }
 
-    private connectAsync() {
-        cmds.setWebUSBPaired(true);
-        return pxt.packetio.initAsync()
-            .then(wrapper => wrapper.reconnectAsync())
-            .then(() => core.infoNotification(lf("Device connected! Try downloading now.")))
-            .catch((err) => {
-                pxt.reportException(err);
-                core.errorNotification(lf("Connection error: {0}", err.message))
-            });
-    }
-
     disconnectAsync(): Promise<void> {
-        return cmds.disconnectAsync()
-            .then(() => core.infoNotification("Device disconnected"));
+        return cmds.disconnectAsync();
     }
 
-    async pairAsync(autoConnect: boolean): Promise<void> {
-        if (autoConnect) {
-            const dev = await pxt.usb.tryGetDeviceAsync();
-            if (dev) {
-                this.connectAsync();
-                return;
-            }
-        }
+    connectAsync(): Promise<void> {
+        return cmds.connectAsync();
+    }
 
-        let res = 1;
-        if (pxt.commands.webUsbPairDialogAsync)
-            res = await pxt.commands.webUsbPairDialogAsync(core.confirmAsync);
-        if (res) {
-            pxt.usb.pairAsync()
-                .then(() => this.connectAsync());
-        }
+    pairAsync(): Promise<void> {
+        return cmds.pairAsync();
     }
 
     ///////////////////////////////////////////////////////////
@@ -3778,7 +3756,7 @@ function render() {
     ReactDOM.render(<ProjectView />, sui.appElement);
 }
 
-function getEditor() {
+export function getEditor(): IProjectView {
     return theEditor
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2242,7 +2242,7 @@ export class ProjectView
         const variants = pxt.getHwVariants()
         if (variants.length == 0)
             return false
-        let pairAsync = () => webusb.showWebUSBPairingInstructionsAsync(null)
+        let pairAsync = () => cmds.pairAsync()
             .then(() => {
                 this.checkForHwVariant()
             }, err => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3756,7 +3756,7 @@ function render() {
     ReactDOM.render(<ProjectView />, sui.appElement);
 }
 
-export function getEditor(): IProjectView {
+function getEditor() {
     return theEditor
 }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -63,6 +63,24 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
     else return pxt.commands.showUploadInstructionsAsync(fn, url, core.confirmAsync);
 }
 
+function webUsbPairDialogAsync(confirmAsync: (options: any) => Promise<number>): Promise<number> {
+    const helpUrl = pxt.appTarget.appTheme.usbDocs;
+    const jsx = pxt.commands?.renderUsbPairDialog();
+    const body = !jsx && lf("Select your device from the dialog and click Pair.")
+
+    return confirmAsync({
+        header: lf("Pair device for one-click downloads"),
+        body,
+        jsx,
+        hasCloseIcon: true,
+        agreeLbl: lf("Pair device"),
+        agreeIcon: "usb",
+        hideCancel: true,
+        helpUrl,
+        className: 'downloaddialog'
+    });
+}
+
 function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (options: core.PromptOptions) => Promise<number>): Promise<void> {
     const boardName = pxt.appTarget.appTheme.boardName || lf("device");
     const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
@@ -294,6 +312,10 @@ function applyExtensionResult() {
         log(`extension upload renderBrowserDownloadInstructions`);
         pxt.commands.renderBrowserDownloadInstructions = res.renderBrowserDownloadInstructions;
     }
+    if (res.renderUsbPairDialog) {
+        log(`extension renderUsbPairDialog`)
+        pxt.commands.renderUsbPairDialog = res.renderUsbPairDialog;
+    }
     if (res.showUploadInstructionsAsync) {
         log(`extension upload instructions async`);
         pxt.commands.showUploadInstructionsAsync = res.showUploadInstructionsAsync;
@@ -327,6 +349,7 @@ export function init(): void {
     pxt.commands.deployCoreAsync = browserDownloadDeployCoreAsync;
     pxt.commands.browserDownloadAsync = browserDownloadAsync;
     pxt.commands.saveOnlyAsync = browserDownloadDeployCoreAsync;
+    pxt.commands.webUsbPairDialogAsync = webUsbPairDialogAsync;
     pxt.commands.showUploadInstructionsAsync = showUploadInstructionsAsync;
     // used by CLI pxt.commands.deployFallbackAsync = undefined;
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -203,7 +203,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     pair() {
         pxt.tickEvent("menu.pair");
-        this.props.parent.pairAsync(false);
+        this.props.parent.pairAsync();
     }
 
     pairBluetooth() {

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -180,7 +180,7 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
     }
     if (options.helpUrl) {
         options.buttons.unshift({
-            className: "help",
+            className: "circular help",
             title: lf("Help"),
             icon: "help",
             url: options.helpUrl

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -179,9 +179,9 @@ export function dialogAsync(options: DialogOptions): Promise<void> {
         })
     }
     if (options.helpUrl) {
-        options.buttons.push({
-            label: lf("Help"),
+        options.buttons.unshift({
             className: "help",
+            title: lf("Help"),
             icon: "help",
             url: options.helpUrl
         })

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -148,6 +148,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     }
 
     protected onConnectClick = () => {
+        pxt.tickEvent("editortools.connect", undefined, { interactiveConsent: true });
         this.props.parent.connectAsync();
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -148,7 +148,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     }
 
     protected onConnectClick = () => {
-        this.props.parent.pairAsync(true);
+        this.props.parent.connectAsync();
     }
 
     protected onDisconnectClick = () => {

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1105,7 +1105,8 @@ export class Menu extends data.Component<MenuProps, MenuState> {
 ///////////////////////////////////////////////////////////
 
 export interface ModalButton {
-    label: string;
+    label?: string;
+    title?: string;
     icon?: string; // defaults to "checkmark"
     className?: string; // defaults "positive"
     onclick?: () => (Promise<void> | void);
@@ -1314,7 +1315,8 @@ export class Modal extends React.Component<ModalProps, ModalState> {
                                 key={`action_${action.label}`}
                                 icon={action.icon}
                                 text={action.label}
-                                className={`ui button approve ${action.icon ? 'icon right labeled' : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""} ${action.disabled ? "disabled" : ""}`}
+                                title={action.title || action.label}
+                                className={`ui button approve ${action.icon ? 'icon right' : ''} ${action.label ? 'labeled' : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""} ${action.disabled ? "disabled" : ""}`}
                                 href={action.url}
                                 target={!action.fileName ? '_blank' : undefined}
                                 download={action.fileName ? pxt.Util.htmlEscape(action.fileName) : undefined}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1341,7 +1341,7 @@ class ModalButtonElement extends data.PureComponent<ModalButton, {}> {
     }
 
     handleClick() {
-        if (!this.props.disabled)
+        if (!this.props.disabled && this.props.onclick)
             this.props.onclick();
     }
 

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -79,7 +79,7 @@ export function webUsbPairDialogAsync(pairAsync: () => Promise<boolean>, confirm
                         icon: "usb",
                         className: "primary",
                         onclick: () => {
-                            core.showLoading("pair", lf("Select device to pair..."));
+                            core.showLoading("pair", lf("Select device and press 'Connect'..."));
                             pairAsync()
                                 .then(r => ok = !!r ? 1 : 0)
                                 .finally(() => {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -2,93 +2,95 @@ import * as React from "react";
 import * as core from "./core";
 import * as cmds from "./cmds";
 
-function firmwareUrlAsync(): Promise<string> {
-    return pxt.targetConfigAsync()
-        .then(config => {
-            const firmwareUrl = (config.firmwareUrls || {})[
-                pxt.appTarget.simulator.boardDefinition ? pxt.appTarget.simulator.boardDefinition.id
-                    : ""];
-            return firmwareUrl;
-        });
+function resolveFirmwareUrl(): string {
+    const boardid = pxt.appTarget?.simulator?.boardDefinition?.id;
+    if (boardid) {
+        const bundled = pxt.appTarget.bundledpkgs[boardid];
+        if (bundled) {
+            const cfg = pxt.Package.parseAndValidConfig(bundled[pxt.CONFIG_NAME]);
+            if (cfg) {
+                return cfg.firmwareUrl;
+            }
+        }
+    }
+    return undefined;
 }
 
 export function webUsbPairDialogAsync(pairAsync: () => Promise<boolean>, confirmAsync: (options: core.PromptOptions) => Promise<number>): Promise<number> {
     let ok = 0;
-    return firmwareUrlAsync()
-        .then(firmwareUrl => {
-            const boardName = pxt.appTarget.appTheme.boardName || lf("device");
-            const helpUrl = pxt.appTarget.appTheme.usbDocs;
-            const jsx = pxt.commands?.renderUsbPairDialog(firmwareUrl)
-                || <div className={`ui ${firmwareUrl ? "four" : "three"} column grid stackable`}>
-                    {firmwareUrl ? <div className="column firmware">
-                        <div className="ui">
-                            <div className="content">
-                                <div className="description">
-                                    {lf("First time here?")}
-                                    <br />
-                                    <a href={firmwareUrl} target="_blank" rel="noopener noreferrer">{lf("Check your firmware version and update if needed")}</a>
-                                </div>
-                            </div>
+    const firmwareUrl = resolveFirmwareUrl();
+    const boardName = pxt.appTarget.appTheme.boardName || lf("device");
+    const helpUrl = pxt.appTarget.appTheme.usbDocs;
+    const jsx = pxt.commands?.renderUsbPairDialog(firmwareUrl)
+        || <div className={`ui ${firmwareUrl ? "four" : "three"} column grid stackable`}>
+            {firmwareUrl ? <div className="column firmware">
+                <div className="ui">
+                    <div className="content">
+                        <div className="description">
+                            {lf("First time here?")}
+                            <br />
+                            <a href={firmwareUrl} target="_blank" rel="noopener noreferrer">{lf("Check your firmware version and update if needed")}</a>
                         </div>
                     </div>
-                        : undefined}
-                    <div className="column">
-                        <div className="ui">
-                            <div className="content">
-                                <div className="description">
-                                    <span className="ui yellow circular label">1</span>
-                                    <strong>{lf("Connect {0} to computer with USB cable", boardName)}</strong>
-                                    <br />
-                                </div>
-                            </div>
+                </div>
+            </div>
+                : undefined}
+            <div className="column">
+                <div className="ui">
+                    <div className="content">
+                        <div className="description">
+                            <span className="ui yellow circular label">1</span>
+                            <strong>{lf("Connect {0} to computer with USB cable", boardName)}</strong>
+                            <br />
                         </div>
                     </div>
-                    <div className="column">
-                        <div className="ui">
-                            <div className="content">
-                                <div className="description">
-                                    <span className="ui blue circular label">2</span>
-                                    {lf("Select the device in the pairing dialog")}
-                                </div>
-                            </div>
+                </div>
+            </div>
+            <div className="column">
+                <div className="ui">
+                    <div className="content">
+                        <div className="description">
+                            <span className="ui blue circular label">2</span>
+                            {lf("Select the device in the pairing dialog")}
                         </div>
                     </div>
-                    <div className="column">
-                        <div className="ui">
-                            <div className="content">
-                                <div className="description">
-                                    <span className="ui blue circular label">3</span>
-                                    {lf("Press \"Connect\"")}
-                                </div>
-                            </div>
+                </div>
+            </div>
+            <div className="column">
+                <div className="ui">
+                    <div className="content">
+                        <div className="description">
+                            <span className="ui blue circular label">3</span>
+                            {lf("Press \"Connect\"")}
                         </div>
                     </div>
-                </div>;
+                </div>
+            </div>
+        </div>;
 
-            return confirmAsync({
-                header: lf("Pair device for one-click downloads"),
-                jsx,
-                hasCloseIcon: true,
-                hideAgree: true,
-                hideCancel: true,
-                helpUrl,
-                className: 'downloaddialog',
-                buttons: [
-                    {
-                        label: lf("Pair device"),
-                        icon: "usb",
-                        className: "primary",
-                        onclick: () => {
-                            core.showLoading("pair", lf("Select device and press 'Connect'..."));
-                            pairAsync()
-                                .then(r => ok = !!r ? 1 : 0)
-                                .finally(() => {
-                                    core.hideLoading("pair")
-                                    core.hideDialog();
-                                });
-                        }
-                    }
-                ]
-            })
-        }).then(() => ok);
+    return confirmAsync({
+        header: lf("Pair device for one-click downloads"),
+        jsx,
+        hasCloseIcon: true,
+        hideAgree: true,
+        hideCancel: true,
+        helpUrl,
+        className: 'downloaddialog',
+        buttons: [
+            {
+                label: lf("Pair device"),
+                icon: "usb",
+                className: "primary",
+                onclick: () => {
+                    core.showLoading("pair", lf("Select device and press 'Connect'..."));
+                    pairAsync()
+                        .then(r => ok = !!r ? 1 : 0)
+                        .finally(() => {
+                            core.hideLoading("pair")
+                            core.hideDialog();
+                        });
+                }
+            }
+        ]
+    }).then(() => ok);
 }


### PR DESCRIPTION
WebUSB cleanup round 2. We have a bunch of logic around download dialogs that is duplicated in microbit, pxt and arcade. Unifying.

I will do another further PR to optimize the double pairing in Arcade.

- [x] remove old dialogs deprecated in favor of ... menu
- [x] new editor hooks to provide react body, leaving logic in pxt
- [x] clean connect/disconnect/pair apis
- [x] move help button as round button to the right
- [x] show firmware upgrade options after first fail
- [x] rename filename button to "download again" + connect button if supported
- [x] don't show firmware option in first pair to keep instructions low. Most likely user has already upgraded firwmare. Show orange box if pairing fails.

## microbit
- [x] connect
- [x] pair
- [x] auto connect

![image](https://user-images.githubusercontent.com/4175913/79006353-d36abb00-7b0d-11ea-8c9d-21e27abcd964.png)

![2020-04-10 09 27 59](https://user-images.githubusercontent.com/4175913/79006294-b209cf00-7b0d-11ea-9934-12cec4c293be.gif)
