### PR TITLE
give notification when pydecompile failed and don't switch preferred editor

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -408,7 +408,7 @@ export class ProjectView
         if (this.isBlocksActive()) {
             this.blocksEditor.openPython();
         } else if (this.isJavaScriptActive()) {
-            this.openPythonAsync();
+            this.openPythonAsync().done();
         } else {
             // make sure there's .py file
             const mpkg = pkg.mainEditorPkg();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -408,7 +408,7 @@ export class ProjectView
         if (this.isBlocksActive()) {
             this.blocksEditor.openPython();
         } else if (this.isJavaScriptActive()) {
-            this.openPythonAsync().done();
+            this.openPythonAsync();
         } else {
             // make sure there's .py file
             const mpkg = pkg.mainEditorPkg();
@@ -418,8 +418,6 @@ export class ProjectView
             else
                 this.setFile(mainpy);
         }
-        // update language pref
-        pxt.Util.setEditorLanguagePref("py");
     }
 
     openJavaScript(giveFocusOnLoading = true) {
@@ -584,17 +582,18 @@ export class ProjectView
                         mainPkg.cacheTranspile(fromLanguage, fromText, "py", mainpy);
                         return this.saveVirtualFileAsync(pxt.PYTHON_PROJECT_NAME, mainpy, true);
                     } else {
-                        // TODO python
                         this.editor.setDiagnostics(this.editorFile, snap);
-                        return Promise.resolve();
+                        return Promise.reject(new Error("Failed to convert to Python."));
                     }
                 })
-                .catch(e => {
+                .then(() => {
+                    // on success, update editor pref
+                    pxt.Util.setEditorLanguagePref("py");
+                }, e => {
                     pxt.reportException(e);
                     core.errorNotification(lf("Oops, something went wrong trying to convert your code."));
-                })
+                });
         }
-
         return core.showLoadingAsync("switchtopython", lf("switching to Python..."), convertPromise);
     }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/2965 so it shows a message like with other transition failures:

![image](https://user-images.githubusercontent.com/5615930/81139742-bc0bcb80-8f1b-11ea-970e-de5a61db5d16.png)

also move the editor pref assignment to be after the successful py decompile, so that we're sure it's a valid transition (fix the other bug I added as a comment on the issue)