### PR TITLE
Longer wait for hint flash, don't pop on new steps

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1071,6 +1071,8 @@ export class ProjectView
         // save and typecheck
         this.typecheckNow();
         // Notify tutorial content pane
+
+        this.stopPokeUserActivity();
         let tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
         if (!tc) return;
         if (step > -1) {

--- a/webapp/src/hinttooltip.tsx
+++ b/webapp/src/hinttooltip.tsx
@@ -37,7 +37,7 @@ export class HintTooltip extends data.Component<HintTooltipProps, HintTooltipSta
 
 export class HintManager {
     private timer: number;
-    private defaultDuration: number = 15000;
+    private defaultDuration: number = 10000;
     private defaultDisplayCount: number = 3;
     private hints: { [key: string]: any } = {};
 

--- a/webapp/src/hinttooltip.tsx
+++ b/webapp/src/hinttooltip.tsx
@@ -37,7 +37,7 @@ export class HintTooltip extends data.Component<HintTooltipProps, HintTooltipSta
 
 export class HintManager {
     private timer: number;
-    private defaultDuration: number = 5000;
+    private defaultDuration: number = 15000;
     private defaultDisplayCount: number = 3;
     private hints: { [key: string]: any } = {};
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -559,8 +559,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                         </div>
                     </div>
                     <div className="avatar-container">
-                        {hasHint && <sui.Button className={`ui circular label blue hintbutton hidelightbox ${hasHint && this.props.pokeUser ? 'shake flash' : ''}`} icon="lightbulb outline" tabIndex={-1} onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter} />}
-                        {hasHint && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={hintOnClick} />}
+                        {(!unplugged && hasHint) && <sui.Button className={`ui circular label blue hintbutton hidelightbox ${hasHint && this.props.pokeUser ? 'shake flash' : ''}`} icon="lightbulb outline" tabIndex={-1} onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter} />}
+                        {(!unplugged && hasHint) && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={hintOnClick} />}
                         <TutorialHint ref="tutorialhint" parent={this.props.parent} />
                     </div>
                     {this.state.showSeeMore && !tutorialStepExpanded && <sui.Button className="fluid compact lightgrey" icon="chevron down" tabIndex={0} text={lf("More...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} />}


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2907

Increases the time before the hint bubble gets popped, and stop the timer between steps (e.g. drag a block and click next step, won't pop till you move a block again); the latter one is the one that I was running into most consistently.

Also got annoyed that it was showing the hint bubble behind unplugged steps, so don't show that