### PR TITLE
Confirm github dependencies available before loading packages

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -73,7 +73,7 @@ namespace pxt.Cloud {
     export function privateRequestAsync(options: Util.HttpRequestOptions) {
         options.url = pxt.webConfig?.isStatic && !options.forceLiveEndpoint ? pxt.webConfig.relprefix + options.url : apiRoot + options.url;
         options.allowGzipPost = true
-        if (!Cloud.isOnline()) {
+        if (!Cloud.isOnline() && !pxt.BrowserUtils.isPxtElectron()) {
             return offlineError(options.url);
         }
         if (!options.headers) options.headers = {}
@@ -140,7 +140,7 @@ namespace pxt.Cloud {
     }
 
     function downloadMarkdownAsync(docid: string, locale?: string, live?: boolean, etag?: string): Promise<{ md: string; etag?: string; }> {
-        const packaged = pxt.webConfig && pxt.webConfig.isStatic;
+        const packaged = pxt.webConfig?.isStatic;
         const targetVersion = pxt.appTarget.versions && pxt.appTarget.versions.target || '?';
         let url: string;
 
@@ -149,7 +149,8 @@ namespace pxt.Cloud {
             const isUnderDocs = /\/?docs\//.test(url);
             const hasExt = /\.\w+$/.test(url);
             if (!isUnderDocs) {
-                url = `docs/${url}`;
+                const hasLeadingSlash = url[0] === "/";
+                url = `docs${hasLeadingSlash ? "" : "/"}${url}`;
             }
             if (!hasExt) {
                 url = `${url}.md`;

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -581,6 +581,27 @@ namespace pxt.github {
             })
     }
 
+    export async function cacheProjectDependenciesAsync(cfg: pxt.PackageConfig): Promise<void> {
+        const ghExtensions = Object.keys(cfg.dependencies)
+                ?.filter(dep => isGithubId(cfg.dependencies[dep]));
+
+        if (ghExtensions.length) {
+            const pkgConfig = await pxt.packagesConfigAsync();
+            // Make sure external packages load before installing header.
+            await Promise.all(
+                ghExtensions.map(
+                    async ext => {
+                        const extSrc = cfg.dependencies[ext];
+                        const ghPkg = await downloadPackageAsync(extSrc, pkgConfig);
+                        if (!ghPkg) {
+                            throw new Error(lf("Cannot load extension {0} from {1}", ext, extSrc));
+                        }
+                    }
+                )
+            );
+        }
+    }
+
     export interface User {
         login: string; // "Microsoft",
         id: number; // 6154722,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2193,24 +2193,7 @@ export class ProjectView
         }
         files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);
 
-        const ghExtensions = Object.keys(cfg.dependencies)
-                ?.filter(dep => pxt.github.isGithubId(cfg.dependencies[dep]));
-
-        if (ghExtensions.length) {
-            const pkgConfig = await pxt.packagesConfigAsync();
-            // Make sure external packages load before installing header.
-            await Promise.all(
-                ghExtensions.map(
-                    async ext => {
-                        const extSrc = cfg.dependencies[ext];
-                        const ghPkg = await pxt.github.downloadPackageAsync(extSrc, pkgConfig);
-                        if (!ghPkg) {
-                            throw new Error(lf("Cannot load extension {0} from {1}", ext, extSrc));
-                        }
-                    }
-                )
-            );
-        }
+        await pxt.github.cacheProjectDependenciesAsync(cfg);
 
         const hd = await workspace.installAsync({
             name: cfg.name,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4301,7 +4301,10 @@ function loadHeaderBySharedId(id: string) {
 
     workspace.installByIdAsync(id)
         .then(hd => theEditor.loadHeaderAsync(hd, null))
-        .catch(core.handleNetworkError)
+        .catch(e => {
+            theEditor.openHome();
+            core.handleNetworkError(e);
+        })
         .finally(() => core.hideLoading("loadingheader"));
 }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2205,7 +2205,7 @@ export class ProjectView
                         const extSrc = cfg.dependencies[ext];
                         const ghPkg = await pxt.github.downloadPackageAsync(extSrc, pkgConfig);
                         if (!ghPkg) {
-                            throw new Error(lf(`Cannot load dependency {0} from {1}`, ext, extSrc));
+                            throw new Error(lf("Cannot load dependency {0} from {1}", ext, extSrc));
                         }
                     }
                 )

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2205,7 +2205,7 @@ export class ProjectView
                         const extSrc = cfg.dependencies[ext];
                         const ghPkg = await pxt.github.downloadPackageAsync(extSrc, pkgConfig);
                         if (!ghPkg) {
-                            throw new Error(lf("Cannot load dependency {0} from {1}", ext, extSrc));
+                            throw new Error(lf("Cannot load extension {0} from {1}", ext, extSrc));
                         }
                     }
                 )
@@ -2292,6 +2292,7 @@ export class ProjectView
             })
             .catch(e => {
                 core.warningNotification(lf("Please check your internet connection and check the example is valid."));
+                pxt.reportException(e);
                 return Promise.reject(e);
             })
             .finally(() => core.hideLoading("changingcode"))

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2212,7 +2212,7 @@ export class ProjectView
             );
         }
 
-        return workspace.installAsync({
+        const hd = await workspace.installAsync({
             name: cfg.name,
             meta: {},
             editor: options.preferredEditor || options.prj.id,
@@ -2224,9 +2224,10 @@ export class ProjectView
             temporary: options.temporary,
             tutorial: options.tutorial,
             extensionUnderTest: options.extensionUnderTest
-        }, files)
-            .then(hd => this.loadHeaderAsync(hd, { filters: options.filters }))
-            .then(() => pxt.perf.measureEnd("createProjectAsync"))
+        }, files);
+
+        await this.loadHeaderAsync(hd, { filters: options.filters });
+        pxt.perf.measureEnd("createProjectAsync");
     }
 
     // in multiboard targets, allow use to pick a different board

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -91,7 +91,12 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         pxt.tickEvent("projects.header");
         core.showLoading("changeheader", lf("loading..."));
         this.props.parent.loadHeaderAsync(hdr)
-            .done(() => {
+            .catch(e => {
+                core.warningNotification(lf("Sorry, we could not load this project."));
+                this.props.parent.openHome();
+                return Promise.reject(e);
+            })
+            .finally(() => {
                 core.hideLoading("changeheader");
             })
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -93,6 +93,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
         this.props.parent.loadHeaderAsync(hdr)
             .catch(e => {
                 core.warningNotification(lf("Sorry, we could not load this project."));
+                pxt.reportException(e);
                 this.props.parent.openHome();
                 return Promise.reject(e);
             })

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -403,8 +403,10 @@ export function installAsync(h0: InstallHeader, text: ScriptText) {
         h.editor = cfg.preferredEditor
         pxt.Util.setEditorLanguagePref(cfg.preferredEditor);
     }
-    return importAsync(h, text)
-        .then(() => h)
+
+    return pxt.github.cacheProjectDependenciesAsync(cfg)
+        .then(() => importAsync(h, text))
+        .then(() => h);
 }
 
 export function renameAsync(h: Header, newName: string) {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2371; this tries to fetch the github dependencies of the file before installing the header. Happy to look for an alternative approach if this feels wrong, but it seems okay to me as we'll need to fetch those dependencies for the project to actually load any way, and it shouldn't take any longer as the extensions get cached locally during `downloadPackageAsync`

And a few related fixes; quit the loading screen and return home with an error message if you try and load an old project and something prevents the header from being loaded (the second part of that issue), as well as a toast for when it fails to load an example (we didn't run into this in microbit as there are only a few non tutorial/project examples, and none of them had extensions)

Also, finally fixes https://github.com/microsoft/pxt-electron/issues/196 (tutorials occasionally failing to load until you refresh), as https://github.com/microsoft/pxt-arcade/issues/2371 actually just ended up being the repro case for it after I fixed the first portions. The fix for that is https://github.com/microsoft/pxt/commit/f5746ea5ef656f1ce120bfe7bd2e3c4a28c2ceb7 - when we sent out a request to something other than the local server while offline, it could potentially get an offline error, which would flip`_isOnline` and cause all future requests to fail, even when they're just to the server. This just says to always attempt the request if we're in pxt electron

Also, we were sending requests for `/docs//tutorial/...`, which we technically handle by ignoring the double slash but no reason to make things hard on ourselves.