### PR TITLE
GitHub write issues handling of orgs

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -133,7 +133,7 @@ namespace pxt.github {
             });
     }
 
-    export function isOrgAsyn(owner: string): Promise<boolean> {
+    export function isOrgAsync(owner: string): Promise<boolean> {
         return ghRequestAsync({ url: `orgs/${owner}`, allowHttpErrors: true, method: "GET" })
             .then(resp => resp.statusCode == 200);
     }

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -133,6 +133,11 @@ namespace pxt.github {
             });
     }
 
+    export function isOrgAsyn(owner: string): Promise<boolean> {
+        return ghRequestAsync({ url: `orgs/${owner}`, allowHttpErrors: true, method: "GET" })
+            .then(resp => resp.statusCode == 200);
+    }
+
     function ghGetJsonAsync(url: string) {
         return ghRequestAsync({ url }).then(resp => resp.json)
     }

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -134,7 +134,7 @@ namespace pxt.github {
     }
 
     export function isOrgAsync(owner: string): Promise<boolean> {
-        return ghRequestAsync({ url: `orgs/${owner}`, allowHttpErrors: true, method: "GET" })
+        return ghRequestAsync({ url: `https://api.github.com/orgs/${owner}`, allowHttpErrors: true, method: "GET" })
             .then(resp => resp.statusCode == 200);
     }
 

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -134,8 +134,8 @@ export class GithubProvider extends cloudsync.ProviderBase {
         }
     }
 
-    public authorizeAppAsync(route: string) {
-        return this.oauthRedirectAsync(route, true);
+    public authorizeAppAsync(route?: string) {
+        return this.oauthRedirectAsync(route || window.location.hash, true);
     }
 
     private oauthRedirectAsync(route: string, consent?: boolean): Promise<void> {

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -134,12 +134,18 @@ export class GithubProvider extends cloudsync.ProviderBase {
         }
     }
 
-    private oauthRedirectAsync(route: string): Promise<void> {
+    public authorizeAppAsync(route: string) {
+        return this.oauthRedirectAsync(route, true);
+    }
+
+    private oauthRedirectAsync(route: string, consent?: boolean): Promise<void> {
         core.showLoading("ghlogin", lf("Signing you into GitHub..."))
+        route = (route || "").replace(/^#/, "");
         const state = cloudsync.setOauth(this.name, route ? `#github:${route}` : undefined);
         const self = window.location.href.replace(/#.*/, "")
         const login = pxt.Cloud.getServiceUrl() +
             "/oauth/login?state=" + state +
+            (consent ? "&prompt=consent" : "") +
             "&response_type=token&client_id=gh-token&redirect_uri=" +
             encodeURIComponent(self)
         window.location.href = login;

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -262,7 +262,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                 provider.authorizeAppAsync();
             }
             org = <p className="ui small">
-                {lf("If you are the owner of the {0} organization, you can authorize the MakeCode App.", parsed.owner)}
+                {lf("If you are the owner of the {0} organization, you can authorize the MakeCode App. Otherwise use a Developer token to sign in.", parsed.owner)}
                 <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={authorize} />
             </p>
         }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -39,7 +39,6 @@ interface GithubState {
     isVisible?: boolean;
     description?: string;
     needsCommitMessage?: boolean;
-    triedFork?: boolean;
     previousCfgKey?: string;
     loadingMessage?: string;
 }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -53,6 +53,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         this.handleBranchClick = this.handleBranchClick.bind(this);
         this.handleGithubError = this.handleGithubError.bind(this);
         this.handlePullRequest = this.handlePullRequest.bind(this);
+        this.handleAutorize = this.handleAutorize.bind(this);
     }
 
     clearCacheDiff(cachePrefix?: string, f?: DiffFile) {
@@ -245,6 +246,12 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         this.pullAsync().done();
     }
 
+    private handleAutorize() {
+        pxt.tickEvent("github.authorize");
+        const provider = cloudsync.githubProvider();
+        provider.authorizeAppAsync();
+    }
+
     async forkAsync(fromError: boolean) {
         const parsed = this.parsedRepoId()
         const provider = cloudsync.githubProvider();
@@ -258,13 +265,9 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             // test if the app can read the repo
             const isOrg = await pxt.github.isOrgAsync(parsed.owner);
             if (isOrg) {
-                const authorize = () => {
-                    pxt.tickEvent("github.forkdialog.authorize");
-                    provider.authorizeAppAsync();
-                }
                 org = <p className="ui small">
                     {lf("You need to authorize the MakeCode App for {0}. Otherwise use a Developer token to sign in.", parsed.owner)}
-                    <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={authorize} />
+                    <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={this.handleAutorize} onKeyDown={sui.fireClickOnEnter} />
                 </p>
             }
         }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -250,13 +250,16 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         const parsed = this.parsedRepoId()
         const provider = cloudsync.githubProvider();
         const user = provider.user();
-        const error = fromError && <div>{lf("You don't seem to have write permission to {0}.\n", parsed.fullName)}</div>;
+        const error = fromError && <div className="ui message warning">{lf("You don't seem to have write permission to {0}.\n", parsed.fullName)}</div>;
         const help =
             <div>{lf("Forking creates a copy of {0} under your account. You can include your changes via a pull request.", parsed.fullName)}</div>
         let org: JSX.Element = undefined;
         if (user && parsed.owner !== user.userName) {
             // this is an org repo, so our OAuth app might not have been granted rights
-            const authorize = () => provider.authorizeAppAsync();
+            const authorize = () => {
+                pxt.tickEvent("github.forkdialog.authorize");
+                provider.authorizeAppAsync();
+            }
             org = <div>
                 {lf("If you are the owner of the {0} organization, make sure to authorize the MakeCode App.")}
                 {lf("Otherwise, use a Developer token instead when signing into GitHub.")}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -264,7 +264,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                     provider.authorizeAppAsync();
                 }
                 org = <p className="ui small">
-                    {lf("If you are the owner of the {0} organization, you can authorize the MakeCode App. Otherwise use a Developer token to sign in.", parsed.owner)}
+                    {lf("You need to authorize the MakeCode App for {0}. Otherwise use a Developer token to sign in.", parsed.owner)}
                     <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={authorize} />
                 </p>
             }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -262,7 +262,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                 provider.authorizeAppAsync();
             }
             org = <p className="ui small">
-                {lf("If you are the owner of the {0} organization, make sure to authorize the MakeCode App. Otherwise, use a Developer token.", parsed.owner)}
+                {lf("If you are the owner of the {0} organization, you can authorize the MakeCode App.", parsed.owner)}
                 <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={authorize} />
             </p>
         }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -257,14 +257,17 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         if (fromError && user && parsed.owner !== user.userName) {
             // this is an org repo, so our OAuth app might not have been granted rights
             // test if the app can read the repo
-            const authorize = () => {
-                pxt.tickEvent("github.forkdialog.authorize");
-                provider.authorizeAppAsync();
+            const isOrg = await pxt.github.isOrgAsync(parsed.owner);
+            if (isOrg) {
+                const authorize = () => {
+                    pxt.tickEvent("github.forkdialog.authorize");
+                    provider.authorizeAppAsync();
+                }
+                org = <p className="ui small">
+                    {lf("If you are the owner of the {0} organization, you can authorize the MakeCode App. Otherwise use a Developer token to sign in.", parsed.owner)}
+                    <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={authorize} />
+                </p>
             }
-            org = <p className="ui small">
-                {lf("If you are the owner of the {0} organization, you can authorize the MakeCode App. Otherwise use a Developer token to sign in.", parsed.owner)}
-                <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={authorize} />
-            </p>
         }
         const res = await core.confirmAsync({
             header: lf("Do you want to fork {0}?", parsed.fullName),

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -259,11 +259,8 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             const authorize = () => provider.authorizeAppAsync();
             org = <div>
                 {lf("If you are the owner of the {0} organization, make sure to authorize the MakeCode App.")}
+                {lf("Otherwise, use a Developer token instead when signing into GitHub.")}
                 <sui.Button text={lf("Authorize MakeCode")} onClick={authorize} />
-                <div className="ui small">
-                    {lf("Looking to use a Developer token instead?")}
-                    <sui.Link className="link" text={lf("Click here")} onClick={showToken} />
-                </div>
             </div>
         }
         const res = await core.confirmAsync({

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -252,19 +252,19 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         const user = provider.user();
         const error = fromError && <div className="ui message warning">{lf("You don't seem to have write permission to {0}.\n", parsed.fullName)}</div>;
         const help =
-            <div>{lf("Forking creates a copy of {0} under your account. You can include your changes via a pull request.", parsed.fullName)}</div>
+            <p>{lf("Forking creates a copy of {0} under your account. You can include your changes via a pull request.", parsed.fullName)}</p>
         let org: JSX.Element = undefined;
-        if (user && parsed.owner !== user.userName) {
+        if (fromError && user && parsed.owner !== user.userName) {
             // this is an org repo, so our OAuth app might not have been granted rights
+            // test if the app can read the repo
             const authorize = () => {
                 pxt.tickEvent("github.forkdialog.authorize");
                 provider.authorizeAppAsync();
             }
-            org = <div>
-                {lf("If you are the owner of the {0} organization, make sure to authorize the MakeCode App.")}
-                {lf("Otherwise, use a Developer token instead when signing into GitHub.")}
-                <sui.Button text={lf("Authorize MakeCode")} onClick={authorize} />
-            </div>
+            org = <p className="ui small">
+                {lf("If you are the owner of the {0} organization, make sure to authorize the MakeCode App. Otherwise, use a Developer token.", parsed.owner)}
+                <sui.Link className="link" text={lf("Authorize MakeCode")} onClick={authorize} />
+            </p>
         }
         const res = await core.confirmAsync({
             header: lf("Do you want to fork {0}?", parsed.fullName),


### PR DESCRIPTION
When failing to write to an org repo, also suggest to authorize app.

This is a common scenario for github classroom, where the teacher might have forgotten to authorize our app. Use special prompt flag to force showing the authorization page in the login flow.