### PR TITLE
Use outline without scale to differentiate details card focus and hover

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -291,13 +291,15 @@
             .card-action:focus-within {
                 cursor: pointer;
                 border-color: @white;
-                transform: scale(1.1);
                 .ui.button {
                     filter: none;
                 }
                 .ui.button:first-child:hover {
                     z-index: auto;
                 }
+            }
+            .card-action:hover {
+                transform: scale(1.1);
             }
             /* custom icons (override font to avoid mac/windows alignment issue) */
             .card-action .xicon:before {


### PR DESCRIPTION
![fix-detail-focus](https://user-images.githubusercontent.com/34112083/83898835-51150680-a70c-11ea-847a-c80a77b163c9.gif)

Fixes https://github.com/microsoft/pxt-microbit/issues/3227