### PR TITLE
collect client size

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3963,8 +3963,10 @@ function enableAnalytics() {
         stats["screen.innerHeight"] = window.innerHeight;
         stats["screen.devicepixelratio"] = pxt.BrowserUtils.devicePixelRatio();
         const body = document.firstElementChild; // body
-        stats["screen.clientWidth"] = body.clientWidth;
-        stats["screen.clientHeight"] = body.clientHeight;
+        if (body) {
+            stats["screen.clientWidth"] = body.clientWidth;
+            stats["screen.clientHeight"] = body.clientHeight;
+        }
     }
     pxt.tickEvent("editor.loaded", stats);
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3962,6 +3962,9 @@ function enableAnalytics() {
         stats["screen.innerWidth"] = window.innerWidth;
         stats["screen.innerHeight"] = window.innerHeight;
         stats["screen.devicepixelratio"] = pxt.BrowserUtils.devicePixelRatio();
+        const body = document.firstElementChild; // body
+        stats["screen.clientWidth"] = body.clientWidth;
+        stats["screen.clientHeight"] = body.clientHeight;
     }
     pxt.tickEvent("editor.loaded", stats);
 }


### PR DESCRIPTION
We don't collect that actual size of the document in our analytics; so we don't know how much space is lost with toolbars, etc...