### PR TITLE
Fixes sprite kinds completion / toolbox snippet

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1958,7 +1958,7 @@ namespace ts.pxtc.service {
                     const kindNamespace = shadowAttrs.kindNamespace || shadowAttrs.blockNamespace || fn.namespace;
                     const defaultValueForKind = pxtc.Util.values(apis.byQName).find(api => api.namespace === kindNamespace && api.attributes.isKind);
                     if (defaultValueForKind) {
-                        return defaultValueForKind.qName;
+                        return python ? defaultValueForKind.pyQName : defaultValueForKind.qName;
                     }
                 }
 

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1955,7 +1955,7 @@ namespace ts.pxtc.service {
 
                 const shadowAttrs = shadowSymbol.attributes;
                 if (shadowAttrs.shim === "KIND_GET" && shadowAttrs.blockId) {
-                    const kindNamespace = shadowAttrs.kindNamespace || shadowAttrs.blockNamespace || fn.namespace;
+                    const kindNamespace = shadowAttrs.kindNamespace || fn.namespace;
                     const defaultValueForKind = pxtc.Util.values(apis.byQName).find(api => api.namespace === kindNamespace && api.attributes.isKind);
                     if (defaultValueForKind) {
                         return python ? defaultValueForKind.pyQName : defaultValueForKind.qName;

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1752,7 +1752,7 @@ namespace ts.pxtc.service {
         return internalSnippetStringify(snippet)
 
         function internalSnippetStringify(snippet: SnippetNode): string {
-            // The format for monaco snippets is: 
+            // The format for monaco snippets is:
             //      foo(${1:bar}, ${2:baz},  ${1:bar})
             // so both instances of "bar" will start highlighted, then tab will cycle to "baz", etc.
             if (isSnippetReplacePoint(snippet)) {
@@ -1950,6 +1950,15 @@ namespace ts.pxtc.service {
                         if (shadowDef) {
                             return shadowDef
                         }
+                    }
+                }
+
+                const shadowAttrs = shadowSymbol.attributes;
+                if (shadowAttrs.shim === "KIND_GET" && shadowAttrs.blockId) {
+                    const kindNamespace = shadowAttrs.kindNamespace || shadowAttrs.blockNamespace || fn.namespace;
+                    const defaultValueForKind = pxtc.Util.values(apis.byQName).find(api => api.namespace === kindNamespace && api.attributes.isKind);
+                    if (defaultValueForKind) {
+                        return defaultValueForKind.qName;
                     }
                 }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1898

took the kindNamespace resolution (defined kindNamespace >  blockNamespace > namespace) from https://github.com/microsoft/pxt/blob/master/pxtlib/service.ts#L512

I wasn't completely sure where in `getBlocksInfo` to include this check, but this seemed like a reasonable spot to start with.

![fix-kinds](https://user-images.githubusercontent.com/5615930/87176240-b1104700-c28e-11ea-8d5a-d09d27fad980.gif)

Side note, looks like block kinds still don't allow default values; that is, adding

```typescript
//% kind.defl=SpriteKind.Player
//% otherKind.defl=SpriteKind.Enemy
```

here https://github.com/microsoft/pxt-common-packages/blob/master/libs/game/spriteevents.ts#L51 doesn't cause `otherKind` to start off as `Enemy` in blocks. (It does in the js/py completions / snippets though)

Maybe something to try and fix, I can give it a look? I guess depends on when we end up releasing / if there's time.
 