### PR TITLE
Allow for pxt.json:codal.libraries

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -63,6 +63,7 @@ declare namespace pxt {
         paletteNames?: string[];
         screenSize?: Size;
         yotta?: YottaConfig;
+        codal?: CodalConfig;
         npmDependencies?: Map<string>;
         card?: CodeCard;
         additionalFilePath?: string;
@@ -105,6 +106,10 @@ declare namespace pxt {
     interface CompilationConfig {
         description: string;
         config: any;
+    }
+
+    interface CodalConfig {
+        libraries?: string[];
     }
 
     interface YottaConfig {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -629,7 +629,7 @@ namespace pxt.github {
     export interface ParsedRepo {
         owner?: string;
         project?: string;
-        // owner/name
+        // owner/project (aka slug)
         fullName: string;
         tag?: string;
         fileName?: string;


### PR DESCRIPTION
Allow pxt.json to specify additional codal libraries to pull in

This requires codal build system 0.8.0 or later