### PR TITLE
Try to parse 'any' values when emitting snippets

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1919,6 +1919,9 @@ namespace ts.pxtc.service {
                     return snippet
                 }
                 return attrs.paramDefl[name];
+            } else {
+                // default to empty string
+                return "\"\"";
             }
 
             function getDefaultValueOfType(type: ts.Type): SnippetNode | undefined {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1919,9 +1919,6 @@ namespace ts.pxtc.service {
                     return snippet
                 }
                 return attrs.paramDefl[name];
-            } else {
-                // default to empty string
-                return "\"\"";
             }
 
             function getDefaultValueOfType(type: ts.Type): SnippetNode | undefined {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1897,21 +1897,22 @@ namespace ts.pxtc.service {
 
             // check for explicit default in the attributes
             if (attrs && attrs.paramDefl && attrs.paramDefl[name]) {
-                // if (typeNode.kind == SK.AnyKeyword) {
-                //     if (typeNode.) {
-                //         // try to parse as a number
-                //         typeNode.kind = SK.NumberKeyword;
-                //     } else if () {
-                //         // try to parse as a bool
-                //         typeNode.kind = SK.BooleanKeyword;
-                //     } else if () {
-                //         // try to parse as an enum
-                //         typeNode.kind = SK.EnumKeyword;
-                //     } else if () {
-                //         // And then make it a string
-                //         typeNode.kind = SK.StringKeyword;
-                //     }
-                // }
+                if (typeNode.kind == SK.AnyKeyword) {
+                    const defaultName = attrs.paramDefl[name].toUpperCase();
+                    if (!Number.isNaN(+defaultName)) {
+                        // try to parse as a number
+                        typeNode.kind = SK.NumberKeyword;
+                    } else if (defaultName == "FALSE" || defaultName == "TRUE") {
+                        // try to parse as a bool
+                        typeNode.kind = SK.BooleanKeyword;
+                    } else if (defaultName.includes(".")) {
+                        // try to parse as an enum
+                        typeNode.kind = SK.EnumKeyword;
+                    } else {
+                        // otherwise it'll be a string
+                        typeNode.kind = SK.StringKeyword;
+                    }
+                }
                 if (typeNode.kind == SK.StringKeyword) {
                     const defaultName = attrs.paramDefl[name];
                     const snippet = typeNode.kind == SK.StringKeyword && defaultName.indexOf(`"`) != 0 ? `"${defaultName}"` : defaultName;

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1897,6 +1897,21 @@ namespace ts.pxtc.service {
 
             // check for explicit default in the attributes
             if (attrs && attrs.paramDefl && attrs.paramDefl[name]) {
+                // if (typeNode.kind == SK.AnyKeyword) {
+                //     if (typeNode.) {
+                //         // try to parse as a number
+                //         typeNode.kind = SK.NumberKeyword;
+                //     } else if () {
+                //         // try to parse as a bool
+                //         typeNode.kind = SK.BooleanKeyword;
+                //     } else if () {
+                //         // try to parse as an enum
+                //         typeNode.kind = SK.EnumKeyword;
+                //     } else if () {
+                //         // And then make it a string
+                //         typeNode.kind = SK.StringKeyword;
+                //     }
+                // }
                 if (typeNode.kind == SK.StringKeyword) {
                     const defaultName = attrs.paramDefl[name];
                     const snippet = typeNode.kind == SK.StringKeyword && defaultName.indexOf(`"`) != 0 ? `"${defaultName}"` : defaultName;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2078

Two issues:
1. I'm a Javascript beginner, so lemme know if there are better ways to check for all these cases. 
2. Also I only tested for the sprite.say string changes. Are there other blocks I should test with?