### PR TITLE
Remove ":" as auto-complete trigger

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -38,7 +38,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
     constructor(public editor: Editor, public python: boolean) {
     }
 
-    triggerCharacters?: string[] = ["(", ".", ":"];
+    triggerCharacters?: string[] = ["(", "."];
 
     kindMap = {}
     private tsKindToMonacoKind(s: pxtc.SymbolKind): monaco.languages.CompletionItemKind {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/3066

This is a regression introduced by: https://github.com/microsoft/pxt/pull/7032

In most cases we don't want auto-complete to trigger on semi-colon. Instead when the user starts typing an identifier or type name, auto-complete will trigger naturally.

This was introduced as a fix for a different issue (part of https://github.com/microsoft/pxt-microbit/issues/2707) but actually this other PR fixed that part better: https://github.com/microsoft/pxt/pull/7034