### PR TITLE
Set editor change debounce back to .5s, increase typecheck debounce

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -733,7 +733,7 @@ export class ProjectView
 
                     this.maybeShowPackageErrors();
                 });
-        }, 1000, false);
+        }, 2000, false);
 
     private markdownChangeHandler = Util.debounce(() => {
         if (this.state.currFile && /\.md$/i.test(this.state.currFile.name))
@@ -745,7 +745,7 @@ export class ProjectView
             this.typecheck();
         }
         this.markdownChangeHandler();
-    }, 2000, true);
+    }, 500, false);
     private initEditors() {
         this.textEditor = new monaco.Editor(this);
         this.pxtJsonEditor = new pxtjson.Editor(this);


### PR DESCRIPTION
Build: https://makecode.microbit.org/app/8a48e8bac428aefbbc9ef60ea441e3f564a9313e-cf060f4d40

Leading edge debounce behaves incorrectly for autorun (blockly sends a sequence of events and we attempt to autorun after the first block dragged event rather than after the user is done editing).

This preserves the error debounce behavior (2s delay) but reduces the save/editor change handler debounce. I tested intellisense/hover in monaco and they seem to behave as expected even with the slightly longer typecheck debounce.

Separately, I think we should force a save any time the editor unloads (changing language) or the user hits download, but probably a different PR.

Fixes https://github.com/microsoft/pxt-microbit/issues/3257