### PR TITLE
More intellisense fixes

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -955,6 +955,10 @@ namespace ts.pxtc.service {
                 if (res.globalNames)
                     lastGlobalNames = res.globalNames
 
+                if (!resultSymbols.length && res.globalNames) {
+                    resultSymbols = completionSymbols(pxt.U.values(res.globalNames))
+                }
+
                 // update our language host
                 Object.keys(res.outfiles)
                     .forEach(k => {
@@ -984,7 +988,7 @@ namespace ts.pxtc.service {
             const prog = service.getProgram()
             const tsAst = prog.getSourceFile(tsFilename)
             const tc = prog.getTypeChecker()
-            let isPropertyAccess = false;
+            let didFindMemberCompletions = false;
 
             // special handing for member completion
             if (isMemberCompletion) {
@@ -1018,7 +1022,7 @@ namespace ts.pxtc.service {
 
                             if (props.length) {
                                 resultSymbols = props;
-                                isPropertyAccess = true;
+                                didFindMemberCompletions = true;
                             }
                         }
                     }
@@ -1077,7 +1081,7 @@ namespace ts.pxtc.service {
                         if (paramType) {
                             // if this is a property access, then weight the results higher if they return the
                             // correct type for the parameter
-                            if (isPropertyAccess && resultSymbols.length) {
+                            if (didFindMemberCompletions && resultSymbols.length) {
                                 const matchingApis = getApisForTsType(paramType, call, tc, resultSymbols);
 
                                 matchingApis.forEach(match => match.weight = 1);

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1020,10 +1020,8 @@ namespace ts.pxtc.service {
                                 .filter(prop => !!prop)
                                 .map(prop => completionSymbol(prop));
 
-                            if (props.length) {
-                                resultSymbols = props;
-                                didFindMemberCompletions = true;
-                            }
+                            resultSymbols = props;
+                            didFindMemberCompletions = true;
                         }
                     }
                 }
@@ -1081,7 +1079,7 @@ namespace ts.pxtc.service {
                         if (paramType) {
                             // if this is a property access, then weight the results higher if they return the
                             // correct type for the parameter
-                            if (didFindMemberCompletions && resultSymbols.length) {
+                            if (didFindMemberCompletions) {
                                 const matchingApis = getApisForTsType(paramType, call, tc, resultSymbols);
 
                                 matchingApis.forEach(match => match.weight = 1);
@@ -1095,7 +1093,7 @@ namespace ts.pxtc.service {
                 }
             }
 
-            if (!isPython && !resultSymbols.length) {
+            if (!isPython && !didFindMemberCompletions) {
                 // TODO: share this with the "syntaxinfo" service
                 // start with global api symbols
                 resultSymbols = completionSymbols(pxt.U.values(lastApiInfo.apis.byQName))
@@ -1498,7 +1496,6 @@ namespace ts.pxtc.service {
             return undefined;
 
         const paramDesc = callSym.parameters[paramIdx]
-        console.dir({ paramDesc })
         let result = paramDesc.type;
 
         // check if this parameter has a shadow block, if so use the type from that instead

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1103,7 +1103,8 @@ namespace ts.pxtc.service {
                 // filter these to just what's at the cursor, otherwise we get things
                 //  like JS Array methods we don't support
                 let matchStr = tsNode.getText()
-                inScopeTsSyms = inScopeTsSyms.filter(s => s.name.indexOf(matchStr) >= 0)
+                if (matchStr !== "_") // if have a real identifier ("_" is a placeholder we added), filter to prefix matches
+                    inScopeTsSyms = inScopeTsSyms.filter(s => s.name.indexOf(matchStr) >= 0)
 
                 // convert these to pxt symbols
                 let inScopePxtSyms = inScopeTsSyms

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1121,6 +1121,9 @@ namespace ts.pxtc.service {
                     .filter(s => !!s)
                     .map(s => completionSymbol(s))
 
+                // in scope locals should be weighter higher
+                inScopePxtSyms.forEach(s => s.weight += 100)
+
                 resultSymbols = [...resultSymbols, ...inScopePxtSyms]
             }
 

--- a/tests/language-service/cases/completions_global.py
+++ b/tests/language-service/cases/completions_global.py
@@ -1,3 +1,5 @@
 oik = "some string"
 
+oi # oik
+
 test_namespace.some_function(oi  # oik

--- a/tests/language-service/cases/completions_global.py
+++ b/tests/language-service/cases/completions_global.py
@@ -1,0 +1,3 @@
+oik = "some string"
+
+test_namespace.some_function(oi  # oik

--- a/tests/language-service/cases/completions_global.ts
+++ b/tests/language-service/cases/completions_global.ts
@@ -1,0 +1,3 @@
+let oik = "some string"
+
+testNamespace.someFunction(oi  // oik

--- a/tests/language-service/cases/completions_local_param.ts
+++ b/tests/language-service/cases/completions_local_param.ts
@@ -1,0 +1,3 @@
+function fib(num: number) {
+    if (nu  // num
+}

--- a/tests/language-service/cases/completions_local_param.ts
+++ b/tests/language-service/cases/completions_local_param.ts
@@ -1,5 +1,5 @@
 function fib(num: number) {
     if (    // testNamespace.someString; num
     ;
-    if (nu  // !testNamespace.someString; num
+    if (nu  // num
 }

--- a/tests/language-service/cases/completions_local_param.ts
+++ b/tests/language-service/cases/completions_local_param.ts
@@ -1,3 +1,5 @@
 function fib(num: number) {
-    if (nu  // num
+    if (    // testNamespace.someString; num
+    ;
+    if (nu  // !testNamespace.someString; num
 }

--- a/tests/language-service/cases/completions_local_param.ts
+++ b/tests/language-service/cases/completions_local_param.ts
@@ -1,5 +1,5 @@
 function fib(num: number) {
-    if (    // testNamespace.someString; num
+    if (    // num; testNamespace.someString
     ;
-    if (nu  // num
+    if (nu  // num; number
 }

--- a/tests/language-service/languageservicerunner.ts
+++ b/tests/language-service/languageservicerunner.ts
@@ -107,21 +107,18 @@ function getTestCases() {
 
                 const lineWithoutCommment = line.substring(0, commentIndex);
 
-                const dotPosition = lineWithoutCommment.lastIndexOf(".");
-                const isCompletionAtDot = dotPosition !== -1
-
-                let relativeCompletionPosition;
-                if (!isCompletionAtDot) {
-                    // find last non-whitespace character
-                    for (let i = lineWithoutCommment.length - 1; i >= 0; i--) {
-                        relativeCompletionPosition = i
-                        if (lineWithoutCommment[i] !== " ") {
-                            break
-                        }
+                // find last non-whitespace character
+                let lastNonWhitespace: number;
+                let endsInDot = false;
+                for (let i = lineWithoutCommment.length - 1; i >= 0; i--) {
+                    lastNonWhitespace = i
+                    if (lineWithoutCommment[i] !== " ") {
+                        endsInDot = lineWithoutCommment[i] === "."
+                        break
                     }
-                } else {
-                    relativeCompletionPosition = dotPosition + 1 // one character beyond the dot
                 }
+
+                let relativeCompletionPosition = endsInDot ? lastNonWhitespace + 1 : lastNonWhitespace
 
                 const completionPosition = position + relativeCompletionPosition;
 

--- a/tests/language-service/languageservicerunner.ts
+++ b/tests/language-service/languageservicerunner.ts
@@ -56,11 +56,17 @@ function getTestCases() {
 
         // ignore files that start with TODO_; these represent future work
         if (file.indexOf("TODO") >= 0) {
+            console.log("Skipping test file marked as 'TODO': " + file);
             continue;
         }
 
-        // TODO(pxt-arcade/1887) support python as well
+        if (file.substr(-3) === ".py") {
+            // TODO(pxt-arcade/1887) support python as well
+            console.warn("Skipping .py file. .py filess are not yet supported in the language service tests: " + file);
+            continue;
+        }
         if (file.substr(-3) !== ".ts") {
+            console.error("Skipping unknown/unsupported file in test folder: " + file);
             continue;
         }
 

--- a/tests/language-service/languageservicerunner.ts
+++ b/tests/language-service/languageservicerunner.ts
@@ -114,7 +114,6 @@ function getTestCases() {
                 if (!isCompletionAtDot) {
                     // find last non-whitespace character
                     for (let i = lineWithoutCommment.length - 1; i >= 0; i--) {
-                        console.log("considering: " + lineWithoutCommment[i])
                         relativeCompletionPosition = i
                         if (lineWithoutCommment[i] !== " ") {
                             break

--- a/tests/language-service/languageservicerunner.ts
+++ b/tests/language-service/languageservicerunner.ts
@@ -162,7 +162,7 @@ function runCompletionTestCaseAsync(testCase: CompletionTestCase) {
 
             const symbolExists = (sym: string) => result.entries.some(s => (testCase.isPython ? s.pyQName : s.qName) === sym)
             for (const sym of testCase.expectedSymbols) {
-                chai.assert(symbolExists(sym), `Did not receive symbol '${sym}' for '${testCase.lineText}'; instead we got ${result.entries.length} other symbols.`);
+                chai.assert(symbolExists(sym), `Did not receive symbol '${sym}' for '${testCase.lineText}'; instead we got ${result.entries.length} other symbols${result.entries.length < 5 ? ": " + result.entries.map(e => e.qName).join(", ") : "."}`);
             }
             for (const sym of testCase.unwantedSymbols) {
                 chai.assert(!symbolExists(sym), `Receive explicitly unwanted symbol '${sym}' for '${testCase.lineText}'`);

--- a/tests/language-service/test-package/namespaces.ts
+++ b/tests/language-service/test-package/namespaces.ts
@@ -8,4 +8,13 @@ namespace testNamespace {
     export interface SomeInterface {
         someField: number;
     }
+
+    export enum SomeEnum {
+        One,
+        Two
+    }
+
+    export class SomeClass {
+        e: SomeEnum;
+    }
 }

--- a/tests/language-service/test-package/namespaces.ts
+++ b/tests/language-service/test-package/namespaces.ts
@@ -1,5 +1,5 @@
 namespace testNamespace {
-    export function someFunction() {
+    export function someFunction(someParam: string) {
 
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -38,7 +38,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
     constructor(public editor: Editor, public python: boolean) {
     }
 
-    triggerCharacters?: string[] = ["(", "."];
+    triggerCharacters?: string[] = ["(", ".", ":"];
 
     kindMap = {}
     private tsKindToMonacoKind(s: pxtc.SymbolKind): monaco.languages.CompletionItemKind {
@@ -581,7 +581,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                             setInsertionSnippet={this.setInsertionSnippet}
                             parent={this.parent} />
                     </div>
-                    {showErrorList ? <ErrorList onSizeChange={this.resize} listenToErrorChanges={this.listenToErrorChanges} goToError={this.goToError}/> : undefined}
+                    {showErrorList ? <ErrorList onSizeChange={this.resize} listenToErrorChanges={this.listenToErrorChanges} goToError={this.goToError} /> : undefined}
                 </div>
             </div>
         )
@@ -593,7 +593,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     goToError(error: pxtc.KsDiagnostic) {
         this.editor.revealLineInCenter(error.line + 1)
-        this.editor.setPosition({column: error.endColumn + 1, lineNumber: error.endLine + 1})
+        this.editor.setPosition({ column: error.endColumn + 1, lineNumber: error.endLine + 1 })
         this.editor.focus()
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -103,7 +103,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                         // remove what precedes the "." in the full snippet.
                         // E.g. if the user is typing "mobs.", we want to complete with "spawn" (name) not "mobs.spawn" (qName)
                         if (completions.isMemberCompletion && completionSnippet) {
-                            const nameStart = completionSnippet.indexOf(name);
+                            const nameStart = completionSnippet.lastIndexOf(name);
                             if (nameStart !== -1) {
                                 completionSnippet = completionSnippet.substr(nameStart)
                             }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/2893
Fixes: https://github.com/microsoft/pxt-microbit/issues/2707
Fixes: https://github.com/microsoft/pxt-microbit/issues/2736
Fixes: https://github.com/microsoft/pxt-microbit/issues/2977
Fixes: https://github.com/microsoft/pxt-microbit/issues/3056

Lots of miscellaneous auto-complete improvements.
We better handle member completion and don't show bogus symbols when we can tell the type  we're completing on.
We make sure we at minimum can complete global symbols in Python.
We fix the ordering on some completions, like putting local variables higher.
We more correctly identify where a completion snippet should start (if it's qualified).
We correctly handle showing local variables after a parenthesis.
We recompute auto-complete after a ":".
Probably more little things..

Language service test enhancements:
- Support for .py files
- Support for more expressions like `some.fn(foo // foobar`
- Support for order sensativity

TODO:
https://github.com/microsoft/pxt-microbit/issues/3056