### PR TITLE
Fix crash when opening packages with no readme

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1374,7 +1374,7 @@ export class ProjectView
                     this.setSideDoc(documentation, editorForFile == this.blocksEditor);
                 else {
                     const readme = main.lookupFile("this/README.md");
-                    const readmeContent = readme.content?.trim();
+                    const readmeContent = readme?.content?.trim();
                     // no auto-popup when editing packages locally
                     // ### @autoOpen false
                     if (!h.githubId && readmeContent && !/#{2,}\s+@autoOpen\s+false\s*/i.test(readmeContent))


### PR DESCRIPTION
repro:
* create new project
* switch to TS
* remove README.md
* go back to home
* re-open project
* hang!

Similarly, will hang when opening published projects without readme.

@abchatra this seem to warrant point-fix
