### PR TITLE
Don't hoist variables that are first assigned in top level scope

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2347,8 +2347,13 @@ namespace pxt.py {
             && sym.modifier === undefined
             && (sym.lastRefPos! > sym.forVariableEndPos!
                 || sym.firstRefPos! < sym.firstAssignPos!
-                || sym.firstAssignDepth! > scope.blockDepth!);
+                || sym.firstAssignDepth! > scope.blockDepth!)
+            && !(isTopLevelScope(scope) && sym.firstAssignDepth! === 0);
         return !!result
+    }
+
+    function isTopLevelScope(scope: py.ScopeDef) {
+        return scope.kind === "Module" && (scope as py.Module).name === "main";
     }
 
     // TODO look at scopes of let

--- a/tests/pyconverter-test/baselines/variable_declared_in_main.ts
+++ b/tests/pyconverter-test/baselines/variable_declared_in_main.ts
@@ -1,0 +1,14 @@
+function on_button_pressed_a() {
+
+    fred += 1
+}
+
+function on_button_pressed_b() {
+
+    fred += -1
+}
+
+let fred = 0
+basic.forever(function on_forever() {
+    basic.showNumber(fred)
+})

--- a/tests/pyconverter-test/cases/variable_declared_in_main.py
+++ b/tests/pyconverter-test/cases/variable_declared_in_main.py
@@ -1,0 +1,10 @@
+def on_button_pressed_a():
+    global fred
+    fred += 1
+def on_button_pressed_b():
+    global fred
+    fred += -1
+fred = 0
+def on_forever():
+    basic.show_number(fred)
+basic.forever(on_forever)


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2944

We don't need to hoist variables if we are already in the top-level scope.