### PR TITLE
Add select all, delete, and cancel selection to sprite editor

### DIFF
--- a/theme/image-editor/imageCanvas.less
+++ b/theme/image-editor/imageCanvas.less
@@ -6,10 +6,6 @@
 
     overflow: hidden;
     touch-action: none;
-
-    &:focus {
-        outline: none;
-    }
 }
 
 .image-editor-canvas.portrait > .image-editor-canvas-spacer {

--- a/theme/image-editor/imageCanvas.less
+++ b/theme/image-editor/imageCanvas.less
@@ -6,6 +6,10 @@
 
     overflow: hidden;
     touch-action: none;
+
+    &:focus {
+        outline: none;
+    }
 }
 
 .image-editor-canvas.portrait > .image-editor-canvas-spacer {

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -247,16 +247,14 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
                 ev.stopPropagation();
             }
 
-            if ((ev.ctrlKey || ev.metaKey) && ev.key === 'a') {
-                // only handle select all if the canvas has the focus or if nothing has the focus
-                const shouldHandleSelectAll = document.activeElement === this.refs["canvas-bounds"] ||
-                    document.activeElement === document.body ||
-                    !document.activeElement;
+            if ((ev.ctrlKey || ev.metaKey) && ev.key === 'a' && this.shouldHandleCanvasShortcut()) {
+                this.selectAll();
+                ev.preventDefault();
+            }
 
-                if (shouldHandleSelectAll) {
-                    this.selectAll();
-                    ev.preventDefault();
-                }
+            if ((ev.key === "Backspace" || ev.key === "Delete") && this.editState?.floating?.image && this.shouldHandleCanvasShortcut()) {
+                this.deleteSelection();
+                ev.preventDefault();
             }
 
             // hotkeys for switching temporarily between tools
@@ -772,6 +770,11 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
         this.editState.mergeFloatingLayer();
         this.editState.copyToLayer(0, 0, this.imageWidth, this.imageHeight, true);
+        this.props.dispatchImageEdit(this.editState.toImageState());
+    }
+
+    protected deleteSelection() {
+        this.editState.floating = null;
         this.props.dispatchImageEdit(this.editState.toImageState());
     }
 

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -82,7 +82,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         const imageState = this.getImageState();
         const isPortrait = !imageState || (imageState.bitmap.height > imageState.bitmap.width);
 
-        return <div ref="canvas-bounds" className={`image-editor-canvas ${isPortrait ? "portrait" : "landscape"}`} tabIndex={-1} onContextMenu={this.preventContextMenu}>
+        return <div ref="canvas-bounds" className={`image-editor-canvas ${isPortrait ? "portrait" : "landscape"}`} onContextMenu={this.preventContextMenu}>
             <div className="paint-container">
                 <canvas ref="paint-surface-bg" className="paint-surface" />
                 <canvas ref="paint-surface" className="paint-surface" />
@@ -95,6 +95,9 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
     }
 
     componentDidMount() {
+        // move initial focus off of the blockly surface
+        (document.activeElement as HTMLElement)?.blur();
+
         this.cellWidth = this.props.isTilemap ? this.props.tilemapState.tileset.tileWidth * TILE_SCALE : SCALE;
         this.canvas = this.refs["paint-surface"] as HTMLCanvasElement;
         this.background = this.refs["paint-surface-bg"] as HTMLCanvasElement;
@@ -104,7 +107,6 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         bindGestureEvents(this.refs["canvas-bounds"] as HTMLDivElement, this);
 
         const canvasBounds = this.refs["canvas-bounds"] as HTMLDivElement;
-        canvasBounds.focus();
 
         canvasBounds.addEventListener("wheel", ev => {
             this.hasInteracted = true
@@ -826,10 +828,8 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
     }
 
     protected shouldHandleCanvasShortcut() {
-        // only handle if focus is in canvas-bounds or if there is no focus
-        return document.activeElement === this.refs["canvas-bounds"] ||
-            document.activeElement === document.body ||
-            !document.activeElement;
+        // canvas shortcuts (select all; delete) should only be handled if the focus is not within a focusable element
+        return document.activeElement === document.body || !document.activeElement;
     }
 
     protected preventContextMenu = (ev: React.MouseEvent<any>) => ev.preventDefault();

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -254,6 +254,11 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
                 ev.preventDefault();
             }
 
+            if (ev.key == "Escape" && this.editState?.floating?.image && this.shouldHandleCanvasShortcut()) {
+                this.cancelSelection();
+                ev.preventDefault();
+            }
+
             if ((ev.key === "Backspace" || ev.key === "Delete") && this.editState?.floating?.image && this.shouldHandleCanvasShortcut()) {
                 this.deleteSelection();
                 ev.preventDefault();
@@ -772,6 +777,11 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
         this.editState.mergeFloatingLayer();
         this.editState.copyToLayer(0, 0, this.imageWidth, this.imageHeight, true);
+        this.props.dispatchImageEdit(this.editState.toImageState());
+    }
+
+    protected cancelSelection() {
+        this.editState.mergeFloatingLayer();
         this.props.dispatchImageEdit(this.editState.toImageState());
     }
 


### PR DESCRIPTION
closes microsoft/pxt-arcade#2093

This PR adds shortcuts for the following actions in the sprite/tile/background image editor:

* `Cmd-A`/`Ctrl-A`: Select all
* `Esc`: Cancel selection
* `Backspace`/`Delete`: Delete selection

![Kapture 2020-07-09 at 20 58 38](https://user-images.githubusercontent.com/194333/87115056-07499f80-c227-11ea-9f63-8d01f0694433.gif)
