### PR TITLE
Compute TS AST for Python completions, remove completion list truncation

### DIFF
--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -591,7 +591,7 @@ namespace ts.pxtc.service {
         resultSymbols.sort(compareCompletionSymbols);
 
         // limit the number of entries
-        if (resultSymbols.length > MAX_SYMBOLS) {
+        if (v.light && resultSymbols.length > MAX_SYMBOLS) {
             resultSymbols = resultSymbols.splice(0, MAX_SYMBOLS)
         }
 

--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -409,8 +409,11 @@ namespace ts.pxtc.service {
             // better at fuzzy matching and fluidly changing but for performance reasons we want to do it here)
             if (!isMemberCompletion && resultSymbols.length > MAX_SYMBOLS_BEFORE_FILTER) {
                 resultSymbols = resultSymbols
-                    .filter(s => (isPython ? s.symbol.pyQName : s.symbol.qName).indexOf(partialWord) >= 0)
+                    .filter(s => (isPython ? s.symbol.pyQName : s.symbol.qName).toLowerCase().indexOf(partialWord.toLowerCase()) >= 0)
             }
+
+            opts.ast = true;
+            const ts2asm = compile(opts, service);
         } else {
             tsPos = position
             opts.ast = true;
@@ -484,7 +487,7 @@ namespace ts.pxtc.service {
 
         if (resultSymbols.length === 0) {
             // if by this point we don't yet have a specialized set of results (like those for member completion), use all global api symbols as the start and filter by matching prefix if possible
-            let wordMatching = allSymbols.filter(s => (isPython ? s.pyQName : s.qName).indexOf(partialWord) >= 0)
+            let wordMatching = allSymbols.filter(s => (isPython ? s.pyQName : s.qName).toLowerCase().indexOf(partialWord.toLowerCase()) >= 0)
             resultSymbols = completionSymbols(wordMatching, COMPLETION_DEFAULT_WEIGHT)
         }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1553,6 +1553,7 @@ namespace ts.pxtc.service {
         projectSearch?: ProjectSearchOptions;
         snippet?: SnippetOptions;
         runtime?: pxt.RuntimeOptions;
+        light?: boolean; // in light mode?
     }
 
     export interface SnippetOptions {

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -226,13 +226,14 @@ export function py2tsAsync(force = false): Promise<pxtc.transpile.TranspileResul
         })
 }
 
-export function completionsAsync(fileName: string, position: number, wordStartPos: number, wordEndPos: number, fileContent?: string): Promise<pxtc.CompletionInfo> {
+export function completionsAsync(fileName: string, position: number, wordStartPos: number, wordEndPos: number, fileContent?: string, light?: boolean): Promise<pxtc.CompletionInfo> {
     return workerOpAsync("getCompletions", {
         fileName,
         fileContent,
         position,
         wordStartPos,
         wordEndPos,
+        light,
         runtime: pxt.appTarget.runtime
     });
 }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -160,7 +160,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                     };
                     return res
                 })
-                return { suggestions: items };
+                return { suggestions: items, incomplete: true };
             });
 
         function tosort(i: number): string {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -68,7 +68,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
         const wordStartOffset = model.getOffsetAt({ lineNumber: position.lineNumber, column: word.startColumn })
         const wordEndOffset = model.getOffsetAt({ lineNumber: position.lineNumber, column: word.endColumn })
 
-        return compiler.completionsAsync(fileName, offset, wordStartOffset, wordEndOffset, source)
+        return compiler.completionsAsync(fileName, offset, wordStartOffset, wordEndOffset, source, pxt.options.light)
             .then(completions => {
                 function stripLocalNamespace(qName: string): string {
                     // leave out namespace qualifiers if we're inside a matching namespace
@@ -160,7 +160,7 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                     };
                     return res
                 })
-                return { suggestions: items, incomplete: true };
+                return { suggestions: items };
             });
 
         function tosort(i: number): string {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/1990

Issue here is the intellisense for call expressions requires our annotated TS AST, which wasn't being computed for Python. I added an additional compile (after the py2ts) to fill in this info.

Fixes https://github.com/microsoft/pxt-minecraft/issues/1989

This is because getCompletions is only called when intellisense initially pops up, and subsequent keystrokes just filter the existing list (eg if you type "PRI" quickly and wait, you'll see "PRIMED_TNT", but if you type "P", wait, then add "RI" you will not). PRIMED_TNT isn't in the initial list because it's a "ProjectileMob" and mobs.spawn is preferencing AnimalMobs. Adding `incomplete: true` will recompute the completions each time.

I also updated our pre-monaco completion result filtering to be case-insensitive (so that "pri" will also bring up "PRIMED_TNT").

These are all kind of perf hits--here's a build, I do think it makes the intellisense noticeably slower so it might be worth discussing whether we should ditch some of these fixes in favor of better perf. Or if folks have ideas for better fixes! (cc @darzu)

Build: https://minecraft.makecode.com/app/e1999a6e25f69f5e6ddbfe5ae1b26d967894fe03-36536a76cc