### PR TITLE
Fix keyboard shortcuts in nested image editor

### DIFF
--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -2,7 +2,7 @@
 import { Store } from 'react-redux';
 import { ImageEditorTool, ImageEditorStore } from './store/imageReducer';
 import { dispatchChangeZoom, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchChangeImageTool, dispatchSwapBackgroundForeground, dispatchChangeSelectedColor} from './actions/dispatch';
-import mainStore from './store/imageStore';
+import { mainStore } from './store/imageStore';
 let store = mainStore;
 
 export function addKeyListener() {

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -1,6 +1,9 @@
-import { ImageEditorTool } from './store/imageReducer';
+
+import { Store } from 'react-redux';
+import { ImageEditorTool, ImageEditorStore } from './store/imageReducer';
 import { dispatchChangeZoom, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchChangeImageTool, dispatchSwapBackgroundForeground, dispatchChangeSelectedColor} from './actions/dispatch';
-import store from './store/imageStore';
+import mainStore from './store/imageStore';
+let store = mainStore;
 
 export function addKeyListener() {
     document.addEventListener("keydown", handleKeyDown);
@@ -12,6 +15,10 @@ export function removeKeyListener() {
     document.removeEventListener("keydown", handleKeyDown);
     document.removeEventListener("keydown", handleUndoRedo, true);
     document.removeEventListener("keydown", overrideBlocklyShortcuts, true);
+}
+
+export function setStore(newStore?: Store<ImageEditorStore>) {
+    store = newStore || mainStore;
 }
 
 function handleUndoRedo(event: KeyboardEvent) {


### PR DESCRIPTION
Two bugs:
- We were always dispatching keyboard shortcut events to "mainStore", even when the nested image editor had a separate store
- We were unbinding events on component unmount, which removed the event binding for the tilemap below as well