### PR TITLE
Error catching for shadow fields in expandable blocks

### DIFF
--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -221,10 +221,12 @@ namespace pxt.blocks {
 
                         Blockly.Events.disable();
 
-                        const nb = Blockly.Xml.domToBlock(shadow, b.workspace);
-                        if (nb) {
-                            input.connection.connect(nb.outputConnection);
-                        }
+                        try {
+                            const nb = Blockly.Xml.domToBlock(shadow, b.workspace);
+                            if (nb) {
+                                input.connection.connect(nb.outputConnection);
+                            }
+                        } catch (e) { }
 
                         Blockly.Events.enable();
                     }


### PR DESCRIPTION
Wrapping this domToBlock in a try-catch to make it safer. For some types of input (eg type="any") we don't have a valid default shadow block, so the correct behavior is just to bail out & leave an empty input.

![fix-empty-shadow](https://user-images.githubusercontent.com/34112083/92818909-165ee200-f37d-11ea-8cd7-1551eeec357c.gif)

Fixes https://github.com/microsoft/pxt-microbit/issues/3366
