### PR TITLE
Add copy/paste support for marquee selections.

### DIFF
--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -273,6 +273,27 @@ export class EditState {
 
         return col >= 0 && col < this.floating.image.width && row >= 0 && row < this.floating.image.height;
     }
+
+    setFloatingLayer(floatingImage: pxt.sprite.Bitmap, offset?: { layerOffsetX: number, layerOffsetY: number }) {
+        this.mergeFloatingLayer();
+
+        this.floating = { image: floatingImage };
+        this.layerOffsetX = offset?.layerOffsetX ?? 0;
+        this.layerOffsetY = offset?.layerOffsetY ?? 0;
+    }
+
+    toImageState(): pxt.sprite.ImageState {
+        return {
+            bitmap: this.image.data(),
+            layerOffsetX: this.layerOffsetX,
+            layerOffsetY: this.layerOffsetY,
+            floating: this.floating && {
+                bitmap: this.floating.image ? this.floating.image.data() : undefined,
+                overlayLayers: this.floating.overlayLayers ? this.floating.overlayLayers.map(el => el.data()) : undefined
+            },
+            overlayLayers: this.overlayLayers ? this.overlayLayers.map(el => el.data()) : undefined
+        };
+    }
 }
 
 export abstract class Edit {


### PR DESCRIPTION
This PR adds support for copy/paste for marquee selections in image/sprite editors:

![Kapture 2020-05-19 at 20 53 24](https://user-images.githubusercontent.com/194333/82497235-c6dd6900-9aa2-11ea-8269-eeae561ad38f.gif)

https://github.com/microsoft/pxt-arcade/issues/1835

This PR also puts the `` img`…` `` formatted data on the clipboard as `text/plain` enabling copy in the sprite editor and pasting into JavaScript:

![Kapture 2020-05-19 at 20 59 30](https://user-images.githubusercontent.com/194333/82497780-b8438180-9aa3-11ea-8d6e-b733e21ce43c.gif)

This functionality isn't required and would be easy to turn off if it's too "cute".

Some implementation discussion over here https://github.com/microsoft/pxt-arcade/issues/1896 and also on a previous PR https://github.com/microsoft/pxt/pull/6990

Currently tilemaps are not supported; it looks like the serialization format I'd want to use for a partial selection of tilemap data is implemented by a non-exported function: https://github.com/microsoft/pxt/blob/c002848a42fdbb7a3a9e118db8e3fe0ee7741222/pxtlib/spriteutils.ts#L432-L435
