### PR TITLE
Re-initialize block SVG after adding dropdown

### DIFF
--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -47,7 +47,8 @@ namespace pxt.blocks {
                 for (let j = 0; j < diff; j++) {
                     const arg = handlerArgs[actuallyVisible + j];
                     i.insertFieldAt(i.fieldRow.length - 1, new Blockly.FieldVariable(arg.name), "HANDLER_" + arg.name);
-                    (b as Blockly.BlockSvg).initSvg(); // call initSvg on block to initialize new fields
+                    const blockSvg = b as Blockly.BlockSvg;
+                    if (blockSvg?.initSvg) blockSvg.initSvg(); // call initSvg on block to initialize new fields
                 }
             }
             else {

--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -47,6 +47,7 @@ namespace pxt.blocks {
                 for (let j = 0; j < diff; j++) {
                     const arg = handlerArgs[actuallyVisible + j];
                     i.insertFieldAt(i.fieldRow.length - 1, new Blockly.FieldVariable(arg.name), "HANDLER_" + arg.name);
+                    (b as Blockly.BlockSvg).initSvg(); // call initSvg on block to initialize new fields
                 }
             }
             else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1937

We need to re-apply all styles (fill, stroke, etc) when we add a new field to the block