### PR TITLE
add key for debugger variables list error message

### DIFF
--- a/webapp/src/debuggerVariables.tsx
+++ b/webapp/src/debuggerVariables.tsx
@@ -112,6 +112,7 @@ export class DebuggerVariables extends data.Component<DebuggerVariablesProps, De
             tableRows.unshift(<DebuggerTableRow
                 leftText={lf("Exception:")}
                 leftClass="exception"
+                key="exception-message"
                 rightText={truncateLength(breakpoint.exceptionMessage)}
                 rightTitle={breakpoint.exceptionMessage}
             />);


### PR DESCRIPTION
Noticed this when debugging a thing in electron app (Only shows up when using dev build of react):

![image](https://user-images.githubusercontent.com/5615930/84093947-74f87680-a9b0-11ea-9ef2-77abb7ce0ad5.png)

Only the extra row for the exception message was missing the key, so it rarely pops up ~