### PR TITLE
Add option for caching tutorial info when creating Github release

### DIFF
--- a/docs/extensions/github-authoring.md
+++ b/docs/extensions/github-authoring.md
@@ -40,6 +40,14 @@ You can view a history of changes by following the version number link on the **
 
 There's also another button next to the GitHub sync - you can use it to add new files to the project. This is mostly to help keep the project organized. For the TypeScript compiler it doesn't matter if you use one big file or a bunch of smaller ones.
 
+## Releases
+
+After committing your changes, you will have the option to create a release of your extension. A release clears the cache and ensures that the latest version of your extension will be loaded (this feature is still rolling out to some targets, so double check that it is supported in your editor).
+
+### Optimize for Tutorials
+
+When creating a release for tutorials hosted on Github, you may also choose to optimize your repository. This will precompute some information about the markdown files, and save the data in a `tutorial-info-cache.json` file. Your tutorial will then load faster when the user opens it. This checkbox has no effect on non-tutorial extensions.
+
 ### Conflicts
 
 It's possible that multiple people are editing the same extension at the same time causing edit conflicts. This is similar to the situation where the same person edits the extension using several computers, browsers, or web sites. In the conflict description below, for simplicity, we'll just concentrate on the case of multiple people working on the same extension.

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -429,6 +429,7 @@ declare namespace pxt {
     }
 
     interface BuiltTutorialInfo {
+        hash?: string;
         usedBlocks: Map<number>;
     }
 

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1007,6 +1007,12 @@ namespace pxt.BrowserUtils {
             pxt.perf.measureStart("tutorial info db setAsync")
             const key = getTutorialInfoKey(filename, branch);
             const hash = getTutorialInfoHash(code);
+            return this.setWithHashAsync(filename, blocks, hash);
+        }
+
+        setWithHashAsync(filename: string, blocks: Map<number>, hash: string, branch?: string ): Promise<void> {
+            pxt.perf.measureStart("tutorial info db setAsync")
+            const key = getTutorialInfoKey(filename, branch);
 
             const entry: TutorialInfoIndexedDbEntry = {
                 id: key,

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -503,6 +503,7 @@ namespace pxt {
     export const DEFAULT_GROUP_NAME = "other"; // used in flyout, for snippet groups
     export const TILEMAP_CODE = "tilemap.g.ts";
     export const TILEMAP_JRES = "tilemap.g.jres";
+    export const TUTORIAL_INFO_FILE = "tutorial-info-cache.json";
 
     export function outputName(trg: pxtc.CompileTarget = null) {
         if (!trg) trg = appTarget.compile

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -359,12 +359,21 @@ ${code}
     }
 
 
-    export function parseCachedTutorialInfo(id: string, json: string) {
-        let cachedInfo = JSON.parse(json) as pxt.BuiltTutorialInfo;
-        if (!cachedInfo?.usedBlocks || !cachedInfo?.hash) return Promise.resolve();
+    export function parseCachedTutorialInfo(json: string, id?: string) {
+        let cachedInfo = JSON.parse(json) as pxt.Map<pxt.BuiltTutorialInfo>;
+        if (!cachedInfo) return Promise.resolve();
 
         return pxt.BrowserUtils.tutorialInfoDbAsync()
-            .then(db =>  db.setWithHashAsync(id, cachedInfo.usedBlocks, cachedInfo.hash))
-            .catch((err) => {})
+            .then(db =>  {
+                if (id && cachedInfo[id]) {
+                    const info = cachedInfo[id];
+                    if (info.usedBlocks && info.hash) db.setWithHashAsync(id, info.usedBlocks, info.hash);
+                } else {
+                    for (let key of Object.keys(cachedInfo)) {
+                        const info = cachedInfo[key];
+                        if (info.usedBlocks && info.hash) db.setWithHashAsync(key, info.usedBlocks, info.hash);
+                    }
+                }
+            }).catch((err) => {})
     }
 }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -358,4 +358,13 @@ ${code}
         return { options: tutorialOptions, editor: tutorialInfo.editor };
     }
 
+
+    export function parseCachedTutorialInfo(id: string, json: string) {
+        let cachedInfo = JSON.parse(json) as pxt.BuiltTutorialInfo;
+        if (!cachedInfo?.usedBlocks || !cachedInfo?.hash) return Promise.resolve();
+
+        return pxt.BrowserUtils.tutorialInfoDbAsync()
+            .then(db =>  db.setWithHashAsync(id, cachedInfo.usedBlocks, cachedInfo.hash))
+            .catch((err) => {})
+    }
 }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -360,7 +360,12 @@ ${code}
 
 
     export function parseCachedTutorialInfo(json: string, id?: string) {
-        let cachedInfo = JSON.parse(json) as pxt.Map<pxt.BuiltTutorialInfo>;
+        let cachedInfo: pxt.Map<pxt.BuiltTutorialInfo>;
+        try {
+            cachedInfo = JSON.parse(json);
+        } catch {
+            return Promise.resolve();
+        }
         if (!cachedInfo) return Promise.resolve();
 
         return pxt.BrowserUtils.tutorialInfoDbAsync()

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -360,12 +360,7 @@ ${code}
 
 
     export function parseCachedTutorialInfo(json: string, id?: string) {
-        let cachedInfo: pxt.Map<pxt.BuiltTutorialInfo>;
-        try {
-            cachedInfo = JSON.parse(json);
-        } catch {
-            return Promise.resolve();
-        }
+        let cachedInfo = pxt.Util.jsonTryParse(json) as pxt.Map<pxt.BuiltTutorialInfo>;
         if (!cachedInfo) return Promise.resolve();
 
         return pxt.BrowserUtils.tutorialInfoDbAsync()

--- a/theme/themes/pxt/modules/checkbox.overrides
+++ b/theme/themes/pxt/modules/checkbox.overrides
@@ -1,3 +1,14 @@
 /*******************************
          Site Overrides
 *******************************/
+
+.field.checkbox input[type=checkbox] {
+    position: relative;
+    bottom: -0.15rem;
+    margin-right: 0.8em;
+    width: 17px;
+    height: 17px;
+    border: 1px solid #d4d4d5;
+    border-radius: .21428571rem;
+    background: #fff;
+}

--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -192,7 +192,7 @@
         .has-actions.content {
             height: calc(100% - @thinMenuHeight - @mainMenuHeight);
         }
-    }    
+    }
 }
 
 /*******************************
@@ -201,7 +201,7 @@
 
 .ui.modal .closeIcon {
     position: absolute;
-    top: 0; 
+    top: 0;
     right: 0;
     height: 4.5rem;
     width: 4.5rem;
@@ -254,4 +254,12 @@
         right: 0.5rem;
         margin: 0;
     }
+}
+
+/*******************************
+        Modal Fields
+*******************************/
+
+.modal .grouped.fields {
+    margin-bottom: 0.5rem;
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3407,8 +3407,8 @@ export class ProjectView
                 }).then(gh => {
                     let p = Promise.resolve();
                     // check for cached tutorial info, save into IndexedDB if found
-                    if (gh.files["tutorial-info-cache.json"]) {
-                        p.then(() => pxt.tutorial.parseCachedTutorialInfo(gh.files["tutorial-info-cache.json"], path));
+                    if (gh.files[pxt.TUTORIAL_INFO_FILE]) {
+                        p.then(() => pxt.tutorial.parseCachedTutorialInfo(gh.files[pxt.TUTORIAL_INFO_FILE], path));
                     }
                     return p.then(() => gh && resolveMarkdown(ghid, gh.files));
                 });

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3404,7 +3404,14 @@ export class ProjectView
                             pxt.log(`tutorial ${ghid.fullName} tag: ${tag}`);
                             return pxt.github.downloadPackageAsync(`${ghid.fullName}#${ghid.tag}`, config);
                         });
-                }).then(gh => gh && resolveMarkdown(ghid, gh.files));
+                }).then(gh => {
+                    let p = Promise.resolve();
+                    // check for cached tutorial info, save into IndexedDB if found
+                    if (gh.files["tutorial-info-cache.json"]) {
+                        p.then(() => { pxt.tutorial.parseCachedTutorialInfo(path, gh.files["tutorial-info-cache.json"]) });
+                    }
+                    return p.then(() => gh && resolveMarkdown(ghid, gh.files));
+                });
         } else if (header) {
             pxt.tickEvent("tutorial.header");
             temporary = true;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3408,7 +3408,7 @@ export class ProjectView
                     let p = Promise.resolve();
                     // check for cached tutorial info, save into IndexedDB if found
                     if (gh.files["tutorial-info-cache.json"]) {
-                        p.then(() => { pxt.tutorial.parseCachedTutorialInfo(path, gh.files["tutorial-info-cache.json"]) });
+                        p.then(() => pxt.tutorial.parseCachedTutorialInfo(gh.files["tutorial-info-cache.json"], path));
                     }
                     return p.then(() => gh && resolveMarkdown(ghid, gh.files));
                 });

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -424,7 +424,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                 </div>
                 <div className="grouped fields">
                     <label>{lf("Advanced")}</label>
-                    <div className="field">
+                    <div className="field checkbox">
                         <input type="checkbox" name="cachetutorial" checked={shouldCacheTutorial} aria-checked={shouldCacheTutorial} onChange={onCacheTutorialChange} />
                         <label>{lf("Optimize for tutorials by caching information about the markdown.")}</label>
                     </div>
@@ -480,7 +480,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         }
 
         await workspace.saveAsync(header, files);
-        return await workspace.commitAsync(header, { message: `Update ${pxt.TUTORIAL_INFO_FILE}` })
+        return await this.commitAsync()
     }
 
     private async showLoading(tick: string, ensureToken: boolean, msg: string) {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -19,11 +19,11 @@ type ISettingsProps = pxt.editor.ISettingsProps;
  * We'll run this step when we first start the tutorial to figure out what blocks are used so we can
  * filter the toolbox.
  */
-export function getUsedBlocksAsync(code: string[], id: string, language?: string): Promise<pxt.Map<number>> {
+export function getUsedBlocksAsync(code: string[], id: string, language?: string, skipCache = false): Promise<pxt.Map<number>> {
     if (!code) return Promise.resolve({});
 
     // check to see if usedblocks has been prebuilt. this is hashed on the tutorial code + pxt version + target version
-    if (pxt.appTarget?.tutorialInfo) {
+    if (pxt.appTarget?.tutorialInfo && !skipCache) {
         const hash = pxt.BrowserUtils.getTutorialInfoHash(code);
         if (pxt.appTarget.tutorialInfo[hash]) {
             pxt.tickEvent(`tutorial.usedblocks.cached`, { tutorial: id });
@@ -34,23 +34,23 @@ export function getUsedBlocksAsync(code: string[], id: string, language?: string
     return pxt.BrowserUtils.tutorialInfoDbAsync()
         .then(db => db.getAsync(id, code)
             .then(entry => {
-                if (entry?.blocks && Object.keys(entry.blocks).length > 0) {
+                if (entry?.blocks && Object.keys(entry.blocks).length > 0 && !skipCache) {
                     pxt.tickEvent(`tutorial.usedblocks.indexeddb`, { tutorial: id });
                     return Promise.resolve(entry.blocks);
                 } else {
-                    return getUsedBlocksInternalAsync(code, id, language, db);
+                    return getUsedBlocksInternalAsync(code, id, language, db, skipCache);
                 }})
             .catch((err) => {
                 // fall back to full blocks decompile on error
-                return getUsedBlocksInternalAsync(code, id, language, db);
+                return getUsedBlocksInternalAsync(code, id, language, db, skipCache);
             })
         ).catch((err) => {
             // fall back to full blocks decompile on error
-            return getUsedBlocksInternalAsync(code, id, language);
+            return getUsedBlocksInternalAsync(code, id, language, null, skipCache);
         })
 }
 
-function getUsedBlocksInternalAsync(code: string[], id: string, language?: string, db?: pxt.BrowserUtils.ITutorialInfoDb): Promise<pxt.Map<number>> {
+function getUsedBlocksInternalAsync(code: string[], id: string, language?: string, db?: pxt.BrowserUtils.ITutorialInfoDb, skipCache= false): Promise<pxt.Map<number>> {
     const usedBlocks: pxt.Map<number> = {};
     return compiler.getBlocksAsync()
         .then(blocksInfo => {
@@ -74,7 +74,7 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                 if (pxt.options.debug)
                     pxt.debug(JSON.stringify(usedBlocks, null, 2));
 
-                if (db) db.setAsync(id, usedBlocks, code);
+                if (db && !skipCache) db.setAsync(id, usedBlocks, code);
                 pxt.tickEvent(`tutorial.usedblocks.computed`, { tutorial: id });
                 return usedBlocks;
             } else {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -50,7 +50,7 @@ export function getUsedBlocksAsync(code: string[], id: string, language?: string
         })
 }
 
-function getUsedBlocksInternalAsync(code: string[], id: string, language?: string, db?: pxt.BrowserUtils.ITutorialInfoDb, skipCache= false): Promise<pxt.Map<number>> {
+function getUsedBlocksInternalAsync(code: string[], id: string, language?: string, db?: pxt.BrowserUtils.ITutorialInfoDb, skipCache = false): Promise<pxt.Map<number>> {
     const usedBlocks: pxt.Map<number> = {};
     return compiler.getBlocksAsync()
         .then(blocksInfo => {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -869,7 +869,7 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
                 // if xml merge fails, leave an empty xml payload to force decompilation
                 blocksNeedDecompilation = blocksNeedDecompilation || !d3;
                 text = d3 || "";
-            } else if (path == BINARY_JS_PATH || path == VERSION_TXT_PATH) {
+            } else if (path == BINARY_JS_PATH || path == VERSION_TXT_PATH || path == pxt.TUTORIAL_INFO_FILE) {
                 // local build wins, does not matter
                 text = files[path];
             } else {


### PR DESCRIPTION
- Adds an "Optimize for tutorials" checkbox to the "Create a release" dialog on the Github page
- If this box is checked, goes through each .md file and computes used blocks + hash of code, saves into `tutorial-info-cache.json`
- On loading a Github tutorial, checks for cached json, loads into IndexedDB--this only loads the cached blocks for the file requested, in case a repository has many tutorials
- The tutorial load path will then check IndexedDb as usual, and if the hash of the code does not match it will recompute, ensuring that the toolbox is always synced even if the json is out of date