### PR TITLE
Remove save icon on snapshot PNGs

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -390,6 +390,7 @@ declare namespace pxt {
         openProjectNewDependentTab?: boolean; // allow opening project in a new tab -- connected
         tutorialExplicitHints?: boolean; // allow use explicit hints
         errorList?: boolean; // error list experiment
+        embedBlocksInSnapshot?: boolean; // embed blocks xml in right-click snapshot
     }
 
     interface SocialOptions {

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -183,7 +183,7 @@ namespace pxt.blocks.layout {
             };
         }
 
-        return toSvgAsync(ws, encodeBlocks)
+        return toSvgAsync(ws)
             .then(sg => {
                 if (!sg) return Promise.resolve<string>(undefined);
                 return toPngAsyncInternal(
@@ -239,7 +239,7 @@ namespace pxt.blocks.layout {
 
     const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
 
-    export function toSvgAsync(ws: Blockly.WorkspaceSvg, encodeBlocks?: boolean): Promise<{
+    export function toSvgAsync(ws: Blockly.WorkspaceSvg): Promise<{
         width: number; height: number; xml: string;
     }> {
         if (!ws)
@@ -251,7 +251,7 @@ namespace pxt.blocks.layout {
 
         let width = metrics.right - metrics.left;
         let height = metrics.bottom - metrics.top;
-        return blocklyToSvgAsync(sg, metrics.left, metrics.top, width, height, encodeBlocks);
+        return blocklyToSvgAsync(sg, metrics.left, metrics.top, width, height);
     }
 
     export function serializeNode(sg: Node): string {
@@ -298,7 +298,7 @@ namespace pxt.blocks.layout {
         return svg;
     }
 
-    export function blocklyToSvgAsync(sg: SVGElement, x: number, y: number, width: number, height: number, encodeBlocks?: boolean): Promise<BlockSvg> {
+    export function blocklyToSvgAsync(sg: SVGElement, x: number, y: number, width: number, height: number): Promise<BlockSvg> {
         if (!sg.childNodes[0])
             return Promise.resolve<BlockSvg>(undefined);
 
@@ -311,11 +311,6 @@ namespace pxt.blocks.layout {
             .replace(/<\/svg>\s*$/i, '') // strip out svg tag
         const svgXml = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="${XLINK_NAMESPACE}" width="${width}" height="${height}" viewBox="${x} ${y} ${width} ${height}" class="pxt-renderer">${xmlString}</svg>`;
         const xsg = new DOMParser().parseFromString(svgXml, "image/svg+xml");
-
-        if (encodeBlocks) {
-            const saveIcon = new pxt.svgUtil.Text("\uf0c7").at(x + width - 25, y + 20).setClass("semanticIcon inverted").el;
-            xsg.firstElementChild.appendChild(saveIcon);
-        }
 
         const cssLink = xsg.createElementNS("http://www.w3.org/1999/xhtml", "style");
         const isRtl = Util.isUserLanguageRtl();

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1573,7 +1573,7 @@ namespace pxt.blocks {
                     enabled: topBlocks.length > 0 || topComments.length > 0,
                     callback: () => {
                         pxt.tickEvent("blocks.context.screenshot", undefined, { interactiveConsent: true });
-                        pxt.blocks.layout.screenshotAsync(this, null, true)
+                        pxt.blocks.layout.screenshotAsync(this, null, pxt.appTarget.appTheme?.embedBlocksInSnapshot)
                             .done((uri) => {
                                 if (pxt.BrowserUtils.isSafari())
                                     uri = uri.replace(/^data:image\/[^;]/, 'data:application/octet-stream');

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -530,7 +530,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         // continue with commit
         let commitId = await workspace.commitAsync(header, {
             message: this.state.description,
-            blocksScreenshotAsync: () => this.props.parent.blocksScreenshotAsync(1, true),
+            blocksScreenshotAsync: () => this.props.parent.blocksScreenshotAsync(1, pxt.appTarget.appTheme?.embedBlocksInSnapshot),
             blocksDiffScreenshotAsync: () => {
                 const f = pkg.mainEditorPkg().sortedFiles().find(f => f.name == "main.blocks");
                 const diff = pxt.blocks.diffXml(f.baseGitContent, f.content);


### PR DESCRIPTION
Sample magic PNG:
![arcade-screenshot (43)](https://user-images.githubusercontent.com/34112083/87614049-e28c7680-c6c3-11ea-9984-fc8b34e07b1d.png)

Build: https://arcade.makecode.com/app/bc01e1b035506c04dd75e400027dce02bf91ea4e-d1be7e138a

Same as before, right-click -> Snapshot to generate PNG, drag into editor to load snippet