### PR TITLE
deep clean compiler on reload

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1227,8 +1227,7 @@ export class ProjectView
             simulator.driver.preload(pxt.appTarget.simulator.aspectRatio);
         this.clearSerial()
         this.firstRun = true
-        // clear caches in all editors
-        compiler.clearCaches();
+        // clear caches in all editors -> compiler.newProjectAsync
         this.allEditors.forEach(editor => editor.clearCaches())
         // always start simulator once at least if autoRun is enabled
         // always disable tracing
@@ -1247,7 +1246,8 @@ export class ProjectView
 
         if (!h.cloudSync && this.cloudSync()) h.cloudSync = true;
 
-        return (h.backupRef ? workspace.restoreFromBackupAsync(h) : Promise.resolve())
+        return compiler.newProjectAsync()
+            .then(() => h.backupRef ? workspace.restoreFromBackupAsync(h) : Promise.resolve())
             .then(() => pkg.loadPkgAsync(h.id))
             .then(() => {
                 if (!this.state || this.state.header != h) {


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-microbit/issues/3027

Treat a header reload as a new project, and deep clean cache state of compiler.