### PR TITLE
Adding detection for ios 13 ipads

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -25,7 +25,9 @@ namespace pxt.BrowserUtils {
     }
 
     export function isIOS(): boolean {
-        return hasNavigator() && /iPad|iPhone|iPod/.test(navigator.userAgent);
+        return hasNavigator() &&
+            (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+            navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
     }
 
     //MacIntel on modern Macs


### PR DESCRIPTION
Should fix https://github.com/microsoft/pxt-microbit/issues/2601

I can't really test it locally but this is the same check we use in monaco for determining if we're on an ipad. I tested that it does return true in the ios 13.3 ipad simulator.