### PR TITLE
performance improvements for intellisense

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -138,16 +138,19 @@ namespace pxt {
                 performance.clearMeasures(`${name} elapsed`)
             }
         }
-        export function report() {
+        export function report(filter: string = null) {
             if (enabled) {
                 let report = `performance report:\n`
                 for (let [msg, time] of stats.milestones) {
-                    let pretty = prettyStr(time)
-                    report += `\t\t${msg} @ ${pretty}\n`
+                    if (!filter || msg.indexOf(filter) >= 0) {
+                        let pretty = prettyStr(time)
+                        report += `\t\t${msg} @ ${pretty}\n`
+                    }
                 }
                 report += `\n`
                 for (let [msg, start, duration] of stats.durations) {
-                    if (duration > 50) {
+                    let filterIncl = filter && msg.indexOf(filter) >= 0
+                    if ((duration > 50 && !filter) || filterIncl) {
                         let pretty = prettyStr(duration)
                         report += `\t\t${msg} took ~ ${pretty}`
                         if (duration > 1000) {
@@ -156,7 +159,7 @@ namespace pxt {
                         report += `\n`
                     }
                 }
-                console.log(report)
+                console.log(report || "nothing to report")
             }
             perfReportLogged = true
         }

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -159,7 +159,7 @@ namespace pxt {
                         report += `\n`
                     }
                 }
-                console.log(report || "nothing to report")
+                console.log(report)
             }
             perfReportLogged = true
         }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1178,7 +1178,7 @@ namespace ts.pxtc.service {
                             paramIdx = callSym.parameters.length - 1
                         const paramType = getParameterTsType(callSym, paramIdx, blocksInfo)
                         if (paramType) {
-                            /// weight the results higher if they return the correct type for the parameter
+                            // weight the results higher if they return the correct type for the parameter
                             const matchingApis = getApisForTsType(paramType, call, tc, resultSymbols);
                             matchingApis.forEach(match => match.weight = COMPLETION_MATCHING_PARAM_TYPE_WEIGHT);
                         }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1286,15 +1286,13 @@ namespace ts.pxtc.service {
                 }
             }
 
-            // swap aliases, filter symbols and add snippets
+            // swap aliases, filter symbols
             resultSymbols
                 .map(sym => sym.symbol.attributes.alias ? completionSymbol(lastApiInfo.apis.byQName[sym.symbol.attributes.alias], sym.weight) : sym)
                 .filter(shouldUseSymbol)
                 .forEach(sym => {
                     entries[sym.symbol.qName] = sym
-                    patchSymbolWithSnippet(sym.symbol)
                 })
-
             resultSymbols = pxt.Util.values(entries)
                 .filter(a => !!a && !!a.symbol)
 
@@ -1305,6 +1303,9 @@ namespace ts.pxtc.service {
             if (resultSymbols.length > MAX_SYMBOLS) {
                 resultSymbols = resultSymbols.splice(0, MAX_SYMBOLS)
             }
+
+            // add in snippets if not present already
+            resultSymbols.forEach(sym => patchSymbolWithSnippet(sym.symbol))
 
             r.entries = resultSymbols.map(sym => sym.symbol);
 

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1233,6 +1233,7 @@ namespace ts.pxtc.service {
                     keywords = [...ts.pxtc.reservedWords, ...ts.pxtc.keywordTypes]
                 }
                 let keywordSymbols = keywords
+                    .filter(k => k.indexOf(partialWord) >= 0)
                     .map(makePxtSymbolFromKeyword)
                     .map(s => completionSymbol(s, COMPLETION_KEYWORD_WEIGHT))
                 resultSymbols = [...resultSymbols, ...keywordSymbols]

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1035,7 +1035,7 @@ namespace ts.pxtc.service {
             const partialWord = isMemberCompletion ? src.slice(dotIdx + 1, wordEndPos) : src.slice(wordStartPos, wordEndPos)
 
             const MAX_SYMBOLS_BEFORE_FILTER = 50
-            const MAX_SYMBOLS = 200
+            const MAX_SYMBOLS = 100
 
             if (isMemberCompletion)
                 complPosition = dotIdx
@@ -1085,7 +1085,7 @@ namespace ts.pxtc.service {
                 // convert our location from python to typescript
                 if (res.sourceMap) {
                     const pySrc = src
-                    const tsSrc = res.outfiles[tsFilename]
+                    const tsSrc = res.outfiles[tsFilename] || ""
                     const srcMap = pxtc.BuildSourceMapHelpers(res.sourceMap, tsSrc, pySrc)
 
                     const smallest = srcMap.py.smallestOverlap(span)

--- a/tests/language-service/cases/completions_keywords.ts
+++ b/tests/language-service/cases/completions_keywords.ts
@@ -1,6 +1,6 @@
 whi // while
 
-; i // if
+; if // if
 
 ; func // function
 

--- a/tests/language-service/languageservicerunner.ts
+++ b/tests/language-service/languageservicerunner.ts
@@ -114,22 +114,30 @@ function getTestCases() {
                     }
                 }
 
-                let relativeCompletionPosition = endsInDot ? lastNonWhitespace + 1 : lastNonWhitespace
+                let relativeCompletionPosition = lastNonWhitespace + 1
 
                 const completionPosition = position + relativeCompletionPosition;
+
+                const lineText = line.substr(0, commentIndex);
+
+                // Find word start and end
+                let wordStartPos = fileText.slice(0, completionPosition).search(/[a-zA-Z\d]+\s*$/)
+                let wordEndPos = wordStartPos + fileText.slice(wordStartPos).search(/[^a-zA-Z\d]/)
+                if (wordStartPos < 0 || wordEndPos < 0) {
+                    wordStartPos = completionPosition
+                    wordEndPos = completionPosition
+                }
 
                 testCases.push({
                     fileName,
                     fileText,
-                    lineText: line.substr(0, commentIndex),
+                    lineText,
                     isPython,
                     expectedSymbols,
                     unwantedSymbols,
                     position: completionPosition,
-                    // TODO: we could be smarter about the word start and end position, but
-                    //  this works for all cases we care about so far.
-                    wordStartPos: completionPosition,
-                    wordEndPos: completionPosition,
+                    wordStartPos,
+                    wordEndPos,
                 })
             }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -68,11 +68,8 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
         const wordStartOffset = model.getOffsetAt({ lineNumber: position.lineNumber, column: word.startColumn })
         const wordEndOffset = model.getOffsetAt({ lineNumber: position.lineNumber, column: word.endColumn })
 
-
-        pxt.perf.measureStart("getCompletions")
         return compiler.completionsAsync(fileName, offset, wordStartOffset, wordEndOffset, source)
             .then(completions => {
-                pxt.perf.measureEnd("getCompletions")
                 function stripLocalNamespace(qName: string): string {
                     // leave out namespace qualifiers if we're inside a matching namespace
                     if (!qName)

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -69,8 +69,10 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
         const wordEndOffset = model.getOffsetAt({ lineNumber: position.lineNumber, column: word.endColumn })
 
 
+        pxt.perf.measureStart("getCompletions")
         return compiler.completionsAsync(fileName, offset, wordStartOffset, wordEndOffset, source)
             .then(completions => {
+                pxt.perf.measureEnd("getCompletions")
                 function stripLocalNamespace(qName: string): string {
                     // leave out namespace qualifiers if we're inside a matching namespace
                     if (!qName)


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/2239

Perf improvements:
1. Global symbols pre-filter
When we don't have a specific  set of symbols to return like for member completion, we would return all PXT APIs and allow Monaco to fuzzy filter and sort based on the users input text. However this means we're generating snippets and doing other processing for potentially hundreds or thousands of APIs. So instead we now filter these global symbols to only those who partially match what the user has already entered.
2. Add snippets late
When returning completion results, wait to generate and add completion snippets until all other filtering is done
3. Enforce a total max number of symbols

TODO:
- [x] validate perf improvements are sufficient
- [x] test to make sure quality of intellisense hasn't regressed
- [x] fix language service tests