### PR TITLE
Don't fix variable names in breakpoint message

### DIFF
--- a/pxtsim/debugger.ts
+++ b/pxtsim/debugger.ts
@@ -130,7 +130,7 @@ namespace pxsim {
             for (let k of Object.keys(frame)) {
                 // skip members starting with __
                 if (!/^__/.test(k) && /___\d+$/.test(k) && (!filters || filters.indexOf(k) !== -1)) {
-                    r[k.replace(/___\d+$/, '')] = valToJSON(frame[k], heap)
+                    r[k] = valToJSON(frame[k], heap)
                 }
             }
             if (frame.fields && fields) {
@@ -142,7 +142,7 @@ namespace pxsim {
             }
             if (frame.fields) {
                 for (let k of Object.keys(frame.fields).filter(field => !field.startsWith('_'))) {
-                    r[k.replace(/___\d+$/, '')] = valToJSON(frame.fields[k], heap)
+                    r[k] = valToJSON(frame.fields[k], heap)
                 }
             } else if (Array.isArray(frame.data)) {
                 // This is an Array.


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3016

We already fix the variable names in the webapp, so we don't need to do it in the simulator. Otherwise we might overwrite two variables in the same scope with the same name (which I think is only possible with for-loops). AFAIK the debugger is the only consumer of the breakpoint message stack frame so I think this change shouldn't break anything.

Ideally we should only show the variable that is currently visible instead of two entries with the same name, but we don't really have a way of checking that. This at least makes the behavior the same as it is for other shadowed variables (which also get duplicate entries)