### PR TITLE
Support the "step" argument in python's slice syntax

### DIFF
--- a/libs/pxt-python/pxt-python-helpers.ts
+++ b/libs/pxt-python/pxt-python-helpers.ts
@@ -2,6 +2,7 @@ namespace _py {
     export const ATTRIBUTE_ERROR: string = "AttributeError";
     export const INDEX_ERROR: string = "IndexError";
     export const VALUE_ERROR: string = "ValueError";
+    export const TYPE_ERROR: string = "TypeError";
 
     export function py_string_capitalize(str: string): string {
         nullCheck(str);
@@ -292,5 +293,53 @@ namespace _py {
         }
 
         return res;
+    }
+
+    function sliceRange(valueLength: number, start?: number, stop?: number, step?: number) {
+        if (step == null) step = 1
+
+        // step must be a nonzero integer (can be negative)
+        if (step === 0 || (step | 0) !== step) {
+            throw _py.VALUE_ERROR;
+        }
+
+        if (step < 0) {
+            if (start == null) {
+                start = valueLength - 1;
+            }
+            if (stop == null) {
+                stop = -1;
+            }
+        }
+        else {
+            if (start == null) {
+                start = 0;
+            }
+            if (stop == null) {
+                stop = valueLength;
+            }
+        }
+
+        return range(start, stop, step)
+    }
+
+    /**
+     * Returns a section of an array according to python's extended slice syntax
+     */
+    export function slice<U>(value: U[], start?: number, stop?: number, step?: number): U[] {
+        if (value == null) {
+            throw TYPE_ERROR;
+        }
+        return sliceRange(value.length, start, stop, step).map(index => value[index]);
+    }
+
+    /**
+     * Returns a section of a string according to python's extended slice syntax
+     */
+    export function stringSlice(value: string, start?: number, stop?: number, step?: number): string {
+        if (value == null) {
+            throw TYPE_ERROR;
+        }
+        return sliceRange(value.length, start, stop, step).map(index => value.charAt(index)).join("");
     }
 }

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2161,8 +2161,21 @@ namespace pxt.py {
                     B.mkText("]"),
                 ])
             } else if (n.slice.kind == "Slice") {
-                unifyTypeOf(n, typeOf(n.value));
+                const valueType = typeOf(n.value);
+                unifyTypeOf(n, valueType);
                 let s = n.slice as py.Slice
+
+                if (s.step) {
+                    const isString = valueType?.primType === "string";
+
+                    return B.H.mkCall(isString ? "_py.stringSlice" : "_py.slice", [
+                        expr(n.value),
+                        s.lower ? expr(s.lower) : B.mkText("null"),
+                        s.upper ? expr(s.upper) : B.mkText("null"),
+                        expr(s.step)
+                    ]);
+                }
+
                 return B.mkInfix(expr(n.value), ".",
                     B.H.mkCall("slice", [s.lower ? expr(s.lower) : B.mkText("0"),
                     s.upper ? expr(s.upper) : null].filter(isTruthy)))

--- a/tests/pyconverter-test/baselines/slice_step.ts
+++ b/tests/pyconverter-test/baselines/slice_step.ts
@@ -1,0 +1,6 @@
+let testString = "hello"
+testString = _py.stringSlice(testString, null, null, -1)
+testString = testString.slice(0)
+testString = testString.slice(1, 1)
+let testArray = [0, 1, 2, 3]
+testArray = _py.slice(testArray, null, null, 1)

--- a/tests/pyconverter-test/cases/slice_step.py
+++ b/tests/pyconverter-test/cases/slice_step.py
@@ -1,0 +1,7 @@
+testString = "hello"
+testString = testString[::-1]
+testString = testString[::]
+testString = testString[1:1:]
+
+testArray = [0, 1, 2, 3]
+testArray = testArray[::1]


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3153

In python, slices can take three arguments:

```python
"hello"[start:stop:step]
```

Currently, we ignore the step part. This adds support for that in the form of some python helper functions. This only goes one way (py -> ts) because this is not an API that is accessible from blocks (the conversion will still work in the other direction, it just won't be pretty).

I added two functions, one for strings and one for arrays.