### PR TITLE
Don't infinite loop on parse error near EOF

### DIFF
--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -232,6 +232,8 @@ namespace pxt.py {
                             break
                     }
                     U.pushRange(outputRange, stmt());
+
+                    if (peekToken().type == TokenType.EOF) break;
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3044

Not sure how to add a test for this. This is the snippet i used while debugging:

```py
def on_forever2():
    for x in range(5):
        
basic.forever(on_forever2)
```

That snippet has nine errors, but many of them are duplicates. Seems wrong to create an error test case that expects those duplicates to exist.