### PR TITLE
Cache tutorial usedBlocks in IndexedDb

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -946,12 +946,12 @@ namespace pxt.BrowserUtils {
     interface TutorialInfoIndexedDbEntry {
         id: string;
         hash: string;
-        blocks: { [ key: string ]: number };
+        blocks: Map<number>;
     }
 
     export interface ITutorialInfoDb {
         getAsync(filename: string, code: string[], branch?: string): Promise<TutorialInfoIndexedDbEntry>;
-        setAsync(filename: string, blocks: { [ key: string ]: number }, code: string[], branch?: string ): Promise<void>;
+        setAsync(filename: string, blocks: Map<number>, code: string[], branch?: string ): Promise<void>;
     }
 
     class TutorialInfoIndexedDb implements ITutorialInfoDb {
@@ -1000,7 +1000,7 @@ namespace pxt.BrowserUtils {
                 });
         }
 
-        setAsync(filename: string, blocks: { [ key: string ]: number }, code: string[], branch?: string ): Promise<void> {
+        setAsync(filename: string, blocks: Map<number>, code: string[], branch?: string ): Promise<void> {
             pxt.perf.measureStart("tutorial info db setAsync")
             const key = getTutorialInfoKey(filename, branch);
             const hash = getTutorialInfoHash(code);

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -991,9 +991,11 @@ namespace pxt.BrowserUtils {
 
             return this.db.getAsync<TutorialInfoIndexedDbEntry>(TutorialInfoIndexedDb.TABLE, key)
                 .then((res) => {
+                    /* tslint:disable:possible-timing-attack (this is not a security-sensitive codepath) */
                     if (res && res.hash == hash) {
                         return res;
                     }
+                    /* tslint:enable:possible-timing-attack */
                     return undefined;
                 });
         }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -932,6 +932,97 @@ namespace pxt.BrowserUtils {
             .catch(e => deleteDbAsync().done());
     }
 
+    function getTutorialInfoHash(code: string[]) {
+        // the code strings are parsed from markdown, so when the
+        // markdown changes the blocks will also be invalidated
+        const input = JSON.stringify(code) + pxt.appTarget.versions.pxt + "_" + pxt.appTarget.versions.target;
+        return pxtc.U.sha256(input);
+    }
+
+    function getTutorialInfoKey(filename: string, branch?: string) {
+        return `${filename}|${branch || "master"}`;
+    }
+
+    interface TutorialInfoIndexedDbEntry {
+        id: string;
+        hash: string;
+        blocks: { [ key: string ]: number };
+    }
+
+    export interface ITutorialInfoDb {
+        getAsync(filename: string, code: string[], branch?: string): Promise<TutorialInfoIndexedDbEntry>;
+        setAsync(filename: string, blocks: { [ key: string ]: number }, code: string[], branch?: string ): Promise<void>;
+    }
+
+    class TutorialInfoIndexedDb implements ITutorialInfoDb {
+        static TABLE = "info";
+        static KEYPATH = "id";
+
+        static dbName() {
+            return `__pxt_tutorialinfo_${pxt.appTarget.id || ""}`;
+        }
+
+        static createAsync(): Promise<TutorialInfoIndexedDb> {
+            function openAsync() {
+                const idbWrapper = new pxt.BrowserUtils.IDBWrapper(TutorialInfoIndexedDb.dbName(), 2, (ev, r) => {
+                    const db = r.result as IDBDatabase;
+                    db.createObjectStore(TutorialInfoIndexedDb.TABLE, { keyPath: TutorialInfoIndexedDb.KEYPATH });
+                }, () => {
+                    // quota exceeeded, clear db
+                    pxt.BrowserUtils.IDBWrapper.deleteDatabaseAsync(TutorialInfoIndexedDb.dbName())
+                });
+                return idbWrapper.openAsync()
+                    .then(() => new TutorialInfoIndexedDb(idbWrapper));
+            }
+            return openAsync()
+                .catch(e => {
+                    console.log(`db: failed to open tutorial info database, try delete entire store...`)
+                    return pxt.BrowserUtils.IDBWrapper.deleteDatabaseAsync(TutorialInfoIndexedDb.dbName())
+                        .then(() => openAsync());
+                })
+        }
+
+        private constructor(protected readonly db: pxt.BrowserUtils.IDBWrapper) {
+        }
+
+        getAsync(filename: string, code: string[], branch?: string): Promise<TutorialInfoIndexedDbEntry> {
+            const key = getTutorialInfoKey(filename, branch);
+            const hash = getTutorialInfoHash(code);
+
+            return this.db.getAsync<TutorialInfoIndexedDbEntry>(TutorialInfoIndexedDb.TABLE, key)
+                .then((res) => {
+                    if (res && res.hash == hash) {
+                        return res;
+                    }
+                    return undefined;
+                });
+        }
+
+        setAsync(filename: string, blocks: { [ key: string ]: number }, code: string[], branch?: string ): Promise<void> {
+            pxt.perf.measureStart("tutorial info db setAsync")
+            const key = getTutorialInfoKey(filename, branch);
+            const hash = getTutorialInfoHash(code);
+
+            const entry: TutorialInfoIndexedDbEntry = {
+                id: key,
+                hash,
+                blocks
+            };
+
+            return this.db.setAsync(TutorialInfoIndexedDb.TABLE, entry)
+                .then(() => {
+                    pxt.perf.measureEnd("tutorial info db setAsync")
+                })
+        }
+    }
+
+    let _tutorialInfoDbPromise: Promise<TutorialInfoIndexedDb>;
+    export function tutorialInfoDbAsync(): Promise<TutorialInfoIndexedDb> {
+        if (!_tutorialInfoDbPromise)
+            _tutorialInfoDbPromise = TutorialInfoIndexedDb.createAsync()
+        return _tutorialInfoDbPromise;
+    }
+
     export interface IPointerEvents {
         up: string,
         down: string[],

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1402,7 +1402,7 @@ export class ProjectView
 
         const t = header.tutorial;
         return this.loadBlocklyAsync()
-            .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.language))
+            .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.tutorial, t.language))
             .then((usedBlocks) => {
                 let editorState: pxt.editor.EditorState = {
                     searchBar: false

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -34,7 +34,10 @@ export function getUsedBlocksAsync(code: string[], id: string, language?: string
                 // fall back to full blocks decompile on error
                 return getUsedBlocksInternalAsync(code, id, language, db);
             })
-        )
+        ).catch((err) => {
+            // fall back to full blocks decompile on error
+            return getUsedBlocksInternalAsync(code, id, language);
+        })
 }
 
 function getUsedBlocksInternalAsync(code: string[], id: string, language?: string, db?: pxt.BrowserUtils.ITutorialInfoDb): Promise<pxt.Map<number>> {


### PR DESCRIPTION
- Database class based off the api info and translations DBs
- Hashes the code snippets and invalidates the blocks based on those--I think this should functionally sync up with invalidating when the cached markdown invalidates/changes
- Next steps are to get the list of used blocks at build time (like the api info) to also speed up the first load

Build: https://minecraft.makecode.com/app/29d4f5abb6b4e1d67b538a9ed500175b4b1eaa18-87b91c9b85

You can compare with beta or just compare first load vs subsequent loads