### PR TITLE
Add handler params to monaco toolbox, fix python snippets

### DIFF
--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -105,6 +105,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     snippetName: "let",
                     snippet: `let item: number`,
                     pySnippet: `item = 0`,
+                    pySnippetName: `item = 0`,
                     snippetOnly: true,
                     attributes: {
                         blockId: 'variables_set',


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2900

- Add handler params to toolbox snippet
- Use pySnippetName for python
- Add pySnippetName for variable declaration