### PR TITLE
Use editors.json in playground, additional editors + "unsupported" flag

### DIFF
--- a/docs/editors.json
+++ b/docs/editors.json
@@ -1,6 +1,5 @@
 {
     "arcade": {
-        "id": "arcade-beta",
         "name": "Arcade BETA",
         "title": "MakeCode Arcade",
         "url": "https://arcade.makecode.com/beta",
@@ -11,7 +10,6 @@
         }
     },
     "arcadestable": {
-        "id": "arcade",
         "name": "Arcade",
         "title": "MakeCode Arcade",
         "url": "https://arcade.makecode.com/",
@@ -22,13 +20,11 @@
         }
     },
     "microbitbeta": {
-        "id": "microbit-beta",
         "name": "micro:bit BETA",
         "url": "https://makecode.microbit.org/beta",
         "unsupported": ["streamer"]
     },
     "microbit": {
-        "id": "microbit",
         "name": "micro:bit",
         "title": "MakeCode for micro:bit",
         "url": "https://makecode.microbit.org/",
@@ -39,7 +35,6 @@
         }
     },
     "adafruit": {
-        "id": "adafruit-beta",
         "name": "Adafruit Circuit Playground Express BETA",
         "title": "MakeCode for Circuit Playground",
         "url": "https://makecode.adafruit.com/beta",
@@ -51,13 +46,11 @@
         }
     },
     "adafruitstable": {
-        "id": "adafruit",
         "name": "Adafruit Circuit Playground Express",
         "url": "https://makecode.adafruit.com/",
         "unsupported": ["streamer"]
     },
     "maker": {
-        "id": "maker",
         "name": "Maker",
         "title": "MakeCode Maker",
         "url": "https://maker.makecode.com",
@@ -69,19 +62,16 @@
         "unsupported": ["playground"]
     },
     "ev3": {
-        "id": "ev3-beta",
         "name": "LEGO® MINDSTORMS® Education EV3 BETA",
         "title": "MakeCode for EV3",
         "url": "https://makecode.mindstorms.com/beta"
     },
     "ev3stable": {
-        "id": "ev3",
         "name": "LEGO® MINDSTORMS® Education EV3",
         "url": "https://makecode.mindstorms.com/",
         "unsupported": ["streamer"]
     },
     "minecraft": {
-        "id": "minecraft-beta",
         "name": "Minecraft BETA",
         "title": "MakeCode for Minecraft",
         "icon": "https://minecraft.makecode.com/favicon.ico",
@@ -93,20 +83,17 @@
         }
     },
     "minecraftstable": {
-        "id": "minecraft",
         "name": "Minecraft",
         "url": "https://minecraft.makecode.com?github=1",
         "unsupported": ["streamer"]
     },
     "calliopemini": {
-        "id": "calliope-beta",
         "name": "Calliope Mini",
         "title": "MakeCode for Calliope",
         "url": "https://makecode.calliope.cc/beta",
         "unsupported": ["playground"]
     },
     "stm32iotnode": {
-        "id": "stm32",
         "name": "STM32L4 Discovery kit IoT node",
         "title": "MakeCode pour STM32",
         "url": "https://makecode.st.com/",

--- a/docs/editors.json
+++ b/docs/editors.json
@@ -21,6 +21,12 @@
             "background": "linear-gradient(90deg, #B1E3DA 0%, #E91E63 100%)"
         }
     },
+    "microbitbeta": {
+        "id": "microbit-beta",
+        "name": "micro:bit BETA",
+        "url": "https://makecode.microbit.org/beta",
+        "unsupported": ["streamer"]
+    },
     "microbit": {
         "id": "microbit",
         "name": "micro:bit",
@@ -34,7 +40,7 @@
     },
     "adafruit": {
         "id": "adafruit-beta",
-        "name": "Adafruit Circuit Playground Express",
+        "name": "Adafruit Circuit Playground Express BETA",
         "title": "MakeCode for Circuit Playground",
         "url": "https://makecode.adafruit.com/beta",
         "icon": "https://pxt.azureedge.net/blob/1215b9ef46d3e04bc9923a1a333d92db92eb5419/static/logo.square.black.svg",
@@ -43,6 +49,12 @@
             "menu": "#FB48C7",
             "background": "linear-gradient(45deg, #1c1f2b 0%, #000 100%)"
         }
+    },
+    "adafruitstable": {
+        "id": "adafruit",
+        "name": "Adafruit Circuit Playground Express",
+        "url": "https://makecode.adafruit.com/",
+        "unsupported": ["streamer"]
     },
     "maker": {
         "id": "maker",
@@ -53,17 +65,24 @@
             "primary": "#1f1f1f",
             "menu": "#444",
             "background": "linear-gradient(45deg, #cccccc 0%, #333333 100%)"
-        }
+        },
+        "unsupported": ["playground"]
     },
     "ev3": {
         "id": "ev3-beta",
-        "name": "LEGO® MINDSTORMS® Education EV3",
+        "name": "LEGO® MINDSTORMS® Education EV3 BETA",
         "title": "MakeCode for EV3",
         "url": "https://makecode.mindstorms.com/beta"
     },
+    "ev3stable": {
+        "id": "ev3",
+        "name": "LEGO® MINDSTORMS® Education EV3",
+        "url": "https://makecode.mindstorms.com/",
+        "unsupported": ["streamer"]
+    },
     "minecraft": {
         "id": "minecraft-beta",
-        "name": "Minecraft",
+        "name": "Minecraft BETA",
         "title": "MakeCode for Minecraft",
         "icon": "https://minecraft.makecode.com/favicon.ico",
         "url": "https://minecraft.makecode.com/beta?github=1",
@@ -73,16 +92,24 @@
             "background": "linear-gradient(215deg, #3C3C3C 0%, #C6C6C6 100%)"
         }
     },
+    "minecraftstable": {
+        "id": "minecraft",
+        "name": "Minecraft",
+        "url": "https://minecraft.makecode.com?github=1",
+        "unsupported": ["streamer"]
+    },
     "calliopemini": {
         "id": "calliope-beta",
         "name": "Calliope Mini",
         "title": "MakeCode for Calliope",
-        "url": "https://makecode.calliope.cc/beta"
+        "url": "https://makecode.calliope.cc/beta",
+        "unsupported": ["playground"]
     },
     "stm32iotnode": {
         "id": "stm32",
         "name": "STM32L4 Discovery kit IoT node",
         "title": "MakeCode pour STM32",
-        "url": "https://makecode.st.com/"
+        "url": "https://makecode.st.com/",
+        "unsupported": ["playground"]
     }
 }

--- a/docs/editors.json
+++ b/docs/editors.json
@@ -1,5 +1,6 @@
 {
     "arcade": {
+        "id": "arcade-beta",
         "name": "Arcade BETA",
         "title": "MakeCode Arcade",
         "url": "https://arcade.makecode.com/beta",
@@ -10,6 +11,7 @@
         }
     },
     "arcadestable": {
+        "id": "arcade",
         "name": "Arcade",
         "title": "MakeCode Arcade",
         "url": "https://arcade.makecode.com/",
@@ -20,6 +22,7 @@
         }
     },
     "microbit": {
+        "id": "microbit",
         "name": "micro:bit",
         "title": "MakeCode for micro:bit",
         "url": "https://makecode.microbit.org/",
@@ -30,17 +33,19 @@
         }
     },
     "adafruit": {
+        "id": "adafruit-beta",
         "name": "Adafruit Circuit Playground Express",
-        "title": "MakeCode for Circuit Playgroung",
+        "title": "MakeCode for Circuit Playground",
         "url": "https://makecode.adafruit.com/beta",
         "icon": "https://pxt.azureedge.net/blob/1215b9ef46d3e04bc9923a1a333d92db92eb5419/static/logo.square.black.svg",
         "styles": {
             "primary": "#1c1f2b",
             "menu": "#FB48C7",
-            "background": "linear-gradient(45deg, #1c1f2b 0%, #000 100%)" 
+            "background": "linear-gradient(45deg, #1c1f2b 0%, #000 100%)"
         }
     },
     "maker": {
+        "id": "maker",
         "name": "Maker",
         "title": "MakeCode Maker",
         "url": "https://maker.makecode.com",
@@ -51,11 +56,13 @@
         }
     },
     "ev3": {
+        "id": "ev3-beta",
         "name": "LEGO® MINDSTORMS® Education EV3",
         "title": "MakeCode for EV3",
         "url": "https://makecode.mindstorms.com/beta"
     },
     "minecraft": {
+        "id": "minecraft-beta",
         "name": "Minecraft",
         "title": "MakeCode for Minecraft",
         "icon": "https://minecraft.makecode.com/favicon.ico",
@@ -67,11 +74,13 @@
         }
     },
     "calliopemini": {
+        "id": "calliope-beta",
         "name": "Calliope Mini",
         "title": "MakeCode for Calliope",
         "url": "https://makecode.calliope.cc/beta"
     },
     "stm32iotnode": {
+        "id": "stm32",
         "name": "STM32L4 Discovery kit IoT node",
         "title": "MakeCode pour STM32",
         "url": "https://makecode.st.com/"

--- a/docs/static/playground/playground.js
+++ b/docs/static/playground/playground.js
@@ -10,6 +10,7 @@ var editor = monaco.editor.create(document.getElementById("container"), {
     minimap: { enabled: false }
 });
 var CUSTOM_FILE = "custom.ts";
+var PLAYGROUND_ID = "playground";
 var endpoints;
 var selectedEndpoint;
 var baseProjects = {};
@@ -38,10 +39,15 @@ function initEndpoints() {
         for (var _i = 0, _a = Object.keys(endpoints); _i < _a.length; _i++) {
             var name_1 = _a[_i];
             var endpoint = endpoints[name_1];
-            var opt = document.createElement("option");
-            opt.value = endpoint.id;
-            opt.innerText = endpoint.name;
-            s.appendChild(opt);
+            if (supportedEndpoint(endpoint)) {
+                var opt = document.createElement("option");
+                opt.value = endpoint.id;
+                opt.innerText = endpoint.name;
+                s.appendChild(opt);
+            }
+            else {
+                delete endpoints[name_1];
+            }
         }
         s.addEventListener("change", function (ev) {
             loadIframe(ev.target.value);
@@ -130,6 +136,10 @@ function loadIframe(selected) {
             return;
         }
     }
+}
+function supportedEndpoint(endpoint) {
+    var _a;
+    return !(((_a = endpoint.unsupported) === null || _a === void 0 ? void 0 : _a.indexOf(PLAYGROUND_ID)) >= 0);
 }
 function sendMessage(action, ts) {
     var msg = {

--- a/docs/static/playground/playground.js
+++ b/docs/static/playground/playground.js
@@ -41,7 +41,7 @@ function initEndpoints() {
             var endpoint = endpoints[name_1];
             if (supportedEndpoint(endpoint)) {
                 var opt = document.createElement("option");
-                opt.value = endpoint.id;
+                opt.value = name_1;
                 opt.innerText = endpoint.name;
                 s.appendChild(opt);
             }
@@ -129,10 +129,10 @@ function loadIframe(selected) {
     for (var _i = 0, _a = Object.keys(endpoints); _i < _a.length; _i++) {
         var name_2 = _a[_i];
         var endpoint = endpoints[name_2];
-        if (!selected || selected === endpoint.id) {
+        if (!selected || selected === name_2) {
             var separator = endpoint.url.indexOf("?") >= 0 ? "&" : "?";
             iframe.setAttribute("src", "" + endpoint.url + separator + "controller=1");
-            selectedEndpoint = endpoint.id;
+            selectedEndpoint = name_2;
             return;
         }
     }

--- a/docs/static/playground/playground.ts
+++ b/docs/static/playground/playground.ts
@@ -20,7 +20,8 @@ interface EndpointInfo {
         primary?: string;
         menu?: string;
         background?: string;
-    }
+    };
+    unsupported?: string[];
 }
 
 interface SampleInfo {
@@ -39,6 +40,7 @@ interface Project {
 
 
 const CUSTOM_FILE = "custom.ts";
+const PLAYGROUND_ID = "playground";
 
 let endpoints: { [key: string]: EndpointInfo };
 let selectedEndpoint: string;
@@ -75,10 +77,14 @@ function initEndpoints() {
         endpoints = JSON.parse(this.responseText);
         for (const name of Object.keys(endpoints)) {
             const endpoint = endpoints[name];
-            const opt = document.createElement("option");
-            opt.value = endpoint.id;
-            opt.innerText = endpoint.name;
-            s.appendChild(opt);
+            if (supportedEndpoint(endpoint)) {
+                const opt = document.createElement("option");
+                opt.value = endpoint.id;
+                opt.innerText = endpoint.name;
+                s.appendChild(opt);
+            } else {
+                delete endpoints[name];
+            }
         }
 
         s.addEventListener("change", ev => {
@@ -177,6 +183,10 @@ function loadIframe(selected: string) {
             return;
         }
     }
+}
+
+function supportedEndpoint(endpoint: EndpointInfo) {
+    return !(endpoint.unsupported?.indexOf(PLAYGROUND_ID) >= 0);
 }
 
 function sendMessage(action: string, ts?: string) {

--- a/docs/static/playground/playground.ts
+++ b/docs/static/playground/playground.ts
@@ -12,7 +12,6 @@ const editor = monaco.editor.create(document.getElementById("container"), {
 
 // interface defined in docs/editors.json
 interface EndpointInfo {
-    id: string;
     name: string;
     title: string;
     url: string;
@@ -79,7 +78,7 @@ function initEndpoints() {
             const endpoint = endpoints[name];
             if (supportedEndpoint(endpoint)) {
                 const opt = document.createElement("option");
-                opt.value = endpoint.id;
+                opt.value = name;
                 opt.innerText = endpoint.name;
                 s.appendChild(opt);
             } else {
@@ -176,10 +175,10 @@ function loadIframe(selected: string) {
 
     for (const name of Object.keys(endpoints)) {
         const endpoint = endpoints[name];
-        if (!selected || selected === endpoint.id) {
+        if (!selected || selected === name) {
             const separator = endpoint.url.indexOf("?") >= 0 ? "&" : "?";
             iframe.setAttribute("src", `${endpoint.url}${separator}controller=1`);
-            selectedEndpoint = endpoint.id;
+            selectedEndpoint = name;
             return;
         }
     }

--- a/docs/static/streamer/script.js
+++ b/docs/static/streamer/script.js
@@ -36,6 +36,7 @@
     const CHAT_SCENE_INDEX = scenes.indexOf("chatscene")
     const COUNTDOWN_SCENE_INDEX = scenes.indexOf("countdownscene")
     const DISPLAY_DEVICE_ID = "display"
+    const STREAMER_ID = "streamer"
     const state = {
         sceneIndex: -1,
         left: false,
@@ -227,7 +228,7 @@
             else
                 addButton(toolbox, "Record2", "Start recording", startRecording)
         }
-        
+
         addButton(toolbox, "Settings", "Show settings", toggleSettings);
 
         function addSep(container) {
@@ -1313,12 +1314,15 @@ background-image: url(${config.backgroundImage});
         const editorselect = document.getElementById("editorselect");
         editorselect.innerHTML = "" // remove all web cams
         Object.keys(editorConfigs).forEach(editorid => {
-            const option = document.createElement("option")
-            option.value = editorid
-            option.text = editorConfigs[editorid].name;
-            editorselect.add(option)
-            if (config.editor == editorid)
-                option.selected = true;
+            const editor = editorConfigs[editorid];
+            if (!editor.unsupported || editor.unsupported.indexOf(STREAMER_ID) < 0) {
+                const option = document.createElement("option")
+                option.value = editorid
+                option.text = editor.name;
+                editorselect.add(option)
+                if (config.editor == editorid)
+                    option.selected = true;
+            }
         })
         editorselect.onchange = function () {
             const selected = editorselect.options[editorselect.selectedIndex];


### PR DESCRIPTION
- Remove target list from playground, use editors.json
- Add "unsupported" array with endpoint names + read this in playground/streamer
- Added new endpoints for playground

I looked into updating the tutorial tool as well but the share code would require some changes to the editor.json structure and it grew to be a slightly larger change so I'm leaving it as-is for now.