### PR TITLE
Rembember me

### DIFF
--- a/docs/github-classroom-redirect.html
+++ b/docs/github-classroom-redirect.html
@@ -37,7 +37,8 @@
                 }
 
                 const assignment = localStorage["core/ghclassroomassigment"];
-                localStorage["core/githubtoken"] = keys["access_token"];
+                // do not store access token as the user has not explicitely allow storage 
+                // localStorage["core/githubtoken"] = keys["access_token"];
                 delete localStorage["core/oauthState"];
                 delete localStorage["core/ghclassroomassigment"];
                 var url = "https://classroom.github.com/" + assignment;

--- a/docs/github-explorer.html
+++ b/docs/github-explorer.html
@@ -88,6 +88,7 @@
         const api = "https://api.github.com";
 
         const targets = await fetchJSON("/editors.json");
+        let token = localStorage["core/githubtoken"];
 
         async function fetchJSON(url) {
             const resp = await fetch(url)
@@ -107,7 +108,7 @@
                 method: 'POST', // *GET, POST, PUT, DELETE, etc.
                 mode: 'cors', // no-cors, *cors, same-origin
                 headers: {
-                    "Authorization": "bearer " + token()
+                    "Authorization": "bearer " + token
                 },
                 body: JSON.stringify({ query: query })
             });
@@ -178,7 +179,7 @@
         }
 
         async function fetchCurrentUser() {
-            if (!token()) return undefined;
+            if (!token) return undefined;
             const response = await fetchGraphQL(`{
   viewer {
       login
@@ -262,10 +263,6 @@
             }
         }
 
-        function token() {
-            return localStorage["core/githubtoken"];
-        }
-
         function checkToken() {
             // sniff oauth
             let keys = {};
@@ -275,9 +272,12 @@
 
             if (keys["access_token"]) {
                 if (keys["state"] == localStorage["core/oauthState"]) {
-                    localStorage["core/githubtoken"] = keys["access_token"];
+                    token = keys["access_token"]
+                    if (keys["state"] == localStorage["core/oauthRememberState"])
+                        localStorage["core/githubtoken"] = token;
                 }
                 delete localStorage["core/oauthState"];
+                delete localStorage["core/oauthRememberState"]
                 window.location.hash = "";
             }
 
@@ -301,6 +301,8 @@
             trackClick("github.explorer.signin")
             const state = Math.random().toString();
             localStorage["core/oauthState"] = state;
+            if (document.getElementById('remembermeinput').checked)
+                localStorage["core/oauthRememberState"] = state;
             const login = "https://makecode.com/oauth/login?state=" + state +
                 "&response_type=token&client_id=gh-token&redirect_uri=" +
                 encodeURIComponent(window.location.href.split('#', 1)[0])
@@ -391,6 +393,8 @@
             <i class="ui github icon"></i>
             Sign in
         </button>
+        <input type="checkbox" id="remembermeinput" />
+        <label for="remembermeinput">Remember me</label>
     </div>
     <footer id="footer" class="hideprint">
         <a class="item" href="https://makecode.com/privacy" target="_blank" rel="noopener">Privacy &amp; Cookies</a>

--- a/docs/github-explorer.html
+++ b/docs/github-explorer.html
@@ -164,7 +164,7 @@
         }
 
         async function fetchUser(user) {
-            if (!token()) return undefined;
+            if (!token) return undefined;
             const response = await fetchGraphQL(`{
   user(login:"${user}") {
     name
@@ -282,7 +282,7 @@
             }
 
             // force sign...
-            if (!token()) {
+            if (!token) {
                 $("#signin").show();
                 $('#signout').hide();
                 $('#userparent').hide();

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -692,12 +692,12 @@ export function loginCheck() {
     // implicit OAuth flow, via query argument
     {
         const qs = core.parseQueryString(pxt.storage.getLocal(OAUTH_HASH) || "")
-        const rememberMe = qs["state"] === pxt.storage.getLocal(OAUTH_REMEMBER_STATE)
         if (qs["access_token"]) {
             const tp = pxt.storage.getLocal(OAUTH_TYPE)
             const impl = provs.filter(p => p.name == tp)[0];
             if (impl) {
                 pxt.storage.removeLocal(OAUTH_HASH);
+                const rememberMe = qs["state"] === pxt.storage.getLocal(OAUTH_REMEMBER_STATE)
                 impl.loginCallback(rememberMe, qs)
             }
             // cleanup

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -94,7 +94,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
             jsxd: () => <div className="ui form">
                 <p>{lf("You need to sign in with GitHub to use this feature.")}</p>
                 <p>{lf("You can host your code on GitHub and collaborate with friends on projects.")}</p>
-                <p><sui.PlainCheckbox label={lf("Remember me")} onChange={handleRememberMe} /></p>
+                <div><sui.PlainCheckbox label={lf("Remember me")} onChange={handleRememberMe} /></div>
                 {!useToken && <p className="ui small">
                     {lf("Looking to use a Developer token instead?")}
                     <sui.Link className="link" text={lf("Use Developer token")} onClick={showToken} />

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -302,11 +302,11 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
             const isOrg = await pxt.github.isOrgAsync(parsed.owner);
             if (isOrg) {
                 // tslint:disable: react-this-binding-issue
-                org = <p className="ui small">
+                org = <div className="ui small">
                     {lf("If you already have write permissions to this repository, you may have to authorize the MakeCode App in the {0} organization.", parsed.owner)}
                     <sui.PlainCheckbox label={lf("Remember me")} onChange={handleRememberMeChanged} />
                     <sui.Link className="ui link" text={lf("Authorize MakeCode")} onClick={handleAutorize} onKeyDown={sui.fireClickOnEnter} />
-                </p>
+                </div>
                 // tslint:enable: react-this-binding-issue
             }
         }

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -287,8 +287,8 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         const user = provider.user();
         let org: JSX.Element = undefined;
         let rememberMe = false
-        const handleRememberMeChanged = (v: boolean) => { 
-            rememberMe = v 
+        const handleRememberMeChanged = (v: boolean) => {
+            rememberMe = v
             core.forceUpdate()
         }
         const handleAutorize = () => {

--- a/webapp/src/onedrive.ts
+++ b/webapp/src/onedrive.ts
@@ -66,7 +66,8 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
             // Redirect
             window.location.href = url
         }).then((resp) => {
-            this.setNewToken(resp.accessToken, resp.expiresIn);
+            // TODO: rememberme review this when implementing goog/onedrive
+            this.setNewToken(resp.accessToken, false, resp.expiresIn);
             return resp;
         }).finally(() => {
             this.loginCompleteInner();

--- a/webapp/src/onedrive.ts
+++ b/webapp/src/onedrive.ts
@@ -175,6 +175,7 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
         // Pop out
         const popupCallback = () => {
             const qs = core.parseQueryString(pxt.storage.getLocal(cloudsync.OAUTH_HASH) || "")
+            const rememberMe = qs["state"] === pxt.storage.getLocal(cloudsync.OAUTH_REMEMBER_STATE)
             const accessToken = qs["access_token"];
             const expiresInSeconds = parseInt(qs["expires_in"]);
 
@@ -188,6 +189,7 @@ export class Provider extends cloudsync.ProviderBase implements cloudsync.Provid
 
             resolve({
                 accessToken: accessToken,
+                rememberMe,
                 expiresIn: expiresInSeconds
             });
         }


### PR DESCRIPTION
Adds a ``remember me`` checkbox to github login dialogs. Remember me in formation is used to decide to store the token in localstorage or not.

When a user checks ``remember me``, we store the OAuth ``state`` in a new localstorage key, ``oauthRememberState`` when starting the login flow. After redirecting from the OAuth, we check if the ``state`` matches the ``oauthRememberState`` key to determine if ``remember me`` was selected.

- [x] force rememberme parameter in all paths
- [x] use state to check remember me
- [x] updated github-explorer (tested both cases)
- [x] updated github-classroom-redirect
- [x] use in-memory token instead of always reading from localstorage

Notes:

It's unclear if the onedrive/google auth path are still working with this since they are mostly dead code/untestable.
