### PR TITLE
Fix 720p size to correct 1280x720 standard

### DIFF
--- a/docs/static/streamer/script.js
+++ b/docs/static/streamer/script.js
@@ -1138,7 +1138,7 @@ background-image: url(${config.backgroundImage});
                 h: 1080,
                 name: "HD 1080p"
             }, {
-                w: 1080,
+                w: 1280,
                 h: 720,
                 name: "SD 720p"
             }

--- a/docs/static/streamer/streamer.ts
+++ b/docs/static/streamer/streamer.ts
@@ -1309,7 +1309,7 @@ background-image: url(${config.backgroundImage});
             h: 1080,
             name: "HD 1080p"
         }, {
-            w: 1080,
+            w: 1280,
             h: 720,
             name: "SD 720p"
         }


### PR DESCRIPTION
720p standard is 1280x720 (16:9) not 1080x720 (3:2)

Google search:
![image](https://user-images.githubusercontent.com/6453828/90694750-09434d00-e22e-11ea-8800-83dd9d0e4a4e.png)
