### PR TITLE
Add tick event for successful github commit

### DIFF
--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -559,16 +559,20 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
     }
 
     async commitAsync() {
+        let success = true;
         this.setState({ needsCommitMessage: false });
         this.showLoading("github.commit", true, lf("commit and push changes to GitHub..."));
         try {
             await this.commitCoreAsync()
             await this.maybeReloadAsync()
         } catch (e) {
+            success = false;
             pxt.tickEvent("github.commit.fail");
             this.handleGithubError(e);
         } finally {
-            pxt.tickEvent("github.commit.success");
+            if (success) {
+                pxt.tickEvent("github.commit.success");
+            }
             this.hideLoading()
         }
     }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -566,9 +566,9 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             await this.maybeReloadAsync()
         } catch (e) {
             this.handleGithubError(e);
+            pxt.tickEvent("github.commit.fail");
         } finally {
             this.hideLoading()
-            pxt.tickEvent("github.commit.success");
         }
     }
 

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -565,9 +565,10 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             await this.commitCoreAsync()
             await this.maybeReloadAsync()
         } catch (e) {
-            this.handleGithubError(e);
             pxt.tickEvent("github.commit.fail");
+            this.handleGithubError(e);
         } finally {
+            pxt.tickEvent("github.commit.success");
             this.hideLoading()
         }
     }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -568,6 +568,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             this.handleGithubError(e);
         } finally {
             this.hideLoading()
+            pxt.tickEvent("github.commit.success");
         }
     }
 


### PR DESCRIPTION
Do we want to add events so we can complete the quiz? We have a tick for when users click the commit button, but nothing to see if the commit was successful.