### PR TITLE
Unify types on calls to slice, str

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -1958,6 +1958,7 @@ namespace pxt.py {
 
             if (isCallTo(n, "str")) {
                 // Our standard method of toString in TypeScript is to concatenate with the empty string
+                unify(n, n.tsType!, tpString);
                 return B.mkInfix(B.mkText(`""`), "+", expr(n.args[0]))
             }
 
@@ -2147,6 +2148,7 @@ namespace pxt.py {
         },
         Subscript: (n: py.Subscript) => {
             if (n.slice.kind == "Index") {
+                unifyTypeOf(n, typeOf(n.value));
                 let idx = (n.slice as py.Index).value
                 if (currIteration > 2 && isFree(typeOf(idx))) {
                     unifyTypeOf(idx, tpNumber)
@@ -2158,6 +2160,7 @@ namespace pxt.py {
                     B.mkText("]"),
                 ])
             } else if (n.slice.kind == "Slice") {
+                unifyTypeOf(n, typeOf(n.value));
                 let s = n.slice as py.Slice
                 return B.mkInfix(expr(n.value), ".",
                     B.H.mkCall("slice", [s.lower ? expr(s.lower) : B.mkText("0"),

--- a/tests/runtime-trace-tests/cases/slice_str_types.py
+++ b/tests/runtime-trace-tests/cases/slice_str_types.py
@@ -1,0 +1,9 @@
+a = [[2,3], [4,5,6], [7]]
+b = a[1]
+print(len(b))
+
+c = "test"[1]
+print(len(c))
+
+d = str(45)
+print(len(d))

--- a/tests/runtime-trace-tests/readme.md
+++ b/tests/runtime-trace-tests/readme.md
@@ -51,7 +51,7 @@ for (let i = 0; i < 5; i++) {
     console.log(i)
 }
 ```
-Then run `gulp testtraces`.
+Then run `gulp testpytraces`.
 At the time of this writing, this test will fail on step #4 mentioned above because ts2py converts the file to:
 ```
 for i in range(5):


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2931

Additional type unification, fixes the following (previously errored on the call to "len"):
```
c = [[2,3], [4,5,6], [7]]
a = c[1]
b = len(a)
```
```
a = "test"[1:2]
b = len(a)
```
```
a = str(45)
b = len(a)
```