### PR TITLE
Check if handler arg is in block def before adding to monaco toolbox

### DIFF
--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -281,11 +281,13 @@ export class MonacoFlyout extends React.Component<MonacoFlyoutProps, MonacoFlyou
         let handler = params && params.find(p => p?.type && p.type.indexOf("=>") >= 0);
         if (handler) {
             description.unshift(<span key="prefix">{lf("run code ")}</span>)
-            if (handler.handlerParameters) {
+            if (compileInfo?.handlerArgs) {
                 // add break between end of block and parameters
                 description.push(<span key="handler_break">{" "}</span>);
-                handler.handlerParameters.forEach((handlerParam) => {
-                    description.push(<span className="argName" key={`handler_${handlerParam.name}`}>{handlerParam.name}</span>);
+                compileInfo.handlerArgs.forEach((arg) => {
+                    if (!arg.inBlockDef) {
+                        description.push(<span className="argName" key={`handler_${arg.name}`}>{arg.name}</span>);
+                    }
                 })
             }
         }


### PR DESCRIPTION
Handle case when handler arg is in the block def as well as when it's not

![image](https://user-images.githubusercontent.com/34112083/83689358-c1ecdf00-a5a3-11ea-9adf-c66a118e2add.png)

Fixes https://github.com/microsoft/pxt-arcade/issues/1801