### PR TITLE
force render of README using _config.yml

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -21,7 +21,7 @@ namespace pxt.template {
   platform: @PLATFORM@
   home_url: @HOMEURL@
 theme: jekyll-theme-slate
-include: 
+include:
   - assets
   - README.md
 `,

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -45,7 +45,7 @@ gem 'github-pages', group: :jekyll_plugins`,
 
 ## ${lf("Use as Extension")}
 
-${lf("This repository can be added as an **Eextension** in MakeCode.")}
+${lf("This repository can be added as an **extension** in MakeCode.")}
 
 * ${lf("open [@HOMEURL@](@HOMEURL@)")}
 * ${lf("click on **New Project**")}

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -21,7 +21,9 @@ namespace pxt.template {
   platform: @PLATFORM@
   home_url: @HOMEURL@
 theme: jekyll-theme-slate
-include: assets
+include: 
+  - assets
+  - README.md
 `,
             "Makefile": `all: deploy
 
@@ -36,24 +38,21 @@ test:
 `,
             "Gemfile": `source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins`,
-            "README.md": `---
-
----
-
+            "README.md": `
 > ${lf("Open this page at {0}",
                 "[https://@REPOOWNER@.github.io/@REPONAME@/](https://@REPOOWNER@.github.io/@REPONAME@/)"
             )}
 
-## ${lf("Use this extension")}
+## ${lf("Use as Extension")}
 
-${lf("This repository can be added as an **extension** in MakeCode.")}
+${lf("This repository can be added as an **Eextension** in MakeCode.")}
 
 * ${lf("open [@HOMEURL@](@HOMEURL@)")}
 * ${lf("click on **New Project**")}
 * ${lf("click on **Extensions** under the gearwheel menu")}
 * ${lf("search for **https://github.com/@REPO@** and import")}
 
-## ${lf("Edit this extension")} ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
+## ${lf("Edit this project")} ![${lf("Build status badge")}](https://github.com/@REPO@/workflows/MakeCode/badge.svg)
 
 ${lf("To edit this repository in MakeCode.")}
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/2849

Use _config.yml to force jekyll to always render README.md - with or without front matter.