### PR TITLE
fix update message when no latest electron build is set

### DIFF
--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -32,7 +32,7 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
     pxt.targetConfigAsync()
         .then(config => {
             const isPxtElectron = pxt.BrowserUtils.isPxtElectron();
-            const electronManifest = config && config.electronManifest;
+            const latestElectronRelease = config?.electronManifest?.latest;
             return core.confirmAsync({
                 header: lf("About"),
                 hasCloseIcon: true,
@@ -41,10 +41,10 @@ export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
                 buttons,
                 jsx: <div>
                     {isPxtElectron ?
-                        (!pxt.Cloud.isOnline() || !electronManifest)
+                        (!pxt.Cloud.isOnline() || !latestElectronRelease)
                             ? <p>{lf("Please connect to internet to check for updates")}</p>
-                            : pxt.semver.strcmp(pxt.appTarget.versions.target, electronManifest.latest) < 0
-                                ? <a target="_blank" rel="noopener noreferrer" href="/offline-app">{lf("An update {0} for {1} is available", electronManifest.latest, pxt.appTarget.title)}</a>
+                            : pxt.semver.strcmp(pxt.appTarget.versions.target, latestElectronRelease) < 0
+                                ? <a target="_blank" rel="noopener noreferrer" href="/offline-app">{lf("An update {0} for {1} is available", latestElectronRelease, pxt.appTarget.title)}</a>
                                 : <p>{lf("{0} is up to date", pxt.appTarget.title)}</p>
                         : undefined}
                     {githubUrl && versions ?


### PR DESCRIPTION
Pretty minor / wouldn't ever be seen by end users, but felt like it was worth checking the code in case there was an actual issue there / might as well fix while there

When you have a build of an electron app that does not yet have a release, it pops up this message in the about dialog:

![image](https://user-images.githubusercontent.com/5615930/86439961-686cf280-bcbe-11ea-9eb0-0e1c4577643c.png)

Which is obviously wrong. Issue is that the targetconfig stored by the electron app gets stamped with `.electronManifest.timestamp`, so it trivially has an electronManifest, even if there is no release yet (and `pxt.semver.strcmp("v0.0.1", undefined)` returns -1)