### PR TITLE
Sticky the debug toolbar

### DIFF
--- a/theme/debugger.less
+++ b/theme/debugger.less
@@ -50,6 +50,8 @@
     width: 100%;
     z-index: @debuggerToolsZIndex;
     display: flex;
+    position: sticky;
+    top: 0;
     .ui.menu {
         border-radius: 0 !important;
         border-left: none;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1972

Here's what it looks like!

![sticky debug](https://user-images.githubusercontent.com/18712271/85082228-1fc41e00-b183-11ea-999b-a1da0ee17b94.gif)
