### PR TITLE
add controller message to set/unset simulator full screen

### DIFF
--- a/docs/streamer/script.js
+++ b/docs/streamer/script.js
@@ -407,7 +407,7 @@
             return;
         }
 
-        let url = `${editorConfig.url}?editorLayout=ide&nosandbox=1`;
+        let url = `${editorConfig.url}?editorLayout=ide&nosandbox=1&controller=1`;
         if (config.multiEditor)
             url += `&nestededitorsim=1`;
         editor.src = url;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -258,6 +258,7 @@ namespace pxt.editor {
         collapseSimulator(): void;
         toggleSimulatorCollapse(): void;
         toggleSimulatorFullscreen(): void;
+        setSimulatorFullScreen(enabled: boolean): void;
         proxySimulatorMessage(content: string): void;
         toggleTrace(intervalSpeed?: number): void;
         setTrace(enabled: boolean, intervalSpeed?: number): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -54,7 +54,8 @@ namespace pxt.editor {
         | "toggletrace" // EditorMessageToggleTraceRequest
         | "togglehighcontrast"
         | "togglegreenscreen"
-        | "settracestate" // 
+        | "settracestate" //
+        | "setsimulatorfullscreen" // EditorMessageSimulatorFullScreenRequest
 
         | "print" // print code
         | "pair" // pair device
@@ -225,6 +226,12 @@ namespace pxt.editor {
         intervalSpeed?: number;
     }
 
+    export interface EditorMessageSetSimulatorFullScreenRequest extends EditorMessageRequest {
+        action: "setsimulatorfullscreen";
+        enabled: boolean;
+    }
+
+
     export interface InfoMessage {
         versions: pxt.TargetVersions;
         locale: string;
@@ -389,6 +396,11 @@ namespace pxt.editor {
                                     const trcmsg = data as EditorMessageSetTraceStateRequest;
                                     return Promise.resolve()
                                         .then(() => projectView.setTrace(trcmsg.enabled, trcmsg.intervalSpeed));
+                                }
+                                case "setsimulatorfullscreen": {
+                                    const fsmsg = data as EditorMessageSetSimulatorFullScreenRequest;
+                                    return Promise.resolve()
+                                        .then(() => projectView.setSimulatorFullScreen(fsmsg.enabled));
                                 }
                                 case "togglehighcontrast": {
                                     return Promise.resolve()

--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -65,6 +65,7 @@
         }
 
         var pendingMsgs = {};
+        var fullScreen = false;
         function sendMessage(action) {
             console.log('send ' + action)
             var logs = document.getElementById("logs");
@@ -88,6 +89,8 @@
             }
             else if (action == 'settracestate') {
                 msg.enabled = true;
+            } else if (action == 'setsimulatorfullscreen') {
+                msg.enabled = fullScreen = !fullScreen;
             }
             if (msg.response)
                 pendingMsgs[msg.id] = msg;
@@ -169,6 +172,7 @@
         <button class="ui button" onclick="sendMessage('redo')">redo</button>
         <button class="ui button" onclick="sendMessage('renderblocks')">renderblocks</button>
         <button class="ui button" onclick="sendMessage('closeflyout')">close flyout</button>
+        <button class="ui button" onclick="sendMessage('setsimulatorfullscreen')">set sim full screen</button>
         <button class="ui button" onclick="sendMessage('togglehighcontrast')">toggle high contrast</button>
         <button class="ui button" onclick="sendMessage('togglegreenscreen')">toggle green screen</button>
         <button class="ui button" onclick="sendMessage('print')">print</button>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2570,16 +2570,19 @@ export class ProjectView
         this.toggleSimulatorFullscreen();
     }
 
-    toggleSimulatorFullscreen() {
-        if (!this.state.fullscreen) {
+    setSimulatorFullScreen(enabled: boolean) {
+        if (!enabled) {
             document.addEventListener('keydown', this.closeOnEscape);
             simulator.driver.focus();
         } else {
             document.removeEventListener('keydown', this.closeOnEscape);
         }
         this.closeFlyout();
+        this.setState({ fullscreen: enabled });
+    }
 
-        this.setState({ fullscreen: !this.state.fullscreen });
+    toggleSimulatorFullscreen() {
+        this.setSimulatorFullScreen(!this.state.fullscreen);
     }
 
     closeFlyout() {


### PR DESCRIPTION
Allows streamer to set editor in full screen mode when swithing between multi editors.