### PR TITLE
noDiffs -> diffs

### DIFF
--- a/docs/writing-docs/macros.md
+++ b/docs/writing-docs/macros.md
@@ -341,9 +341,10 @@ If you need a rendering of typescript, javascript code, specify the language as 
 
 #### ~ hint
 
-In tutorial, MakeCode automatically renders a diff between each typescrit or spy snippets.
+In tutorial, MakeCode can render a diff between each typescrit or spy snippets.
 To reset the diff on a step, use the ``@resetDiff`` metadata. 
-Use ``### @noDiffs`` to disable diffs for the entire tutorial
+
+Use ``### @diffs true/false`` to enable/disable diffs for the entire tutorial
 
 #### ~
 

--- a/docs/writing-docs/tutorials.md
+++ b/docs/writing-docs/tutorials.md
@@ -142,14 +142,14 @@ Tutorial metadata is optionally specified at the top of the document. Metadata i
 * **explicitHints**: Indicates explicit hints, in the format ``### ~ tutorialhint``. The default is ``false`` making hints available for each step.
 * **flyoutOnly**: Indicates that the tutorial should display all available blocks in a permanently-visible flyout, instead of the toolbox. The default is ``false``.
 * **hideIteration**: Hides the step controls. This includes the previous, next, and exit tutorial buttons, as well as the step counter in the menu bar. The default is ``false``.
-* **noDiffs**: disable automatic diffs between snippets
+* **diffs**: enable/disable diffs on all languages
 
 ```markdown
 ### @activities true
 ### @explicitHints true
 ### @flyoutOnly true
 ### @hideIteration true
-### @noDiffs true
+### @diffs true
 ```
 
 ### Title

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -875,6 +875,7 @@ declare namespace pxt.tutorial {
         explicitHints?: boolean; // tutorial expects explicit hints in `#### ~ tutorialhint` format
         flyoutOnly?: boolean; // no categories, display all blocks in flyout
         hideIteration?: boolean; // hide step control in tutorial
+        diffs?: boolean; // automatically diff snippets
         noDiffs?: boolean; // don't automatically generated diffs
         codeStart?: string; // command to run when code starts (MINECRAFT HOC ONLY)
         codeStop?: string; // command to run when code stops (MINECRAFT HOC ONLY)

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -12,13 +12,16 @@ namespace pxt.tutorial {
         // collect code and infer editor
         const { code, templateCode, editor, language } = computeBodyMetadata(body);
 
-        if (!metadata.noDiffs
-            && (
-                (editor == pxt.BLOCKS_PROJECT_NAME && pxt.appTarget.appTheme.tutorialBlocksDiff)  //blocks enabled always
-                || (editor != pxt.BLOCKS_PROJECT_NAME && pxt.appTarget.appTheme.tutorialTextDiff) // text enabled always
-            )
-        )
+        // noDiffs legacy
+        if (metadata.diffs === true // enabled in tutorial
+            || (metadata.diffs !== false && metadata.noDiffs !== true // not disabled
+                && (
+                    (editor == pxt.BLOCKS_PROJECT_NAME && pxt.appTarget.appTheme.tutorialBlocksDiff)  //blocks enabled always
+                    || (editor != pxt.BLOCKS_PROJECT_NAME && pxt.appTarget.appTheme.tutorialTextDiff) // text enabled always
+                ))
+        ) {
             diffify(steps, activities);
+        }
 
         // strip hidden snippets
         steps.forEach(step => {

--- a/tests/tutorial-test/baselines/activities.json
+++ b/tests/tutorial-test/baselines/activities.json
@@ -45,6 +45,6 @@
     "code": "\n{\nlet x = 1;\nlet y = x + 2;\n}\n",
     "metadata": {
         "activities": true,
-        "noDiffs": true
+        "diffs": false
     }
 }

--- a/tests/tutorial-test/baselines/explicitHints.json
+++ b/tests/tutorial-test/baselines/explicitHints.json
@@ -19,7 +19,7 @@
     "activities": null,
     "code": "\n{\nbasic.showString(\"Micro!\")\n}\n\n{\nlet x = 1;\nlet y = x + 2;\n}\n\n{\nbasic.showIcon(IconNames.Square)\n}\n",
     "metadata": {
-        "noDiffs": true,
+        "diffs": false,
         "explicitHints": true
     }
 }

--- a/tests/tutorial-test/baselines/flyoutOnly.json
+++ b/tests/tutorial-test/baselines/flyoutOnly.json
@@ -15,7 +15,7 @@
     "activities": null,
     "code": "\n{\nlet x = 8;\nlet y = x + 2;\n}\n\n{\nbasic.showIcon(IconNames.Square)\n}\n",
     "metadata": {
-        "noDiffs": true,
+        "diffs": false,
         "flyoutOnly": true
     }
 }

--- a/tests/tutorial-test/baselines/ghost.json
+++ b/tests/tutorial-test/baselines/ghost.json
@@ -16,6 +16,6 @@
     "activities": null,
     "code": "\n{\nbasic.forever(() => {\n    basic.showIcon(IconNames.Yes);\n});\n}\n\n{\nbasic.showString(\"Hello\")\n}\n\n{\nbasic.forever(function() {\n    basic.showLeds(`\n        . # . # .\n        # # # # #\n        # # # # #\n        . # # # .\n        . . # . .`);\n})\n}\n\n{\ninput.onButtonPressed(Button.A, () => {\n    radio.sendNumber(0)\n})\n}\n",
     "metadata": {
-        "noDiffs": true
+        "diffs": false
     }
 }

--- a/tests/tutorial-test/baselines/hideIteration.json
+++ b/tests/tutorial-test/baselines/hideIteration.json
@@ -15,7 +15,7 @@
     "activities": null,
     "code": "\n{\nbasic.showString(\"Micro!\")\n}\n\n{\nbasic.showIcon(IconNames.Square)\n}\n",
     "metadata": {
-        "noDiffs": true,
+        "diffs": false,
         "hideIteration": true
     }
 }

--- a/tests/tutorial-test/baselines/legacySteps.json
+++ b/tests/tutorial-test/baselines/legacySteps.json
@@ -23,6 +23,6 @@
     "code": "\n{\nbasic.showString(\"Micro!\")\n}\n",
     "metadata": {
         "flyoutOnly": true,
-        "noDiffs": true
+        "diffs": false
     }
 }

--- a/tests/tutorial-test/baselines/python.json
+++ b/tests/tutorial-test/baselines/python.json
@@ -17,7 +17,7 @@
     "activities": null,
     "code": "\ndef __wrapper_0():\n    basic.show_string(\"Hello\")\n\ndef __wrapper_1():\n    basic.forever(function() {\n        basic.show_leds(`\n            . # . # .\n            # # # # #\n            # # # # #\n            . # # # .\n            . . # . .`);\n    })\n",
     "metadata": {
-        "noDiffs": true
+        "diffs": false
     },
     "language": "python"
 }

--- a/tests/tutorial-test/baselines/singleStep.json
+++ b/tests/tutorial-test/baselines/singleStep.json
@@ -13,6 +13,6 @@
     "activities": null,
     "code": "\n{\nbasic.showString(\"Micro!\")\n}\n",
     "metadata": {
-        "noDiffs": true
+        "diffs": false
     }
 }

--- a/tests/tutorial-test/baselines/steps.json
+++ b/tests/tutorial-test/baselines/steps.json
@@ -22,6 +22,6 @@
     "activities": null,
     "code": "\n{\nbasic.showString(\"Micro!\")\n}\n",
     "metadata": {
-        "noDiffs": true
+        "diffs": false
     }
 }

--- a/tests/tutorial-test/baselines/template.json
+++ b/tests/tutorial-test/baselines/template.json
@@ -17,6 +17,6 @@
     "code": "\n{\nbasic.forever(() => {\n    basic.showString(\"MICRO\");\n});\n}\n",
     "templateCode": "basic.forever(() => {\n    basic.showString(\"MICRO\");\n});",
     "metadata": {
-        "noDiffs": true
+        "diffs": false
     }
 }

--- a/tests/tutorial-test/cases/activities.md
+++ b/tests/tutorial-test/cases/activities.md
@@ -1,5 +1,5 @@
 ### @activities true
-### @noDiffs true
+### @diffs false
 
 # Tutorial title
 

--- a/tests/tutorial-test/cases/button.md
+++ b/tests/tutorial-test/cases/button.md
@@ -1,6 +1,6 @@
 # Description
 
-### @noDiffs true
+### @diffs false
 ### ~button /#tutorial:/tutorials/tutorial-
 
 Tutorials may have a button, only to be displayed during markdown

--- a/tests/tutorial-test/cases/description.md
+++ b/tests/tutorial-test/cases/description.md
@@ -1,6 +1,6 @@
 # Description
 
-### @noDiffs true
+### @diffs false
 ### @description Tutorial descriptions are not displayed
 
 ## Step 1

--- a/tests/tutorial-test/cases/explicitHints.md
+++ b/tests/tutorial-test/cases/explicitHints.md
@@ -1,6 +1,6 @@
 # Explicit Hints
 
-### @noDiffs true
+### @diffs false
 ### @explicitHints true
 
 ## Introduction

--- a/tests/tutorial-test/cases/flyoutOnly.md
+++ b/tests/tutorial-test/cases/flyoutOnly.md
@@ -1,6 +1,6 @@
 # Explicit Hints
 
-### @noDiffs true
+### @diffs false
 ### @flyoutOnly true
 
 ## Introduction

--- a/tests/tutorial-test/cases/ghost.md
+++ b/tests/tutorial-test/cases/ghost.md
@@ -6,7 +6,7 @@ basic.forever(() => {
 
 # Ghost blocks
 
-### @noDiffs true
+### @diffs false
 ## Step 1 @fullscreen
 
 Ghost blocks do not show up in the tutorial, but display in the workspace.

--- a/tests/tutorial-test/cases/hideIteration.md
+++ b/tests/tutorial-test/cases/hideIteration.md
@@ -1,6 +1,6 @@
 # Hide Iteration
 
-### @noDiffs true
+### @diffs false
 ### @hideIteration true
 
 ## Introduction

--- a/tests/tutorial-test/cases/legacySteps.md
+++ b/tests/tutorial-test/cases/legacySteps.md
@@ -2,7 +2,7 @@
 
 # Getting started
 
-### @noDiffs true
+### @diffs false
 ### Introduction @unplugged
 
 Let's get started!

--- a/tests/tutorial-test/cases/python.md
+++ b/tests/tutorial-test/cases/python.md
@@ -1,6 +1,6 @@
 # Native python
 
-### @noDiffs true
+### @diffs false
 ## Step 1 @fullscreen
 
 Tutorials can be written with code in Python.

--- a/tests/tutorial-test/cases/singleStep.md
+++ b/tests/tutorial-test/cases/singleStep.md
@@ -1,6 +1,6 @@
 # Getting started
 
-### @noDiffs true
+### @diffs false
 ## Introduction @unplugged
 
 Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.

--- a/tests/tutorial-test/cases/steps.md
+++ b/tests/tutorial-test/cases/steps.md
@@ -1,6 +1,6 @@
 # Getting started
 
-### @noDiffs true
+### @diffs false
 ## Introduction @unplugged
 
 Let's get started!

--- a/tests/tutorial-test/cases/template.md
+++ b/tests/tutorial-test/cases/template.md
@@ -1,6 +1,6 @@
 # Template blocks
 
-### @noDiffs true
+### @diffs false
 ## Introduction @unplugged
 
 Let's get started!

--- a/tests/tutorial-test/cases/tutorialCompleted.md
+++ b/tests/tutorial-test/cases/tutorialCompleted.md
@@ -1,6 +1,6 @@
 # Tutorial Completed 
 
-### @noDiffs true
+### @diffs false
 ## Introduction
 
 Let's get started!


### PR DESCRIPTION
Use ```### @diffs true/false`` to enable/disable diffs in tutorials, so that they can be turned on even if the target does not have them on by default. Deprecating noDiffs.