### PR TITLE
Handle the other format of the tile tag in sprite meta json

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4690,7 +4690,7 @@ function buildJResSpritesDirectoryAsync(dir: string) {
                 // These are space-separated lists of tags
                 let tags = `${info.tags || ""} ${metaInfo.tags || ""}`.split(" ").filter(t => !!t);
 
-                const isTile = tags.indexOf("tile") !== -1;
+                const isTile = tags.some(t => t === "tile" || t === "?tile");
 
                 if (storeIcon || isTile) {
                     let jres = jresources[key]


### PR DESCRIPTION
Part of the fix for https://github.com/microsoft/pxt-arcade/issues/2103
Used to build https://github.com/microsoft/pxt-arcade/pull/2109

@jwunderl any other forms of the tags I should know about?