### PR TITLE
fix checkdocs for tutorials with namespaces

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5349,18 +5349,18 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
                                 }
 
                                 // Handles tilemaps, spritekinds
-                                if (tutorial.code.indexOf("namespace") !== -1
+                                if (tutorial.code.some(tut => tut.indexOf("namespace") !== -1)
                                     // Handles ```python``` snippets
                                     || (tutorial.language == "python")) {
                                     tutorial.steps
                                         .filter(step => !!step.contentMd)
-                                        .forEach((step, stepIndex) => getCodeSnippets(`${gal.name}-${stepIndex}`, step.contentMd)
+                                        .forEach((step, stepIndex) => getCodeSnippets(`${card.name}-${stepIndex}`, step.contentMd)
                                             .forEach((snippet, snippetIndex) => {
                                                 snippet.packages = pkgs;
                                                 snippet.extraFiles = extraFiles;
                                                 addSnippet(
                                                     snippet,
-                                                    "tutorial" + `${gal.name}-${stepIndex}-${snippetIndex}`,
+                                                    `tutorial${card.name}-${stepIndex}-${snippetIndex}`,
                                                     cardIndex
                                                 )
                                             })


### PR DESCRIPTION
fix build https://travis-ci.org/github/microsoft/pxt-arcade/builds/720834034

Issue was that tutorial.code changed from string->array<string> in https://github.com/microsoft/pxt/pull/7382/files#diff-87390c8316b0230db07feb98ebca1fc0L5341, so the portion just above the cli change there was doing `array<string>.indexOf("namespace")` instead of `<string>.indexOf("namespace")` and never hitting the tutorial with namespace path

~still waiting on arcade checkdocs to pass locally (takes a while) in case there are any other issues, but this should be the fix.~ yup all works

![image](https://user-images.githubusercontent.com/5615930/91112537-3c277f80-e638-11ea-830c-5d973bb5eb95.png)

(also change to show card name instead of gal.name, as gallery name doesn't give much info when there are tons of things in the category)