### PR TITLE
Objects should not be assignable to Function type

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -400,9 +400,15 @@ declare function parseFloat(text: string): number;
 declare function randint(min: number, max: number): number;
 
 interface Object { }
-interface Function { }
-interface IArguments { }
-interface RegExp { }
+interface Function {
+  __assignableToFunction: Function;
+}
+interface IArguments { 
+  __assignableToIArguments: IArguments;
+}
+interface RegExp { 
+  __assignableToRegExp: RegExp;
+}
 type TemplateStringsArray = Array<string>;
 
 type uint8 = number;


### PR DESCRIPTION
Before this change the following code would pass the type checker:

```typescript
const foobar = 1
foobar()
```

This was problematic because people were using `sprite.x()` or something, which would kind of work, except the return type would be `any`.

Note that this may break existing scripts, but I would rather take it and have people fix the scripts. The current behavior is non-standard, confusing, and bug-prone.

Fixes https://github.com/microsoft/pxt-arcade/issues/2019
