### PR TITLE
fix caching for packages given an alias in md

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -659,6 +659,7 @@ async function cacheApiInfoAsync(project: pkg.EditorPackage, info: pxtc.ApisInfo
 
         for (const dep of externalPackages) {
             const name = dep.getKsPkg().config.name;
+            const pkgId = dep.getPkgId();
             const entry: pxt.PackageApiInfo = {
                 sha: null,
                 apis: { byQName: {} }
@@ -666,8 +667,9 @@ async function cacheApiInfoAsync(project: pkg.EditorPackage, info: pxtc.ApisInfo
 
 
             for (const api of apiList) {
-                if (info.byQName[api].pkg === name) {
-                    entry.apis.byQName[api] = info.byQName[api];
+                const apiInfo = info.byQName[api];
+                if (apiInfo.pkg === name || apiInfo.pkg === pkgId) {
+                    entry.apis.byQName[api] = apiInfo;
                 }
             }
 


### PR DESCRIPTION
fix issue with api caching of external packages that causes https://minecraft.makecode.com/?ipc=1&inGame=1&noRunOnX=1#tutorial:github:fountainstudios/AIMakecodeMarkdown/testAI to succeed in loading the first time, but fail on any future loads.

Usually a `pkg.EditorPackage`'s `.getPkgId()` is equal to it's configs name, but when https://github.com/fountainstudios/AIMakecodeMarkdown/blob/master/testAI.md loads in https://github.com/fountainstudios/AICustomBlocks, it gives it a name to reference locally (the = part at the beginning / `AIBlocks`) which gets set as it's ID.

When the compiler runs and builds the api info, it attaches the `getPkgId` as the api's `.pkg`, but when we cache that api info we do it based off the config's name. In the section changed in this pr, when the external packages api info is cached, it was missing all the apis built off the package (the blocks all had `.pkg` set as `AIBlocks`, where it was looking for `aicustomblocks`) and caching an empty set of apis.

Could also just cache the external packages based off the id; leaving as the minimal change to start with though.