### PR TITLE
Adding range function for python

### DIFF
--- a/libs/pxt-python/pxt-python-helpers.ts
+++ b/libs/pxt-python/pxt-python-helpers.ts
@@ -260,4 +260,37 @@ namespace _py {
         }
         return index;
     }
+
+    /**
+     * Returns a sequence of numbers up to but not including the limit
+     * @param first The value to end the sequence before. This value will not show up in the result.
+     *      If more than one argument is passed, this argument is instead used for the first value in the range
+     * @param stop  The value to end the sequence before. This value will not show up in the result
+     * @param step  The value to increase or decrease by for each step in the range. Must be a nonzero integer
+     */
+    export function range(first: number, stop?: number, step?: number) {
+        if (step === undefined) step = 1
+        // step must be a nonzero integer (can be negative)
+        if (step === 0 || (step | 0) !== step) {
+            throw VALUE_ERROR;
+        }
+
+        // If only one argument is given, then start is actually stop
+        if (stop === undefined) {
+            stop = first;
+            first = 0;
+        }
+
+        const res: number[] = [];
+        if (step > 0 && first >= stop || step < 0 && first <= stop) return res;
+
+        let index = first;
+
+        while (step < 0 ? index > stop : index < stop) {
+            res.push(index);
+            index += step
+        }
+
+        return res;
+    }
 }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -31,7 +31,8 @@ namespace ts.pxtc {
         "!!": { n: "bool", t: ts.SyntaxKind.BooleanKeyword },
         "Array.indexOf": { n: "Array.index", t: ts.SyntaxKind.Unknown },
         "Array.push": { n: "Array.append", t: ts.SyntaxKind.Unknown },
-        "parseInt": { n: "int", t: ts.SyntaxKind.NumberKeyword, snippet: 'int("0")' }
+        "parseInt": { n: "int", t: ts.SyntaxKind.NumberKeyword, snippet: 'int("0")' },
+        "_py.range": { n: "range", t: ts.SyntaxKind.Unknown, snippet: 'range("0")' }
     }
 
     export function snakify(s: string) {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -32,7 +32,7 @@ namespace ts.pxtc {
         "Array.indexOf": { n: "Array.index", t: ts.SyntaxKind.Unknown },
         "Array.push": { n: "Array.append", t: ts.SyntaxKind.Unknown },
         "parseInt": { n: "int", t: ts.SyntaxKind.NumberKeyword, snippet: 'int("0")' },
-        "_py.range": { n: "range", t: ts.SyntaxKind.Unknown, snippet: 'range("0")' }
+        "_py.range": { n: "range", t: ts.SyntaxKind.Unknown, snippet: 'range("4")' }
     }
 
     export function snakify(s: string) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3104

This adds an implementation for `range()`. It does not change anything about for-loops, they still get mapped the same way and they still can only take one argument in the call to `range()`.

Requires https://github.com/microsoft/pxt-microbit/pull/3109