### PR TITLE
fix playground / tutorial-tool on safari

### DIFF
--- a/docs/static/shared/iframeeditor.css
+++ b/docs/static/shared/iframeeditor.css
@@ -40,6 +40,7 @@ body {
     flex-direction: row;
     flex-grow: 1;
     margin: 0.5rem 0.5rem 0;
+    height: 100%;
 }
 
 #container {


### PR DESCRIPTION
fix view on current safari re: https://github.com/microsoft/pxt/issues/7248 (was there another issue for this?)

It's possible there's an issue on much older versions of safari (as there are a few 'still used but old' versions that don't support some es5 functions), but if there is we'd probably need browserstack to get them; oldest safari I can get access to on my device is ios 10.3.1 and with this change it works there ~