### PR TITLE
Don't use deprecated setText in python grey blocks

### DIFF
--- a/pxtblocks/fields/field_tsexpression.ts
+++ b/pxtblocks/fields/field_tsexpression.ts
@@ -5,6 +5,7 @@ namespace pxtblockly {
         public isFieldCustom_ = true;
         protected pythonMode = false;
 
+
         /**
          * Same as parent, but adds a different class to text when disabled
          */
@@ -24,27 +25,15 @@ namespace pxtblockly {
             }
         }
 
-        doValueUpdate_(newValue: string) {
-            super.doValueUpdate_(newValue);
-
-            if (this.pythonMode) this.setPythonText();
-        }
-
         public setPythonEnabled(enabled: boolean) {
             if (enabled === this.pythonMode) return;
 
             this.pythonMode = enabled;
-
-            if (enabled) {
-                this.setPythonText();
-            }
-            else {
-                this.setText(this.getValue());
-            }
+            this.forceRerender();
         }
 
-        protected setPythonText() {
-            this.setText(pxt.Util.lf("<python code>"))
+        getText() {
+            return this.pythonMode ? pxt.Util.lf("<python code>") : this.getValue();
         }
 
         applyColour() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2897