### PR TITLE
Don't strip out python namespaces when getting used blocks

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -316,7 +316,6 @@ export function pySnippetToBlocksAsync(code: string, blockInfo?: ts.pxtc.BlocksI
 
 // Py[] -> blocks
 export function pySnippetArrayToBlocksAsync(code: string[], blockInfo?: ts.pxtc.BlocksInfo): Promise<pxtc.CompileResult> {
-    const namespaceRegex = /^\s*namespace\s+[^\s]+\s*{([\S\s]*)}\s*$/im;
     const snippetBlocks = "main.blocks";
     let trg = pkg.mainPkg.getTargetOptions()
     let files: string[] = [];

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -344,15 +344,15 @@ export function pySnippetArrayToBlocksAsync(code: string[], blockInfo?: ts.pxtc.
             for (let file of files) {
                 let match = res.outfiles[file + ".ts"].match(namespaceRegex);
                 if (match && match[1]) {
-                    let noNamespace = match[1];
+                    const noNamespace = match[1];
+                    // strip out 'export let' and 'export function'. This won't hit custom kinds since those are always const
                     let lines = noNamespace.split("\n");
-                    let cleanLines = lines.map((element: string)=>{
-                        match = element.match(exportLetRegex);
-                        let strippedExportLet;
-                        match? strippedExportLet = match[1] : strippedExportLet = element;
-                        match = strippedExportLet.match(exportFunctionRegex);
-                        if (match) {
-                            return match[1];
+                    let cleanLines = lines.map((element: string) => {
+                        const matchExportLet = element.match(exportLetRegex);
+                        const strippedExportLet = matchExportLet? matchExportLet[1] : element;
+                        const strippedExportFunc = strippedExportLet.match(exportFunctionRegex);
+                        if (strippedExportFunc) {
+                            return strippedExportFunc[1];
                         } else {
                             return strippedExportLet;
                         }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -340,8 +340,7 @@ export function pySnippetArrayToBlocksAsync(code: string[], blockInfo?: ts.pxtc.
             // strip the namespace declaration out of the converted snippets and concat to convert to blocks
             let ts = "";
             for (let file of files) {
-                let match = res.outfiles[file + ".ts"].match(namespaceRegex);
-                if (match && match[1]) ts += `{\n${match[1]}\n}\n`
+                ts += `{\n${res.outfiles[file + ".ts"]}\n}\n`
             }
             return decompileBlocksSnippetAsync(ts, blockInfo)
         });

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -349,7 +349,7 @@ export function pySnippetArrayToBlocksAsync(code: string[], blockInfo?: ts.pxtc.
                     let lines = noNamespace.split("\n");
                     let cleanLines = lines.map((element: string) => {
                         const matchExportLet = element.match(exportLetRegex);
-                        const strippedExportLet = matchExportLet? matchExportLet[1] : element;
+                        const strippedExportLet = matchExportLet ? matchExportLet[1] : element;
                         const strippedExportFunc = strippedExportLet.match(exportFunctionRegex);
                         if (strippedExportFunc) {
                             return strippedExportFunc[1];


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/1979

the issue was with these two snippets from the tutorial:
![image](https://user-images.githubusercontent.com/18712271/93400842-a5647200-f835-11ea-9cd6-215e21939262.png)

since it gets converted to "export let p = ....", it was hitting an assert in "getExportInfo" in typescript.

This is one way to fix it, Shannon also suggested just stripping out the "export" for export let and export function, but I'm still working on those regexes XD figured I'd put this up so I can get feedback on which way would be better