### PR TITLE
Store simulator state in local storage on shared pages

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -412,6 +412,10 @@ namespace pxt.runner {
 
     function setStoredState(id: string, key: string, value: any) {
         let storedState: Map<any> = getStoredState(id);
+        if (!id) {
+            return
+        }
+
         if (value)
             storedState[key] = value
         else


### PR DESCRIPTION
Implement a handler for the "setstate" command in runner.ts. The simulator state is now stored in local storage in a separate object per project. This stored state is then read from local storage when the page loads, the simulator is restarted, or a simulator setting is changed.

#### Tests
- Ran local tests with the https://arcade.makecode.com/48707-52405-10993-28535 project that increments a score.
- The score, along with other simulator settings such as volume, now persist across simulator and page restarts
- Confirmed the developer/button-tester works as expected
- Confirmed that disabling local storage does not throw uncaught exceptions, though the simulator state will not be saved

fixes microsoft/pxt-arcade#2330