### PR TITLE
Save/typecheck immediately on change, then debounce

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -745,7 +745,7 @@ export class ProjectView
             this.typecheck();
         }
         this.markdownChangeHandler();
-    }, 2000, false);
+    }, 2000, true);
     private initEditors() {
         this.textEditor = new monaco.Editor(this);
         this.pxtJsonEditor = new pxtjson.Editor(this);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3257

Not sure if there's a reason we had it as a trailing debounce instead of immediate? I tested toggling quickly between various languages and also refreshing the page, and it seems to all work.