### PR TITLE
Deprecating Math.randomRange in favor of randint

### DIFF
--- a/common-docs/reference/math/randint.md
+++ b/common-docs/reference/math/randint.md
@@ -1,21 +1,12 @@
-# random Range
+# random int
 
 Return a pseudo-random value within a range of numbers.
 
 ```sig
-Math.randomRange(0, 10)
+randint(0, 10)
 ```
 
-## ~ hint
-
-**Deprecated**
-
-This API has been deprecated!
-Use [randint](/reference/math/randint) instead.
-
-## ~
-
-Returns a pseudo-random number in the range ``[min, max];`` that is, from ``0`` (inclusive) up to including ``1`` (inclusive), which you can then scale to your desired range.
+Returns a pseudo-random number in the range ``[min, max];`` that is, from ``min`` (inclusive) up to and including ``max`` (inclusive).
 
 ## Parameters
 
@@ -31,7 +22,7 @@ Returns a pseudo-random number in the range ``[min, max];`` that is, from ``0`` 
 Generate a random number between `0` and `100`.
 
 ```blocks
-let centoRandom = Math.randomRange(0, 100);
+let centoRandom = randint(0, 100);
 ```
 
 ## See Also

--- a/common-docs/reference/math/randint.md
+++ b/common-docs/reference/math/randint.md
@@ -8,6 +8,15 @@ randint(0, 10)
 
 Returns a pseudo-random number in the range ``[min, max];`` that is, from ``min`` (inclusive) up to and including ``max`` (inclusive).
 
+### ~ hint
+
+#### What is pseudo-random?
+
+Random numbers generated on a computer are often called _pseudo-random_. This because the method to create the number is based on some 
+starting value obtained from the computer itself. The formula for the random number could use some amount of mathematical operations on a value derived from a timer or some other input. The resulting "random" number isn't considered entirely random because it started with some initial value and a repeatable set of operations on it. Therefore, it's called a pseudo-random number.
+
+### ~
+
 ## Parameters
 
 * **min**: the smallest possible pseudo-random number to return.

--- a/docs/static/playground/pxt-common/pxt-core.d.js
+++ b/docs/static/playground/pxt-common/pxt-core.d.js
@@ -387,6 +387,18 @@ declare interface String {
 //% text.defl="123"
 declare function parseFloat(text: string): number;
 
+/**
+ * Returns a pseudorandom number between min and max included.
+ * If both numbers are integral, the result is integral.
+ * @param min the lower inclusive bound, eg: 0
+ * @param max the upper inclusive bound, eg: 10
+ */
+//% blockId="device_random" block="pick random %min|to %limit"
+//% blockNamespace="Math"
+//% help=math/randint
+//% shim=Math_::randomRange
+declare function randint(min: number, max: number): number;
+
 interface Object { }
 interface Function { }
 interface IArguments { }
@@ -477,8 +489,8 @@ declare namespace Math {
      * @param min the lower inclusive bound, eg: 0
      * @param max the upper inclusive bound, eg: 10
      */
-    //% blockId="device_random" block="pick random %min|to %limit"
-    //% help=math/random-range
+    //% blockId="device_random_deprecated" block="pick random %min|to %limit"
+    //% help=math/random-range deprecated
     //% shim=Math_::randomRange
     function randomRange(min: number, max: number): number;
 

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -387,6 +387,18 @@ declare interface String {
 //% text.defl="123"
 declare function parseFloat(text: string): number;
 
+/**
+ * Returns a pseudorandom number between min and max included.
+ * If both numbers are integral, the result is integral.
+ * @param min the lower inclusive bound, eg: 0
+ * @param max the upper inclusive bound, eg: 10
+ */
+//% blockId="device_random" block="pick random %min|to %limit"
+//% blockNamespace="Math"
+//% help=math/randint
+//% shim=Math_::randomRange
+declare function randint(min: number, max: number): number;
+
 interface Object { }
 interface Function { }
 interface IArguments { }
@@ -477,8 +489,8 @@ declare namespace Math {
      * @param min the lower inclusive bound, eg: 0
      * @param max the upper inclusive bound, eg: 10
      */
-    //% blockId="device_random" block="pick random %min|to %limit"
-    //% help=math/random-range
+    //% blockId="device_random_deprecated" block="pick random %min|to %limit"
+    //% help=math/random-range deprecated
     //% shim=Math_::randomRange
     function randomRange(min: number, max: number): number;
 

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -19,7 +19,6 @@ namespace ts.pxtc {
         "Math.min": { n: "min", t: ts.SyntaxKind.NumberKeyword, snippet: "min(0, 0)" },
         "Math.max": { n: "max", t: ts.SyntaxKind.NumberKeyword, snippet: "max(0, 0)" },
         "Math.abs": { n: "abs", t: ts.SyntaxKind.NumberKeyword, snippet: "abs(0)" },
-        "Math.randomRange": { n: "randint", t: ts.SyntaxKind.NumberKeyword, snippet: "randint(0, 10)" },
         "console.log": { n: "print", t: ts.SyntaxKind.VoidKeyword, snippet: 'print(":)")' },
         ".length": { n: "len", t: ts.SyntaxKind.NumberKeyword },
         ".toLowerCase()": { n: "string.lower", t: ts.SyntaxKind.StringKeyword },
@@ -1984,7 +1983,7 @@ namespace ts.pxtc.service {
     }
 
     function makePxtSymbolFromKeyword(keyword: string): SymbolInfo {
-        // TODO: since keywords aren't exactly symbols, consider using a different 
+        // TODO: since keywords aren't exactly symbols, consider using a different
         //       type than "SymbolInfo" to carry auto completion information.
         //       Some progress on this exists here: dazuniga/completionitem_refactor
 

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -250,9 +250,9 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     retType: "number"
                 },
                 {
-                    name: "Math.randomRange",
-                    snippetName: "randomRange",
-                    snippet: `Math.randomRange(0, 10)`,
+                    name: "randint",
+                    snippetName: "randint",
+                    snippet: `randint(0, 10)`,
                     pySnippetName: `randint`,
                     pySnippet: `randint(0, 10)`,
                     attributes: {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2894
Fixes https://github.com/microsoft/pxt-microbit/issues/2955

This deprecates `Math.randomRange(0, 1)` in favor of `randint(0, 1)`.

The reasoning for this change is that we already made up the nonstandard API of `Math.randomRange()` and we need to support `randint()` for python so we might as well unify the two. I'm using our usual strategy of leaving the API accessible in TypeScript but hiding the block from the toolbox.

All existing projects should be unaffected. No upgrade rules required!