### PR TITLE
Add pxt.json "utf8" option

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5746,8 +5746,12 @@ function initCommands() {
 The following environment variables modify the behavior of the CLI when set to
 non-empty string:
 
-PXT_DEBUG        - display extensive logging info
-PXT_USE_HID      - use webusb or hid to flash device
+PXT_DEBUG            - display extensive logging info
+PXT_USE_HID          - use webusb or hid to flash device
+PXT_COMPILE_SWITCHES - same as ?compile=... in the webapp, interesting options
+   PXT_COMPILE_SWITCHES=profile - enable profiling
+   PXT_COMPILE_SWITCHES=time    - print-out compilation times
+   PXT_COMPILE_SWITCHES=rawELF  - generate ELF files for Linux, without UF2 continer
 
 These apply to the C++ runtime builds:
 

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -85,6 +85,7 @@ declare namespace pxt {
         supportedTargets?: string[]; // a hint about targets in which this extension is supported
         firmwareUrl?: string; // link to documentation page about upgrading firmware
         disablesVariants?: string[]; // don't build these variants, when this extension is enabled
+        utf8?: boolean; // force compilation with UTF8 enabled
     }
 
     interface PackageExtension {

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -200,7 +200,7 @@ namespace pxt.cpp {
             }
         compileService = U.clone(compileService)
 
-        let compile = appTarget.compile
+        let compile = mainPkg.getTargetOptions()
         if (!compile)
             compile = {
                 isNative: false,

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -839,6 +839,14 @@ namespace pxt {
         getTargetOptions(): pxtc.CompileTarget {
             let res = U.clone(appTarget.compile)
             U.assert(!!res)
+            if (!res.utf8) {
+                this.sortedDeps(true).forEach(p => {
+                    if (p.config && p.config.utf8) {
+                        pxt.debug("forcing utf8 mode: pkg=" + p.id)
+                        res.utf8 = true
+                    }
+                })
+            }
             return res
         }
 


### PR DESCRIPTION
When target has utf8 disabled, pxt.json of any package can enable it with `"utf8": true`

Also adds some docs on env variables

Fixes https://github.com/microsoft/pxt-microbit/issues/2372
