### PR TITLE
Apply upgrade rules on docs/share and don't ignore config writes

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -53,8 +53,6 @@ namespace pxt.runner {
         }
 
         writeFile(module: pxt.Package, filename: string, contents: string): void {
-            if (filename == pxt.CONFIG_NAME)
-                return; // ignore config writes
             const epkg = getEditorPkg(module);
             epkg.files[filename] = contents;
         }
@@ -351,10 +349,35 @@ namespace pxt.runner {
     }
 
     export function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
+        let didUpgrade = false;
+
         return loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies)
             .then(() => compileAsync(false, opts => {
                 if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+
+                // Apply upgrade rules if necessary
+                const sharedTargetVersion = mainPkg.config.targetVersions.target;
+                const currentTargetVersion = pxt.appTarget.versions.target;
+
+                if (sharedTargetVersion && currentTargetVersion &&
+                    pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), pxt.semver.parse(currentTargetVersion)) < 0) {
+                    for (const fileName of Object.keys(opts.fileSystem)) {
+                        if (!pxt.Util.startsWith(fileName, "pxt_modules") && pxt.Util.endsWith(fileName, ".ts")) {
+                            didUpgrade = true;
+                            opts.fileSystem[fileName] = pxt.patching.patchJavaScript(sharedTargetVersion, opts.fileSystem[fileName]);
+                        }
+                    }
+                }
             }))
+            .then(resp => {
+                if (resp.diagnostics?.length > 0 && didUpgrade) {
+                    pxt.log("Compile with upgrade rules failed, trying again with original code");
+                    return compileAsync(false, opts => {
+                        if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+                    });
+                }
+                return resp;
+            })
             .then(resp => {
                 if (resp.diagnostics && resp.diagnostics.length > 0) {
                     console.error("Diagnostics", resp.diagnostics)


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2426

This adds upgrade rules to pxtembed (docs and share page) and also fixes a bug where package upgrades were not being applied. Package upgrades should have worked already but our host in pxtembed was ignoring all updates to pxt.json.

I can't really test the package upgrades locally because of a bug that prevents localhost serves from fetching targetconfig.json, which is where the package upgrades live. That being said I'm pretty sure this was the issue (I debugged it on the live site).


The ignoring config writes bit goes back to [five years ago](https://github.com/microsoft/pxt/commit/7533ecbf8726cbf5f2006a99232fbc63e0563043#diff-6cc6e6c354361d72c27d7b6b5861eea3R52) and was just there to make sure that config writes didn't cause an exception; back then we threw an exception on writes to any file except config. Now we keep the files in memory so there's no reason for the check.
