### PR TITLE
Adding the ability to expand the tilemap categories

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -369,9 +369,9 @@ namespace pxt.sprite {
 
         return syms.map(sym => {
             const splitTags = (sym.attributes.tags || "")
-                .toLowerCase()
                 .split(" ")
-                .filter(el => !!el);
+                .filter(el => !!el)
+                .map(tag => pxt.Util.startsWith(tag, "category-") ? tag : tag.toLowerCase());
 
             return {
                 qName: sym.qName,


### PR DESCRIPTION
We hardcoded the tilemap categories, which was a bad decision! This adds the ability to add extra categories.

To add a category, give a tile a tag of the form `category-<name>` (no angle brackets) and it will be placed in a new category with that name. Those names can be localized if you add a localization file with a key like this: `{id:tilecategory}name`.