### PR TITLE
Scroll formatted code to top left corner of workspace

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -142,6 +142,9 @@ namespace pxt.blocks.layout {
             .forEach(b => b.setCollapsed(collapsed));
     }
 
+    // Workspace margins
+    const marginx = 20;
+    const marginy = 20;
     export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {
         if (opts) {
             if (opts.useViewWidth) {
@@ -150,6 +153,7 @@ namespace pxt.blocks.layout {
                 // Only use the width if in portrait, otherwise the blocks are too spread out
                 if (metrics.viewHeight > metrics.viewWidth) {
                     flowBlocks(ws.getTopComments(true) as Blockly.WorkspaceCommentSvg[], ws.getTopBlocks(true) as Blockly.BlockSvg[], undefined, metrics.viewWidth)
+                    ws.scroll(marginx, marginy);
                     return;
                 }
             }
@@ -158,6 +162,7 @@ namespace pxt.blocks.layout {
         else {
             flowBlocks(ws.getTopComments(true) as Blockly.WorkspaceCommentSvg[], ws.getTopBlocks(true) as Blockly.BlockSvg[]);
         }
+        ws.scroll(marginx, marginy);
     }
 
     export function screenshotEnabled(): boolean {
@@ -394,10 +399,6 @@ namespace pxt.blocks.layout {
 
         // Margin between groups of blocks and comments
         const outerGroupMargin = 45;
-
-        // Workspace margins
-        const marginx = 20;
-        const marginy = 20;
 
         const groups: Formattable[] = [];
         const commentMap: Map<Blockly.WorkspaceCommentSvg> = {};


### PR DESCRIPTION
Scrolls blocks to the top left corner of the workspace after format/flow which I think is reasonable/expected behavior. You can load the test program into /beta and see the current behavior, which changes based on where in the workspace you are (eg try scrolling to the top-right corner and format).

Test program: https://makecode.microbit.org/_Dkw2emRfjKRk
Build: https://makecode.microbit.org/app/e3d66d88919b640778708d582fb76001a12b2085-c5005c49da

Fixes https://github.com/microsoft/pxt-microbit/issues/3007