### PR TITLE
Enable pinch zoom in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.15",
+    "pxt-blockly": "3.0.16",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.13",
+    "pxt-blockly": "3.0.15",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1017,7 +1017,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 maxScale: 2.5,
                 minScale: .2,
                 scaleSpeed: 1.5,
-                startScale: pxt.BrowserUtils.isMobile() ? 0.7 : 0.9
+                startScale: pxt.BrowserUtils.isMobile() ? 0.7 : 0.9,
+                pinch: true
             },
             rtl: Util.isUserLanguageRtl()
         };


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3132

I'm pulling in the new pxt-blockly and adding the zoom option to enable pinch zoom