### PR TITLE
Add support for right-click to copy a marquee selection.

### DIFF
--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -273,6 +273,19 @@ export class EditState {
 
         return col >= 0 && col < this.floating.image.width && row >= 0 && row < this.floating.image.height;
     }
+
+    toImageState(): pxt.sprite.ImageState {
+        return {
+            bitmap: this.image.data(),
+            layerOffsetX: this.layerOffsetX,
+            layerOffsetY: this.layerOffsetY,
+            floating: this.floating && {
+                bitmap: this.floating.image ? this.floating.image.data() : undefined,
+                overlayLayers: this.floating.overlayLayers ? this.floating.overlayLayers.map(el => el.data()) : undefined
+            },
+            overlayLayers: this.overlayLayers ? this.overlayLayers.map(el => el.data()) : undefined
+        };
+    }
 }
 
 export abstract class Edit {


### PR DESCRIPTION
This PR adds support for right-click to "copy" the current marquee selection.

Currently, as you make a marquee selection, the pixels are "cut" from the image layer and "pasted" to the floating layer. **None of that behavior changes with this PR.**

With this PR, after making a selection, if you right-click within it, the selected pixels are "pasted" back to the image layer and a new copy (to the floating layer) is made **without** cutting.

Here's a gif (black circles are left-clicks; green circles are right-clicks):

![Kapture 2020-05-07 at 23 01 46](https://user-images.githubusercontent.com/194333/81375627-c7dfc500-90b6-11ea-933c-c547942f11e9.gif)

I tested this within the sprite editor, tilemap editor, and background image editor, and all worked as I'd expected.

I fully recognize right-click is a less discoverable mechanism for exposing this functionality. microsoft/pxt-arcade#1835 mentions Ctrl+C, Ctrl+V. But some of the interactions seemed harder/more awkward as I started to consider the steps required to duplicate pixels with the existing move/cut-by-default behavior of the marquee tool and a clipboard Ctrl+C, Ctrl+V metaphor.

I'd love to hear your feedback on this, and I'm happy to make any changes!