### PR TITLE
[stable5.33] Port versioned tutorials fix from beta to live

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * [Try out the editors in your browser...](https://makecode.com)
 
-[![Build Status](https://travis-ci.org/microsoft/pxt.svg?branch=master)](https://travis-ci.org/microsoft/pxt) 
+[![Build Status](https://travis-ci.org/microsoft/pxt.svg?branch=master)](https://travis-ci.org/microsoft/pxt)
 [![Community Discord](https://img.shields.io/discord/448979533891371018.svg)](https://aka.ms/makecodecommunity)
 
 Microsoft MakeCode is based on the open source project [Microsoft Programming Experience Toolkit (PXT)](https://github.com/microsoft/pxt). ``Microsoft MakeCode`` is the name in the user-facing editors, ``PXT`` is used in all the GitHub sources.
@@ -58,7 +58,7 @@ If you run `npm i` afterwards (in either the target or pxt), you might need to r
 
 ## Build
 
-First, install [Node](https://nodejs.org/en/): minimum version 8. 
+First, install [Node](https://nodejs.org/en/): minimum version 8.
 
 To build the PXT command line tools:
 
@@ -77,6 +77,9 @@ After this you can run `pxt` from anywhere within the build tree.
 
 To start the local web server, run `pxt serve` from within the root
 of an app target (e.g. pxt-microbit). PXT will open the editor in your default web browser.
+
+If you are developing against pxt, you can run `gulp watch` from within the root of the
+pxt repository to watch for changes and rebuild.
 
 ### Icons
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,6 +110,47 @@ const pxtdts = () => gulp.src("built/cli.d.ts")
     .pipe(gulp.dest("built"));
 
 
+function initWatch() {
+    gulp.watch("./docfiles/pxtweb/**/*", pxtweb);
+
+    const tasks = [
+        pxtlib,
+        gulp.parallel(pxtcompiler, pxtsim, backendutils),
+        gulp.parallel(pxtpy, gulp.series(copyBlockly, pxtblocks, pxtblockly)),
+        pxteditor,
+        gulp.parallel(pxtrunner, pxtwinrt, cli, pxtcommon),
+        updatestrings,
+        gulp.parallel(pxtjs, pxtdts, pxtapp, pxtworker, pxtembed),
+        targetjs,
+        webapp,
+        browserifyWebapp
+    ];
+
+
+    gulp.watch("./pxtlib/**/*", gulp.series(...tasks));
+
+    gulp.watch("./pxtcompiler/**/*", gulp.series(pxtcompiler, ...tasks.slice(2)));
+    gulp.watch("./pxtsim/**/*", gulp.series(pxtsim, ...tasks.slice(2)));
+    gulp.watch("./backendutils/**/*", gulp.series(backendutils, ...tasks.slice(2)));
+
+    gulp.watch("./pxtpy/**/*", gulp.series(pxtpy, ...tasks.slice(3)));
+    gulp.watch("./pxtblockly/**/*", gulp.series(gulp.series(copyBlockly, pxtblocks, pxtblockly), ...tasks.slice(3)));
+
+    gulp.watch("./pxteditor/**/*", gulp.series(pxteditor, ...tasks.slice(4)));
+
+    gulp.watch("./pxtrunner/**/*", gulp.series(pxtrunner, ...tasks.slice(5)));
+    gulp.watch("./pxtwinrt/**/*", gulp.series(pxtwinrt, ...tasks.slice(5)));
+    gulp.watch("./cli/**/*", gulp.series(cli, ...tasks.slice(5)));
+
+    gulp.watch("./webapp/src/**/*", gulp.series(updatestrings, webapp, browserifyWebapp));
+
+    gulp.watch(["./theme/**/*.less", "./theme/**/*.overrides", "./theme/**/*.variables", "./svgicons/**/*.svg"], gulp.parallel(buildcss, buildSVGIcons))
+
+    buildAll();
+}
+
+
+
 const targetjs = () => exec("node built/pxt.js buildtarget", true);
 
 const buildcss = () => exec("node built/pxt.js buildcss", true);
@@ -558,3 +599,4 @@ exports.travis = travis;
 exports.karma = karma;
 exports.update = update;
 exports.uglify = runUglify;
+exports.watch = initWatch;

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1081,4 +1081,10 @@ namespace pxt.BrowserUtils {
             document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}; path=/`;
         }
     }
+
+    export function cacheBustingUrl(url: string): string {
+        if (!url) return url;
+        if (/[?&]rnd=/.test(url)) return url; // already busted
+        return `${url}${url.indexOf('?') > 0 ? "&" : "?"}rnd=${Math.random()}`
+    }
 }

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -607,15 +607,21 @@ namespace pxt.github {
         // status failed, try enabling pages
         if (!url) {
             // enable pages
-            const r = await ghPostAsync(`https://api.github.com/repos/${repo}/pages`, {
-                source: {
-                    branch: "master",
-                    path: ""
-                }
-            }, {
-                "Accept": "application/vnd.github.switcheroo-preview+json"
-            });
-            url = r.html_url;
+            try {
+                const r = await ghPostAsync(`https://api.github.com/repos/${repo}/pages`, {
+                    source: {
+                        branch: "master",
+                        path: "/"
+                    }
+                }, {
+                    "Accept": "application/vnd.github.switcheroo-preview+json"
+                });
+                url = r.html_url;
+            }
+            catch (e) {// this is still an experimental api subject to changes
+                pxt.tickEvent("github.pages.error");
+                pxt.reportException(e);
+            }
         }
 
         // we have a URL, update project

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3174,14 +3174,14 @@ export class ProjectView
                     return (ghid.tag ? Promise.resolve(ghid.tag) : pxt.github.latestVersionAsync(ghid.fullName, config, true))
                         .then(tag => {
                             if (!tag) {
-                                // pxt.log(`tutorial github tag not found at ${ghid.fullName}`);
-                                // return undefined;
                                 /**
                                  * DIFF: in /beta and above, this path returns undefined,
                                  * but I'm just returning based off main branch to minimize
                                  * the chance of breaking existing tutorials with the patch /
                                  * give time to check existing tutorials for release.
                                  */
+                                pxt.log(`tutorial github tag not found at ${ghid.fullName}`);
+                                // return undefined;
                                 return pxt.github.downloadPackageAsync(ghid.fullName, config);
                             }
                             ghid.tag = tag;

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -640,7 +640,10 @@ export async function commitAsync(hd: Header, options: CommitOptions = {}) {
         })
         if (options.createRelease) {
             await pxt.github.createReleaseAsync(parsed.fullName, options.createRelease, newCommit)
-            await pxt.github.enablePagesAsync(parsed.fullName); // ensure pages are on
+             // ensure pages are on
+            await pxt.github.enablePagesAsync(parsed.fullName);
+            // clear the cloud cache
+            await pxt.github.listRefsAsync(parsed.fullName, "tags", true);
         }
         return ""
     }


### PR DESCRIPTION
this commit is the change: https://github.com/microsoft/pxt/commits?author=jwunderl, but I had to port over the gulp watch change for pxt-minecraft to build on my machine: https://github.com/microsoft/pxt/pull/6544 (it kept getting random ts ref errors when running gulp as part of pxt serve). I can drop that if we want to minimize, but I don't think that change has any effect outside of our local builds

partial port of https://github.com/microsoft/pxt/pull/7063, https://github.com/microsoft/pxt/pull/7029 and some other PR that added a `pxt.BrowserUtils.cacheBustingUrl`, and cherry picks finally https://github.com/microsoft/pxt/pull/7359

Also, note the comment starting with [DIFF](https://github.com/microsoft/pxt/pull/7363/files#diff-325ec83a257a791d33bd4484fd67fb24R3180); the behavior is slightly different from master, but I wanted to minimize the behavioral difference from live site, which would mean not breaking repos that do not have a release. If we're not worried about that can change back to normal.

Started as a draft because I wanted to test for a few more minutes after the live stream / run through making a test tutorial and doing a few updates.