### PR TITLE
blocks upgrades: don't crash when symbol.params is null

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -284,7 +284,7 @@ namespace pxt.blocks {
         if (!symbol || !b) return;
 
         let comp = compileInfo(symbol);
-        symbol.parameters.forEach((p, i) => {
+        symbol.parameters?.forEach((p, i) => {
             let ptype = info.apis.byQName[p.type];
             if (ptype && ptype.kind == pxtc.SymbolKind.Enum) {
                 let field = getFirstChildWithAttr(block, "field", "name", comp.actualNameToParam[p.name].definitionName);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2173, again

Looks like my branch of pxt was a few commits behind master, so I didn't run into this bug until after everything was merged / beta was bumped. It was still failing to upgrade https://github.com/jwunderl/garden-crop-duster because of this pesky little guy:

![image](https://user-images.githubusercontent.com/5615930/88146715-14647800-cbb1-11ea-8e6c-e69b6ddce9e9.png)

notice parameters is null. No reason to fail hard here, we bail out whenever any other value in this function is falsey anyways.

I'm not sure if there are other places where we'd care if .parameters was null / if this is potentially indicative of another bug? I'll look into what caused that, maybe the object assignability fix?

As a side note, it would probably be nice to turn off the last parameter here:

https://github.com/microsoft/pxt/blob/master/webapp/src/compiler.ts#L717

the parameter is `skipReport` which suppresses the error. (I guess could also just log out the error if `skipReport === true`). For some reason even with 'stop on caught errors' turned on it was skipping over that, so it seemed like I was just missing breakpoints. Ended up reading through everything in the blocks upgrade path a few times and just guessing where the issue was