### PR TITLE
trim padding when emitting large images

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -640,11 +640,12 @@ namespace pxt.sprite {
 
     export function imageLiteralFromDimensions(width: number, height: number, color: number, fileType: "typescript" | "python"): string {
         let res = imageLiteralPrologue(fileType);
+        const paddingBetweenPixels = (width * height > 300) ? "" : " ";
 
         for (let r = 0; r < height; r++) {
             res += "\n"
             for (let c = 0; c < width; c++) {
-                res += hexChars[color] + " ";
+                res += hexChars[color] + paddingBetweenPixels;
             }
         }
 
@@ -658,10 +659,12 @@ namespace pxt.sprite {
         let res = imageLiteralPrologue(fileType);
 
         if (bitmap) {
+            const paddingBetweenPixels = (bitmap.width * bitmap.height > 300) ? "" : " ";
+
             for (let r = 0; r < bitmap.height; r++) {
                 res += "\n"
                 for (let c = 0; c < bitmap.width; c++) {
-                    res += hexChars[bitmap.get(c, r)] + " ";
+                    res += hexChars[bitmap.get(c, r)] + paddingBetweenPixels;
                 }
             }
         }


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/pull/2299

When emitting images, only add space between characters when image is 'small'; I arbitrarily set it at 300pixels so that 16x16 and slightly larger still get the spaced out format, but not larger images like 32x32 or 160x120.

Beyond not upsetting the word count on crowdin, it seems like it'll be helpful for file sizes when sharing a project / avoiding hitting size limits due to multiple backgrounds - right now I think it's sending an extra 38400 white space characters per background image (120 * 160 * 2 as it'd be in both the blocks and ts file). Also a bit easier to deal with in the editor, as right now adding a background image makes the max line length ~~ 4 screens wide for my laptop which makes navigating a bit harder.

