### PR TITLE
webusb: better error handling during download

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -189,11 +189,11 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
         return browserDownloadDeployCoreAsync(resp);
     let isRetry = false;
     const LOADING_KEY = "hiddeploy";
-    return core.showLoadingAsync(LOADING_KEY, lf("Downloading..."), deployAsync(), 5000);
+    return deployAsync();
 
     function deployAsync(): Promise<void> {
         return pxt.packetio.initAsync(isRetry)
-            .then(dev => dev.reflashAsync(resp))
+            .then(dev => core.showLoadingAsync(LOADING_KEY, lf("Downloading..."), dev.reflashAsync(resp), 5000))
             .then(() => core.infoNotification("Download completed!"))
             .finally(() => core.hideLoading(LOADING_KEY))
             .timeout(120000, "timeout") // packetio should time out first

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -187,13 +187,15 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
     // error message handled in browser download
     if (!resp.success)
         return browserDownloadDeployCoreAsync(resp);
-    core.infoNotification(lf("Downloading..."));
     let isRetry = false;
-    return deployAsync();
+    const LOADING_KEY = "hiddeploy";
+    return core.showLoadingAsync(LOADING_KEY, lf("Downloading..."), deployAsync(), 5000);
 
     function deployAsync(): Promise<void> {
         return pxt.packetio.initAsync(isRetry)
             .then(dev => dev.reflashAsync(resp))
+            .then(() => core.infoNotification("Download completed!"))
+            .finally(() => core.hideLoading(LOADING_KEY))
             .timeout(120000, "timeout") // packetio should time out first
             .catch((e) => {
                 pxt.reportException(e)

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -118,23 +118,11 @@ function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (opt
 
 export function showDeviceNotFoundDialogAsync(docPath?: string, resp?: pxtc.CompileResult): Promise<void> {
     pxt.tickEvent(`compile.devicenotfound`);
-    setWebUSBEnabled(false);
     const helpUrl = pxt.appTarget.appTheme.usbDocs;
     return core.dialogAsync({
         header: lf("Oops, we couldn't find your {0}", pxt.appTarget.appTheme.boardName),
         body: lf("Please make sure your {0} is connected and try again.", pxt.appTarget.appTheme.boardName),
         helpUrl: docPath || helpUrl,
-        buttons: [
-            !!resp && {
-                label: lf("Download again"),
-                icon: "download",
-                className: "primary",
-                onclick: () => {
-                    pxt.tickEvent(`compile.devicenotfound.download`);
-                    return pxt.commands.saveOnlyAsync(resp);
-                }
-            }
-        ],
         hideCancel: true,
         hasCloseIcon: true
     });

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -169,6 +169,7 @@ export interface DialogOptions {
 }
 
 export function dialogAsync(options: DialogOptions): Promise<void> {
+    if (!options.buttons) options.buttons = [];
     if (!options.type) options.type = 'dialog';
     if (!options.hideCancel) {
         if (!options.buttons) options.buttons = [];


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/2858
- [x] display full screen download dialog if download > 5sec
- [x] don't try to download again after failed download. instead user can disconnect (the button is called download again but is not a link)
- [x] show a "download completed!" message when done -- it happens quite fast on webusb.
![2020-04-20 22 04 28](https://user-images.githubusercontent.com/4175913/79827362-f50c4380-8352-11ea-9407-7eb190bf3efc.gif)
