### PR TITLE
Moving transpile cache into webapp and fixing snippet bug

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -798,7 +798,6 @@ declare namespace ts.pxtc {
         skipPxtModulesEmit?: boolean; // skip re-emit of pxt_modules/*
 
         syntaxInfo?: SyntaxInfo;
-        forceTranspile?: boolean;
 
         // decompiler only
         alwaysDecompileOnStart?: boolean;

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -801,7 +801,6 @@ namespace ts.pxtc.service {
             lastApiInfo = undefined
             lastGlobalNames = undefined
             host.reset()
-            transpile.resetCache()
         },
 
         setOptions: v => {

--- a/pxtcompiler/emitter/transpile.ts
+++ b/pxtcompiler/emitter/transpile.ts
@@ -3,9 +3,6 @@
 //      is easily handled if we used proper TS modules.
 //// <reference path="../../built/pxtpy.d.ts"/>
 
-// This code centralizes transpiling between typescript and python
-// so that we can cache results for better performance and user
-// experience (since compile -> decompile round-trips are lossy)
 namespace ts.pxtc.transpile {
     export interface TranspileCodeResult {
         outfiles: pxt.Map<string>,
@@ -20,103 +17,11 @@ namespace ts.pxtc.transpile {
 
     const mainName = (l: CodeLang) => `main.${l}`
 
-    export interface LangEquivSet extends TranspileCodeResult {
-        comparable: { [key in CodeLang]: string }
-    }
-    // a circular buffer of size MAX_CODE_EQUIVS that stores
-    // sets of equivalent code files so that when we translate
-    // from ts -> py -> ts we get back the same ts.
-    let codeEquivalences: LangEquivSet[] = []
-    const MAX_CODE_EQUIVS = 10
-
-    function toComparable(code: string): string {
-        // Note that whitespace is semantic for Python
-        return code
-    }
-    export function resetCache() {
-        codeEquivalences = []
-    }
-    function tryGetCachedTranspile(lang: CodeLang, txt: string): LangEquivSet | undefined {
-        let txtComp = toComparable(txt)
-        for (let eq of codeEquivalences) {
-            if (eq.comparable[lang] === txtComp) {
-                return eq
-            }
-        }
-        return undefined
-    }
-    function cacheTranspile(lang1: CodeLang, lang1Txt: string, lang2: CodeLang, lang2Txt: string, sourceMap: SourceInterval[]) {
-        let equiv: LangEquivSet = {
-            comparable: {
-                "ts": undefined,
-                "blocks": undefined,
-                "py": undefined
-            },
-            outfiles: {},
-            sourceMap
-        }
-        equiv.outfiles[mainName(lang1)] = lang1Txt
-        equiv.comparable[lang1] = toComparable(lang1Txt)
-        equiv.outfiles[mainName(lang2)] = lang2Txt
-        equiv.comparable[lang2] = toComparable(lang2Txt)
-
-        codeEquivalences.unshift(equiv)
-
-        if (codeEquivalences.length > MAX_CODE_EQUIVS) {
-            codeEquivalences.pop()
-        }
-    }
-    function makeSuccess(equiv: LangEquivSet): TranspileResult {
-        return {
-            diagnostics: [],
-            success: true,
-            outfiles: equiv.outfiles,
-            sourceMap: equiv.sourceMap,
-            globalNames: equiv.globalNames,
-            syntaxInfo: equiv.syntaxInfo
-        }
-    }
-
-    // @param force: forces a live transpile, and does not cache the result (unless forceOverwrite is true)
-    function transpileInternal(from: CodeLang, fromTxt: string, to: CodeLang, doRealTranspile: () => TranspileResult, force?: boolean, forceOverwrite?: boolean): TranspileResult {
-        let equiv = tryGetCachedTranspile(from, fromTxt)
-        if (equiv && equiv.outfiles[mainName(to)] && !force) {
-            // return from cache
-            let res = makeSuccess(equiv)
-            return res
-        }
-
-        // not found in cache, do the compile
-        let res = doRealTranspile()
-
-        if (res.success && (!force || forceOverwrite)) {
-            // store the result
-            let toTxt = res.outfiles[mainName(to)] || ""
-            cacheTranspile(from, fromTxt, to, toTxt, res.sourceMap)
-        }
-        return res
-    }
-
     export function pyToTs(options: pxtc.CompileOptions, filename: string = mainName("py")): TranspileResult {
-        let doRealTranspile = () => {
-            return (pxt as any).py.py2ts(options) as TranspileResult
-        }
-
-        let fromTxt = options.fileSystem[filename];
-        if (fromTxt === undefined || fromTxt === null)
-            fromTxt = ""; // don't crash if main.ts is missing, just create new file
-
-        return transpileInternal("py", fromTxt, "ts", doRealTranspile, !!(options.syntaxInfo || options.forceTranspile), !!options.forceTranspile)
+        return (pxt as any).py.py2ts(options) as TranspileResult;
     }
 
     export function tsToPy(program: ts.Program, filename: string = mainName("ts")): TranspileResult {
-        let doRealTranspile = () => {
-            return (pxt as any).py.decompileToPython(program, filename) as TranspileResult
-        }
-        let tsSrc = program.getSourceFile(filename)
-        U.assert(tsSrc !== undefined && tsSrc !== null, `Missing file "${filename}" when converting from ts->py`)
-        let fromTxt = tsSrc.getFullText()
-
-        return transpileInternal("ts", fromTxt, "py", doRealTranspile)
+        return (pxt as any).py.decompileToPython(program, filename) as TranspileResult;
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -544,7 +544,23 @@ export class ProjectView
     }
 
     openPythonAsync(): Promise<void> {
-        return this.convertTypeScriptToPythonAsync();
+        const pySrcFile = pkg.mainEditorPkg().files["main.py"];
+        if (pySrcFile) { // do we have any python yet?
+            // convert python to typescript, if same as current source, skip decompilation
+            const tsSrc = pkg.mainEditorPkg().files["main.ts"].content;
+            return this.textEditor.convertPythonToTypeScriptAsync()
+                .then(pyAsTsSrc => {
+                    if (pyAsTsSrc == tsSrc) {
+                        // decompiled python is same current typescript, go back to python without ts->py conversion
+                        pxt.debug(`ts -> py shortcut`)
+                        this.setFile(pySrcFile);
+                        return Promise.resolve();
+                    }
+                    else return this.convertTypeScriptToPythonAsync();
+                });
+        } else {
+            return this.convertTypeScriptToPythonAsync();
+        }
     }
 
     private convertTypeScriptToPythonAsync() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -544,47 +544,42 @@ export class ProjectView
     }
 
     openPythonAsync(): Promise<void> {
-        const pySrcFile = pkg.mainEditorPkg().files["main.py"];
-        if (pySrcFile) { // do we have any python yet?
-            // convert python to typescript, if same as current source, skip decompilation
-            const tsSrc = pkg.mainEditorPkg().files["main.ts"].content;
-            return this.textEditor.convertPythonToTypeScriptAsync()
-                .then(pyAsTsSrc => {
-                    if (pyAsTsSrc == tsSrc) {
-                        // decompiled python is same current typescript, go back to python without ts->py conversion
-                        pxt.debug(`ts -> py shortcut`)
-                        this.setFile(pySrcFile);
-                        return Promise.resolve();
-                    }
-                    else return this.convertTypeScriptToPythonAsync();
-                });
-        } else {
-            return this.convertTypeScriptToPythonAsync();
-        }
+        return this.convertTypeScriptToPythonAsync();
     }
 
     private convertTypeScriptToPythonAsync() {
         const snap = this.editor.snapshotState();
-        let p = this.saveTypeScriptAsync(false)
-            .then(() => compiler.pyDecompileAsync("main.ts"))
-            .then(cres => {
-                if (cres && cres.success) {
-                    const mainpy = cres.outfiles["main.py"];
-                    return this.saveVirtualFileAsync(pxt.PYTHON_PROJECT_NAME, mainpy, true);
-                } else {
-                    // TODO python
-                    this.editor.setDiagnostics(this.editorFile, snap);
-                    return Promise.resolve();
-                }
-            })
-            .catch(e => {
-                pxt.reportException(e);
-                core.errorNotification(lf("Oops, something went wrong trying to convert your code."));
-            })
-        if (open)
-            p = core.showLoadingAsync("switchtopython", lf("switching to Python..."), p);
+        const fromLanguage = this.isBlocksActive() ? "blocks" : "ts";
+        const fromText = this.editorFile.content;
+        const mainPkg = pkg.mainEditorPkg();
 
-        return p;
+        let convertPromise: Promise<void>;
+
+        const cached = mainPkg.getCachedTranspile(fromLanguage, fromText, "py");
+        if (cached) {
+            convertPromise = this.saveVirtualFileAsync(pxt.PYTHON_PROJECT_NAME, cached, true);
+        }
+        else {
+            convertPromise = this.saveTypeScriptAsync(false)
+                .then(() => compiler.pyDecompileAsync("main.ts"))
+                .then(cres => {
+                    if (cres && cres.success) {
+                        const mainpy = cres.outfiles["main.py"];
+                        mainPkg.cacheTranspile(fromLanguage, fromText, "py", mainpy);
+                        return this.saveVirtualFileAsync(pxt.PYTHON_PROJECT_NAME, mainpy, true);
+                    } else {
+                        // TODO python
+                        this.editor.setDiagnostics(this.editorFile, snap);
+                        return Promise.resolve();
+                    }
+                })
+                .catch(e => {
+                    pxt.reportException(e);
+                    core.errorNotification(lf("Oops, something went wrong trying to convert your code."));
+                })
+        }
+
+        return core.showLoadingAsync("switchtopython", lf("switching to Python..."), convertPromise);
     }
 
     openSimView() {
@@ -2154,12 +2149,33 @@ export class ProjectView
     }
 
     saveTypeScriptAsync(open = false): Promise<void> {
-        if (!this.editor || !this.state.currFile || this.editorFile.epkg != pkg.mainEditorPkg() || this.reload)
+        const mainPkg = pkg.mainEditorPkg();
+        if (!this.editor || !this.state.currFile || this.editorFile.epkg != mainPkg || this.reload)
             return Promise.resolve();
+
+        const fromLanguage = this.editorFile.getExtension() as pxtc.CodeLang;
+        const fromText = this.editorFile.content;
 
         let promise = open ? this.textEditor.loadMonacoAsync() : Promise.resolve();
         promise = promise
-            .then(() => this.editor.saveToTypeScriptAsync())
+            .then(() => {
+                if (open) {
+                    const cached = mainPkg.getCachedTranspile(fromLanguage, fromText, "ts");
+                    if (cached) {
+                        return Promise.resolve(cached);
+                    }
+
+                    return this.editor.saveToTypeScriptAsync()
+                        .then(src => {
+                            if (src !== undefined) {
+                                mainPkg.cacheTranspile(fromLanguage, fromText, "ts", src);
+                            }
+                            return src;
+                        });
+                }
+
+                return this.editor.saveToTypeScriptAsync()
+            })
             .then((src) => {
                 if (src === undefined && open) { // failed to convert
                     return core.confirmAsync({

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -219,7 +219,6 @@ export function py2tsAsync(force = false): Promise<pxtc.transpile.TranspileResul
         .then(() => pkg.mainPkg.getCompileOptionsAsync(trg))
         .then(opts => {
             opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME
-            if (force) opts.forceTranspile = true;
 
             return workerOpAsync("py2ts", { options: opts })
         })
@@ -431,10 +430,16 @@ export function formatAsync(input: string, pos: number) {
 }
 
 export function snippetAsync(qName: string, python?: boolean): Promise<string> {
-    return workerOpAsync("snippet", {
+    let initStep = Promise.resolve();
+    if (python) {
+        // To make sure that the service is working with the most recent version of the file,
+        // run a typecheck
+        initStep = typecheckAsync().then(() => {})
+    }
+    return initStep.then(() => workerOpAsync("snippet", {
         snippet: { qName, python },
         runtime: pxt.appTarget.runtime
-    }).then(res => res as string)
+    })).then(res => res as string)
 }
 
 export function typecheckAsync() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2649

As we discussed offline, this PR removes the transpile cache from the language service and puts it into the webapp. Specifically, I'm now storing transpile results on the EditorPackage for the project.

There are two main differences between this and the old cache:

1. Transpile results are only cached when the user hits the toggle to switch languages. All other conversions are not cached
2. The transpile cache is only read from when the user hits the toggle to switch languages. All other conversions for compiling, syntaxInfo, snippets, etc. go through the language service

I left the roundtrip checks intact because they still serve a purpose if you reload the project in between conversions. The transpile cache is not saved with the project but that would be pretty easy to add if we wanted to.
