### PR TITLE
hide github button, github import in winrt app

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -255,7 +255,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const showZoomControls = true;
         const showGithub = !!pxt.appTarget.cloud
             && !!pxt.appTarget.cloud.githubPackages
-            && !!targetTheme.githubEditor
+            && targetTheme.githubEditor && !pxt.winrt.isWinRT() // not supported in windows 10
             && !readOnly && !isController && !debugging && !tutorial;
 
         const downloadIcon = pxt.appTarget.appTheme.downloadIcon || "download";

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1011,9 +1011,11 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
 
     renderCore() {
         const { visible } = this.state;
+        const targetTheme = pxt.appTarget.appTheme;
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const showImport = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
-        const showCreateGithubRepo = pxt.appTarget?.cloud?.cloudProviders?.github;
+        const showCreateGithubRepo = targetTheme.githubEditor && !pxt.winrt.isWinRT() // not supported in windows 10
+            && pxt.appTarget?.cloud?.cloudProviders?.github;
         /* tslint:disable:react-a11y-anchors */
         return (
             <sui.Modal isOpen={visible} className="importdialog" size="small"


### PR DESCRIPTION
In Windows 10 app, 
- [x] hide "import your github repo"
- [x] hide github button near project name
Fix for https://github.com/microsoft/pxt-microbit/issues/3213