### PR TITLE
redo callkeys in blocklycompiler to not use compile

### DIFF
--- a/tests/blocklycompiler-test/baselines/draggable_parameters.ts
+++ b/tests/blocklycompiler-test/baselines/draggable_parameters.ts
@@ -1,12 +1,12 @@
-testNamespace.callbackWithDraggableParams(function (okay, d) {
-
-})
 testNamespace.callbackWithDraggableParams(function (hello, goodbye) {
 
 })
-testNamespace.callbackWithDraggableParams(function (c, d) {
+testNamespace.callbackWithDraggableParams(function (okay, d) {
 
 })
 testNamespace.callbackWithDraggableParams(function (sure, whatever) {
+
+})
+testNamespace.callbackWithDraggableParams(function (c, d) {
 
 })

--- a/tests/blocklycompiler-test/baselines/draggable_parameters.ts
+++ b/tests/blocklycompiler-test/baselines/draggable_parameters.ts
@@ -1,12 +1,12 @@
-testNamespace.callbackWithDraggableParams(function (hello, goodbye) {
-
-})
-testNamespace.callbackWithDraggableParams(function (sure, whatever) {
-
-})
 testNamespace.callbackWithDraggableParams(function (okay, d) {
 
 })
+testNamespace.callbackWithDraggableParams(function (hello, goodbye) {
+
+})
 testNamespace.callbackWithDraggableParams(function (c, d) {
+
+})
+testNamespace.callbackWithDraggableParams(function (sure, whatever) {
 
 })

--- a/tests/blocklycompiler-test/baselines/mc_chat_blocks.ts
+++ b/tests/blocklycompiler-test/baselines/mc_chat_blocks.ts
@@ -1,10 +1,10 @@
-player.onChat("run", function (num1) {
-  num1 = 0
-  asb = 0
-})
 player.onChat("hello", function (asb, num2) {
   asb = 0
   num2 = 0
+})
+player.onChat("run", function (num1) {
+  num1 = 0
+  asb = 0
 })
 let asb = 0
 let num2 = 0

--- a/tests/blocklycompiler-test/baselines/mc_chat_blocks.ts
+++ b/tests/blocklycompiler-test/baselines/mc_chat_blocks.ts
@@ -1,10 +1,10 @@
-player.onChat("hello", function (asb, num2) {
-  asb = 0
-  num2 = 0
-})
 player.onChat("run", function (num1) {
   num1 = 0
   asb = 0
+})
+player.onChat("hello", function (asb, num2) {
+  asb = 0
+  num2 = 0
 })
 let asb = 0
 let num2 = 0

--- a/tests/blocklycompiler-test/baselines/mc_old_chat_blocks.ts
+++ b/tests/blocklycompiler-test/baselines/mc_old_chat_blocks.ts
@@ -1,14 +1,14 @@
-player.onChatCommand("run",  [ChatArgument.number],function ({ number }) {
-  let string = 0
-  if (number == string) {
-
-  }
-})
 player.onChatCommand("jump",  [ChatArgument.string, ChatArgument.number],function ({ string, number }) {
   if (number == 0) {
 
   }
   if (string == "") {
+
+  }
+})
+player.onChatCommand("run",  [ChatArgument.number],function ({ number }) {
+  let string = 0
+  if (number == string) {
 
   }
 })


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2976
Fixes https://github.com/microsoft/pxt-arcade/issues/1879

We generate a "key" for all events on the workspace so that we can determine if there are any duplicates and disable them. This runs as the first step in the blockly compiler, because we need to know what blocks are disabled before we can start tracking variables, inferring types, etc.

The old way of generating a key was to just compile the arguments, but that led to a chicken-and-egg problem where we needed the variable/type info to compile the argument. Instead I've removed that dependency by only basing the key off of the blocks and not the compiled result.

As a side effect, the keys are now different than they used to be and so our emit order has changed slightly. It shouldn't be an issue because it was always pretty arbitrary. I had to fix a few test case baselines