### PR TITLE
Debugger slow-mo center on collapsed parent instead of hidden child

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -909,15 +909,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.updateDebuggerVariables(brk);
         if (stmt) {
             let bid = pxt.blocks.findBlockIdByLine(this.compilationResult.sourceMap, { start: stmt.line, length: stmt.endLine - stmt.line });
-            const b = this.editor.getBlockById(bid) as Blockly.BlockSvg;
             if (bid) {
-                const parent = pxt.blocks.getTopLevelParent(b);
-                if (parent.isCollapsed()) {
-                    this.editor.highlightBlock(parent.id)
-                } else {
-                    this.editor.highlightBlock(bid);
-                }
+                const parent = pxt.blocks.getTopLevelParent(this.editor.getBlockById(bid));
+                bid = parent?.isCollapsed() ? parent.id : bid;
+                this.editor.highlightBlock(bid);
                 if (brk) {
+                    const b = this.editor.getBlockById(bid) as Blockly.BlockSvg;
                     b.setWarningText(brk ? brk.exceptionMessage : undefined);
                     // ensure highlight is in the screen when a breakpoint info is available
                     // TODO: make warning mode look good


### PR DESCRIPTION
prevents unnecessary jumping around the screen