### PR TITLE
Add tile gallery to sprite editor in monaco

### DIFF
--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -23,7 +23,8 @@ namespace pxt.editor {
             return {
                 initWidth: 16,
                 initHeight: 16,
-                blocksInfo: this.host.blocksInfo()
+                blocksInfo: this.host.blocksInfo(),
+                showTiles: true
             };
         }
     }

--- a/pxtlib/imageConverter.ts
+++ b/pxtlib/imageConverter.ts
@@ -137,6 +137,7 @@ namespace pxt {
 
             let inP = 4
             let outP = bmpHeaderSize
+            let isTransparent = true;
 
             for (let x = 0; x < w; x++) {
                 let high = false;
@@ -147,6 +148,7 @@ namespace pxt {
                 let colorStart = high ? (((v >> 4) & 0xf) << 2) : ((v & 0xf) << 2);
 
                 for (let y = 0; y < h; y++) {
+                    if (v) isTransparent = false;
                     bmp[outP] = this.palette[colorStart]
                     bmp[outP + 1] = this.palette[colorStart + 1]
                     bmp[outP + 2] = this.palette[colorStart + 2]
@@ -161,6 +163,12 @@ namespace pxt {
 
                         colorStart = high ? (((v >> 4) & 0xf) << 2) : ((v & 0xf) << 2);
                     }
+                }
+
+                if (isTransparent) {
+                    // If all pixels are completely transparent, browsers won't render the image properly;
+                    // set one pixel to be slightly opaque to fix that
+                    bmp[bmpHeaderSize + 3] = 1;
                 }
 
                 if (x % intScale === intScale - 1) {

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -168,6 +168,22 @@
     transition: transform 0.3s;
 }
 
+.gallery-editor-show-tiles {
+    position: absolute;
+    height: 2.3rem;
+    top: 0.3rem;
+    right: 1rem;
+
+    border: 2px solid #4067b3;
+    border-radius: 8px;
+    color: #4B7BEC;
+    background-color: #ffffff;
+    font-family: @pageFont;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    line-height: 2.25rem;
+}
+
 .image-editor-gallery {
     position: absolute;
     height: 100%;

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -195,7 +195,7 @@ export function init() {
 
         switch (fieldEditorId) {
             case "image-editor":
-                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} />);
+                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} showTiles={options?.showTiles} />);
                 break;
             case "animation-editor":
                 current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={false} />);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2172

only affects monaco

![2020-08-20 15 02 12](https://user-images.githubusercontent.com/13754588/90830301-47a43f00-e2f6-11ea-9d25-e9bb7d074c1b.gif)
