### PR TITLE
hide mobile expand / hide sim button on mobile fullscreen

### DIFF
--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -141,9 +141,9 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
                 {restart && <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} />}
                 {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
                 {/* These buttons are for mobile view only, attached to reduce extra padding */}
-                {fullscreen && <sui.Button key='fullscreenbtn' className={`fullscreen-button tablet only`} icon={`xicon ${isFullscreen ? 'fullscreencollapse' : 'fullscreen'}`} title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
+                {fullscreen && <sui.Button key='fullscreenbtn' className={`fullscreen-button tablet only hidefullscreen`} icon={`xicon ${isFullscreen ? 'fullscreencollapse' : 'fullscreen'}`} title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
                 {collapse && <sui.Button
-                    className={`expand-button portrait only ${this.props.collapsed ? "green" : "red"}`}
+                    className={`expand-button portrait only ${this.props.collapsed ? "green" : "red"} hidefullscreen`}
                     icon={`${this.props.collapsed ? 'play' : 'stop'}`}
                     title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse}
                 />}


### PR DESCRIPTION
Just noticed I forgot to add hidefullscreen on these, so these two were also showing up mobile fullscreen view