### PR TITLE
Use built-in blockly CSS for font weight

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -59,11 +59,6 @@ body.blocklyMinimalBody {
 *******************************/
 
 .pxt-renderer {
-    text.blocklyText, input.blocklyHtmlInput, .blocklyDropDownDiv .goog-menuitem, textarea.blocklyCommentTextarea {
-        font-family: @blocklyFont !important;
-        font-weight: normal;
-    }
-
     text.blocklyFlyoutLabelText, .blocklyFlyoutButton text.blocklyText {
         font-family: @pageFont !important;
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2928

Rely on Blockly's pxt-renderer for CSS as much as possible