### PR TITLE
Fix the monaco sprite editor for python

### DIFF
--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -5,12 +5,15 @@ namespace pxt.editor {
     const fieldEditorId = "image-editor";
 
     export class MonacoSpriteEditor extends MonacoReactFieldEditor<pxt.sprite.Bitmap> {
+        protected isPython: boolean;
+
         protected textToValue(text: string): pxt.sprite.Bitmap {
+            this.isPython = text.indexOf("`") === -1
             return pxt.sprite.imageLiteralToBitmap(text);
         }
 
         protected resultToText(result: pxt.sprite.Bitmap): string {
-            return pxt.sprite.bitmapToImageLiteral(result, "typescript");
+            return pxt.sprite.bitmapToImageLiteral(result, this.isPython ? "python" : "typescript");
         }
 
         protected getFieldEditorId() {
@@ -32,7 +35,7 @@ namespace pxt.editor {
         heightInPixels: 510,
         matcher: {
             // match both JS and python
-            searchString: "img\\s*(?:`|\\(\"\"\")(?:[ a-fA-F0-9\\.]|\\n)*\\s*(?:`|\"\"\"\\))",
+            searchString: "img\\s*(?:`|\\(\\s*\"\"\")[ a-fA-F0-9\\.\\n]*\\s*(?:`|\"\"\"\\s*\\))",
             isRegex: true,
             matchCase: true,
             matchWholeWord: false

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1183,6 +1183,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (!this.fieldEditors) {
             this.fieldEditors = new FieldEditorManager(this.editor);
             monaco.languages.registerFoldingRangeProvider("typescript", this.fieldEditors);
+            monaco.languages.registerFoldingRangeProvider("python", this.fieldEditors);
         }
 
         pxt.appTarget.appTheme.monacoFieldEditors.forEach(name => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2079

Three changes:

1. Emit the python syntax and not typescript when we are editing python
2. Made the regex a little more robust
3. Register the folding range provider for python (this is what actually makes the icon show up)