### PR TITLE
minor fixes for api cards

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -409,12 +409,15 @@ namespace pxt.blocks {
         // inject Blockly with all block definitions
         return blockInfo.blocks
             .map(fn => {
+                const comp = compileInfo(fn);
+                const block = createToolboxBlock(blockInfo, fn, comp);
+
                 if (fn.attributes.blockBuiltin) {
                     Util.assert(!!builtinBlocks()[fn.attributes.blockId]);
-                    builtinBlocks()[fn.attributes.blockId].symbol = fn;
+                    const builtin = builtinBlocks()[fn.attributes.blockId];
+                    builtin.symbol = fn;
+                    builtin.block.codeCard = mkCard(fn, block);
                 } else {
-                    let comp = compileInfo(fn);
-                    let block = createToolboxBlock(blockInfo, fn, comp);
                     injectBlockDefinition(blockInfo, fn, comp, block);
                 }
                 return fn;

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -840,11 +840,18 @@ namespace pxt.runner {
             .then((r) => {
                 const info = r.compileBlocks.blocksInfo;
                 const symbols = pxt.Util.values(info.apis.byQName)
-                    .filter(symbol => !symbol.attributes.hidden && !!symbol.attributes.jsDoc && !/^__/.test(symbol.name));
+                    .filter(symbol => !symbol.attributes.hidden
+                        && !symbol.attributes.deprecated
+                        && !symbol.attributes.blockAliasFor
+                        && !!symbol.attributes.jsDoc
+                        && symbol.attributes.shim != "TD_ID"
+                        && !/^__/.test(symbol.name)
+                    );
                 apisEl.each((i, e) => {
                     let c = $(e);
                     const namespaces = pxt.Util.toDictionary(c.text().split('\n'), n => n); // list of namespace to list apis for.
-                    const csymbols = symbols.filter(symbol => !!namespaces[symbol.namespace])
+
+                    const csymbols = symbols.filter(symbol => !!namespaces[symbol.attributes.blockNamespace || symbol.namespace])
                     if (!csymbols.length) return;
 
                     csymbols.sort((l,r) => {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -844,7 +844,6 @@ namespace pxt.runner {
                         && !symbol.attributes.deprecated
                         && !symbol.attributes.blockAliasFor
                         && !!symbol.attributes.jsDoc
-                        && symbol.attributes.shim != "TD_ID"
                         && !/^__/.test(symbol.name)
                     );
                 apisEl.each((i, e) => {


### PR DESCRIPTION
A few minor fixes api cards I noticed while testing https://github.com/microsoft/pxt-arcade/pull/2325

* Filter out deprecated, ~`shim=TD_ID`~, and blockAliasFor (e.g. the second version of array.pop as a statement)
* create code card for `.blockBuiltin` (only hits array.length and string.length I believe?)
* use `.blockNamespace` if it exists (make arrays, images, loops show up)