### PR TITLE
don't export Fuse objects

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -740,8 +740,9 @@ namespace ts.pxtc.service {
     export let lastGlobalNames: pxt.Map<SymbolInfo> | undefined;
     export let lastBlocksInfo: BlocksInfo;
     export let lastLocBlocksInfo: BlocksInfo;
-    export let lastFuse: Fuse<SearchInfo>;
-    export let lastProjectFuse: Fuse<ProjectSearchInfo>;
+    // don't export, fuse is internal only
+    let lastFuse: Fuse<SearchInfo>;
+    let lastProjectFuse: Fuse<ProjectSearchInfo>;
     export let builtinItems: SearchInfo[];
     export let blockDefinitions: pxt.Map<pxt.blocks.BlockDefinition>;
     export let tbSubset: pxt.Map<boolean | string>;


### PR DESCRIPTION
This change https://github.com/microsoft/pxt/commit/fc8fd4a0feea14cb82401f02bd2f857eb9dee585 exports the Fuse symbols, which creates a dependency on fuse typings. It breaks editor as the pxtcompiler.d.ts now tries to load fuse.d.ts.

Fuse is an internal implementation details and should not be exported.