### PR TITLE
Bump pxt-blockly to 3.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.8",
+    "pxt-blockly": "3.0.9",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -564,6 +564,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             blocklyDiv.style.width = blocklyArea.offsetWidth + 'px';
             blocklyDiv.style.height = blocklyArea.offsetHeight + 'px';
             Blockly.svgResize(this.editor);
+            Blockly.WidgetDiv.repositionForWindowResize();
+            Blockly.DropDownDiv.repositionForWindowResize();
             this.resizeToolbox();
             this.resizeFieldEditorView();
         }


### PR DESCRIPTION
Pulling in pxt-blockly changes:
- Yellow connection line (https://github.com/microsoft/pxt-blockly/pull/292)
- Reposition widget div when block resizes (https://github.com/microsoft/pxt-blockly/pull/289)
- Fix breakpoint click events (https://github.com/microsoft/pxt-blockly/pull/291)
- Restore "New variable..." option to variable dropdown (https://github.com/microsoft/pxt-blockly/pull/290)

\+ Call reposition functions on workspace resize (simulator collapse/expand). Fixes https://github.com/microsoft/pxt-microbit/issues/2903