### PR TITLE
Hide checkmark for tablet/mobile editor language dropdown

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1413,8 +1413,7 @@ p.ui.font.small {
 
     /* Python/JS dropdown */
     #editordropdown .menu > .item.selected:after {
-        position: absolute;
-        left: 1em;
+        display: none;
     }
     #root #editordropdown .menu .item {
         width: auto;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1939