### PR TITLE
don't lose tilemap when clicking outside tile editor

### DIFF
--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -159,7 +159,7 @@ namespace pxt.editor {
                         openParen++;
                     }
                     else if (line.charAt(i) === ")") {
-                        openParen --;
+                        openParen--;
 
                         if (openParen === 0) {
                             const end = new monaco.Position(current.lineNumber, current.column + i + 2);

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -23,6 +23,7 @@ export interface FieldEditorComponent<U> extends React.Component {
     onResize?: () => void;
     loadJres?: (jres: string) => void;
     getJres?: () => string;
+    shouldPreventHide?: () => boolean;
 }
 
 let cachedBounds: EditorBounds;
@@ -36,7 +37,6 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
     protected componentRef: FieldEditorComponent<U>;
     protected overlayDiv: HTMLDivElement;
     protected persistentData: any;
-
     protected hideCallback: () => void;
 
     constructor(protected contentDiv: HTMLDivElement) {
@@ -72,6 +72,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
 
     hide() {
         if (!this.visible || !this.contentDiv) return;
+        if (this.componentRef?.shouldPreventHide?.()) return;
 
         this.visible = false;
         if (this.resizeFrameRef) cancelAnimationFrame(this.resizeFrameRef);
@@ -166,6 +167,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
         if (!this.contentBounds) return;
 
         if (!inBounds(ev.clientX, ev.clientY, this.contentBounds)) {
+            ev.stopPropagation();
             this.hide();
         }
     }

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -91,7 +91,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                     {alert && alert.title && <Alert title={alert.title} text={alert.text} options={alert.options} />}
                 </div>
             </Provider>
-            {editingTile && <ImageEditor store={tileEditorStore} onDoneClicked={this.onTileEditorFinished} initialValue={editTileValue} singleFrame={true} resizeDisabled={true} nested={true} />}
+            {editingTile && <ImageEditor store={tileEditorStore} ref="nested-image-editor" onDoneClicked={this.onTileEditorFinished} initialValue={editTileValue} singleFrame={true} resizeDisabled={true} nested={true} />}
         </div>
     }
 
@@ -161,6 +161,12 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
 
     disableResize() {
         this.dispatchOnStore(dispatchDisableResize());
+    }
+
+    closeNestedEditor() {
+        if (this.state.editingTile) {
+            (this.refs["nested-image-editor"] as ImageEditor)?.onDoneClick();
+        }
     }
 
     protected getStore() {

--- a/webapp/src/components/TilemapFieldEditor.tsx
+++ b/webapp/src/components/TilemapFieldEditor.tsx
@@ -75,6 +75,14 @@ export class TilemapFieldEditor extends React.Component<TilemapFieldEditorProps,
         }
     }
 
+    shouldPreventHide() {
+        if (this.ref?.state.editingTile) {
+            this.ref.closeNestedEditor();
+            return true;
+        }
+        return false;
+    }
+
     protected initTilemap(data: pxt.sprite.TilemapData, options?: any) {
         if (data.tilemap.width === 0 || data.tilemap.height === 0) {
             data.tilemap = new pxt.sprite.Tilemap(options.initWidth || 16, options.initHeight || 16)


### PR DESCRIPTION
When you're editing a tile and click outside the editor area, just close / commit tile editor, don't destroy your progress :(

![dont-destroy-tiles](https://user-images.githubusercontent.com/5615930/90592746-2da21980-e19b-11ea-957c-277da48e4d97.gif)
