### PR TITLE
Consider activeLayer data in addition to image data when filling

### DIFF
--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -650,9 +650,11 @@ export class FillEdit extends Edit {
     }
 
     protected doEditCore(state: EditState) {
-        // Read image layer, but write to the active layer; allows wall fill to fill based on tiles
-        const colorToReplace = state.image.get(this.col, this.row);
-        if (state.activeLayer === state.image && colorToReplace === this.color) {
+        const includeActiveLayerData = state.activeLayer !== state.image;
+        const getData = (col: number, row: number) => (includeActiveLayerData ? state.activeLayer.get(col, row) << 8 : 0) + state.image.get(col, row);
+
+        const colorToReplace = getData(this.col, this.row);
+        if (colorToReplace === this.color) {
             return;
         }
 
@@ -663,7 +665,7 @@ export class FillEdit extends Edit {
         const q: pxt.sprite.Coord[] = [{x: this.col, y: this.row}];
         while (q.length) {
             const curr = q.pop();
-            if (state.image.get(curr.x, curr.y) === colorToReplace) {
+            if (getData(curr.x, curr.y) === colorToReplace) {
                 state.activeLayer.set(curr.x, curr.y, this.color);
                 tryPush(curr.x + 1, curr.y);
                 tryPush(curr.x - 1, curr.y);


### PR DESCRIPTION
Adjusts fill to be based on a computed value that includes data from the `activeLayer` in addition to the pixel value from the `image` layer.

fixes microsoft/pxt-arcade#2374

![Kapture 2020-08-26 at 12 27 48](https://user-images.githubusercontent.com/194333/91347695-99861280-e797-11ea-9bdf-c464e8f9ab8d.gif)
