### PR TITLE
Adding preview for debugger variable values

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -203,6 +203,31 @@
     }
 }
 
+.debugger-preview {
+    position: fixed;
+    background-color: white;
+    color: black;
+    border: solid 1px black;
+    padding: 0.25rem;
+
+    -webkit-touch-callout: text; /* iOS Safari */
+    -webkit-user-select: text;   /* Chrome/Safari/Opera */
+    -khtml-user-select: text;    /* Konqueror */
+    -moz-user-select: text;      /* Firefox */
+    -ms-user-select: text;       /* Internet Explorer/Edge */
+    user-select: text;           /* Non-prefixed version, currently
+                                    not supported by any browser */
+    overflow-wrap: break-word;
+    max-width: 500px;
+}
+
+// When the preview appears, the text is selected so that the user can copy it.
+// Hide the selection formatting because it makes it look like the text can be edited
+.debugger-preview::selection {
+    color: black;
+    background-color: white;
+}
+
 .debugging .ui.segment.debugvariables {
     display: block;
     margin: 0;

--- a/webapp/src/debuggerTable.tsx
+++ b/webapp/src/debuggerTable.tsx
@@ -49,7 +49,7 @@ export class DebuggerTableRow extends React.Component<DebuggerTableRowProps> {
                     { <i className={`ui icon small ${this.props.icon || "invisible"}`} /> }
                     <span>{this.props.leftText}</span>
                 </div>
-                <div className="variable detail" style={{ padding: 0.2 }} title={this.props.rightTitle} onClick={this.valueClickHandler}>
+                <div className="variable detail" role="button" style={{ padding: 0.2 }} title={this.props.rightTitle} onClick={this.valueClickHandler}>
                     <span className={`varval ${this.props.rightClass || ""}`}>{this.props.rightText}</span>
                 </div>
             </div>

--- a/webapp/src/debuggerTable.tsx
+++ b/webapp/src/debuggerTable.tsx
@@ -35,19 +35,21 @@ export interface DebuggerTableRowProps {
     leftClass?: string;
     depth?: number;
     rowClass?: string;
+    describedBy?: string;
 
     onClick?: (e: React.SyntheticEvent<HTMLDivElement>, component: DebuggerTableRow) => void;
+    onValueClick?: (e: React.SyntheticEvent<HTMLDivElement>, component: DebuggerTableRow) => void;
 }
 
 export class DebuggerTableRow extends React.Component<DebuggerTableRowProps> {
     render() {
-        return <div role="listitem" className={`item ${this.props.rowClass || ""}`} onClick={this.props.onClick ? this.clickHandler : undefined}>
+        return <div role="listitem" className={`item ${this.props.rowClass || ""}`} onClick={this.props.onClick ? this.clickHandler : undefined} aria-describedby={this.props.describedBy}>
             <div className="variableAndValue">
                 <div className={`variable varname ${this.props.leftClass || ""}`} title={this.props.leftTitle} style={this.props.depth ? { marginLeft: (this.props.depth * 0.75) + "em" } : undefined}>
                     { <i className={`ui icon small ${this.props.icon || "invisible"}`} /> }
                     <span>{this.props.leftText}</span>
                 </div>
-                <div className="variable detail" style={{ padding: 0.2 }} title={this.props.rightTitle}>
+                <div className="variable detail" style={{ padding: 0.2 }} title={this.props.rightTitle} onClick={this.valueClickHandler}>
                     <span className={`varval ${this.props.rightClass || ""}`}>{this.props.rightText}</span>
                 </div>
             </div>
@@ -56,5 +58,9 @@ export class DebuggerTableRow extends React.Component<DebuggerTableRowProps> {
 
     protected clickHandler = (e: React.SyntheticEvent<HTMLDivElement>) => {
         if (this.props.onClick) this.props.onClick(e, this);
+    }
+
+    protected valueClickHandler = (e: React.SyntheticEvent<HTMLDivElement>) => {
+        if (this.props.onValueClick) this.props.onValueClick(e, this);
     }
 }

--- a/webapp/src/debuggerVariables.tsx
+++ b/webapp/src/debuggerVariables.tsx
@@ -118,6 +118,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
         }
 
         const previewVar = this.getVariableById(preview?.id);
+        const previewLabel = previewVar && lf("Current value for '{0}'", previewVar.name);
 
         return <div>
             <DebuggerTable header={variableTableHeader} placeholderText={placeholderText}>
@@ -129,6 +130,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                     className="debugger-preview"
                     ref={this.handlePreviewRef}
                     tabIndex={0}
+                    aria-label={previewLabel}
                     style={{
                         top: `${preview.top}px`,
                         left: `${preview.left}px`

--- a/webapp/src/debuggerVariables.tsx
+++ b/webapp/src/debuggerVariables.tsx
@@ -19,6 +19,12 @@ interface Variable {
     children?: Variable[];
 }
 
+interface PreviewState {
+    id: number;
+    top: number;
+    left: number;
+}
+
 interface DebuggerVariablesProps {
     apis: pxt.Map<pxtc.SymbolInfo>;
     sequence: number;
@@ -34,6 +40,8 @@ interface DebuggerVariablesState {
     renderedSequence?: number;
 
     frozen?: boolean;
+
+    preview: PreviewState | null;
 }
 
 export class DebuggerVariables extends data.Component<DebuggerVariablesProps, DebuggerVariablesState> {
@@ -45,7 +53,8 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                 variables: []
             },
             stackFrames: [],
-            nextID: 0
+            nextID: 0,
+            preview: null
         };
 
     }
@@ -56,12 +65,13 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                 title: this.state.globalFrame.title,
                 variables: []
             },
-            stackFrames: []
+            stackFrames: [],
+            preview: null
         });
     }
 
     update(frozen = false) {
-        this.setState({ frozen });
+        this.setState({ frozen, preview: frozen ? null : this.state.preview });
     }
 
     componentDidUpdate(prevProps: DebuggerVariablesProps) {
@@ -71,12 +81,12 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             }
         }
         else if (!this.state.frozen) {
-            this.setState({ frozen: true });
+            this.update(true);
         }
     }
 
     renderCore() {
-        const { globalFrame, stackFrames, frozen } = this.state;
+        const { globalFrame, stackFrames, frozen, preview } = this.state;
         const { activeFrame, breakpoint } = this.props;
         const variableTableHeader = lf("Variables");
         let variables = globalFrame.variables;
@@ -107,17 +117,37 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             />);
         }
 
-        return <DebuggerTable header={variableTableHeader} placeholderText={placeholderText}>
-            {tableRows}
-        </DebuggerTable>
+        const previewVar = this.getVariableById(preview?.id);
+
+        return <div>
+            <DebuggerTable header={variableTableHeader} placeholderText={placeholderText}>
+                {tableRows}
+            </DebuggerTable>
+            { preview &&
+                <div id="debugger-preview"
+                    role="tooltip"
+                    className="debugger-preview"
+                    ref={this.handlePreviewRef}
+                    tabIndex={0}
+                    style={{
+                        top: `${preview.top}px`,
+                        left: `${preview.left}px`
+                    }}>
+                        {renderValue(previewVar.value)}
+                    </div>
+            }
+        </div>
     }
 
     renderVars(vars: Variable[], depth = 0, result: JSX.Element[] = []) {
+        const previewed = this.state.preview?.id;
+
         vars.forEach(varInfo => {
             const valueString = renderValue(varInfo.value);
             const typeString = variableType(varInfo);
 
             result.push(<DebuggerTableRow key={varInfo.id}
+                describedBy={varInfo.id === previewed ? "debugger-preview" : undefined}
                 refID={varInfo.id}
                 icon={(varInfo.value && varInfo.value.hasFields) ? (varInfo.children ? "down triangle" : "right triangle") : undefined}
                 leftText={varInfo.name + ":"}
@@ -127,6 +157,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
                 rightTitle={shouldShowValueOnHover(typeString) ? valueString : undefined}
                 rightClass={typeString}
                 onClick={this.handleComponentClick}
+                onValueClick={this.handleValueClick}
                 depth={depth}
             />)
 
@@ -205,16 +236,62 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
         }
     }
 
+    protected getVariableById(id: number) {
+        if (id === null) return null;
+        for (const v of this.getFullVariableList()) {
+            if (v.id === id) {
+                return v;
+            }
+        }
+        return null;
+    }
+
     protected handleComponentClick = (e: React.SyntheticEvent<HTMLDivElement>, component: DebuggerTableRow) => {
         if (this.state.frozen) return;
 
-        const id = component.props.refID;
+        const variable = this.getVariableById(component.props.refID as number);
 
-        for (const v of this.getFullVariableList()) {
-            if (v.id === id) {
-                this.toggle(v);
-                return;
+        if (variable) {
+            this.toggle(variable);
+
+            if (this.state.preview !== null) {
+                this.setState({
+                    preview: null
+                });
             }
+        }
+    }
+
+    protected handleValueClick = (e: React.SyntheticEvent<HTMLDivElement>, component: DebuggerTableRow) => {
+        if (this.state.frozen) return;
+
+        const id = component.props.refID;
+        const bb = (e.target as HTMLDivElement).getBoundingClientRect();
+        this.setState({
+            preview: {
+                id: id as number,
+                top: bb.top,
+                left: bb.left
+            }
+        });
+    }
+
+    protected handlePreviewRef = (ref: HTMLDivElement) => {
+        if (ref) {
+            const previewed = this.state.preview;
+            ref.focus();
+            ref.addEventListener("blur", () => {
+                if (this.state.preview?.id === previewed.id) {
+                    this.setState({
+                        preview: null
+                    });
+                }
+            });
+            const select = window.getSelection();
+            select.removeAllRanges();
+            const range = document.createRange();
+            range.selectNodeContents(ref);
+            select.addRange(range);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2979

![2020-05-07 12 05 04](https://user-images.githubusercontent.com/13754588/81334518-08115a00-905b-11ea-8041-68915a93e7b0.gif)

The preview disappears when it loses focus. It also selects the text contents when it appears so that you can copy with ctrl-c