### PR TITLE
Group errors by line number and show count

### DIFF
--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -209,7 +209,5 @@ function groupErrors(errors: pxtc.KsDiagnostic[]) {
             grouped.get(key).count++;
         }
     }
-    let sorted: GroupedError[] = [];
-    grouped.forEach(value => sorted.push(value));
-    return sorted.sort((a, b) => a.index - b.index);
+    return [...grouped.values()].sort((a, b) => a.index - b.index);
 }

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -49,15 +49,15 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
     render() {
         const {isCollapsed, errors, exception} = this.state;
 
-        const errorCount = exception ? 1 : errors.length;
-        const errorsAvailable = errorCount > 0 || !!exception;
         const errorListContent = !isCollapsed ? (exception ? this.generateStackTraces(exception) : this.getCompilerErrors(errors)) : undefined;
+        const errorsAvailable = !!errors?.length || !!exception;	
+        const collapseTooltip = lf("Collapse Error List");
 
         return (
             <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`} hidden={!errorsAvailable}>
                 <div className="errorListHeader" role="button" aria-label={lf("{0} error list", isCollapsed ? lf("Expand") : lf("Collapse"))} onClick={this.onCollapseClick} onKeyDown={sui.fireClickOnEnter} tabIndex={0}>
                     <h4>{lf("Problems")}</h4>
-                    <div className="ui red circular label countBubble">{exception ? 1 : errorCount}</div>
+                    <div className="ui red circular label countBubble">{exception ? 1 : errors.length}</div>
                     <div className="toggleButton"><sui.Icon icon={`chevron ${isCollapsed ? 'up' : 'down'}`}/></div>
                 </div>
                 {!isCollapsed && <div className="errorListInner">

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -48,8 +48,9 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
 
     render() {
         const {isCollapsed, errors, exception} = this.state;
-        const errorsAvailable = !!errors?.length || !!exception;
         const collapseTooltip = lf("Collapse Error List");
+        const errorsAvailable = !!errors?.length || !!exception;
+    
         const errorListContent = !isCollapsed ? (exception ? this.generateStackTraces(exception) : this.getCompilerErrors(errors)) : undefined;
 
         return (

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -47,10 +47,10 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
     }
 
     render() {
-        const {isCollapsed, errors, exception} = this.state;
-        const collapseTooltip = lf("Collapse Error List");
+        const { isCollapsed, errors, exception } = this.state;
         const errorsAvailable = !!errors?.length || !!exception;
-    
+        const collapseTooltip = lf("Collapse Error List");
+
         const errorListContent = !isCollapsed ? (exception ? this.generateStackTraces(exception) : this.getCompilerErrors(errors)) : undefined;
 
         return (
@@ -58,12 +58,12 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
                 <div className="errorListHeader" role="button" aria-label={lf("{0} error list", isCollapsed ? lf("Expand") : lf("Collapse"))} onClick={this.onCollapseClick} onKeyDown={sui.fireClickOnEnter} tabIndex={0}>
                     <h4>{lf("Problems")}</h4>
                     <div className="ui red circular label countBubble">{exception ? 1 : errors.length}</div>
-                    <div className="toggleButton"><sui.Icon icon={`chevron ${isCollapsed ? 'up' : 'down'}`}/></div>
+                    <div className="toggleButton"><sui.Icon icon={`chevron ${isCollapsed ? 'up' : 'down'}`} /></div>
                 </div>
                 {!isCollapsed && <div className="errorListInner">
                     {exception && <div className="debuggerSuggestion" role="button" onClick={this.props.startDebugger} onKeyDown={sui.fireClickOnEnter} tabIndex={0}>
                         {lf("Debug this project")}
-                        <sui.Icon className="debug-icon" icon="icon bug"/>
+                        <sui.Icon className="debug-icon" icon="icon bug" />
                     </div>}
                     {errorListContent}
                 </div>}
@@ -94,7 +94,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
     }
 
     onErrorMessageClick(e: pxtc.LocationInfo, index: number) {
-        pxt.tickEvent('errorlist.goto', {errorIndex: index}, { interactiveConsent: true });
+        pxt.tickEvent('errorlist.goto', { errorIndex: index }, { interactiveConsent: true });
         this.props.goToError(e)
     }
 
@@ -136,7 +136,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
 
                     if (!location) return null;
 
-                    return <ErrorListItem key={index} index={index} stackframe={sf} location={location} revealError={this.onErrorMessageClick}/>
+                    return <ErrorListItem key={index} index={index} stackframe={sf} location={location} revealError={this.onErrorMessageClick} />
                 })}
             </div>
         </div>;
@@ -163,7 +163,7 @@ class ErrorListItem extends React.Component<ErrorListItemProps, ErrorListItemSta
     }
 
     render() {
-        const {error, stackframe, location} = this.props
+        const { error, stackframe, location } = this.props
 
         const message = stackframe ?
             stackFrameMessageStringWithLineNumber(stackframe, location) :
@@ -171,10 +171,10 @@ class ErrorListItem extends React.Component<ErrorListItemProps, ErrorListItemSta
         const errorCount = stackframe ? 1 : error.count;
 
         return <div className={`item ${stackframe ? 'stackframe' : ''}`} role="button"
-                    onClick={this.onErrorListItemClick}
-                    onKeyDown={sui.fireClickOnEnter}
-                    aria-label={lf("Go to {0}: {1}", stackframe ? '' : 'error', message)}
-                    tabIndex={0}>
+            onClick={this.onErrorListItemClick}
+            onKeyDown={sui.fireClickOnEnter}
+            aria-label={lf("Go to {0}: {1}", stackframe ? '' : 'error', message)}
+            tabIndex={0}>
             {message} {(errorCount <= 1) ? null : <div className="ui gray circular label countBubble">{errorCount}</div>}
         </div>
     }

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -209,5 +209,7 @@ function groupErrors(errors: pxtc.KsDiagnostic[]) {
             grouped.get(key).count++;
         }
     }
-    return [...grouped.values()].sort((a, b) => a.index - b.index);
+    const sorted: GroupedError[] = [];
+    grouped.forEach(value => sorted.push(value));
+    return sorted.sort((a, b) => a.index - b.index);
 }

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -48,10 +48,9 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
 
     render() {
         const {isCollapsed, errors, exception} = this.state;
-
-        const errorListContent = !isCollapsed ? (exception ? this.generateStackTraces(exception) : this.getCompilerErrors(errors)) : undefined;
         const errorsAvailable = !!errors?.length || !!exception;	
         const collapseTooltip = lf("Collapse Error List");
+        const errorListContent = !isCollapsed ? (exception ? this.generateStackTraces(exception) : this.getCompilerErrors(errors)) : undefined;
 
         return (
             <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''}`} hidden={!errorsAvailable}>

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -48,7 +48,7 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
 
     render() {
         const {isCollapsed, errors, exception} = this.state;
-        const errorsAvailable = !!errors?.length || !!exception;	
+        const errorsAvailable = !!errors?.length || !!exception;
         const collapseTooltip = lf("Collapse Error List");
         const errorListContent = !isCollapsed ? (exception ? this.generateStackTraces(exception) : this.getCompilerErrors(errors)) : undefined;
 

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -16,7 +16,6 @@
         "emitDecoratorMetadata": true,
         "declaration": false,
         "preserveConstEnums": true,
-        "downlevelIteration": true,
         "lib": [
             "dom",
             "dom.iterable",

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -16,6 +16,7 @@
         "emitDecoratorMetadata": true,
         "declaration": false,
         "preserveConstEnums": true,
+        "downlevelIteration": true,
         "lib": [
             "dom",
             "dom.iterable",


### PR DESCRIPTION
Duplicate compiler errors are grouped, and a count bubble is shown (if count > 1).

Before:
![image](https://user-images.githubusercontent.com/12176807/87212927-218e8680-c2d6-11ea-90ee-8f956a687761.png)

After:
![image](https://user-images.githubusercontent.com/12176807/87212935-2bb08500-c2d6-11ea-92df-128d4937a098.png)

(screenshots not taken from the same project, so total error count is different)

Fixes: https://github.com/microsoft/pxt-arcade/issues/2105