### PR TITLE
Bump pxt-blockly to 3.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.16",
+    "pxt-blockly": "3.0.18",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
- Save block-level comment position in XML (https://github.com/microsoft/pxt-blockly/pull/311)
- Pass extra options object to Blockly.prompt (https://github.com/microsoft/pxt-blockly/pull/312)

Fixes https://github.com/microsoft/pxt-arcade/issues/1867
Options object is for https://github.com/microsoft/pxt-arcade/issues/1797 (will make separate PR with pxt changes)