### PR TITLE
Bump pxt-blockly to 3.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.9",
+    "pxt-blockly": "3.0.10",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1471,12 +1471,10 @@ namespace pxt.blocks {
         };
 
         // Use Blockly hook to customize context menu
-        (<any>Blockly).WorkspaceSvg.prototype.configureContextMenu = function (options: Blockly.ContextMenu.Option[]) {
+        (<any>Blockly).WorkspaceSvg.prototype.configureContextMenu = function (options: Blockly.ContextMenu.Option[], e: any) {
             if (this.options.readOnly || this.isFlyout) {
                 return;
             }
-            // Store workspace comment option
-            const commentOption = options.find(el => el.text.toLowerCase().includes("comment"));
 
             // Clear default Blockly options
             options.length = 0;
@@ -1487,7 +1485,7 @@ namespace pxt.blocks {
 
             // Option to add a workspace comment.
             if (this.options.comments && !BrowserUtils.isIE()) {
-                options.push(commentOption);
+                options.push(Blockly.ContextMenu.workspaceCommentOption(ws, e));
             }
 
 

--- a/pxtblocks/fields/field_imagedropdown.ts
+++ b/pxtblocks/fields/field_imagedropdown.ts
@@ -127,8 +127,7 @@ namespace pxtblockly {
 
             Blockly.DropDownDiv.setColour(this.backgroundColour_, this.borderColour_);
 
-            Blockly.DropDownDiv.showPositionedByBlock(
-                this, this.sourceBlock_, this.onHide_.bind(this));
+            Blockly.DropDownDiv.showPositionedByField(this, this.onHide_.bind(this));
 
             let source = this.sourceBlock_ as Blockly.BlockSvg;
             this.savedPrimary_ = source?.getColour();


### PR DESCRIPTION
- Re-create workspace comment option
- Use position by field instead of position by block for image dropdown
- Separate input indicators for empty inputs (https://github.com/microsoft/pxt-blockly/pull/293)
- Only reposition widget and dropdown divs when visible (https://github.com/microsoft/pxt-blockly/pull/297)


Fixes https://github.com/microsoft/pxt-microbit/issues/2969
Fixes https://github.com/microsoft/pxt-microbit/issues/2987
Fixes https://github.com/microsoft/pxt-microbit/issues/2933
