### PR TITLE
Versioned tutorials

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3225,6 +3225,7 @@ export class ProjectView
                 });
         } else if (!!ghid && ghid.owner && ghid.project) {
             pxt.tickEvent("tutorial.github");
+            pxt.log(`loading tutorial from ${ghid.fullName}`)
             p = pxt.packagesConfigAsync()
                 .then(config => {
                     const status = pxt.github.repoStatus(ghid, config);
@@ -3241,6 +3242,7 @@ export class ProjectView
                     return (ghid.tag ? Promise.resolve(ghid.tag) : pxt.github.latestVersionAsync(ghid.fullName, config))
                         .then(tag => {
                             ghid.tag = tag;
+                            pxt.log(`tutorial ${ghid.fullName} tag: ${tag}`);
                             return pxt.github.downloadPackageAsync(`${ghid.fullName}#${ghid.tag}`, config);
                         });
                 }).then(gh => resolveMarkdown(ghid, gh.files));
@@ -3266,7 +3268,8 @@ export class ProjectView
             };
         }).catch(e => {
             core.handleNetworkError(e);
-            core.errorNotification(lf("Oops, we could not load this activity."))
+            core.errorNotification(lf("Oops, we could not load this activity."));
+            this.openHome(); // don't stay stranded
         });
 
         function processMarkdown(md: string) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3238,9 +3238,12 @@ export class ProjectView
                             reportId = "https://github.com/" + ghid.fullName;
                             break;
                     }
-                    return pxt.github.downloadPackageAsync(ghid.fullName, config);
-                })
-                .then(gh => resolveMarkdown(ghid, gh.files));
+                    return (ghid.tag ? Promise.resolve(ghid.tag) : pxt.github.latestVersionAsync(ghid.fullName, config))
+                        .then(tag => {
+                            ghid.tag = tag;
+                            return pxt.github.downloadPackageAsync(`${ghid.fullName}#${ghid.tag}`, config);
+                        });
+                }).then(gh => resolveMarkdown(ghid, gh.files));
         } else if (header) {
             pxt.tickEvent("tutorial.header");
             temporary = true;


### PR DESCRIPTION
Support snapping to releases for loading tutorials + caching.

- [x] this fixes issues where we would cache a tutorial indifinitely locally
- [x] aligns caching / release behavior with extensions