### PR TITLE
Don't use the relprefix in embed urls

### DIFF
--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -342,8 +342,18 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                     case ShareMode.Simulator:
                         let padding = '81.97%';
                         // TODO: parts aspect ratio
+                        let simulatorRunString = `${verPrefix}---run`;
+                        if (pxt.webConfig.runUrl) {
+                            if (pxt.webConfig.isStatic) {
+                                simulatorRunString = pxt.webConfig.runUrl;
+                            }
+                            else {
+                                // Always use live, not /beta etc.
+                                simulatorRunString = pxt.webConfig.runUrl.replace(pxt.webConfig.relprefix, "/---")
+                            }
+                        }
                         if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio).toPrecision(4) + '%';
-                        const runUrl = rootUrl + (pxt.webConfig.runUrl || `${verPrefix}--run`).replace(/^\//, '');
+                        const runUrl = rootUrl + simulatorRunString.replace(/^\//, '');
                         embed = pxt.docs.runUrl(runUrl, padding, pubId);
                         break;
                     case ShareMode.Url:


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2154

There's no real way to test this except by deploying it to beta.

For context, the webConfig URLs are patched by the backend but the three ones I reference here should look like this:

```typescript
    export interface WebConfig {
        relprefix: string; // "/beta---",
        runUrl?: string; // "/beta---run",
        verprefix?: string; // "v1"
    }
```