### PR TITLE
Strip whitespace from monaco filter text

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -121,6 +121,11 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                         endLineNumber: position.lineNumber
                     }
 
+                    // Need to take the whitespace out of this string, otherwise monaco
+                    // won't dismiss the suggest widget when the user types a space. Replace
+                    // them with commas so that we don't confuse the fuzzy matcher in monaco
+                    const filterText = `${label},${documentation},${block}`.replace(/\s/g, ",")
+
                     let res: monaco.languages.CompletionItem = {
                         label: label,
                         range,
@@ -129,7 +134,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                         detail: insertSnippet,
                         // force monaco to use our sorting
                         sortText: `${tosort(i)} ${insertSnippet}`,
-                        filterText: `${label} ${documentation} ${block}`,
+                        filterText: filterText,
                         insertText: completionSnippet || undefined,
                     };
                     return res


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3015

Basically, we pass the filter text to the completion provider so that completions work better in localized languages, but monaco will not dismiss the suggest widget if the current word exists inside the filtertext for an item! In this case the word was " " (space)

I'll have you know I had to read the vscode source and debug the stock monaco typescript service in the playground to figure this one out!