### PR TITLE
handle changes in github apis

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -728,15 +728,21 @@ namespace pxt.github {
         // status failed, try enabling pages
         if (!url) {
             // enable pages
-            const r = await ghPostAsync(`https://api.github.com/repos/${repo}/pages`, {
-                source: {
-                    branch: "master",
-                    path: ""
-                }
-            }, {
-                "Accept": "application/vnd.github.switcheroo-preview+json"
-            });
-            url = r.html_url;
+            try {
+                const r = await ghPostAsync(`https://api.github.com/repos/${repo}/pages`, {
+                    source: {
+                        branch: "master",
+                        path: "/"
+                    }
+                }, {
+                    "Accept": "application/vnd.github.switcheroo-preview+json"
+                });
+                url = r.html_url;
+            }
+            catch (e) {// this is still an experimental api subject to changes
+                pxt.tickEvent("github.pages.error");
+                pxt.reportException(e);
+            }
         }
 
         // we have a URL, update project


### PR DESCRIPTION
The API to enable pages in github changed slightly breaking the github integration. This fixes it.

https://developer.github.com/v3/repos/pages/#enable-a-pages-site

* catch and report any failure of the api, ignore result
