### PR TITLE
Clean up carousel resize event subscriptions on unmount

### DIFF
--- a/webapp/src/carousel.tsx
+++ b/webapp/src/carousel.tsx
@@ -136,16 +136,18 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
     public componentDidMount() {
         this.initDragSurface();
         this.updateDimensions();
-        window.addEventListener("resize", (e) => {
-            this.updateDimensions();
-        })
+        window.addEventListener("resize", this.updateDimensions);
+    }
+
+    public componentWillUnmount() {
+        window.removeEventListener("resize", this.updateDimensions);
     }
 
     public componentDidUpdate() {
         this.updateDimensions();
     }
 
-    public updateDimensions() {
+    public updateDimensions = () => {
         if (this.container) {
             let shouldReposition = false;
             this.containerWidth = this.container.getBoundingClientRect().width;


### PR DESCRIPTION
I happened to notice that the carousel resize event handlers were never unsubscribed:

![Kapture 2020-06-05 at 9 27 26](https://user-images.githubusercontent.com/194333/83900995-d8637980-a70e-11ea-9f87-8cc4b7645af1.gif)

