### PR TITLE
Append README content instead of ignoring

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -74,7 +74,8 @@ ${lf("This image may take a few minutes to refresh.")}
 `,
 
             ".gitignore":
-                `built
+                `# MakeCode
+built
 node_modules
 yotta_modules
 yotta_targets
@@ -83,6 +84,7 @@ _site
 *.db
 *.tgz
 .header.json
+.simstate.json
 `,
             ".vscode/settings.json":
                 `{

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -493,6 +493,7 @@ namespace pxt {
     export const SIMSTATE_JSON = ".simstate.json"
     export const SERIAL_EDITOR_FILE = "serial.txt"
     export const README_FILE = "README.md"
+    export const GITIGNORE_FILE = ".gitignore"
     export const CLOUD_ID = "pxt/"
     export const BLOCKS_PROJECT_NAME = "blocksprj";
     export const JAVASCRIPT_PROJECT_NAME = "tsprj";

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -492,6 +492,7 @@ namespace pxt {
     export const CONFIG_NAME = "pxt.json"
     export const SIMSTATE_JSON = ".simstate.json"
     export const SERIAL_EDITOR_FILE = "serial.txt"
+    export const README_FILE = "README.md"
     export const CLOUD_ID = "pxt/"
     export const BLOCKS_PROJECT_NAME = "blocksprj";
     export const JAVASCRIPT_PROJECT_NAME = "tsprj";

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1176,9 +1176,7 @@ export async function importGithubAsync(id: string): Promise<Header> {
             // ask user before modifying project
             const r = await core.confirmAsync({
                 header: lf("Initialize repository for MakeCode?"),
-                body: lf("We need to add a few files to your repository to make it work with MakeCode.")
-                    + " "
-                    + lf("Your existing files will not be modified."),
+                body: lf("We need to add a few files to your repository to make it work with MakeCode."),
                 agreeLbl: lf("Ok")
             })
             if (!r) return Promise.resolve(undefined);

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1175,11 +1175,12 @@ export async function importGithubAsync(id: string): Promise<Header> {
             forceTemplateFiles = false;
             // ask user before modifying project
             const r = await core.confirmAsync({
-                header: lf("Initialize repository for MakeCode?"),
-                body: lf("We need to add a few files to your repository to make it work with MakeCode."),
+                header: lf("Initialize GitHub repository for MakeCode?"),
+                body: lf("We need to add a few files to your GitHub repository to make it work with MakeCode."),
                 agreeLbl: lf("Ok"),
                 hideCancel: true,
-                hasCloseIcon: true
+                hasCloseIcon: true,
+                helpUrl: "/github/import"
             })
             if (!r) return Promise.resolve(undefined);
         }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1097,15 +1097,26 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
         if (!pxt.Package.parseAndValidConfig(currFiles[pxt.CONFIG_NAME]))
             delete currFiles[pxt.CONFIG_NAME];
         // special case append README.md content: append to existing file
-        const templateREADME = templateFiles[pxt.README_FILE];
+        let templateREADME = templateFiles[pxt.README_FILE];
         const currREADME = currFiles[pxt.README_FILE];
         if (templateREADME || currREADME)
-            templateFiles[pxt.README_FILE] = [currREADME, templateREADME].filter(s => !!s).join(`
+            templateREADME = [currREADME, templateREADME].filter(s => !!s).join(`
 
 `);
+        let templateGitIgnore = templateFiles[pxt.GITIGNORE_FILE]
+        const currGitIgnore = currFiles[pxt.GITIGNORE_FILE]
+        if (templateREADME || currGitIgnore)
+        templateGitIgnore = [currGitIgnore, templateGitIgnore].filter(s => !!s).join(`
+
+`);
+
         // current files override defaults
         U.jsonMergeFrom(templateFiles, currFiles);
         currFiles = templateFiles;
+        if (templateREADME)
+            currFiles[pxt.README_FILE] = templateREADME;
+        if (templateGitIgnore)
+            currFiles[pxt.GITIGNORE_FILE] = templateGitIgnore;
     }
 
     // update config with files if needed

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1103,20 +1103,11 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
             templateREADME = [currREADME, templateREADME].filter(s => !!s).join(`
 
 `);
-        let templateGitIgnore = templateFiles[pxt.GITIGNORE_FILE]
-        const currGitIgnore = currFiles[pxt.GITIGNORE_FILE]
-        if (templateREADME || currGitIgnore)
-            templateGitIgnore = [currGitIgnore, templateGitIgnore].filter(s => !!s).join(`
-
-`);
-
         // current files override defaults
         U.jsonMergeFrom(templateFiles, currFiles);
         currFiles = templateFiles;
         if (templateREADME)
             currFiles[pxt.README_FILE] = templateREADME;
-        if (templateGitIgnore)
-            currFiles[pxt.GITIGNORE_FILE] = templateGitIgnore;
     }
 
     // update config with files if needed

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1177,7 +1177,9 @@ export async function importGithubAsync(id: string): Promise<Header> {
             const r = await core.confirmAsync({
                 header: lf("Initialize repository for MakeCode?"),
                 body: lf("We need to add a few files to your repository to make it work with MakeCode."),
-                agreeLbl: lf("Ok")
+                agreeLbl: lf("Ok"),
+                hideCancel: true,
+                hasCloseIcon: true
             })
             if (!r) return Promise.resolve(undefined);
         }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1096,16 +1096,16 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
         // special handling of broken/missing/corrupted pxt.json
         if (!pxt.Package.parseAndValidConfig(currFiles[pxt.CONFIG_NAME]))
             delete currFiles[pxt.CONFIG_NAME];
-        // special case override README.md if empty
-        let templateREADME = templateFiles["README.md"];
-        if (currFiles["README.md"] && currFiles["README.md"].trim())
-            templateREADME = undefined;
+        // special case append README.md content: append to existing file
+        const templateREADME = templateFiles[pxt.README_FILE];
+        const currREADME = currFiles[pxt.README_FILE];
+        if (templateREADME || currREADME)
+            templateFiles[pxt.README_FILE] = [currREADME, templateREADME].filter(s => !!s).join(`
+
+`);
         // current files override defaults
         U.jsonMergeFrom(templateFiles, currFiles);
         currFiles = templateFiles;
-
-        if (templateREADME)
-            currFiles["README.md"] = templateREADME;
     }
 
     // update config with files if needed
@@ -1115,7 +1115,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
     if (!files.filter(f => /\.ts$/.test(f)).length) {
         // add files from the template
         Object.keys(currFiles)
-            .filter(f => /\.(blocks|ts|py|asm|md)$/.test(f))
+            .filter(f => /\.(blocks|ts|py|asm|md|json)$/.test(f))
             .filter(f => f != pxt.CONFIG_NAME)
             .forEach(f => files.push(f));
     }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1106,7 +1106,7 @@ export async function initializeGithubRepoAsync(hd: Header, repoid: string, forc
         let templateGitIgnore = templateFiles[pxt.GITIGNORE_FILE]
         const currGitIgnore = currFiles[pxt.GITIGNORE_FILE]
         if (templateREADME || currGitIgnore)
-        templateGitIgnore = [currGitIgnore, templateGitIgnore].filter(s => !!s).join(`
+            templateGitIgnore = [currGitIgnore, templateGitIgnore].filter(s => !!s).join(`
 
 `);
 


### PR DESCRIPTION
- [x] When initializaing a project and a README is present, append our template.

When creating a repo in classroom/github, the user has the option to add a dummy README/.gitignore. This changes allows us to deal with this.
