### PR TITLE
Fix blocks upgrades with tilemaps

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -729,9 +729,13 @@ function upgradeFromBlocksAsync(): Promise<UpgradeResult> {
             return project.buildTilemapsAsync();
         })
         .then(() => {
-            if (project.getAllFiles()["tilemap.g.ts"]) {
-                patchedFiles["tilemap.g.ts"] = project.getAllFiles()["tilemap.g.ts"];
+            const compiledFiles = project.getAllFiles();
+            const generatedFileNames = Object.keys(compiledFiles).filter(el => /\.g\.ts/.test(el));
+
+            for (const fname of generatedFileNames) {
+                patchedFiles[fname] = compiledFiles[fname];
             }
+
             return checkPatchAsync(patchedFiles);
         })
         .then(() => {

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -730,9 +730,9 @@ function upgradeFromBlocksAsync(): Promise<UpgradeResult> {
         })
         .then(() => {
             const compiledFiles = project.getAllFiles();
-            const generatedFileNames = Object.keys(compiledFiles).filter(el => /\.g\.ts/.test(el));
+            const otherFiles = Object.keys(compiledFiles).filter(el => !/^main\.(blocks|ts|py)$/.test(el));
 
-            for (const fname of generatedFileNames) {
+            for (const fname of otherFiles) {
                 patchedFiles[fname] = compiledFiles[fname];
             }
 


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/pull/2197, this fixes blocks upgrades when there's a tilemap.

The issue was that the blocks compile was generating `main.ts` as if `tilemap.g.ts` exists, so it didn't have the namespace at the top. This adds on to the blocks patch logic to copy over the generated files to the patch when we're validating that it creates an okay program. 

This feels like potentially a bit too much tilemap specific logic in the upgrade logic, but not sure where a better fix would be.