### PR TITLE
Hide logo on mobile, darken button hover/focus

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -460,6 +460,11 @@ div.simframe > iframe {
     position: relative;
 }
 
+.ui.button:hover,
+.ui.button:focus {
+    filter: grayscale(.15) brightness(.85) contrast(1.3);
+}
+
 /* Icon and text */
 .ui.item.link.dbg-btn > .icon-and-text.icon ~ .ui.text,
 .ui.item.link > .icon-and-text.icon ~ .ui.text.exit-debugmode-btn,
@@ -1359,7 +1364,7 @@ p.ui.font.small {
         padding-bottom: 0.5rem;
     }
 
-    .logo-wide #mainmenu {
+    #mainmenu {
         .ui.logo.brand,
         .ui.logo.organization {
             display: none !important;


### PR DESCRIPTION
Old | New
-- | --
![bug-button-hover](https://user-images.githubusercontent.com/34112083/79173274-e4d0f300-7dab-11ea-8f6a-d360efde80c9.gif) | ![fix-button-hover](https://user-images.githubusercontent.com/34112083/79173288-eb5f6a80-7dab-11ea-8fed-2dc7da397fa3.gif)

Darken the hover state for all buttons, remove logo on mobile view.

Fixes https://github.com/microsoft/pxt-microbit/issues/2746
Fixes https://github.com/microsoft/pxt-microbit/issues/2677