### PR TITLE
Fix print code typo

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -1077,7 +1077,7 @@ ${linkString}
 
                         return <DecompileResult>{
                             package: mainPkg,
-                            blockSvg: blockSvg,
+                            blocksSvg: blockSvg,
                             apiInfo: apis
                         };
                     })


### PR DESCRIPTION
Regression introduced by me in https://github.com/microsoft/pxt/pull/7405

TIL: the typescript compiler lets you specify extra properties in an object literal even if you cast it to an interface type.