### PR TITLE
Fix parameter defaults for javascript/python snippets and auto-complete for fixed instances

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1734,6 +1734,8 @@ namespace ts.pxtc.service {
         }
     }
     export function getSnippet(apis: ApisInfo, takenNames: pxt.Map<SymbolInfo>, runtimeOps: pxt.RuntimeOptions, fn: SymbolInfo, decl: ts.FunctionLikeDeclaration, python?: boolean, recursionDepth = 0): SnippetResult {
+        // TODO: a lot of this is duplicate logic with blocklyloader.ts:buildBlockFromDef; we should
+        //  unify these approaches
         const PY_INDENT: string = (pxt as any).py.INDENT;
 
         let preStmt = "";
@@ -1787,8 +1789,8 @@ namespace ts.pxtc.service {
                     const defl = getDefaultEnumValue(type, python)
                     return asSnippetRes(defl)
                 }
+                const typeSymbol = getPxtSymbolFromTsSymbol(type.symbol, apis, checker)
                 if (isObjectType(type)) {
-                    const typeSymbol = getPxtSymbolFromTsSymbol(type.symbol, apis, checker)
                     const snip = typeSymbol && typeSymbol.attributes && (python ? typeSymbol.attributes.pySnippet : typeSymbol.attributes.snippet);
                     if (snip) return asSnippetRes(snip);
                     if (type.objectFlags & ts.ObjectFlags.Anonymous) {
@@ -1802,7 +1804,31 @@ namespace ts.pxtc.service {
                 if (type.flags & ts.TypeFlags.NumberLike) {
                     return asSnippetRes("0");
                 }
+
+                // check for fixed instances
+                if (typeSymbol && typeSymbol.attributes.fixedInstances) {
+                    const fixedSyms = getFixedInstancesOf(typeSymbol)
+                    if (fixedSyms.length) {
+                        const defl = fixedSyms[0]
+                        return asSnippetRes(python ? defl.pyQName : defl.qName)
+                    }
+
+                }
                 return null
+            }
+
+            function getFixedInstancesOf(type: SymbolInfo) {
+                return pxt.Util.values(apis.byQName).filter(sym => sym.kind === pxtc.SymbolKind.Variable
+                    && sym.attributes.fixedInstance
+                    && isSubtype(apis, sym.retType, type.qName));
+            }
+
+            function isSubtype(apis: pxtc.ApisInfo, specific: string, general: string) {
+                if (specific == general) return true
+                let inf = apis.byQName[specific]
+                if (inf && inf.extendsTypes)
+                    return inf.extendsTypes.indexOf(general) >= 0
+                return false
             }
 
             function getShadowSymbol(paramName: string): SymbolInfo | null {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1176,8 +1176,7 @@ namespace ts.pxtc.service {
                 resultSymbols = completionSymbols(pxt.U.values(lastApiInfo.apis.byQName))
 
                 // then use the typescript service to get symbols in scope
-                if (!tsNode)
-                    tsNode = findInnerMostNodeAtPosition(tsAst, wordStartPos);
+                tsNode = findInnerMostNodeAtPosition(tsAst, wordStartPos);
                 if (!tsNode)
                     tsNode = tsAst.getSourceFile()
                 let symSearch = SymbolFlags.Variable;

--- a/tests/language-service/cases/completions_local_param.ts
+++ b/tests/language-service/cases/completions_local_param.ts
@@ -3,3 +3,7 @@ function fib(num: number) {
     ;
     if (nu  // num; number
 }
+
+function foo(sprite: number) {
+    spr // sprite
+}


### PR DESCRIPTION
Depends on: https://github.com/microsoft/pxt/pull/7277
Fixes: https://github.com/microsoft/pxt-arcade/issues/2069

Before:
![2020-07-07 14 23 41](https://user-images.githubusercontent.com/6453828/86845254-13363580-c05e-11ea-9e7a-74620b5620c8.gif)

After:
![2020-07-07 14 22 49](https://user-images.githubusercontent.com/6453828/86845266-16c9bc80-c05e-11ea-8dee-5eb6f59eb155.gif)
