### PR TITLE
account for error list in portrait simulator positioning

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -37,6 +37,11 @@ namespace pxt.editor {
         fileHistory: FileHistoryEntry[];
     }
 
+    export enum ErrorListState {
+        HeaderOnly = "errorListHeader",
+        Expanded = "errorListExpanded"
+    }
+
     export interface IAppProps { }
     export interface IAppState {
         active?: boolean; // is this tab visible at all
@@ -88,6 +93,8 @@ namespace pxt.editor {
 
         simSerialActive?: boolean;
         deviceSerialActive?: boolean;
+
+        errorListState?: ErrorListState;
 
         screenshoting?: boolean;
     }

--- a/theme/common.less
+++ b/theme/common.less
@@ -121,6 +121,16 @@ pre {
     }
 }
 
+#root {
+    --extra-mobile-sim-padding: 0px;
+    &.errorListHeader {
+        --extra-mobile-sim-padding: @errorListHeaderHeight;
+    }
+    &.errorListExpanded {
+        --extra-mobile-sim-padding: @errorListHeight;
+    }
+}
+
 .transparentEditorTools #editortools {
     background-color: transparent;
     z-index: (@blocklyFlyoutZIndex)-1;
@@ -1218,7 +1228,7 @@ p.ui.font.small {
         position:absolute;
         padding: 0;
         margin: 1em;
-        bottom: 4.5rem !important;
+        bottom: ~"calc(4.5rem + var(--extra-mobile-sim-padding))" !important;
         right: 0.5rem;
         top: unset;
         left: unset;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3716,7 +3716,8 @@ export class ProjectView
             flyoutOnly ? "flyoutOnly" : "",
             hideTutorialIteration ? "hideIteration" : "",
             this.editor != this.blocksEditor ? "editorlang-text" : "",
-            'full-abs'
+            this.editor == this.textEditor && this.state.errorListState,
+            'full-abs',
         ];
         const rootClasses = sui.cx(rootClassList);
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -370,7 +370,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     constructor(parent: pxt.editor.IProjectView) {
         super(parent);
 
-        this.resize = this.resize.bind(this);
+        this.setErrorListState = this.setErrorListState.bind(this);
         this.listenToErrorChanges = this.listenToErrorChanges.bind(this);
         this.listenToExceptionChanges = this.listenToExceptionChanges.bind(this)
         this.goToError = this.goToError.bind(this);
@@ -615,7 +615,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                             setInsertionSnippet={this.setInsertionSnippet}
                             parent={this.parent} />
                     </div>
-                    {showErrorList && <ErrorList onSizeChange={this.resize} listenToErrorChanges={this.listenToErrorChanges}
+                    {showErrorList && <ErrorList onSizeChange={this.setErrorListState} listenToErrorChanges={this.listenToErrorChanges}
                         listenToExceptionChanges={this.listenToExceptionChanges} goToError={this.goToError}/>}
                 </div>
             </div>
@@ -784,6 +784,17 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             });
 
             if (monacoToolboxDiv) monacoToolboxDiv.style.height = `100%`;
+        }
+    }
+
+    setErrorListState(newState?: pxt.editor.ErrorListState) {
+        const oldState = this.parent.state.errorListState;
+
+        if (oldState != newState) {
+            this.resize();
+            this.parent.setState({
+                errorListState: newState
+            });
         }
     }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3106

![woo-resizing](https://user-images.githubusercontent.com/5615930/83222407-1bc95100-a12d-11ea-9900-8da6e44f3fab.gif)

Few notes on errors I was thinking about while doing this (@hristoramirez maybe interesting?)

* we'll need to think about this for minecraft (transparent editor tools) as well; could just apply the same extra padding to the editor tools when they're transparent easily enough, but that'll need a design meeting so I left it out of this PR, maybe outside scope of internship as it wouldn't ship for a while?
* the 2 second debounce feels alright to me when adding the error (longer than I would personally like but I agree it's probably better for kids), but it's pretty painful when you fix an error as it feels like you're doing wrong / 2 seconds is long enough to second guess yourself. Maybe if we could keep the squiggle after .5 seconds, and delay showing the error list for the rest of the time or something? Not sure

