### PR TITLE
Line break arrays if blocks have external inputs

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -755,7 +755,7 @@ namespace pxt.blocks {
         let args = b.inputList.map(input => input.connection && input.connection.targetBlock() ? compileExpression(e, input.connection.targetBlock(), comments) : undefined)
             .filter(e => !!e);
 
-        return H.mkArrayLiteral(args);
+        return H.mkArrayLiteral(args, !b.getInputsInline());
     }
 
     function compileListGet(e: Environment, b: Blockly.Block, comments: string[]): JsNode {

--- a/pxtlib/jsoutput.ts
+++ b/pxtlib/jsoutput.ts
@@ -105,10 +105,10 @@ namespace pxt.blocks {
     // A series of utility functions for constructing various J* AST nodes.
     export namespace Helpers {
 
-        export function mkArrayLiteral(args: JsNode[]) {
+        export function mkArrayLiteral(args: JsNode[], withNewlines?: boolean) {
             return mkGroup([
                 mkText("["),
-                mkCommaSep(args, false),
+                mkCommaSep(args, withNewlines),
                 mkText("]")
             ])
         }


### PR DESCRIPTION
Matches line breaks for function calls (breaks based on block shape)

For https://github.com/microsoft/pxt-arcade/issues/2143