### PR TITLE
Fix overflow issue when scrolling blockly dropdowns

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -169,6 +169,7 @@ div.blocklyWidgetDiv.functioneditor {
 
 div.blocklyDropDownDiv {
     z-index: @blocklyDropdownDivZIndex;
+    overflow: hidden;
 }
 
 div.blocklyTooltipDiv {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2388