### PR TITLE
Update partner approval message

### DIFF
--- a/docfiles/package.html
+++ b/docfiles/package.html
@@ -35,7 +35,7 @@
                     Approved content
                 </h3>
                 <p>
-                    The content below is provided by partner.
+                    The content below is provided by a partner.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
The current message just says:

`"The content below is provided by partner."`

![image](https://user-images.githubusercontent.com/27789908/83560963-e37a9780-a4cb-11ea-8097-72635275c8e6.png)

Here, I've **only** added the **"a"** as a minimum to update the message.

`"The content below is provided by a partner."`

However, the ask from https://github.com/microsoft/pxt-microbit/issues/3207 is to have something more like:

![image](https://user-images.githubusercontent.com/27789908/83561334-80d5cb80-a4cc-11ea-8924-c5775674b467.png)

This could be done through use of a macro like `@approver@` or something like that.

```
 <div class="content">
   <h3 class="header">
       Approved content
   </h3>
   <p>
       The content below is provided by a partner and approved by the @approver@.
   </p>
</div>
```