### PR TITLE
Remove 'Blocks' text for forumUrl card, use pencil icon

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -1,6 +1,6 @@
 declare namespace pxt {
 
-    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw" | "forumUrl" | "sharedExample";
+    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw" | "forumUrl" | "forumExample" | "sharedExample";
     type CodeCardEditorType = "blocks" | "js" | "py";
 
     interface Map<T> {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -821,12 +821,15 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
             case "forumUrl":
                 icon = "comments"
                 break;
+            case "forumExample":
+                icon = "pencil"
+                break;
             case "template":
             default:
                 if (youTubeId || youTubePlaylistId) icon = "youtube";
                 break;
         }
-        return this.isLink() && type != "example" // TODO (shakao)  migrate forumurl to otherAction json in md
+        return this.isLink() && type != "forumExample" // TODO (shakao)  migrate forumurl to otherAction json in md
             ? <sui.Link role="button" className="link button attached" icon={icon} href={this.getUrl()} target="_blank" tabIndex={-1} />
             : <sui.Item role="button" className="button attached" icon={icon} onClick={onClick} tabIndex={-1} />
     }
@@ -850,7 +853,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
         return <div className={`card-action ui items ${editor || ""}`} key={key}>
             {this.getActionIcon(onClick, type, editor)}
             {title && <div className="card-action-title">{title}</div>}
-            {this.isLink() && type != "example" ? // TODO (shakao)  migrate forumurl to otherAction json in md
+            {this.isLink() && type != "forumExample" ? // TODO (shakao)  migrate forumurl to otherAction json in md
                 <sui.Link
                     href={this.getUrl()}
                     refCallback={autoFocus ? this.linkRef : undefined}
@@ -965,7 +968,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
                     })}
                     {cardType === "forumUrl" &&
                         // TODO (shakao) migrate forumurl to otherAction json in md
-                        this.getActionCard(lf("Open in Editor"), "example", this.handleOpenForumUrlInEditor)
+                        this.getActionCard(lf("Open in Editor"), "forumExample", this.handleOpenForumUrlInEditor)
                     }
                 </div>
             </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/88243179-64404f00-cc44-11ea-83ca-a2ff2bef739c.png)

Match previous behavior of "open in editor" text without specifying language. Since forum games are just a share URL, we don't know what language they're in, and this saves us the effort of having to manually check every game.

(Still eventually want to move the extra "open in editor" card to the otherActions field but that change touches more places and requires updating the discourse download script to output the updated format)

Fixes https://github.com/microsoft/pxt-arcade/issues/2229

Also a build: https://arcade.makecode.com/app/52c89c868dd520e607c5abb60364871a26703ea0-6e76a989ff