### PR TITLE
Several small arcade bug fixes

### DIFF
--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -600,7 +600,7 @@ namespace ts.pxtc.service {
                 let functionArgument = "()";
                 if (!attrs.optionalVariableArgs) {
                     let displayParts = (ts as any).mapToDisplayParts((writer: ts.DisplayPartsSymbolWriter) => {
-                        checker.getSymbolDisplayBuilder().buildSignatureDisplay(functionSignature, writer);
+                        checker.getSymbolDisplayBuilder().buildSignatureDisplay(functionSignature, writer, undefined, TypeFormatFlags.UseFullyQualifiedType);
                     });
                     let displayPartsStr = ts.displayPartsToString(displayParts);
                     functionArgument = displayPartsStr.substr(0, displayPartsStr.lastIndexOf(":"));

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -224,7 +224,13 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
 
     protected onGalleryItemSelect = (item: pxt.sprite.GalleryItem) => {
         if (this.ref) {
-            this.ref.setCurrentFrame(pxt.sprite.getBitmap(this.blocksInfo, item.qName));
+            let selectedBitmap = pxt.sprite.getBitmap(this.blocksInfo, item.qName);
+
+            if (!selectedBitmap) {
+                selectedBitmap = pxt.sprite.Bitmap.fromData(pxt.react.getTilemapProject().resolveTile(item.qName).bitmap);
+            }
+
+            this.ref.setCurrentFrame(selectedBitmap);
         }
 
         tickImageEditorEvent("gallery-selection");

--- a/webapp/src/monacoFieldEditorHost.ts
+++ b/webapp/src/monacoFieldEditorHost.ts
@@ -305,6 +305,7 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
 
         const oldDecorations = this.decorations[owner];
         const ranges = this.liveRanges.filter(r => r.owner === owner);
+        const model = this.editor.getModel();
 
         const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
         for (const r of ranges) {
@@ -315,7 +316,7 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
             }
 
             newDecorations.push({
-                range: r.range,
+                range: new monaco.Range(r.line, model.getLineMinColumn(r.line), r.line, model.getLineMaxColumn(r.line)),
                 options: {
                     glyphMarginClassName: glyph
                 }

--- a/webapp/src/monacoFieldEditorHost.ts
+++ b/webapp/src/monacoFieldEditorHost.ts
@@ -285,7 +285,7 @@ export class FieldEditorManager implements monaco.languages.FoldingRangeProvider
         // We use FoldingRangeKind.Comment for field editors and FoldingRangeKind.Region for everything else
         const editorRanges: monaco.languages.FoldingRange[] = this.liveRanges.map(range => ({
             start: range.range.startLineNumber,
-            end: range.range.endLineNumber,
+            end: range.range.endLineNumber - 1,
             kind: monaco.languages.FoldingRangeKind.Comment
         }));
 

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -531,6 +531,20 @@ export class EditorPackage {
 
         return null;
     }
+
+    invalidateCachedTranspile(fromLanguage: pxtc.CodeLang, fromText: string, toLanguage: pxtc.CodeLang) {
+        for (let i = 0; i < this.transpileCache.length; i++) {
+            const ct = this.transpileCache[i];
+
+            const backwardMatch = ct.toLanguage === fromLanguage && ct.fromLanguage === toLanguage && codeIsEqual(fromLanguage, ct.toText, fromText);
+            const forwardMatch = ct.fromLanguage === fromLanguage && ct.toLanguage === toLanguage && codeIsEqual(fromLanguage, ct.fromText, fromText)
+
+            if (backwardMatch || forwardMatch) {
+                this.transpileCache.splice(i, 1);
+                return;
+            }
+        }
+    }
 }
 
 function codeIsEqual(language: pxtc.CodeLang, a: string, b: string) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2367
Fixes https://github.com/microsoft/pxt-arcade/issues/2368
Fixes https://github.com/microsoft/pxt-arcade/issues/2366
Fixes https://github.com/microsoft/pxt-arcade/issues/2363
Fixes https://github.com/microsoft/pxt-arcade/issues/2357

Also fixes a longstanding bug with the folding behavior where monaco folds image literals in such a way that it becomes impossible to enter a newline after them. 

For example, here is sprites.create in the current editor:
<img width="426" alt="Screen Shot 2020-08-25 at 3 13 25 PM" src="https://user-images.githubusercontent.com/13754588/91233187-87e43280-e6e5-11ea-9ca2-336a9cf92c0b.png">

And here it is with these changes:
<img width="377" alt="Screen Shot 2020-08-25 at 3 14 04 PM" src="https://user-images.githubusercontent.com/13754588/91233241-9f232000-e6e5-11ea-89d7-4fcda7643207.png">

In the first picture you would need to unfold the code before you could add another line the document because pressing enter would just edit the image literal and cause it to fold again.