### PR TITLE
Fire resize event instead of repositioning widget divs

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2526,11 +2526,13 @@ export class ProjectView
             this.startSimulator();
         }
         this.setState({ collapseEditorTools: false });
+        this.fireResize();
     }
 
     collapseSimulator() {
         simulator.hide(() => {
             this.setState({ collapseEditorTools: true });
+            this.fireResize();
         })
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -564,8 +564,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             blocklyDiv.style.width = blocklyArea.offsetWidth + 'px';
             blocklyDiv.style.height = blocklyArea.offsetHeight + 'px';
             Blockly.svgResize(this.editor);
-            Blockly.WidgetDiv.repositionForWindowResize();
-            Blockly.DropDownDiv.repositionForWindowResize();
             this.resizeToolbox();
             this.resizeFieldEditorView();
         }


### PR DESCRIPTION
resize is called pretty frequently so i'm firing a manual resize event (which triggers the default blockly logic of hiding the widget div) instead of repositioning it inside our resize call.

Fixes https://github.com/microsoft/pxt-microbit/issues/2932