### PR TITLE
Support multiple tilewidths for tilemaps

### DIFF
--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -7,6 +7,7 @@ namespace pxtblockly {
     export interface FieldTilemapOptions {
         initWidth: string;
         initHeight: string;
+        tileWidth: string | number;
 
         filter?: string;
     }
@@ -14,6 +15,7 @@ namespace pxtblockly {
     interface ParsedFieldTilemapOptions {
         initWidth: number;
         initHeight: number;
+        tileWidth: 8 | 16 | 32;
         filter?: string;
     }
 
@@ -274,7 +276,7 @@ namespace pxtblockly {
                 }
             }
 
-            const tilemap = pxt.sprite.decodeTilemap(newText, "typescript", pxt.react.getTilemapProject()) || emptyTilemap(this.params.initWidth, this.params.initHeight);
+            const tilemap = pxt.sprite.decodeTilemap(newText, "typescript", pxt.react.getTilemapProject()) || emptyTilemap(this.params.tileWidth, this.params.initWidth, this.params.initHeight);
 
             // Ignore invalid bitmaps
             if (checkTilemap(tilemap)) {
@@ -290,7 +292,7 @@ namespace pxtblockly {
 
         protected initState() {
             if (!this.state) {
-                this.state = pxt.react.getTilemapProject().blankTilemap(16, this.params.initWidth, this.params.initHeight);
+                this.state = pxt.react.getTilemapProject().blankTilemap(this.params.tileWidth, this.params.initWidth, this.params.initHeight);
             }
         }
 
@@ -316,6 +318,7 @@ namespace pxtblockly {
         const parsed: ParsedFieldTilemapOptions = {
             initWidth: 16,
             initHeight: 16,
+            tileWidth: 16
         };
 
         if (!opts) {
@@ -324,6 +327,39 @@ namespace pxtblockly {
 
         if (opts.filter) {
             parsed.filter = opts.filter;
+        }
+
+        if (opts.tileWidth) {
+            if (typeof opts.tileWidth === "number") {
+                switch (opts.tileWidth) {
+                    case 8:
+                        parsed.tileWidth = 8;
+                        break;
+                    case 16:
+                        parsed.tileWidth = 16;
+                        break;
+                    case 32:
+                        parsed.tileWidth = 32;
+                        break;
+                }
+            }
+            else {
+                const tw = opts.tileWidth.trim().toLowerCase();
+                switch (tw) {
+                    case "8":
+                    case "eight":
+                        parsed.tileWidth = 8;
+                        break;
+                    case "16":
+                    case "sixteen":
+                        parsed.tileWidth = 16;
+                        break;
+                    case "32":
+                    case "thirtytwo":
+                        parsed.tileWidth = 32;
+                        break;
+                }
+            }
         }
 
         parsed.initWidth = withDefault(opts.initWidth, parsed.initWidth);
@@ -386,10 +422,10 @@ namespace pxtblockly {
         }
     }
 
-    function emptyTilemap(width: number, height: number) {
+    function emptyTilemap(tileWidth: number, width: number, height: number) {
         return new pxt.sprite.TilemapData(
             new pxt.sprite.Tilemap(width, height),
-            {tileWidth: 16, tiles: []},
+            {tileWidth: tileWidth, tiles: []},
             new pxt.sprite.Bitmap(width, height).data()
         );
     }

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -7,6 +7,7 @@ namespace pxt.editor {
     export class MonacoTilemapEditor extends MonacoReactFieldEditor<pxt.sprite.TilemapData> {
         protected tilemapName: string;
         protected isTilemapLiteral: boolean;
+        protected tilemapLiteral: string;
 
         protected textToValue(text: string): pxt.sprite.TilemapData {
             const tm = this.readTilemap(text);
@@ -47,15 +48,23 @@ namespace pxt.editor {
             this.isTilemapLiteral = true;
 
             // This matches the regex for the field editor, so it should always match
-            const match = /^\s*tilemap\s*(?:`([^`]*)`)|(?:\(\s*"""([^"]*)"""\s*\))\s*$/.exec(text);
-            const name = (match[1] || match[2] || "").trim();
+            const match = /^\s*(tilemap(?:8|16|32)?)\s*(?:`([^`]*)`)|(?:\(\s*"""([^"]*)"""\s*\))\s*$/.exec(text);
+            const name = (match[2] || match[3] || "").trim();
+            this.tilemapLiteral = match[1];
 
             if (name) {
                 let id = ts.pxtc.escapeIdentifier(name)
                 let proj = project.getTilemap(id);
 
                 if (!proj) {
-                    const [ name, map ] = project.createNewTilemap(id, 16, 16, 16);
+                    let tileWidth = 16;
+                    if (this.tilemapLiteral === "tilemap8") {
+                        tileWidth = 8;
+                    }
+                    else if (this.tilemapLiteral === "tilemap32") {
+                        tileWidth = 32;
+                    }
+                    const [ name, map ] = project.createNewTilemap(id, tileWidth, 16, 16);
                     proj = map;
                     id = name;
                 }
@@ -179,7 +188,7 @@ namespace pxt.editor {
         weight: 5,
         matcher: {
             // match both JS and python
-            searchString: "(?:tilemap\\s*(?:`|\\(\"\"\")(?:[ a-zA-Z0-9_]|\\n)*\\s*(?:`|\"\"\"\\)))|(?:tiles\\s*\\.\\s*createTilemap\\s*\\([^\\)]+\\))",
+            searchString: "(?:tilemap(?:8|16|32)?\\s*(?:`|\\(\"\"\")(?:[ a-zA-Z0-9_]|\\n)*\\s*(?:`|\"\"\"\\)))|(?:tiles\\s*\\.\\s*createTilemap\\s*\\([^\\)]+\\))",
             isRegex: true,
             matchCase: true,
             matchWholeWord: false

--- a/webapp/src/components/ImageEditor/Dropdown.tsx
+++ b/webapp/src/components/ImageEditor/Dropdown.tsx
@@ -42,11 +42,11 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
 
         return <div className="image-editor-dropdown-outer">
             <button className="image-editor-dropdown" aria-haspopup="listbox" onClick={this.handleDropdownClick}>
-                { selectedOption.text }
+                { selectedOption?.text || "" }
                 <span className="image-editor-dropdown-chevron ms-Icon ms-Icon--ChevronDown">
                 </span>
             </button>
-            <ul tabIndex={-1} role="listbox" aria-activedescendant={selectedOption.id} className={open ? "" : "hidden"}>
+            <ul tabIndex={-1} role="listbox" aria-activedescendant={selectedOption?.id} className={(open && options.length) ? "" : "hidden"}>
                 {
                     options.map((option, index) =>
                         <li key={option.id}

--- a/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
+++ b/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
@@ -100,13 +100,8 @@ class TilePaletteImpl extends React.Component<TilePaletteProps,{}> {
     constructor(props: TilePaletteProps) {
         super(props);
 
-        const { gallery, tileset } = props;
-        options.forEach(opt => {
-            if (opt.tiles.length == 0) {
-                opt.tiles.push.apply(opt.tiles,
-                    gallery.filter(t => t.tags.indexOf(opt.id) !== -1 && t.tileWidth === tileset.tileWidth));
-                }
-        })
+        const { gallery } = props;
+        this.refreshGallery(props);
 
         const extraCategories: pxt.Map<Category> = {};
         for (const tile of gallery) {
@@ -139,6 +134,7 @@ class TilePaletteImpl extends React.Component<TilePaletteProps,{}> {
         } else if (this.props.backgroundColor != nextProps.backgroundColor) {
             this.jumpToPageContaining(nextProps.backgroundColor);
         }
+        this.refreshGallery(nextProps);
     }
 
     componentDidUpdate() {
@@ -189,7 +185,7 @@ class TilePaletteImpl extends React.Component<TilePaletteProps,{}> {
             </div>
             <Pivot options={tabs} selected={galleryOpen ? 1 : 0} onChange={this.pivotHandler} />
             <div className="tile-palette-controls-outer">
-                { galleryOpen && <Dropdown onChange={this.dropdownHandler} options={this.categories} selected={category} /> }
+                { galleryOpen && <Dropdown onChange={this.dropdownHandler} options={this.categories.filter(c => !!c.tiles.length)} selected={category} /> }
 
                 { !galleryOpen &&
                     <div className="tile-palette-controls">
@@ -442,6 +438,13 @@ class TilePaletteImpl extends React.Component<TilePaletteProps,{}> {
             // automatically switch into tile drawing mode
             this.props.dispatchChangeDrawingMode(TileDrawingMode.Default);
         }
+    }
+
+    protected refreshGallery(props: TilePaletteProps) {
+        const { gallery, tileset } = props;
+        options.forEach(opt => {
+            opt.tiles = gallery.filter(t => t.tags.indexOf(opt.id) !== -1 && t.tileWidth === tileset.tileWidth);
+        });
     }
 
     protected positionCreateTileButton() {


### PR DESCRIPTION
This fixes a long-standing regression where we lost the ability to use different widths for tilemap tiles when we shipped the new tilemap editor. This PR has no UI changes, it just adds a field option to the tilemap field that lets you give an alternate tilewidth (8, 16, or 32). This way we can ship an extension that adds blocks for 8x8 and 32x32 tiles.

Also adds a way to do it in Monaco, but it isn't the prettiest. Basically, you can type `tilemap8`, `tilemap16`, or `tilemap32` when creating a tilemap and this will hint to the editor that it should create a tilemap with that tile width. If a tilemap with the same name already exists, then it will ignore the tile width and just open the existing one. I have a PR upcoming for common packages that adds those alternate APIs.