### PR TITLE
Avoid github throttling in CI when caching used blocks

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5457,6 +5457,7 @@ function cacheUsedBlocksAsync() {
 }
 
 function internalCacheUsedBlocksAsync(): Promise<Map<pxt.BuiltTutorialInfo>> {
+    pxt.github.forceProxy = true; // avoid throttling in CI machines
     const mdPaths: string[] = [];
     const mdRegex = /\.md$/;
     const targetDirs = pxt.appTarget.cacheusedblocksdirs;


### PR DESCRIPTION
Same as testSnippetsAsync