### PR TITLE
Override codicon css for monaco breakpoints

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -270,8 +270,16 @@ div.simframe div.pause-overlay {
     transition: opacity 0.2s;
 }
 
-.monaco-breakpoint:hover {
-    opacity: 0.7;
+.monaco-editor .margin-view-overlays:hover {
+    .codicon.monaco-breakpoint {
+        opacity: 0;
+    }
+    .codicon.monaco-breakpoint:hover {
+        opacity: 0.7;
+    }
+    .monaco-breakpoint.active {
+        opacity: 1;
+    }
 }
 
 .monaco-breakpoint.active {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3017

I eventually resorted to doing a manual diff of the css between the live site and master and found the selector that was causing the bug. This restores the old behavior of only showing the breakpoint you're hovering over.