### PR TITLE
display state while tracing

### DIFF
--- a/localtypings/pxtparts.d.ts
+++ b/localtypings/pxtparts.d.ts
@@ -177,6 +177,7 @@ declare namespace pxsim {
 
     // subtype=breakpoint
     export interface DebuggerBreakpointMessage extends DebuggerMessage {
+        subtype: "breakpoint" | "trace";
         breakpointId: number;
         globals: Variables;
         stackframes: StackFrameInfo[];
@@ -199,11 +200,6 @@ declare namespace pxsim {
     export interface FunctionArgument {
         name: string;
         value: any;
-    }
-
-    // subtype=trace
-    export interface TraceMessage extends DebuggerMessage {
-        breakpointId: number;
     }
 
     // subtype=traceConfig

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -1179,11 +1179,9 @@ namespace pxsim {
             function trace(brkId: number, s: StackFrame, retPc: number, info: any) {
                 setupResume(s, retPc);
                 if (info.functionName === "<main>" || info.fileName === "main.ts") {
-                    Runtime.postMessage({
-                        type: "debugger",
-                        subtype: "trace",
-                        breakpointId: brkId,
-                    } as TraceMessage)
+                    const { msg } = getBreakpointMsg(s, brkId, userGlobals);
+                    msg.subtype = "trace";
+                    Runtime.postMessage(msg)
                     thread.pause(tracePauseMs || 1)
                 }
                 else {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -6,7 +6,7 @@ namespace pxsim {
         unhideElement?: (el: HTMLElement) => void;
         onDebuggerWarning?: (wrn: DebuggerWarningMessage) => void;
         onDebuggerBreakpoint?: (brk: DebuggerBreakpointMessage) => void;
-        onTraceMessage?: (msg: TraceMessage) => void;
+        onTraceMessage?: (msg: DebuggerBreakpointMessage) => void;
         onDebuggerResume?: () => void;
         onStateChanged?: (state: SimulatorState) => void;
         onSimulatorReady?: () => void;
@@ -694,8 +694,8 @@ namespace pxsim {
                     if (this.options.onDebuggerWarning)
                         this.options.onDebuggerWarning(msg as pxsim.DebuggerWarningMessage);
                     break;
-                case "breakpoint":
-                    let brk = msg as pxsim.DebuggerBreakpointMessage
+                case "breakpoint": {
+                    const brk = msg as pxsim.DebuggerBreakpointMessage
                     if (this.state == SimulatorState.Running) {
                         if (brk.exceptionMessage)
                             this.suspend();
@@ -713,11 +713,14 @@ namespace pxsim {
                         console.error("debugger: trying to pause from " + this.state);
                     }
                     break;
-                case "trace":
-                    if (this.options.onTraceMessage) {
-                        this.options.onTraceMessage(msg as pxsim.TraceMessage);
+                }
+                case "trace": {
+                    const brk = msg as pxsim.DebuggerBreakpointMessage
+                    if (this.state == SimulatorState.Running && this.options.onTraceMessage) {
+                        this.options.onTraceMessage(brk);
                     }
                     break;
+                }
                 default:
                     const seq = msg.req_seq;
                     if (seq) {

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -139,7 +139,7 @@ export function init(root: HTMLElement, cfg: SimulatorConfig) {
         },
         onTraceMessage: function (msg) {
             let brkInfo = lastCompileResult.breakpoints[msg.breakpointId]
-            if (config) config.highlightStatement(brkInfo)
+            if (config) config.highlightStatement(brkInfo, msg)
         },
         onDebuggerWarning: function (wrn) {
             for (let id of wrn.breakpointIds) {


### PR DESCRIPTION
Always send a full "breakpoint" info while tracing. This allows to see the state changing while running the code. I merged the TraceMessage into a breakpoint message (different subtype), there may be cleaner types to do this.

![2020-04-18 21 55 26](https://user-images.githubusercontent.com/4175913/79679974-70d58700-81bf-11ea-9528-52db2a53924c.gif)
