### PR TITLE
Bump pxt-blockly to 3.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.20",
+    "pxt-blockly": "3.0.21",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
- Don't allow renaming functions to a blank string (https://github.com/microsoft/pxt-blockly/pull/320)