### PR TITLE
Show 'hex file is not available' error when offline

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2447,10 +2447,9 @@ export class ProjectView
                     let fn = pxt.outputName()
                     if (!resp.outfiles[fn]) {
                         pxt.tickEvent("compile.noemit")
-                        const topDiagnostic = resp.diagnostics?.[0];
-                        // if "cannot download hex file" error
-                        if (topDiagnostic?.code === 9043) {
-                            core.warningNotification(topDiagnostic.messageText as string);
+                        const noHexFileDiagnostic = resp.diagnostics?.find(diag => diag.code === 9043);
+                        if (noHexFileDiagnostic) {
+                            core.warningNotification(noHexFileDiagnostic.messageText as string);
                         } else {
                             core.warningNotification(lf("Compilation failed, please check your code for errors."));
                         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2447,7 +2447,13 @@ export class ProjectView
                     let fn = pxt.outputName()
                     if (!resp.outfiles[fn]) {
                         pxt.tickEvent("compile.noemit")
-                        core.warningNotification(lf("Compilation failed, please check your code for errors."));
+                        const topDiagnostic = resp.diagnostics?.[0];
+                        // if "cannot download hex file" error
+                        if (topDiagnostic?.code === 9043) {
+                            core.warningNotification(topDiagnostic.messageText as string);
+                        } else {
+                            core.warningNotification(lf("Compilation failed, please check your code for errors."));
+                        }
                         return Promise.resolve(null)
                     }
                     resp.saveOnly = saveOnly


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2127 (the other error re: not getting the right hex file was fixed in https://github.com/microsoft/pxt/pull/7320)

Propagate the error message from https://github.com/microsoft/pxt/blob/master/pxtcompiler/emitter/emitter.ts#L967 in the toast

![image](https://user-images.githubusercontent.com/5615930/87609730-31341380-c6b8-11ea-9467-809cb5eccf8e.png)
