### PR TITLE
setBackgroundImage snippet improvements

### DIFF
--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -168,6 +168,8 @@ namespace pxtblockly {
     }
 
     function parseFieldOptions(opts: FieldSpriteEditorOptions) {
+        // NOTE: This implementation is duplicated in pxtcompiler/emitter/service.ts
+        // TODO: Refactor to share implementation.
         const parsed: ParsedSpriteEditorOptions = {
             initColor: 1,
             initWidth: 16,

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -2025,13 +2025,12 @@ namespace ts.pxtc.service {
             }
 
             function getDefaultValueFromFieldEditor(paramName: string): SnippetNode | null {
-                const blockParam = attrs._def?.parameters?.find((p) => p.name === name);
+                const compileInfo = pxt.blocks.compileInfo(fn)
+                const blockParam = compileInfo.parameters?.find((p) => p.actualName === name)
                 if (!blockParam?.shadowBlockId)
                     return null
                 let sym = blocksById[blockParam.shadowBlockId]
                 if (!sym)
-                    return null
-                if (sym.attributes?.blockId !== blockParam.shadowBlockId)
                     return null
                 const fieldEditor = sym.attributes?.paramFieldEditor
                 if (!fieldEditor)

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -598,7 +598,7 @@ namespace pxt.sprite {
         return result;
     }
 
-    export function bitmapToImageLiteral(bitmap: Bitmap, fileType: "typescript" | "python"): string {
+    function imageLiteralPrologue(fileType: "typescript" | "python"): string {
         let res = '';
         switch (fileType) {
             case "python":
@@ -608,6 +608,40 @@ namespace pxt.sprite {
                 res = "img`";
                 break;
         }
+        return res;
+    }
+
+    function imageLiteralEpilogue(fileType: "typescript" | "python"): string {
+        let res = '';
+        switch (fileType) {
+            case "python":
+                res += "\"\"\")";
+                break;
+            default:
+                res += "`";
+                break;
+        }
+        return res;
+    }
+
+    export function imageLiteralFromDimensions(width: number, height: number, color: number, fileType: "typescript" | "python"): string {
+        let res = imageLiteralPrologue(fileType);
+
+        for (let r = 0; r < height; r++) {
+            res += "\n"
+            for (let c = 0; c < width; c++) {
+                res += hexChars[color] + " ";
+            }
+        }
+
+        res += "\n";
+        res += imageLiteralEpilogue(fileType);
+
+        return res;
+    }
+
+    export function bitmapToImageLiteral(bitmap: Bitmap, fileType: "typescript" | "python"): string {
+        let res = imageLiteralPrologue(fileType);
 
         if (bitmap) {
             for (let r = 0; r < bitmap.height; r++) {
@@ -619,15 +653,7 @@ namespace pxt.sprite {
         }
 
         res += "\n";
-
-        switch (fileType) {
-            case "python":
-                res += "\"\"\")";
-                break;
-            default:
-                res += "`";
-                break;
-        }
+        res += imageLiteralEpilogue(fileType);
 
         return res;
     }


### PR DESCRIPTION
Resolves https://github.com/microsoft/pxt-arcade/issues/2169

With this change, when the user types or drags `scene.setBackgroundImage(...`, it creates an image literal the same dimensions as the screen.

**Rough edge**: The resulting snippet is 120-ish lines long, _and isn't automatically collapsed after being inserted_. Which is kind of bad. One fix would be to make snippets optionally foldable, perhaps parameterized from a block comment. That might be a lot of additional code, and seems separate from this change.

Tested with JS and PY.

