### PR TITLE
Allow duplicate comment to be translated

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1451,6 +1451,7 @@ namespace pxt.blocks {
         // Translate the context menu for blocks.
         const msg = Blockly.Msg;
         msg.DUPLICATE_BLOCK = lf("{id:block}Duplicate");
+        msg.DUPLICATE_COMMENT = lf("Duplicate Comment");
         msg.REMOVE_COMMENT = lf("Remove Comment");
         msg.ADD_COMMENT = lf("Add Comment");
         msg.EXTERNAL_INPUTS = lf("External Inputs");


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/1911

I guess minor question, is there value in it specifying duplicate *comment*? Could just use the same duplicate as we use for DUPLICATE_BLOCK if we want, but maybe specifying it is a comment is valuable for students.