### PR TITLE
Fix signature help for Typescript

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -806,7 +806,7 @@ namespace ts.pxtc.service {
     }
 
     function addApiInfo(opts: CompileOptions) {
-        if (!opts.apisInfo && opts.target.preferredEditor == pxt.PYTHON_PROJECT_NAME) {
+        if (!opts.apisInfo) {
             const info = getLastApiInfo(opts);
             opts.apisInfo = U.clone(info.apis)
         }
@@ -874,41 +874,66 @@ namespace ts.pxtc.service {
         },
 
         syntaxInfo: v => {
-            // TODO: TypeScript currently only supports syntaxInfo for symbols
             let src: string = v.fileContent
             if (v.fileContent) {
                 host.setFile(v.fileName, v.fileContent);
             }
             let opts = cloneCompileOpts(host.opts)
             opts.fileSystem[v.fileName] = src
+            addApiInfo(opts);
             opts.syntaxInfo = {
                 position: v.position,
                 type: v.infoType
             };
 
             const isPython = opts.target.preferredEditor == pxt.PYTHON_PROJECT_NAME;
-            const isSymbol = opts.syntaxInfo.type === "symbol";
+            const isSymbolReq = opts.syntaxInfo.type === "symbol";
+            const isSignatureReq = opts.syntaxInfo.type === "signature";
 
             if (isPython) {
-                addApiInfo(opts);
                 let res = transpile.pyToTs(opts)
                 if (res.globalNames)
                     lastGlobalNames = res.globalNames
             }
-            else if (isSymbol) {
-                const info = getNodeAndSymbolAtLocation(service.getProgram(), v.fileName, v.position, getLastApiInfo(opts).apis);
+            else {
+                // typescript
+                opts.ast = true;
+                host.setOpts(opts)
+                const res = runConversionsAndCompileUsingService()
+                const prog = service.getProgram()
+                const tsAst = prog.getSourceFile(v.fileName)
+                const tc = prog.getTypeChecker()
 
-                if (info) {
-                    const [node, sym] = info;
-                    if (sym) {
-                        opts.syntaxInfo.symbols = [sym];
-                        opts.syntaxInfo.beginPos = node.getStart();
-                        opts.syntaxInfo.endPos = node.getEnd();
+                if (isSymbolReq || isSignatureReq) {
+                    let tsNode = findInnerMostNodeAtPosition(tsAst, v.position);
+                    if (tsNode) {
+                        if (isSymbolReq) {
+                            const symbol = tc.getSymbolAtLocation(tsNode);
+                            if (symbol) {
+                                let pxtSym = getPxtSymbolFromTsSymbol(symbol, opts.apisInfo, tc)
+                                opts.syntaxInfo.symbols = [pxtSym];
+                                opts.syntaxInfo.beginPos = tsNode.getStart();
+                                opts.syntaxInfo.endPos = tsNode.getEnd();
+                            }
+                        }
+                        else if (isSignatureReq) {
+                            const pxtCall = tsNode.pxt.callInfo
+                            const pxtSym = opts.apisInfo.byQName[pxtCall.qName]
+                            opts.syntaxInfo.symbols = [pxtSym];
+                            opts.syntaxInfo.beginPos = tsNode.getStart();
+                            opts.syntaxInfo.endPos = tsNode.getEnd();
+
+                            const tsCall = getParentCallExpression(tsNode)
+                            if (tsCall) {
+                                const argIdx = findCurrentCallArgIdx(tsCall, tsNode, v.position)
+                                opts.syntaxInfo.auxResult = argIdx
+                            }
+                        }
                     }
                 }
             }
 
-            if (isSymbol && !opts.syntaxInfo.symbols?.length) {
+            if (isSymbolReq && !opts.syntaxInfo.symbols?.length) {
                 const possibleKeyword = getWordAtPosition(v.fileContent, v.position);
                 if (possibleKeyword) {
                     // In python if range() is used in a for-loop, we don't convert
@@ -942,14 +967,16 @@ namespace ts.pxtc.service {
 
             if (opts.syntaxInfo.symbols?.length) {
                 const apiInfo = getLastApiInfo(opts).apis;
-                opts.syntaxInfo.symbols = opts.syntaxInfo.symbols.map(s => {
-                    // symbol info gathered during the py->ts compilation phase
-                    // is less precise than the symbol info created when doing
-                    // a pass over ts, so we prefer the latter if available
-                    return apiInfo.byQName[s.qName] || s
-                })
+                if (isPython) {
+                    opts.syntaxInfo.symbols = opts.syntaxInfo.symbols.map(s => {
+                        // symbol info gathered during the py->ts compilation phase
+                        // is less precise than the symbol info created when doing
+                        // a pass over ts, so we prefer the latter if available
+                        return apiInfo.byQName[s.qName] || s
+                    })
+                }
 
-                if (isSymbol) {
+                if (isSymbolReq) {
                     opts.syntaxInfo.auxResult = opts.syntaxInfo.symbols.map(s =>
                         displayStringForSymbol(s, isPython, apiInfo))
                 }
@@ -1107,42 +1134,10 @@ namespace ts.pxtc.service {
             }
 
             // special handling for call expressions
-            if (tsNode && tsNode.parent && ts.isCallExpression(tsNode.parent)) {
-                const call = tsNode.parent as ts.CallExpression;
-
-                function findArgIdx() {
-                    // does our cursor syntax node trivially map to an argument?
-                    let paramIdx = call.arguments
-                        .map(a => a === tsNode)
-                        .indexOf(true)
-                    if (paramIdx >= 0)
-                        return paramIdx
-
-                    // is our cursor within the argument range?
-                    const inRange = call.arguments.pos <= tsPos && tsPos < call.end
-                    if (!inRange)
-                        return -1
-
-                    // no arguments?
-                    if (call.arguments.length === 0)
-                        return 0
-
-                    // then find which argument we're refering to
-                    paramIdx = 0;
-                    for (let a of call.arguments) {
-                        if (a.end <= tsPos)
-                            paramIdx++
-                        else
-                            break
-                    }
-                    if (!call.arguments.hasTrailingComma)
-                        paramIdx = Math.max(0, paramIdx - 1)
-
-                    return paramIdx
-                }
-
+            const call = getParentCallExpression(tsNode)
+            if (call) {
                 // which argument are we ?
-                let paramIdx = findArgIdx()
+                let paramIdx = findCurrentCallArgIdx(call, tsNode, tsPos)
 
                 // if we're not one of the arguments, are we at the
                 // determine parameter idx
@@ -1580,6 +1575,48 @@ namespace ts.pxtc.service {
         projectSearchClear: () => {
             lastProjectFuse = undefined;
         }
+    }
+
+    function getParentCallExpression(tsNode: Node): ts.CallExpression | undefined {
+        while (tsNode && !ts.isCallExpression(tsNode)) {
+            if (ts.isBlock(tsNode.parent))
+                return undefined // we don't want to traverse through a block scope (e.g. an anonymous function)
+            tsNode = tsNode.parent
+        }
+        if (tsNode && ts.isCallExpression(tsNode))
+            return tsNode as ts.CallExpression
+        return undefined
+    }
+
+    function findCurrentCallArgIdx(call: ts.CallExpression, tsNode: Node, tsPos: number) {
+        // does our cursor syntax node trivially map to an argument?
+        let paramIdx = call.arguments
+            .map(a => a === tsNode)
+            .indexOf(true)
+        if (paramIdx >= 0)
+            return paramIdx
+
+        // is our cursor within the argument range?
+        const inRange = call.arguments.pos <= tsPos && tsPos < call.end
+        if (!inRange)
+            return -1
+
+        // no arguments?
+        if (call.arguments.length === 0)
+            return 0
+
+        // then find which argument we're refering to
+        paramIdx = 0;
+        for (let a of call.arguments) {
+            if (a.end <= tsPos)
+                paramIdx++
+            else
+                break
+        }
+        if (!call.arguments.hasTrailingComma)
+            paramIdx = Math.max(0, paramIdx - 1)
+
+        return paramIdx
     }
 
     function getCallSymbol(callExp: CallExpression): SymbolInfo {// pxt symbol

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -917,16 +917,18 @@ namespace ts.pxtc.service {
                             }
                         }
                         else if (isSignatureReq) {
-                            const pxtCall = tsNode.pxt.callInfo
-                            const pxtSym = opts.apisInfo.byQName[pxtCall.qName]
-                            opts.syntaxInfo.symbols = [pxtSym];
-                            opts.syntaxInfo.beginPos = tsNode.getStart();
-                            opts.syntaxInfo.endPos = tsNode.getEnd();
+                            const pxtCall = tsNode?.pxt?.callInfo
+                            if (pxtCall) {
+                                const pxtSym = opts.apisInfo.byQName[pxtCall.qName]
+                                opts.syntaxInfo.symbols = [pxtSym];
+                                opts.syntaxInfo.beginPos = tsNode.getStart();
+                                opts.syntaxInfo.endPos = tsNode.getEnd();
 
-                            const tsCall = getParentCallExpression(tsNode)
-                            if (tsCall) {
-                                const argIdx = findCurrentCallArgIdx(tsCall, tsNode, v.position)
-                                opts.syntaxInfo.auxResult = argIdx
+                                const tsCall = getParentCallExpression(tsNode)
+                                if (tsCall) {
+                                    const argIdx = findCurrentCallArgIdx(tsCall, tsNode, v.position)
+                                    opts.syntaxInfo.auxResult = argIdx
+                                }
                             }
                         }
                     }
@@ -1579,7 +1581,7 @@ namespace ts.pxtc.service {
 
     function getParentCallExpression(tsNode: Node): ts.CallExpression | undefined {
         while (tsNode && !ts.isCallExpression(tsNode)) {
-            if (ts.isBlock(tsNode.parent))
+            if (ts.isBlock(tsNode))
                 return undefined // we don't want to traverse through a block scope (e.g. an anonymous function)
             tsNode = tsNode.parent
         }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/2071

We hadn't implemented finding the current call expression and current argument for signature help in Typescript using our own language service, so I fixed that and did a little refactoring as well.

After:
![2020-07-14 11 44 30](https://user-images.githubusercontent.com/6453828/87464128-76c4e380-c5c7-11ea-9d08-81dccce87ac3.gif)

And a bonus fix for an unfiled bug.
Before:
![2020-07-14 11 57 25](https://user-images.githubusercontent.com/6453828/87465281-3a928280-c5c9-11ea-9fd8-9bf392e70330.gif)

After:
![2020-07-14 11 56 02](https://user-images.githubusercontent.com/6453828/87465193-159e0f80-c5c9-11ea-85c6-5948dc05487b.gif)

