### PR TITLE
Auto-complete: Rank symbols matching current parameter type higher; rank keywords lower

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1161,8 +1161,7 @@ namespace ts.pxtc.service {
                             paramIdx = callSym.parameters.length - 1
                         const paramType = getParameterTsType(callSym, paramIdx, blocksInfo)
                         if (paramType) {
-                            // if this is a property access, then weight the results higher if they return the
-                            // correct type for the parameter
+                            // weight the results higher if they return the correct type for the parameter
                             const MATCHING_TYPE_WEIGHT = 10
                             const matchingApis = getApisForTsType(paramType, call, tc, resultSymbols);
                             matchingApis.forEach(match => match.weight = MATCHING_TYPE_WEIGHT);

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1114,7 +1114,7 @@ namespace ts.pxtc.service {
             }
 
             if (resultSymbols.length === 0) {
-                // if we don't have a set of symbols yet, start with all global api symbols
+                // if by this point we don't yet have a specialized set of results (like those for member completion or a specific type for a call expression), use all global api symbols as the start (Monaco will filter and sort these based on the prefix user input)
                 resultSymbols = completionSymbols(pxt.U.values(lastApiInfo.apis.byQName), COMPLETION_DEFAULT_WEIGHT)
             }
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/2070

Fixes the way we were sorting completion symbols that match the type of the current parameter. Also deprioritized keywords by default since we only have them in the completion list so that we don't accidently auto complete a symbol when someone types "if".

After:
![2020-07-13 19 46 39](https://user-images.githubusercontent.com/6453828/87378049-d7114200-c541-11ea-8b82-0b2c69ce9786.gif)
