### PR TITLE
Don't include symbols from test files in the API cache

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4816,7 +4816,8 @@ function internalGenDocsAsync(docs: boolean, locs: boolean, fileFilter?: string,
         docs,
         locs,
         fileFilter,
-        createOnly
+        createOnly,
+        ignoreTests: true
     }).then((compileOpts) => { });
 
     // from target location?

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3500,6 +3500,7 @@ function testForBuildTargetAsync(useNative: boolean, cachedSHA: string): Promise
 
     return mainPkg.loadAsync()
         .then(() => {
+            mainPkg.ignoreTests = true
             copyCommonFiles();
             setBuildEngine();
             let target = mainPkg.getTargetOptions()


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/2164

Try yourself here: https://arcade.makecode.com/app/8e0b07b65f911e8dd2a4c14352fe7d87a7c8b56f-8c8b963622#editor

The API cache was including symbols from test.ts files and those symbols were sometimes conflicting with the user's program. The problem was revealed (but not introduced) by: https://github.com/microsoft/pxt/pull/6568 when we actually started checking for collisions between library top-level variables and user variables.

This PR has a targeted fix, but many issues still remain:
1. Even if test symbols are included, the user blocks program should correctly rename conflicting symbols
2. When gathering cached API info, the compiler is keeping around API info state from earlier compiles that might have conflicting build options (e.g. "ignoreTests")
3. All over the code we're using and editing PackageInfo .files member directly instead of the getFiles() method which is where we filter out or include test files. This effectively ignores the "ignoreTests" flag and leads to confusion and possibly inconsistencies.

mini post-mortem:

For future reference, when localhost and beta/ don't agree here are three things to try:
1. Enable full API caching on localhost. This makes localhost more consistent with how hosted versions work
2. Use `pxt uploadtrg` to create a hosted environment with custom changes
3. Use the `/vX.Y.Z` versioned editors to binary search for the changes that introduced or revealed the inconsistencies (thanks @livcheerful !)

Recommendation for future work:
- Build a long-running, non-PR-blocking test suite that compiles a bunch of the community games. This could be run overnight. This would have spotted the issue much much closer to when it was first revealed and subsequent fixes would have been much quicker to come by.
- We need to rethink the compiler state. We call compile very aggressively and thus we depend on it reusing previous results in order to be performant. I think we need a model where we compute a cache key based on the inputs to the compiler and use previous results if and only if it is safe to do so.