### PR TITLE
Can't use query parameters in favicon loading on Edge

### DIFF
--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -764,7 +764,9 @@ function pingApiHandlerAsync(p: string): Promise<any> {
     const url = data.stripProtocol(p);
     // special case favicon.ico
     if (/\.ico$/.test(p)) {
-        const imgUrl = `${url}?v=${Math.random()}&origin=${encodeURIComponent(window.location.origin)}`;
+        const imgUrl = pxt.BrowserUtils.isEdge()
+            ? url
+            : `${url}?v=${Math.random()}&origin=${encodeURIComponent(window.location.origin)}`;
         const img = document.createElement("img")
         return new Promise<boolean>((resolve, reject) => {
             img.onload = () => resolve(true);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2693

does not error when loading in the Edge console but does when we do it in code....