### PR TITLE
Update floating workspace elements on resize

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -564,6 +564,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             blocklyDiv.style.width = blocklyArea.offsetWidth + 'px';
             blocklyDiv.style.height = blocklyArea.offsetHeight + 'px';
             Blockly.svgResize(this.editor);
+            Blockly.hideChaffOnResize(true);
             this.resizeToolbox();
             this.resizeFieldEditorView();
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2903

This happens when the workspace resizes without hiding the floating elements (dropdowns, "active" fields, etc). I tested against the collapse/expand simulator case, but it should apply to anywhere we use the editor.resize() call.