### PR TITLE
Set canIndentInside to true for multiline arguments

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1261,7 +1261,9 @@ namespace pxt.blocks {
                 }
             }
 
-            return mkText(f);
+            let text = mkText(f)
+            text.canIndentInside = typeof f == "string" && f.indexOf('\n') >= 0;
+            return text;
         }
         else {
             attachPlaceholderIf(e, b, p.definitionName);


### PR DESCRIPTION
Fixes TS image literal indentation https://github.com/microsoft/pxt-arcade/issues/2143