### PR TITLE
Update blockly to 3.0.8, add renderer class to preview SVG

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.7",
+    "pxt-blockly": "3.0.8",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -242,7 +242,7 @@ namespace pxt.blocks.layout {
 
     export function cleanUpBlocklySvg(svg: SVGElement): SVGElement {
         pxt.BrowserUtils.removeClass(svg, "blocklySvg");
-        pxt.BrowserUtils.addClass(svg, "blocklyPreview");
+        pxt.BrowserUtils.addClass(svg, "blocklyPreview pxt-renderer");
 
         pxt.U.toArray(svg.querySelectorAll('.blocklyMainBackground,.blocklyScrollbarBackground'))
             .forEach(el => { if (el) el.parentNode.removeChild(el) });


### PR DESCRIPTION
- Reindeer connection indicator (https://github.com/microsoft/pxt-blockly/pull/287)
- add pxt-renderer class to preview to apply relevant CSS (hiding connection indicator in sidedocs)

![feature-reindeer](https://user-images.githubusercontent.com/34112083/80399319-dd125380-886d-11ea-8a84-72781e7f5239.gif)
