### PR TITLE
Add new row of tutorials as experiment to test caching

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -372,6 +372,7 @@ declare namespace pxt {
         qrCode?: boolean; // generate QR code for shared urls
         importExtensionFiles?: boolean; // import extensions from files
         debugExtensionCode?: boolean; // debug extension and libs code in the Monaco debugger
+        markdownCache?: boolean; // experiment to test caching times for markdown moving
         snippetBuilder?: boolean; // Snippet builder experimental feature
         experimentalHw?: boolean; // enable experimental hardware
         // recipes?: boolean; // inlined tutorials - deprecated

--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -162,6 +162,11 @@ namespace pxt.editor.experiments {
                 id: "errorList",
                 name: lf("Error List"),
                 description: lf("Show an error list panel for JavaScript and Python.")
+            },
+            {
+                id: "markdownCache",
+                name: lf("Markdown Cache"),
+                description: lf("For testing the cache timing")
             }
         ].filter(experiment => ids.indexOf(experiment.id) > -1);
     }


### PR DESCRIPTION
Adding a new experiment to toggle an arbitrary line of tutorials so we can move the markdown around