### PR TITLE
Blog note for micro:bit 2020 release

### DIFF
--- a/docs/blog/microbit/2020-beta.md
+++ b/docs/blog/microbit/2020-beta.md
@@ -2,6 +2,14 @@
 
 **Posted on April 28th, 2020 by [Jaqster](https://github.com/jaqster)**
 
+### ~ reminder
+
+#### Release Update!
+
+The **MakeCode for the micro:bit 2020 Release** is almost ready and will go live on June 12th!
+
+### ~
+
 It’s springtime, and even though all of us are working from home these days, the release cycle doesn’t stop! We are happy to announce the Beta for our 2020 MakeCode for the micro:bit release which is still scheduled to ship for general availability in June.
 
 Thank you to everyone who has helped us identify bugs and suggested new features throughout the year. And a special "Thank You" to our translators and proofreaders who have helped us localize in 28 different languages!


### PR DESCRIPTION
Put in a note for the date of the general micro:bit 2020 release.

![image](https://user-images.githubusercontent.com/27789908/83436113-2cf6b400-a3f2-11ea-8c44-d320f2a389c9.png)
