### PR TITLE
Check for provided snippets

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1968,7 +1968,7 @@ namespace ts.pxtc.service {
         doesAddDefinition = args.reduce((p, n) => p || n.addsDefinitions, doesAddDefinition)
         let snippet = attrs && (python ? attrs.pySnippet : attrs.snippet);
         if (!snippet) {
-            snippet = `${fnName}(${args.map(a => a.snippet).join(', ')})`; // vivian this is suspicious. what if we dont wanna do that...
+            snippet = `${fnName}(${args.map(a => a.snippet).join(', ')})`;
         }
         let insertText = snippetPrefix ? `${snippetPrefix}.${snippet}` : snippet;
         insertText = addNamespace ? `${firstWord(namespaceToUse)}.${insertText}` : insertText;

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1966,7 +1966,10 @@ namespace ts.pxtc.service {
         }
 
         doesAddDefinition = args.reduce((p, n) => p || n.addsDefinitions, doesAddDefinition)
-        let snippet = `${fnName}(${args.map(a => a.snippet).join(', ')})`;
+        let snippet = attrs && (python ? attrs.pySnippet : attrs.snippet);
+        if (!snippet) {
+            snippet = `${fnName}(${args.map(a => a.snippet).join(', ')})`; // vivian this is suspicious. what if we dont wanna do that...
+        }
         let insertText = snippetPrefix ? `${snippetPrefix}.${snippet}` : snippet;
         insertText = addNamespace ? `${firstWord(namespaceToUse)}.${insertText}` : insertText;
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1945
fixes https://github.com/microsoft/pxt-arcade/issues/1929

The way the img snippets were being resolved before was by checking the default value for parameters. However, now that we're recursing on resolving snippets, we don't have that special case to see if there's a snippet already provided. Images seem to be the only type of block that we've defined that has the snippet provided though, so I don't feel suuper good about adding more code for such a special case

I have two questions for this mainly:
1. I saw that there was a TODO to pull out the 'getParameterDefault' function out of getSnippet for general use - maybe I should refactor a bit and try to reuse the getDefault code? Do we not have to get the default for non parameter snippets?
2. Should I add some tests to check how img snippets get resolved? Where should I do that?

Thanks :D :D :D