### PR TITLE
Fix emit order

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1003,7 +1003,15 @@ namespace ts.pxtc {
 
         let allStmts: Statement[] = [];
         if (!opts.forceEmit || res.diagnostics.length == 0) {
-            const files = program.getSourceFiles();
+            let files = program.getSourceFiles().slice();
+
+            const main = files.find(sf => sf.fileName === "main.ts");
+
+            if (main) {
+                files = files.filter(sf => sf.fileName !== "main.ts");
+                files.push(main);
+            }
+
             files.forEach(f => {
                 f.statements.forEach(s => {
                     allStmts.push(s)


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2190

I'm not sure how this got out of sync, but for some reason the emit order sometimes changes on the program. Make sure main.ts is always last.