### PR TITLE
Check block translations have equivalent parameters

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -658,8 +658,7 @@ namespace ts.pxtc {
                             fn.attributes.block = nsDoc;
                         }
                         updateBlockDef(fn.attributes);
-                    }
-                    else if (fn.attributes.block && locBlock) {
+                    } else if (fn.attributes.block && locBlock) {
                         const ps = pxt.blocks.compileInfo(fn);
                         const oldBlock = fn.attributes.block;
                         fn.attributes.block = pxt.blocks.normalizeBlock(locBlock, err => errors[`${fn.attributes.blockId}.${lang}`] = 1);
@@ -674,6 +673,8 @@ namespace ts.pxtc {
                                 updateBlockDef(fn.attributes);
                             }
                         }
+                    } else {
+                        updateBlockDef(fn.attributes);
                     }
                 })
             })))

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -693,14 +693,17 @@ namespace ts.pxtc {
     }
 
     function hasEquivalentParameters(a: pxt.blocks.BlockCompileInfo, b: pxt.blocks.BlockCompileInfo) {
-        if (a.parameters.length != b.parameters.length)
+        if (a.parameters.length != b.parameters.length) {
+            pxt.debug(`Localized block has extra or missing parameters`);
             return false;
+        }
 
         for (const aParam of a.parameters) {
             const bParam = b.actualNameToParam[aParam.actualName];
             if (!bParam
                 || aParam.type != bParam.type
                 || aParam.shadowBlockId != bParam.shadowBlockId) {
+                pxt.debug(`Parameter ${aParam.actualName} type or shadow block does not match after localization`);
                 return false;
             }
         }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -657,6 +657,7 @@ namespace ts.pxtc {
                         } else {
                             fn.attributes.block = nsDoc;
                         }
+                        updateBlockDef(fn.attributes);
                     }
                     else if (fn.attributes.block && locBlock) {
                         const ps = pxt.blocks.compileInfo(fn);
@@ -664,14 +665,15 @@ namespace ts.pxtc {
                         fn.attributes.block = pxt.blocks.normalizeBlock(locBlock, err => errors[`${fn.attributes.blockId}.${lang}`] = 1);
                         fn.attributes._untranslatedBlock = oldBlock;
                         if (oldBlock != fn.attributes.block) {
+                            updateBlockDef(fn.attributes);
                             const locps = pxt.blocks.compileInfo(fn);
                             if (JSON.stringify(ps) != JSON.stringify(locps)) {
                                 pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`)
                                 fn.attributes.block = oldBlock;
+                                updateBlockDef(fn.attributes);
                             }
                         }
                     }
-                    updateBlockDef(fn.attributes);
                 })
             })))
             .then(() => cleanLocalizations(apis))

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -667,8 +667,8 @@ namespace ts.pxtc {
                         if (oldBlock != fn.attributes.block) {
                             updateBlockDef(fn.attributes);
                             const locps = pxt.blocks.compileInfo(fn);
-                            if (JSON.stringify(ps) != JSON.stringify(locps)) {
-                                pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`)
+                            if (!hasEquivalentParameters(ps, locps)) {
+                                pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`);
                                 fn.attributes.block = oldBlock;
                                 updateBlockDef(fn.attributes);
                             }
@@ -688,6 +688,21 @@ namespace ts.pxtc {
             .filter(fb => fb.attributes.block && /^{[^:]+:[^}]+}/.test(fb.attributes.block))
             .forEach(fn => { fn.attributes.block = fn.attributes.block.replace(/^{[^:]+:[^}]+}/, ''); });
         return apis;
+    }
+
+    function hasEquivalentParameters(a: pxt.blocks.BlockCompileInfo, b: pxt.blocks.BlockCompileInfo) {
+        if (a.parameters.length != b.parameters.length)
+            return false;
+
+        for (const aParam of a.parameters) {
+            const bParam = b.actualNameToParam[aParam.actualName];
+            if (!bParam
+                || aParam.type != bParam.type
+                || aParam.shadowBlockId != bParam.shadowBlockId) {
+                return false;
+            }
+        }
+        return true;
     }
 
     export function emptyExtInfo(): ExtensionInfo {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -669,6 +669,7 @@ namespace ts.pxtc {
                             const locps = pxt.blocks.compileInfo(fn);
                             if (!hasEquivalentParameters(ps, locps)) {
                                 pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`);
+                                errors[`${fn.attributes.blockId}.${lang}`] = 2;
                                 fn.attributes.block = oldBlock;
                                 updateBlockDef(fn.attributes);
                             }


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/3351 and a ton of equivalent errors throughout all targets; when a user translates a block, it's really easy to accidentally break the block. This can be done by change parameter order (with % params), changing a shadow value, dropping a parameter, etc -- in the linked issue it was translating the shadow block from `device_arrow` to `devise_arrow`. This changes makes `localizeApisAsync` ignore translations when the blocks parameters get broken

![image](https://user-images.githubusercontent.com/5615930/90945479-f4a3b800-e3d9-11ea-8459-f868fd6d89d9.png)

The code was there to try and check it, but it was basically a noop; `ps` and `locps` were always equal because `pxt.blocks.compileInfo` uses the `._def` that is built and attached to the function's attributes by `updateBlockInfo`, which wasn't run until after the comparison.

Worth noting I left out two things from the comparison that can be changed in the block definition; `param.defaultValue` and `param.definitionName`. `defaultValue` seems fine to be able to change, e.g. to change a string's value to a localized equivalent, and `definitionName` seems fine as it already checks the types match / it is associated properly with a parameter as defined in typescript. Can add those to the checks and fail them if we want, but it would probably invalidate extra translations that are mostly valid / not currently breaking blocks.