### PR TITLE
only allow enter for image editor buttons, as space is overloaded.

### DIFF
--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { ImageEditorStore, AnimationState, TilemapState } from './store/imageReducer';
 import { dispatchChangeImageDimensions, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchToggleAspectRatioLocked, dispatchChangeZoom, dispatchToggleOnionSkinEnabled} from './actions/dispatch';
 import { IconButton } from "./Button";
-import { fireClickOnEnter } from "../../sui";
+import { fireClickOnlyOnEnter } from "./util";
 
 export interface BottomBarProps {
     dispatchChangeImageDimensions: (dimensions: [number, number]) => void;
@@ -138,7 +138,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                     title={lf("Done")}
                     tabIndex={0}
                     onClick={onDoneClick}
-                    onKeyDown={fireClickOnEnter}>
+                    onKeyDown={fireClickOnlyOnEnter}>
                         {lf("Done")}
                 </div>
             </div>

--- a/webapp/src/components/ImageEditor/Button.tsx
+++ b/webapp/src/components/ImageEditor/Button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireClickOnEnter } from '../../sui';
+import { fireClickOnlyOnEnter } from './util';
 
 export interface ButtonProps {
     title: string;
@@ -22,7 +22,7 @@ export class IconButton extends React.Component<ButtonProps, {}> {
                 title={title}
                 tabIndex={(noTab || disabled) ? -1 : 0}
                 onClick={onClick}
-                onKeyDown={fireClickOnEnter}>
+                onKeyDown={fireClickOnlyOnEnter}>
                     <span className={iconClass} />
             </div>
         );

--- a/webapp/src/components/ImageEditor/Pivot.tsx
+++ b/webapp/src/components/ImageEditor/Pivot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireClickOnEnter } from '../../sui';
+import { fireClickOnlyOnEnter } from './util';
 
 export interface PivotOption {
     text: string;
@@ -43,7 +43,7 @@ export class Pivot extends React.Component<PivotProps, PivotState> {
                     className={`image-editor-pivot-option ${option === selectedOption ? "selected" : ""}`}
                     tabIndex={0}
                     onClick={this.clickHandler(index)}
-                    onKeyDown={fireClickOnEnter}>
+                    onKeyDown={fireClickOnlyOnEnter}>
                     { option.text }
                 </div>
             ) }

--- a/webapp/src/components/ImageEditor/util.ts
+++ b/webapp/src/components/ImageEditor/util.ts
@@ -97,6 +97,18 @@ export function clientCoord(ev: PointerEvent | MouseEvent | TouchEvent): ClientC
     return (ev as PointerEvent | MouseEvent);
 }
 
+/**
+ * Similar to sui.fireClickOnEnter, but interactions limited to enter key / ignores
+ * space bar.
+ */
+export function fireClickOnlyOnEnter(e: React.KeyboardEvent<HTMLElement>): void {
+    const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
+    if (charCode === 13 /** enter key **/) {
+        e.preventDefault();
+        (e.currentTarget as HTMLElement).click();
+    }
+}
+
 export interface GestureTarget {
     onClick(coord: ClientCoordinates, isRightClick?: boolean): void;
     onDragStart(coord: ClientCoordinates, isRightClick?: boolean): void;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2424; spacebar has a particular meaning in the image editor, so only fire the click events on enter, not spacebar; effectively the same as

https://github.com/microsoft/pxt/blob/ac96cba14b0198821d67df38e64d96e339ef5f11/webapp/src/sui.tsx#L49-L55

just dropping the spacebar click from triggering it.