### PR TITLE
Mark simulator dirty when setting file content

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -372,13 +372,15 @@ export class ProjectView
         if (!this.editorFile)
             return Promise.resolve()
         return this.saveTypeScriptAsync()
-            .then(() => {
-                let txt = this.editor.getCurrentSource()
-                if (txt != this.editorFile.content)
-                    simulator.setDirty();
-                if (this.editor.isIncomplete()) return Promise.resolve();
-                return this.editorFile.setContentAsync(txt);
-            });
+            .then(() => this.setFileContentAsync());
+    }
+
+    setFileContentAsync(): Promise<void> {
+        let txt = this.editor.getCurrentSource()
+        if (txt != this.editorFile.content)
+            simulator.setDirty();
+        if (this.editor.isIncomplete()) return Promise.resolve();
+        return this.editorFile.setContentAsync(txt);
     }
 
     isEmbedSimActive(): boolean {
@@ -2256,7 +2258,7 @@ export class ProjectView
 
         // Python uses the virtual file and not the current editor content, so sync content
         if (fromLanguage == "py") {
-            promise = promise.then(() => this.editorFile.setContentAsync(this.editor.getCurrentSource()));
+            promise = promise.then(() => this.setFileContentAsync());
         }
 
         promise = promise


### PR DESCRIPTION
Build: https://arcade.makecode.com/app/d4b73124891dd52e049a7878a777f5ef8fc8a13c-0b1a4ef7af

Fixes https://github.com/microsoft/pxt-arcade/issues/2237

Tested general saving, compile in ts/py, intellisense, error display in python--would love extra eyes though!