### PR TITLE
clean up config.name vs pkg id in package api caching

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -502,6 +502,8 @@ namespace pxt {
     export const DEFAULT_GROUP_NAME = "other"; // used in flyout, for snippet groups
     export const TILEMAP_CODE = "tilemap.g.ts";
     export const TILEMAP_JRES = "tilemap.g.jres";
+    export const TUTORIAL_CODE_START = "_onCodeStart.ts"
+    export const TUTORIAL_CODE_STOP = "_onCodeStop.ts"
 
     export function outputName(trg: pxtc.CompileTarget = null) {
         if (!trg) trg = appTarget.compile

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -503,8 +503,8 @@ namespace pxt {
     export const DEFAULT_GROUP_NAME = "other"; // used in flyout, for snippet groups
     export const TILEMAP_CODE = "tilemap.g.ts";
     export const TILEMAP_JRES = "tilemap.g.jres";
-    export const TUTORIAL_CODE_START = "_onCodeStart.ts"
-    export const TUTORIAL_CODE_STOP = "_onCodeStop.ts"
+    export const TUTORIAL_CODE_START = "_onCodeStart.ts";
+    export const TUTORIAL_CODE_STOP = "_onCodeStop.ts";
     export const TUTORIAL_INFO_FILE = "tutorial-info-cache.json";
 
     export function outputName(trg: pxtc.CompileTarget = null) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2181,14 +2181,12 @@ export class ProjectView
         }
         if (options.tutorial && options.tutorial.metadata) {
             if (options.tutorial.metadata.codeStart) {
-                let codeStart = "_onCodeStart.ts";
-                files[codeStart] = "control._onCodeStart('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStart) + "')";
-                cfg.files.splice(cfg.files.indexOf("main.ts"), 0, codeStart);
+                files[pxt.TUTORIAL_CODE_START] = "control._onCodeStart('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStart) + "')";
+                cfg.files.splice(cfg.files.indexOf("main.ts"), 0, pxt.TUTORIAL_CODE_START);
             }
             if (options.tutorial.metadata.codeStop) {
-                let codeStop = "_onCodeStop.ts";
-                files[codeStop] = "control._onCodeStop('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStop) + "')";
-                cfg.files.push(codeStop);
+                files[pxt.TUTORIAL_CODE_STOP] = "control._onCodeStop('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStop) + "')";
+                cfg.files.push(pxt.TUTORIAL_CODE_STOP);
             }
         }
         files[pxt.CONFIG_NAME] = pxt.Package.stringifyConfig(cfg);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2185,11 +2185,11 @@ export class ProjectView
         }
         if (options.tutorial && options.tutorial.metadata) {
             if (options.tutorial.metadata.codeStart) {
-                files[pxt.TUTORIAL_CODE_START] = "control._onCodeStart('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStart) + "')";
+                files[pxt.TUTORIAL_CODE_START] = `control._onCodeStart('${pxt.U.htmlEscape(options.tutorial.metadata.codeStart)}')`;
                 cfg.files.splice(cfg.files.indexOf("main.ts"), 0, pxt.TUTORIAL_CODE_START);
             }
             if (options.tutorial.metadata.codeStop) {
-                files[pxt.TUTORIAL_CODE_STOP] = "control._onCodeStop('" + pxt.U.htmlEscape(options.tutorial.metadata.codeStop) + "')";
+                files[pxt.TUTORIAL_CODE_STOP] = `control._onCodeStop('${pxt.U.htmlEscape(options.tutorial.metadata.codeStop)}')`;
                 cfg.files.push(pxt.TUTORIAL_CODE_STOP);
             }
         }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -546,9 +546,20 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
     const corePkg = bundled[corePkgName];
     if (!corePkg) return null;
 
-    // If the project has a TypeScript file beside main.ts, it could export blocks so we can't use the cache
+    // If the project has a TypeScript file beside one of the generated files, it could export blocks so we can't use the cache
     const files = project.getAllFiles();
-    if (Object.keys(files).some(filename => filename != "main.ts" && filename.indexOf("/") === -1 && pxt.Util.endsWith(filename, ".ts"))) {
+    const generatedFiles = [
+        "main.ts",
+        pxt.TUTORIAL_CODE_START,
+        pxt.TUTORIAL_CODE_STOP,
+        pxt.TILEMAP_CODE
+    ];
+
+    if (Object.keys(files).some(
+            filename => generatedFiles.indexOf(filename) === -1
+            && filename.indexOf("/") === -1
+            && pxt.Util.endsWith(filename, ".ts")
+        )) {
         return null;
     }
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -676,7 +676,7 @@ async function cacheApiInfoAsync(project: pkg.EditorPackage, info: pxtc.ApisInfo
             }
 
             await db.setAsync(dep, entry);
-            pxt.debug(`Stored API info for ${dep}`);
+            pxt.debug(`Stored API info for ${getPackageKey(dep)}`);
         }
     }
 }
@@ -964,7 +964,7 @@ function getPackageKey(pack: pkg.EditorPackage) {
     const verspec = ksPkg._verspec;
     if (pxt.github.isGithubId(verspec)) {
         // only cache one version of repo; drop #tag
-        const slug = /^[^#]+/.exec(verspec);
+        const slug = /^([^#]+)/.exec(verspec);
         return slug[1];
     } else {
         return ksPkg.config.name;


### PR DESCRIPTION
re: last portion of message in https://github.com/microsoft/pxt/pull/7427 and discussion last friday

**[edit]** + a quick fix along the same code path for extension caching when we add in extra built files, like tilemap of code start.

After looking through stuff a bit more I think this is the right way to handle things. I don't think this necessarily needs to go into this release, as it hasn't been run into in arcade yet / is a pretty subtle case

quick context on all the relevant fields;
* `SymbolInfo.pkg` is the package that the api came from. this gets picked from the symbol info we get out of the ts compiler base off the name of the folder the symbol is found in https://github.com/microsoft/pxt/blob/7589ccebd32df24e1cb7ceb8e620eb4e617ab55c/pxtcompiler/emitter/service.ts#L218-L225
* epkg.getPkgId gets the id for the editor package (this is equal to pxt.package / kspkg .id, if kspkg exists). This id typically matches either pkg.config.name or an alias defined by the user if it's not a builtin pkg (as described in the linked PR), and is used when passing things to the compiler, eg https://github.com/microsoft/pxt/blob/7589ccebd32df24e1cb7ceb8e620eb4e617ab55c/pxtlib/package.ts#L1071-L1081
* pkg.config.name is the name of the package as listed in pxt.json
* Package._verspec describes the packages version; for github dependencies this will be `github:{repo slug}(#{tag})?`, for builtin packages this will usually be '*', and for the main package / user local deps / etc this will be something like `workspace:60fc5898-522b-40a5-7c4f-77754c92fce5`

So, at runtime, the information we have about a block <-> api correlation is the package id, which will link to a specific package. This value is meaningless when persisting the apis though / is specific to a project, so we would want to key it off some other value -- verspec if there's a meaningful one is useful, otherwise just config.name is likely the best. So, we want to accumulate the apis using the package id, and store them in the db based off the relevant key.


** side note, we had discussed adding a field containing the verspec to the block; after looking into it this seems like it would be either a hacky implementation of building it wherever we call `getApiInfo`, or require a decent amount reworking / passing things around that I'm not sure is warranted. This is because the point at which we create the api info only really has context for the ts program, and not our view of the program; which is why we e.g. get the package of the block by pulling it out of the file path. If we want that information, I think a method on `pkg.EditorPackage` would be better (`getApiSource(info: ApiInfo): pkg.EditorPackage`), that takes an api's .pkg, uses that to find the package with the same id, and returns that (or it's `.config.name` / `._verspec` like I have it doing in `getPackageKey`)