### PR TITLE
Relax table of contents parsing regex for docs TOC localization

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -903,7 +903,8 @@ ${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}#${opts.repo.
                 case "text":
                     let lastTocEntry = currentStack[currentStack.length - 1]
                     if (token.text.indexOf("[") >= 0) {
-                        token.text.replace(/^\[(.*)\]\((.*)\)$/i, function (full: string, name: string, path: string) {
+                        let text = token.text.trim()
+                        text.replace(/\[(.*?)\]\((.*?)\)/i, function (full: string, name: string, path: string) {
                             lastTocEntry.name = name;
                             lastTocEntry.path = path.replace('.md', '');
                         });

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -903,8 +903,7 @@ ${opts.repo.name.replace(/^pxt-/, '')}=github:${opts.repo.fullName}#${opts.repo.
                 case "text":
                     let lastTocEntry = currentStack[currentStack.length - 1]
                     if (token.text.indexOf("[") >= 0) {
-                        let text = token.text.trim()
-                        text.replace(/\[(.*?)\]\((.*?)\)/i, function (full: string, name: string, path: string) {
+                        token.text.replace(/\[(.*?)\]\((.*?)\)/i, function (full: string, name: string, path: string) {
                             lastTocEntry.name = name;
                             lastTocEntry.path = path.replace('.md', '');
                         });


### PR DESCRIPTION
Crowdin returns list headings with extra whitespace at the end (eg `* [따라해보기](/tutorials)`); the regex doesn't match this and so all localized TOC headings are empty. I'm modifying the regex so it doesn't match start/end of line but making the .* groups nongreedy, which I think should be pretty safe. It should still always match the first link of `[text](path)` format. 

I've tested this locally by calling buildTOC manually on an input string I copied from Crowdin, but haven't been able to deploy to staging to test there.

Fixes https://github.com/microsoft/pxt-microbit/issues/3263