### PR TITLE
make VM work again

### DIFF
--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -73,7 +73,7 @@ ${info.id}_IfaceVT:
             }
         }
 
-        descs += "  .word 0, 0 ; the end\n"
+        descs += "  .word 0, 0, 0, 0 ; the end\n"
         offset += descSize
 
         for (let i = 0; i < mapping.length; ++i) {

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -63,11 +63,12 @@ ${info.id}_IfaceVT:
         let offsets: pxt.Map<number> = {}
         for (let e of info.itable) {
             offsets[e.idx + ""] = offset
-            descs += `  .short ${e.idx}, ${e.info} ; ${e.name}\n`
+            const desc = !e.proc ? 0 : e.proc.isGetter() ? 1 : 2
+            descs += `  .short ${e.idx}, ${desc} ; ${e.name}\n`
             descs += `  .word ${e.proc ? e.proc.vtLabel() + "@fn" : e.info}\n`
             offset += descSize
             if (e.setProc) {
-                descs += `  .short ${e.idx}, 0 ; set ${e.name}\n`
+                descs += `  .short ${e.idx}, 2 ; set ${e.name}\n`
                 descs += `  .word ${e.setProc.vtLabel()}@fn\n`
                 offset += descSize
             }

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -433,8 +433,10 @@ _start_${name}:
                     return
                 case EK.SharedRef:
                     let arg = e.args[0]
-                    U.assert(!!arg.currUses) // not first use
-                    U.assert(arg.currUses < arg.totalUses)
+                    if (!arg.currUses || arg.currUses >= arg.totalUses) {
+                        console.log(arg.sharingInfo())
+                        U.assert(false)
+                    }
                     arg.currUses++
                     let idx = currTmps.indexOf(arg)
                     if (idx < 0) {
@@ -591,8 +593,13 @@ _start_${name}:
             let calledProcId = topExpr.data as ir.ProcId
             let calledProc = calledProcId.proc
 
-            if (calledProc && calledProc.inlineBody)
-                return emitExpr(calledProc.inlineSelf(topExpr.args))
+            if (calledProc && calledProc.inlineBody) {
+                const inlined = calledProc.inlineSelf(topExpr.args)
+                if (pxt.options.debug) {
+                    console.log("INLINE", inlined.toString())
+                }
+                return emitExpr(inlined)
+            }
 
             let numPush = 0
             const args = topExpr.args.slice()

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1435,9 +1435,12 @@ namespace ts.pxtc {
             inf.vtable = tbl
             inf.itable = []
 
+            const fieldNames: pxt.Map<boolean> = {}
+
             for (let fld of inf.allfields) {
                 let fname = getName(fld)
                 let finfo = fieldIndexCore(inf, fld, false)
+                fieldNames[fname] = true
                 inf.itable.push({
                     name: fname,
                     info: (finfo.idx + 1) * (isStackMachine() ? 1 : 4),
@@ -1461,6 +1464,7 @@ namespace ts.pxtc {
                             ex.setProc = proc
                         else if (isGet && !ex.proc)
                             ex.proc = proc
+                        ex.info = 0
                     } else {
                         inf.itable.push({
                             name: n,

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -49,6 +49,7 @@ namespace ts.pxtc.ir {
 
     export class Expr extends Node {
         public jsInfo: {};
+        public prevTotalUses: number;
         public totalUses: number; // how many references this expression has; only for the only child of Shared
         public currUses: number;
         public irCurrUses: number;
@@ -76,6 +77,12 @@ namespace ts.pxtc.ir {
             copy.mask = e.mask
             copy.isStringLiteral = e.isStringLiteral
             return copy
+        }
+
+        reset() {
+            this.currUses = 0
+            if (this.prevTotalUses)
+                this.totalUses = this.prevTotalUses
         }
 
         ptrlabel() {
@@ -631,7 +638,7 @@ namespace ts.pxtc.ir {
         }
 
         inlineSelf(args: ir.Expr[]) {
-            const { precomp, flattened } = flattenArgs(args)
+            const { precomp, flattened } = flattenArgs(args, false, true)
             U.assert(flattened.length == this.args.length)
             this.args.map((a, i) => {
                 a.repl = flattened[i]
@@ -640,6 +647,8 @@ namespace ts.pxtc.ir {
             const r = inlineSubst(this.inlineBody)
             this.args.forEach((a, i) => {
                 if (a.repl.exprKind == EK.SharedRef) {
+                    if (!a.repl.args[0].prevTotalUses)
+                        a.repl.args[0].prevTotalUses = a.repl.args[0].totalUses
                     a.repl.args[0].totalUses += a.replUses - 1
                 }
                 a.repl = null
@@ -925,7 +934,7 @@ namespace ts.pxtc.ir {
         return r
     }
 
-    export function flattenArgs(args: ir.Expr[], reorder = false) {
+    export function flattenArgs(args: ir.Expr[], reorder = false, keepcomplex = false) {
         let didStateUpdate = reorder ? args.some(a => a.canUpdateCells()) : false
         let complexArgs: ir.Expr[] = []
         for (let a of U.reversed(args)) {
@@ -936,7 +945,7 @@ namespace ts.pxtc.ir {
         }
         complexArgs.reverse()
 
-        if (isStackMachine())
+        if (isStackMachine() && !keepcomplex)
             complexArgs = []
 
         let precomp: ir.Expr[] = []

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -226,7 +226,7 @@ namespace ts.pxtc.ir {
                         return `SHARED_REF(#${a0.getId()})`
 
                     case EK.SharedDef:
-                        return `SHARED_DEF(#${a0.getId()}: ${str(a0)})`
+                        return `SHARED_DEF(#${a0.getId()} u(${a0.totalUses}): ${str(a0)})`
 
                     case EK.FieldAccess:
                         return `${str(a0)}.${(e.data as FieldAccessInfo).name}`

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -926,7 +926,7 @@ namespace pxt.cpp {
                         fileName = fullName
 
                         parseCpp(src, isHeader)
-                        src = src.replace(/^[ \t]*/mg, "") // shrink the files
+                        // src = src.replace(/^[ \t]*/mg, "") // HACK: shrink the files
                         res.extensionFiles[sourcePath + fullName] = src
 
                         if (pkg.level == 0)

--- a/tests/compile-test/lang-test0/22lambdas.ts
+++ b/tests/compile-test/lang-test0/22lambdas.ts
@@ -48,7 +48,7 @@ function testNested() {
     bar2()
     assert(glb1 == 12)
     glb1 = 0
-    const arr = [1,20,300]
+    const arr = [1, 20, 300]
     for (let k of arr) {
         qux()
         function qux() {
@@ -81,3 +81,16 @@ function testNested() {
 testLambdas();
 testLambdaDecrCapture();
 testNested()
+
+namespace inlinetest {
+    function ignore(v: any) { }
+    function incr() {
+        glb1++
+    }
+    function run() {
+        glb1 = 0
+        ignore(incr())
+        assert(glb1 == 1)
+    }
+    run()
+}

--- a/tests/compile-test/lang-test0/27accessors.ts
+++ b/tests/compile-test/lang-test0/27accessors.ts
@@ -244,7 +244,7 @@ namespace WithArgs {
     bar(31, new Baz())
     qux(41)
     qux(51)
-    bar(61, new Qux())
+    bar(61, new Qux()) // this currently fails on VM
     msg("WithArgs OK")
 }
 


### PR DESCRIPTION
Mostly port of https://github.com/microsoft/pxt/pull/6299 for VM

* there is one aspect still missing - getters that return lambdas cannot be called directly (see comment in `27accessors.ts`); this is somewhat esoteric though
* also disable whitespace squeeze since the cloud compile limit is now higher
