### PR TITLE
fix width of tutorial message on mobile

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -548,7 +548,7 @@ code.lang-filterblocks {
         --bubble-pulse-size: 16px;
     }
 
-    .tutorial #tutorialcard .tutorialmessage {
+    .tutorial #tutorialcard.hasHint .tutorialmessage {
         width: ~'calc(100% - @{mobileAvatarMargin} - 0.5rem)';
     }
 


### PR DESCRIPTION
fix mobile width, the change to the selector made the normal one overpower the mobile only one

curr:

![image](https://user-images.githubusercontent.com/5615930/82087166-687c4900-96a4-11ea-9c6e-cc9b4867bbfa.png)

fixed:

![image](https://user-images.githubusercontent.com/5615930/82087143-5f8b7780-96a4-11ea-8206-92bfb69039cc.png)
