### PR TITLE
Add missing parm description for 'insertAt()'

### DIFF
--- a/common-docs/reference/arrays/insert-at.md
+++ b/common-docs/reference/arrays/insert-at.md
@@ -19,6 +19,7 @@ myNumbers.insertAt(3, 2);
 ## Parameters
 
 * **index**: a [number](/types/number) which is the position in the array to insert the element at.
+* **value**: a value to insert into the array at the position of **index**. The value has the same [type](/types) as the the type that array was created with, [number](/types/number), [boolean](/types/boolean), [string](/types/string), etc.
 
 ## Example
 

--- a/common-docs/reference/arrays/insert-at.md
+++ b/common-docs/reference/arrays/insert-at.md
@@ -19,7 +19,7 @@ myNumbers.insertAt(3, 2);
 ## Parameters
 
 * **index**: a [number](/types/number) which is the position in the array to insert the element at.
-* **value**: a value to insert into the array at the position of **index**. The value has the same [type](/types) as the the type that array was created with, [number](/types/number), [boolean](/types/boolean), [string](/types/string), etc.
+* **value**: a value to insert into the array at the position of **index**. The value has the same [type](/types) as the type that array was created with, [number](/types/number), [boolean](/types/boolean), [string](/types/string), etc.
 
 ## Example
 


### PR DESCRIPTION
Update the reference page for **Array.insertAt()** to include the missing parameter description for **value**.

RE: https://crowdin.com/translate/kindscript/1934/en-ru#q=71774