### PR TITLE
fix script manager sort button size, loosen hc dropdown selectors selectivity

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -507,15 +507,15 @@
     }
 
     /* Dropdown */
-    .ui.menu .ui.dropdown .menu,
-    #editortools .ui.dropdown .menu {
+    .ui.dropdown .menu,
+    .ui.menu .ui.dropdown .menu {
         border: 1px solid @HCtextColor !important;
     }
 
+    .ui.dropdown .menu,
+    .ui.dropdown .menu > .item,
     .ui.menu .ui.dropdown .menu,
-    .ui.menu .ui.dropdown .menu > .item,
-    #editortools .ui.dropdown .menu,
-    #editortools .ui.dropdown .menu > .item {
+    .ui.menu .ui.dropdown .menu > .item {
         background: @HCbackground !important;
         color: @HCtextColor !important;
 
@@ -530,8 +530,8 @@
         }
     }
 
-    .ui.menu .ui.dropdown .menu > .divider,
-    #editortools .ui.dropdown .menu > .divider {
+    .ui.dropdown .menu > .divider,
+    .ui.menu .ui.dropdown .menu > .divider {
         background: @HCbackground !important;
         border-top: 1px solid @HCtextColor !important;
     }

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -378,7 +378,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                 {hasHeaders && view == 'grid' ?
                     <div role="button" className="ui container fluid" style={{ height: "100%" }} onClick={this.handleAreaClick} onKeyDown={this.handleKeyDown}>
                         <div className="sort-by">
-                            <div role="menu" className="ui menu compact buttons">
+                            <div role="menu" className="ui compact buttons">
                                 <sui.DropdownMenu role="menuitem" text={sortedBy == 'time' ? lf("Last Modified") : lf("Name")} title={lf("Sort by dropdown")} className={`inline button ${darkTheme ? 'inverted' : ''}`}>
                                     <sui.Item role="menuitem" icon={sortedBy == 'name' ? 'check' : undefined} className={`${sortedBy != 'name' ? 'no-icon' : ''} ${darkTheme ? 'inverted' : ''}`} text={lf("Name")} tabIndex={-1} onClick={this.handleSortName} />
                                     <sui.Item role="menuitem" icon={sortedBy == 'time' ? 'check' : undefined} className={`${sortedBy != 'time' ? 'no-icon' : ''} ${darkTheme ? 'inverted' : ''}`} text={lf("Last Modified")} tabIndex={-1} onClick={this.handleSortTime} />


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2731

the reason the selectors look redundant is because sui has rules matching ` .ui.menu .ui.dropdown .menu` that unnecessarily override a bunch of things with `!important`, so it gets into a selectivity fight.

Dropdowns without the extra selectors at the beginning (e.g. editor toolbar and this one) don't have that same problem