### PR TITLE
quick pass updating modals to use close icon where needed

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2228,6 +2228,7 @@ export class ProjectView
                         agreeLbl: lf("Done"),
                         agreeClass: "cancel",
                         agreeIcon: "cancel",
+                        hasCloseIcon: true,
                     }).then(b => {
                         if (this.isPythonActive()) {
                             pxt.Util.setEditorLanguagePref("py"); // stay in python, else go to blocks
@@ -2617,7 +2618,6 @@ export class ProjectView
         core.dialogAsync({
             header: lf("Print Code"),
             hasCloseIcon: true,
-            hideCancel: true,
             size: "large",
             jsx:
                 /* tslint:disable:react-iframe-missing-sandbox */
@@ -3160,7 +3160,6 @@ export class ProjectView
         return core.dialogAsync({
             header: options.header,
             body: options.body,
-            hideCancel: true,
             hasCloseIcon: true,
             buttons: options.buttons
         })

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -353,7 +353,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 header: message,
                 initialValue: defaultValue,
                 agreeLbl: lf("Ok"),
-                hideCancel: true,
                 hasCloseIcon: true,
                 size: "tiny"
             }).then(value => {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -428,7 +428,7 @@ export function pairAsync(): Promise<void> {
 export function showDisconnectAsync(): Promise<void> {
     if (pxt.commands.renderDisconnectDialog) {
         const { header, jsx, helpUrl } = pxt.commands.renderDisconnectDialog();
-        return core.dialogAsync({ header, jsx, helpUrl, hideCancel: true, hasCloseIcon: true });
+        return core.dialogAsync({ header, jsx, helpUrl, hasCloseIcon: true });
     }
     return Promise.resolve();
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -89,7 +89,6 @@ function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (opt
         body,
         jsx,
         hasCloseIcon: true,
-        hideCancel: true,
         hideAgree: true,
         helpUrl,
         className: 'downloaddialog',

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -255,8 +255,6 @@ export function promptAsync(options: PromptOptions): Promise<string> {
 
     let result = options.initialValue || "";
     let oked: boolean = false;
-    if (options.hasCloseIcon)
-        options.hideCancel = true;
 
     options.onInputChanged = (v: string) => { result = v };
 

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -171,6 +171,8 @@ export interface DialogOptions {
 export function dialogAsync(options: DialogOptions): Promise<void> {
     if (!options.buttons) options.buttons = [];
     if (!options.type) options.type = 'dialog';
+    if (options.hasCloseIcon)
+        options.hideCancel = true;
     if (!options.hideCancel) {
         if (!options.buttons) options.buttons = [];
         options.buttons.push({

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -35,7 +35,6 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
             const electronManifest = config && config.electronManifest;
             return core.confirmAsync({
                 header: lf("About"),
-                hideCancel: true,
                 hasCloseIcon: true,
                 agreeLbl: lf("Ok"),
                 agreeClass: "positive",
@@ -108,7 +107,6 @@ export function showPackageErrorDialogAsync(badPackages: pkg.EditorPackage[], up
     return core.dialogAsync({
         header: lf("Extension Errors"),
         hasCloseIcon: true,
-        hideCancel: true,
         jsx: <div className="wizard-wrapper">
             <ExtensionErrorWizard
                 openLegacyEditor={openLegacyEditor}
@@ -357,7 +355,6 @@ export function showImportUrlDialogAsync() {
     return core.confirmAsync({
         header: lf("Open project URL"),
         hasCloseIcon: true,
-        hideCancel: true,
         onLoaded: (el) => {
             input = el.querySelector('input');
             input.onkeydown = ev => {
@@ -462,7 +459,6 @@ export function showCreateGithubRepoDialogAsync(name?: string) {
     }
 
     return core.confirmAsync({
-        hideCancel: true,
         hasCloseIcon: true,
         header: lf("Create GitHub repository"),
         jsxd: () => {
@@ -542,7 +538,6 @@ export function showImportGithubDialogAsync() {
             return core.confirmAsync({
                 header: lf("Clone or create your own GitHub repo"),
                 hideAgree: true,
-                hideCancel: true,
                 hasCloseIcon: true,
                 /* tslint:disable:react-a11y-anchors */
                 jsx: <div className="ui form">
@@ -601,7 +596,6 @@ export function showImportFileDialogAsync(options?: pxt.editor.ImportFileOptions
     return core.confirmAsync({
         header: lf("Open {0} file", exts.join(lf(" or "))),
         hasCloseIcon: true,
-        hideCancel: true,
         onLoaded: (el) => {
             input = el.querySelectorAll('input')[0] as HTMLInputElement;
         },
@@ -637,7 +631,6 @@ export function showReportAbuseAsync(pubId?: string) {
     const shareUrl = pxt.appTarget.appTheme.shareUrl || "https://makecode.com/";
     core.confirmAsync({
         header: lf("Report Abuse"),
-        hideCancel: true,
         hasCloseIcon: true,
         onLoaded: (el) => {
             urlInput = el.querySelectorAll('input')[0] as HTMLInputElement;
@@ -695,7 +688,6 @@ export function showResetDialogAsync() {
 export function promptTranslateBlock(blockid: string, blockTranslationIds: string[]) {
     core.confirmAsync({
         header: lf("Translate this block"),
-        hideCancel: true,
         hideAgree: true,
         hasCloseIcon: true,
         helpUrl: "/translate",

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -422,7 +422,6 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
             header: lf("Share this tutorial"),
             body: lf("The URL will start the MakeCode editor in your tutorial."),
             copyable: this.props.shareUrl,
-            hideCancel: true,
             hasCloseIcon: true
         })
     }

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -78,7 +78,6 @@ export class GithubProvider extends cloudsync.ProviderBase {
         let form: HTMLElement;
         return core.confirmAsync({
             header: lf("Sign in with GitHub"),
-            hideCancel: true,
             hasCloseIcon: true,
             helpUrl: "/github",
             agreeLbl: lf("Sign in"),

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -215,7 +215,6 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             header: lf("Switch to a different branch"),
             hasCloseIcon: true,
             hideAgree: true,
-            hideCancel: true,
             /* tslint:disable:react-a11y-anchors */
             jsx: <div className="ui form">
                 <div className="ui relaxed divided list" role="menu">
@@ -280,7 +279,6 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             <p>{lf("Forking creates a copy of {0} under your account. You can submit your changes back via a pull request.", parsed.fullName)}</p>
         const res = await core.confirmAsync({
             header: lf("Do you want to fork {0}?", parsed.fullName),
-            hideCancel: true,
             hasCloseIcon: true,
             helpUrl: "/github/fork",
             jsx: <div>
@@ -564,7 +562,6 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             jsx: <p>{lf("Pull requests let you tell others about changes you've pushed to a branch in a repository on GitHub.")}</p>,
             helpUrl: "/github/pull-request",
             hasCloseIcon: true,
-            hideCancel: true
         });
         if (!res) return;
 
@@ -584,10 +581,10 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             /*
                         `
             ![${lf("A rendered view of the blocks")}](https://github.com/${gh.fullName}/raw/${gh.tag}/.github/makecode/blocks.png)
-            
+
             ${lf("This image shows the blocks code from the last commit in this pull request.")}
             ${lf("This image may take a few minutes to refresh.")}
-            
+
             `
             */
             const id = await pxt.github.createPRFromBranchAsync(gh.fullName, "master", gh.tag, title, msg);
@@ -846,7 +843,7 @@ class DiffView extends sui.StatelessUIElement<DiffViewProps> {
             // the xml payload needs to be decompiled
             diffJSX = <div className="ui basic segment">{lf("Your blocks were updated. Go back to the editor to view the changes.")}</div>
         } else {
-            // if the xml is completed reconstructed, 
+            // if the xml is completed reconstructed,
             // bail off to decompiled diffs
             let markdown: string;
             if (f.tsEditorFile &&
@@ -1163,7 +1160,6 @@ class PullRequestZone extends sui.StatelessUIElement<GitHubViewProps> {
             jsx: <p>{lf("Your changes will merged as a single commit into the base branch and you will switch back to the base branch.")}</p>,
             agreeLbl: lf("Confirm merge"),
             helpUrl: "/github/pull-request",
-            hideCancel: true,
             hasCloseIcon: true,
             placeholder: lf("Describe your changes")
         }).then(message => {

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -57,7 +57,6 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
                 url: `https://crowdin.com/project/${pxt.appTarget.appTheme.crowdinProject}`
             }],
             agreeLbl: lf("Translate"),
-            hideCancel: true,
             hasCloseIcon: true
         }).then(r => {
             if (r) {

--- a/webapp/src/make.tsx
+++ b/webapp/src/make.tsx
@@ -63,7 +63,6 @@ export function makeAsync(): Promise<void> {
     return core.dialogAsync({
         header: lf("Make"),
         size: "large",
-        hideCancel: true,
         hasCloseIcon: true,
         jsx:
             /* tslint:disable:react-iframe-missing-sandbox */

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -78,7 +78,6 @@ export function webUsbPairDialogAsync(pairAsync: () => Promise<boolean>, confirm
                 jsxd,
                 hasCloseIcon: true,
                 hideAgree: true,
-                hideCancel: true,
                 helpUrl,
                 className: 'downloaddialog',
                 buttons: [

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1183,7 +1183,6 @@ export async function importGithubAsync(id: string): Promise<Header> {
                 header: lf("Initialize GitHub repository for MakeCode?"),
                 body: lf("We need to add a few files to your GitHub repository to make it work with MakeCode."),
                 agreeLbl: lf("Ok"),
-                hideCancel: true,
                 hasCloseIcon: true,
                 helpUrl: "/github/import"
             })


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3105

Did a quick pass over all the calls to the core modals in pxt and the one in the issue was the only one that seemed like it needed to be switched to a close button. Also went ahead and cleaned up a bit by making the `hasCloseIcon ⇒ hideCancel` consistent across all the modal methods / clearing out the redundant options.