### PR TITLE
any is evil

### DIFF
--- a/pxtcompiler/emitter/plaintsc.ts
+++ b/pxtcompiler/emitter/plaintsc.ts
@@ -49,7 +49,7 @@ namespace ts.pxtc {
     }
 
     function isTsDiagnostic(a: KsDiagnostic | Diagnostic): a is Diagnostic {
-        return (DiagnosticCategory as any).file != undefined;
+        return (a as any).file !== undefined;
     }
 
     export function plainTscCompileDir(dir: string): Program {


### PR DESCRIPTION
I was trying to figure out why we did not get file names in compilation errors for common-sim.

Bug introduced 14 months ago. https://github.com/microsoft/pxt/commit/df519380dd03d67317ac61f4cb88e620c00d035d