### PR TITLE
respect file type when loading a project with a file that is deleted

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1264,8 +1264,20 @@ export class ProjectView
                     h.editor = pkg.mainPkg.config.preferredEditor
                 let file = main.getMainFile();
                 const e = h.editor != pxt.BLOCKS_PROJECT_NAME && this.settings.fileHistory.filter(e => e.id == h.id)[0]
-                if (e)
-                    file = main.lookupFile(e.name) || file
+                if (e) {
+                    const lastEdited = main.lookupFile(e.name);
+
+                    if (lastEdited) {
+                        file = lastEdited
+                    }
+                    else if (pkg.getExtensionOfFileName(e.name) === "ts") {
+                        file = main.lookupFile("this/" + file.getFileNameWithExtension("ts")) || file;
+                    }
+                    else if (pkg.getExtensionOfFileName(e.name) === "py") {
+                        file = main.lookupFile("this/" + file.getFileNameWithExtension("py")) || file;
+                    }
+                }
+
 
                 // no history entry, and there is a virtual file for the current file in the language recorded in the header
                 if ((!e && h.editor && file.getVirtualFileName(h.editor)))

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -50,9 +50,7 @@ export class File implements pxt.editor.IFile {
     }
 
     getExtension() {
-        let m = /\.([^\.]+)$/.exec(this.name)
-        if (m) return m[1]
-        return ""
+        return getExtensionOfFileName(this.name);
     }
 
     getVirtualFileName(forPrj: string): string {
@@ -825,3 +823,10 @@ data.mountVirtualApi("pkg-status", {
         return ""
     },
 })
+
+
+export function getExtensionOfFileName(filename: string) {
+    let m = /\.([^\.]+)$/.exec(filename)
+    if (m) return m[1]
+    return ""
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1855

If we try to reload the header after the current file is deleted, we pretty much always end up loading blocks which immediately overwrites main.ts