### PR TITLE
Offline app page updates

### DIFF
--- a/docfiles/offline-app-body.html
+++ b/docfiles/offline-app-body.html
@@ -1,5 +1,5 @@
 
-    <div class="ui inverted vertical center aligned segment content">
+    <div id="offline-app-body" class="ui inverted vertical center aligned segment content">
         <div class="topbar @tocclass@">
             <div class="left flex-wrapper">
                 <img class="headerlogo" src="@cardLogo@" />

--- a/docfiles/offline-app-body.html
+++ b/docfiles/offline-app-body.html
@@ -2,11 +2,15 @@
     <div id="offline-app-body" class="ui inverted vertical center aligned segment content">
         <div class="topbar @tocclass@">
             <div class="left flex-wrapper">
-                <img class="headerlogo" src="@cardLogo@" />
+                <a href="/" tabindex="0" title="Go to editor">
+                    <img class="headerlogo" src="@cardLogo@" alt="Editor logo" />
+                </a>
             </div>
             <h1 class="welcomeheader">MakeCode Offline App</h1>
             <div class="right flex-wrapper">
-                <img class="headerlogo" src="/static/Microsoft-logo_rgb_c-white.png" />
+                <a href="@organizationUrl@" tabindex="0" title="Go to organization">
+                    <img class="headerlogo" src="/static/Microsoft-logo_rgb_c-white.png" alt="Microsoft logo" />
+                </a>
             </div>
         </div>
 

--- a/docfiles/offline-app-body.html
+++ b/docfiles/offline-app-body.html
@@ -1,15 +1,13 @@
 
     <div class="ui inverted vertical center aligned segment content">
         <div id="loader" class="ui active loader"></div>
-        <div class="ui grid topbar">
-            <div class="three wide column">
-                <img class="ui tiny image left" src="@cardLogo@" />
+        <div class="topbar @tocclass@">
+            <div class="left flex-wrapper">
+                <img class="targetlogo" src="@cardLogo@" />
             </div>
-            <div class="ten wide column">
-                <h1 class="ui inverted welcomeheader">MakeCode Offline App</h1>
-            </div>
-            <div class="three wide column">
-                <img class="ui small image right" src="/static/Microsoft-logo_rgb_c-white.png" />
+            <h1 class="welcomeheader">MakeCode Offline App</h1>
+            <div class="right flex-wrapper">
+                <img class="headerlogo" src="/static/Microsoft-logo_rgb_c-white.png" />
             </div>
         </div>
 

--- a/docfiles/offline-app-body.html
+++ b/docfiles/offline-app-body.html
@@ -1,9 +1,8 @@
 
     <div class="ui inverted vertical center aligned segment content">
-        <div id="loader" class="ui active loader"></div>
         <div class="topbar @tocclass@">
             <div class="left flex-wrapper">
-                <img class="targetlogo" src="@cardLogo@" />
+                <img class="headerlogo" src="@cardLogo@" />
             </div>
             <h1 class="welcomeheader">MakeCode Offline App</h1>
             <div class="right flex-wrapper">
@@ -11,6 +10,9 @@
             </div>
         </div>
 
+        <div id="loading-icon">
+            <div id="loader" class="ui active loader"></div>
+        </div>
         <div id="segments" class="ui compact segments terms-container">
             <div id="read-segment" class="ui secondary center aligned segment hidden">
                 Please read and accept the following terms to download the app.

--- a/docfiles/offline-app-body.html
+++ b/docfiles/offline-app-body.html
@@ -23,431 +23,172 @@
             </div>
             <div id="legal-segment" class="ui left aligned segment terms hidden">
                 <div class="c17">
-                    <p class="c11">
-                        <span class="c4 c1">MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS</span>
-                    </p>
-                    <p class="c11">
-                        <span class="c4 c1">MICROSOFT MAKECODE SOFTWARE FOR @boardName@</span>
-                    </p>
-                    <p class="c7">
-                        <span class="c4 c1"></span>
-                    </p>
-                    <p class="c11">
-                        <span class="c3 c1">These license terms are an agreement between Microsoft Corporation (or based
-                            on where you live, one
-                            of its affiliates) and you. They apply to the software named above. The terms also apply to
-                            any
-                            Microsoft services or updates for the software, except to the extent those have additional
-                            terms.</span>
-                    </p>
-                    <p class="c7">
-                        <span class="c3 c1"></span>
-                    </p>
-                    <p class="c11">
-                        <span class="c4 c1">IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">1.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">INSTALLATION AND USE RIGHTS. </span>
-                        <span class="c3 c1">You may install and use any number of copies of the software to evaluate it
-                            as you develop and test
-                            your software applications for use with @boardName@ hardware.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">2.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">PRE-RELEASE SOFTWARE. </span>
-                        <span class="c3 c1">The software is a pre-release version. It may not work the way a final
-                            version of the software will.
-                            Microsoft may change it for the final, commercial version. We also may not release a
-                            commercial
-                            version. Microsoft is not obligated to provide maintenance, technical support or updates to
-                            you
-                            for the software.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">3.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">ASSOCIATED ONLINE SERVICES.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Some features of the software
-                            provide access
-                            to, or rely on, online services to provide you information about updates to the software or
-                            extensions,
-                            or to enable you to retrieve content, collaborate with others, or otherwise supplement your
-                            development
-                            experience. As used throughout these license terms, the term <q>software</q> includes these
-                            online
-                            services and features. By using these online services and features you consent to the to the
-                            transmission of information as described in Section 5, DATA.
-                        </span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">4.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">LICENSES FOR OTHER COMPONENTS.</span>
-                        <span class="c3 c1">&nbsp;The software may include third party components with separate legal
-                            notices or governed by
-                            other agreements, as described in the ThirdPartyNotices file accompanying the software. Even
-                            if such components are governed by other agreements, the disclaimers and the limitations on
-                            and
-                            exclusions of damages below also apply.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">5.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c1 c4">DATA.</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c5 c1">a.</span>
-                        <span class="c1">&nbsp; &nbsp;</span>
-                        <span class="c1 c5">Data Collection. </span>
-                        <span class="c1">The software may collect information about you and your use of the software,
-                            and send that to Microsoft.
-                            Microsoft may use this information to provide services and improve our products and
-                            services.
-                            You may opt out of many of these scenarios, but not all, as described in the product
-                            documentation.
-                            In using the software, you must comply with applicable law. You can learn more about data
-                            collection
-                            and use in the help documentation and the privacy statement at </span>
-                        <span class="c14 c1">
-                            <a class="c9"
-                                href="http://go.microsoft.com/fwlink/?LinkId=398505">http://go.microsoft.com/fwlink/?LinkId=398505</a>
-                        </span>
-                        <span class="c1">.</span>
-                        <span class="c3 c1">&nbsp;Your use of the software operates as your consent to these
-                            practices.</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c5 c1">b.</span>
-                        <span class="c1">&nbsp; &nbsp;</span>
-                        <span class="c5 c1">Processing of Personal Data. </span>
-                        <span class="c1">To the extent Microsoft is a processor or subprocessor of personal data in
-                            connection with the software,
-                            Microsoft makes the commitments in the European Union General Data Protection Regulation
-                            Terms
-                            of the Online Services Terms to all customers effective May 25, 2018, at </span>
-                        <span class="c1 c14">
-                            <a class="c9"
-                                href="http://go.microsoft.com/?linkid=9840733">http://go.microsoft.com/?linkid=9840733</a>
-                        </span>
-                        <span class="c3 c1">.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">6.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">FEEDBACK. </span>
-                        <span class="c3 c1">If you give feedback about the software to Microsoft, you give to Microsoft,
-                            without charge, the
-                            right to use, share and commercialize your feedback in any way and for any purpose. You will
-                            not give feedback that is subject to a license that requires Microsoft to license its
-                            software
-                            or documentation to third parties because we include your feedback in them. These rights
-                            survive
-                            this agreement.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">7.</span>
-                        <span class="c1">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">SCOPE OF LICENSE.</span>
-                        <span class="c3 c1">&nbsp;The software is licensed, not sold. This agreement only gives you some
-                            rights to use the software.
-                            Microsoft reserves all other rights. Unless applicable law gives you more rights despite
-                            this
-                            limitation, you may use the software only as expressly permitted in this agreement. &nbsp;In
-                            doing so, you must comply with any technical limitations in the software that only allow you
-                            to use it in certain ways. You may not:</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c3 c1">- &nbsp; &nbsp; work around any technical limitations in the
-                            software;</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c3 c1">- &nbsp; &nbsp; reverse engineer, decompile or disassemble the software, or
-                            attempt to do so, except
-                            and only to the extent required by third party licensing terms governing use of certain open
-                            source components that may be included with the software;</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c3 c1">- &nbsp; &nbsp; remove, minimize, block or modify any notices of Microsoft
-                            or its suppliers in the
-                            software;
-                        </span>
-                    </p>
-                    <p class="c8">
-                        <span class="c3 c1">- &nbsp; &nbsp; use the software in any way that is against the law;
-                            or</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c3 c1">- &nbsp; &nbsp; share, publish, rent or lease the software, or provide the
-                            software as a stand-alone
-                            offering for others to use.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">8. &nbsp; UPDATES. </span>
-                        <span class="c3 c1">The software may periodically check for updates and download and install
-                            them for you. You may obtain
-                            updates only from Microsoft or authorized sources. Microsoft may need to update your system
-                            to
-                            provide you with updates. You agree to receive these automatic updates without any
-                            additional
-                            notice. Updates may not include or support all existing software features, services, or
-                            peripheral
-                            devices.
-                        </span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">9.</span>
-                        <span class="c1">&nbsp; &nbsp;</span>
-                        <span class="c5 c1">EXPORT RESTRICTIONS.</span>
-                        <span class="c3 c1">&nbsp;You must comply with all domestic and international export laws and
-                            regulations that apply
-                            to the software, which include restrictions on destinations, end users and end use. For
-                            further
-                            information on export restrictions, visit (aka.ms/exporting).</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">10.</span>
-                        <span class="c1">&nbsp;</span>
-                        <span class="c5 c1">SUPPORT SERVICES. </span>
-                        <span class="c3 c1">Because the software is &ldquo;as is,&rdquo; we may not provide support
-                            services for it.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">11.</span>
-                        <span class="c1">&nbsp;</span>
-                        <span class="c5 c1">ENTIRE AGREEMENT.</span>
-                        <span class="c3 c1">&nbsp;This agreement, and the terms for supplements, updates, Internet-based
-                            services and support
-                            services that you use, are the entire agreement for the software and support
-                            services.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">12.</span>
-                        <span class="c1">&nbsp;</span>
-                        <span class="c5 c1">APPLICABLE LAW. </span>
-                        <span class="c3 c1">If you acquired the software in the United States, Washington State law
-                            applies to interpretation
-                            of and claims for breach of this agreement, and the laws of the state where you live apply
-                            to
-                            all other claims. If you acquired the software in any other country, its laws apply.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">13.</span>
-                        <span class="c1">&nbsp;</span>
-                        <span class="c5 c1">CONSUMER RIGHTS; REGIONAL VARIATIONS. </span>
-                        <span class="c3 c1">This agreement describes certain legal rights. You may have other rights,
-                            including consumer rights,
-                            under the laws of your state or country. Separate and apart from your relationship with
-                            Microsoft,
-                            you may also have rights with respect to the party from which you acquired the software.
-                            This
-                            agreement does not change those other rights if the laws of your state or country do not
-                            permit
-                            it to do so. For example, if you acquired the software in one of the below regions, or
-                            mandatory
-                            country law applies, then the following provisions apply to you:</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c5 c1">a.</span>
-                        <span class="c1">&nbsp; &nbsp;</span>
-                        <span class="c5 c1">Australia. </span>
-                        <span class="c3 c1">You have statutory guarantees under the Australian Consumer Law and nothing
-                            in this agreement is
-                            intended to affect those rights.</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c5 c1">b.</span>
-                        <span class="c1">&nbsp; &nbsp;</span>
-                        <span class="c5 c1">Canada. </span>
-                        <span class="c3 c1">If you acquired the software in Canada, you may stop receiving updates by
-                            turning off the automatic
-                            update feature, disconnecting your device from the Internet (if and when you re-connect to
-                            the
-                            Internet, however, the software will resume checking for and installing updates), or
-                            uninstalling
-                            the software. The product documentation, if any, may also specify how to turn off updates
-                            for
-                            your specific device or software.</span>
-                    </p>
-                    <p class="c8">
-                        <span class="c5 c1">c.</span>
-                        <span class="c1">&nbsp; &nbsp;</span>
-                        <span class="c5 c1">Germany and Austria</span>
-                        <span class="c3 c1">.</span>
-                    </p>
-                    <p class="c6">
-                        <span class="c5 c1">(i)</span>
-                        <span class="c1">&nbsp; &nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">Warranty</span>
-                        <span class="c3 c1">. The properly licensed software will perform substantially as described in
-                            any Microsoft materials
-                            that accompany the software. However, Microsoft gives no contractual guarantee in relation
-                            to
-                            the licensed software.</span>
-                    </p>
-                    <p class="c6">
-                        <span class="c4 c1">&nbsp;</span>
-                    </p>
-                    <p class="c6">
-                        <span class="c5 c1">(ii)</span>
-                        <span class="c1">&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-                        <span class="c5 c1">Limitation of Liability</span>
-                        <span class="c3 c1">. In case of intentional conduct, gross negligence, claims based on the
-                            Product Liability Act, as
-                            well as, in case of death or personal or physical injury, Microsoft is liable according to
-                            the
-                            statutory law.</span>
-                    </p>
-                    <p class="c10">
-                        <span class="c3 c1">Subject to the foregoing clause (ii), Microsoft will only be liable for
-                            slight negligence if Microsoft
-                            is in breach of such material contractual obligations, the fulfillment of which facilitate
-                            the
-                            due performance of this agreement, the breach of which would endanger the purpose of this
-                            agreement
-                            and the compliance with which a party may constantly trust in (so-called &quot;cardinal
-                            obligations&quot;).
-                            In other cases of slight negligence, Microsoft will not be liable for slight
-                            negligence.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">14.</span>
-                        <span class="c1">&nbsp;</span>
-                        <span class="c5 c1">LEGAL EFFECT.</span>
-                        <span class="c3 c1">&nbsp;This agreement describes certain legal rights. You may have other
-                            rights under the laws of
-                            your country. You may also have rights with respect to the party from whom you acquired the
-                            software.
-                            This agreement does not change your rights under the laws of your country if the laws of
-                            your
-                            country do not permit it to do so.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">15.</span>
-                        <span class="c1">&nbsp;</span>
-                        <span class="c4 c1">DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED &ldquo;AS-IS.&rdquo;
-                            &nbsp;YOU BEAR THE RISK OF
-                            USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT
-                            PERMITTED
-                            UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
-                            FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c5 c1">16.</span>
-                        <span class="c1">&nbsp;</span>
-                        <span class="c4 c1">LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND
-                            ITS SUPPLIERS ONLY DIRECT
-                            DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL,
-                            LOST
-                            PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.</span>
-                    </p>
-                    <p class="c0">
-                        <span class="c3 c1">This limitation applies to (a) anything related to the software, services,
-                            content (including code)
-                            on third party Internet sites, or third party programs; and (b) claims for breach of
-                            contract,
-                            breach of warranty, guarantee or condition, strict liability, negligence, or other tort to
-                            the
-                            extent permitted by applicable law.</span>
-                    </p>
-                    <p class="c0">
-                        <span class="c3 c1">It also applies even if Microsoft knew or should have known about the
-                            possibility of the damages.
-                            The above limitation or exclusion may not apply to you because your country may not allow
-                            the
-                            exclusion or limitation of incidental, consequential or other damages.</span>
-                    </p>
-                    <p class="c12">
-                        <span class="c4 c1">Please note: As the software is distributed in Quebec, Canada, some of the
-                            clauses in this agreement
-                            are provided below in French.</span>
-                    </p>
-                    <p class="c12">
-                        <span class="c4 c1">Remarque : Ce logiciel &eacute;tant distribu&eacute; au Qu&eacute;bec,
-                            Canada, certaines des clauses
-                            dans ce contrat sont fournies ci-dessous en fran&ccedil;ais.</span>
-                    </p>
-                    <p class="c11">
-                        <span class="c5 c1">EXON&Eacute;RATION DE GARANTIE.</span>
-                        <span class="c1 c3">&nbsp;Le logiciel vis&eacute; par une licence est offert &laquo; tel quel
-                            &raquo;. Toute utilisation
-                            de ce logiciel est &agrave; votre seule risque et p&eacute;ril. Microsoft n&rsquo;accorde
-                            aucune
-                            autre garantie expresse. Vous pouvez b&eacute;n&eacute;ficier de droits additionnels en
-                            vertu
-                            du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou
-                            elles
-                            sont permises par le droit locale, les garanties implicites de qualit&eacute; marchande,
-                            d&rsquo;ad&eacute;quation
-                            &agrave; un usage particulier et d&rsquo;absence de contrefa&ccedil;on sont exclues.
-                        </span>
-                    </p>
-                    <p class="c11">
-                        <span class="c5 c1">LIMITATION DES DOMMAGES-INT&Eacute;R&Ecirc;TS ET EXCLUSION DE
-                            RESPONSABILIT&Eacute; POUR LES DOMMAGES.</span>
-                        <span class="c3 c1">&nbsp;Vous pouvez obtenir de Microsoft et de ses fournisseurs une
-                            indemnisation en cas de dommages
-                            directs uniquement &agrave; hauteur de 5,00 $ US. Vous ne pouvez pr&eacute;tendre &agrave;
-                            aucune
-                            indemnisation pour les autres dommages, y compris les dommages sp&eacute;ciaux, indirects ou
-                            accessoires et pertes de b&eacute;n&eacute;fices.</span>
-                    </p>
-                    <p class="c12">
-                        <span class="c3 c1">Cette limitation concerne :</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c3 c1">- &nbsp; &nbsp; &nbsp; &nbsp; tout ce qui est reli&eacute; au logiciel, aux
-                            services ou au contenu
-                            (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers ;
-                            et</span>
-                    </p>
-                    <p class="c2">
-                        <span class="c3 c1">- &nbsp; &nbsp; &nbsp; &nbsp; les r&eacute;clamations au titre de violation
-                            de contrat ou de garantie,
-                            ou au titre de responsabilit&eacute; stricte, de n&eacute;gligence ou d&rsquo;une autre
-                            faute
-                            dans la limite autoris&eacute;e par la loi en vigueur.</span>
-                    </p>
-                    <p class="c12">
-                        <span class="c3 c1">Elle s&rsquo;applique &eacute;galement, m&ecirc;me si Microsoft connaissait
-                            ou devrait conna&icirc;tre
-                            l&rsquo;&eacute;ventualit&eacute; d&rsquo;un tel dommage. Si votre pays n&rsquo;autorise pas
-                            l&rsquo;exclusion ou la limitation de responsabilit&eacute; pour les dommages indirects,
-                            accessoires
-                            ou de quelque nature que ce soit, il se peut que la limitation ou l&rsquo;exclusion
-                            ci-dessus
-                            ne s&rsquo;appliquera pas &agrave; votre &eacute;gard.</span>
-                    </p>
-                    <p class="c16">
-                        <span class="c5 c1">EFFET JURIDIQUE.</span>
-                        <span class="c3 c1">&nbsp;Le pr&eacute;sent contrat d&eacute;crit certains droits juridiques.
-                            Vous pourriez avoir d&rsquo;autres
-                            droits pr&eacute;vus par les lois de votre pays. Le pr&eacute;sent contrat ne modifie pas
-                            les
-                            droits que vous conf&egrave;rent les lois de votre pays si celles-ci ne le permettent
-                            pas.</span>
-                    </p>
-                    <p class="c15">
-                        <span class="c3 c1"></span>
-                    </p>
-                    <p class="c16">
-                        <span class="c3 c1">&nbsp;</span>
-                    </p>
-
-                    <p class="c11">
-                        @trademarks@
-                    </p>
-                    <p class="c11">
-                        <span class="c3 c1">&nbsp;</span>
-                    </p>
-                    <p class="c20">
-                        <span class="c5 c1 c13">Remainder of this page intentionally left blank.</span>
-                    </p>
-                    <p class="c7">
-                        <span class="c3 c19"></span>
-                    </p>
+                    <p class="c12"><span class="c3 c2">MICROSOFT SOFTWARE LICENSE TERMS</span></p>
+                    <p class="c0"><span class="c3 c2">MICROSOFT MAKECODE SOFTWARE FOR <span class="touppercase">@boardName@</span></span></p>
+                    <p class="c12"><span class="c6">These license terms are an agreement between Microsoft Corporation (or based on
+                            where you live, one of its affiliates) and you. They apply to the software named above. The terms also apply
+                            to any Microsoft services or updates for the software, except to the extent those have additional
+                            terms.</span></p>
+                    <p class="c16"><span class="c3 c2">IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.</span></p>
+                    <p class="c1 c9"><span class="c2">1.</span><span class="c6">&nbsp;&nbsp;&nbsp; </span><span class="c2">INSTALLATION
+                            AND USE RIGHTS. </span><span class="c6">You may install and use any number of copies of the software to
+                            develop and test your software applications for use with @boardName@ hardware. </span></p>
+                    <p class="c1 c9"><span class="c2">2.</span><span class="c6">&nbsp;&nbsp;&nbsp; </span><span class="c2">ASSOCIATED
+                            ONLINE SERVICES.</span><span class="c3 c5">&nbsp;&nbsp;Some features of the software provide access to, or
+                            rely on, online services to provide you information about updates to the software or extensions, or to
+                            enable you to retrieve content, collaborate with others, or otherwise supplement your development
+                            experience.&nbsp; As used throughout these license terms, the term &ldquo;software&rdquo; includes these
+                            online services and features. By using these online services and features you consent to the to the
+                            transmission of information as described in Section 4, DATA.</span></p>
+                    <p class="c1 c9"><span class="c2">3.</span><span class="c6">&nbsp;&nbsp;&nbsp; </span><span class="c2">LICENSES FOR
+                            OTHER COMPONENTS.</span><span class="c6">&nbsp;T</span><span class="c6">he software may include third party
+                            components with separate legal notices or governed by other agreements, as described in the
+                            ThirdPartyNotices file accompanying the software. </span></p>
+                    <p class="c1 c9"><span class="c2">4.</span><span class="c6">&nbsp;&nbsp;&nbsp; </span><span class="c3 c2">DATA.
+                        </span></p>
+                    <p class="c1 c4"><span class="c2">a.</span><span class="c6">&nbsp;&nbsp;&nbsp;</span><span class="c2">Data
+                            Collection. </span><span class="c6">The software may collect information about you and your use of the
+                            software, and send that to Microsoft. Microsoft may use this information to provide services and improve our
+                            products and services. You may opt out of many of these scenarios, but not all, as described in the product
+                            documentation. In using the software, you must comply with applicable law. You can learn more about data
+                            collection and use in the help documentation and the privacy statement at </span><span class="c13 c6"><a
+                                class="c20"
+                                href="http://go.microsoft.com/fwlink/?LinkId%3D398505&amp;sa=D&amp;ust=1597949364473000&amp;usg=AOvVaw24fB1PnltFHDLgJ0_YTHvZ">http://go.microsoft.com/fwlink/?LinkId=398505</a></span><span
+                            class="c6">. Your use of the software operates as your consent to these practices.</span></p>
+                    <p class="c1 c4"><span class="c2">b.</span><span class="c6">&nbsp;&nbsp;&nbsp;</span><span class="c2">Processing of
+                            Personal Data. </span><span class="c6">To the extent Microsoft is a processor or subprocessor of personal
+                            data in connection with the software, Microsoft makes the commitments in the European Union General Data
+                            Protection Regulation Terms of the Online Services Terms to all customers effective May 25, 2018, at
+                        </span><span class="c6 c13"><a class="c20"
+                                href="https://docs.microsoft.com/en-us/legal/gdpr&amp;sa=D&amp;ust=1597949364473000&amp;usg=AOvVaw19LtkrFSFLU55xCLkIXR-W">https://docs.microsoft.com/en-us/legal/gdpr</a></span><span
+                            class="c6">.</span></p>
+                    <p class="c1 c9"><span class="c2">5.</span><span class="c6">&nbsp;&nbsp;&nbsp; </span><span class="c2">SCOPE OF
+                            LICENSE.</span><span class="c6">&nbsp;The software is licensed, not sold. This agreement only gives you some
+                            rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights
+                            despite this limitation, you may use the software only as expressly permitted in this agreement. &nbsp;In
+                            doing so, you must comply with any technical limitations in the software that only allow you to use it in
+                            certain ways. You may not:</span></p>
+                    <p class="c1 c18"><span class="c3 c5">&middot;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;work around any
+                            technical limitations in the software;</span></p>
+                    <p class="c1 c18"><span class="c3 c5">&middot;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reverse engineer,
+                            decompile or disassemble the software, or otherwise attempt to derive the source code for the software,
+                            except and only to the extent required by third party licensing terms governing use of certain open source
+                            components that may be included with the software;</span></p>
+                    <p class="c1 c18"><span class="c3 c5">&middot;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remove, minimize,
+                            block or modify any notices of Microsoft or its suppliers in the software;</span></p>
+                    <p class="c1 c18"><span class="c3 c5">&middot;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use the software in
+                            any way that is against the law; or</span></p>
+                    <p class="c1 c18"><span class="c3 c5">&middot;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;share, publish, rent
+                            or lease the software, or provide the software as a stand-alone offering for others to use.</span></p>
+                    <p class="c1 c9"><span class="c2">6.&nbsp;&nbsp;&nbsp;UPDATES. </span><span class="c6">The software may periodically
+                            check for updates and download and install them for you. You may obtain updates only from Microsoft or
+                            authorized sources. Microsoft may need to update your system to provide you with updates. You agree to
+                            receive these automatic updates without any additional notice. Updates may not include or support all
+                            existing software features, services, or peripheral devices.</span></p>
+                    <p class="c1 c9"><span class="c2">7.</span><span class="c6">&nbsp;&nbsp; </span><span class="c2">EXPORT
+                            RESTRICTIONS.</span><span class="c6">&nbsp;You must comply with all domestic and international export laws
+                            and regulations that apply to the software, which include restrictions on destinations, end users and end
+                            use. For further information on export restrictions, visit (aka.ms/exporting).</span></p>
+                    <p class="c1 c9"><span class="c2">8.</span><span class="c6">&nbsp;&nbsp;&nbsp;</span><span class="c2">SUPPORT SERVICES.
+                        </span><span class="c6">Because the software is &ldquo;as is,&rdquo; we may not provide support services for
+                            it.</span></p>
+                    <p class="c1 c9"><span class="c2">9.</span><span class="c6">&nbsp;&nbsp;&nbsp;</span><span class="c2">ENTIRE
+                            AGREEMENT.</span><span class="c6">&nbsp;This agreement, and the terms for supplements, updates,
+                            Internet-based services and support services that you use, are the entire agreement for the software and
+                            support services.</span></p>
+                    <p class="c1 c9"><span class="c2">10.</span><span class="c6">&nbsp;</span><span class="c2">APPLICABLE LAW.
+                        </span><span class="c6">If you acquired the software in the United States, Washington State law applies to
+                            interpretation of and claims for breach of this agreement, and the laws of the state where you live apply to
+                            all other claims. If you acquired the software in any other country, its laws apply.</span></p>
+                    <p class="c1 c9"><span class="c2">11.</span><span class="c6">&nbsp;</span><span class="c2">CONSUMER RIGHTS; REGIONAL
+                            VARIATIONS. </span><span class="c6">This agreement describes certain legal rights. You may have other
+                            rights, including consumer rights, under the laws of your state or country. Separate and apart from your
+                            relationship with Microsoft, you may also have rights with respect to the party from which you acquired the
+                            software. This agreement does not change those other rights if the laws of your state or country do not
+                            permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory
+                            country law applies, then the following provisions apply to you:</span></p>
+                    <p class="c1 c4"><span class="c2">a.</span><span class="c6">&nbsp; &nbsp;</span><span class="c2">Australia.
+                        </span><span class="c6">You have statutory guarantees under the Australian Consumer Law and nothing in this
+                            agreement is intended to affect those rights.</span></p>
+                    <p class="c1 c4"><span class="c2">b.</span><span class="c6">&nbsp; &nbsp;</span><span class="c2">Canada.
+                        </span><span class="c6">If you acquired the software in Canada, you may stop receiving updates by turning off
+                            the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the
+                            Internet, however, the software will resume checking for and installing updates), or uninstalling the
+                            software. The product documentation, if any, may also specify how to turn off updates for your specific
+                            device or software.</span></p>
+                    <p class="c1 c4"><span class="c2">c.</span><span class="c6">&nbsp;&nbsp; </span><span class="c2">Germany and
+                            Austria</span><span class="c6">.</span></p>
+                    <p class="c8"><span class="c2">(i)</span><span class="c6">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span><span
+                            class="c2">Warranty</span><span class="c3 c5">. The properly licensed software will perform substantially as
+                            described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual
+                            guarantee in relation to the licensed software.</span></p>
+                    <p class="c8 c11"><span class="c3 c2"></span></p>
+                    <p class="c8"><span class="c2">(ii)</span><span class="c6">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span><span
+                            class="c2">Limitation of Liability</span><span class="c3 c5">. In case of intentional conduct, gross
+                            negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical
+                            injury, Microsoft is liable according to the statutory law.</span></p>
+                    <p class="c1 c7"><span class="c6">Subject to the foregoing clause (ii), Microsoft will only be liable for slight
+                            negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which
+                            facilitate the due performance of this agreement, the breach of which would endanger the purpose of this
+                            agreement and the compliance with which a party may constantly trust in (so-called &quot;cardinal
+                            obligations&quot;). In other cases of slight negligence, Microsoft will not be liable for slight
+                            negligence.</span></p>
+                    <p class="c1 c9 c11"><span class="c3 c2"></span></p>
+                    <p class="c1 c9"><span class="c2">12.</span><span class="c6">&nbsp;</span><span class="c3 c2">DISCLAIMER OF
+                            WARRANTY. THE SOFTWARE IS LICENSED &ldquo;AS-IS.&rdquo; &nbsp;YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES
+                            NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT
+                            EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+                            NON-INFRINGEMENT.</span></p>
+                    <p class="c1 c9"><span class="c2">13.</span><span class="c6">&nbsp;</span><span class="c3 c2">LIMITATION ON AND
+                            EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00.
+                            YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL
+                            DAMAGES.</span></p>
+                    <p class="c1 c22"><span class="c3 c5">This limitation applies to (a) anything related to the software, services,
+                            content (including code) on third party Internet sites, or third party programs; and (b) claims for breach
+                            of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the
+                            extent permitted by applicable law.</span></p>
+                    <p class="c1 c22"><span class="c3 c5">It also applies even if Microsoft knew or should have known about the
+                            possibility of the damages. The above limitation or exclusion may not apply to you because your country may
+                            not allow the exclusion or limitation of incidental, consequential or other damages.</span></p>
+                    <p class="c1"><span class="c3 c2">Please note: As the software is distributed in Quebec, Canada, some of the clauses
+                            in this agreement are provided below in French.</span></p>
+                    <p class="c1"><span class="c3 c2">Remarque : Ce logiciel &eacute;tant distribu&eacute; au Qu&eacute;bec, Canada,
+                            certaines des clauses dans ce contrat sont fournies ci-dessous en fran&ccedil;ais.</span></p>
+                    <p class="c24"><span class="c2">EXON&Eacute;RATION DE GARANTIE.</span><span class="c3 c5">&nbsp;Le logiciel
+                            vis&eacute; par une licence est offert &laquo; tel quel &raquo;. Toute utilisation de ce logiciel est
+                            &agrave; votre seule risque et p&eacute;ril. Microsoft n&rsquo;accorde aucune autre garantie expresse. Vous
+                            pouvez b&eacute;n&eacute;ficier de droits additionnels en vertu du droit local sur la protection des
+                            consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties
+                            implicites de qualit&eacute; marchande, d&rsquo;ad&eacute;quation &agrave; un usage particulier et
+                            d&rsquo;absence de contrefa&ccedil;on sont exclues.</span></p>
+                    <p class="c24"><span class="c2">LIMITATION DES DOMMAGES-INT&Eacute;R&Ecirc;TS ET EXCLUSION DE RESPONSABILIT&Eacute;
+                            POUR LES DOMMAGES.</span><span class="c3 c5">&nbsp;Vous pouvez obtenir de Microsoft et de ses fournisseurs
+                            une indemnisation en cas de dommages directs uniquement &agrave; hauteur de 5,00 $ US. Vous ne pouvez
+                            pr&eacute;tendre &agrave; aucune indemnisation pour les autres dommages, y compris les dommages
+                            sp&eacute;ciaux, indirects ou accessoires et pertes de b&eacute;n&eacute;fices.</span></p>
+                    <p class="c1"><span class="c3 c5">Cette limitation concerne :</span></p>
+                    <p class="c1 c10"><span class="c3 c5">&middot;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; tout ce qui est
+                            reli&eacute; au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet
+                            tiers ou dans des programmes tiers ; et</span></p>
+                    <p class="c1 c10"><span class="c3 c5">&middot;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; les
+                            r&eacute;clamations au titre de violation de contrat ou de garantie, ou au titre de responsabilit&eacute;
+                            stricte, de n&eacute;gligence ou d&rsquo;une autre faute dans la limite autoris&eacute;e par la loi en
+                            vigueur.</span></p>
+                    <p class="c1"><span class="c3 c5">Elle s&rsquo;applique &eacute;galement, m&ecirc;me si Microsoft connaissait ou
+                            devrait conna&icirc;tre l&rsquo;&eacute;ventualit&eacute; d&rsquo;un tel dommage. Si votre pays
+                            n&rsquo;autorise pas l&rsquo;exclusion ou la limitation de responsabilit&eacute; pour les dommages
+                            indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l&rsquo;exclusion
+                            ci-dessus ne s&rsquo;appliquera pas &agrave; votre &eacute;gard.</span></p>
+                    <p class="c15"><span class="c2">EFFET JURIDIQUE.</span><span class="c3 c5">&nbsp;Le pr&eacute;sent contrat
+                            d&eacute;crit certains droits juridiques. Vous pourriez avoir d&rsquo;autres droits pr&eacute;vus par les
+                            lois de votre pays. Le pr&eacute;sent contrat ne modifie pas les droits que vous conf&egrave;rent les lois
+                            de votre pays si celles-ci ne le permettent pas.<br></span></p>
+                    <p class="c23"><span class="c3 c5">
+                        <!-- @include offline-app-trademarks.html -->
+                    </span></p>
+                    <p class="c11 c15"><span class="c3 c5"></span></p>
+                    <p class="c26"><span class="c2 c25">Remainder of this page intentionally left blank.</span></p>
+                    <p class="c11 c21"><span class="c3 c14"></span></p>
                 </div>
             </div>
             <div id="agree-segment" class="ui center aligned segment hidden">

--- a/docfiles/offline-app-body.html
+++ b/docfiles/offline-app-body.html
@@ -53,14 +53,14 @@
                             documentation. In using the software, you must comply with applicable law. You can learn more about data
                             collection and use in the help documentation and the privacy statement at </span><span class="c13 c6"><a
                                 class="c20"
-                                href="http://go.microsoft.com/fwlink/?LinkId%3D398505&amp;sa=D&amp;ust=1597949364473000&amp;usg=AOvVaw24fB1PnltFHDLgJ0_YTHvZ">http://go.microsoft.com/fwlink/?LinkId=398505</a></span><span
+                                href="http://go.microsoft.com/fwlink/?LinkId=398505">http://go.microsoft.com/fwlink/?LinkId=398505</a></span><span
                             class="c6">. Your use of the software operates as your consent to these practices.</span></p>
                     <p class="c1 c4"><span class="c2">b.</span><span class="c6">&nbsp;&nbsp;&nbsp;</span><span class="c2">Processing of
                             Personal Data. </span><span class="c6">To the extent Microsoft is a processor or subprocessor of personal
                             data in connection with the software, Microsoft makes the commitments in the European Union General Data
                             Protection Regulation Terms of the Online Services Terms to all customers effective May 25, 2018, at
                         </span><span class="c6 c13"><a class="c20"
-                                href="https://docs.microsoft.com/en-us/legal/gdpr&amp;sa=D&amp;ust=1597949364473000&amp;usg=AOvVaw19LtkrFSFLU55xCLkIXR-W">https://docs.microsoft.com/en-us/legal/gdpr</a></span><span
+                                href="https://docs.microsoft.com/en-us/legal/gdpr">https://docs.microsoft.com/en-us/legal/gdpr</a></span><span
                             class="c6">.</span></p>
                     <p class="c1 c9"><span class="c2">5.</span><span class="c6">&nbsp;&nbsp;&nbsp; </span><span class="c2">SCOPE OF
                             LICENSE.</span><span class="c6">&nbsp;The software is licensed, not sold. This agreement only gives you some

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -27,7 +27,7 @@
             flex-direction: column;
         }
 
-        .segments.terms-container {
+        #docs .segments.terms-container {
             margin: auto;
         }
 
@@ -414,7 +414,7 @@
             $("#agree-segment").removeClass("hidden");
             $("#read-segment").removeClass("hidden");
             $("#legal-segment").removeClass("hidden");
-}
+        }
 
         function showNoDownloads() {
             $("#no-download-segment").removeClass("hidden");

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -15,8 +15,11 @@
             height: 65vh;
         }
 
-        .segments {
-            max-width: 60%;
+        body#docs > .container {
+            display: grid;
+            grid-template-rows: 1fr auto;
+            min-height: 100vh;
+            overflow-x: hidden;
         }
 
         .segments.terms-container {
@@ -30,7 +33,8 @@
         #legal-segment {
             background:white;
             min-height: 18em;
-            max-height: 35em;
+            max-height: 40em;
+            height: 50vh;
             overflow-y: scroll;
         }
 

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -22,8 +22,13 @@
             overflow-x: hidden;
         }
 
+        #offline-app-body {
+            display: flex;
+            flex-direction: column;
+        }
+
         .segments.terms-container {
-            margin-top: 2em;
+            margin: auto;
         }
 
         .terms-container .segment {
@@ -41,8 +46,8 @@
         .topbar {
             display: flex;
             align-items: center;
-            padding: 1em 2em;
-            margin: -1em;
+            padding: 1em 1em;
+            margin: -1em 0 1em 0;
         }
 
         #docs .topbar .welcomeheader {

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -3,28 +3,16 @@
     <meta name="Description" content="A @targetname@ offline app" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" data-rtl="/blb/rtlsemantic.css" href="/doccdn/semantic.css" />
-    <link rel="stylesheet" href="/docfiles/style.css" />
     <link rel="stylesheet" href="/docfiles/target.css" />
 
     <script src="/doccdn/jquery.js" type="text/javascript"></script>
-    <script src="/doccdn/semantic.js" type="text/javascript"></script>
-    <script src="/docfiles/target.js" type="text/javascript"></script>
-
-    <style>
-        @targetstyle@
-    </style>
     <style>
         p.item {
             color: rgba(0, 0, 0, 0.4);
         }
 
-        .topbar {
-            background: rgb(170, 39, 143) !important;
-        }
-
         .ui.inverted.content {
-            /* background: #00a5c8; */
-            background: #2a7af3;
+            background: none;
         }
 
         .content.segment {
@@ -64,14 +52,50 @@
         #legal-segment {
             background:white;
             height: 18rem;
-            overflow-y: scroll;            
+            overflow-y: scroll;
         }
-        .welcomeheader {
+
+        .topbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1em 2em;
+            margin: -1em;
+        }
+        #docs .topbar .welcomeheader {
             text-transform: uppercase;
+            margin: 0;
+            color: white;
+        }
+        .targetlogo {
+            max-height: 2em;
+            min-width: 2em;
+            width: auto;
+        }
+        .headerlogo {
+            max-height: 2em;
+            min-width: 2em;
+            width: auto;
+        }
+
+        .flex-wrapper {
+            flex: 1;
+            display: flex;
+        }
+
+        .left.flex-wrapper {
+            justify-content: flex-start;
+        }
+        .right.flex-wrapper {
+            justify-content: flex-end;;
+        }
+
+        #docs .footer {
+            margin-top: 0;
         }
 
         @media only screen and (max-width: 800px) {
-            .grid .column .image {
+            .flex-wrapper img {
                 display: none;
             }
 
@@ -383,20 +407,9 @@
         }
     </style>
 
+    <!-- @include tickevent.html -->
+
     <script>
-        var electronLatestVersion = "";
-        function tickEvent(id, data) {
-            if (!pxt.aiTrackEvent) return;
-            if (!data) pxt.aiTrackEvent(id);
-            else {
-                var props = {};
-                var measures = {};
-                for (var k in data)
-                    if (typeof data[k] == "string") props[k] = data[k];
-                    else measures[k] = data[k];
-                pxt.aiTrackEvent(id, props, measures);
-            }
-        }
 
         function agreeCheckboxChanged() {
             $("#agree-checkbox").attr("disabled", "true");
@@ -404,7 +417,7 @@
         }
 
         function hideLoader() {
-            $("#loader").remove();            
+            $("#loader").remove();
         }
 
         function showAgree() {
@@ -420,30 +433,38 @@
         }
 
         function showDownloads() {
-            $("#download-win64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronLatestVersion + "/win64");
-            $("#download-mac64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronLatestVersion + "/mac64");
             $("#download-segment").removeClass("hidden");
         }
+
+        function updateDownloadLinks(electronVersion) {
+            $("#download-win64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronVersion + "/win64");
+            $("#download-mac64").attr("href", "https://makecode.com/api/release/@targetid@/" + electronVersion + "/mac64");
+        }
         function downloadWin64() {
-            tickEvent("offlineapp.download", { "target": "@targetid@", "platform": "win64" });
+            window.pxtTickEvent("offlineapp.download", { "target": "@targetid@", "platform": "win64" });
         }
         function downloadMac64() {
-            tickEvent("offlineapp.download", { "target": "@targetid@", "platform": "mac64" });
+            window.pxtTickEvent("offlineapp.download", { "target": "@targetid@", "platform": "mac64" });
         }
         $(function () {
             $.getJSON("https://makecode.com/api/config/@targetid@/targetconfig")
                 .then(function (data) {
                     hideLoader();
-                    if (data && data.electronManifest && data.electronManifest.latest) {
-                        electronLatestVersion = data.electronManifest.latest;
+                    // if (data && data.electronManifest && data.electronManifest.latest) {
+                        // todo remove new js features / uncomment surrounding block
+                        updateDownloadLinks(data?.electronManifest?.latest ?? "v1.0.16");
                         showAgree();
-                    } else {
-                        showNoDownloads();
-                    }
+                    // } else {
+                    //     showNoDownloads();
+                    // }
                 })
                 .catch(function () {
                     hideLoader();
                     showNoDownloads();
                 })
+        });
+
+        window.addEventListener('load', function () {
+            $("#langpicker").remove();
         });
     </script>

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -55,7 +55,6 @@
         }
 
         #docs .topbar .welcomeheader {
-            text-transform: uppercase;
             font-weight: 300;
             font-size: 1.5em;
             margin: 0;

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -440,13 +440,12 @@
             $.getJSON("https://makecode.com/api/config/@targetid@/targetconfig")
                 .then(function (data) {
                     hideLoader();
-                    // if (data && data.electronManifest && data.electronManifest.latest) {
-                        // todo remove new js features / uncomment surrounding block
-                        updateDownloadLinks(data?.electronManifest?.latest ?? "v1.0.16");
+                    if (data && data.electronManifest && data.electronManifest.latest) {
+                        updateDownloadLinks(data.electronManifest.latest);
                         showAgree();
-                    // } else {
-                    //     showNoDownloads();
-                    // }
+                    } else {
+                        showNoDownloads();
+                    }
                 })
                 .catch(function () {
                     hideLoader();

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -83,6 +83,10 @@
             margin-top: 0;
         }
 
+        span.touppercase {
+            text-transform: uppercase;
+        }
+
         @media only screen and (max-width: 800px) {
             .flex-wrapper img {
                 display: none;
@@ -98,183 +102,188 @@
     <style type="text/css">
         .terms ol {
             margin: 0;
-            padding: 0
+            padding: 0;
         }
 
         .terms table td,
         .terms table th {
-            padding: 0
+            padding: 0;
         }
 
-        .c2 {
-            margin-left: 22.5pt;
+        .terms .c0 {
             padding-top: 6pt;
-            text-indent: -18pt;
+            border-bottom-color: #000000;
+            border-bottom-width: 0.5pt;
+            padding-bottom: 1pt;
+            line-height: 1.0;
+            border-bottom-style: solid;
+            text-align: left;
+        }
+
+        .terms .c16 {
+            padding-top: 1pt;
+            border-top-width: 0.5pt;
+            border-top-color: #000000;
             padding-bottom: 6pt;
-            line-height: 1.15;
+            line-height: 1.0;
+            border-top-style: solid;
+            text-align: left;
+        }
+
+        .terms .c8 {
+            margin-left: 36pt;
+            padding-top: 0pt;
+            padding-bottom: 0pt;
+            line-height: 1.0;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
-        .c8 {
-            margin-left: 40.5pt;
-            padding-top: 6pt;
-            text-indent: -18pt;
-            padding-bottom: 6pt;
-            line-height: 1.15;
+        .terms .c26 {
+            padding-top: 0pt;
+            padding-bottom: 8pt;
+            line-height: 1.0791666666666666;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: center;
         }
 
-        .c15 {
+        .terms .c24 {
+            padding-top: 0pt;
+            padding-bottom: 0pt;
+            line-height: 1.0;
+            orphans: 2;
+            widows: 2;
+            text-align: left;
+        }
+
+        .terms .c15 {
             padding-top: 0pt;
             padding-bottom: 12pt;
+            line-height: 1.0;
+            orphans: 2;
+            widows: 2;
+            text-align: left;
+        }
+
+        .terms .c23 {
+            padding-top: 0pt;
+            padding-bottom: 8pt;
+            line-height: 1.0791666666666666;
+            orphans: 2;
+            widows: 2;
+            text-align: left;
+        }
+
+        .terms .c1 {
+            padding-top: 6pt;
+            padding-bottom: 6pt;
+            line-height: 1.0;
+            orphans: 2;
+            widows: 2;
+            text-align: left;
+        }
+
+        .terms .c21 {
+            padding-top: 0pt;
+            padding-bottom: 0pt;
             line-height: 1.15;
             orphans: 2;
             widows: 2;
             text-align: left;
-            height: 11pt
         }
 
-        .c7 {
-            padding-top: 0pt;
-            padding-bottom: 0pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: left;
-            height: 11pt
-        }
-
-        .c0 {
-            margin-left: 23pt;
-            padding-top: 6pt;
-            padding-bottom: 6pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: left
-        }
-
-        .c10 {
-            margin-left: 40.5pt;
-            padding-top: 6pt;
-            padding-bottom: 6pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: left
-        }
-
-        .c6 {
-            margin-left: 40.5pt;
-            padding-top: 0pt;
-            padding-bottom: 0pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: left
-        }
-
-        .c20 {
-            padding-top: 0pt;
-            padding-bottom: 0pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: center
-        }
-
-        .c4 {
+        .terms .c3 {
             color: #000000;
-            font-weight: 700;
             text-decoration: none;
             vertical-align: baseline;
             font-family: "Arial";
             font-style: normal;
-            text-transform: uppercase;
         }
 
-        .c11 {
-            padding-top: 0pt;
-            padding-bottom: 0pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: left
+        .terms .c25 {
+            color: #000000;
+            text-decoration: none;
+            vertical-align: baseline;
+            font-family: "Arial";
+            font-style: italic;
         }
 
-        .c12 {
+        .terms .c12 {
             padding-top: 6pt;
             padding-bottom: 6pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: left
+            line-height: 1.0;
+            text-align: left;
         }
 
-        .c3 {
-            color: #000000;
-            font-weight: 400;
-            text-decoration: none;
-            vertical-align: baseline;
-            font-family: "Arial";
-            font-style: normal
-        }
-
-        .c16 {
-            padding-top: 0pt;
-            padding-bottom: 12pt;
-            line-height: 1.15;
-            orphans: 2;
-            widows: 2;
-            text-align: left
-        }
-
-        .c13 {
-            color: #000000;
-            text-decoration: none;
-            vertical-align: baseline;
-            font-family: "Arial";
-            font-style: italic
-        }
-
-        .c14 {
+        .terms .c13 {
             text-decoration-skip-ink: none;
             -webkit-text-decoration-skip: none;
-            color: #1155cc;
-            text-decoration: underline
+            color: #0000ff;
+            text-decoration: underline;
         }
 
-        .c17 {
+        .terms .c17 {
             background-color: #ffffff;
-            max-width: 540pt;
-            padding: 36pt 36pt 36pt 36pt
+            max-width: 468pt;
+            padding: 2em;
         }
 
-        .c18 {
-            text-decoration-skip-ink: none;
-            -webkit-text-decoration-skip: none;
-            text-decoration: underline
+        .terms .c18 {
+            margin-left: 36pt;
+            text-indent: -18pt;
         }
 
-        .c9 {
+        .terms .c9 {
+            margin-left: 22.4pt;
+            text-indent: -17.9pt;
+        }
+
+        .terms .c14 {
+            font-weight: 400;
+            font-size: 11pt;
+        }
+
+        .terms .c2 {
+            font-size: 10pt;
+            font-weight: 700;
+        }
+
+        .terms .c10 {
+            margin-left: 18pt;
+            text-indent: -18pt;
+        }
+
+        .terms .c20 {
             color: inherit;
-            text-decoration: inherit
+            text-decoration: inherit;
         }
 
-        .c5 {
-            font-weight: 700
+        .terms .c4 {
+            margin-left: 40.5pt;
+            text-indent: -18.1pt;
         }
 
-        .c1 {
-            font-size: 10pt
+        .terms .c5 {
+            font-weight: 400;
+            font-size: 10pt;
         }
 
-        .c19 {
-            font-size: 11pt
+        .terms .c7 {
+            margin-left: 35.9pt;
+        }
+
+        .terms .c22 {
+            margin-left: 22.5pt;
+        }
+
+        .terms .c11 {
+            height: 11pt;
+        }
+
+        .terms .c6 {
+            font-size: 10pt;
         }
 
         .terms .title {
@@ -287,7 +296,7 @@
             page-break-after: avoid;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
         .terms .subtitle {
@@ -300,20 +309,20 @@
             page-break-after: avoid;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
         .terms li {
             color: #000000;
             font-size: 11pt;
-            font-family: "Arial"
+            font-family: "Arial";
         }
 
         .terms p {
             margin: 0;
             color: #000000;
             font-size: 11pt;
-            font-family: "Arial"
+            font-family: "Arial";
         }
 
         .terms h1 {
@@ -326,7 +335,7 @@
             page-break-after: avoid;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
         .terms h2 {
@@ -339,7 +348,7 @@
             page-break-after: avoid;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
         .terms h3 {
@@ -352,7 +361,7 @@
             page-break-after: avoid;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
         .terms h4 {
@@ -365,7 +374,7 @@
             page-break-after: avoid;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
         .terms h5 {
@@ -378,7 +387,7 @@
             page-break-after: avoid;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
 
         .terms h6 {
@@ -392,9 +401,10 @@
             font-style: italic;
             orphans: 2;
             widows: 2;
-            text-align: left
+            text-align: left;
         }
     </style>
+
     <style>
         @targetstyle@
     </style>

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -396,6 +396,9 @@
             text-align: left
         }
     </style>
+    <style>
+        @targetstyle@
+    </style>
 
     <!-- @include tickevent.html -->
 

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -7,34 +7,12 @@
 
     <script src="/doccdn/jquery.js" type="text/javascript"></script>
     <style>
-        p.item {
-            color: rgba(0, 0, 0, 0.4);
-        }
-
         .ui.inverted.content {
             background: none;
         }
 
-        .content.segment {
-            min-height: 80%;
-        }
-
-        .content .welcomeheader {
-            font-weight: 300;
-            font-size: 1.5rem;
-        }
-
-        .footer.segment {
-            padding: 5em 0em;
-        }
-
-        .image.left {
-            padding-left: 2em;
-        }
-
-        .image.right {
-            padding-right: 2em;
-            float: right;
+        #loading-icon {
+            height: 65vh;
         }
 
         .segments {
@@ -42,7 +20,7 @@
         }
 
         .segments.terms-container {
-            margin-top: 5em;
+            margin-top: 2em;
         }
 
         .terms-container .segment {
@@ -51,31 +29,24 @@
 
         #legal-segment {
             background:white;
-            height: 18rem;
+            min-height: 18em;
+            max-height: 35em;
             overflow-y: scroll;
         }
 
         .topbar {
             display: flex;
             align-items: center;
-            justify-content: space-between;
             padding: 1em 2em;
             margin: -1em;
         }
+
         #docs .topbar .welcomeheader {
             text-transform: uppercase;
+            font-weight: 300;
+            font-size: 1.5em;
             margin: 0;
             color: white;
-        }
-        .targetlogo {
-            max-height: 2em;
-            min-width: 2em;
-            width: auto;
-        }
-        .headerlogo {
-            max-height: 2em;
-            min-width: 2em;
-            width: auto;
         }
 
         .flex-wrapper {
@@ -88,6 +59,12 @@
         }
         .right.flex-wrapper {
             justify-content: flex-end;;
+        }
+
+        .flex-wrapper img {
+            max-height: 2em;
+            min-width: 2em;
+            width: auto;
         }
 
         #docs .footer {
@@ -417,7 +394,7 @@
         }
 
         function hideLoader() {
-            $("#loader").remove();
+            $("#loading-icon").remove();
         }
 
         function showAgree() {

--- a/docfiles/offline-app-head.html
+++ b/docfiles/offline-app-head.html
@@ -35,6 +35,10 @@
             background-color: rgb(250, 250, 250);
         }
 
+        #docs .terms-container a {
+            color: blue;
+        }
+
         #legal-segment {
             background:white;
             min-height: 18em;

--- a/docfiles/offline-app-trademarks.html
+++ b/docfiles/offline-app-trademarks.html
@@ -1,0 +1,1 @@
+<!-- To be overridden by target -->

--- a/theme/docs.less
+++ b/theme/docs.less
@@ -29,6 +29,7 @@
 @docsCardHoverBorderColor: #1dacf4;
 
 #docs .footer,
+#docs .topbar,
 .ui.menu.fixed.docs,
 #docs {
     top: auto;


### PR DESCRIPTION
align offline app page with docs styling, and clean up a bit of unused imports / rules / etc.

current state is https://arcade.makecode.com/offline-app ; if you want to see what it looks like when expanded need to open console and run:

```javascript
showAgree(); document.querySelector("#no-download-segment").remove();
```

~worth a note I left the generated css / html for the legal stuff  the same for now.~ last two commits update to current legal text; probably easiest to compare https://github.com/microsoft/pxt/pull/7398/files/a7f1279255aa091f83718926bd47975e7d63347e for the main primarily non-generated diffs

Doesn't currently change microbit as that has it's own page set / doesn't use these rules yet https://github.com/microsoft/pxt-microbit/blob/master/docs/offline-app.html (same with lego)

![image](https://user-images.githubusercontent.com/5615930/90575502-67a9f600-e170-11ea-943b-8476db7460a8.png)

gif \\/

<details>
  <summary>Click to expand (7mb gif)</summary>
  
![offline-app-page](https://user-images.githubusercontent.com/5615930/90574800-b060af80-e16e-11ea-8e4e-9925e3563342.gif)

</details>
