### PR TITLE
Added some of the suggestions made at the design meeting on 4/29

### DIFF
--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -6,24 +6,32 @@
     min-height: 200px;
     border-top: 1px #e5e5e5 solid;
 
-    h4 {
+    .errorListHeader {
         padding: 1em;
         margin-bottom: 0;
-    }
 
-    .collapseButton {
-        float: right;
-        cursor: pointer;
-        position: absolute;
-        top: 1em;
-        right: 1em;
-
-        i {
-            font-size: 2em;
+        h4 {
+            margin: 0;
+            display: inline-block;
+            vertical-align: middle;
         }
 
-        i:not(:hover) {
-            opacity: 0.5;
+        .collapseButton {
+            //float: right;
+            cursor: pointer;
+            position: relative;
+            //top: 1em;
+            //right: 1em;
+            display: inline-block;
+            vertical-align: middle;
+
+            i {
+                font-size: 0.5em; // FIX THIS
+            }
+
+            i:not(:hover) {
+                opacity: 0.5;
+            }
         }
     }
 

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -3,11 +3,13 @@
 // Expanded error list
 .errorList {
     position: relative;
-    min-height: 200px;
+    max-height: 16em;
+    min-height: 16em;
     border-top: 2px #e5e5e5 solid;
 
     .errorListHeader {
         padding: 1em;
+        height: 4em;
         margin-bottom: 0;
 
         h4 {
@@ -37,7 +39,7 @@
     }
 
     .errorListInner {
-        height: 160px;
+        height: 12em;
         padding: 0 1em 1em 1em;
         overflow-y: scroll;
 

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -20,13 +20,10 @@
             float: right;
             cursor: pointer;
             position: relative;
-            //top: 1em;
-            //right: 1em;
-            //display: inline-block;
             vertical-align: middle;
 
             i {
-                font-size: 1.5em; // FIX THIS
+                font-size: 1.5em;
             }
 
             i:not(:hover) {
@@ -39,6 +36,10 @@
         height: 160px;
         padding: 0 1em 1em 1em;
         overflow-y: scroll;
+
+        .errorMessage {
+            padding: 0.25em;
+        }
     }
 }
 
@@ -46,15 +47,22 @@
 .errorList.errorListSummary {
     min-height: unset;
 
+    &.errorsAvailable:hover {
+        background-color: rgba(0, 0, 0, 0.02);
+    }
+
     .errorListInner {
         height: unset;
         overflow-y: unset;
         padding: 1em;
 
-        .summaryMessage:hover {
-            cursor: pointer;
-            color: @summary-hover-color;
-            text-decoration: underline;
+        .summaryMessage {
+
+            &:hover {
+                cursor: pointer;
+                color: @summary-hover-color;
+                text-decoration: underline;
+            }
         }
     }
 }

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -1,43 +1,47 @@
 @summary-hover-color: #00000067;
 
+// Expanded error list
 .errorList {
     position: relative;
     min-height: 200px;
+    border-top: 1px #e5e5e5 solid;
+
+    h4 {
+        padding: 1em;
+        margin-bottom: 0;
+    }
+
+    .collapseButton {
+        float: right;
+        cursor: pointer;
+        position: absolute;
+        top: 1em;
+        right: 1em;
+
+        i {
+            font-size: 2em;
+        }
+
+        i:not(:hover) {
+            opacity: 0.5;
+        }
+    }
 
     .errorListInner {
-        height: 200px;
-        border-top: 1px #e5e5e5 solid;
-        padding: 1em;
+        height: 160px;
+        padding: 0 1em 1em 1em;
         overflow-y: scroll;
-
-        h4 {
-            margin-bottom: 0.5em;
-        }
-
-        .closeIcon {
-            float: right;
-            cursor: pointer;
-            position: absolute;
-            top: 1em;
-            right: 1em;
-
-            i {
-                font-size: 2em;
-            }
-
-            i:not(:hover) {
-                opacity: 0.5;
-            }
-        }
     }
 }
 
+// collapsed error list
 .errorList.errorListSummary {
     min-height: unset;
 
     .errorListInner {
         height: unset;
         overflow-y: unset;
+        padding: 1em;
 
         .summaryMessage:hover {
             cursor: pointer;

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -16,7 +16,7 @@
             vertical-align: middle;
         }
 
-        a {
+        .countBubble {
             margin-left: 1em;
         }
 
@@ -42,7 +42,7 @@
         overflow-y: scroll;
 
         .errorMessage {
-            padding: 0.25em;
+            padding: 0.1em;
         }
     }
 }
@@ -51,22 +51,8 @@
 .errorList.errorListSummary {
     min-height: unset;
 
-    &.errorsAvailable:hover {
+    &:hover {
+        cursor: pointer;
         background-color: rgba(0, 0, 0, 0.02);
-    }
-
-    .errorListInner {
-        height: unset;
-        overflow-y: unset;
-        padding: 1em;
-
-        .summaryMessage {
-
-            &:hover {
-                cursor: pointer;
-                color: @summary-hover-color;
-                text-decoration: underline;
-            }
-        }
     }
 }

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -4,7 +4,7 @@
 .errorList {
     position: relative;
     min-height: 200px;
-    border-top: 1px #e5e5e5 solid;
+    border-top: 2px #e5e5e5 solid;
 
     .errorListHeader {
         padding: 1em;
@@ -17,16 +17,16 @@
         }
 
         .collapseButton {
-            //float: right;
+            float: right;
             cursor: pointer;
             position: relative;
             //top: 1em;
             //right: 1em;
-            display: inline-block;
+            //display: inline-block;
             vertical-align: middle;
 
             i {
-                font-size: 0.5em; // FIX THIS
+                font-size: 1.5em; // FIX THIS
             }
 
             i:not(:hover) {

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -1,15 +1,19 @@
-@summary-hover-color: #00000067;
+@total-height: 16em;
+@header-height: 4em;
+@inner-height: (@total-height - @header-height);
+@collapsed-errors-hover-color: rgba(0, 0, 0, 0.02);
+@border-color: #e5e5e5;
 
 // Expanded error list
 .errorList {
     position: relative;
-    max-height: 16em;
-    min-height: 16em;
-    border-top: 2px #e5e5e5 solid;
+    max-height: @total-height;
+    min-height: @total-height;
+    border-top: 2px @border-color solid;
 
     .errorListHeader {
         padding: 1em;
-        height: 4em;
+        height: @header-height;
         margin-bottom: 0;
 
         h4 {
@@ -39,7 +43,7 @@
     }
 
     .errorListInner {
-        height: 12em;
+        height: @inner-height;
         padding: 0 1em 1em 1em;
         overflow-y: scroll;
 
@@ -55,6 +59,6 @@
 
     &:hover {
         cursor: pointer;
-        background-color: rgba(0, 0, 0, 0.02);
+        background-color: @collapsed-errors-hover-color;
     }
 }

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -16,6 +16,10 @@
             vertical-align: middle;
         }
 
+        a {
+            margin-left: 1em;
+        }
+
         .collapseButton {
             float: right;
             cursor: pointer;

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -41,7 +41,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
         //const collapseButton = <sui.Button className="circular collapseButton" icon={`chevron down`} tooltip={collapseTooltip} onClick={this.onCollapseClick} />
         const collapseButton = <div className="collapseButton"><sui.Icon icon={`chevron down`} onClick={this.onCollapseClick} /></div>
         const errorListHeader = <div className="errorListHeader">
-            <h4 hidden={isCollapsed}>Error List</h4>
+            <h4 hidden={isCollapsed}>Problems</h4>
             {!isCollapsed && collapseButton}
         </div>
 
@@ -53,13 +53,13 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
                 </div>
             } else {
                 errorListContent = (errors).map(e =>
-                    <div key={errorKey(e)}>{`${e.messageText} - (${e.line + 1}:${e.column + 1})`}</div>)
+                    <div key={errorKey(e)} className="errorMessage">{`${e.messageText} ${lf("at line {0}", e.line + 1)}`}</div>)
             }
         } else {
             errorListContent = <div>{lf("Problems: looking good!")}</div>
         }
 
-        return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`}>
+        return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''} ${errorsAvailable ? 'errorsAvailable': ''}`}>
             {!isCollapsed && errorListHeader}
             <div className="errorListInner">
                 {errorListContent}

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -38,33 +38,26 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
             return `${error.messageText}-${error.fileName}-${error.line}-${error.column}`
         }
 
-        //const collapseButton = <sui.Button className="circular collapseButton" icon={`chevron down`} tooltip={collapseTooltip} onClick={this.onCollapseClick} />
+        // Header
         const collapseButton = <div className="collapseButton"><sui.Icon icon={`chevron down`} onClick={this.onCollapseClick} /></div>
         const errorListHeader = <div className="errorListHeader">
-            <h4 hidden={isCollapsed}>Problems</h4>
-            <a className="ui grey circular label">{errors?.length}</a>
+            <h4>Problems</h4>
+            {<div className="ui grey circular label countBubble">{errors?.length}</div>}
             {!isCollapsed && collapseButton}
         </div>
 
-        let errorListContent;
-        if (errorsAvailable) {
-            if (isCollapsed) {
-                errorListContent = <div className="summaryMessage" role="button" onClick={this.onCollapseClick}>
-                    {lf("Problems: Uh oh! We found {0} problem(s)", errors.length)}
-                </div>
-            } else {
-                errorListContent = (errors).map(e =>
-                    <div key={errorKey(e)} className="errorMessage">{`${e.messageText} ${lf("at line {0}", e.line + 1)}`}</div>)
-            }
-        } else {
-            errorListContent = <div>{lf("Problems: looking good!")}</div>
-        }
+        const errorListContent = (errors).map(e =>
+            <div key={errorKey(e)} className="errorMessage">{`${e.messageText} ${lf("at line {0}", e.line + 1)}`}</div>)
 
-        return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''} ${errorsAvailable ? 'errorsAvailable': ''}`}>
-            {!isCollapsed && errorListHeader}
-            <div className="errorListInner">
-                {errorListContent}
-            </div>
+        return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`}
+                    onClick={isCollapsed ? this.onCollapseClick : null}
+                    hidden={!errorsAvailable}>
+            {errorListHeader}
+            {!isCollapsed &&
+                <div className="errorListInner">
+                    {errorListContent}
+                </div>
+            }
         </div>
     }
 

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -49,14 +49,14 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
         if (errorsAvailable) {
             if (isCollapsed) {
                 errorListContent = <div className="summaryMessage" role="button" onClick={this.onCollapseClick}>
-                    {lf("Error List: Uh oh! We found {0} error(s)", errors.length)}
+                    {lf("Problems: Uh oh! We found {0} problem(s)", errors.length)}
                 </div>
             } else {
                 errorListContent = (errors).map(e =>
                     <div key={errorKey(e)}>{`${e.messageText} - (${e.line + 1}:${e.column + 1})`}</div>)
             }
         } else {
-            errorListContent = <div>{lf("Error List: looking good!")}</div>
+            errorListContent = <div>{lf("Problems: looking good!")}</div>
         }
 
         return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`}>

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -51,6 +51,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
 
         return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`}
                     onClick={isCollapsed ? this.onCollapseClick : null}
+                    role={isCollapsed ? "button" : null}
                     hidden={!errorsAvailable}>
             {errorListHeader}
             {!isCollapsed &&

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -42,6 +42,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
         const collapseButton = <div className="collapseButton"><sui.Icon icon={`chevron down`} onClick={this.onCollapseClick} /></div>
         const errorListHeader = <div className="errorListHeader">
             <h4 hidden={isCollapsed}>Problems</h4>
+            <a className="ui grey circular label">{errors?.length}</a>
             {!isCollapsed && collapseButton}
         </div>
 

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -38,7 +38,11 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
             return `${error.messageText}-${error.fileName}-${error.line}-${error.column}`
         }
 
-        const collapseButton = <sui.Button className="collapseButton" icon={`chevron down`} onClick={this.onCollapseClick} />
+        const collapseButton = <sui.Button className="circular collapseButton" icon={`chevron down`} tooltip={collapseTooltip} onClick={this.onCollapseClick} />
+        const errorListHeader = <div className="errorListHeader">
+            <h4 hidden={isCollapsed}>Error List</h4>
+            {!isCollapsed && collapseButton}
+        </div>
 
         let errorListContent;
         if (errorsAvailable) {
@@ -55,8 +59,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
         }
 
         return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`}>
-            <h4 hidden={isCollapsed}>Error List</h4>
-            {!isCollapsed && collapseButton}
+            {!isCollapsed && errorListHeader}
             <div className="errorListInner">
                 {errorListContent}
             </div>

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -38,7 +38,8 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
             return `${error.messageText}-${error.fileName}-${error.line}-${error.column}`
         }
 
-        const collapseButton = <sui.Button className="circular collapseButton" icon={`chevron down`} tooltip={collapseTooltip} onClick={this.onCollapseClick} />
+        //const collapseButton = <sui.Button className="circular collapseButton" icon={`chevron down`} tooltip={collapseTooltip} onClick={this.onCollapseClick} />
+        const collapseButton = <div className="collapseButton"><sui.Icon icon={`chevron down`} onClick={this.onCollapseClick} /></div>
         const errorListHeader = <div className="errorListHeader">
             <h4 hidden={isCollapsed}>Error List</h4>
             {!isCollapsed && collapseButton}

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -18,7 +18,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
         super(props);
 
         this.state = {
-            isCollapsed: false,
+            isCollapsed: true,
             errors: []
         }
 

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -38,7 +38,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
             return `${error.messageText}-${error.fileName}-${error.line}-${error.column}`
         }
 
-        const xButton = <sui.CloseButton onClick={this.onCollapseClick} />
+        const collapseButton = <sui.Button className="collapseButton" icon={`chevron down`} onClick={this.onCollapseClick} />
 
         let errorListContent;
         if (errorsAvailable) {
@@ -55,9 +55,9 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
         }
 
         return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`}>
+            <h4 hidden={isCollapsed}>Error List</h4>
+            {!isCollapsed && collapseButton}
             <div className="errorListInner">
-                <h4 hidden={isCollapsed}>Error List</h4>
-                {!isCollapsed && xButton}
                 {errorListContent}
             </div>
         </div>

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -44,14 +44,14 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
         if (errorsAvailable) {
             if (isCollapsed) {
                 errorListContent = <div className="summaryMessage" role="button" onClick={this.onCollapseClick}>
-                    {lf("Uh oh! You have {0} error(s)!", errors.length)}
+                    {lf("Error List: Uh oh! We found {0} error(s)", errors.length)}
                 </div>
             } else {
                 errorListContent = (errors).map(e =>
                     <div key={errorKey(e)}>{`${e.messageText} - (${e.line + 1}:${e.column + 1})`}</div>)
             }
         } else {
-            errorListContent = <div>{lf("Everything seems fine!")}</div>
+            errorListContent = <div>{lf("Error List: looking good!")}</div>
         }
 
         return <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`}>


### PR DESCRIPTION
- made the header sticky when scrolling and show on collapse, fixes: microsoft/pxt-microbit#2938

- changed to collapse chevron

- border slightly thicker

- start collapsed, fixes: microsoft/pxt-microbit#2953

- changed wording to problems

- switched to just using line numbers

- hide error list when there are no errors

- display number of errors in bubble

- sizing change to accommodate header, fixes: microsoft/pxt-microbit#2895

![design-changes-1](https://user-images.githubusercontent.com/46362603/81015483-a4492000-8e13-11ea-89cc-85a61c7f14ae.gif)
