### PR TITLE
Bump pxt-blockly to 3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.6",
+    "pxt-blockly": "3.0.7",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
- Make the string field width narrower for empty string (https://github.com/microsoft/pxt-blockly/pull/285)
- Hide "Add Comment" on draggable param (https://github.com/microsoft/pxt-blockly/pull/286)
- Fix shadow arg renaming (https://github.com/microsoft/pxt-blockly/pull/286)