### PR TITLE
Add high contrast rules for Minecraft/inverted toolbox

### DIFF
--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -972,16 +972,18 @@ namespace ts.pxtc {
             }
 
             let extinfo = opts.extinfo
+            let optstarget = opts.target
             // if current (main) extinfo is disabled use another one
             if (extinfo && extinfo.disabledDeps) {
                 const enabled = (opts.otherMultiVariants || []).find(e => e.extinfo && !e.extinfo.disabledDeps)
                 if (enabled) {
                     pxt.debug(`using alternative extinfo (due to ${extinfo.disabledDeps})`)
                     extinfo = enabled.extinfo
+                    optstarget = enabled.target
                 }
             }
 
-            hexfile.setupFor(opts.target, extinfo || emptyExtInfo());
+            hexfile.setupFor(optstarget, extinfo || emptyExtInfo());
             hexfile.setupInlineAssembly(opts);
         }
 

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -235,9 +235,9 @@
         }
     }
     #mainmenu.inverted, #homemenu.inverted {
-        background-color: @HCmainMenuTextColor !important;
         color: @HCmainMenuBackground !important;
         border-bottom: 4px solid @HCtextColor;
+        background: @HCmainMenuTextColor !important;
 
         .ui.item {
             color: @HCmainMenuBackground;

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -115,6 +115,12 @@
         }
     }
 
+    .pxtToolbox {
+        .blocklyTreeRow:not(.blocklyTreeSelected) {
+            background-color: @HCblocklyToolboxColor !important;
+        }
+    }
+
     #monacoEditor .monacoDraggableBlock {
         background: none !important;
 
@@ -156,6 +162,11 @@
         stroke-width: 4px;
         stroke: @HCblocklyTreeLabelColor;
     }
+
+    .blocklyFlyoutButton .blocklyText {
+        fill: @HCtextColor !important;
+    }
+
     .monacoFlyout {
         background: @HCblocklySvgColor !important;
         border-right: 4px solid @HCtextColor !important;
@@ -168,8 +179,10 @@
         }
     }
 
+    rect.blocklyFlyoutButtonBackground,
     .blocklyFlyoutButtonBackground {
         stroke: @HCtextColor !important;
+        fill: transparent !important;
     }
 
     /* Main editor areas */
@@ -186,6 +199,7 @@
     }
     svg.blocklySvg {
         background-color: @HCblocklySvgColor !important;
+        background: @HCblocklySvgColor !important;
     }
 
     .blocklyMainBackground {
@@ -365,8 +379,12 @@
             }
         }
     }
-
+    // VVN TODO match: .ui.icon.input input.blocklyGridPickerSearchBar
     /* Inputs */
+    .ui.input input.blocklyGridPickerSearchBar {
+        background: @HCbackground !important;
+        color: @HCtextColor !important;
+    }
     .ui.input input,
     .ui.input .input {
         background: @HCbackground !important;
@@ -458,6 +476,14 @@
                 }
             }
         }
+    }
+    .ui.card.link.newprojectcard{
+        background-color: #1B8800 !important;
+        color: white;
+    }
+
+    .ui.image~.content {
+        background: rgba(0,0,0,.75) !important;
     }
 
     .ui.form .content .description {

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -179,7 +179,6 @@
         }
     }
 
-    rect.blocklyFlyoutButtonBackground,
     .blocklyFlyoutButtonBackground {
         stroke: @HCtextColor !important;
         fill: transparent !important;
@@ -474,7 +473,7 @@
         }
     }
     .ui.card.link.newprojectcard{
-        background-color: #1B8800 !important;
+        background: darken(@primaryColor, 20%) !important;
         color: white;
     }
 

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -379,12 +379,8 @@
             }
         }
     }
-    // VVN TODO match: .ui.icon.input input.blocklyGridPickerSearchBar
+
     /* Inputs */
-    .ui.input input.blocklyGridPickerSearchBar {
-        background: @HCbackground !important;
-        color: @HCtextColor !important;
-    }
     .ui.input input,
     .ui.input .input {
         background: @HCbackground !important;

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -245,7 +245,7 @@ a.ui.card:focus,
             top: 2rem;
             left: 1rem;
             width: 2rem;
-            height: 1.5rem;                
+            height: 1.5rem;
         }
     }
 


### PR DESCRIPTION
Here are some screenshots, but also, a target! https://minecraft.makecode.com/app/f16ee16d161060d22fb9d9005df5bce0b7f6fda8-783dcb27ba

I haven't tested the other targets to make sure they haven't changed from these edits yet, but I'll do that next. I'll do it for arcade, microbit, and LEGO, but lemme know if this list should be changed

It looks like that it's not possible to have a HC change for the field editors yet/it would need more work than just CSS changes? Tell me if this is wrong :D or if there's a field editor where it's been done before so I can take a look

the corresponding pxt-minecraft PR: https://github.com/microsoft/pxt-minecraft/pull/1992

Blocks:
![image](https://user-images.githubusercontent.com/18712271/93123198-95edf900-f67c-11ea-9fc4-08926122ee62.png)
![image](https://user-images.githubusercontent.com/18712271/93123275-adc57d00-f67c-11ea-85a9-2cd8bb2d6826.png)


Homepage:
![image](https://user-images.githubusercontent.com/18712271/93123340-c6ce2e00-f67c-11ea-82c0-3c5070ecc345.png)

Monaco:
![image](https://user-images.githubusercontent.com/18712271/93123233-a30ae800-f67c-11ea-8bca-b5ff671987c6.png)
