### PR TITLE
[stable6.0] don't try hid on electron app (#7245)

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -353,7 +353,8 @@ export async function initAsync() {
     }
 
     // check if webUSB is available and usable
-    if (pxt.appTarget?.compile?.isNative || pxt.appTarget?.compile?.hasHex) {
+    if ((pxt.appTarget?.compile?.isNative || pxt.appTarget?.compile?.hasHex) && !pxt.BrowserUtils.isPxtElectron()) {
+        // TODO: web USB is currently disabled in electron app, but should be supported.
         if (pxt.usb.isAvailable() && pxt.appTarget?.compile?.webUSB) {
             log(`enabled webusb`);
             pxt.usb.setEnabled(true);


### PR DESCRIPTION
Cherry pick https://github.com/microsoft/pxt/pull/7245 for electron release

Not strictly needed / doesn't have a behavioral change, but this prevents the very noisey exception I mentioned before in electron; we don't currently use the hid or web usb path for downloading there (it's separately handled with the drive deploy logic), and the hid init fails with a scary looking error message every time a project is loaded / refreshed which drowns out other potentially important errors