### PR TITLE
Filter out completions that start with _

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -84,12 +84,10 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                     return qName
                 }
 
-                let entries = completions.entries;
-                if (entries) {
-                    entries = entries.filter(si => si.name.indexOf("_") != 0);
-                }
+                let entries = completions.entries || [];
+                entries = entries.filter(si => si.name.indexOf("_") != 0);
 
-                const items = (entries || []).map((si, i) => {
+                const items = entries.map((si, i) => {
                     let insertSnippet = stripLocalNamespace(this.python ? si.pySnippet : si.snippet);
                     let qName = stripLocalNamespace(this.python ? si.pyQName : si.qName);
                     let name = this.python ? si.pyName : si.name;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -84,7 +84,12 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                     return qName
                 }
 
-                const items = (completions.entries || []).map((si, i) => {
+                let entries = completions.entries;
+                if (entries) {
+                    entries = entries.filter(si => si.name.indexOf("_") != 0);
+                }
+
+                const items = (entries || []).map((si, i) => {
                     let insertSnippet = stripLocalNamespace(this.python ? si.pySnippet : si.snippet);
                     let qName = stripLocalNamespace(this.python ? si.pyQName : si.qName);
                     let name = this.python ? si.pyName : si.name;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1918

I wanted to be smart and still show them if the word starts with an underscore but it doesn't work that way, unfortunately. Monaco just uses the same list as you type and filters it down.


So instead I indiscriminately remove all symbols that start with _.

