### PR TITLE
Readonly fixes

### DIFF
--- a/docs/github-explorer.html
+++ b/docs/github-explorer.html
@@ -151,6 +151,9 @@
     repositories(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
         name
+        owner {
+            login
+        }
         nameWithOwner
         object(expression: "master:pxt.json") {
           ... on Blob {
@@ -216,17 +219,22 @@
                     </div>`)
                     return;
                 }
-                $('#repoes')
-                    .append(`
-<a href="https://github.com/${user.login}" target="_blank" class="ui link item" title="Open user profile">
-                    <div class="ui mini image">
-      <img src="${user.avatarUrl}">
+                const userEl = $(`
+<a href="" target="_blank" class="ui link item" title="Open user profile">
+    <div class="ui mini image">
+      <img src="">
     </div>
     <div class="content">
-        <div class="header">${user.name}</div>
-        <div class="description">${user.login}</div>
+        <div class="header"></div>
+        <div class="description"></div>
     </div>
 </a>`)
+                userEl.attr("href", `https://github.com/${user.login}`)
+                userEl.find("img").attr('src', user.avatarUrl)
+                userEl.find(".header").text(user.name)
+                userEl.find(".description").text(user.login)
+                $('#repoes')
+                    .append(userEl)
                 const repoes = await fetchUserRepos(userName);
                 $("#repoes")
                     .append(`<div class="ui divider"></div>`)
@@ -237,13 +245,16 @@
                             const item = $(
                                 `<div class="ui link item">
     <div class="ui mini image">
-      <img src="${icon}">
+        <img src="">
     </div>
     <div class="content">
-        <div class="header">${repo.name.replace(/^pxt-/, '')}</div>
-        <div class="description">${target.name}</div>
+        <div class="header"></div>
+        <div class="description"></a></div>
     </div>
 </div>`);
+                            item.find("img").attr("src", icon)
+                            item.find(".header").text(repo.name)
+                            item.find(".description").text(repo.owner.login)
                             item.click(event => {
                                 trackClick("github.explorer.open")
                                 $('#repoes').children().removeClass('active');

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -120,7 +120,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && /\.md$/.test(file.name)
                 && !/^_locales\//.test(file.name)
             const fn = file.name.replace(/\.[a-z]+$/, '');
-            const previewUrl = !shellReadonly 
+            const previewUrl = !shellReadonly
                 && isTutorialMd
                 && `#tutorial:${header.id}:${fn}`;
             const ghid = usesGitHub && pxt.github.parseRepoId(header.githubId)
@@ -129,7 +129,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && `${window.location.origin}${window.location.pathname || ""}#tutorial:github:${ghid.fullName}/${fn}`
             const lang = pxt.Util.userLanguage();
             const localized = `_locales/${lang}/${file.name}`;
-            const addLocale =  !shellReadonly
+            const addLocale = !shellReadonly
                 && isTutorialMd
                 && pxt.Util.userLanguage() !== (pxt.appTarget.appTheme.defaultLocale || "en")
                 && !files.some(f => f.name == localized);
@@ -162,7 +162,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
 
     private packageOf(p: pkg.EditorPackage) {
         const expandedPkg = this.state.expandedPkg;
-        const del = !pxt.shell.isReadOnly()        
+        const del = !pxt.shell.isReadOnly()
             && p.getPkgId() != pxt.appTarget.id
             && p.getPkgId() != "built"
             && p.getPkgId() != "assets"

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -91,7 +91,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
         const { currentFile } = this.state;
         const header = this.props.parent.state.header;
         const topPkg = pkg.isTopLevel();
-        const deleteFiles = topPkg && !pxt.shell.isReadOnly();
+        const shellReadonly = pxt.shell.isReadOnly();
+        const deleteFiles = topPkg && !shellReadonly;
         const langRestrictions = pkg.getLanguageRestrictions();
         let files = pkg.sortedFiles();
 
@@ -119,7 +120,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && /\.md$/.test(file.name)
                 && !/^_locales\//.test(file.name)
             const fn = file.name.replace(/\.[a-z]+$/, '');
-            const previewUrl = isTutorialMd
+            const previewUrl = !shellReadonly 
+                && isTutorialMd
                 && `#tutorial:${header.id}:${fn}`;
             const ghid = usesGitHub && pxt.github.parseRepoId(header.githubId)
             const shareUrl = isTutorialMd && ghid
@@ -127,7 +129,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && `${window.location.origin}${window.location.pathname || ""}#tutorial:github:${ghid.fullName}/${fn}`
             const lang = pxt.Util.userLanguage();
             const localized = `_locales/${lang}/${file.name}`;
-            const addLocale = isTutorialMd
+            const addLocale =  !shellReadonly
+                && isTutorialMd
                 && pxt.Util.userLanguage() !== (pxt.appTarget.appTheme.defaultLocale || "en")
                 && !files.some(f => f.name == localized);
             const hasDelete = deleteFiles

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -159,7 +159,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
 
     private packageOf(p: pkg.EditorPackage) {
         const expandedPkg = this.state.expandedPkg;
-        const del = p.getPkgId() != pxt.appTarget.id
+        const del = !pxt.shell.isReadOnly()        
+            && p.getPkgId() != pxt.appTarget.id
             && p.getPkgId() != "built"
             && p.getPkgId() != "assets"
             && p.getPkgId() != pxt.appTarget.corepkg


### PR DESCRIPTION
A few glitch found while using github-explorer (readonly mode)
- [x] don't allow deleting extension references
- [x] don't add localized .md files
- [x] don't create preview url for .md files
- [x] assemble DOM via jquery in github-explorer