### PR TITLE
Fix WindowsRT download

### DIFF
--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -127,7 +127,7 @@ export function hf2ConnectAsync(path: string, raw = false) {
         }
 
         return pxt.usb.pairAsync()
-            .then(() => pxt.usb.mkPacketIOAsync())
+            .then(() => pxt.usb.mkUSBPacketIOAsync())
             .then(io => new HF2.Wrapper(io))
             .then(d => d.reconnectAsync().then(() => d))
     }

--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -127,7 +127,7 @@ export function hf2ConnectAsync(path: string, raw = false) {
         }
 
         return pxt.usb.pairAsync()
-            .then(() => pxt.usb.mkUSBPacketIOAsync())
+            .then(() => pxt.usb.mkWebUSBHIDPacketIOAsync())
             .then(io => new HF2.Wrapper(io))
             .then(d => d.reconnectAsync().then(() => d))
     }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -27,7 +27,7 @@ namespace pxt.BrowserUtils {
     export function isIOS(): boolean {
         return hasNavigator() &&
             (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
-            navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+                navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
     }
 
     export function isAndroid(): boolean {
@@ -131,6 +131,9 @@ namespace pxt.BrowserUtils {
     export function isElectron() {
         return isPxtElectron() || isIpcRenderer();
     }
+
+    // this function gets overriden when loading pxtwinrt.js
+    export let isWinRT = () => false;
 
     export function isLocalHost(ignoreFlags?: boolean): boolean {
         try {

--- a/pxtlib/hf2.ts
+++ b/pxtlib/hf2.ts
@@ -540,7 +540,7 @@ namespace pxt.HF2 {
 
     }
 
-    export function mkPacketIOWrapper(io: pxt.packetio.PacketIO): pxt.packetio.PacketIOWrapper {
+    export function mkHF2PacketIOWrapper(io: pxt.packetio.PacketIO): pxt.packetio.PacketIOWrapper {
         pxt.debug(`packetio: wrapper hf2`)
         return new Wrapper(io);
     }

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -125,6 +125,9 @@ namespace pxt.packetio {
                 wrapper = mkPacketIOWrapper(io);
                 if (onSerialHandler)
                     wrapper.onSerial = onSerialHandler;
+                // trigger ui update
+                if (onConnectionChangedHandler)
+                    onConnectionChangedHandler();
                 return wrapper;
             })
     }

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -515,7 +515,7 @@ namespace pxt.usb {
     }
 
     export function isAvailable() {
-        if (pxt.BrowserUtils.isElectron())
+        if (pxt.BrowserUtils.isElectron() || pxt.BrowserUtils.isWinRT())
             return false;
 
         if (!!(navigator as any).usb) {

--- a/pxtlib/webusb.ts
+++ b/pxtlib/webusb.ts
@@ -499,7 +499,7 @@ namespace pxt.usb {
     }
 
     let _hid: WebUSBHID;
-    export function mkPacketIOAsync(): Promise<pxt.packetio.PacketIO> {
+    export function mkWebUSBHIDPacketIOAsync(): Promise<pxt.packetio.PacketIO> {
         pxt.debug(`packetio: mk webusb io`)
         if (!_hid)
             _hid = new WebUSBHID();

--- a/pxtwinrt/deploy.ts
+++ b/pxtwinrt/deploy.ts
@@ -1,34 +1,6 @@
 /// <reference path="./winrtrefs.d.ts"/>
 /// <reference path="../built/pxtlib.d.ts"/>
 namespace pxt.winrt {
-    export function driveDeployCoreAsync(res: pxtc.CompileResult): Promise<void> {
-        const drives = pxt.appTarget.compile.deployDrives;
-        pxt.Util.assert(!!drives);
-        pxt.debug(`deploying to drives ${drives}`)
-
-        const drx = new RegExp(drives);
-        const firmware = pxt.outputName()
-        const r = res.outfiles[firmware];
-
-        function writeAsync(folder: Windows.Storage.StorageFolder): Promise<void> {
-            pxt.debug(`writing ${firmware} to ${folder.displayName}`)
-            return pxt.winrt.promisify(
-                folder.createFileAsync(firmware, Windows.Storage.CreationCollisionOption.replaceExisting)
-                    .then(file => Windows.Storage.FileIO.writeTextAsync(file, r))
-            ).then(r => { }).catch(e => {
-                pxt.debug(`failed to write ${firmware} to ${folder.displayName} - ${e}`)
-            })
-        }
-
-        return pxt.winrt.promisify(Windows.Storage.KnownFolders.removableDevices.getFoldersAsync())
-            .then(ds => {
-                let df = ds.filter(d => drx.test(d.displayName));
-                let pdf = df.map(writeAsync);
-                let all = Promise.join(...pdf)
-                return all;
-            }).then(r => { });
-    }
-
     export function browserDownloadAsync(text: string, name: string, contentType: string): Promise<void> {
         let file: Windows.Storage.StorageFile;
         return pxt.winrt.promisify<void>(

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -183,7 +183,7 @@ namespace pxt.winrt {
     let expectingAdd: boolean = false;
     let expectingRemove: boolean = false;
 
-    export function initWinrtHid(reconnectUf2WrapperCb: () => Promise<void>, disconnectUf2WrapperCb: () => Promise<void>) {
+    export function initWinrtHid(reconnectAsync: () => Promise<void>, disconnectAsync: () => Promise<void>) {
         const wd = Windows.Devices;
         const wde = Windows.Devices.Enumeration.DeviceInformation;
         const whid = wd.HumanInterfaceDevice.HidDevice;
@@ -205,8 +205,8 @@ namespace pxt.winrt {
                     // A new device was plugged in. If it's the first one, then reconnect the UF2 wrapper. Otherwise,
                     // we're already connected to a plugged device, so don't do anything.
                     ++deviceCount
-                    if (deviceCount === 1 && reconnectUf2WrapperCb) {
-                        reconnectUf2WrapperCb();
+                    if (deviceCount === 1 && reconnectAsync) {
+                        reconnectAsync();
                     }
                 }
             });
@@ -219,10 +219,10 @@ namespace pxt.winrt {
                     // one is the one we were connected to. In that case, reconnect the UF2 wrapper. If no more devices
                     // are left, disconnect the existing wrapper while we wait for a new device to be plugged in.
                     --deviceCount
-                    if (deviceCount > 0 && reconnectUf2WrapperCb) {
-                        reconnectUf2WrapperCb();
-                    } else if (deviceCount === 0 && disconnectUf2WrapperCb) {
-                        disconnectUf2WrapperCb();
+                    if (deviceCount > 0 && reconnectAsync) {
+                        reconnectAsync();
+                    } else if (deviceCount === 0 && disconnectAsync) {
+                        disconnectAsync();
                     }
                 }
             });

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -159,11 +159,13 @@ namespace pxt.winrt {
         }
     }
 
+    export let packetIO: WinRTPacketIO = undefined;
     export function mkWinRTPacketIOAsync(): Promise<pxt.packetio.PacketIO> {
         pxt.debug(`packetio: mk winrt packetio`)
-        const packetIO = new WinRTPacketIO();
+        packetIO = new WinRTPacketIO();
         return packetIO.initAsync()
             .catch((e) => {
+                packetIO = undefined;
                 return Promise.reject(e);
             })
             .then(() => packetIO);
@@ -215,6 +217,7 @@ namespace pxt.winrt {
                         reconnectAsync();
                     } else if (deviceCount === 0 && disconnectAsync) {
                         disconnectAsync();
+                        packetIO = undefined;
                     }
                 }
             });

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -159,8 +159,10 @@ namespace pxt.winrt {
 
     export let packetIO: WindowsRuntimeIO = undefined;
     export function mkWinRTPacketIOAsync(): Promise<pxt.packetio.PacketIO> {
-        pxt.U.assert(!packetIO);
         pxt.debug(`packetio: mk winrt`)
+        if (packetIO)
+            return Promise.resolve(packetIO);
+
         packetIO = new WindowsRuntimeIO();
         return packetIO.initAsync()
             .catch((e) => {

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -158,7 +158,7 @@ namespace pxt.winrt {
     }
 
     export let packetIO: WindowsRuntimeIO = undefined;
-    export function mkPacketIOAsync(): Promise<pxt.packetio.PacketIO> {
+    export function mkWinRTPacketIOAsync(): Promise<pxt.packetio.PacketIO> {
         pxt.U.assert(!packetIO);
         pxt.debug(`packetio: mk winrt`)
         packetIO = new WindowsRuntimeIO();

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -78,12 +78,12 @@ namespace pxt.winrt {
             return pxt.winrt.promisify(
                 this.dev.sendOutputReportAsync(report)
                     .then(value => {
-                        pxt.debug(`hf2: ${value} bytes written`)
+                        //pxt.debug(`hf2: ${value} bytes written`)
                     }));
         }
 
         private handleInputReport(e: Windows.Devices.HumanInterfaceDevice.HidInputReportReceivedEventArgs) {
-            pxt.debug(`input report`)
+            //pxt.debug(`input report`)
             const dr = Windows.Storage.Streams.DataReader.fromBuffer(e.report.data);
             const values: number[] = [];
             while (dr.unconsumedBufferLength) {

--- a/pxtwinrt/hiddeploy.ts
+++ b/pxtwinrt/hiddeploy.ts
@@ -26,12 +26,9 @@ namespace pxt.winrt {
         }
 
         private setConnecting(v: boolean) {
-            if (v != this.connecting) {
-                this.connecting = v;
-                console.log(`winrt ${this.connecting ? "connecting" : "connected"}`)
-                if (this.onConnectionChanged)
-                    this.onConnectionChanged();
-            }
+            this.connecting = v;
+            if (this.onConnectionChanged)
+                this.onConnectionChanged();
         }
 
         isConnecting(): boolean {

--- a/pxtwinrt/serial.ts
+++ b/pxtwinrt/serial.ts
@@ -90,7 +90,7 @@ namespace pxt.winrt {
     /**
      * Most Arduino devices support switching into bootloader by opening the COM port at 1200 baudrate.
      */
-    export function bootloaderViaBaud() {
+    export function bootloaderViaBaud(io: packetio.PacketIO) {
         if (!appTarget || !appTarget.compile || !appTarget.compile.useUF2 ||
             !appTarget.simulator || !appTarget.simulator.boardDefinition || !appTarget.simulator.boardDefinition.bootloaderBaudSwitchInfo) {
             return Promise.reject(new Error("device does not support switching to bootloader via baudrate"));
@@ -113,7 +113,7 @@ namespace pxt.winrt {
                 allSerialDevices = serialDevices;
 
                 if (allSerialDevices.length) {
-                    isSwitchingToBootloader();
+                    io.isSwitchingToBootloader();
                 }
 
                 allSerialDevices.forEach((dev) => {

--- a/pxtwinrt/winrt.ts
+++ b/pxtwinrt/winrt.ts
@@ -4,6 +4,8 @@ namespace pxt.winrt {
     type SuspendingArgs = Windows.ApplicationModel.ISuspendingEventArgs;
     type ResumingArgs = any;
 
+    pxt.BrowserUtils.isWinRT = isWinRT;
+
     export function promisify<T>(p: Windows.Foundation.IAsyncOperation<T> | Windows.Foundation.Projections.Promise<T>): Promise<T> {
         return new Promise<T>((resolve, reject) => {
             p.done(v => resolve(v), e => reject(e));

--- a/pxtwinrt/winrtworkspace.ts
+++ b/pxtwinrt/winrtworkspace.ts
@@ -87,7 +87,9 @@ namespace pxt.winrt.workspace {
         return promisify(folder.createFolderAsync(logicalDirname, Windows.Storage.CreationCollisionOption.openIfExists))
             .then(() => Promise.map(data.files, f => readFileAsync(pathjoin(logicalDirname, f.name))
                 .then(text => {
-                    if (f.name == pxt.CONFIG_NAME) {
+                    if (f.name == pxt.SIMSTATE_JSON)
+                        return; // ignore conflicts in sim inernal file
+                    else if (f.name == pxt.CONFIG_NAME) {
                         try {
                             let cfg: pxt.PackageConfig = JSON.parse(f.content)
                             if (!cfg.name) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3837,7 +3837,7 @@ function initPacketIO() {
     pxt.debug(`packetio: hook events`)
     pxt.packetio.configureEvents(
         () => {
-            pxt.debug(`packetio: ${pxt.packetio.isConnected() ? 'connected' : 'disconnected'}`)
+            pxt.debug(`packetio on connection changed: ${pxt.packetio.isConnected() ? pxt.packetio.isConnecting() ? 'connecting' : 'connected' : 'disconnected'}`)
             data.invalidate("packetio:*")
         },
         (buf, isErr) => {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3836,10 +3836,7 @@ function initLogin() {
 function initPacketIO() {
     pxt.debug(`packetio: hook events`)
     pxt.packetio.configureEvents(
-        () => {
-            pxt.debug(`packetio on connection changed: ${pxt.packetio.isConnected() ? pxt.packetio.isConnecting() ? 'connecting' : 'connected' : 'disconnected'}`)
-            data.invalidate("packetio:*")
-        },
+        () => data.invalidate("packetio:*"),
         (buf, isErr) => {
             const data = Util.fromUTF8(Util.uint8ArrayToString(buf))
             //pxt.debug('serial: ' + data)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4342,7 +4342,8 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(() => {
             pxt.BrowserUtils.initTheme();
             pxt.editor.experiments.syncTheme();
-            cmds.init();
+            return cmds.initAsync();
+        }).then(() => {
             // editor messages need to be enabled early, in case workspace provider is IFrame
             if (theme.allowParentController
                 || theme.allowPackageExtensions

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4342,8 +4342,6 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(() => {
             pxt.BrowserUtils.initTheme();
             pxt.editor.experiments.syncTheme();
-            return cmds.initAsync();
-        }).then(() => {
             // editor messages need to be enabled early, in case workspace provider is IFrame
             if (theme.allowParentController
                 || theme.allowPackageExtensions
@@ -4356,13 +4354,13 @@ document.addEventListener("DOMContentLoaded", () => {
             render(); // this sets theEditor
             if (state)
                 theEditor.setState({ editorState: state });
+            return initExtensionsAsync(); // need to happen before cmd init
+        }).then(() => cmds.initAsync())
+        .then(() => {
             initPacketIO();
             initSerial();
             initHashchange();
             socketbridge.tryInit();
-            return initExtensionsAsync();
-        })
-        .then(() => {
             electron.initElectron(theEditor);
             return pxt.winrt.initAsync(importHex);
         })

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -159,8 +159,10 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
     pxt.tickEvent(`hid.deploy`);
     log(`hid deploy`)
     // error message handled in browser download
-    if (!resp.success)
+    if (!resp.success) {
+        log(`compilation failed, use browser deploy instead`)
         return browserDownloadDeployCoreAsync(resp);
+    }
     let isRetry = false;
     const LOADING_KEY = "hiddeploy";
     return deployAsync();
@@ -192,6 +194,7 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
                     return pxt.commands.saveOnlyAsync(resp);
                 } else {
                     pxt.tickEvent("hid.flash.error");
+                    log(`hid error ${e.message}`)
                     pxt.reportException(e)
                     if (d) d.reportError(e.message);
                 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -209,7 +209,6 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
                 // default, save file
                 return pxt.commands.saveOnlyAsync(resp);
             })
-            .finally(() => data.invalidate("packetio:*"))
     }
 }
 
@@ -221,7 +220,7 @@ function pairBootloaderAsync(): Promise<void> {
 function winrtDeployCoreAsync(r: pxtc.CompileResult, d: pxt.commands.DeployOptions): Promise<void> {
     log(`winrt deploy`)
     return hidDeployCoreAsync(r, d)
-        .timeout(20000)
+        .timeout(60000)
         .catch((e) => {
             return pxt.packetio.disconnectAsync()
                 .catch((e) => {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -371,7 +371,7 @@ export function init(): void {
     } else if (pxt.winrt.isWinRT()) { // windows app
         log(`deploy: winrt`)
         pxt.packetio.mkPacketIOAsync = pxt.winrt.mkWinRTPacketIOAsync;
-        pxt.commands.browserDownloadAsync = pxt.winrt.winrtbrowserDownloadAsync;
+        pxt.commands.browserDownloadAsync = pxt.winrt.browserDownloadAsync;
         pxt.commands.deployCoreAsync = winrtDeployCoreAsync;
         pxt.commands.saveOnlyAsync = winrtSaveAsync;
     } else if (pxt.BrowserUtils.isPxtElectron()) {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -208,7 +208,8 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
 
                 // default, save file
                 return pxt.commands.saveOnlyAsync(resp);
-            });
+            })
+            .finally(() => data.invalidate("packetio:*"))
     }
 }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -323,12 +323,15 @@ function applyExtensionResult() {
     }
 }
 
-export function init(): void {
+export async function initAsync() {
     log(`cmds init`);
     pxt.onAppTargetChanged = () => {
         log('app target changed')
-        init()
+        initAsync()
     }
+
+    // unplug any existing packetio
+    await pxt.packetio.disconnectAsync()
 
     // reset commands to browser
     pxt.packetio.mkPacketIOWrapper = undefined;

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -167,8 +167,9 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const packetioConnecting = !!this.getData("packetio:connecting");
         const packetioIcon = this.getData("packetio:icon") as string;
         const downloadIcon = (!!packetioConnecting && "ping " + packetioIcon)
-            || (!!packetioConnected && "ping2s " + packetioIcon)
-            || targetTheme.downloadIcon || "download";
+            || (!!packetioConnected && packetioIcon)
+            || targetTheme.downloadIcon
+            || "download";
         const hasMenu = boards || webUSBSupported;
 
         let downloadButtonClasses = hasMenu ? "left attached " : "";
@@ -186,17 +187,17 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
             downloadButtonClasses += "connecting ";
         switch (view) {
             case View.Mobile:
-                downloadButtonClasses += "download-button-full";
+                downloadButtonClasses += "download-button-full ";
                 displayRight = collapsed;
                 break;
             case View.Tablet:
-                downloadButtonClasses += `download-button-full ${!collapsed ? 'large fluid' : ''}`;
+                downloadButtonClasses += `download-button-full ${!collapsed ? 'large fluid' : ''} `;
                 hwIconClasses = !collapsed ? "large" : "";
                 displayRight = collapsed;
                 break;
             case View.Computer:
             default:
-                downloadButtonClasses += "huge fluid";
+                downloadButtonClasses += "huge fluid ";
                 hwIconClasses = "large";
         }
 

--- a/webapp/src/hidbridge.ts
+++ b/webapp/src/hidbridge.ts
@@ -57,7 +57,7 @@ export function shouldUse() {
     return serial && serial.useHF2 && (pxt.BrowserUtils.isLocalHost() && !!Cloud.localToken || pxt.winrt.isWinRT());
 }
 
-export function mkBridgeAsync(): Promise<pxt.packetio.PacketIO> {
+export function mkHIDBridgePacketIOAsync(): Promise<pxt.packetio.PacketIO> {
     init()
     let raw = false
     if (pxt.appTarget.serial && pxt.appTarget.serial.rawHID)


### PR DESCRIPTION
This PR fixes download in Windows10 app. Tested also that webusb still works. The heart of the issue was that we running cmds.init before configurating DAPLink.

- [x] disable webusb in electron
- [x] rename mk*PacketIOAsync to relevant names to help with stacktraces
- [x] removed drive deployment in WinRT - this is dead code.
- [x] ignore .simstate.json conflict state
- [x] initialize commands **after** loading extensions -- since micro:bit loads DAP extension.
- [x] always disconnect before running cmds.init
- [x] avoid ping2s animation, does not work in Edge
