### PR TITLE
load markdown on tutorials

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1337,8 +1337,15 @@ export class ProjectView
 
                 // load side docs
                 const editorForFile = this.pickEditorFor(file);
-                if (pkg?.mainPkg?.config?.documentation)
-                    this.setSideDoc(pkg.mainPkg.config.documentation, editorForFile == this.blocksEditor);
+                const documentation = pkg?.mainPkg?.config?.documentation;
+                if (documentation)
+                    this.setSideDoc(documentation, editorForFile == this.blocksEditor);
+                else {
+                    const readme = main.lookupFile("this/README.md");
+                    // no auto-popup when editing packages locally
+                    if (!h.githubId && readme && readme.content && readme.content.trim())
+                        this.setSideMarkdown(readme.content);
+                }
 
                 // update recentUse on the header
                 return workspace.saveAsync(h)


### PR DESCRIPTION
Loads readme in sidedocs (if not a github repo).

Fix for https://github.com/microsoft/pxt-microbit/issues/3269