### PR TITLE
Add support for arrow key selection movement in sprite/tilemap/background editor.

### DIFF
--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -242,7 +242,36 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
     }
 
     protected onKeyDown = (ev: KeyboardEvent): void => {
-        this.hasInteracted = true
+        this.hasInteracted = true;
+
+        if (this.shouldHandleCanvasShortcut() && this.editState?.floating?.image) {
+            let moved = false;
+
+            switch (ev.key) {
+                case 'ArrowLeft':
+                    this.editState.layerOffsetX = Math.max(this.editState.layerOffsetX - 1, -this.editState.floating.image.width);
+                    moved = true;
+                    break;
+                case 'ArrowUp':
+                    this.editState.layerOffsetY = Math.max(this.editState.layerOffsetY - 1, -this.editState.floating.image.height);
+                    moved = true;
+                    break;
+                case 'ArrowRight':
+                    this.editState.layerOffsetX = Math.min(this.editState.layerOffsetX + 1, this.editState.width);
+                    moved = true;
+                    break;
+                case 'ArrowDown':
+                    this.editState.layerOffsetY = Math.min(this.editState.layerOffsetY + 1, this.editState.height);
+                    moved = true;
+                    break;
+            }
+
+            if (moved) {
+                this.props.dispatchImageEdit(this.editState.toImageState());
+                ev.preventDefault();
+            }
+        }
+
         if (!ev.repeat) {
             // prevent blockly's ctrl+c / ctrl+v handler
             if ((ev.ctrlKey || ev.metaKey) && (ev.key === 'c' || ev.key === 'v')) {


### PR DESCRIPTION
closes microsoft/pxt-arcade#1561

![Kapture 2020-08-06 at 17 04 20](https://user-images.githubusercontent.com/194333/89594535-ee70e180-d806-11ea-9cd8-14cbff115c82.gif)

Enables arrow keys for moving the selection. Movement is capped to "just offscreen" in each direction (I tried to demonstrate this in the gif; not sure if you can tell that's what's going on).