### PR TITLE
Tilemap woes and the solutions thereof

### DIFF
--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -114,7 +114,6 @@ namespace pxtblockly {
                     this.state.projectReferences = null;
 
 
-
                     const lastRevision = project.revision();
                     project.pushUndo();
 
@@ -130,10 +129,9 @@ namespace pxtblockly {
                             const edited = result.tileset.tiles[editedIndex];
 
                             // New tiles start with *. We haven't created them yet so ignore
-                            if (edited.id.startsWith("*")) continue;
-                            if (edited) {
-                                result.tileset.tiles[editedIndex] = project.updateTile(edited.id, edited.bitmap)
-                            }
+                            if (!edited || edited.id.startsWith("*")) continue;
+
+                            result.tileset.tiles[editedIndex] = project.updateTile(edited.id, edited.bitmap);
                         }
                     }
 

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -13,6 +13,9 @@ namespace pxtblockly {
     const PREVIEW_SIDE_LENGTH = 32;
 
     export class FieldTileset extends FieldImages implements Blockly.FieldCustom {
+        // private member of FieldDropdown
+        protected selectedOption_: TilesetDropdownOption;
+
         protected static referencedTiles: TilesetDropdownOption[];
         protected static cachedRevision: number;
         protected static cachedWorkspaceId: string;
@@ -102,6 +105,26 @@ namespace pxtblockly {
                 return v;
             }
             return super.getText();
+        }
+
+        render_() {
+            if (this.value_ && this.selectedOption_) {
+                if (this.selectedOption_[1] !== this.value_) {
+                    const tile = pxt.react.getTilemapProject().resolveTile(this.value_);
+                    FieldTileset.cachedRevision = -1;
+
+                    if (tile) {
+                        this.selectedOption_ = [{
+                            src: bitmapToImageURI(pxt.sprite.Bitmap.fromData(tile.bitmap), PREVIEW_SIDE_LENGTH, false),
+                            width: PREVIEW_SIDE_LENGTH,
+                            height: PREVIEW_SIDE_LENGTH,
+                            alt: tile.id
+                        }, this.value_]
+                    }
+                }
+
+            }
+            super.render_();
         }
 
         getOptions(): any[] {

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -84,10 +84,9 @@ namespace pxt.editor {
                     const edited = result.tileset.tiles[editedIndex];
 
                     // New tiles start with *. We haven't created them yet so ignore
-                    if (edited.id.startsWith("*")) continue;
-                    if (edited) {
-                        result.tileset.tiles[editedIndex] = project.updateTile(edited.id, edited.bitmap)
-                    }
+                    if (!edited || edited.id.startsWith("*")) continue;
+
+                    result.tileset.tiles[editedIndex] = project.updateTile(edited.id, edited.bitmap);
                 }
             }
 

--- a/pxtlib/legacyTilemap.ts
+++ b/pxtlib/legacyTilemap.ts
@@ -31,7 +31,7 @@ namespace pxt.sprite.legacy {
         }
 
         literal = literal.substr(literal.indexOf("(") + 1);
-        literal = literal.substr(0, literal.lastIndexOf(")") - 1);
+        literal = literal.substr(0, literal.lastIndexOf(")"));
 
         const tm = literal.substr(0, literal.indexOf(","));
         literal = literal.substr(tm.length + 1);

--- a/webapp/src/components/ImageEditor/Alert.tsx
+++ b/webapp/src/components/ImageEditor/Alert.tsx
@@ -35,7 +35,7 @@ class AlertImpl extends React.Component<AlertProps, {}> {
                 </div>
                 <div className="text">{text}</div>
                 {options && <div className="options">
-                    { options.map(opt => <div className="button" role="button" onClick={opt.onClick}>{opt.label}</div>) }
+                    { options.map((opt, index) => <div key={index} className="button" role="button" onClick={opt.onClick}>{opt.label}</div>) }
                 </div>}
             </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2311 (this is also the issue that Andy's students hit). This issue was caused by creating a tile, editing it, deleting it, and creating a new tile. The deleted tile caused an exception when encoding the tilemap.

Fixes https://github.com/microsoft/pxt-arcade/issues/2315. This issue was an off by one error that I fixed for the parsing of tilemaps (but not the legacy parsing).

Fixes https://github.com/microsoft/pxt-arcade/issues/2281. This issue was caused by the tileset cache being created while the workspace was being loaded. Fixed by invalidating the cache when we detect that something is wrong at render time