### PR TITLE
Pass tutorial snippets as array, isolate python snippets in modules

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5357,7 +5357,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
                                 else {
                                     addSnippet(<CodeSnippet>{
                                         name: card.name,
-                                        code: tutorial.code,
+                                        code: tutorial.code.join("\n"),
                                         type: "blocks",
                                         ext: "ts",
                                         packages: pkgs

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -884,7 +884,7 @@ declare namespace pxt.tutorial {
         title?: string;
         steps: TutorialStepInfo[];
         activities: TutorialActivityInfo[];
-        code: string; // all code
+        code: string[]; // all code
         language?: string; // language of code snippet (ts or python)
         templateCode?: string;
         metadata?: TutorialMetadata;
@@ -929,7 +929,7 @@ declare namespace pxt.tutorial {
         tutorialHintCounter?: number // count for number of times hint has been shown
         tutorialStepExpanded?: boolean; // display full step in dialog
         tutorialMd?: string; // full tutorial markdown
-        tutorialCode?: string; // all tutorial code bundled
+        tutorialCode?: string[]; // all tutorial code bundled
         tutorialRecipe?: boolean; // micro tutorial running within the context of a script
         templateCode?: string;
         autoexpandStep?: boolean; // autoexpand tutorial card if instruction text overflows

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -46,7 +46,7 @@ namespace pxt.tutorial {
         // collect code and infer editor
         let editor: string = undefined;
         const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
-        let code = '';
+        let code: string[] = [];
         let templateCode: string;
         let language: string;
         let idx = 0;
@@ -79,9 +79,7 @@ namespace pxt.tutorial {
                         templateCode = m2;
                         break;
                 }
-                code += `\n${m1 == "python"
-                    ? "def __wrapper_" + idx + "():\n" + m2.replace(/^/gm, "    ")
-                    : "{\n" + m2 + "\n}"}\n`;
+                code.push(m1 == "python" ? `\n${m2}\n` : `{\n${m2}\n}`);
                 idx++
                 return "";
             });

--- a/tests/tutorial-test/baselines/activities.json
+++ b/tests/tutorial-test/baselines/activities.json
@@ -42,7 +42,9 @@
             "step": 3
         }
     ],
-    "code": "\n{\nlet x = 1;\nlet y = x + 2;\n}\n",
+    "code": [
+        "{\nlet x = 1;\nlet y = x + 2;\n}"
+    ],
     "metadata": {
         "activities": true,
         "diffs": false

--- a/tests/tutorial-test/baselines/button.json
+++ b/tests/tutorial-test/baselines/button.json
@@ -12,6 +12,8 @@
         }
     ],
     "activities": null,
-    "code": "",
-    "metadata": {}
+    "code": [],
+    "metadata": {
+        "diffs": false
+    }
 }

--- a/tests/tutorial-test/baselines/description.json
+++ b/tests/tutorial-test/baselines/description.json
@@ -12,8 +12,9 @@
         }
     ],
     "activities": null,
-    "code": "",
+    "code": [],
     "metadata": {
+        "diffs": false,
         "description": "Tutorial descriptions are not displayed"
     }
 }

--- a/tests/tutorial-test/baselines/diff.json
+++ b/tests/tutorial-test/baselines/diff.json
@@ -33,7 +33,14 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nlet k = 0\n}\n\n{\nlet x = 0\n}\n\n{\nlet x = 0\nlet y = 0\n}\n\n{\nlet x = 0\nlet y = 0\nlet z = 0\n}\n\n{\nlet x = 0\nlet y = 0\nlet z = 0\nlet a = 0\n}\n\n{\nlet x = 0\nlet y = 0\nlet z = 0\nlet a = 0\nlet b = 0\n}\n",
+    "code": [
+        "{\nlet k = 0\n}",
+        "{\nlet x = 0\n}",
+        "{\nlet x = 0\nlet y = 0\n}",
+        "{\nlet x = 0\nlet y = 0\nlet z = 0\n}",
+        "{\nlet x = 0\nlet y = 0\nlet z = 0\nlet a = 0\n}",
+        "{\nlet x = 0\nlet y = 0\nlet z = 0\nlet a = 0\nlet b = 0\n}"
+    ],
     "templateCode": "let k = 0",
     "metadata": {}
 }

--- a/tests/tutorial-test/baselines/explicitHints.json
+++ b/tests/tutorial-test/baselines/explicitHints.json
@@ -17,7 +17,11 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nbasic.showString(\"Micro!\")\n}\n\n{\nlet x = 1;\nlet y = x + 2;\n}\n\n{\nbasic.showIcon(IconNames.Square)\n}\n",
+    "code": [
+        "{\nbasic.showString(\"Micro!\")\n}",
+        "{\nlet x = 1;\nlet y = x + 2;\n}",
+        "{\nbasic.showIcon(IconNames.Square)\n}"
+    ],
     "metadata": {
         "diffs": false,
         "explicitHints": true

--- a/tests/tutorial-test/baselines/flyoutOnly.json
+++ b/tests/tutorial-test/baselines/flyoutOnly.json
@@ -13,7 +13,10 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nlet x = 8;\nlet y = x + 2;\n}\n\n{\nbasic.showIcon(IconNames.Square)\n}\n",
+    "code": [
+        "{\nlet x = 8;\nlet y = x + 2;\n}",
+        "{\nbasic.showIcon(IconNames.Square)\n}"
+    ],
     "metadata": {
         "diffs": false,
         "flyoutOnly": true

--- a/tests/tutorial-test/baselines/ghost.json
+++ b/tests/tutorial-test/baselines/ghost.json
@@ -14,7 +14,12 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nbasic.forever(() => {\n    basic.showIcon(IconNames.Yes);\n});\n}\n\n{\nbasic.showString(\"Hello\")\n}\n\n{\nbasic.forever(function() {\n    basic.showLeds(`\n        . # . # .\n        # # # # #\n        # # # # #\n        . # # # .\n        . . # . .`);\n})\n}\n\n{\ninput.onButtonPressed(Button.A, () => {\n    radio.sendNumber(0)\n})\n}\n",
+    "code": [
+        "{\nbasic.forever(() => {\n    basic.showIcon(IconNames.Yes);\n});\n}",
+        "{\nbasic.showString(\"Hello\")\n}",
+        "{\nbasic.forever(function() {\n    basic.showLeds(`\n        . # . # .\n        # # # # #\n        # # # # #\n        . # # # .\n        . . # . .`);\n})\n}",
+        "{\ninput.onButtonPressed(Button.A, () => {\n    radio.sendNumber(0)\n})\n}"
+    ],
     "metadata": {
         "diffs": false
     }

--- a/tests/tutorial-test/baselines/hideIteration.json
+++ b/tests/tutorial-test/baselines/hideIteration.json
@@ -13,7 +13,10 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nbasic.showString(\"Micro!\")\n}\n\n{\nbasic.showIcon(IconNames.Square)\n}\n",
+    "code": [
+        "{\nbasic.showString(\"Micro!\")\n}",
+        "{\nbasic.showIcon(IconNames.Square)\n}"
+    ],
     "metadata": {
         "diffs": false,
         "hideIteration": true

--- a/tests/tutorial-test/baselines/legacySteps.json
+++ b/tests/tutorial-test/baselines/legacySteps.json
@@ -20,7 +20,9 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nbasic.showString(\"Micro!\")\n}\n",
+    "code": [
+        "{\nbasic.showString(\"Micro!\")\n}"
+    ],
     "metadata": {
         "flyoutOnly": true,
         "diffs": false

--- a/tests/tutorial-test/baselines/python.json
+++ b/tests/tutorial-test/baselines/python.json
@@ -3,19 +3,22 @@
     "title": "Native python",
     "steps": [
         {
-            "contentMd": "Tutorials can be written with code in Python.\n```python\nbasic.show_string(\"Hello\")\n```",
+            "contentMd": "Tutorials can be written with code in Python.\n```python\ndef on_chat():\n    # @highlight\n    player.teleport(pos(0, 100, 0))\nplayer.on_chat(\"jump\", on_chat)\n```",
             "headerContentMd": "Tutorials can be written with code in Python.",
             "fullscreen": true,
-            "hintContentMd": "```python\nbasic.show_string(\"Hello\")\n```"
+            "hintContentMd": "```python\ndef on_chat():\n    # @highlight\n    player.teleport(pos(0, 100, 0))\nplayer.on_chat(\"jump\", on_chat)\n```"
         },
         {
-            "contentMd": "Show some LEDs\n\n```python\nbasic.forever(function() {\n    basic.show_leds(`\n        . # . # .\n        # # # # #\n        # # # # #\n        . # # # .\n        . . # . .`);\n})\n\n```",
+            "contentMd": "Show some LEDs\n\n```python\nbuilder.teleport_to(pos(0, 0, 0))\nfor i in range(25):\n    builder.move(FORWARD, 1)\n    builder.move(UP, 1)\n```",
             "headerContentMd": "Show some LEDs",
-            "hintContentMd": "```python\nbasic.forever(function() {\n    basic.show_leds(`\n        . # . # .\n        # # # # #\n        # # # # #\n        . # # # .\n        . . # . .`);\n})\n\n```"
+            "hintContentMd": "```python\nbuilder.teleport_to(pos(0, 0, 0))\nfor i in range(25):\n    builder.move(FORWARD, 1)\n    builder.move(UP, 1)\n```"
         }
     ],
     "activities": null,
-    "code": "\ndef __wrapper_0():\n    basic.show_string(\"Hello\")\n\ndef __wrapper_1():\n    basic.forever(function() {\n        basic.show_leds(`\n            . # . # .\n            # # # # #\n            # # # # #\n            . # # # .\n            . . # . .`);\n    })\n",
+    "code": [
+        "\ndef on_chat():\n    # @highlight\n    player.teleport(pos(0, 100, 0))\nplayer.on_chat(\"jump\", on_chat)\n",
+        "\nbuilder.teleport_to(pos(0, 0, 0))\nfor i in range(25):\n    builder.move(FORWARD, 1)\n    builder.move(UP, 1)\n"
+    ],
     "metadata": {
         "diffs": false
     },

--- a/tests/tutorial-test/baselines/singleStep.json
+++ b/tests/tutorial-test/baselines/singleStep.json
@@ -11,7 +11,9 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nbasic.showString(\"Micro!\")\n}\n",
+    "code": [
+        "{\nbasic.showString(\"Micro!\")\n}"
+    ],
     "metadata": {
         "diffs": false
     }

--- a/tests/tutorial-test/baselines/steps.json
+++ b/tests/tutorial-test/baselines/steps.json
@@ -20,7 +20,9 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nbasic.showString(\"Micro!\")\n}\n",
+    "code": [
+        "{\nbasic.showString(\"Micro!\")\n}"
+    ],
     "metadata": {
         "diffs": false
     }

--- a/tests/tutorial-test/baselines/template.json
+++ b/tests/tutorial-test/baselines/template.json
@@ -14,7 +14,9 @@
         }
     ],
     "activities": null,
-    "code": "\n{\nbasic.forever(() => {\n    basic.showString(\"MICRO\");\n});\n}\n",
+    "code": [
+        "{\nbasic.forever(() => {\n    basic.showString(\"MICRO\");\n});\n}"
+    ],
     "templateCode": "basic.forever(() => {\n    basic.showString(\"MICRO\");\n});",
     "metadata": {
         "diffs": false

--- a/tests/tutorial-test/baselines/tutorialCompleted.json
+++ b/tests/tutorial-test/baselines/tutorialCompleted.json
@@ -17,6 +17,8 @@
         }
     ],
     "activities": null,
-    "code": "",
-    "metadata": {}
+    "code": [],
+    "metadata": {
+        "diffs": false
+    }
 }

--- a/tests/tutorial-test/cases/python.md
+++ b/tests/tutorial-test/cases/python.md
@@ -5,7 +5,10 @@
 
 Tutorials can be written with code in Python.
 ```python
-basic.show_string("Hello")
+def on_chat():
+    # @highlight
+    player.teleport(pos(0, 100, 0))
+player.on_chat("jump", on_chat)
 ```
 
 ## Step 2
@@ -13,13 +16,8 @@ basic.show_string("Hello")
 Show some LEDs
 
 ```python
-basic.forever(function() {
-    basic.show_leds(`
-        . # . # .
-        # # # # #
-        # # # # #
-        . # # # .
-        . . # . .`);
-})
-
+builder.teleport_to(pos(0, 0, 0))
+for i in range(25):
+    builder.move(FORWARD, 1)
+    builder.move(UP, 1)
 ```

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -19,15 +19,15 @@ type ISettingsProps = pxt.editor.ISettingsProps;
  * We'll run this step when we first start the tutorial to figure out what blocks are used so we can
  * filter the toolbox.
  */
-export function getUsedBlocksAsync(code: string, language?: string): Promise<pxt.Map<number>> {
+export function getUsedBlocksAsync(code: string[], language?: string): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
     const usedBlocks: pxt.Map<number> = {};
     return compiler.getBlocksAsync()
         .then(blocksInfo => {
             pxt.blocks.initializeAndInject(blocksInfo);
             if (language == "python")
-                return compiler.pySnippetToBlocksAsync(code, blocksInfo);
-            return compiler.decompileBlocksSnippetAsync(code, blocksInfo);
+                return compiler.pySnippetArrayToBlocksAsync(code, blocksInfo);
+            return compiler.decompileBlocksSnippetAsync(code.join("\n"), blocksInfo);
         }).then(resp => {
             const blocksXml = resp.outfiles["main.blocks"];
             if (blocksXml) {


### PR DESCRIPTION
Main changes: instead of concatenating the code when we parse the tutorial, save an array of snippets. When decompiling to get the used blocks, TS behavior is unchanged (concat snippets, decompile). For Python, each snippet is put in a separate module (file) to convert to TS, then we strip out the "namespace" declarations generated from the modules, concatenate the snippets and decompile.

Long-term, it could be useful to precompute or cache the used blocks; this data only really changes when the tutorial content changes so we probably don't need to generate it every time a tutorial is loaded.

Fixes https://github.com/microsoft/pxt-minecraft/issues/1926