### PR TITLE
github: fix min upgrade rule

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -990,11 +990,11 @@ namespace pxt.github {
             return null
 
         const m = /^min:(.*)/.exec(upgr)
-        if (m && pxt.semver.parse(m[1])) {
+        const minV = m && pxt.semver.tryParse(m[1]);
+        if (minV) {
             const parsed = parseRepoId(id)
-            const minV = pxt.semver.parse(m[1])
-            const currV = pxt.semver.parse(parsed.tag)
-            if (currV && pxt.semver.cmp(currV, minV) < 0) {
+            const currV = pxt.semver.tryParse(parsed.tag)
+            if (minV && currV && pxt.semver.cmp(currV, minV) < 0) {
                 parsed.tag = m[1]
                 pxt.debug(`upgrading ${id} to ${m[1]}`)
                 return stringifyRepo(parsed)

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -994,7 +994,7 @@ namespace pxt.github {
         if (minV) {
             const parsed = parseRepoId(id)
             const currV = pxt.semver.tryParse(parsed.tag)
-            if (minV && currV && pxt.semver.cmp(currV, minV) < 0) {
+            if (currV && pxt.semver.cmp(currV, minV) < 0) {
                 parsed.tag = m[1]
                 pxt.debug(`upgrading ${id} to ${m[1]}`)
                 return stringifyRepo(parsed)

--- a/pxtlib/semver.ts
+++ b/pxtlib/semver.ts
@@ -51,14 +51,15 @@ namespace pxt.semver {
         }
     }
 
-    export function parse(v: string): Version {
-        let r = tryParse(v)
+    export function parse(v: string, defaultVersion?: string): Version {
+        let r = tryParse(v) || tryParse(defaultVersion)
         if (!r)
             U.userError(U.lf("'{0}' doesn't look like a semantic version number", v))
         return r
     }
 
     export function tryParse(v: string): Version {
+        if (!v) return null
         if ("*" === v) {
             return {
                 major: Number.MAX_SAFE_INTEGER,

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -378,7 +378,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             return;
         }
 
-        const v = pxt.semver.parse(pkg.mainPkg.config.version || "0.0.0")
+        const v = pxt.semver.parse(pkg.mainPkg.config.version, "0.0.0")
         const vmajor = pxt.semver.parse(pxt.semver.stringify(v)); vmajor.major++; vmajor.minor = 0; vmajor.patch = 0;
         const vminor = pxt.semver.parse(pxt.semver.stringify(v)); vminor.minor++; vminor.patch = 0;
         const vpatch = pxt.semver.parse(pxt.semver.stringify(v)); vpatch.patch++;

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -588,7 +588,7 @@ export async function prAsync(hd: Header, commitId: string, msg: string) {
 }
 
 export function bumpedVersion(cfg: pxt.PackageConfig) {
-    let v = pxt.semver.parse(cfg.version || "0.0.0")
+    let v = pxt.semver.parse(cfg.version, "0.0.0")
     v.patch++
     return pxt.semver.stringify(v)
 }


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-arcade/issues/2288

The min github upgrade rule is too picky about semver parsing and throws when a tag is not provided. Making parsing more resilient to missing tag.

Note: only affects pxt-tilemap, arcade-sprite-data + there is a workaround.