### PR TITLE
fix runtime error toast

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -804,8 +804,6 @@ export class ProjectView
             orphanException: brk => {
                 // TODO: start debugging session
                 // TODO: user friendly error message
-                //core.warningNotification(lf("Program Error: {0}", brk.exceptionMessage));
-                //this.currentEditor.onExceptionDetected(brk)
                 this.editor?.onExceptionDetected(brk)
             },
             highlightStatement: (stmt, brk) => {

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -1,4 +1,5 @@
 import * as pkg from "./package";
+import * as core from "./core";
 import * as React from "react";
 
 export type ViewState = any;
@@ -143,5 +144,6 @@ export class Editor implements pxt.editor.IEditor {
 
     // allows all editors to send exceptions to error list
     onExceptionDetected(exception: pxsim.DebuggerBreakpointMessage) {
+        core.warningNotification(lf("Program Error: {0}", exception?.exceptionMessage));
     }
 }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2211

Add back in toast when we get a runtime error. This got dropped when adding support for runtime errors to error list ([here](https://github.com/microsoft/pxt/pull/7048/files#diff-325ec83a257a791d33bd4484fd67fb24R784)); this adds it in as the default behavior for the method that gets overwritten to propagate to the error list, so that it shows the error as a toast when the editor doesn't have error list support.
