### PR TITLE
Fix flyout buttons in high contrast

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -142,6 +142,10 @@
         }
     }
 
+    .blocklyFlyoutButtonBackground {
+        stroke: @HCtextColor !important;
+    }
+
     /* Main editor areas */
 
     #root {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2961

<img width="373" alt="Screen Shot 2020-05-04 at 10 31 29 AM" src="https://user-images.githubusercontent.com/13754588/80995080-88815200-8df2-11ea-85c9-fe654471547b.png">
