### PR TITLE
CLI command for collecting block ids used in tutorial markdown

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1213,9 +1213,11 @@ function readLocalPxTarget() {
         process.exit(1)
     }
     nodeutil.setTargetDir(process.cwd())
+    const pkg = readJson("package.json");
     const cfg: pxt.TargetBundle = readJson("pxtarget.json");
     cfg.versions = {
-        target: readJson("package.json")["version"]
+        target: pkg["version"],
+        pxt: (pxt.appTarget.versions && pxt.appTarget.versions.pxt) || pkg["dependencies"]["pxt-core"]
     };
 
     return cfg
@@ -2057,6 +2059,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
     let cfg = readLocalPxTarget()
     updateDefaultProjects(cfg);
     updateTOC(cfg);
+
     cfg.bundledpkgs = {}
     pxt.setAppTarget(cfg);
     let statFiles: Map<number> = {}
@@ -2091,6 +2094,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
 
     return buildWebStringsAsync()
         .then(() => options.quick ? null : internalGenDocsAsync(false, true))
+        .then(() => pxt.appTarget.cacheusedblocksdirs ? internalCacheUsedBlocksAsync().then((usedBlocks) => cfg.tutorialInfo = usedBlocks) : null)
         .then(() => forEachBundledPkgAsync((pkg, dirname) => {
             pxt.log(`building bundled ${dirname}`);
             let isPrj = /prj$/.test(dirname);
@@ -2210,6 +2214,7 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
             delete targetlight.bundledpkgs;
             delete targetlight.appTheme;
             delete targetlight.apiInfo;
+            delete targetlight.tutorialInfo;
             if (targetlight.compile)
                 delete targetlight.compile.compilerExtension;
             const targetlightjson = nodeutil.stringify(targetlight);
@@ -4012,8 +4017,9 @@ function testSnippetsAsync(snippets: CodeSnippet[], re?: string, pyStrictSyntaxC
                             snippetMode: false,
                             errorOnGreyBlocks: true
                         });
-                        let blockSucces = !!bresp.outfiles['main.blocks']
-                        if (!blockSucces) {
+
+                        let blockSuccess = !!bresp.outfiles['main.blocks'];
+                        if (!blockSuccess) {
                             return addFailure(fn, bresp.diagnostics)
                         }
 
@@ -5427,6 +5433,110 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
     })
 }
 
+interface TutorialInfo extends pxt.tutorial.TutorialInfo {
+    pkgs?: Map<string>
+}
+
+function cacheUsedBlocksAsync() {
+    return internalCacheUsedBlocksAsync()
+        .then((usedBlocks) => {
+            nodeutil.writeFileSync(path.resolve(process.cwd(), "built", "tutorial-info-cache.json"), JSON.stringify(usedBlocks));
+        })
+}
+
+function internalCacheUsedBlocksAsync() {
+    const mdPaths: string[] = [];
+    const mdRegex = /\.md$/;
+    const targetDirs = pxt.appTarget.cacheusedblocksdirs;
+    const usedBlocks: Map<Map<number>> = {};
+    if (targetDirs) {
+        targetDirs.forEach(dir => {
+            pxt.log(`looking for tutorial markdown in ${dir}`);
+            nodeutil.allFiles(path.join("docs", dir), 3).filter(f => mdRegex.test(f))
+                .forEach(md => {
+                    mdPaths.push(md.slice(5).replace(mdRegex, ""));
+                });
+        })
+    }
+    const tutorialInfo: Map<TutorialInfo> = {}
+    for (let i = 0; i < mdPaths.length; i++) {
+        const path = mdPaths[i];
+        let md = nodeutil.resolveMd(nodeutil.targetDir, path);
+        if (!md) {
+            pxt.log(`error resolving tutorial markdown at ${path}`);
+        }
+        const tutorial = pxt.tutorial.parseTutorial(md) as TutorialInfo;
+        const pkgs: pxt.Map<string> = { "blocksprj": "*" };
+        pxt.Util.jsonMergeFrom(pkgs, pxt.gallery.parsePackagesFromMarkdown(md) || {});
+        tutorial.pkgs = pkgs;
+
+        const hash = pxt.BrowserUtils.getTutorialInfoHash(tutorial.code);
+        tutorialInfo[hash] = tutorial;
+    }
+
+    const namespaceRegex = /^\s*namespace\s+[^\s]+\s*{([\S\s]*)}\s*$/im;
+    return Promise.map(Object.keys(tutorialInfo), (hash: string) => {
+        const info = tutorialInfo[hash];
+        const cache: Map<string> = {};
+        let isPy = info.language === "python"
+        let inFiles;
+        if (isPy) {
+            let extra: Map<string> = {};
+            info.code.forEach((snippet, i) => extra["snippet_" + i + ".py"] = snippet);
+            inFiles = { "main.ts": "", "main.py": "", "main.blocks": "", ...extra }
+        } else {
+            inFiles = { "main.ts": info.code.join("\n"), "main.py": "", "main.blocks": "" }
+        }
+
+        const host = new SnippetHost("usedblocks", inFiles, info.pkgs);
+        host.cache = cache;
+        const pkg = new pxt.MainPackage(host);
+        return pkg.installAllAsync()
+            .then(() => pkg.getCompileOptionsAsync().then(opts => {
+                opts.ast = true;
+                // convert python to ts
+                if (isPy) {
+                    opts.target.preferredEditor = pxt.JAVASCRIPT_PROJECT_NAME
+                    const stsCompRes = pxtc.compile(opts);
+                    const apisInfo = pxtc.getApiInfo(stsCompRes.ast, opts.jres)
+                    if (!apisInfo || !apisInfo.byQName)
+                        throw Error("Failed to get apisInfo")
+
+                    opts.apisInfo = apisInfo
+                    opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME
+                    const { outfiles } = pxt.py.py2ts(opts)
+
+                    let ts = "";
+                    for (let f of Object.keys(outfiles)) {
+                        if (f.match(/^snippet/)) {
+                            let match = outfiles[f].match(namespaceRegex);
+                            if (match && match[1]) ts += `{\n${match[1]}\n}\n`
+                        }
+                    }
+                    opts.fileSystem["main.ts"] = ts;
+                }
+
+                // convert ts to blocks
+                const decompiled = pxtc.decompile(pxtc.getTSProgram(opts), opts, "main.ts");
+                if (decompiled.success) {
+                    const blocksXml = decompiled.outfiles["main.blocks"];
+                    // scrape block IDs matching <block type="block_id">
+                    const blockIdRegex = /<\s*block(?:[^>]*)? type="([^ ]*)"/ig;
+                    let ids: pxt.Map<number> = usedBlocks[hash] || {};
+                    blocksXml.replace(blockIdRegex, (m0, m1) => {
+                        ids[m1] = 1;
+                        return m0;
+                    })
+                    usedBlocks[hash] = ids;
+                }
+            }))
+            .catch((err) => pxt.log(err));
+    }).then(() => {
+        pxt.log("cached tutorial used blocks");
+        return usedBlocks
+    })
+}
+
 export interface SnippetInfo {
     type: string;
     code: string;
@@ -6212,6 +6322,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
             }
         }
     }, checkDocsAsync);
+
+    p.defineCommand({
+        name: "usedblocks",
+        help: "extract list of block ids used in each tutorial"
+    }, cacheUsedBlocksAsync);
 
     advancedCommand("api", "do authenticated API call", pc => apiAsync(pc.args[0], pc.args[1]), "<path> [data]");
     advancedCommand("pokecloud", "same as 'api pokecloud {}'", () => apiAsync("pokecloud", "{}"));

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -425,7 +425,11 @@ declare namespace pxt {
         bundleddirs: string[];
         versions: TargetVersions;        // @derived
         apiInfo?: Map<PackageApiInfo>;
-        tutorialInfo?: Map<Map<number>>;
+        tutorialInfo?: Map<BuiltTutorialInfo>; // hash of tutorial code mapped to prebuilt info for each tutorial
+    }
+
+    interface BuiltTutorialInfo {
+        usedBlocks: Map<number>;
     }
 
     interface PackageApiInfo {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -69,7 +69,8 @@ declare namespace pxt {
         alwaysMultiVariant?: boolean;
         queryVariants?: Map<AppTarget>; // patches on top of the current AppTarget using query url regex
         unsupportedBrowsers?: BrowserOptions[]; // list of unsupported browsers for a specific target (eg IE11 in arcade). check browserutils.js browser() function for strings
-        checkdocsdirs?: string[]; // list of folders for checkdocs, irrespective of SUMMARY.md
+        checkdocsdirs?: string[]; // list of /docs subfolders for checkdocs, irrespective of SUMMARY.md
+        cacheusedblocksdirs?: string[]; // list of /docs subfolders for parsing and caching used block ids (for tutorial loading)
         blockIdMap?: Map<string[]>; // list of target-specific blocks that are "synonyms" (eg. "agentturnright" and "minecraftAgentTurn")
     }
 
@@ -424,6 +425,7 @@ declare namespace pxt {
         bundleddirs: string[];
         versions: TargetVersions;        // @derived
         apiInfo?: Map<PackageApiInfo>;
+        tutorialInfo?: Map<Map<number>>;
     }
 
     interface PackageApiInfo {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -932,7 +932,7 @@ namespace pxt.BrowserUtils {
             .catch(e => deleteDbAsync().done());
     }
 
-    function getTutorialInfoHash(code: string[]) {
+    export function getTutorialInfoHash(code: string[]) {
         // the code strings are parsed from markdown, so when the
         // markdown changes the blocks will also be invalidated
         const input = JSON.stringify(code) + pxt.appTarget.versions.pxt + "_" + pxt.appTarget.versions.target;
@@ -996,6 +996,9 @@ namespace pxt.BrowserUtils {
                         return res;
                     }
                     /* tslint:enable:possible-timing-attack */
+
+                    // delete stale db entry
+                    this.db.deleteAsync(TutorialInfoIndexedDb.TABLE, key);
                     return undefined;
                 });
         }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -22,6 +22,12 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 export function getUsedBlocksAsync(code: string[], id: string, language?: string): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
 
+    // check to see if usedblocks has been prebuilt. this is hashed on the tutorial code + pxt version + target version
+    if (pxt.appTarget?.tutorialInfo) {
+        const hash = pxt.BrowserUtils.getTutorialInfoHash(code);
+        if (pxt.appTarget.tutorialInfo[hash]) return Promise.resolve(pxt.appTarget.tutorialInfo[hash]);
+    }
+
     return pxt.BrowserUtils.tutorialInfoDbAsync()
         .then(db => db.getAsync(id, code)
             .then(entry => {


### PR DESCRIPTION
- Separate CLI command for collecting blockIds, run on an allowlist of directories specified in pxtarget.json (eg ["hour-of-code", "tutorials"])
- Key on a hash of the tutorial code, pxt version, and target version--only use prebuilt blocks if the hash matches
- Used blocks saved in target.json