### PR TITLE
webusb: disconnect recoonect between tabs

### DIFF
--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -75,8 +75,9 @@ namespace pxt.packetio {
         let p = Promise.resolve();
         if (wrapper) {
             log('disconnect')
-            p = p.then(() => wrapper.disconnectAsync())
-                .then(() => wrapper.io.disposeAsync())
+            const w = wrapper;
+            p = p.then(() => w.disconnectAsync())
+                .then(() => w.io ? w.io.disposeAsync() : Promise.resolve())
                 .catch(e => {
                     // swallow execeptions
                     pxt.reportException(e);

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -72,9 +72,9 @@ namespace pxt.packetio {
     }
 
     export function disconnectAsync(): Promise<void> {
-        log('disconnect')
         let p = Promise.resolve();
         if (wrapper) {
+            log('disconnect')
             p = p.then(() => wrapper.disconnectAsync())
                 .then(() => wrapper.io.disposeAsync())
                 .catch(e => {
@@ -85,9 +85,9 @@ namespace pxt.packetio {
                     initPromise = undefined; // dubious
                     wrapper = undefined;
                 });
+            if (onConnectionChangedHandler)
+                p = p.then(() => onConnectionChangedHandler());
         }
-        if (onConnectionChangedHandler)
-            p = p.then(() => onConnectionChangedHandler());
         return p;
     }
 

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -71,13 +71,16 @@ namespace pxt.packetio {
         return !!wrapper && (wrapper.icon || "usb");
     }
 
+    let disconnectPromise: Promise<void>
     export function disconnectAsync(): Promise<void> {
+        if (disconnectPromise)
+            return disconnectPromise;
         let p = Promise.resolve();
         if (wrapper) {
             log('disconnect')
             const w = wrapper;
             p = p.then(() => w.disconnectAsync())
-                .then(() => w.io ? w.io.disposeAsync() : Promise.resolve())
+                .then(() => w.io.disposeAsync())
                 .catch(e => {
                     // swallow execeptions
                     pxt.reportException(e);
@@ -85,9 +88,11 @@ namespace pxt.packetio {
                 .finally(() => {
                     initPromise = undefined; // dubious
                     wrapper = undefined;
+                    disconnectPromise = undefined;
                 });
             if (onConnectionChangedHandler)
                 p = p.then(() => onConnectionChangedHandler());
+            disconnectPromise = p;
         }
         return p;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -228,6 +228,12 @@ export class ProjectView
         data.invalidate('pkg-git-pr');
         data.invalidate('pkg-git-pages')
 
+        // disconnect devices to avoid locking between tabs
+        if (!active)
+            cmds.disconnectAsync(); // turn off any kind of logging
+        else if (this.state.header) // turn it back on if in the editor
+            cmds.maybeReconnectAsync();
+
         if (!active && this.state.autoRun) {
             if (simulator.driver.state == pxsim.SimulatorState.Running) {
                 this.suspendSimulator();
@@ -4354,6 +4360,8 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("unload", ev => {
         if (theEditor)
             theEditor.saveSettings()
+        // don't lock device while being away from tab
+        pxt.packetio.disconnectAsync().done();
     });
     window.addEventListener("resize", ev => {
         if (theEditor && theEditor.editor) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4361,7 +4361,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (theEditor)
             theEditor.saveSettings()
         // don't lock device while being away from tab
-        pxt.packetio.disconnectAsync().done();
+        cmds.disconnectAsync();
     });
     window.addEventListener("resize", ev => {
         if (theEditor && theEditor.editor) {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -434,7 +434,6 @@ export function showDisconnectAsync(): Promise<void> {
 }
 
 export function disconnectAsync(): Promise<void> {
-    pxt.tickEvent("cmds.disconnect")
     return pxt.packetio.disconnectAsync();
 }
 


### PR DESCRIPTION
Always disconnect all webusb devices when switching tabs. This prevents a rogue tab to keep a lock with a device and disable other tabs. It may have some annoying side effect, like you can't leave an editor logging in the background, but it minimize locking issues when people have lots of tabs.

fix for https://github.com/microsoft/pxt-microbit/issues/3034
fix for https://github.com/microsoft/pxt-microbit/issues/3033

note that different browsers (chrome/edge) will still be able to lock a device