### PR TITLE
Set enabled/disabled on child blocks, prevent unnecessary warnings

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1887,6 +1887,15 @@ namespace pxt.blocks {
         };
     }
 
+    function setChildrenEnabled(block: Blockly.Block, enabled: boolean) {
+        block.setEnabled(enabled);
+        // propagate changes
+        var children = block.getDescendants(false);
+        for (var i = 0, child; (child = children[i]); i++) {
+            child.setEnabled(enabled);
+        }
+    }
+
     function updateDisabledBlocks(e: Environment, allBlocks: Blockly.Block[], topBlocks: Blockly.Block[]) {
         // unset disabled
         allBlocks.forEach(b => b.setEnabled(true));
@@ -1898,9 +1907,9 @@ namespace pxt.blocks {
             const otherEvent = events[key];
             if (otherEvent) {
                 // another block is already registered
-                block.setEnabled(false);
+                setChildrenEnabled(block, false);
             } else {
-                block.setEnabled(true);
+                setChildrenEnabled(block, true);
                 events[key] = block;
             }
         }
@@ -1921,7 +1930,7 @@ namespace pxt.blocks {
                 // all non-events are disabled
                 let t = b;
                 while (t) {
-                    t.setEnabled(false);
+                    setChildrenEnabled(b, false);
                     t = t.getNextBlock();
                 }
             }
@@ -1976,7 +1985,8 @@ namespace pxt.blocks {
     }
 
     export function getTopLevelParent(block: Blockly.Block): Blockly.Block {
-        if (!block.previousConnection && !block.nextConnection) {
+        const parent = block.getParent();
+        if (!parent || parent.id == block.id) {
             return block;
         } else {
             return pxt.blocks.getTopLevelParent(block.getParent())

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1890,8 +1890,8 @@ namespace pxt.blocks {
     function setChildrenEnabled(block: Blockly.Block, enabled: boolean) {
         block.setEnabled(enabled);
         // propagate changes
-        var children = block.getDescendants(false);
-        for (var i = 0, child; (child = children[i]); i++) {
+        const children = block.getDescendants(false);
+        for (const child of children) {
             child.setEnabled(enabled);
         }
     }

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1984,15 +1984,6 @@ namespace pxt.blocks {
         return undefined;
     }
 
-    export function getTopLevelParent(block: Blockly.Block): Blockly.Block {
-        const parent = block.getParent();
-        if (!parent || parent.id == block.id) {
-            return block;
-        } else {
-            return pxt.blocks.getTopLevelParent(block.getParent())
-        }
-    }
-
     export function compileAsync(b: Blockly.Workspace, blockInfo: pxtc.BlocksInfo): Promise<BlockCompilationResult> {
         const e = mkEnv(b, blockInfo);
         const [nodes, diags] = compileWorkspace(e, b, blockInfo);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -907,7 +907,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (stmt) {
             let bid = pxt.blocks.findBlockIdByLine(this.compilationResult.sourceMap, { start: stmt.line, length: stmt.endLine - stmt.line });
             if (bid) {
-                const parent = pxt.blocks.getTopLevelParent(this.editor.getBlockById(bid));
+                const parent = this.editor.getBlockById(bid).getRootBlock();
                 bid = parent?.isCollapsed() ? parent.id : bid;
                 this.editor.highlightBlock(bid);
                 if (brk) {


### PR DESCRIPTION
Partial fix for https://github.com/microsoft/pxt-arcade/issues/1692

This prevents the warnings that pop up on disabled blocks. Real cause of the issue is when a big stack of blocks with many warnings overlaps another one, it triggers a chain of calls to bumpNeighbours that bumps the stack way down into the right corner. 

The other part of the fix will be on the blockly end to either tweak the bump functionality or just disable it in some cases--in general I feel it's better to have overlapping blocks than to move blocks that the user did not drag.

\+ small update to remove unnecessary getTopLevelParent function