### PR TITLE
support for jres snippets in tutorials

### DIFF
--- a/docs/writing-docs/tutorials.md
+++ b/docs/writing-docs/tutorials.md
@@ -309,6 +309,43 @@ player.onChat("blockleft", function () {
 ```
 ````
 
+
+### JRes
+
+You can add a JRes file to the project if your tutorial relies on one being present in the user's project. This is usually necessary when creating a tutorial that references tilemaps (copy the contents of tilemap.g.jres into a snippet).
+
+````
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAACIiIiIiIiIiIiIiIiIiIiIiISIiIiIiIiISIiIiIhIiIiIhIiIiISIiIhIiIhIiIiIiIiEiISIiIiIiEhIiIiIiIiIiISIiIiIiIhISIiIiIiIiISIhIiIiIhIiIhIiIiIiISIiIiEiIhIiIiIiEiIiIiIiIiIiISIiIiIiIiIiA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "level": {
+        "id": "level",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAxMDAwMTAwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMjAyMDIwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMjAyMDIwMjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAyMDIwMjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "sprites.castle.tileGrass2"
+        ]
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```
+````
+
 ## Using Python
 
 If the target supports Python, snippets can be written in JavaScript or Python directly.
@@ -358,7 +395,7 @@ To have a tutorial appear on the home screen, you will need to create or use an 
 
 ### JavaScript and Python tutorial ("Spy tutorials")
 
-If you are able to author your tutorial in a language agnostic way, 
+If you are able to author your tutorial in a language agnostic way,
 you will be able to have a single source document for both JavaScript and Python. You can specify a single tutorial for multiple languages using the [otherActions](/targets/home-screen#otheractions) field in the tutorial code card.
 
 ## In context tutorials

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -888,6 +888,7 @@ declare namespace pxt.tutorial {
         language?: string; // language of code snippet (ts or python)
         templateCode?: string;
         metadata?: TutorialMetadata;
+        jres?: string; // JRES to be used when generating hints; necessary for tilemaps
     }
 
     interface TutorialMetadata {
@@ -935,6 +936,7 @@ declare namespace pxt.tutorial {
         autoexpandStep?: boolean; // autoexpand tutorial card if instruction text overflows
         metadata?: TutorialMetadata; // metadata about the tutorial parsed from the markdown
         language?: string; // native language of snippets ("python" for python, otherwise defaults to typescript)
+        jres?: string; // JRES to be used when generating hints; necessary for tilemaps
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -262,6 +262,11 @@ namespace pxtblockly {
         private parseBitmap(newText: string) {
             if (!this.blocksInfo) return;
 
+            if (newText) {
+                // backticks are escaped inside markdown content
+                newText = newText.replace(/&#96;/g, "`");
+            }
+
             const match = /^\s*tilemap\s*`([^`]*)`\s*$/.exec(newText);
 
             if (match) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -205,35 +205,7 @@ namespace pxt {
         parseJRes(allres: Map<JRes> = {}) {
             for (const f of this.getFiles()) {
                 if (U.endsWith(f, ".jres")) {
-                    let js: Map<JRes> = JSON.parse(this.readFile(f))
-                    let base: JRes = js["*"] || {} as any
-                    for (let k of Object.keys(js)) {
-                        if (k == "*") continue
-                        let v = js[k]
-                        if (typeof v == "string") {
-                            // short form
-                            v = { data: v } as any
-                        }
-                        let ns = v.namespace || base.namespace || ""
-                        if (ns) ns += "."
-                        let id = v.id || ns + k
-                        let icon = v.icon
-                        let mimeType = v.mimeType || base.mimeType
-                        let dataEncoding = v.dataEncoding || base.dataEncoding || "base64"
-                        if (!icon && dataEncoding == "base64" && (mimeType == "image/png" || mimeType == "image/jpeg")) {
-                            icon = "data:" + mimeType + ";base64," + v.data
-                        }
-                        allres[id] = {
-                            id,
-                            data: v.data,
-                            dataEncoding: v.dataEncoding || base.dataEncoding || "base64",
-                            icon,
-                            namespace: ns,
-                            mimeType,
-                            tilemapTile: v.tilemapTile,
-                            tileset: v.tileset
-                        }
-                    }
+                    inflateJRes(JSON.parse(this.readFile(f)), allres)
                 }
             }
             return allres
@@ -1204,6 +1176,39 @@ namespace pxt {
             })
             return res;
         }
+    }
+
+    export function inflateJRes(js: Map<JRes>, allres: Map<JRes> = {}) {
+        let base: JRes = js["*"] || {} as any
+        for (let k of Object.keys(js)) {
+            if (k == "*") continue
+            let v = js[k]
+            if (typeof v == "string") {
+                // short form
+                v = { data: v } as any
+            }
+            let ns = v.namespace || base.namespace || ""
+            if (ns) ns += "."
+            let id = v.id || ns + k
+            let icon = v.icon
+            let mimeType = v.mimeType || base.mimeType
+            let dataEncoding = v.dataEncoding || base.dataEncoding || "base64"
+            if (!icon && dataEncoding == "base64" && (mimeType == "image/png" || mimeType == "image/jpeg")) {
+                icon = "data:" + mimeType + ";base64," + v.data
+            }
+            allres[id] = {
+                id,
+                data: v.data,
+                dataEncoding: v.dataEncoding || base.dataEncoding || "base64",
+                icon,
+                namespace: ns,
+                mimeType,
+                tilemapTile: v.tilemapTile,
+                tileset: v.tileset
+            }
+        }
+
+        return allres;
     }
 
     export function allPkgFiles(cfg: PackageConfig) {

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1199,7 +1199,7 @@ namespace pxt {
             allres[id] = {
                 id,
                 data: v.data,
-                dataEncoding: v.dataEncoding || base.dataEncoding || "base64",
+                dataEncoding,
                 icon,
                 namespace: ns,
                 mimeType,

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -217,6 +217,26 @@ namespace pxt {
             return null;
         }
 
+        public resolveTileByBitmap(data: pxt.sprite.BitmapData): Tile {
+            const all = [this.state.projectTileSet].concat(this.extensionTileSets);
+
+            const dataString = pxt.sprite.base64EncodeBitmap(data);
+
+            for (const tileSets of all) {
+                for (const tileSet of tileSets.tileSets) {
+                    if (tileSet.tileWidth === data.width) {
+                        for (const tile of tileSet.tiles) {
+                            if (dataString === tile.data) {
+                                return tile;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
         public getTransparency(tileWidth: number) {
             for (const tileSet of this.state.projectTileSet.tileSets) {
                 if (tileSet.tileWidth === tileWidth) {
@@ -325,7 +345,7 @@ namespace pxt {
 
             for (const dep of allPackages) {
                 const isProject = dep.id === "this";
-                const tiles = readTiles(dep, isProject);
+                const tiles = readTiles(dep.parseJRes(), dep.id, isProject);
 
                 if (tiles) {
                     if (isProject) {
@@ -343,7 +363,7 @@ namespace pxt {
                 }
             }
 
-            this.state.projectTilemaps = getTilemaps(pack)
+            this.state.projectTilemaps = getTilemaps(pack.parseJRes())
                 .map(tm => ({
                     id: tm.id,
                     data: decodeTilemap(tm, id => this.resolveTile(id))
@@ -354,6 +374,54 @@ namespace pxt {
 
             this.state.takenNames = {};
             for (const id of Object.keys(allJRes)) this.state.takenNames[id] = true;
+        }
+
+        loadJres(jres: Map<JRes>, skipDuplicates = false) {
+            jres = inflateJRes(jres)
+
+            const tiles = readTiles(jres, "this", true);
+
+            // If we are loading JRES into an existing project (i.e. in multipart tutorials)
+            // we need to correct the tile ids because the user may have created new tiles
+            // and taken some of the ids that were used by the tutorial author
+            let tileMapping: Map<string> = {};
+
+            if (tiles) {
+                for (const tileset of tiles.tileSets) {
+                    for (const tile of tileset.tiles) {
+                        if (skipDuplicates) {
+                            const existing = this.resolveTileByBitmap(tile.bitmap);
+                            if (existing) {
+                                tileMapping[tile.id] = existing.id;
+                                continue;
+                            }
+                        }
+
+                        const newTile = this.createNewTile(tile.bitmap, tile.id);
+
+                        if (newTile.id !== tile.id) {
+                            tileMapping[tile.id] = newTile.id;
+                        }
+                    }
+                }
+            }
+
+            const maps = getTilemaps(jres)
+                .map(tm => ({
+                    id: tm.id,
+                    data: decodeTilemap(tm, id => {
+                        if (tileMapping[id]) {
+                            id = tileMapping[id];
+                        }
+
+                        return this.resolveTile(id)
+                    })
+                }));
+
+            this.state.projectTilemaps.push(...maps);
+
+            for (const id of Object.keys(jres)) this.state.takenNames[id] = true;
+
         }
 
         protected createTileset(tileWidth: number) {
@@ -391,9 +459,7 @@ namespace pxt {
         }
     }
 
-    function readTiles(pack: pxt.Package, isProjectTile = false): TileSetCollection | null {
-        const allJRes = pack.parseJRes();
-
+    function readTiles(allJRes: Map<JRes>, id: string, isProjectTile = false): TileSetCollection | null {
         const tiles: Tile[] = [];
 
         for (const key of Object.keys(allJRes)) {
@@ -433,16 +499,14 @@ namespace pxt {
         if (!tileSets.length) return null;
 
         const collection = {
-            extensionID: pack.id,
+            extensionID: id,
             tileSets: tileSets
         };
 
         return collection;
     }
 
-    function getTilemaps(pack: pxt.Package): JRes[] {
-        const allJRes = pack.parseJRes();
-
+    function getTilemaps(allJRes: Map<JRes>): JRes[] {
         const res: JRes[] = [];
         for (const key of Object.keys(allJRes)) {
             const entry = allJRes[key];

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -419,9 +419,7 @@ namespace pxt {
                 }));
 
             this.state.projectTilemaps.push(...maps);
-
-            for (const id of Object.keys(jres)) this.state.takenNames[id] = true;
-
+            maps.forEach(tm => this.state.takenNames[tm.id] = true);
         }
 
         protected createTileset(tileWidth: number) {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -10,7 +10,7 @@ namespace pxt.tutorial {
             return undefined; // error parsing steps
 
         // collect code and infer editor
-        const { code, templateCode, editor, language } = computeBodyMetadata(body);
+        const { code, templateCode, editor, language, jres } = computeBodyMetadata(body);
 
         // noDiffs legacy
         if (metadata.diffs === true // enabled in tutorial
@@ -38,14 +38,16 @@ namespace pxt.tutorial {
             code,
             templateCode,
             metadata,
-            language
+            language,
+            jres
         };
     }
 
     function computeBodyMetadata(body: string) {
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python)?\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres)?\s*\n([\s\S]*?)\n```/gmi;
+        let jres: string;
         let code: string[] = [];
         let templateCode: string;
         let language: string;
@@ -78,6 +80,9 @@ namespace pxt.tutorial {
                     case "template":
                         templateCode = m2;
                         break;
+                    case "jres":
+                        jres = m2;
+                        break;
                 }
                 code.push(m1 == "python" ? `\n${m2}\n` : `{\n${m2}\n}`);
                 idx++
@@ -85,7 +90,7 @@ namespace pxt.tutorial {
             });
         // default to blocks
         editor = editor || pxt.BLOCKS_PROJECT_NAME
-        return { code, templateCode, editor, language }
+        return { code, templateCode, editor, language, jres }
 
         function checkTutorialEditor(expected: string) {
             if (editor && editor != expected) {
@@ -262,7 +267,7 @@ ${code}
     /* Remove hidden snippets from text */
     function stripHiddenSnippets(str: string): string {
         if (!str) return str;
-        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres)\s*\n([\s\S]*?)\n```/gmi;
         return str.replace(hiddenSnippetRegex, '').trim();
     }
 
@@ -346,7 +351,8 @@ ${code}
             templateCode: tutorialInfo.templateCode,
             autoexpandStep: true,
             metadata: tutorialInfo.metadata,
-            language: tutorialInfo.language
+            language: tutorialInfo.language,
+            jres: tutorialInfo.jres
         };
 
         return { options: tutorialOptions, editor: tutorialInfo.editor };

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1288,6 +1288,7 @@ export class ProjectView
                 simulator.setDirty();
                 return compiler.newProjectAsync();
             }).then(() => compiler.applyUpgradesAsync())
+            .then(() => this.loadTutorialJresCodeAsync())
             .then(() => this.loadTutorialTemplateCodeAsync())
             .then(() => {
                 const main = pkg.getEditorPkg(pkg.mainPkg)
@@ -1468,6 +1469,31 @@ export class ProjectView
         }
 
         return decompilePromise.then(() => workspace.saveAsync(header));
+    }
+
+    private loadTutorialJresCodeAsync(): Promise<void> {
+        const header = pkg.mainEditorPkg().header;
+        if (!header || !header.tutorial || !header.tutorial.jres)
+            return Promise.resolve();
+
+        const jres = header.tutorial.jres;
+
+        // Delete from the header so that we don't double-load the tiles into
+        // the project if the project gets reloaded
+        delete header.tutorial.jres;
+
+        let parsed: any;
+
+        try {
+            parsed = JSON.parse(jres);
+        }
+        catch (e) {
+            return Promise.reject(e);
+        }
+
+        const project = pxt.react.getTilemapProject();
+        project.loadJres(parsed, true);
+        return pkg.mainEditorPkg().buildTilemapsAsync();
     }
 
     removeProject() {


### PR DESCRIPTION
Part of a fix for https://github.com/microsoft/pxt-arcade/issues/2250

You can add tilemaps and custom tiles to a tutorial by using a `jres` snippet. Just copy/paste the contents of `tilemap.g.jres` (no need to copy `tilemap.g.ts`). The tiles will also show up in the user project if they are custom.