### PR TITLE
bump pxt-blockly

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.19",
+    "pxt-blockly": "3.0.20",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
bumping pxt-blockly to include a fix to my recent changes to that repo.

Looks like the pxt-blockly npm package is automatically published for new tags, cool!
