### PR TITLE
A couple tilemap bugs

### DIFF
--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -170,14 +170,6 @@ namespace pxt.editor {
         }
     }
 
-    const defaultTileset = `{
-        "*": {
-            "namespace": "myTiles",
-            "mimeType": "image/x-mkcd-f4",
-            "dataEncoding": "base64"
-          }
-    }`
-
     export const tilemapEditorDefinition: MonacoFieldEditorDefinition = {
         id: fieldEditorId,
         foldMatches: true,

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -8,15 +8,6 @@ namespace pxt.editor {
         protected tilemapName: string;
         protected isTilemapLiteral: boolean;
 
-        protected initAsync(): Promise<void> {
-            const projectTiles = this.host.readFile("tilemap.jres");
-            if (!projectTiles) {
-                return this.host.writeFileAsync("tilemap.jres", defaultTileset);
-            }
-
-            return Promise.resolve();
-        }
-
         protected textToValue(text: string): pxt.sprite.TilemapData {
             const tm = this.readTilemap(text);
 

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -196,7 +196,7 @@ namespace pxt.editor {
         weight: 5,
         matcher: {
             // match both JS and python
-            searchString: "(?:tilemap\\s*(?:`|\\(\"\"\")(?:[ a-zA-Z0-9\\.]|\\n)*\\s*(?:`|\"\"\"\\)))|(?:tiles\\s*\\.\\s*createTilemap\\s*\\([^\\)]+\\))",
+            searchString: "(?:tilemap\\s*(?:`|\\(\"\"\")(?:[ a-zA-Z0-9_]|\\n)*\\s*(?:`|\"\"\"\\)))|(?:tiles\\s*\\.\\s*createTilemap\\s*\\([^\\)]+\\))",
             isRegex: true,
             matchCase: true,
             matchWholeWord: false

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -135,7 +135,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && !files.some(f => f.name == localized);
             const hasDelete = deleteFiles
                 && file.name != pxt.CONFIG_NAME
-                && (usesGitHub || file.name != "main.ts");
+                && (usesGitHub || file.name != "main.ts")
+                && !file.isReadonly();
 
             return (
                 <FileTreeItem key={"file" + file.getName()}

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -19,8 +19,8 @@ export function setupAppTarget(trgbundle: pxt.TargetBundle) {
     pxt.setAppTarget(trgbundle)
 }
 
-const TILEMAP_CODE = "_tilemap.ts";
-const TILEMAP_JRES = "tilemap.jres";
+const TILEMAP_CODE = "tilemap.g.ts";
+const TILEMAP_JRES = "tilemap.g.jres";
 
 export class File implements pxt.editor.IFile {
     inSyncWithEditor = true;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2098

Also fixes part of the issue https://github.com/microsoft/pxt-arcade/issues/2125

And makes it so that the generated tilemap and tileset files can't be deleted