### PR TITLE
Experiment: open in streamer

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -390,6 +390,7 @@ declare namespace pxt {
         openProjectNewDependentTab?: boolean; // allow opening project in a new tab -- connected
         tutorialExplicitHints?: boolean; // allow use explicit hints
         errorList?: boolean; // error list experiment
+        openInStreamer?: boolean;
     }
 
     interface SocialOptions {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -390,7 +390,7 @@ declare namespace pxt {
         openProjectNewDependentTab?: boolean; // allow opening project in a new tab -- connected
         tutorialExplicitHints?: boolean; // allow use explicit hints
         errorList?: boolean; // error list experiment
-        openInStreamer?: boolean;
+        openInStreamer?: string; // url of the streamer interface
     }
 
     interface SocialOptions {

--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -162,6 +162,11 @@ namespace pxt.editor.experiments {
                 id: "errorList",
                 name: lf("Error List"),
                 description: lf("Show an error list panel for JavaScript and Python.")
+            },
+            {
+                id: "openInStreamer",
+                name: lf("Open in Streamer"),
+                description: lf("Open project in streamer to record a video.")
             }
         ].filter(experiment => ids.indexOf(experiment.id) > -1);
     }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -414,7 +414,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             this.setState({ sharingError: undefined, loading: true });
             const streamerUrl = `https://makecode.com/streamer`
             window.location.href =
-                `${targetTheme.openInStreamer}#editor:${pxt.appTarget.id}:workspace:${header.id}`
+                `${streamerUrl}#editor:${pxt.appTarget.id}:workspace:${header.id}`
         }
 
         const formats = [
@@ -429,16 +429,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             ? lf("Record video") : undefined;
 
         let actions: sui.ModalButton[] = [];
-        if (action) {
-            actions.push({
-                label: action,
-                onclick: publish,
-                icon: 'share alternate',
-                loading: actionLoading,
-                className: 'primary',
-                disabled: recordingState != ShareRecordingState.None
-            })
-        }
         if (streamerAction) {
             actions.push({
                 label: streamerAction,
@@ -446,6 +436,16 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 icon: 'camera',
                 loading: actionLoading,
                 disabled: recordingState != ShareRecordingState.None
+            })
+        }
+        if (action) {
+            actions.push({
+                label: action,
+                onclick: publish,
+                icon: 'share alternate',
+                loading: actionLoading,
+                title: lf("Open this project in our recording studio"),
+                className: 'primary'
             })
         }
 

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -414,7 +414,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             this.setState({ sharingError: undefined, loading: true });
             const streamerUrl = `https://makecode.com/streamer`
             window.location.href =
-                `${targetTheme.openInStreamer}#editorshare:${pxt.appTarget.id}:workspace:${header.id}`
+                `${targetTheme.openInStreamer}#editor:${pxt.appTarget.id}:workspace:${header.id}`
         }
 
         const formats = [

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -443,9 +443,9 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 label: action,
                 onclick: publish,
                 icon: 'share alternate',
-                loading: actionLoading,
                 title: lf("Open this project in our recording studio"),
-                className: 'primary'
+                className: 'primary',
+                disabled: recordingState != ShareRecordingState.None
             })
         }
 

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -414,7 +414,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             this.setState({ sharingError: undefined, loading: true });
             const streamerUrl = `https://makecode.com/streamer`
             window.location.href =
-                `${targetTheme.openInStreamer}#editor:${pxt.appTarget.id}:workspace:${header.id}`
+                `${targetTheme.openInStreamer}#editorshare:${pxt.appTarget.id}:workspace:${header.id}`
         }
 
         const formats = [

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -434,7 +434,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 label: streamerAction,
                 onclick: streamer,
                 icon: 'camera',
-                loading: actionLoading,
                 title: lf("Open this project in our recording studio"),
                 disabled: recordingState != ShareRecordingState.None
             })
@@ -444,6 +443,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 label: action,
                 onclick: publish,
                 icon: 'share alternate',
+                loading: actionLoading,
                 className: 'primary',
                 disabled: recordingState != ShareRecordingState.None
             })

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -435,6 +435,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 onclick: streamer,
                 icon: 'camera',
                 loading: actionLoading,
+                title: lf("Open this project in our recording studio"),
                 disabled: recordingState != ShareRecordingState.None
             })
         }
@@ -443,7 +444,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 label: action,
                 onclick: publish,
                 icon: 'share alternate',
-                title: lf("Open this project in our recording studio"),
                 className: 'primary',
                 disabled: recordingState != ShareRecordingState.None
             })

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -409,6 +409,13 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 });
             this.forceUpdate();
         }
+        const streamer = () => {
+            pxt.tickEvent("menu.embed.streamer", undefined, { interactiveConsent: true });
+            this.setState({ sharingError: undefined, loading: true });
+            const streamerUrl = `https://makecode.com/streamer`
+            window.location.href =
+                `${targetTheme.openInStreamer}#editor:${pxt.appTarget.id}:workspace:${header.id}`
+        }
 
         const formats = [
             { mode: ShareMode.Code, label: lf("Code") },
@@ -418,6 +425,8 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
 
         const action = !ready ? lf("Publish project") : undefined;
         const actionLoading = loading && !this.state.sharingError;
+        const streamerAction = action && targetTheme.openInStreamer && !pxt.BrowserUtils.isSafari()
+            ? lf("Record video") : undefined;
 
         let actions: sui.ModalButton[] = [];
         if (action) {
@@ -427,6 +436,15 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 icon: 'share alternate',
                 loading: actionLoading,
                 className: 'primary',
+                disabled: recordingState != ShareRecordingState.None
+            })
+        }
+        if (streamerAction) {
+            actions.push({
+                label: streamerAction,
+                onclick: streamer,
+                icon: 'camera',
+                loading: actionLoading,
                 disabled: recordingState != ShareRecordingState.None
             })
         }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1350,6 +1350,7 @@ class ModalButtonElement extends data.PureComponent<ModalButton, {}> {
         return <Button
             icon={action.icon}
             text={action.label}
+            title={action.title}
             labelPosition={action.labelPosition}
             className={`approve ${action.icon ? `icon ${action.labelPosition ? action.labelPosition : 'right'} labeled` : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""} ${action.disabled ? "disabled" : ""}`}
             onClick={this.handleClick}


### PR DESCRIPTION
Adds  an experiment to display button in the share dialog as an entry point to the streamer. The button opens the streamer on the same project.

![image](https://user-images.githubusercontent.com/4175913/86412190-4c902f00-bc73-11ea-9ecb-2c1f86a260e8.png)
