### PR TITLE
swap restart button for fullscreen on mobile simtoolbar

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1093,6 +1093,12 @@ p.ui.font.small {
         left: -2rem;
     }
 
+    #filelist .simtoolbar > .buttons {
+        > .restart-button {
+            display: block !important;
+        }
+    }
+
     #downloadArea {
         // .25rem from padding around editortoolbar in portrait mode
         width: ~"calc(@{blocklyRowWidthTablet} - .25rem)";
@@ -1276,11 +1282,6 @@ p.ui.font.small {
         #filelist .simtoolbar > div:not(:first-child),
         #filelist .simtoolbar > .buttons > .button {
             display: none;
-        }
-        #filelist .simtoolbar > .buttons {
-            > .restart-button {
-                display: block;
-            }
         }
         #filelist .simtoolbar > div:first-child {
             flex-direction: column;

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -138,7 +138,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make && <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} />}
                 {run && !targetTheme.bigRunButton && <PlayButton parent={parent} simState={parentState.simState} debugging={parentState.debugging} />}
-                {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button tablet only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
+                {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button portrait only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
                 {restart && <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} />}
                 {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
                 {collapse && <sui.Button


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5615930/82591976-019fd980-9b55-11ea-8cb5-9c1ae853bdd3.png)

fix https://github.com/microsoft/pxt-microbit/issues/3128