### PR TITLE
Minecaft monaco css fixes

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1040,6 +1040,7 @@ p.ui.font.small {
         left: auto;
         height: 5.7rem;
         margin-right: 1rem;
+        bottom: var(--extra-mobile-sim-padding);
     }
 
     #editortools #downloadArea,

--- a/theme/monaco.less
+++ b/theme/monaco.less
@@ -95,6 +95,14 @@
     z-index: @menuBarZIndex+1 !important;
 }
 
+/*
+ * Monaco drops this in the bottom right by default,
+ * but we end up using that position for simulator / toolbar depending on view.
+ */
+.monaco-editor .iPadShowKeyboard {
+    top: 0 !important;
+}
+
 @keyframes bobbing {
     0% {
         transform: translateY(0px);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/1756 -- the ipad 'show keyboard' button shows up behind editor tools / sometimes mobile sim. Worth noting we already have it in the correct position on some versions of ios due to 
https://github.com/microsoft/pxt/blob/c6531e3fb05a6521cddd0607c1dfa6eafa4fa1cd/webapp/src/monaco.tsx#L2115 but the built in one is the one that we can't easily reposition / the linked code is throw away code next time we update monaco most likely anyways. vscodes top position just places it at 0 anyways: https://github.com/microsoft/vscode/blob/2cb96e9c7a9ad82b9649ea6f3508cd224d64de75/src/vs/editor/browser/viewParts/overlayWidgets/overlayWidgets.ts#L130

![image](https://user-images.githubusercontent.com/5615930/93825318-d966db00-fc19-11ea-8758-57e50ba645c9.png)

also fix positioning issue with the transparent editor tools, just using the positioning variable I added in https://github.com/microsoft/pxt/pull/7106/files; didn't see any issue for that yet

![minecraft-positioning-fixes](https://user-images.githubusercontent.com/5615930/93825521-47130700-fc1a-11ea-9983-a5466f0da00b.gif)
