### PR TITLE
Set help path for 'isEmpty()'

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -334,6 +334,7 @@ declare interface String {
 
     /** Returns a value indicating if the string is empty */
     //% helper=stringEmpty
+    //% help=text/is-empty
     //% blockId="string_isempty" blockNamespace="text"
     //% block="%this=text| is empty"
     isEmpty(): boolean;


### PR DESCRIPTION
Add the missing help path for **String.isEmpty()**.