### PR TITLE
use editor tools colors instead of red / green, padding in tablet view

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1092,6 +1092,12 @@ p.ui.font.small {
         transform: translateX(0%)!important;
         left: -2rem;
     }
+
+    #downloadArea {
+        // .25rem from padding around editortoolbar in portrait mode
+        width: ~"calc(@{blocklyRowWidthTablet} - .25rem)";
+        margin-right: 0 !important;
+    }
 }
 
 /* Mobile */

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -138,12 +138,11 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make && <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} />}
                 {run && !targetTheme.bigRunButton && <PlayButton parent={parent} simState={parentState.simState} debugging={parentState.debugging} />}
+                {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button tablet only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
                 {restart && <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} />}
                 {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
-                {/* These buttons are for mobile view only, attached to reduce extra padding */}
-                {fullscreen && <sui.Button key='fullscreenbtn' className={`fullscreen-button tablet only hidefullscreen`} icon={`xicon ${isFullscreen ? 'fullscreencollapse' : 'fullscreen'}`} title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
                 {collapse && <sui.Button
-                    className={`expand-button portrait only ${this.props.collapsed ? "green" : "red"} hidefullscreen`}
+                    className={`expand-button portrait only editortools-btn hidefullscreen`}
                     icon={`${this.props.collapsed ? 'play' : 'stop'}`}
                     title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse}
                 />}


### PR DESCRIPTION
quick changes we discussed on teams:

![image](https://user-images.githubusercontent.com/5615930/82481092-a5bc4e80-9a89-11ea-9ce3-c618eab95750.png)

move fullscreen button to top in tablet mode, make the collapse / expand show up in same color as other editor tools, and a little space around download button in tablet view