### PR TITLE
Compute program hash at the binary, not asm, level

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -4833,7 +4833,6 @@ ${lbl}: .short 0xffff
         res: CompileResult;
         options: CompileOptions;
         usedClassInfos: ClassInfo[] = [];
-        sourceHash = "";
         checksumBlock: number[];
         numStmts = 1;
         commSize = 0;

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -901,7 +901,7 @@ namespace pxt.cpp {
                         fileName = fullName
 
                         parseCpp(src, isHeader)
-                        src = src.replace(/^\s*/mg, "") // shrink the files
+                        src = src.replace(/^[ \t]*/mg, "") // shrink the files
                         res.extensionFiles[sourcePath + fullName] = src
 
                         if (pkg.level == 0)


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2823

The problem was that if we hit "Download" twice we get slightly different literal sequence numbers in the assembly. The resulting code is exactly the same though, so we now compute hash of the machine code, not assembly code.
