### PR TITLE
Add preferred editor to compile tick && typecheck tick

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -738,6 +738,7 @@ export class ProjectView
                     pxt.tickEvent("light.typecheck")
                     pxt.options.light = true;
                 }
+                pxt.tickEvent("typecheck.complete", { editor: this.getPreferredEditor() });
                 this.editor.setDiagnostics(this.editorFile, state);
                 data.invalidate("open-pkg-meta:" + pkg.mainEditorPkg().getPkgId());
                 if (this.state.autoRun) {
@@ -2419,7 +2420,7 @@ export class ProjectView
     beforeCompile() { }
 
     compile(saveOnly = false) {
-        pxt.tickEvent("compile");
+        pxt.tickEvent("compile", { editor: this.getPreferredEditor() });
         pxt.debug('compiling...');
 
         if (this.checkForHwVariant())

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -429,7 +429,6 @@ export class EditorPackage {
     saveFilesAsync(immediate?: boolean) {
         if (!this.header) return Promise.resolve();
 
-        pxt.tickEvent("package.save", { editor: this.topPkg?.ksPkg?.getPreferredEditor() });
         let cfgFile = this.files[pxt.CONFIG_NAME]
         if (cfgFile) {
             try {

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -429,6 +429,7 @@ export class EditorPackage {
     saveFilesAsync(immediate?: boolean) {
         if (!this.header) return Promise.resolve();
 
+        pxt.tickEvent("package.save", { editor: this.topPkg?.ksPkg?.getPreferredEditor() });
         let cfgFile = this.files[pxt.CONFIG_NAME]
         if (cfgFile) {
             try {


### PR DESCRIPTION
so we can see where compilations / typechecks are coming from

the `typecheck.complete` tick would get sent a lot, as it triggers every run / every time we need to update typings for monaco, but it seems useful for knowing accurately how often each language is being used.