### PR TITLE
add line break in png save dialogue

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1797,6 +1797,7 @@ export class ProjectView
                                 <div className="description">
                                     <p>
                                         {lf("Your project is saved in this image.")}
+                                        <br />
                                         {lf("Import or drag it into the editor to reload it.")}
                                     </p>
                                 </div>


### PR DESCRIPTION
this stuck out a bit when watching https://youtu.be/iEWkWQAXNx0

currently no spacing between sentences, and breaks in the middle of the second one: 
![image](https://user-images.githubusercontent.com/5615930/79781014-b4301280-82f1-11ea-8a93-989cd2b0087f.png)

add a break to clean up a little:

![image](https://user-images.githubusercontent.com/5615930/79781076-cd38c380-82f1-11ea-9f4a-9b932c45bb86.png)
