### PR TITLE
Get usedblocks when checking snippets, save to target.json

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -424,6 +424,7 @@ declare namespace pxt {
         bundleddirs: string[];
         versions: TargetVersions;        // @derived
         apiInfo?: Map<PackageApiInfo>;
+        tutorialInfo?: Map<Map<number>>;
     }
 
     interface PackageApiInfo {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -996,6 +996,9 @@ namespace pxt.BrowserUtils {
                         return res;
                     }
                     /* tslint:enable:possible-timing-attack */
+
+                    // delete stale db entry
+                    this.db.deleteAsync(TutorialInfoIndexedDb.TABLE, key);
                     return undefined;
                 });
         }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -22,6 +22,8 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 export function getUsedBlocksAsync(code: string[], id: string, language?: string): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
 
+    if (pxt.appTarget?.tutorialInfo && pxt.appTarget.tutorialInfo[id]) return Promise.resolve(pxt.appTarget.tutorialInfo[id]);
+
     return pxt.BrowserUtils.tutorialInfoDbAsync()
         .then(db => db.getAsync(id, code)
             .then(entry => {


### PR DESCRIPTION
Build https://minecraft.makecode.com/app/4d2ba8743c44fbea28e32007b8aed731d205caeb-0268f72fcd

Marks tutorial snippets with the source file URL and an "extractIds" flag. When decompiling each snippet during checkdocs, we extract the blockIds and save them to a file (used when pxt serve called after checkdocs, eg locally) and patch them into the target.json (when uploading, the target is built before checkdocs is called).

Also includes a change for deleting stale usedblocks entries from IndexedDb