### PR TITLE
Disable tooltip hover when dragging block from toolbox

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -203,6 +203,9 @@ class HoverProvider implements monaco.languages.HoverProvider {
      * to the word range at the position when omitted.
      */
     provideHover(model: monaco.editor.IReadOnlyModel, position: monaco.Position, token: monaco.CancellationToken): monaco.languages.Hover | monaco.Thenable<monaco.languages.Hover> {
+        // Don't provide hover if currently dragging snippet
+        if (this.editor.hasInsertionSnippet()) return null;
+
         const offset = model.getOffsetAt(position);
         const source = model.getValue();
         const fileName = this.editor.currFile.name;
@@ -1878,6 +1881,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     // Snippet as string, or "qName:" + qualified name of block
     public setInsertionSnippet = (snippet: string) => {
         this.insertionSnippet = snippet;
+    }
+
+    // Check if insertion snippet is currently set
+    public hasInsertionSnippet = (): boolean => {
+        return !!this.insertionSnippet;
     }
 
     ///////////////////////////////////////////////////////////


### PR DESCRIPTION
Checks insertion snippet (set from toolbox) and does not return hover if it is set 

Fixes https://github.com/microsoft/pxt-microbit/issues/2703