### PR TITLE
Don't trace unless the debugger is shown

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2714,7 +2714,7 @@ export class ProjectView
 
             if (!opts.background)
                 this.editor.beforeCompile();
-            if (this.state.tracing)
+            if (this.state.tracing && this.state.debugging)
                 opts.trace = true;
 
             if (opts.debug) {


### PR DESCRIPTION
A tiny fix for https://github.com/microsoft/pxt/pull/6939

If tracing is enabled, only use it when the debugger is shown.