### PR TITLE
Set tutorial card width for steps with no hint

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -157,10 +157,14 @@ body#docs.tutorial {
 }
 
 .tutorial #tutorialcard .tutorialmessage {
-    width: ~'calc(100% - @{avatarMargin} - 0.5rem)';
+    width: 100%;
     padding: 0.5rem;
     height: calc(@tutorialCardHeight - 1.5rem);
     overflow: hidden;
+}
+
+.tutorial #tutorialcard.hasHint .tutorialmessage {
+    width: ~'calc(100% - @{avatarMargin} - 0.5rem)';
 }
 
 .tutorial.tutorialExpanded #tutorialcard .tutorialmessage {


### PR DESCRIPTION
adjust width now that we hide the entire hint bubble on steps with no hint

removes gap:
![image](https://user-images.githubusercontent.com/34112083/81977792-6bf9cc80-95df-11ea-8719-239c45938552.png)
