### PR TITLE
Only add parenthesis to method and function snippets

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -2169,7 +2169,7 @@ namespace ts.pxtc.service {
             snippet = [preDefinedSnippet];
         } else {
             snippet = [fnName];
-            if (args?.length || element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Function) {
+            if (args?.length || element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Function || element.kind == pxtc.SymbolKind.Class) {
                 const argsWithCommas = args.reduce((p: SnippetNode[], n) => [...p, p.length ? ", " : "", n], []) as SnippetNode[]
                 snippet = snippet.concat(["(", ...argsWithCommas, ")"]);
             }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -2168,8 +2168,11 @@ namespace ts.pxtc.service {
         if (preDefinedSnippet) {
             snippet = [preDefinedSnippet];
         } else {
-            const argsWithCommas = args.reduce((p: SnippetNode[], n) => [...p, p.length ? ", " : "", n], []) as SnippetNode[]
-            snippet = [fnName, "(", ...argsWithCommas, ")"];
+            snippet = [fnName];
+            if (args?.length || element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Function) {
+                const argsWithCommas = args.reduce((p: SnippetNode[], n) => [...p, p.length ? ", " : "", n], []) as SnippetNode[]
+                snippet = snippet.concat(["(", ...argsWithCommas, ")"]);
+            }
         }
         let insertText = snippetPrefix ? [snippetPrefix, ".", ...snippet] : snippet;
         insertText = addNamespace ? [firstWord(namespaceToUse), ".", ...insertText] : insertText;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -146,12 +146,13 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                     // them with commas so that we don't confuse the fuzzy matcher in monaco
                     const filterText = `${label},${documentation},${block}`.replace(/\s/g, ",")
 
+                    const kind = this.tsKindToMonacoKind(si.kind);
                     let res: monaco.languages.CompletionItem = {
                         label: label,
                         range,
-                        kind: this.tsKindToMonacoKind(si.kind),
+                        kind,
                         documentation,
-                        detail: snippetWithoutMarkers,
+                        detail: `(${monaco.languages.CompletionItemKind[kind].toLowerCase()}) ${snippetWithoutMarkers || ""}`,
                         // force monaco to use our sorting
                         sortText: `${tosort(i)} ${snippet}`,
                         filterText: filterText,


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2177

Fixes completions for properties, also adds back in the "(method)", "(property)" preview text in the autocomplete list--easy to remove if it seems cluttered but it felt helpful to me.

![fix-completions](https://user-images.githubusercontent.com/34112083/87690792-bcf08300-c73e-11ea-9ab3-d43accccc6a4.gif)
