### PR TITLE
allow pasting image literals from text into image editor

### DIFF
--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -292,7 +292,15 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
             return;
         }
 
-        const imageData = ev.clipboardData.getData('application/makecode-image');
+        let imageData = ev.clipboardData.getData('application/makecode-image');
+
+        if (!imageData) {
+            const textData = ev.clipboardData.getData("text/plain");
+            if (/^\s*img`(.|\s)+`\s*$/im.test(textData)) {
+                imageData = textData;
+            }
+        }
+
         const image = imageData && pxt.sprite.imageLiteralToBitmap(imageData);
 
         if (image && image.width && image.height) {

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -296,7 +296,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
         if (!imageData) {
             const textData = ev.clipboardData.getData("text/plain");
-            if (/^\s*img`(.|\s)+`\s*$/im.test(textData)) {
+            if (/^\s*img`[\s\S]+`\s*$/im.test(textData)) {
                 imageData = textData;
             }
         }

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -296,7 +296,8 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
         if (!imageData) {
             const textData = ev.clipboardData.getData("text/plain");
-            if (/^\s*img`[\s\S]+`\s*$/im.test(textData)) {
+            // text data 'looks like' an image
+            if (/^\s*img`[\s\da-f.#tngrpoyw]+`\s*$/im.test(textData)) {
                 imageData = textData;
             }
         }


### PR DESCRIPTION
Enable pasting into image editor from elsewhere if the plain text looks roughly like an image literal. Also see https://forum.makecode.com/t/copying-makecode-image-data-from-another-application/2656

re: @jacobcarpenter tried to add you as a reviewer too but it didn't let me :(