### PR TITLE
Fix detail card focus, clear toolbox expanded item when unloaded

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -282,7 +282,8 @@
                 transform: translateX(-50%) translateY(-50%);
                 pointer-events: none;
             }
-            .card-action:hover {
+            .card-action:hover,
+            .card-action:focus-within {
                 cursor: pointer;
                 border-color: @white;
                 transform: scale(1.1);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -101,8 +101,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
         else {
             pxt.Util.toArray(document.querySelectorAll(classes)).forEach((el: HTMLElement) => el.style.display = 'none');
-            if (this.editor)
-                Blockly.hideChaff();
+            if (this.editor) Blockly.hideChaff();
+            if (this.toolbox) this.toolbox.clearExpandedItem();
         }
     }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -838,7 +838,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             {this.isLink() && type != "example" ? // TODO (shakao)  migrate forumurl to otherAction json in md
                 <sui.Link
                     href={this.getUrl()}
-                    refCallback={this.linkRef}
+                    refCallback={autoFocus ? this.linkRef : undefined}
                     target={'_blank'}
                     text={text}
                     className={`button attached approve large`}
@@ -947,7 +947,6 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                             <div className="card-action-title">YouTube</div>
                             <sui.Link
                                 href={`https://youtu.be/${youTubeId}`}
-                                refCallback={this.linkRef}
                                 target="_blank"
                                 text={lf("Play Video")}
                                 className={`button attached approve large`}

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -188,7 +188,11 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     }
 
     clearSelection() {
-        this.setState({ selectedItem: undefined, focusSearch: false })
+        this.setState({ selectedItem: undefined, focusSearch: false });
+    }
+
+    clearExpandedItem() {
+        this.setState({ expandedItem: undefined });
     }
 
     clearSearch() {


### PR DESCRIPTION
Also only pass linkRef to items that are autofocused.

Fixes https://github.com/microsoft/pxt-microbit/issues/2844
Fixes https://github.com/microsoft/pxt-microbit/issues/2846