### PR TITLE
don't try hid on electron app

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -353,7 +353,7 @@ export async function initAsync() {
     }
 
     // check if webUSB is available and usable
-    if (pxt.appTarget?.compile?.isNative || pxt.appTarget?.compile?.hasHex) {
+    if ((pxt.appTarget?.compile?.isNative || pxt.appTarget?.compile?.hasHex) && !pxt.BrowserUtils.isPxtElectron()) {
         if (pxt.usb.isAvailable() && pxt.appTarget?.compile?.webUSB) {
             log(`enabled webusb`);
             pxt.usb.setEnabled(true);

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -354,6 +354,7 @@ export async function initAsync() {
 
     // check if webUSB is available and usable
     if ((pxt.appTarget?.compile?.isNative || pxt.appTarget?.compile?.hasHex) && !pxt.BrowserUtils.isPxtElectron()) {
+        // TODO: web USB is currently disabled in electron app, but should be supported.
         if (pxt.usb.isAvailable() && pxt.appTarget?.compile?.webUSB) {
             log(`enabled webusb`);
             pxt.usb.setEnabled(true);


### PR DESCRIPTION
The webusb changes have the electron app trying to use Hid; this ends up failing due this [this](https://github.com/microsoft/pxt/blob/master/webapp/src/hidbridge.ts#L47) bailing out of initializing iface and then gives an NPE [here](https://github.com/microsoft/pxt/blob/master/webapp/src/hidbridge.ts#L156). Not a big deal, it just ends up in a failed promise without a visible effect on the app, but it does end up flooding the console a bit in the electron app / makes pinpointing other errors a bit harder.

Eventually I'll have to get webusb working in the electron app (should be able to get away without even popping up the selection dialog), but fixing all the build pipeline / signing errors in the electron app took too much time to look at that for this release.