### PR TITLE
streamer: show hardware on land screen if enabled

### DIFF
--- a/docs/streamer.html
+++ b/docs/streamer.html
@@ -798,6 +798,11 @@ body.countdownscene #countdown {
 body.countdownscene #social {
     left: 18%;
 }
+body.countdownscene.hardware #hardwarecam {
+    right: -10%;
+    width: 120%;
+    bottom: -10%;
+}
     </style>
     <style id="editorstyle"></style>
 </head>


### PR DESCRIPTION
Show hardware video fulil screen when enable on "start soon" screen.