### PR TITLE
Update virtual python file before typecheck

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2255,6 +2255,12 @@ export class ProjectView
         const fromText = this.editorFile.content;
 
         let promise = open ? this.textEditor.loadMonacoAsync() : Promise.resolve();
+
+        // Python uses the virtual file and not the current editor content, so sync content
+        if (fromLanguage == "py") {
+            promise = promise.then(() => this.editorFile.setContentAsync(this.editor.getCurrentSource()));
+        }
+
         promise = promise
             .then(() => {
                 if (open) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2167
Fixes https://github.com/microsoft/pxt-arcade/issues/2176

Python is pulling from the virtual file system, so it's compiling the last saved version instead of what is currently in the editor. This forces a sync before running py->ts and saving. Swapping the order of the calls to setContentAsync and saveTypeScriptAsync in "saveFileAsync" also works, but I think this is the less intrusive fix... I didn't want to mess up anything with the saveFileAsync code.