### PR TITLE
unify error handling in github

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -365,7 +365,7 @@ namespace pxt.github {
     }
 
     export async function fastForwardAsync(repopath: string, branch: string, commitid: string) {
-        let resp = await ghRequestAsync({
+        const resp = await ghRequestAsync({
             url: "https://api.github.com/repos/" + repopath + "/git/refs/heads/" + branch,
             method: "PATCH",
             allowHttpErrors: true,
@@ -378,7 +378,7 @@ namespace pxt.github {
     }
 
     export async function putFileAsync(repopath: string, path: string, content: string) {
-        let resp = await ghRequestAsync({
+        await ghRequestAsync({
             url: "https://api.github.com/repos/" + repopath + "/contents/" + path,
             method: "PUT",
             allowHttpErrors: true,
@@ -386,10 +386,9 @@ namespace pxt.github {
                 message: lf("Initialize empty repo"),
                 content: btoa(U.toUTF8(content)),
                 branch: "master"
-            }
+            },
+            successCodes: [201]
         })
-        if (resp.statusCode != 201)
-            U.userError("PUT file failed")
     }
 
     export async function createTagAsync(repopath: string, tag: string, commitid: string) {
@@ -418,14 +417,14 @@ namespace pxt.github {
             base: baseBranch,
             maintainer_can_modify: true
         })
-        return res.html_url as string
+        return res?.html_url as string
     }
 
     export function mergeAsync(repopath: string, base: string, head: string, message?: string) {
         return ghRequestAsync({
             url: "https://api.github.com/repos/" + repopath + "/merges",
             method: "POST",
-            allowHttpErrors: true,
+            successCodes: [201, 204, 409],
             data: {
                 base,
                 head,

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -342,11 +342,13 @@ namespace pxt.github {
     }
 
     function ghPostAsync(path: string, data: any, headers?: any, method?: string): Promise<any> {
+        // need to handle 204
         return ghRequestAsync({
             url: /^https:/.test(path) ? path : "https://api.github.com/repos/" + path,
             headers,
             method: method || "POST",
-            data: data
+            data: data,
+            successCodes: [200, 201, 202, 204]
         }).then(resp => resp.json);
     }
 

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -606,6 +606,7 @@ namespace ts.pxtc.Util {
         allowGzipPost?: boolean;
         responseArrayBuffer?: boolean;
         forceLiveEndpoint?: boolean;
+        successCodes?: number[];
     }
 
     export interface HttpResponse {
@@ -626,7 +627,8 @@ namespace ts.pxtc.Util {
                 //if (debugHttpRequests)
                 //    pxt.debug(`  << ${resp.statusCode}`);
                 const statusCode = resp.statusCode;
-                if ((resp.statusCode != 304 && !(resp.statusCode >= 200 && resp.statusCode <= 202)) && !options.allowHttpErrors) {
+                const successCodes = options.successCodes || [304, 200, 201, 202];
+                if (successCodes.indexOf(statusCode) < 0 && !options.allowHttpErrors) {
                     const msg = Util.lf("Bad HTTP status code: {0} at {1}; message: {2}",
                         resp.statusCode, options.url, (resp.text || "").slice(0, 500))
                     const err: any = new Error(msg)

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -625,15 +625,16 @@ namespace ts.pxtc.Util {
             .then(resp => {
                 //if (debugHttpRequests)
                 //    pxt.debug(`  << ${resp.statusCode}`);
-                if ((resp.statusCode != 200 && resp.statusCode != 304) && !options.allowHttpErrors) {
-                    let msg = Util.lf("Bad HTTP status code: {0} at {1}; message: {2}",
+                const statusCode = resp.statusCode;
+                if ((resp.statusCode != 304 && !(resp.statusCode >= 200 && resp.statusCode <= 204)) && !options.allowHttpErrors) {
+                    const msg = Util.lf("Bad HTTP status code: {0} at {1}; message: {2}",
                         resp.statusCode, options.url, (resp.text || "").slice(0, 500))
-                    let err: any = new Error(msg)
+                    const err: any = new Error(msg)
                     err.statusCode = resp.statusCode
                     return Promise.reject(err)
                 }
                 if (resp.text && /application\/json/.test(resp.headers["content-type"] as string))
-                    resp.json = JSON.parse(resp.text)
+                    resp.json = U.jsonTryParse(resp.text)
                 return resp
             })
     }

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -626,7 +626,7 @@ namespace ts.pxtc.Util {
                 //if (debugHttpRequests)
                 //    pxt.debug(`  << ${resp.statusCode}`);
                 const statusCode = resp.statusCode;
-                if ((resp.statusCode != 304 && !(resp.statusCode >= 200 && resp.statusCode <= 204)) && !options.allowHttpErrors) {
+                if ((resp.statusCode != 304 && !(resp.statusCode >= 200 && resp.statusCode <= 202)) && !options.allowHttpErrors) {
                     const msg = Util.lf("Bad HTTP status code: {0} at {1}; message: {2}",
                         resp.statusCode, options.url, (resp.text || "").slice(0, 500))
                     const err: any = new Error(msg)

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -10,13 +10,15 @@ export const PROVIDER_NAME = "github";
 export class GithubProvider extends cloudsync.ProviderBase {
     constructor() {
         super(PROVIDER_NAME, lf("GitHub"), "icon github", "https://api.github.com");
-        pxt.github.handleGithubNetworkError = (e: any) => {
-            if (e.statusCode == 401) {
+        pxt.github.handleGithubNetworkError = (opts: pxt.U.HttpRequestOptions, e: any) => {
+            if (e.statusCode == 401 && pxt.github.token) {
                 pxt.log(`github: invalid token`)
                 this.clearToken();
-                return true; // retry
+                return opts.method == "GET"; // retry gets
             } else if (e.statusCode == 403) {
                 pxt.log(`github: unauthorized access`)
+            } else if (e.statusCode == 404) {
+                (e as any).needsWritePermission = true;
             }
             return false;
         }


### PR DESCRIPTION
- [x] treat 304, 200..202 as success code in httpRequest (for all requests)
- [x] unify more github calls
- [x] configurable set of success codes

Fix for https://github.com/microsoft/pxt-microbit/issues/3075