### PR TITLE
fix error list colors in inverted-editor

### DIFF
--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -55,21 +55,21 @@
         overflow-y: auto;
 
         .exceptionMessage {
-            color: black;
+            color: @textColor;
             padding: 0.5em 1em;
             width: 70%;
         }
 
         // errors
         .ui.selection.list {
-            color: black;
+            color: @textColor;
             cursor: pointer;
             margin: 0;
 
             .item {
                 border-radius: unset;
                 padding: 0.5em 1em;
-                color: black;
+                color: @textColor;
 
                 &:hover, &:focus {
                     background-color: @errorListMessageHoverColor !important;
@@ -77,10 +77,6 @@
 
                 &:nth-child(even):not(:hover) {
                     background-color: @errorListEven;
-                }
-
-                &:nth-child(odd):not(:hover) {
-                    background-color: @errorListOdd;
                 }
 
                 &.stackframe {
@@ -116,5 +112,42 @@
 
     &:hover {
         background-color: @errorListMessageHoverColor;
+    }
+}
+
+.inverted-theme .errorList {
+    .errorListHeader {
+        color: @errorListInvertedTextColor;
+    }
+
+    .errorListInner {
+        .exceptionMessage {
+            color: @errorListInvertedTextColor;
+        }
+        .ui.selection.list {
+            color: @errorListInvertedTextColor;
+            cursor: pointer;
+            margin: 0;
+
+            .item {
+                border-radius: unset;
+                padding: 0.5em 1em;
+                color: @errorListInvertedTextColor;
+
+                &:hover, &:focus {
+                    background-color: @errorListInvertedMessageHoverColor !important;
+                }
+
+                &:nth-child(even):not(:hover) {
+                    background-color: @errorListInvertedEven;
+                }
+            }
+        }
+
+        .debuggerSuggestion {
+            // TODO?
+            color: @errorListDebugSuggestionColor;
+        }
+
     }
 }

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -126,12 +126,8 @@
         }
         .ui.selection.list {
             color: @errorListInvertedTextColor;
-            cursor: pointer;
-            margin: 0;
 
             .item {
-                border-radius: unset;
-                padding: 0.5em 1em;
                 color: @errorListInvertedTextColor;
 
                 &:hover, &:focus {

--- a/theme/errorList.less
+++ b/theme/errorList.less
@@ -143,11 +143,5 @@
                 }
             }
         }
-
-        .debuggerSuggestion {
-            // TODO?
-            color: @errorListDebugSuggestionColor;
-        }
-
     }
 }

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -358,6 +358,8 @@
 @errorListInnerHeight: (@errorListHeight - @errorListHeaderHeight);
 @errorListMessageHoverColor: rgba(0, 0, 0, 0.1);
 @errorListBorderColor: #e5e5e5;
-@errorListOdd: @homeScreenBackground;
-@errorListEven: darken(@errorListOdd, 3%);
-@errorListDebugSuggestionColor:rgb(52, 84, 209); // TODO: maybe change to display color based on editor
+@errorListEven: rgba(0, 0, 0, 0.03);
+@errorListDebugSuggestionColor: rgb(52, 84, 209); // TODO: maybe change to display color based on editor
+@errorListInvertedEven: rgba(255, 255, 255, 0.03);
+@errorListInvertedTextColor: white;
+@errorListInvertedMessageHoverColor: rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/1918, but there's a minor diff in styling for other editors I'll add a note on below; can maintain the same behavior but it'd require a bit of duplication / an extra less var defined for each editor

![image](https://user-images.githubusercontent.com/5615930/89687364-f7b88780-d8b4-11ea-85dd-fce00259561f.png)

w/ highlight on error:

![image](https://user-images.githubusercontent.com/5615930/89687344-eff8e300-d8b4-11ea-955c-b6352b0f0d36.png)
