### PR TITLE
hide fullscreen button in mobile view instead of debug btn

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1103,12 +1103,6 @@ p.ui.font.small {
         left: -2rem;
     }
 
-    #filelist .simtoolbar > .buttons {
-        > .debug-button {
-            display: block !important;
-        }
-    }
-
     #downloadArea {
         // .25rem from padding around editortoolbar in portrait mode
         width: ~"calc(@{blocklyRowWidthTablet} - .25rem)";
@@ -1238,6 +1232,11 @@ p.ui.font.small {
         background: transparent !important;
         overflow: visible;
         z-index: 20;
+    }
+    #filelist .simtoolbar > .buttons {
+        > .debug-button {
+            display: block !important;
+        }
     }
     .collapsedEditorTools #filelist {
         > div {

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -138,7 +138,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
                 {make && <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} />}
                 {run && !targetTheme.bigRunButton && <PlayButton parent={parent} simState={parentState.simState} debugging={parentState.debugging} />}
-                {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button portrait only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
+                {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button tablet only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}
                 {restart && <sui.Button disabled={!runControlsEnabled} key='restartbtn' className={`restart-button`} icon="refresh" title={restartTooltip} onClick={this.restartSimulator} />}
                 {run && debug && <sui.Button disabled={!debugBtnEnabled} key='debugbtn' className={`debug-button ${debugging ? "orange" : ""}`} icon="icon bug" title={debugTooltip} onClick={this.toggleDebug} />}
                 {collapse && <sui.Button


### PR DESCRIPTION
close https://github.com/microsoft/pxt-microbit/issues/3200

Starting as a draft as adding back fullscreen button in mobile was a request when it was fullscreen & restart; I think showing debug button is more important, just want to confirm.