### PR TITLE
Adding bobbing animation to gutter icons on selected line

### DIFF
--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -95,6 +95,28 @@
     z-index: @menuBarZIndex+1 !important;
 }
 
+@keyframes bobbing {
+    0% {
+        transform: translateY(0px);
+    }
+
+    25% {
+        transform: translateY(3px);
+    }
+
+    75% {
+        transform: translateY(-3px);
+    }
+
+    100% {
+        transform: translateY(0px);
+    }
+}
+
+.pxt-monaco-glyph-highlight {
+    animation: bobbing 1s linear infinite;
+}
+
 
 /*******************************
      Monaco Flyout

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1190,6 +1190,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             monaco.languages.registerFoldingRangeProvider("python", this.fieldEditors);
         }
 
+        this.editor.onDidChangeCursorPosition((e: monaco.editor.ICursorPositionChangedEvent) => {
+            if (this.fieldEditors) this.fieldEditors.setCursorLine(e.position.lineNumber);
+        });
+
         pxt.appTarget.appTheme.monacoFieldEditors.forEach(name => {
             const editor = pxt.editor.getMonacoFieldEditor(name);
             if (editor) {

--- a/webapp/src/monacoFieldEditorHost.ts
+++ b/webapp/src/monacoFieldEditorHost.ts
@@ -299,7 +299,7 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
     }
 
     protected reapplyDecorations(owner: string, highlightLine = -1) {
-        const fe = this.fieldEditors.filter(f => f.id === owner)[0];
+        const fe = this.fieldEditors.find(f => f.id === owner);
 
         if (!fe) return;
 

--- a/webapp/src/monacoFieldEditorHost.ts
+++ b/webapp/src/monacoFieldEditorHost.ts
@@ -4,6 +4,7 @@
 import * as compiler from "./compiler";
 import * as blocklyFieldView from "./blocklyFieldView";
 import * as pkg from "./package";
+import { highContrast } from "./core";
 
 interface OwnedRange {
     line: number;
@@ -185,6 +186,8 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
     protected liveRanges: OwnedRange[] = [];
     protected fieldEditorsEnabled = true;
 
+    protected currentCursorLine: number;
+
     private rangeID = 0;
 
     constructor(protected editor: monaco.editor.IStandaloneCodeEditor) {}
@@ -192,6 +195,24 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
     setFieldEditorsEnabled(enabled: boolean) {
         this.fieldEditorsEnabled = enabled;
         if (!enabled) this.clearRanges(this.editor);
+    }
+
+    setCursorLine(line: number) {
+        if (!this.fieldEditorsEnabled) return;
+        if (line != this.currentCursorLine) {
+            const oldHighlight = this.getInfoForLine(this.currentCursorLine);
+
+            if (oldHighlight) {
+                this.reapplyDecorations(oldHighlight.owner)
+            }
+
+            const newHighlight = this.getInfoForLine(line);
+            if (newHighlight) {
+                this.reapplyDecorations(newHighlight.owner, line);
+            }
+
+            this.currentCursorLine = line;
+        }
     }
 
     addFieldEditor(definition: pxt.editor.MonacoFieldEditorDefinition) {
@@ -277,6 +298,33 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
         });
 
         return editorRanges.concat(indentRanges);
+    }
+
+    protected reapplyDecorations(owner: string, highlightLine = -1) {
+        const fe = this.fieldEditors.filter(f => f.id === owner)[0];
+
+        if (!fe) return;
+
+        const oldDecorations = this.decorations[owner];
+        const ranges = this.liveRanges.filter(r => r.owner === owner);
+
+        const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
+        for (const r of ranges) {
+            let glyph = fe.glyphCssClass;
+
+            if (r.line === highlightLine) {
+                glyph += " pxt-monaco-glyph-highlight";
+            }
+
+            newDecorations.push({
+                range: r.range,
+                options: {
+                    glyphMarginClassName: glyph
+                }
+            });
+        }
+
+        this.setDecorations(fe.id, this.editor.deltaDecorations(oldDecorations, newDecorations));
     }
 
     protected updateFieldEditorRanges(model: monaco.editor.ITextModel) {

--- a/webapp/src/monacoFieldEditorHost.ts
+++ b/webapp/src/monacoFieldEditorHost.ts
@@ -2,9 +2,7 @@
 /// <reference path="../../built/pxteditor.d.ts" />
 
 import * as compiler from "./compiler";
-import * as blocklyFieldView from "./blocklyFieldView";
 import * as pkg from "./package";
-import { highContrast } from "./core";
 
 interface OwnedRange {
     line: number;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2265

Implementing the quick-fix proposed by @soniakandah in https://github.com/microsoft/pxt-arcade/issues/2265

The gutter icon bobs on the selected line:

![2020-08-11 17 18 06](https://user-images.githubusercontent.com/13754588/89961581-f6f65d00-dbf6-11ea-8699-3bbd2a6f2cc3.gif)
