### PR TITLE
allow using local translations when building staticpkg

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4415,7 +4415,8 @@ export async function staticpkgAsync(parsed: commandParser.ParsedCommand) {
     const minify = !!parsed.flags["minify"];
     const bump = !!parsed.flags["bump"];
     const disableAppCache = !!parsed.flags["no-appcache"];
-    const locs = !!parsed.flags["locs"];
+    const locsSrc = parsed.flags["locs-src"] as string;
+    const locs = !!locsSrc || !!parsed.flags["locs"];
     if (parsed.flags["cloud"]) forceCloudBuild = true;
     if (minify && process.env["PXT_ENV"] === undefined) {
         process.env["PXT_ENV"] = "production";
@@ -4428,9 +4429,28 @@ export async function staticpkgAsync(parsed: commandParser.ParsedCommand) {
     if (bump) {
         await bumpAsync();
     }
+
     if (locs) {
         await internalGenDocsAsync(false, true);
-        await crowdin.downloadTargetTranslationsAsync();
+        if (locsSrc) {
+            const languages = pxt.appTarget?.appTheme?.availableLocales
+                    .filter(langId => nodeutil.existsDirSync(path.join(locsSrc, langId)));
+            const buildFileTranslationsAsync = async (fileName: string) => {
+                const output: pxt.Map<pxt.Map<string>> = {};
+
+                for (const langId of languages) {
+                    const srcFilePath = path.join(locsSrc, langId, fileName);
+                    if (nodeutil.fileExistsSync(srcFilePath)) {
+                        output[langId] = pxt.Util.jsonTryParse(fs.readFileSync(srcFilePath, { encoding: "utf8" }));
+                    }
+                }
+
+                return output;
+            }
+            await crowdin.buildAllTranslationsAsync(buildFileTranslationsAsync);
+        } else {
+            await crowdin.downloadTargetTranslationsAsync();
+        }
     }
 
     await internalBuildTargetAsync({ packaged: true });

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4435,7 +4435,8 @@ export async function staticpkgAsync(parsed: commandParser.ParsedCommand) {
         if (locsSrc) {
             const languages = pxt.appTarget?.appTheme?.availableLocales
                     .filter(langId => nodeutil.existsDirSync(path.join(locsSrc, langId)));
-            const buildFileTranslationsAsync = async (fileName: string) => {
+
+            await crowdin.buildAllTranslationsAsync(async (fileName: string) => {
                 const output: pxt.Map<pxt.Map<string>> = {};
 
                 for (const langId of languages) {
@@ -4446,8 +4447,7 @@ export async function staticpkgAsync(parsed: commandParser.ParsedCommand) {
                 }
 
                 return output;
-            }
-            await crowdin.buildAllTranslationsAsync(buildFileTranslationsAsync);
+            });
         } else {
             await crowdin.downloadTargetTranslationsAsync();
         }

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -6180,6 +6180,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
                 description: "Download localization files and bundle them",
                 aliases: ["locales", "crowdin"]
             },
+            "locs-src": {
+                description: "Bundle localization files that have already been downloaded to a given directory",
+                argument: "locs-src",
+                type: "string"
+            },
             "no-appcache": {
                 description: "Disables application cache"
             }

--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -119,7 +119,7 @@ function uploadBundledTranslationsAsync(crowdinDir: string, branch: string, prj:
         if (fs.existsSync(locdir))
             fs.readdirSync(locdir)
                 .filter(f => /strings\.json$/i.test(f))
-                .forEach(f => todo.push(path.join(locdir, f)))
+                .forEach(f => todo.push(path.join(locdir, f)));
     });
 
     pxt.log(`uploading bundled translations to Crowdin (${todo.length} files)`);
@@ -202,6 +202,7 @@ export async function buildAllTranslationsAsync(langToStringsHandlerAsync: (file
                     .filter(k => !!dataLang[k] && !strings[k])
                     .forEach(k => strings[k] = dataLang[k]);
             }
+
             const errorIds = Object.keys(errors);
             if (errorIds.length) {
                 pxt.log(`${errorIds.length} errors`);

--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -135,95 +135,90 @@ function uploadBundledTranslationsAsync(crowdinDir: string, branch: string, prj:
     return nextFileAsync();
 }
 
-export function downloadTargetTranslationsAsync(parsed?: commandParser.ParsedCommand) {
-    const name = (parsed && parsed.args[0]) || "";
-    const crowdinDir = pxt.appTarget.id;
-    return crowdinCredentialsAsync()
-        .then(cred => {
-            if (!cred) return Promise.resolve();
+export async function downloadTargetTranslationsAsync(parsed?: commandParser.ParsedCommand) {
+    const name = parsed?.args[0];
+    const cred = await crowdinCredentialsAsync();
 
-            return downloadFilesAsync(cred, ["sim-strings.json"], "sim")
-                .then(() => downloadFilesAsync(cred, ["target-strings.json"], "target"))
-                .then(() => {
-                    const files: string[] = [];
-                    pxt.appTarget.bundleddirs
-                        .filter(dir => !name || dir == "libs/" + name)
-                        .forEach(dir => {
-                            const locdir = path.join(dir, "_locales");
-                            if (fs.existsSync(locdir))
-                                fs.readdirSync(locdir)
-                                    .filter(f => /\.json$/i.test(f))
-                                    .forEach(f => files.push(path.join(locdir, f)))
-                        });
-                    return downloadFilesAsync(cred, files, "bundled");
-                });
+    if (!cred)
+        return;
+
+    const downloadCrowdinFileAsync = async (fileName: string) => {
+        pxt.log(`downloading ${fileName}`);
+        return pxt.crowdin.downloadTranslationsAsync(cred.branch, cred.prj, cred.key, fileName, { translatedOnly: true, validatedOnly: true });
+    };
+
+    await buildAllTranslationsAsync(downloadCrowdinFileAsync, name);
+}
+
+export async function buildAllTranslationsAsync(langToStringsHandlerAsync: (fileName: string) => Promise<Map<Map<string>>>, singleDir?: string) {
+    await buildTranslationFilesAsync(["sim-strings.json"], "sim");
+    await buildTranslationFilesAsync(["target-strings.json"], "target");
+
+    const files: string[] = [];
+    pxt.appTarget.bundleddirs
+        .filter(dir => !singleDir || dir == "libs/" + singleDir)
+        .forEach(dir => {
+            const locdir = path.join(dir, "_locales");
+            if (fs.existsSync(locdir))
+                fs.readdirSync(locdir)
+                    .filter(f => /\.json$/i.test(f))
+                    .forEach(f => files.push(path.join(locdir, f)))
         });
 
-    function downloadFilesAsync(cred: CrowdinCredentials, todo: string[], outputName: string) {
+    await buildTranslationFilesAsync(files, "bundled");
+
+    async function buildTranslationFilesAsync(files: string[], outputName: string) {
+        const crowdinDir = pxt.appTarget.id;
         const locs: pxt.Map<pxt.Map<string>> = {};
-        const nextFileAsync = (): Promise<void> => {
-            const f = todo.pop();
-            if (!f) {
-                return Promise.resolve();
-            }
-
+        for (const filePath of files) {
             const errors: pxt.Map<number> = {};
-            const fn = path.basename(f);
+            const fn = path.basename(filePath);
             const crowdf = path.join(crowdinDir, fn);
-            const locdir = path.dirname(f);
+            const locdir = path.dirname(filePath);
             const projectdir = path.dirname(locdir);
-            pxt.log(`downloading ${crowdf}`);
-            pxt.debug(`projectdir: ${projectdir}`)
-            return pxt.crowdin.downloadTranslationsAsync(cred.branch, cred.prj, cred.key, crowdf, { translatedOnly: true, validatedOnly: true })
-                .then(data => {
-                    Object.keys(data)
-                        .filter(lang => Object.keys(data[lang]).some(k => !!data[lang][k]))
-                        .forEach(lang => {
-                            const dataLang = data[lang];
-                            const langTranslations = stringifyTranslations(dataLang);
-                            if (!langTranslations) return;
+            pxt.debug(`projectdir: ${projectdir}`);
+            const data = await langToStringsHandlerAsync(crowdf);
 
-                            // validate translations
-                            if (/-strings\.json$/.test(fn) && !/jsdoc-strings\.json$/.test(fn)) {
-                                // block definitions
-                                Object.keys(dataLang).forEach(id => {
-                                    const tr = dataLang[id];
-                                    pxt.blocks.normalizeBlock(tr, err => {
-                                        const errid = `${fn}.${lang}`;
-                                        errors[`${fn}.${lang}`] = 1
-                                        pxt.log(`error ${errid}: ${err}`)
-                                    });
-                                });
-                            }
+            for (const lang of Object.keys(data)) {
+                const dataLang = data[lang];
+                if (!dataLang || !stringifyTranslations(dataLang))
+                    continue;
 
-                            // merge translations
-                            let strings = locs[lang];
-                            if (!strings) strings = locs[lang] = {};
-                            Object.keys(dataLang)
-                                .filter(k => !!dataLang[k] && !strings[k])
-                                .forEach(k => strings[k] = dataLang[k]);
-                        })
-
-                    const errorIds = Object.keys(errors);
-                    if (errorIds.length) {
-                        pxt.log(`${errorIds.length} errors`);
-                        errorIds.forEach(blockid => pxt.log(`error in ${blockid}`));
-                        pxt.reportError("loc.errors", "invalid translation", errors);
+                // validate translations
+                if (/-strings\.json$/.test(fn) && !/jsdoc-strings\.json$/.test(fn)) {
+                    // block definitions
+                    for (const id of Object.keys(dataLang)) {
+                        const tr = dataLang[id];
+                        pxt.blocks.normalizeBlock(tr, err => {
+                            const errid = `${fn}.${lang}`;
+                            errors[`${fn}.${lang}`] = 1;
+                            pxt.log(`error ${errid}: ${err}`);
+                        });
                     }
+                }
 
-                    return nextFileAsync()
-                });
+                // merge translations
+                let strings = locs[lang];
+                if (!strings) strings = locs[lang] = {};
+                Object.keys(dataLang)
+                    .filter(k => !!dataLang[k] && !strings[k])
+                    .forEach(k => strings[k] = dataLang[k]);
+            }
+            const errorIds = Object.keys(errors);
+            if (errorIds.length) {
+                pxt.log(`${errorIds.length} errors`);
+                errorIds.forEach(blockid => pxt.log(`error in ${blockid}`));
+                pxt.reportError("loc.errors", "invalid translation", errors);
+            }
         }
-        return nextFileAsync()
-            .then(() => {
-                Object.keys(locs).forEach(lang => {
-                    const tf = path.join(`sim/public/locales/${lang}/${outputName}-strings.json`);
-                    pxt.log(`writing ${tf}`);
-                    const dataLang = locs[lang];
-                    const langTranslations = stringifyTranslations(dataLang);
-                    nodeutil.writeFileSync(tf, langTranslations, { encoding: "utf8" });
-                })
-            })
+
+        for (const lang of Object.keys(locs)) {
+            const tf = path.join(`sim/public/locales/${lang}/${outputName}-strings.json`);
+            pxt.log(`writing ${tf}`);
+            const dataLang = locs[lang];
+            const langTranslations = stringifyTranslations(dataLang);
+            nodeutil.writeFileSync(tf, langTranslations, { encoding: "utf8" });
+        }
     }
 }
 

--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -142,12 +142,10 @@ export async function downloadTargetTranslationsAsync(parsed?: commandParser.Par
     if (!cred)
         return;
 
-    const downloadCrowdinFileAsync = async (fileName: string) => {
+    await buildAllTranslationsAsync(async (fileName: string) => {
         pxt.log(`downloading ${fileName}`);
         return pxt.crowdin.downloadTranslationsAsync(cred.branch, cred.prj, cred.key, fileName, { translatedOnly: true, validatedOnly: true });
-    };
-
-    await buildAllTranslationsAsync(downloadCrowdinFileAsync, name);
+    }, name);
 }
 
 export async function buildAllTranslationsAsync(langToStringsHandlerAsync: (fileName: string) => Promise<Map<Map<string>>>, singleDir?: string) {

--- a/docs/cli/staticpkg.md
+++ b/docs/cli/staticpkg.md
@@ -45,6 +45,10 @@ Files must be listed as follows:
 {locs-src}/{lang id}/{package id}-jsdoc-strings.json
 ```
 
+where `{locs-src}` is the directory parameter passed in here,
+`{lang id}` is one of the language identifiers listed as in `availableLocales` in `pxtarget.json`,
+and `{package id}` is the for packages listed in `bundleddirs` (e.g. `core`).
+
 ### minify (optional)
 
 Minifies all generated js files.

--- a/docs/cli/staticpkg.md
+++ b/docs/cli/staticpkg.md
@@ -5,7 +5,7 @@
 Packages the target into static HTML pages
 
 ```
-pxt staticpkg [--route route] [--githubpages] [--output output]
+pxt staticpkg [--route route] [--githubpages] [--output output] [--locs-src locs-src]
 ```
 
 ## Description
@@ -24,11 +24,7 @@ Generate a web site compatible with GitHub pages.
 
 ### output (optional)
 
-Directory for generated files. 
-
-### bump (option)
-
-Bump version number generating pages
+Directory for generated files.
 
 ### ~ hint
 
@@ -36,6 +32,30 @@ This directory is cleaned before starting the process.
 
 ### ~
 
+### locs-src <directory> (optional)
+
+Directory to fetch editor translations to include in the build.
+
+Files must be listed as follows:
+
+```
+{locs-src}/{lang id}/target-strings.json
+{locs-src}/{lang id}/sim-strings.json
+{locs-src}/{lang id}/{package id}-strings.json
+{locs-src}/{lang id}/{package id}-jsdoc-strings.json
+```
+
+### minify (optional)
+
+Minifies all generated js files.
+
+### githubpages (optional)
+
+Generate a web site compatible with GitHub pages.
+
+### bump (option)
+
+Bump version number generating pages.
 
 ## Deploying PXT with static files
 


### PR DESCRIPTION
When building a staticpkg, allow user to specify a directory to act as the source of translations, instead of fetching translations from crowdin. Directory needs to have the same set up as our crowdin, i.e. the files should be found like

```
{locs-src}/{lang id}/target-strings.json
{locs-src}/{lang id}/sim-strings.json
{locs-src}/{lang id}/{package id}-strings.json
{locs-src}/{lang id}/{package id}-jsdoc-strings.json
```

I had to split up `downloadTargetTranslations` quite a bit to add the right hook in, so it ended up being easier to asyncify it and separate it out a bit. Ran test builds of arcade electron app with both downloaded translations from `locs` and prebuilt translations from `locs-src` and both worked ~