### PR TITLE
Show deprecated blocks if they're being used in a tutorial

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1229,7 +1229,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private filterBlocks(subns: string, blocks: toolbox.BlockDefinition[]) {
-        return blocks.filter((block => !(block.attributes.blockHidden || block.attributes.deprecated)
+        return blocks.filter((block => !(block.attributes.blockHidden)
+            && !(block.attributes.deprecated && this.parent.state.tutorialOptions == undefined)
             && ((!subns && !block.attributes.subcategory && !block.attributes.advanced)
                 || (subns && ((block.attributes.advanced && subns == lf("more"))
                     || (block.attributes.subcategory && subns == block.attributes.subcategory))))));
@@ -1671,7 +1672,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         return [blockXml];
         function shouldShowBlock(fn: pxtc.SymbolInfo) {
             if (fn.attributes.debug && !pxt.options.debug) return false;
-            if (!shadow && (fn.attributes.deprecated || fn.attributes.blockHidden)) return false;
+            if (!shadow && fn.attributes.blockHidden) return false;
+            if (fn.attributes.deprecated && that.parent.state.tutorialOptions == undefined) return false;
             let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
             return that.shouldShowBlock(fn.attributes.blockId, ns, shadow);
         }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3096

I tested this with the random-range deprecated block, and the radio.receiveString() because they seem to be deprecated in different ways?