### PR TITLE
fixed issue where clicking on error sends to line 1

### DIFF
--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -49,7 +49,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
                 <div className="ui selection list">
                     {(errors).map((e, index) =>
                     <div className="item" key={errorKey(e)} role="button" onClick={createOnErrorMessageClick(e, index)}>
-                        {lf("Line {0}: {1}", e.line + 1, e.messageText)}
+                        {lf("Line {0}: {1}", e.endLine + 1 || e.line + 1, e.messageText)}
                     </div>)
                     }
                 </div>

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -49,7 +49,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
                 <div className="ui selection list">
                     {(errors).map((e, index) =>
                     <div className="item" key={errorKey(e)} role="button" onClick={createOnErrorMessageClick(e, index)}>
-                        {lf("Line {0}: {1}", e.endLine + 1 || e.line + 1, e.messageText)}
+                        {lf("Line {0}: {1}", (e.endLine) ? e.endLine + 1 : e.line + 1, e.messageText)}
                     </div>)
                     }
                 </div>

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -592,10 +592,17 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     goToError(error: pxtc.KsDiagnostic) {
-        // Uses length to set cursor since errors in javascript
-        // are missing endColumn...
-        const line = error.line + 1;
-        const column = error.column + error.length + 1;
+        // Use endLine and endColumn to position the cursor when
+        // when errors do have them
+        let line, column;
+        if (error.endLine && error.endColumn) {
+            line = error.endLine + 1;
+            column = error.endColumn + 1;
+        } else {
+            line = error.line + 1;
+            column = error.column + error.length + 1;
+
+        }
 
         this.editor.revealLineInCenter(line);
         this.editor.setPosition({column: column, lineNumber: line});

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -592,9 +592,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     goToError(error: pxtc.KsDiagnostic) {
-        this.editor.revealLineInCenter(error.line + 1)
-        this.editor.setPosition({column: error.endColumn + 1, lineNumber: error.endLine + 1})
-        this.editor.focus()
+        // Uses length to set cursor since errors in javascript
+        // are missing endColumn...
+        const line = error.line + 1;
+        const column = error.column + error.length + 1;
+
+        this.editor.revealLineInCenter(line);
+        this.editor.setPosition({column: column, lineNumber: line});
+        this.editor.focus();
     }
 
     private onErrorChanges(errors: pxtc.KsDiagnostic[]) {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -601,7 +601,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         } else {
             line = error.line + 1;
             column = error.column + error.length + 1;
-
         }
 
         this.editor.revealLineInCenter(line);


### PR DESCRIPTION
There was an issue with the errors given while using javascript that would send to line 1
fixes: microsoft/pxt-microbit#3005