### PR TITLE
Check that runtime id is still current

### DIFF
--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -221,7 +221,7 @@ s.pc = -1;
         }
         writeRaw(`
 while (true) {
-if (yieldSteps-- < 0 && maybeYield(s, step, r0) || runtime.id !== pxsim.runtime.id) return null;
+if (yieldSteps-- < 0 && maybeYield(s, step, r0) || runtime !== pxsim.runtime) return null;
 switch (step) {
   case 0:
 `)

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -221,7 +221,7 @@ s.pc = -1;
         }
         writeRaw(`
 while (true) {
-if (yieldSteps-- < 0 && maybeYield(s, step, r0)) return null;
+if (yieldSteps-- < 0 && maybeYield(s, step, r0) || runtime.id !== pxsim.runtime.id) return null;
 switch (step) {
   case 0:
 `)


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3012

We were getting interleaved evals that were consuming each other's resumes. Fixed by checking to make sure that the runtime embedded in the binary matches the global one.