### PR TITLE
Ensure name uniqueness for auto-complete and toolbox snippets

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -767,6 +767,7 @@ declare namespace ts.pxtc {
         combinedProperties?: string[];
         pyName?: string;
         pyQName?: string;
+        snippetAddsDefinitions?: boolean;
     }
 
     interface ApisInfo {


### PR DESCRIPTION
when generating snippets for auto-complete  or toolbox, track when we introduce new definitions so that we can make sure we regenerate those snippets when names might have changed.

I believe this regression was introduced as a side effect of better caching of symbol info between intellisense calls. Really snippets are very stateful and so we need extra info to know when to invalidate them.

Fixes: https://github.com/microsoft/pxt-microbit/issues/3068
Fixes: https://github.com/microsoft/pxt-microbit/issues/3074

![2020-05-19 14 55 13](https://user-images.githubusercontent.com/6453828/82382854-971a5c80-99e1-11ea-9d30-b7abee36be92.gif)
