### PR TITLE
Move trace to be part of the debugger

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -176,7 +176,6 @@ declare namespace pxt {
         emptyRunCode?: string; // when non-empty and autoRun is disabled, this code is run upon simulator first start
         hideRestart?: boolean;
         // moved to theme
-        // enableTrace?: boolean;
         // moved to theme
         // debugger?: boolean;
         hideFullscreen?: boolean;
@@ -312,7 +311,6 @@ declare namespace pxt {
         print?: boolean; //Print blocks and text feature
         greenScreen?: boolean; // display webcam stream in background
         instructions?: boolean; // display make instructions
-        enableTrace?: boolean; // Slow-Mo button
         debugger?: boolean; // debugger button
         selectLanguage?: boolean; // add language picker to settings menu
         availableLocales?: string[]; // the list of enabled language codes

--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -91,6 +91,26 @@
     color: #87D282 !important;
 }
 
+.ui.compact.menu .dbg-btn.dbg-trace {
+    border-radius: 0;
+}
+
+.ui.compact.menu .dbg-btn.dbg-trace.tracing {
+    background-color: @orange;
+
+    .icon {
+        color: @white;
+    }
+}
+
+.ui.compact.menu .dbg-btn.dbg-trace.tracing:hover {
+    background-color: darken(@orange, 10%);
+
+    .icon {
+        color: darken(@white, 5%);
+    }
+}
+
 .ui.item.link.dbg-btn.dbg-exit {
     background-color: #cccccc;
     color: rgb(255, 21, 0);

--- a/webapp/src/debuggerToolbar.tsx
+++ b/webapp/src/debuggerToolbar.tsx
@@ -27,6 +27,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
         this.dbgStepInto = this.dbgStepInto.bind(this);
         this.dbgStepOut = this.dbgStepOut.bind(this);
         this.exitDebugging = this.exitDebugging.bind(this);
+        this.toggleTrace = this.toggleTrace.bind(this);
     }
 
     restartSimulator() {
@@ -59,6 +60,11 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
         simulator.dbgStepOut();
     }
 
+    toggleTrace() {
+        pxt.tickEvent("simulator.trace", undefined, { interactiveConsent: true });
+        this.props.parent.toggleTrace();
+    }
+
     getMenuDom() {
         const node = ReactDOM.findDOMNode(this);
         return node && node.firstElementChild;
@@ -88,6 +94,9 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
         const dbgStepOverTooltip = lf("Step over");
         const dbgStepOutTooltip = lf("Step out");
 
+        const tracing = this.props.parent.state.tracing;
+        const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
+
         if (!isDebugging) {
             return <div className="debugtoolbar" role="complementary" aria-label={lf("Debugger toolbar")} />
         } else if (advancedDebugging) {
@@ -100,6 +109,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
                         <sui.Item key='dbgstepinto' className={`dbg-btn dbg-step-into ${dbgStepDisabledClass}`} icon={`xicon stepinto ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} />
                         <sui.Item key='dbgstepout' className={`dbg-btn dbg-step-out ${dbgStepDisabledClass}`} icon={`xicon stepout ${isDebuggerRunning ? "disabled" : ""}`} title={dbgStepOutTooltip} onClick={this.dbgStepOut} />
                         <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart right`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
+                        <sui.Item key='dbgslowmo' className={`dbg-btn dbg-trace ${tracing ? "tracing" : ""}`} icon={`xicon turtle`} title={traceTooltip} onClick={this.toggleTrace} />
                     </div>}
             </div>;
         } else {
@@ -109,6 +119,7 @@ export class DebuggerToolbar extends data.Component<DebuggerToolbarProps, Debugg
                     <sui.Item key='dbgstep' className={`dbg-btn dbg-step separator-after ${dbgStepDisabledClass}`} icon={`arrow right ${dbgStepDisabled ? "disabled" : "blue"}`} title={dbgStepIntoTooltip} onClick={this.dbgStepInto} text={"Step"} />
                     <sui.Item key='dbgpauseresume' className={`dbg-btn dbg-pause-resume ${isDebuggerRunning ? "pause" : "play"}`} icon={`${isDebuggerRunning ? "pause blue" : "play green"}`} title={dbgPauseResumeTooltip} onClick={this.dbgPauseResume} />
                     <sui.Item key='dbgrestart' className={`dbg-btn dbg-restart`} icon={`refresh green`} title={restartTooltip} onClick={this.restartSimulator} />
+                    <sui.Item key='dbgslowmo' className={`dbg-btn dbg-trace ${tracing ? "tracing" : ""}`} icon={`xicon turtle`} title={traceTooltip} onClick={this.toggleTrace} />
                 </div>
             </div>;
         }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -25,7 +25,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         this.zoomIn = this.zoomIn.bind(this);
         this.zoomOut = this.zoomOut.bind(this);
         this.startStopSimulator = this.startStopSimulator.bind(this);
-        this.toggleTrace = this.toggleTrace.bind(this);
         this.toggleDebugging = this.toggleDebugging.bind(this);
     }
 
@@ -69,11 +68,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
     startStopSimulator(view?: string) {
         pxt.tickEvent("editortools.startStopSimulator", { view: view, collapsed: this.getCollapsedState(), headless: this.getHeadlessState() }, { interactiveConsent: true });
         this.props.parent.startStopSimulator({ clickTrigger: true });
-    }
-
-    toggleTrace(view?: string) {
-        pxt.tickEvent("editortools.trace", { view: view, collapsed: this.getCollapsedState(), headless: this.getHeadlessState() }, { interactiveConsent: true });
-        this.props.parent.toggleTrace();
     }
 
     toggleDebugging(view?: string) {
@@ -266,9 +260,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             && !!targetTheme.githubEditor
             && !readOnly && !isController && !debugging && !tutorial;
 
-        const trace = !!targetTheme.enableTrace;
-        const tracing = this.props.parent.state.tracing;
-        const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debug = !!targetTheme.debugger && !readOnly;
         const debugTooltip = debugging ? lf("Disable Debugging") : lf("Debugging")
         const downloadIcon = pxt.appTarget.appTheme.downloadIcon || "download";
@@ -344,7 +335,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                 <div className="row" style={readOnly || !showUndoRedo ? undefined : { paddingTop: 0 }}>
                                     <div className="column">
                                         <div className="ui icon large buttons">
-                                            {trace && <EditorToolbarButton key='tracebtn' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onButtonClick={this.toggleTrace} view='mobile' />}
                                             {debug && <EditorToolbarButton key='debugbtn' className={`debug-button ${debugging ? 'orange' : ''}`} icon="icon bug" title={debugTooltip} onButtonClick={this.toggleDebugging} view='mobile' />}
                                             {compileBtn && this.getCompileButton(mobile)}
                                         </div>
@@ -409,7 +399,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                                     </div>}
                                 <div className="row" style={showUndoRedo || showZoomControls ? { paddingTop: 0 } : {}}>
                                     <div className="column">
-                                        {trace && <EditorToolbarButton key='tracebtn' className={`large trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onButtonClick={this.toggleTrace} view='tablet' />}
                                         {debug && <EditorToolbarButton key='debugbtn' className={`large debug-button ${debugging ? 'orange' : ''}`} icon="icon bug" title={debugTooltip} onButtonClick={this.toggleDebugging} view='tablet' />}
                                     </div>
                                 </div>

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -20,7 +20,6 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         if (pxt.BrowserUtils.isIOS())
             this.props.parent.setMute(true);
 
-        this.toggleTrace = this.toggleTrace.bind(this);
         this.toggleMute = this.toggleMute.bind(this);
         this.restartSimulator = this.restartSimulator.bind(this);
         this.openInstructions = this.openInstructions.bind(this);
@@ -43,11 +42,6 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
     restartSimulator() {
         pxt.tickEvent('simulator.restart', undefined, { interactiveConsent: true });
         this.props.parent.restartSimulator();
-    }
-
-    toggleTrace() {
-        pxt.tickEvent("simulator.trace", undefined, { interactiveConsent: true });
-        this.props.parent.toggleTrace();
     }
 
     toggleDebug() {
@@ -89,11 +83,8 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
 
         const run = true;
         const restart = run && !simOpts.hideRestart;
-        const trace = !!targetTheme.enableTrace;
         // We hide debug button in Monaco because it's not implemented yet.
         const debug = targetTheme.debugger && !inTutorial && !pxt.BrowserUtils.isIE();
-        const tracing = this.props.parent.state.tracing;
-        const traceTooltip = tracing ? lf("Disable Slow-Mo") : lf("Slow-Mo")
         const debugging = parentState.debugging;
         // we need to escape full screen from a tutorial!
         const fullscreen = run && !simOpts.hideFullscreen && !sandbox;
@@ -118,7 +109,6 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
                 {run && !targetTheme.bigRunButton && <PlayButton parent={this.props.parent} simState={parentState.simState} debugging={parentState.debugging} />}
                 {restart && <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} />}
                 {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
-                {trace && <sui.Button key='trace' className={`trace-button ${tracing ? 'orange' : ''}`} icon="xicon turtle" title={traceTooltip} onClick={this.toggleTrace} />}
             </div>
             {!isHeadless && <div className={`ui icon tiny buttons computer only`} style={{ padding: "0" }}>
                 {audio && <sui.Button key='mutebtn' className={`mute-button ${isMuted ? 'red' : ''}`} icon={`${isMuted ? 'volume off' : 'volume up'}`} title={muteTooltip} onClick={this.toggleMute} />}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2857

The trace button is moving to the debugger toolbar! Here's a GIF of monaco and blocks:

![2020-04-29 14 10 10](https://user-images.githubusercontent.com/13754588/80647465-5d2dea00-8a23-11ea-8a79-500ac0797a29.gif)
