### PR TITLE
fix extension search in electron app

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -3,7 +3,7 @@ namespace pxt.Cloud {
     import Util = pxtc.Util;
 
     // hit /api/ to stay on same domain and avoid CORS
-    export let apiRoot = pxt.BrowserUtils.isLocalHost() || Util.isNodeJS ? "https://www.makecode.com/api/" : "/api/";
+    export let apiRoot = (pxt.BrowserUtils.isLocalHost() || Util.isNodeJS) ? "https://www.makecode.com/api/" : "/api/";
     export let accessToken = "";
     export let localToken = "";
     let _isOnline = true;
@@ -71,7 +71,7 @@ namespace pxt.Cloud {
     }
 
     export function privateRequestAsync(options: Util.HttpRequestOptions) {
-        options.url = pxt.webConfig && pxt.webConfig.isStatic && !options.forceLiveEndpoint ? pxt.webConfig.relprefix + options.url : apiRoot + options.url;
+        options.url = pxt.webConfig?.isStatic && !options.forceLiveEndpoint ? pxt.webConfig.relprefix + options.url : apiRoot + options.url;
         options.allowGzipPost = true
         if (!Cloud.isOnline()) {
             return offlineError(options.url);

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -146,7 +146,10 @@ namespace pxt.github {
     }
 
     function ghProxyWithCdnJsonAsync(path: string) {
-        return Cloud.apiRequestWithCdnAsync({ url: "gh/" + path }).then(r => r.json)
+        return Cloud.apiRequestWithCdnAsync({
+            url: "gh/" + path,
+            forceLiveEndpoint: true
+        }).then(r => r.json);
     }
 
     function ghProxyHandleException(e: any) {


### PR DESCRIPTION
Fix extension search in electron app (and normal staticpkg, I would assume?)

it was hitting `/gh/owner/repo` instead of `/api/gh/owner/repo` in the electron app as it was using `relprefix`