### PR TITLE
bring image blocks size back down to normal (reduce vert padding)

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -20,12 +20,13 @@ namespace pxtblockly {
     // 32 is specifically chosen so that we can scale the images for the default
     // sprite sizes without getting browser anti-aliasing
     const PREVIEW_WIDTH = 32;
-    const PADDING = 5;
+    const X_PADDING = 5;
+    const Y_PADDING = 1;
     const BG_PADDING = 4;
     const BG_WIDTH = BG_PADDING * 2 + PREVIEW_WIDTH;
     const ICON_WIDTH = 30;
-    const TOTAL_HEIGHT = PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
-    const TOTAL_WIDTH = TOTAL_HEIGHT + ICON_WIDTH;
+    const TOTAL_HEIGHT = Y_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
+    const TOTAL_WIDTH = X_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH + ICON_WIDTH;
 
     export class FieldAnimationEditor extends Blockly.Field implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
@@ -155,7 +156,7 @@ namespace pxtblockly {
             pxsim.U.clear(this.fieldGroup_);
 
             const bg = new svg.Rect()
-                .at(PADDING + ICON_WIDTH, PADDING)
+                .at(X_PADDING + ICON_WIDTH, Y_PADDING)
                 .size(BG_WIDTH, BG_WIDTH)
                 .corner(4)
                 .setClass("blocklyAnimationField");
@@ -163,7 +164,7 @@ namespace pxtblockly {
             this.fieldGroup_.appendChild(bg.el);
 
             const icon = new svg.Text("\uf008")
-                .at(PADDING, 5 + (TOTAL_HEIGHT >> 1))
+                .at(X_PADDING, 5 + (TOTAL_HEIGHT >> 1))
                 .fill((this.sourceBlock_ as Blockly.BlockSvg).getColourSecondary())
                 .setClass("semanticIcon");
 
@@ -173,7 +174,7 @@ namespace pxtblockly {
                 this.frames = this.state.frames.map(frame => bitmapToImageURI(pxt.sprite.Bitmap.fromData(frame), PREVIEW_WIDTH, this.lightMode));
                 this.preview = new svg.Image()
                     .src(this.frames[0])
-                    .at(PADDING + BG_PADDING + ICON_WIDTH, PADDING + BG_PADDING)
+                    .at(X_PADDING + BG_PADDING + ICON_WIDTH, Y_PADDING + BG_PADDING)
                     .size(PREVIEW_WIDTH, PREVIEW_WIDTH);
                 this.fieldGroup_.appendChild(this.preview.el);
             }

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -30,10 +30,12 @@ namespace pxtblockly {
     // 32 is specifically chosen so that we can scale the images for the default
     // sprite sizes without getting browser anti-aliasing
     const PREVIEW_WIDTH = 32;
-    const PADDING = 5;
+    const X_PADDING = 5;
+    const Y_PADDING = 1;
     const BG_PADDING = 4;
     const BG_WIDTH = BG_PADDING * 2 + PREVIEW_WIDTH;
-    const TOTAL_WIDTH = PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
+    const TOTAL_WIDTH = X_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
+    const TOTAL_HEIGHT = Y_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
 
     export class FieldSpriteEditor extends Blockly.Field implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
@@ -113,7 +115,7 @@ namespace pxtblockly {
 
         render_() {
             super.render_();
-            this.size_.height = TOTAL_WIDTH
+            this.size_.height = TOTAL_HEIGHT;
             this.size_.width = TOTAL_WIDTH;
         }
 
@@ -137,7 +139,7 @@ namespace pxtblockly {
             pxsim.U.clear(this.fieldGroup_);
 
             const bg = new svg.Rect()
-                .at(PADDING, PADDING)
+                .at(X_PADDING, Y_PADDING)
                 .size(BG_WIDTH, BG_WIDTH)
                 .setClass("blocklySpriteField")
                 .stroke("#898989", 1)
@@ -149,7 +151,7 @@ namespace pxtblockly {
                 const data = bitmapToImageURI(this.state, PREVIEW_WIDTH, this.lightMode);
                 const img = new svg.Image()
                     .src(data)
-                    .at(PADDING + BG_PADDING, PADDING + BG_PADDING)
+                    .at(X_PADDING + BG_PADDING, Y_PADDING + BG_PADDING)
                     .size(PREVIEW_WIDTH, PREVIEW_WIDTH);
                 this.fieldGroup_.appendChild(img.el);
             }

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -34,8 +34,8 @@ namespace pxtblockly {
     const Y_PADDING = 1;
     const BG_PADDING = 4;
     const BG_WIDTH = BG_PADDING * 2 + PREVIEW_WIDTH;
-    const TOTAL_WIDTH = X_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
     const TOTAL_HEIGHT = Y_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
+    const TOTAL_WIDTH = X_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
 
     export class FieldSpriteEditor extends Blockly.Field implements Blockly.FieldCustom {
         public isFieldCustom_ = true;

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -20,10 +20,12 @@ namespace pxtblockly {
     // 32 is specifically chosen so that we can scale the images for the default
     // sprite sizes without getting browser anti-aliasing
     const PREVIEW_WIDTH = 32;
-    const PADDING = 5;
+    const X_PADDING = 5;
+    const Y_PADDING = 1;
     const BG_PADDING = 4;
     const BG_WIDTH = BG_PADDING * 2 + PREVIEW_WIDTH;
-    const TOTAL_WIDTH = PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
+    const TOTAL_HEIGHT = Y_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
+    const TOTAL_WIDTH = X_PADDING * 2 + BG_PADDING * 2 + PREVIEW_WIDTH;
 
     export class FieldTilemap extends Blockly.Field implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
@@ -172,7 +174,7 @@ namespace pxtblockly {
             super.render_();
 
             if (!this.isGreyBlock) {
-                this.size_.height = TOTAL_WIDTH
+                this.size_.height = TOTAL_HEIGHT;
                 this.size_.width = TOTAL_WIDTH;
             }
         }
@@ -219,7 +221,7 @@ namespace pxtblockly {
             }
 
             const bg = new svg.Rect()
-                .at(PADDING, PADDING)
+                .at(X_PADDING, Y_PADDING)
                 .size(BG_WIDTH, BG_WIDTH)
                 .setClass("blocklyTilemapField")
                 .corner(4);
@@ -230,7 +232,7 @@ namespace pxtblockly {
                 const data = tilemapToImageURI(this.state, PREVIEW_WIDTH, this.lightMode, this.blocksInfo);
                 const img = new svg.Image()
                     .src(data)
-                    .at(PADDING + BG_PADDING, PADDING + BG_PADDING)
+                    .at(X_PADDING + BG_PADDING, Y_PADDING + BG_PADDING)
                     .size(PREVIEW_WIDTH, PREVIEW_WIDTH);
                 this.fieldGroup_.appendChild(img.el);
             }


### PR DESCRIPTION
Reduce vertical padding around img blocks back down to what it is on live site:

live site:

![image](https://user-images.githubusercontent.com/5615930/87634686-9f95c780-c6f2-11ea-8800-e2d7e0289789.png)

/beta:

![image](https://user-images.githubusercontent.com/5615930/87634649-8c82f780-c6f2-11ea-92d2-b589669e8196.png)

after this change:

![image](https://user-images.githubusercontent.com/5615930/87634945-1d59d300-c6f3-11ea-834c-5cd0adf17224.png)

Not certain why this behavior changed; this code hasn't changed for ~2 years, so it seems like it must have been being compressed vertically in blockly and that got changed with the new renderer? I could look around if we want, but maybe after release