### PR TITLE
Special case range in for-loops for symbol info

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -880,6 +880,12 @@ namespace ts.pxtc.service {
             if (isSymbol && !opts.syntaxInfo.symbols?.length) {
                 const possibleKeyword = getWordAtPosition(v.fileContent, v.position);
                 if (possibleKeyword) {
+                    // In python if range() is used in a for-loop, we don't convert
+                    // it to a function call when going to TS (we just convert it to
+                    // a regular for-loop). Because our symbol detection is based off
+                    // of the TS, we won't get a symbol result for range at this position
+                    // in the file. This special case makes sure we return the same help
+                    // as a standalone call to range().
                     if (isPython && possibleKeyword.text === "range") {
                         const apiInfo = getLastApiInfo(opts).apis;
                         if (apiInfo.byQName["_py.range"]) {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -877,25 +877,35 @@ namespace ts.pxtc.service {
                 }
             }
 
-            if (isSymbol && opts.syntaxInfo.symbols) {
-                const apiInfo = getLastApiInfo(opts).apis;
-                opts.syntaxInfo.auxResult = opts.syntaxInfo.symbols.map(s => displayStringForSymbol(s, isPython, apiInfo))
-            }
-
             if (isSymbol && !opts.syntaxInfo.symbols?.length) {
                 const possibleKeyword = getWordAtPosition(v.fileContent, v.position);
                 if (possibleKeyword) {
-                    const help = getHelpForKeyword(possibleKeyword.text, isPython);
+                    if (isPython && possibleKeyword.text === "range") {
+                        const apiInfo = getLastApiInfo(opts).apis;
+                        if (apiInfo.byQName["_py.range"]) {
+                            opts.syntaxInfo.symbols = [apiInfo.byQName["_py.range"]];
+                            opts.syntaxInfo.beginPos = possibleKeyword.start;
+                            opts.syntaxInfo.endPos = possibleKeyword.end;
+                        }
+                    }
+                    else {
+                        const help = getHelpForKeyword(possibleKeyword.text, isPython);
 
-                    if (help) {
-                        opts.syntaxInfo.auxResult = {
-                            documentation: help,
-                            displayString: displayStringForKeyword(possibleKeyword.text, isPython),
-                        };
-                        opts.syntaxInfo.beginPos = possibleKeyword.start;
-                        opts.syntaxInfo.endPos = possibleKeyword.end;
+                        if (help) {
+                            opts.syntaxInfo.auxResult = {
+                                documentation: help,
+                                displayString: displayStringForKeyword(possibleKeyword.text, isPython),
+                            };
+                            opts.syntaxInfo.beginPos = possibleKeyword.start;
+                            opts.syntaxInfo.endPos = possibleKeyword.end;
+                        }
                     }
                 }
+            }
+
+            if (isSymbol && opts.syntaxInfo.symbols?.length) {
+                const apiInfo = getLastApiInfo(opts).apis;
+                opts.syntaxInfo.auxResult = opts.syntaxInfo.symbols.map(s => displayStringForSymbol(s, isPython, apiInfo))
             }
 
             return opts.syntaxInfo


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3046

We don't treat `range()` as a symbol when it's in a for-loop because we convert it to the TS style of for-loops (not a function call). Adding a special case to the language service to make sure that you get the same hover text in a for-loop as you do in standalone calls to `range()`