### PR TITLE
bump jquery to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "pouchdb": "7.2.1",
     "pouchdb-adapter-memory": "7.2.1",
     "typescript": "3.7.5",
-    "jquery": "3.4.1",
+    "jquery": "3.5.0",
     "fuse.js": "3.2.0",
     "highlight.js": "9.12.0",
     "smoothie": "1.35.0",

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -153,12 +153,12 @@ namespace pxt.runner {
     }
 
     function appendJs($parent: JQuery, $js: JQuery, woptions: WidgetOptions) {
-        $parent.append($(`<div class="ui content js"><div class="subheading"><i class="ui icon xicon js"/>JavaScript</div></div>`).append($js));
+        $parent.append($(`<div class="ui content js"><div class="subheading"><i class="ui icon xicon js"></i>JavaScript</div></div>`).append($js));
         highlight($js);
     }
 
     function appendPy($parent: JQuery, $py: JQuery, woptions: WidgetOptions) {
-        $parent.append($(`<div class="ui content py"><div class="subheading"><i class="ui icon xicon python"/>Python</div></div>`).append($py));
+        $parent.append($(`<div class="ui content py"><div class="subheading"><i class="ui icon xicon python"></i>Python</div></div>`).append($py));
         highlight($py);
     }
 
@@ -479,7 +479,7 @@ namespace pxt.runner {
             // add an html widge that allows to translate the block
             if (pxt.Util.isTranslationMode()) {
                 const trs = $('<div class="ui segment" />');
-                trs.append($(`<div class="ui header"><i class="ui xicon globe" /></div>`));
+                trs.append($(`<div class="ui header"><i class="ui xicon globe"></i></div>`));
                 if (symbolInfo.attributes.translationId)
                     trs.append($('<div class="ui message">').text(symbolInfo.attributes.translationId));
                 if (symbolInfo.attributes.jsDoc)


### PR DESCRIPTION
re: https://github.com/microsoft/pxt/pull/6944

Spent a bit looking at docs / sidedocs / etc and this was the only regression I saw; either they removed ability to use self closing `<i>`'s, or it was undefined behavior in the first place. The js / python words were being parsed as children of the icon element instead of being siblings of the icons.