### PR TITLE
Hide 'Blocks' toggle if main.blocks not found

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -333,8 +333,8 @@ div.simframe > iframe {
     box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
     background: @editorToggleColor !important;
 }
-.active.item.javascript-menuitem ~ .toggle,
-.active.item.python-menuitem ~ .toggle {
+.blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
+.blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
     margin-left: 140px !important;
     box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
     background: @editorToggleColor !important;
@@ -847,8 +847,8 @@ p.ui.font.small {
             box-shadow: 2px 0px 0px rgba(0,0,0,0.1), -2px 0px 0px rgba(0,0,0,0.1) !important;
             background: @editorToggleColor !important;
         }
-        .active.item.javascript-menuitem ~ .toggle,
-        .active.item.python-menuitem ~ .toggle {
+        .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
+        .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
             margin-left: 80px !important;
             box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
             background: @editorToggleColor !important;
@@ -1385,8 +1385,8 @@ p.ui.font.small {
         width: 40px;
         height: 38px;
     }
-    .active.item.javascript-menuitem ~ .toggle,
-    .active.item.python-menuitem ~ .toggle {
+    .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
+    .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
         margin-left: 40px !important;
     }
     /* Top Menu */
@@ -1676,8 +1676,8 @@ div.simframe.ui.embed {
         box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;
     }
-    &:not(.headless) .active.item.javascript-menuitem ~ .toggle,
-    &:not(.headless) .active.item.python-menuitem ~ .toggle {
+    &:not(.headless) .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
+    &:not(.headless) .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
         margin-left: 280px !important;
         box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
         background: @editorToggleColor !important;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -429,11 +429,12 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         const pyOnly = languageRestriction === pxt.editor.LanguageRestriction.PythonOnly;
         // show python in toggle if: python editor currently active, or blocks editor active & saved language pref is python
         const showPython = parent.isPythonActive() || (parent.isBlocksActive() && pxt.Util.isPyLangPref());
+        const showBlocks = !!pkg.mainEditorPkg().files["main.blocks"];
 
         return (
             <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`}>
                 {sandbox && !headless && <SandboxMenuItem parent={parent} />}
-                {!pyOnly && !tsOnly && <BlocksMenuItem parent={parent} />}
+                {!pyOnly && !tsOnly && showBlocks && <BlocksMenuItem parent={parent} />}
                 {python && showPython ? <PythonMenuItem parent={parent} /> : <JavascriptMenuItem parent={parent} />}
                 {!pyOnly && !tsOnly && python && <sui.DropdownMenu id="editordropdown" role="menuitem" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
                     <JavascriptMenuItem parent={parent} />


### PR DESCRIPTION
Build: https://minecraft.makecode.com/app/7adcf5195e910034edd540bd57e8e0af233df8db-4ee9321a95

![image](https://user-images.githubusercontent.com/34112083/90789060-4b66a000-e2bb-11ea-9c64-18911073b1a4.png)

Certain types of project do not have a main.blocks file ("codeExample" homepage items, eg Hilbert Fractals in Minecraft, or some Arcade extensions); clicking on the "Blocks" part of the toggle does nothing and makes it look like the project is stuck. This just hides that part of the toggle if there is no blocks file.

Fixes https://github.com/microsoft/pxt-minecraft/issues/1955