### PR TITLE
Handling invalid github token

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -123,6 +123,7 @@ namespace pxt.github {
                 opts.headers['Authorization'] = `token ${token}`
             }
         }
+        opts.allowHttpErrors = true;
         return U.requestAsync(opts)
             .catch(e => {
                 if (handleGithubNetworkError) {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -129,9 +129,10 @@ namespace pxt.github {
                     opts.headers['Authorization'] = `token ${token}`
                 }
             }
-            opts.allowHttpErrors = canRetry;
+            opts.allowHttpErrors = false;
             return U.requestAsync(opts)
                 .catch(e => {
+                    pxt.tickEvent("github.error", { statusCode: e.statusCode });
                     if (handleGithubNetworkError) {
                         const retry = handleGithubNetworkError(e)
                         // retry if it may fix the issue

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3239,7 +3239,7 @@ export class ProjectView
                             reportId = "https://github.com/" + ghid.fullName;
                             break;
                     }
-                    return (ghid.tag ? Promise.resolve(ghid.tag) : pxt.github.latestVersionAsync(ghid.fullName, config))
+                    return (ghid.tag ? Promise.resolve(ghid.tag) : pxt.github.latestVersionAsync(ghid.fullName, config, true))
                         .then(tag => {
                             ghid.tag = tag;
                             pxt.log(`tutorial ${ghid.fullName} tag: ${tag}`);

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -157,6 +157,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
             return Promise.resolve(undefined);
         return pxt.github.authenticatedUserAsync()
             .then(ghuser => {
+                if (!ghuser) return undefined;
                 return {
                     id: ghuser.login,
                     userName: ghuser.login,

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -11,7 +11,6 @@ export class GithubProvider extends cloudsync.ProviderBase {
     constructor() {
         super(PROVIDER_NAME, lf("GitHub"), "icon github", "https://api.github.com");
         pxt.github.handleGithubNetworkError = (e: any) => {
-            pxt.tickEvent("github.error", { statusCode: e.statusCode });
             if (e.statusCode == 401) {
                 pxt.log(`github: invalid token`)
                 this.clearToken();

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -157,7 +157,11 @@ export class GithubProvider extends cloudsync.ProviderBase {
             return Promise.resolve(undefined);
         return pxt.github.authenticatedUserAsync()
             .then(ghuser => {
-                if (!ghuser) return undefined;
+                if (!ghuser) {
+                    pxt.log(`unkown github user, clearing token`)
+                    this.setNewToken(undefined); // token is expired or deleted
+                    return undefined;
+                }
                 return {
                     id: ghuser.login,
                     userName: ghuser.login,
@@ -165,12 +169,6 @@ export class GithubProvider extends cloudsync.ProviderBase {
                     photo: ghuser.avatar_url,
                     profile: `https://github.com/${ghuser.login}`
                 }
-            }).catch(e => {
-                // the token expired or got deleted by the user
-                if (e.statusCode == 401) {
-                    this.setNewToken(undefined);
-                }
-                throw e;
             })
     }
 

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -11,6 +11,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
     constructor() {
         super(PROVIDER_NAME, lf("GitHub"), "icon github", "https://api.github.com");
         pxt.github.handleGithubNetworkError = (e: any) => {
+            pxt.tickEvent("github.error", { statusCode: e.statusCode });
             if (e.statusCode == 401) {
                 pxt.log(`github: invalid token`)
                 this.clearToken();
@@ -158,8 +159,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
         return pxt.github.authenticatedUserAsync()
             .then(ghuser => {
                 if (!ghuser) {
-                    pxt.log(`unkown github user, clearing token`)
-                    this.setNewToken(undefined); // token is expired or deleted
+                    pxt.log(`unkown github user`)
                     return undefined;
                 }
                 return {


### PR DESCRIPTION
It seems that GitHub is expeiring OAuth tokens (maybe there is a limit of clients) or the user might just invalidate it too. SInce any github request may fail, we handle this at the request level and simply erase the token from the browser.
This change also guarantees that loading a tutorial does **not**rely on a token since that token might be bogus.
This fix is not bullet proof, i should really be wrapping every github call with a retry without token that goes through the proxy.
Added tick for errors to track them.