### PR TITLE
few fixes for simple tab indices / visual issues in tilemap editor

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -209,6 +209,7 @@
     background-color: @green;
     color: @white;
     cursor: pointer;
+    user-select: none;
 }
 
 .image-editor-confirm:hover {

--- a/theme/image-editor/pivot.less
+++ b/theme/image-editor/pivot.less
@@ -7,6 +7,9 @@
 
     padding: 0 0.5rem;
     margin-bottom: 0.5rem;
+
+    cursor: pointer;
+    user-select: none;
 }
 
 .image-editor-pivot-option {

--- a/theme/image-editor/sideBar.less
+++ b/theme/image-editor/sideBar.less
@@ -15,6 +15,11 @@
     line-height: calc(~'1.75rem - 2px');
     border-radius: 0;
     border: 1px solid var(--sidebar-icon-active-color);
+
+    &:not(.toggle):focus {
+        // already has selected border
+        outline: none;
+    }
 }
 
 .image-editor-tool-buttons .image-editor-button.toggle {

--- a/theme/image-editor/toggle.less
+++ b/theme/image-editor/toggle.less
@@ -7,6 +7,7 @@
     color: var(--sidebar-icon-active-color);
     font-family: sans-serif;
     margin-right: 0.375rem;
+    cursor: default;
 }
 
 .image-editor-toggle {

--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { ImageEditorStore, AnimationState, TilemapState } from './store/imageReducer';
 import { dispatchChangeImageDimensions, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchToggleAspectRatioLocked, dispatchChangeZoom, dispatchToggleOnionSkinEnabled} from './actions/dispatch';
 import { IconButton } from "./Button";
+import { fireClickOnEnter } from "../../sui";
 
 export interface BottomBarProps {
     dispatchChangeImageDimensions: (dimensions: [number, number]) => void;
@@ -66,6 +67,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                         <input className="image-editor-input"
                             title={lf("Image Width")}
                             value={width}
+                            tabIndex={0}
                             onChange={this.handleWidthChange}
                             onBlur={this.handleDimensionalBlur}
                             onKeyDown={this.handleDimensionalKeydown}
@@ -76,11 +78,13 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                             iconClass={aspectRatioLocked ? "ms-Icon ms-Icon--Lock" : "ms-Icon ms-Icon--Unlock"}
                             title={aspectRatioLocked ? lf("Unlock Aspect Ratio") : lf("Lock Aspect Ratio")}
                             toggle={!aspectRatioLocked}
+                            noTab
                         />
 
                         <input className="image-editor-input"
                             title={lf("Image Height")}
                             value={height}
+                            tabIndex={0}
                             onChange={this.handleHeightChange}
                             onBlur={this.handleDimensionalBlur}
                             onKeyDown={this.handleDimensionalKeydown}
@@ -132,7 +136,9 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                 <div role="button"
                     className={`image-editor-confirm`}
                     title={lf("Done")}
-                    onClick={onDoneClick}>
+                    tabIndex={0}
+                    onClick={onDoneClick}
+                    onKeyDown={fireClickOnEnter}>
                         {lf("Done")}
                 </div>
             </div>

--- a/webapp/src/components/ImageEditor/Button.tsx
+++ b/webapp/src/components/ImageEditor/Button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { fireClickOnEnter } from '../../sui';
 
 export interface ButtonProps {
     title: string;
@@ -7,18 +8,21 @@ export interface ButtonProps {
 
     toggle?: boolean;
     disabled?: boolean;
+    noTab?: boolean;
 }
 
 export class IconButton extends React.Component<ButtonProps, {}> {
     render() {
-        const { title, iconClass, onClick, toggle, disabled } = this.props;
+        const { title, iconClass, onClick, toggle, disabled, noTab } = this.props;
 
         return (
             <div
                 role="button"
                 className={`image-editor-button ${toggle ? "toggle" : ""} ${disabled ? "disabled" : ""}`}
                 title={title}
-                onClick={onClick}>
+                tabIndex={(noTab || disabled) ? -1 : 0}
+                onClick={onClick}
+                onKeyDown={fireClickOnEnter}>
                     <span className={iconClass} />
             </div>
         );

--- a/webapp/src/components/ImageEditor/Dropdown.tsx
+++ b/webapp/src/components/ImageEditor/Dropdown.tsx
@@ -41,7 +41,7 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         const selectedOption = options[selected];
 
         return <div className="image-editor-dropdown-outer">
-            <button className="image-editor-dropdown" aria-haspopup="listbox" onClick={this.handleDropdownClick}>
+            <button className="image-editor-dropdown" aria-haspopup="listbox" onClick={this.handleDropdownClick} tabIndex={-1}>
                 { selectedOption?.text || "" }
                 <span className="image-editor-dropdown-chevron ms-Icon ms-Icon--ChevronDown">
                 </span>

--- a/webapp/src/components/ImageEditor/Pivot.tsx
+++ b/webapp/src/components/ImageEditor/Pivot.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { fireClickOnEnter } from '../../sui';
 
 export interface PivotOption {
     text: string;
@@ -40,7 +41,9 @@ export class Pivot extends React.Component<PivotProps, PivotState> {
                     role="tab"
                     key={option.id}
                     className={`image-editor-pivot-option ${option === selectedOption ? "selected" : ""}`}
-                    onClick={this.clickHandler(index)}>
+                    tabIndex={0}
+                    onClick={this.clickHandler(index)}
+                    onKeyDown={fireClickOnEnter}>
                     { option.text }
                 </div>
             ) }


### PR DESCRIPTION
* make the `my tiles` and `gallery` toggles feel like buttons; no select on text, pointer is hand instead of text select
* tab accessible for the buttons where it's simple to add - definitely a lot more work to make it fully accessible, but this has a nice side benefit when e.g. tabbing through image size and not ending up with the accessibility menu right away

![tabs-and-buttons](https://user-images.githubusercontent.com/5615930/90684574-4bb05e00-e21d-11ea-9dca-ac40b56e70c6.gif)

