### PR TITLE
Show deprecated blocks in Python/JS tutorial

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -241,6 +241,7 @@ namespace pxt.editor {
         exitTutorial(): void;
         completeTutorialAsync(): Promise<void>;
         showTutorialHint(): void;
+        isTutorial(): boolean;
         pokeUserActivity(): void;
         stopPokeUserActivity(): void;
         clearUserPoke(): void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3470,6 +3470,10 @@ export class ProjectView
         if (tc) tc.showHint(true, showFullText);
     }
 
+    isTutorial() {
+        return this.state.tutorialOptions != undefined;
+    }
+
     getExpandedCardStyle(flyoutOnly?: boolean): any {
         let tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
         let margin = 2;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1230,7 +1230,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private filterBlocks(subns: string, blocks: toolbox.BlockDefinition[]) {
         return blocks.filter((block => !(block.attributes.blockHidden)
-            && !(block.attributes.deprecated && this.parent.state.tutorialOptions == undefined)
+            && !(block.attributes.deprecated && !this.parent.isTutorial())
             && ((!subns && !block.attributes.subcategory && !block.attributes.advanced)
                 || (subns && ((block.attributes.advanced && subns == lf("more"))
                     || (block.attributes.subcategory && subns == block.attributes.subcategory))))));
@@ -1673,7 +1673,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         function shouldShowBlock(fn: pxtc.SymbolInfo) {
             if (fn.attributes.debug && !pxt.options.debug) return false;
             if (!shadow && fn.attributes.blockHidden) return false;
-            if (fn.attributes.deprecated && that.parent.state.tutorialOptions == undefined) return false;
+            if (fn.attributes.deprecated && !that.parent.isTutorial()) return false;
             let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
             return that.shouldShowBlock(fn.attributes.blockId, ns, shadow);
         }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1764,7 +1764,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private filterBlocks(subns: string, blocks: toolbox.BlockDefinition[]) {
-        return blocks.filter((block => !(block.attributes.blockHidden || block.attributes.deprecated)
+        return blocks.filter((block => !(block.attributes.blockHidden)
+            && !(block.attributes.deprecated && this.parent.state.tutorialOptions == undefined)
             && (block.name.indexOf('_') != 0)
             && ((!subns && !block.attributes.subcategory && !block.attributes.advanced)
                 || (subns && ((block.attributes.advanced && subns == lf("more"))
@@ -1774,7 +1775,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private getBuiltinBlocks(ns: string, subns: string) {
         let cat = snippets.getBuiltinCategory(ns);
         let blocks = cat.blocks || [];
-        if (!cat.custom && this.nsMap[ns]) blocks = blocks.concat(this.nsMap[ns].filter(block => !(block.attributes.blockHidden || block.attributes.deprecated)));
+        if (!cat.custom && this.nsMap[ns]) blocks = blocks.concat(this.nsMap[ns].filter(block => !(block.attributes.blockHidden) &&  !(block.attributes.deprecated && this.parent.state.tutorialOptions == undefined)));
         return this.filterBlocks(subns, blocks);
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1765,7 +1765,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private filterBlocks(subns: string, blocks: toolbox.BlockDefinition[]) {
         return blocks.filter((block => !(block.attributes.blockHidden)
-            && !(block.attributes.deprecated && this.parent.state.tutorialOptions == undefined)
+            && !(block.attributes.deprecated && !this.parent.isTutorial())
             && (block.name.indexOf('_') != 0)
             && ((!subns && !block.attributes.subcategory && !block.attributes.advanced)
                 || (subns && ((block.attributes.advanced && subns == lf("more"))
@@ -1775,7 +1775,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private getBuiltinBlocks(ns: string, subns: string) {
         let cat = snippets.getBuiltinCategory(ns);
         let blocks = cat.blocks || [];
-        if (!cat.custom && this.nsMap[ns]) blocks = blocks.concat(this.nsMap[ns].filter(block => !(block.attributes.blockHidden) &&  !(block.attributes.deprecated && this.parent.state.tutorialOptions == undefined)));
+        if (!cat.custom && this.nsMap[ns]) blocks = blocks.concat(this.nsMap[ns].filter(block => !(block.attributes.blockHidden) &&  !(block.attributes.deprecated && !this.parent.isTutorial())));
         return this.filterBlocks(subns, blocks);
     }
 

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -119,7 +119,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
         let that = this;
 
         function filterNamespaces(namespaces: [string, pxtc.CommentAttrs][]) {
-            return namespaces.filter(([, md]) => !(md.deprecated && that.parent.state.tutorialOptions == undefined)&& (isAdvanced ? md.advanced : !md.advanced));
+            return namespaces.filter(([, md]) => !(md.deprecated && that.parent.state.tutorialOptions == undefined) && (isAdvanced ? md.advanced : !md.advanced));
         }
 
         const namespaces = filterNamespaces(this.getNamespaces()

--- a/webapp/src/toolboxeditor.tsx
+++ b/webapp/src/toolboxeditor.tsx
@@ -76,7 +76,8 @@ export abstract class ToolboxEditor extends srceditor.Editor {
                 let ns = (fn.attributes.blockNamespace || fn.namespace).split('.')[0];
 
                 if (fn.attributes.debug && !pxt.options.debug) return;
-                if (fn.attributes.deprecated || fn.attributes.blockHidden) return;
+                if (fn.attributes.blockHidden) return;
+                if (fn.attributes.deprecated && this.parent.state.tutorialOptions == undefined) return;
                 if (this.shouldShowBlock(fn.attributes.blockId, ns)) {
                     // Add to search subset
                     searchSubset[fn.attributes.blockId] = true;
@@ -118,7 +119,7 @@ export abstract class ToolboxEditor extends srceditor.Editor {
         let that = this;
 
         function filterNamespaces(namespaces: [string, pxtc.CommentAttrs][]) {
-            return namespaces.filter(([, md]) => !md.deprecated && (isAdvanced ? md.advanced : !md.advanced));
+            return namespaces.filter(([, md]) => !(md.deprecated && that.parent.state.tutorialOptions == undefined)&& (isAdvanced ? md.advanced : !md.advanced));
         }
 
         const namespaces = filterNamespaces(this.getNamespaces()


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3198#event-3389041242

related to https://github.com/microsoft/pxt/commit/2e9fde5a3a9f6900d652442d4c031b1995e0344f

Show the deprecated blocks if we're in a tutorial in Python or JS