### PR TITLE
Move hex eof [stable6.0]

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -500,6 +500,7 @@ declare namespace ts.pxtc {
         useModulator?: boolean;
         webUSB?: boolean; // use WebUSB when supported
         hexMimeType?: string;
+        moveHexEof?: boolean;
         driveName?: string;
         jsRefCounting?: boolean;
         utf8?: boolean;

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -622,6 +622,13 @@ namespace ts.pxtc {
                     Util.pushRange(myhex, app)
             }
 
+            if (!uf2 && bin.target.moveHexEof) {
+                while (!myhex[myhex.length - 1])
+                    myhex.pop()
+                if (myhex[myhex.length - 1] == ":00000001FF")
+                    myhex.pop()
+            }
+
             if (bin.packedSource) {
                 if (uf2) {
                     addr = (uf2.currPtr + 0x1000) & ~0xff
@@ -644,6 +651,9 @@ namespace ts.pxtc {
                     }
                 }
             }
+
+            if (!uf2 && bin.target.moveHexEof)
+                myhex.push(":00000001FF")
 
             if (uf2)
                 return [UF2.serializeFile(uf2)]


### PR DESCRIPTION
Integrate hex generation fix for calliope - ad2ee958b48a4eefcab6e3b370dc65eea378527a .

Calliope is in sync with the micro:bit release. This change requires a flag in pxttarget to do anything (no-op in microbit case)