### PR TITLE
Lazy reconnect

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5527,10 +5527,18 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
         })
     }
 
+    let errorCount = 0;
+    function reportWarning(er: { repo: string; title: string; body: string; }) {
+        const msg = `- [ ]  [${er.repo}](https://github.com/${er.repo}) ${er.title} / [new issue](https://github.com/${er.repo}/issues/new?title=${encodeURIComponent(er.title)}&body=${encodeURIComponent(er.body)})`;
+        console.log(`warning: https://github.com/${er.repo} ${er.title}`)
+        fs.appendFileSync(logfile, msg + "\n");
+    }
+
     function reportError(er: { repo: string; title: string; body: string; }) {
         const msg = `- [ ]  [${er.repo}](https://github.com/${er.repo}) ${er.title} / [new issue](https://github.com/${er.repo}/issues/new?title=${encodeURIComponent(er.title)}&body=${encodeURIComponent(er.body)})`;
         console.error(`error: https://github.com/${er.repo} ${er.title}`)
         fs.appendFileSync(logfile, msg + "\n");
+        errorCount++;
     }
 
     function reportLog(msg: any) {
@@ -5543,7 +5551,7 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
             .then(tags => {
                 let tag = pxt.semver.sortLatestTags(tags)[0];
                 if (!tag) {
-                    reportError({ repo: fullname, title: "create a release", body: "You need to create a release in this repository. Follow the instructions at https://makecode.com/extensions/versioning." });
+                    reportWarning({ repo: fullname, title: "create a release", body: "You need to create a release in this repository. Follow the instructions at https://makecode.com/extensions/versioning." });
                     tag = "master";
                 }
                 else {
@@ -5617,7 +5625,12 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
             reportLog(nodeutil.stringify(fullnames));
             return Promise.mapSeries(fullnames, nextAsync);
         })
-        .then(() => { })
+        .then(() => {
+            if (errorCount > 0) {
+                reportLog(`${errorCount} errors found`);
+                process.exit(1);
+            }
+        })
 }
 
 interface BlockTestCase {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5515,7 +5515,6 @@ function testGithubPackagesAsync(parsed: commandParser.ParsedCommand): Promise<v
     if (!packages) {
         pxt.log(`packages section not found in targetconfig.json`)
     }
-    let todo: string[];
     const pkgsroot = path.join("temp", "ghpkgs");
     const logfile = path.join(pkgsroot, "log.txt");
     nodeutil.writeFileSync(logfile, ""); // reset file

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -197,12 +197,17 @@ export class HidIO implements pxt.packetio.PacketIO {
         this.connect()
     }
 
+    private setConnecting(v: boolean) {
+        if (v != this.connecting) {
+            this.connecting = v;
+            if(this.onConnectionChanged)
+                this.onConnectionChanged();
+        }
+    }
+
     private connect() {
         U.assert(isInstalled(false))
-        U.assert(!this.connecting)
-        this.connecting = true;
-        if (this.onConnectionChanged)
-            this.onConnectionChanged();
+        this.setConnecting(true);
         try {
             if (this.requestedPath == null) {
                 let devs = getHF2Devices()
@@ -220,9 +225,7 @@ export class HidIO implements pxt.packetio.PacketIO {
             })
             this.dev.on("error", (v: Error) => this.onError(v))
         } finally {
-            this.connecting = false;
-            if (this.onConnectionChanged)
-                this.onConnectionChanged();
+            this.setConnecting(false);
         }
     }
 

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -200,7 +200,7 @@ export class HidIO implements pxt.packetio.PacketIO {
     private setConnecting(v: boolean) {
         if (v != this.connecting) {
             this.connecting = v;
-            if(this.onConnectionChanged)
+            if (this.onConnectionChanged)
                 this.onConnectionChanged();
         }
     }

--- a/pxtlib/hf2.ts
+++ b/pxtlib/hf2.ts
@@ -418,8 +418,7 @@ namespace pxt.HF2 {
             return this.io.reconnectAsync()
                 .then(() => this.flashAsync(blocks))
                 .then(() => Promise.delay(100))
-                .then(() => this.reconnectAsync())
-                .finally(() => this.flashing = false);
+                .finally(() => this.flashing = false)
         }
 
         writeWordsAsync(addr: number, words: number[]) {

--- a/pxtlib/hwdbg.ts
+++ b/pxtlib/hwdbg.ts
@@ -307,7 +307,8 @@ namespace pxt.HWDBG {
                 let f = lastCompileResult.outfiles[pxtc.BINARY_UF2]
                 let blockBuf = U.stringToUint8Array(atob(f))
                 lastFlash = pxtc.UF2.toBin(blockBuf)
-                return hid.reflashAsync(lastCompileResult) // this will reset into app at the end
+                return hid.reflashAsync(lastCompileResult)
+                    .then(() => hid.reconnectAsync()) // this will reset into app at the end
             })
             .then(() => hid.talkAsync(HF2_DBG_RESTART).catch(e => { }))
             .then(() => Promise.delay(200))

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -63,6 +63,10 @@ namespace pxt.packetio {
         return !!wrapper && wrapper.io.isConnected();
     }
 
+    export function isConnecting() {
+        return !!wrapper && wrapper.io.isConnecting();
+    }
+
     export function icon() {
         return !!wrapper && (wrapper.icon || "usb");
     }

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -14,6 +14,7 @@ namespace pxt.packetio {
 
         reconnectAsync(): Promise<void>;
         disconnectAsync(): Promise<void>;
+        // flash the device, does **not** reconnect
         reflashAsync(resp: pxtc.CompileResult): Promise<void>;
     }
 

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -28,6 +28,7 @@ namespace pxt.packetio {
         error(msg: string): any;
         reconnectAsync(): Promise<void>;
         disconnectAsync(): Promise<void>;
+        isConnecting(): boolean;
         isConnected(): boolean;
         isSwitchingToBootloader?: () => void;
         // release any native resource before being released

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -253,7 +253,7 @@ namespace pxt.usb {
         private setConnecting(v: boolean) {
             if (v != this.connecting) {
                 this.connecting = v;
-                if(this.onConnectionChanged)
+                if (this.onConnectionChanged)
                     this.onConnectionChanged();
             }
         }

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -431,12 +431,6 @@ namespace pxt.usb {
             })
     }
 
-    export function isPairedAsync(): Promise<boolean> {
-        if (!isEnabled) return Promise.resolve(false);
-        return tryGetDeviceAsync()
-            .then(dev => !!dev);
-    }
-
     export function tryGetDeviceAsync(): Promise<USBDevice> {
         log(`webusb: get devices`)
         return ((navigator as any).usb.getDevices() as Promise<USBDevice[]>)

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -436,7 +436,7 @@ namespace pxt.usb {
     }
 
     export function tryGetDeviceAsync(): Promise<USBDevice> {
-        log(`get devices`)
+        log(`webusb: get devices`)
         return ((navigator as any).usb.getDevices() as Promise<USBDevice[]>)
             .then<USBDevice>((devs: USBDevice[]) => devs && devs[0]);
     }

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -271,7 +271,6 @@ namespace pxt.usb {
             this.log("connect device: " + dev.manufacturerName + " " + dev.productName)
             this.dev = dev;
             return this.initAsync()
-                .delay(1000)
                 .finally(() => this.setConnecting(false));
         }
 

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -271,6 +271,7 @@ namespace pxt.usb {
             this.log("connect device: " + dev.manufacturerName + " " + dev.productName)
             this.dev = dev;
             return this.initAsync()
+                .delay(1000)
                 .finally(() => this.setConnecting(false));
         }
 

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -180,11 +180,13 @@ namespace pxt.usb {
 
             (navigator as any).usb.addEventListener('disconnect', this.handleUSBDisconnected, false);
             (navigator as any).usb.addEventListener('connect', this.handleUSBConnected, false);
+            this.log(`registered webusb events`)
         }
 
         disposeAsync(): Promise<void> {
             (navigator as any).usb.removeEventListener('disconnect', this.handleUSBDisconnected);
             (navigator as any).usb.removeEventListener('connect', this.handleUSBConnected);
+            this.log(`unregistered webusb events`)
             return Promise.resolve();
         }
 

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -201,7 +201,7 @@ namespace pxt.usb {
         }
         private handleUSBConnected(event: any) {
             const newdev = event.device as USBDevice;
-            this.log("device connected")
+            this.log(`device connected ${newdev.serialNumber}`)
             if (!this.dev) {
                 this.log("attach device")
                 if (this.onDeviceConnectionChanged)

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -159,7 +159,7 @@ namespace pxt.usb {
         reset(): Promise<void>;
     }
 
-    class HID implements pxt.packetio.PacketIO {
+    class WebUSBHID implements pxt.packetio.PacketIO {
         dev: USBDevice;
         ready = false;
         connecting = false;
@@ -455,11 +455,11 @@ namespace pxt.usb {
             })
     }
 
-    let _hid: HID;
+    let _hid: WebUSBHID;
     export function mkPacketIOAsync(): Promise<pxt.packetio.PacketIO> {
         pxt.log(`packetio: mk webusb io`)
         if (!_hid)
-            _hid = new HID();
+            _hid = new WebUSBHID();
         return Promise.resolve(_hid);
     }
 

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -27,7 +27,7 @@ namespace pxt.winrt {
         private setConnecting(v: boolean) {
             if (v != this.connecting) {
                 this.connecting = v;
-                if(this.onConnectionChanged)
+                if (this.onConnectionChanged)
                     this.onConnectionChanged();
             }
         }

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -11,6 +11,7 @@ namespace pxt.winrt {
         onEvent = (v: Uint8Array) => { };
         onError = (e: Error) => { };
         public dev: Windows.Devices.HumanInterfaceDevice.HidDevice;
+        private connecting = false;
 
         constructor() {
         }
@@ -21,6 +22,10 @@ namespace pxt.winrt {
 
         error(msg: string) {
             throw new Error(U.lf("USB/HID error ({0})", msg))
+        }
+
+        isConnecting(): boolean {
+            return this.connecting;
         }
 
         isConnected(): boolean {
@@ -86,6 +91,7 @@ namespace pxt.winrt {
                 });
             }, Promise.resolve<Windows.Devices.Enumeration.DeviceInformationCollection>(null));
 
+            this.connecting = false;
             let deviceId: string;
             return getDevicesPromise
                 .then((devices) => {
@@ -123,6 +129,11 @@ namespace pxt.winrt {
                     if (this.onConnectionChanged)
                         this.onConnectionChanged();
                     return Promise.resolve();
+                })
+                .finally(() => {
+                    this.connecting = false
+                    if (this.onConnectionChanged)
+                        this.onConnectionChanged();
                 })
                 .catch((e) => {
                     if (isRetry) {

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -24,6 +24,14 @@ namespace pxt.winrt {
             throw new Error(U.lf("USB/HID error ({0})", msg))
         }
 
+        private setConnecting(v: boolean) {
+            if (v != this.connecting) {
+                this.connecting = v;
+                if(this.onConnectionChanged)
+                    this.onConnectionChanged();
+            }
+        }
+
         isConnecting(): boolean {
             return this.connecting;
         }
@@ -91,7 +99,7 @@ namespace pxt.winrt {
                 });
             }, Promise.resolve<Windows.Devices.Enumeration.DeviceInformationCollection>(null));
 
-            this.connecting = false;
+            this.setConnecting(true);
             let deviceId: string;
             return getDevicesPromise
                 .then((devices) => {
@@ -131,9 +139,7 @@ namespace pxt.winrt {
                     return Promise.resolve();
                 })
                 .finally(() => {
-                    this.connecting = false
-                    if (this.onConnectionChanged)
-                        this.onConnectionChanged();
+                    this.setConnecting(false);
                 })
                 .catch((e) => {
                     if (isRetry) {

--- a/theme/common.less
+++ b/theme/common.less
@@ -662,6 +662,21 @@ Avatar
     transition: outline 0.3s linear;
 }
 
+/* ping anim */
+@keyframes ping {
+    from {
+        transform: scale(.5);
+        opacity: 1;
+    }
+    to {
+        transform: scale(1);
+        opacity: 0.5;
+    }
+}
+.ping {
+    animation: ping 1s infinite;
+}
+
 .grayscale {
     -moz-filter: grayscale(1);
     -webkit-filter: grayscale(1);

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -170,12 +170,7 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
         return pxt.packetio.initAsync(isRetry)
             .then(dev => core.showLoadingAsync(LOADING_KEY, lf("Downloading..."), 
                 dev.reflashAsync(resp)
-                    .then(() => {
-                        // reconnect it he background, don't block
-                        log(`background reconnect`)
-                        dev.reconnectAsync().done();                        
-                    }), 
-                5000))
+                    .then(() => dev.reconnectAsync()), 5000))
             .then(() => core.infoNotification("Download completed!"))
             .finally(() => core.hideLoading(LOADING_KEY))
             .timeout(120000, "timeout") // packetio should time out first

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -168,7 +168,13 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
 
     function deployAsync(): Promise<void> {
         return pxt.packetio.initAsync(isRetry)
-            .then(dev => core.showLoadingAsync(LOADING_KEY, lf("Downloading..."), dev.reflashAsync(resp), 5000))
+            .then(dev => core.showLoadingAsync(LOADING_KEY, lf("Downloading..."), 
+                dev.reflashAsync(resp)
+                    .then(() => {
+                        // reconnect it he background, don't block
+                        dev.reconnectAsync().done();                        
+                    }), 
+                5000))
             .then(() => core.infoNotification("Download completed!"))
             .finally(() => core.hideLoading(LOADING_KEY))
             .timeout(120000, "timeout") // packetio should time out first

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -443,6 +443,8 @@ function handlePacketIOApi(r: string) {
             return pxt.packetio.isActive();
         case "connected":
             return pxt.packetio.isConnected();
+        case "connecting":
+            return pxt.packetio.isConnecting();
         case "icon":
             return pxt.packetio.icon();
     }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -168,7 +168,7 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
 
     function deployAsync(): Promise<void> {
         return pxt.packetio.initAsync(isRetry)
-            .then(dev => core.showLoadingAsync(LOADING_KEY, lf("Downloading..."), 
+            .then(dev => core.showLoadingAsync(LOADING_KEY, lf("Downloading..."),
                 dev.reflashAsync(resp)
                     .then(() => dev.reconnectAsync()), 5000))
             .then(() => core.infoNotification("Download completed!"))

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -172,6 +172,7 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
                 dev.reflashAsync(resp)
                     .then(() => {
                         // reconnect it he background, don't block
+                        log(`background reconnect`)
                         dev.reconnectAsync().done();                        
                     }), 
                 5000))

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -163,10 +163,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const downloadText = targetTheme.useUploadMessage ? lf("Upload") : lf("Download");
         const boards = pxt.appTarget.simulator && !!pxt.appTarget.simulator.dynamicBoardDefinition;
         const webUSBSupported = pxt.usb.isEnabled && pxt.appTarget?.compile?.webUSB;
-        const packetioActive = !!this.getData("packetio:active");
         const packetioConnected = !!this.getData("packetio:connected");
+        const packetioConnecting = !!this.getData("packetio:connecting");
         const packetioIcon = !!packetioConnected && this.getData("packetio:icon") as string;
-        const downloadIcon = packetioIcon || targetTheme.downloadIcon || "download";
+        const downloadIcon = (packetioConnecting && "plug") || packetioIcon || targetTheme.downloadIcon || "download";
         const hasMenu = boards || webUSBSupported;
 
         let downloadButtonClasses = hasMenu ? "left attached " : "";

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -180,6 +180,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         }
         if (packetioConnected)
             downloadButtonClasses += "connected ";
+        else if (packetioConnecting)
+            downloadButtonClasses += "connecting ";
         switch (view) {
             case View.Mobile:
                 downloadButtonClasses += "download-button-full";
@@ -202,6 +204,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const deviceName = pxt.hwName || pxt.appTarget.appTheme.boardNickname || lf("device");
         const tooltip = pxt.hwName
             || (packetioConnected && lf("Connected to {0}", deviceName))
+            || (packetioConnecting && lf("Connecting..."))
             || (boards ? lf("Click to select hardware") : lf("Click for one-click downloads."));
 
         const hardwareMenuText = view == View.Mobile ? lf("Hardware") : lf("Choose hardware");
@@ -211,7 +214,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             el.push(
                 <sui.DropdownMenu key="downloadmenu" role="menuitem" icon={`${downloadButtonIcon} horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight}>
                     {webUSBSupported && !packetioConnected && <sui.Item role="menuitem" icon="usb" text={lf("Pair device")} tabIndex={-1} onClick={this.onPairClick} />}
-                    {webUSBSupported && packetioConnected && <sui.Item role="menuitem" icon="usb" text={lf("Disconnect")} tabIndex={-1} onClick={this.onDisconnectClick} />}
+                    {webUSBSupported && (packetioConnecting || packetioConnected) && <sui.Item role="menuitem" icon="usb" text={lf("Disconnect")} tabIndex={-1} onClick={this.onDisconnectClick} />}
                     {boards && <sui.Item role="menuitem" icon="microchip" text={hardwareMenuText} tabIndex={-1} onClick={this.onHwItemClick} />}
                     <sui.Item role="menuitem" icon="download" text={downloadMenuText} tabIndex={-1} onClick={this.onHwDownloadClick} />
                 </sui.DropdownMenu>

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -166,7 +166,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const packetioConnected = !!this.getData("packetio:connected");
         const packetioConnecting = !!this.getData("packetio:connecting");
         const packetioIcon = this.getData("packetio:icon") as string;
-        const downloadIcon = (!!packetioConnecting && "ping " + packetioIcon) 
+        const downloadIcon = (!!packetioConnecting && "ping " + packetioIcon)
             || (!!packetioConnected && packetioIcon)
             || targetTheme.downloadIcon || "download";
         const hasMenu = boards || webUSBSupported;

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -166,7 +166,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const packetioConnected = !!this.getData("packetio:connected");
         const packetioConnecting = !!this.getData("packetio:connecting");
         const packetioIcon = !!packetioConnected && this.getData("packetio:icon") as string;
-        const downloadIcon = (packetioConnecting && "plug") || packetioIcon || targetTheme.downloadIcon || "download";
+        const downloadIcon = (packetioConnecting && "ping plug") || packetioIcon || targetTheme.downloadIcon || "download";
         const hasMenu = boards || webUSBSupported;
 
         let downloadButtonClasses = hasMenu ? "left attached " : "";

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -165,8 +165,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const webUSBSupported = pxt.usb.isEnabled && pxt.appTarget?.compile?.webUSB;
         const packetioConnected = !!this.getData("packetio:connected");
         const packetioConnecting = !!this.getData("packetio:connecting");
-        const packetioIcon = !!packetioConnected && this.getData("packetio:icon") as string;
-        const downloadIcon = (packetioConnecting && "ping plug") || packetioIcon || targetTheme.downloadIcon || "download";
+        const packetioIcon = this.getData("packetio:icon") as string;
+        const downloadIcon = (!!packetioConnecting && "ping " + packetioIcon) 
+            || (!!packetioConnected && packetioIcon)
+            || targetTheme.downloadIcon || "download";
         const hasMenu = boards || webUSBSupported;
 
         let downloadButtonClasses = hasMenu ? "left attached " : "";

--- a/webapp/src/hidbridge.ts
+++ b/webapp/src/hidbridge.ts
@@ -76,6 +76,7 @@ class BridgeIO implements pxt.packetio.PacketIO {
     onSerial = (v: Uint8Array, isErr: boolean) => { };
     public dev: HidDevice;
     private connected: boolean;
+    private connecting = false;
 
     constructor(public rawMode = false) {
         if (rawMode)
@@ -84,6 +85,10 @@ class BridgeIO implements pxt.packetio.PacketIO {
 
     disposeAsync(): Promise<void> {
         return Promise.resolve();
+    }
+
+    isConnecting(): boolean {
+        return this.connecting;
     }
 
     isConnected(): boolean {
@@ -147,6 +152,7 @@ class BridgeIO implements pxt.packetio.PacketIO {
 
     initAsync(): Promise<void> {
         this.connected = false;
+        this.connecting = true;
         return iface.opAsync("list", {})
             .then((devs0: any) => {
                 let devs = devs0.devices as HidDevice[]
@@ -167,6 +173,9 @@ class BridgeIO implements pxt.packetio.PacketIO {
             }))
             .then(() => {
                 this.connected = true;
+            })
+            .finally(() => {
+                this.connecting = false;
                 if (this.onConnectionChanged)
                     this.onConnectionChanged();
             })


### PR DESCRIPTION
- [x] don't try to reconnect before flashing, if it fails, disconnect and try again.
- [x] display "connecting state in UI". in some instance, enumerating USB devices takes a long time and connecting takes several seconds. at least the user knows something is going on
+ a couple fixes for testGithubpackages in the cli.