### PR TITLE
Fix issue where examples loaded empty workspaces on slow computers

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -123,6 +123,7 @@ export class ProjectView
 
     private runToken: pxt.Util.CancellationToken;
     private updatingEditorFile: boolean;
+    private loadingExample: boolean;
     private openingTypeScript: boolean;
     private preserveUndoStack: boolean;
 
@@ -370,7 +371,7 @@ export class ProjectView
     }
 
     saveFileAsync(): Promise<void> {
-        if (!this.editorFile)
+        if (!this.editorFile || this.loadingExample)
             return Promise.resolve()
         return this.saveTypeScriptAsync()
             .then(() => this.setFileContentAsync());
@@ -2227,6 +2228,7 @@ export class ProjectView
     importExampleAsync(options: pxt.editor.ExampleImportOptions): Promise<void> {
         const { name, path, loadBlocks, prj, preferredEditor } = options;
         core.showLoading("changingcode", lf("loading..."));
+        this.loadingExample = true;
         return this.loadActivityFromMarkdownAsync(path, name.toLowerCase(), preferredEditor)
             .then(r => {
                 const { filename, md, features, autoChooseBoard: autoChooseBoardMeta } = (r || {});
@@ -2278,7 +2280,10 @@ export class ProjectView
                 pxt.reportException(e);
                 return Promise.reject(e);
             })
-            .finally(() => core.hideLoading("changingcode"))
+            .finally(() => {
+                this.loadingExample = false;
+                core.hideLoading("changingcode")
+            })
     }
 
     switchTypeScript() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2138

The sequence of events when we load a blocks example looks something like this:

1. Create a project for the example (w/ `main.ts` but not `main.blocks`)
2. Load the Blockly editor
3. Decompile the `main.ts` file to get the `main.blocks` for the new project
4. Load the new `main.blocks` into the workspace

We need to do these things in this order because we rely on the blocks info created in step 2 to do the decompile in step 3.

However, on slow machines there is a chance that between step 2 and step 3 our autosave handler will run. When that happens the current code in the Blockly workspace (which is empty) is compiled and saved over the `main.ts` turning `main.ts` into an empty file. Then when we get to step 3, we decompile that empty file into an empty workspace.

This fixes that by making sure that we don't save files when we're loading an example.