### PR TITLE
Use rightmost part for python callback naming

### DIFF
--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -934,11 +934,11 @@ namespace pxt.py {
             // TODO(dz): Impl skip namespaces properly. Right now we just skip the left-most part of a property access
             if (ts.isPropertyAccessExpression(s)) {
                 let nmPart = getName(s.name)
+                let nmRight = nmPart.substr(nmPart.lastIndexOf(".") + 1)
                 if (ts.isIdentifier(s.expression)) {
-                    if (nmPart.indexOf(".") >= 0) nmPart = nmPart.substr(nmPart.lastIndexOf(".") + 1);
-                    return [nmPart]
+                    return [nmRight]
                 }
-                return getSimpleExpNameParts(s.expression).concat([nmPart])
+                return getSimpleExpNameParts(s.expression).concat([nmRight])
             }
             else if (ts.isIdentifier(s)) {
                 return [getName(s)]

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -931,7 +931,6 @@ namespace pxt.py {
             return asExpRes(`${expToStr(left)}.${right}`, leftSup);
         }
         function getSimpleExpNameParts(s: ts.Expression): string[] {
-            // TODO(dz): Impl skip namespaces properly. Right now we just skip the left-most part of a property access
             if (ts.isPropertyAccessExpression(s)) {
                 let nmPart = getName(s.name)
                 let nmRight = nmPart.substr(nmPart.lastIndexOf(".") + 1)


### PR DESCRIPTION
We were previously concatenating the entire qname which resulted in controller.combos.attachCombo -> combos_controller.combos.attach_combo during the recursion.

Tested: Warehouese, Jumping Mateo, HackMan, Raptor Run

Fixes Warehouse and Jumping Mateo from https://github.com/microsoft/pxt-arcade/issues/2083