### PR TITLE
adding settings to disable target template files

### DIFF
--- a/common-docs/github/pages.md
+++ b/common-docs/github/pages.md
@@ -15,3 +15,11 @@ https://youtu.be/vkOWnBfBqak
 It may take up to 10 minutes for updates to be reflected on the GitHub pages web site.
 
 ### ~
+
+## Custom pages
+
+By default, MakeCode overrides the supporting files to render the pages project in each release. You can disable this behavior by adding this code in ``pxt.json``:
+
+```
+disableTargetTemplateFiles: true
+```

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -87,6 +87,7 @@ declare namespace pxt {
         firmwareUrl?: string; // link to documentation page about upgrading firmware
         disablesVariants?: string[]; // don't build these variants, when this extension is enabled
         utf8?: boolean; // force compilation with UTF8 enabled
+        disableTargetTemplateFiles?: boolean; // do not override target template files when commiting to github
     }
 
     interface PackageExtension {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -676,10 +676,12 @@ export async function commitAsync(hd: Header, options: CommitOptions = {}) {
             await addToTree(BINARY_JS_PATH, compileResp.outfiles[pxtc.BINARY_JS]);
             await addToTree(VERSION_TXT_PATH, v);
             // ensure template files are up to date
-            const templates = pxt.template.targetTemplateFiles();
-            if (templates) {
-                for (const fn of Object.keys(templates)) {
-                    await addToTree(fn, templates[fn]);
+            if (!cfg.disableTargetTemplateFiles) {
+                const templates = pxt.template.targetTemplateFiles();
+                if (templates) {
+                    for (const fn of Object.keys(templates)) {
+                        await addToTree(fn, templates[fn]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Flag to disable overriding the generated HTML in github projects.