### PR TITLE
disable entry points to gh integration in pxt electron

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4123,6 +4123,12 @@ function isProjectRelatedHash(hash: { cmd: string; arg: string }): boolean {
 }
 
 async function importGithubProject(repoid: string, requireSignin?: boolean) {
+    if (!pxt.appTarget.appTheme.githubEditor || pxt.winrt.isWinRT() || pxt.BrowserUtils.isPxtElectron()) {
+        core.warningNotification(lf("Importing GitHub projects not currently supported"));
+        theEditor.openHome();
+        return;
+    }
+
     core.showLoading("loadingheader", lf("importing GitHub project..."));
     try {
         // normalize for precise matching

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -256,7 +256,9 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
         const showZoomControls = true;
         const showGithub = !!pxt.appTarget.cloud
             && !!pxt.appTarget.cloud.githubPackages
-            && targetTheme.githubEditor && !pxt.winrt.isWinRT() // not supported in windows 10
+            && targetTheme.githubEditor
+            && !pxt.winrt.isWinRT() // not supported in windows 10
+            && !pxt.BrowserUtils.isPxtElectron()
             && !readOnly && !isController && !debugging && !tutorial;
 
         const downloadIcon = pxt.appTarget.appTheme.downloadIcon || "download";

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1014,7 +1014,9 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
         const targetTheme = pxt.appTarget.appTheme;
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const showImport = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
-        const showCreateGithubRepo = targetTheme.githubEditor && !pxt.winrt.isWinRT() // not supported in windows 10
+        const showCreateGithubRepo = targetTheme.githubEditor
+            && !pxt.winrt.isWinRT() // not supported in windows 10
+            && !pxt.BrowserUtils.isPxtElectron()
             && pxt.appTarget?.cloud?.cloudProviders?.github;
         /* tslint:disable:react-a11y-anchors */
         return (


### PR DESCRIPTION
Disabling for now re: https://github.com/microsoft/pxt/pull/7130#issuecomment-639077631

Question, do we want any special behavior for if the user passes in a github url to `import url` ? e.g. importing https://github.com/jwunderl/untitled-testasdf will import the repo as a github extension with a slightly off ui. I don't think I saw any special handling for the gh extension so I'm guessing it just does nothing or errors; should I just pop an error in both for now?