### PR TITLE
Blockly upgrade for legacy animation enum blocks

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -157,9 +157,8 @@ namespace pxtblockly {
             const bg = new svg.Rect()
                 .at(PADDING + ICON_WIDTH, PADDING)
                 .size(BG_WIDTH, BG_WIDTH)
-                .fill("#dedede")
-                .stroke("#898989", 1)
-                .corner(4);
+                .corner(4)
+                .setClass("blocklyAnimationField");
 
             this.fieldGroup_.appendChild(bg.el);
 

--- a/pxtblocks/fields/field_userenum.ts
+++ b/pxtblocks/fields/field_userenum.ts
@@ -9,7 +9,7 @@ namespace pxtblockly {
             this.initVariables();
         }
 
-        onItemSelected(menu: Blockly.Menu, menuItem: Blockly.MenuItem) {
+        onItemSelected_(menu: Blockly.Menu, menuItem: Blockly.MenuItem) {
             const value = menuItem.getValue();
             if (value === "CREATE") {
                 promptAndCreateEnum(this.sourceBlock_.workspace, this.opts, lf("New {0}:", this.opts.memberName),
@@ -20,28 +20,26 @@ namespace pxtblockly {
             }
         }
 
+        doClassValidation_(value: any) {
+            // update cached option list when adding a new kind
+            if (this.opts?.initialMembers && !this.opts.initialMembers.find(el => el == value)) this.getOptions();
+            return super.doClassValidation_(value);
+        }
 
         private initVariables() {
             if (this.sourceBlock_ && this.sourceBlock_.workspace) {
-                if (this.sourceBlock_.isInFlyout) {
-                    // Can't create variables from within the flyout, so we just have to fake it
-                    // by setting the text instead of the value
-                    this.setText(this.opts.initialMembers[0]);
-                }
-                else {
-                    const ws = this.sourceBlock_.workspace;
-                    const existing = getMembersForEnum(ws, this.opts.name);
-                    this.opts.initialMembers.forEach(memberName => {
-                        if (!existing.some(([name, value]) => name === memberName)) {
-                            createNewEnumMember(ws, this.opts, memberName);
-                        }
-                    });
+                const ws = this.sourceBlock_.workspace;
+                const existing = getMembersForEnum(ws, this.opts.name);
+                this.opts.initialMembers.forEach(memberName => {
+                    if (!existing.some(([name, value]) => name === memberName)) {
+                        createNewEnumMember(ws, this.opts, memberName);
+                    }
+                });
 
-                    if (this.getValue() === "CREATE") {
-                        const newValue = getVariableNameForMember(ws, this.opts.name, this.opts.initialMembers[0])
-                        if (newValue) {
-                            this.setValue(newValue);
-                        }
+                if (this.getValue() === "CREATE") {
+                    const newValue = getVariableNameForMember(ws, this.opts.name, this.opts.initialMembers[0])
+                    if (newValue) {
+                        this.setValue(newValue);
                     }
                 }
             }
@@ -60,6 +58,9 @@ namespace pxtblockly {
                     const withoutValue = model.name.replace(/^\d+/, "")
                     res.push([withoutValue, model.name]);
                 });
+            } else {
+                // Can't create variables from within the flyout, so we just have to fake it
+                opts.initialMembers.forEach((e) => res.push([e, e]) );
             }
 
 

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -58,32 +58,34 @@ body.blocklyMinimalBody {
         Blockly Text
 *******************************/
 
-text.blocklyText, input.blocklyHtmlInput, .blocklyDropDownDiv .goog-menuitem, textarea.blocklyCommentTextarea {
-    font-family: @blocklyFont !important;
-    font-weight: normal;
-}
+.pxt-renderer {
+    text.blocklyText, input.blocklyHtmlInput, .blocklyDropDownDiv .goog-menuitem, textarea.blocklyCommentTextarea {
+        font-family: @blocklyFont !important;
+        font-weight: normal;
+    }
 
-text.blocklyFlyoutLabelText, .blocklyFlyoutButton text.blocklyText {
-    font-family: @pageFont !important;
-}
+    text.blocklyFlyoutLabelText, .blocklyFlyoutButton text.blocklyText {
+        font-family: @pageFont !important;
+    }
 
-text.blocklyText.blocklyBoldText {
-    font-weight: bold;
-}
+    text.blocklyText.blocklyBoldText {
+        font-weight: bold;
+    }
 
-text.blocklyText.blocklyItalicizedText {
-    font-style: italic;
-}
+    text.blocklyText.blocklyItalicizedText {
+        font-style: italic;
+    }
 
-text.blocklyText.blocklyBoldItalicizedText {
-    font-weight: bold;
-    font-style: italic;
-}
+    text.blocklyText.blocklyBoldItalicizedText {
+        font-weight: bold;
+        font-style: italic;
+    }
 
-text.semanticIcon {
-    fill: #fff;
-    font-family: "Icons";
-    font-size: 19px;
+    text.semanticIcon {
+        fill: #fff;
+        font-family: "Icons";
+        font-size: 19px;
+    }
 }
 
 
@@ -202,6 +204,7 @@ text.blocklyCheckbox {
 
 /* (arcade only) Sets the correct background color for the sprite image field */
 .pxt-renderer .blocklyEditableText > rect.blocklySpriteField,
+.pxt-renderer .blocklyEditableText > rect.blocklyAnimationField,
 .pxt-renderer .blocklyEditableText > rect.blocklyTilemapField {
     fill: #dedede;
     stroke: #898989;


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-arcade/issues/1872

\+ small CSS fixes for new animation editor block