### PR TITLE
github integration: include version info in pxt.json and use it on import

### DIFF
--- a/pxtlib/diff.ts
+++ b/pxtlib/diff.ts
@@ -533,6 +533,7 @@ namespace pxt.diff {
                         break;
                     case "languageRestriction":
                     case "preferredEditor":
+                    case "targetVersion":
                         r[key] = vA; // keep current one
                         break;
                     case "public":

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -657,7 +657,7 @@ export function applyUpgradesAsync(): Promise<UpgradeResult> {
     const pkgVersion = pxt.semver.parse(epkg.header.targetVersion || "0.0.0");
     const trgVersion = pxt.semver.parse(pxt.appTarget.versions.target);
 
-    if (pxt.semver.cmp(pkgVersion, trgVersion) !== 0) {
+    if (pxt.semver.cmp(pkgVersion, trgVersion) === 0) {
         pxt.debug("Skipping project upgrade")
         return Promise.resolve({
             success: true

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -657,7 +657,7 @@ export function applyUpgradesAsync(): Promise<UpgradeResult> {
     const pkgVersion = pxt.semver.parse(epkg.header.targetVersion || "0.0.0");
     const trgVersion = pxt.semver.parse(pxt.appTarget.versions.target);
 
-    if (pkgVersion.major === trgVersion.major && pkgVersion.minor === trgVersion.minor) {
+    if (pxt.semver.cmp(pkgVersion, trgVersion) !== 0) {
         pxt.debug("Skipping project upgrade")
         return Promise.resolve({
             success: true

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -937,6 +937,10 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
     gitjson.commit = commit
     files[GIT_JSON] = JSON.stringify(gitjson, null, 4)
 
+    /**
+     * If the repo was last opened in this target, use that version number in the header;
+     * otherwise, use current target version to avoid mismatched updates.
+     */
     const targetVersionToUse = (cfg.targetVersions?.targetId === pxt.appTarget.id && cfg.targetVersions.target) ?
         cfg.targetVersions.target : pxt.appTarget.versions.target;
 
@@ -1082,6 +1086,7 @@ export function prepareConfigForGithub(content: string, createRelease?: boolean)
         cfg.supportedTargets = supportedTargets;
     }
 
+    // track target and target version this was last editted in, so we can apply upgrade rules on import.
     cfg.targetVersions = {
         ...cfg.targetVersions,
         target: pxt.appTarget.versions.target,

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -937,6 +937,9 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
     gitjson.commit = commit
     files[GIT_JSON] = JSON.stringify(gitjson, null, 4)
 
+    const targetVersionToUse = (cfg.targetVersions?.targetId === pxt.appTarget.id && cfg.targetVersions.target) ?
+        cfg.targetVersions.target : pxt.appTarget.versions.target;
+
     if (!hd) {
         hd = await installAsync({
             name: cfg.name,
@@ -946,7 +949,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
             meta: {},
             editor: pxt.BLOCKS_PROJECT_NAME,
             target: pxt.appTarget.id,
-            targetVersion: cfg.targetVersions?.target || pxt.appTarget.versions.target,
+            targetVersion: targetVersionToUse,
         }, files)
     } else {
         hd.name = cfg.name
@@ -1081,7 +1084,8 @@ export function prepareConfigForGithub(content: string, createRelease?: boolean)
 
     cfg.targetVersions = {
         ...cfg.targetVersions,
-        target: pxt.appTarget.versions.target
+        target: pxt.appTarget.versions.target,
+        targetId: pxt.appTarget.id
     }
 
     // patch dependencies

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -921,6 +921,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         if (!justJSON)
             files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
     }
+
     if (!justJSON) {
         // if any block needs decompilation, don't allow merge error markers
         if (blocksNeedDecompilation && conflicts)
@@ -945,7 +946,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
             meta: {},
             editor: pxt.BLOCKS_PROJECT_NAME,
             target: pxt.appTarget.id,
-            targetVersion: pxt.appTarget.versions.target,
+            targetVersion: cfg.targetVersions?.target || pxt.appTarget.versions.target,
         }, files)
     } else {
         hd.name = cfg.name
@@ -1069,7 +1070,6 @@ export function prepareConfigForGithub(content: string, createRelease?: boolean)
     delete (<any>cfg).installedVersion // cleanup old pxt.json files
     delete cfg.additionalFilePath
     delete cfg.additionalFilePaths
-    delete cfg.targetVersions;
 
     // add list of supported targets
     const supportedTargets = cfg.supportedTargets || [];
@@ -1077,6 +1077,11 @@ export function prepareConfigForGithub(content: string, createRelease?: boolean)
         supportedTargets.push(pxt.appTarget.id);
         supportedTargets.sort(); // keep list stable
         cfg.supportedTargets = supportedTargets;
+    }
+
+    cfg.targetVersions = {
+        ...cfg.targetVersions,
+        target: pxt.appTarget.versions.target
     }
 
     // patch dependencies


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/pull/2197 not upgrading scripts imported from github

The issue is that we don't store any editor version info in the github repo, and instead just make it apply the current version, so none of the upgrade rules were applying when importing a github script. (Previously loaded ones are fine)

Unfortunately, I don't think there's actually a way to fix this one for the current release, as the information just isn't there; we can't safely pretend like the script is from `0.0.0` and run all the upgrade rules because they don't necessarily work when reapplied (e.g. SpriteKind upgrade rule would break new scripts, etc). This change should make it work for the future as it makes the version number available in pxt.json

if we want to hack in a fix for any particular repo, easy enough to patch the pxt.json and add in the targetVersions field, and this change would then pick that up / apply upgrade rules

as a side fix, also changes the upgrade logic to apply upgrade rules when any part of the version is different; it was bailing out early on patch changes, which could result in patches being missed / we don't consistently update minor version along with minor breaking changes that need patches.