### PR TITLE
Bail out on generics in python type inference

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -538,7 +538,9 @@ namespace pxt.py {
         t0 = find(t0)
         t1 = find(t1)
 
-        if (t0 === t1)
+        // We don't handle generic types yet, so bail out. Worst case
+        // scenario is that we infer some extra types as "any"
+        if (t0 === t1 || isGenericType(t0) || isGenericType(t1))
             return
 
         if (t0.primType === "any") {
@@ -569,6 +571,10 @@ namespace pxt.py {
             // detect late unifications
             // if (currIteration > 2) error(a, `unify ${t2s(t0)} ${t2s(t1)}`)
         }
+    }
+
+    function isGenericType(t: Type) {
+        return !!(t?.primType?.startsWith("'"));
     }
 
     function mkSymbol(kind: SK, qname: string): SymbolInfo {

--- a/tests/pyconverter-test/baselines/array_generics.ts
+++ b/tests/pyconverter-test/baselines/array_generics.ts
@@ -1,0 +1,13 @@
+//  This test case exists to make sure
+//  we make it through the converter, but
+//  the output is not ideal. In the future
+//  we may want to improve the type inference
+function whatever(y: any) {
+    let x = [1, 2, 3]
+    x.push(y)
+}
+
+let z = []
+z.push("")
+let q = ["a", "b"]
+q.push(0)

--- a/tests/pyconverter-test/cases/array_generics.py
+++ b/tests/pyconverter-test/cases/array_generics.py
@@ -1,0 +1,14 @@
+# This test case exists to make sure
+# we make it through the converter, but
+# the output is not ideal. In the future
+# we may want to improve the type inference
+
+def whatever(y):
+    x = [1, 2, 3]
+    x.push(y)
+
+z = []
+z.push("")
+
+q = ["a", "b"]
+q.push(0)

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -15,7 +15,8 @@ function setDiagnostics(diagnostics: pxtc.KsDiagnostic[], sourceMap?: pxtc.Sourc
     //  TS errors to PY
     let tsErrToPyLoc: (err: pxtc.LocationInfo) => pxtc.LocationInfo = undefined;
     if (diagnostics.length > 0
-        && mainPkg.filterFiles(f => f.name === "main.ts" || f.name === "main.py").length === 2
+        && mainPkg.files["main.ts"]
+        && mainPkg.files["main.py"]
         && sourceMap) {
         const tsFile = mainPkg.files["main.ts"].content
         const pyFile = mainPkg.files["main.py"].content


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2825

We don't handle generics in our python converter. I'm not sure when this regressed exactly, but i remember it working at some point. In any case I am not adding generic support because it should probably be left to the TypeScript compiler. 

While fixing this bug I also figured out the issue that was causing TS errors to only sometimes show up in python programs. The check we were doing in setDiagnostics wasn't accounting for the "built" package and so it always failed after the first run of the project.