### PR TITLE
Suppress tilemap shortcut handling when editing a tile.

### DIFF
--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -32,6 +32,8 @@ export interface ImageCanvasProps {
     tilemapState?: TilemapState;
     imageState?: pxt.sprite.ImageState;
     prevFrame?: pxt.sprite.ImageState;
+
+    suppressShortcuts: boolean;
 }
 
 /**
@@ -839,7 +841,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
     protected shouldHandleCanvasShortcut() {
         // canvas shortcuts (select all; delete) should only be handled if the focus is not within a focusable element
-        return document.activeElement === document.body || !document.activeElement;
+        return !this.props.suppressShortcuts && document.activeElement === document.body || !document.activeElement;
     }
 
     protected preventContextMenu = (ev: React.MouseEvent<any>) => ev.preventDefault();

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -84,7 +84,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                     <TopBar singleFrame={singleFrame} />
                     <div className="image-editor-content">
                         <SideBar />
-                        <ImageCanvas />
+                        <ImageCanvas suppressShortcuts={editingTile} />
                         {isAnimationEditor && !singleFrame ? <Timeline /> : undefined}
                     </div>
                     <BottomBar singleFrame={singleFrame} onDoneClick={this.onDoneClick} />


### PR DESCRIPTION
@riknoll @livcheerful 

Here's a fix for microsoft/pxt-arcade#2317. I hadn't realized that when editing an individual tile, there were _two_ `ImageCanvas`es being rendered! 😱 😅

I'm also **totally** happy for you to independently solve this one, if you'd prefer.

I haven't actually done much with Redux... perhaps it's unusual to directly pass props to components like I do in ImageEditor line 87.