### PR TITLE
Minor tileset fixes for different tile sizes

### DIFF
--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -88,7 +88,7 @@ namespace pxtblockly {
             this.state.projectReferences = getAllReferencedTiles(this.sourceBlock_.workspace, this.sourceBlock_.id).map(t => t.id);
             const project = pxt.react.getTilemapProject();
 
-            const allTiles = project.getProjectTiles(this.state.tileset.tileWidth);
+            const allTiles = project.getProjectTiles(this.state.tileset.tileWidth, true);
 
             for (const tile of allTiles.tiles) {
                 if (!this.state.tileset.tiles.some(t => t.id === tile.id)) {

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -28,13 +28,19 @@ namespace pxtblockly {
                 FieldTileset.cachedWorkspaceId = workspace.id;
                 const references = getAllReferencedTiles(workspace);
 
-                const projectTiles = project.getProjectTiles(16)
+                const supportedTileWidths = [16, 8, 32];
 
-                for (const tile of projectTiles.tiles) {
-                    if (!references.find(t => t.id === tile.id)) {
-                        references.push(tile);
+                for (const width of supportedTileWidths) {
+                    const projectTiles = project.getProjectTiles(width, width === 16);
+                    if (!projectTiles) continue;
+
+                    for (const tile of projectTiles.tiles) {
+                        if (!references.find(t => t.id === tile.id)) {
+                            references.push(tile);
+                        }
                     }
                 }
+
 
                 let weights: pxt.Map<number> = {};
                 references.sort((a, b) => {
@@ -54,7 +60,7 @@ namespace pxtblockly {
                 });
 
                 const getTileImage = (t: pxt.Tile) => tileWeight(t.id) <= 2 ?
-                    mkTransparentTileImage(16) :
+                    mkTransparentTileImage(t.bitmap.width) :
                     bitmapToImageURI(pxt.sprite.Bitmap.fromData(t.bitmap), PREVIEW_SIDE_LENGTH, false);
 
                 FieldTileset.referencedTiles = references.map(tile => [{
@@ -181,10 +187,11 @@ namespace pxtblockly {
 
     function tileWeight(id: string) {
         switch (id) {
-            case "myTiles.transparency8":
             case "myTiles.transparency16":
-            case "myTiles.transparency32":
                 return 1;
+            case "myTiles.transparency8":
+            case "myTiles.transparency32":
+                return 2;
             default:
                 if (id.startsWith("myTiles.tile")) {
                     const num = parseInt(id.slice(12));

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -12,7 +12,7 @@ namespace pxt.editor {
         protected textToValue(text: string): pxt.sprite.TilemapData {
             const tm = this.readTilemap(text);
 
-            const allTiles = pxt.react.getTilemapProject().getProjectTiles(tm.tileset.tileWidth);
+            const allTiles = pxt.react.getTilemapProject().getProjectTiles(tm.tileset.tileWidth, true);
 
             for (const tile of allTiles.tiles) {
                 if (!tm.tileset.tiles.some(t => t.id === tile.id)) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -62,14 +62,14 @@ namespace pxt {
             return null;
         }
 
-        public getProjectTiles(tileWidth: number): TileSet | null {
+        public getProjectTiles(tileWidth: number, createIfMissing: boolean): TileSet | null {
             if (this.state.projectTileSet) {
                 const res = this.state.projectTileSet.tileSets.find(tileSet => tileSet.tileWidth === tileWidth);
 
-                if (!res) {
+                if (!res && createIfMissing) {
                     // This will create a new tileset with the correct width
                     this.createNewTile(new pxt.sprite.Bitmap(tileWidth, tileWidth).data())
-                    return this.getProjectTiles(tileWidth);
+                    return this.getProjectTiles(tileWidth, false);
                 }
 
                 return res;
@@ -374,7 +374,7 @@ namespace pxt {
             }
 
             // Always create a transparent tile
-            const bitmap = new pxt.sprite.Bitmap(16, 16).data();
+            const bitmap = new pxt.sprite.Bitmap(tileWidth, tileWidth).data();
             tileSet.tiles.push({
                 id: transparencyID,
                 bitmap: bitmap,


### PR DESCRIPTION
Minor fix for a bug I found after merging this PR: https://github.com/microsoft/pxt/pull/7388

This fixes the tileset picker to include all project tiles and makes it so that the different transparency sizes are visually different.