### PR TITLE
Replace 'devdocs' JS links

### DIFF
--- a/common-docs/javascript/functions.md
+++ b/common-docs/javascript/functions.md
@@ -142,7 +142,7 @@ foo(() => { // arrow function!
 
 Often, a function like ``foo()`` will save the arrow function ``handler`` in a variable to run the code inside the function later when a certain condition occurs. Arrow functions serve as a kind of shortcut to provide extra code to run without having to write a separate formal function for that purpose. In this way arrow, or lambda, functions are thought of as "anonymous" functions.
 
-[Read more about arrow functions...](http://devdocs.io/javascript/functions/arrow_functions)
+[Read more about arrow functions...](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 
 
 ## Anonymous Functions

--- a/common-docs/javascript/operators.md
+++ b/common-docs/javascript/operators.md
@@ -4,11 +4,11 @@ The following JavaScript operators are supported for the @boardname@.
 
 ## Assignment, arithmetic and bitwise
 
-* [assignment operators](http://devdocs.io/javascript/operators/assignment_operators)
-* [arithmetic operators](http://devdocs.io/javascript/operators/arithmetic_operators) 
-* [bitwise operators](http://devdocs.io/javascript/operators/bitwise_operators)
+* [assignment operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Assignment_Operators)
+* [arithmetic operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators) 
+* [bitwise operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators)
 
 ## Comparison and conditional
 
-* [comparison operators](http://devdocs.io/javascript/operators/comparison_operators)
-* [conditional operator](http://devdocs.io/javascript/operators/conditional_operator)
+* [comparison operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators)
+* [conditional operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator)

--- a/common-docs/javascript/statements.md
+++ b/common-docs/javascript/statements.md
@@ -3,26 +3,26 @@
 The following JavaScript statements are supported for the @boardname@:
 
 ## Variable declarations
-* [`const` statement](http://devdocs.io/javascript/statements/const)
-* [`let` statement](http://devdocs.io/javascript/statements/let)
+* [`const` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const)
+* [`let` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)
 
 ## Block-structured statements
 
-* [`{ }` block statement](http://devdocs.io/javascript/statements/block)
-* [`if-else` conditional statement](http://devdocs.io/javascript/statements/if...else)
-* [`while` loop](http://devdocs.io/javascript/statements/while)
-* [`do-while` loop](http://devdocs.io/javascript/statements/do...while)
-* [`for(;;)` loop](http://devdocs.io/javascript/statements/for)
-* [`switch` statement (on numbers only)](http://devdocs.io/javascript/statements/switch)
+* [`{ }` block statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block)
+* [`if-else` conditional statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else)
+* [`while` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while)
+* [`do-while` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/do...while)
+* [`for(;;)` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for)
+* [`switch` statement (on numbers only)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch)
 
 ## Control-flow commands
 
-* [`break` statement](http://devdocs.io/javascript/statements/break)
-* [`continue` statement](http://devdocs.io/javascript/statements/continue)
-* [`return` statement](http://devdocs.io/javascript/statements/return)
-* [`debugger` statement for breakpoints](http://devdocs.io/javascript/statements/debugger)
+* [`break` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break)
+* [`continue` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue)
+* [`return` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return)
+* [`debugger` statement for breakpoints](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger)
 
 ## Labeling statements
 
-* [`label:` statement](http://devdocs.io/javascript/statements/label)
-* [`default` statement](http://devdocs.io/javascript/statements/default)
+* [`label:` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label)
+* [`default` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/default)


### PR DESCRIPTION
The links to `devdocs.io` pages have equivalent pages at `https://developer.mozilla.org`. Those page links are replaced with the MDN page links. If linking to MDN is not appropriate, then we'll have to figure something else out.

Closes #7058 