### PR TITLE
disable oauth in pxt electron

### DIFF
--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -70,6 +70,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
         pxt.tickEvent("github.login.dialog");
         // auth flow if github provider is prsent
         const oAuthSupported = pxt.appTarget
+            && !pxt.BrowserUtils.isPxtElectron()
             && pxt.appTarget.cloud
             && pxt.appTarget.cloud.cloudProviders
             && !!pxt.appTarget.cloud.cloudProviders[this.name];
@@ -159,7 +160,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
         return pxt.github.authenticatedUserAsync()
             .then(ghuser => {
                 if (!ghuser) {
-                    pxt.log(`unkown github user`)
+                    pxt.log(`unknown github user`)
                     return undefined;
                 }
                 return {

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -103,6 +103,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
         const modalSize = languageList.length > 4 ? "large" : "small";
         const translateTheEditor = !pxt.BrowserUtils.isIE()
             && !pxt.shell.isReadOnly()
+            && !pxt.BrowserUtils.isPxtElectron()
             && pxt.appTarget.appTheme.crowdinProject;
 
         return (


### PR DESCRIPTION
disable oauth in pxt electron for now (I'll fix it later, but have a few other issues that are more pressing / it's not the typical scenario for the offline build to need oauth)

I guess question if we should disable these in minecraft too? Haven't tested if they work but I don't think they will?