### PR TITLE
Android monaco fixes

### DIFF
--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -112,6 +112,7 @@ namespace pxt.vs {
     export function createEditor(element: HTMLElement): monaco.editor.IStandaloneCodeEditor {
         const inverted = pxt.appTarget.appTheme.invertedMonaco;
         const hasFieldEditors = !!(pxt.appTarget.appTheme.monacoFieldEditors && pxt.appTarget.appTheme.monacoFieldEditors.length);
+        const isAndroid = pxt.BrowserUtils.isAndroid();
 
         let editor = monaco.editor.create(element, {
             model: null,
@@ -134,6 +135,7 @@ namespace pxt.vs {
             dragAndDrop: true,
             matchBrackets: "always",
             occurrencesHighlight: false,
+            quickSuggestions: !isAndroid,
             quickSuggestionsDelay: 200,
             theme: inverted ? 'vs-dark' : 'vs',
             renderIndentGuides: true,

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -138,7 +138,6 @@ namespace pxt.vs {
             quickSuggestionsDelay: 200,
             theme: inverted ? 'vs-dark' : 'vs',
             renderIndentGuides: true,
-            //accessibilitySupport: 'on',
             accessibilityHelpUrl: "", //TODO: Add help url explaining how to use the editor with a screen reader
             // disable completions on android
             quickSuggestions: {
@@ -148,6 +147,7 @@ namespace pxt.vs {
            },
             acceptSuggestionOnCommitCharacter: !isAndroid,
             acceptSuggestionOnEnter: !isAndroid ? "on" : "off",
+            accessibilitySupport: !isAndroid ? "on" : "off"
         });
 
         editor.layout();

--- a/pxteditor/monaco.ts
+++ b/pxteditor/monaco.ts
@@ -135,12 +135,19 @@ namespace pxt.vs {
             dragAndDrop: true,
             matchBrackets: "always",
             occurrencesHighlight: false,
-            quickSuggestions: !isAndroid,
             quickSuggestionsDelay: 200,
             theme: inverted ? 'vs-dark' : 'vs',
             renderIndentGuides: true,
             //accessibilitySupport: 'on',
-            accessibilityHelpUrl: "" //TODO: Add help url explaining how to use the editor with a screen reader
+            accessibilityHelpUrl: "", //TODO: Add help url explaining how to use the editor with a screen reader
+            // disable completions on android
+            quickSuggestions: {
+                "other": !isAndroid,
+                "comments": !isAndroid,
+                "strings": !isAndroid
+           },
+            acceptSuggestionOnCommitCharacter: !isAndroid,
+            acceptSuggestionOnEnter: !isAndroid ? "on" : "off",
         });
 
         editor.layout();

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -30,6 +30,10 @@ namespace pxt.BrowserUtils {
             navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
     }
 
+    export function isAndroid(): boolean {
+        return hasNavigator() && /android/i.test(navigator.userAgent);
+    }
+
     //MacIntel on modern Macs
     export function isMac(): boolean {
         return hasNavigator() && /Mac/i.test(navigator.platform);

--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -348,6 +348,11 @@
     z-index: @monacoHintsZIndex !important;
 }
 
+// .monacoEditorArea.disable-android-autocomplete .monaco-editor .editor-widget {
+//     display: none !important;
+//     visibility: hidden !important;
+// }
+
 .line-numbers {
     display:none;
 }

--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -348,10 +348,17 @@
     z-index: @monacoHintsZIndex !important;
 }
 
-// .monacoEditorArea.disable-android-autocomplete .monaco-editor .editor-widget {
-//     display: none !important;
-//     visibility: hidden !important;
-// }
+#monacoEditorArea.android {
+    .monaco-editor .editor-widget {
+        display: none !important;
+        visibility: hidden !important;
+    }
+
+    // on android, the cursor / text area overlay gets offset
+    textarea.inputarea {
+        margin-left: .5rem;
+    }
+}
 
 .line-numbers {
     display:none;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -598,9 +598,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     display(): JSX.Element {
-        let showErrorList = pxt.appTarget.appTheme.errorList;
+        const showErrorList = pxt.appTarget.appTheme.errorList;
+        const isAndroid = pxt.BrowserUtils.isAndroid();
         return (
-            <div id="monacoEditorArea" className="monacoEditorArea" style={{ direction: 'ltr' }}>
+            <div id="monacoEditorArea" className={`monacoEditorArea ${isAndroid ? "disable-android-autocomplete" : ""}`} style={{ direction: 'ltr' }}>
                 {this.isVisible && <div className={`monacoToolboxDiv ${(this.toolbox && !this.toolbox.state.visible && !this.isDebugging()) ? 'invisible' : ''}`}>
                     <toolbox.Toolbox ref={this.handleToolboxRef} editorname="monaco" parent={this} />
                     <div id="monacoDebuggerToolbox"></div>

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -601,7 +601,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const showErrorList = pxt.appTarget.appTheme.errorList;
         const isAndroid = pxt.BrowserUtils.isAndroid();
         return (
-            <div id="monacoEditorArea" className={`monacoEditorArea ${isAndroid ? "disable-android-autocomplete" : ""}`} style={{ direction: 'ltr' }}>
+            <div id="monacoEditorArea" className={`monacoEditorArea ${isAndroid ? "android" : ""}`} style={{ direction: 'ltr' }}>
                 {this.isVisible && <div className={`monacoToolboxDiv ${(this.toolbox && !this.toolbox.state.visible && !this.isDebugging()) ? 'invisible' : ''}`}>
                     <toolbox.Toolbox ref={this.handleToolboxRef} editorname="monaco" parent={this} />
                     <div id="monacoDebuggerToolbox"></div>


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3170 / a handful of issues on (devices claiming to be) android. (I'll file an issue for actually fixing android autocomplete)

- disable accessibility support on android; this setting causes this awful bug where every letter you type after a period doubles the contents of the line:

![misbehaving-mobile-monaco-3](https://user-images.githubusercontent.com/5615930/83113053-f0d2f480-a07b-11ea-9ece-cbdb556cc029.gif)

Full fix for that seems like it's in vscode / monaco-editor

- disable auto complete on android; even with the previous fix it is not consistently applying the correct autocomplete (or at least fixing it). Note the css hiding it, as it's not actually an option to completely disable intellisense with just the options passed in (still triggers on periods, etc - ([more info](https://github.com/microsoft/monaco-editor/issues/1681)). 

- The lagging textarea thing is pretty curious (what's causing the last letter to appear doubled and offset), but it happens both on my phone and the emulated devices I tried. The margin left 'fixes' it, but I don't see why the position for it is actually getting calculated incorrectly right away (maybe something with the gutter?). Seems like it should have a better fix (this one doesn't repro in the monaco editor page / the new typescript website, so it definitely seems like an us problem).