### PR TITLE
github: revert all + support for generated files

### DIFF
--- a/theme/github.less
+++ b/theme/github.less
@@ -127,6 +127,9 @@
                 color: @githubInvertedTextColor !important;
             }
         }
+        .ui.filediffs {
+            margin-top: 0.5rem;
+        }
         .diffheader {
             background: @mainMenuInvertedBackground !important;
         }

--- a/theme/github.less
+++ b/theme/github.less
@@ -41,7 +41,9 @@
         .ui.divider {
             margin-bottom: 5px;
         }
-
+        .ui.section {
+            margin-top: 1rem;
+        }
         .ui.segment.diff {
             padding: 0;
         }
@@ -126,9 +128,6 @@
             .meta, .description {
                 color: @githubInvertedTextColor !important;
             }
-        }
-        .ui.section {
-            margin-top: 0.5rem;
         }
         .diffheader {
             background: @mainMenuInvertedBackground !important;

--- a/theme/github.less
+++ b/theme/github.less
@@ -127,7 +127,7 @@
                 color: @githubInvertedTextColor !important;
             }
         }
-        .ui.filediffs {
+        .ui.section {
             margin-top: 0.5rem;
         }
         .diffheader {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -11,6 +11,7 @@ let hostCache = new db.Table("hostcache")
 let extWeight: pxt.Map<number> = {
     "ts": 10,
     "blocks": 20,
+    "jres": 25,
     "json": 30,
     "md": 40,
 }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -221,6 +221,15 @@ export class EditorPackage {
         return cfg && cfg.languageRestriction;
     }
 
+    getGeneratedFiles(file: File): File[] {
+        const GENERATED = ".g."
+        if (file.name.indexOf(GENERATED) > -1) {
+            const prefix = file.name.substring(0, file.name.indexOf(GENERATED) + GENERATED.length);
+            return Util.values(this.files).filter(vf => vf !== file && pxt.U.startsWith(vf.name, prefix));
+        }
+        return [];
+    }
+
     afterMainLoadAsync() {
         if (this.assetsPkg)
             return this.assetsPkg.loadAssetsAsync()

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -20,6 +20,7 @@ export function setupAppTarget(trgbundle: pxt.TargetBundle) {
     pxt.setAppTarget(trgbundle)
 }
 
+const GENERATED_EXTENSION = ".g."
 const TILEMAP_CODE = "tilemap.g.ts";
 const TILEMAP_JRES = "tilemap.g.jres";
 
@@ -223,9 +224,8 @@ export class EditorPackage {
     }
 
     getGeneratedFiles(file: File): File[] {
-        const GENERATED = ".g."
-        if (file.name.indexOf(GENERATED) > -1) {
-            const prefix = file.name.substring(0, file.name.indexOf(GENERATED) + GENERATED.length);
+        if (file.name.indexOf(GENERATED_EXTENSION) > -1) {
+            const prefix = file.name.substring(0, file.name.indexOf(GENERATED_EXTENSION) + GENERATED_EXTENSION.length);
             return Util.values(this.files).filter(vf => vf !== file && pxt.U.startsWith(vf.name, prefix));
         }
         return [];

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -553,14 +553,14 @@ export async function revertAllAsync(hd: Header) {
     // store pxt.json
     revertedFiles[pxt.CONFIG_NAME] = configEntry.blobContent;
     // go through all files and restore content
-    config.files.concat(config.testFiles).forEach(f => {
+    for (const f of config.files.concat(config.testFiles)) {
         const entry = pxt.github.lookupFile(commit, f);
         if (!entry || entry.blobContent === undefined) {
             pxt.log(`cannot revert ${f}, corrupted based commit`)
             return PullStatus.NoSourceControl
         }
         revertedFiles[f] = entry.blobContent;
-    })
+    }
     // save updated file content
     await forceSaveAsync(hd, revertedFiles)
 

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -550,9 +550,8 @@ export async function revertAllAsync(hd: Header) {
         return PullStatus.NoSourceControl
 
     const revertedFiles: pxt.Map<string> = {};
-    // store pxt.json
+    revertedFiles[GIT_JSON] = gitjsontext;
     revertedFiles[pxt.CONFIG_NAME] = configEntry.blobContent;
-    // go through all files and restore content
     for (const f of config.files.concat(config.testFiles)) {
         const entry = pxt.github.lookupFile(commit, f);
         if (!entry || entry.blobContent === undefined) {
@@ -563,7 +562,6 @@ export async function revertAllAsync(hd: Header) {
     }
     // save updated file content
     await forceSaveAsync(hd, revertedFiles)
-
     return PullStatus.UpToDate;
 }
 


### PR DESCRIPTION
* revert all button
![image](https://user-images.githubusercontent.com/4175913/87353106-078cb800-c511-11ea-8e1c-5966296830c7.png)
* revert sibling generated files
![image](https://user-images.githubusercontent.com/4175913/87358112-001ddc80-c51a-11ea-8d48-30d882aa9593.png)

fix for https://github.com/microsoft/pxt-arcade/issues/1964