### PR TITLE
only count non-transparency when computing average color

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -306,7 +306,7 @@ namespace pxt.sprite {
         return;
     }
 
-    export function computeAverageColor(bitmap: Bitmap, colors: string[]) {
+    export function computeAverageColor(bitmap: Bitmap, colors: string[]): string {
         const parsedColors = colors.map(colorStringToRGB);
         const averageColor = [0, 0, 0];
         let numPixels = 0;
@@ -324,8 +324,7 @@ namespace pxt.sprite {
             }
         }
 
-        numPixels = numPixels || 1;
-        return "#" + toHex(averageColor.map(c => Math.floor(c / numPixels)));
+        return !!numPixels ? "#" + toHex(averageColor.map(c => Math.floor(c / numPixels))) : "#00000000";
     }
 
     export interface GalleryItem {

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -308,19 +308,23 @@ namespace pxt.sprite {
 
     export function computeAverageColor(bitmap: Bitmap, colors: string[]) {
         const parsedColors = colors.map(colorStringToRGB);
-        let color: number[];
         const averageColor = [0, 0, 0];
+        let numPixels = 0;
 
         for (let x = 0; x < bitmap.width; x++) {
             for (let y = 0; y < bitmap.height; y++) {
-                color = parsedColors[bitmap.get(x, y)];
-                averageColor[0] += color[0];
-                averageColor[1] += color[1];
-                averageColor[2] += color[2];
+                const color = bitmap.get(x, y);
+                if (color) {
+                    ++numPixels;
+                    const parsedColor = parsedColors[color];
+                    averageColor[0] += parsedColor[0];
+                    averageColor[1] += parsedColor[1];
+                    averageColor[2] += parsedColor[2];
+                }
             }
         }
 
-        const numPixels = bitmap.width * bitmap.height;
+        numPixels = numPixels || 1;
         return "#" + toHex(averageColor.map(c => Math.floor(c / numPixels)));
     }
 


### PR DESCRIPTION
When computing average color, ignore transparent pixels / don't count them as black. e.g. for https://makecode.com/_5yMWc3WTWEyL

Right now if you have a tile that isn't completely colored in (e.g. a sign or a flag) the preview color in the minimap gets darkened a lot / almost completely. (This one's annoying for me as I usually set the background color to green or tan and draw smaller tiles, and then my tilemap preview is all black 😢)

instead of all gunky colors in the top left:

![image](https://user-images.githubusercontent.com/5615930/90586687-a057c880-e18c-11ea-9b0a-457fdbc6df3e.png)

shows up as the actual colors in the tiles:

![image](https://user-images.githubusercontent.com/5615930/90586643-861dea80-e18c-11ea-8b9c-5771cb03fa87.png)
