### PR TITLE
Fix some typos in the v0 docs

### DIFF
--- a/common-docs/browsers/technical.md
+++ b/common-docs/browsers/technical.md
@@ -13,7 +13,7 @@ same [Monaco][] editor that powers [Visual Studio Code][].
 [visual studio code]: http://code.visualstudio.com
 
 Most modern browsers automatically update themselves. In some environments,
-such as schools, these automatic updates are disabled for security. **We
+such as schools, automatic updates are disabled so that any change to browser software can wait until it is approved by an administrator. **We
 strongly recommend that you use the most recent version of any of these
 browsers**, but if you can't then you must use at least:
 

--- a/common-docs/javascript/interfaces.md
+++ b/common-docs/javascript/interfaces.md
@@ -170,8 +170,8 @@ mySearch = function (src: string, i: number): string {
 
 Function parameters are checked one at a time, with the type in each corresponding parameter position checked against each other.
 If you do not want to specify types at all, TypeScript's contextual typing can infer the argument types since the function value is assigned directly to a variable of type `SearchFunc`.
-Here, also, the return type of our function expression is implied by the values it returns (here `false` and `true`).
-Had the function expression returned numbers or strings, the type-checker would have warned us that return type doesn't match the return type described in the `SearchFunc` interface.
+Here, also, the return type of our function expression is implied by the values it returns (here it's a string).
+Had the function expression returned numbers or booleans, the type-checker would have warned us that return type doesn't match the return type described in the `SearchFunc` interface.
 
 ```ts
 let mySearch: SubstrFunc;

--- a/common-docs/javascript/sts.md
+++ b/common-docs/javascript/sts.md
@@ -148,7 +148,7 @@ associated with the class.
 ### Functions
 
 In STS, functions and methods are related by classical function subtyping (no parameter 
-bivariance, as in TypeScript). Furthemore:
+bivariance, as in TypeScript). Furthermore:
 * function/method overloading is not permitted;
 * a function can only be cast to an interface J which has a single call signature 
   matching the function's type; the interface J can have no other properties
@@ -156,7 +156,7 @@ bivariance, as in TypeScript). Furthemore:
 ### Arrays
 
 As with functions, arrays can only be cast to an interface J with has a single index
-singature matching the array's type; the interface J can have no other properties.
+signature matching the array's type; the interface J can have no other properties.
 
 ## Optional properties
 

--- a/common-docs/javascript/sts.md
+++ b/common-docs/javascript/sts.md
@@ -36,7 +36,8 @@ STS disallows programs where a program element can denote many kinds of runtime 
 (for example, a variable that is a string at one point in execution and a number at another point, 
 as specified by the union type *string | number*).
 
-As a result of this choice, many dynamic features of JavaScript (and thus TypeScript) are out of STS: 
+As a result of this choice, many dynamic features of JavaScript (and thus TypeScript) are out of STS:
+
 * the *eval* function;
 * the *with* statement;
 * access to the prototype property (goodbye to prototype-based inheritance);

--- a/docs/packages/getting-started.md
+++ b/docs/packages/getting-started.md
@@ -84,7 +84,7 @@ in `README.md`. Otherwise the package will not show up in search.**
 
 ### ~
 
-Read more an [defining-blocks](https://makecode.com/defining-blocks) to learn how to surface your APIs into blocks and JavaScript.
+Read more on [defining-blocks](https://makecode.com/defining-blocks) to learn how to surface your APIs into blocks and JavaScript.
 
 ### Icon
 


### PR DESCRIPTION
A few typos found by Crowdin translators.