### PR TITLE
Don't use enum aliases for member completions

### DIFF
--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -579,7 +579,14 @@ namespace ts.pxtc.service {
 
         // swap aliases, filter symbols
         resultSymbols
-            .map(sym => sym.symbol.attributes.alias ? completionSymbol(lastApiInfo.apis.byQName[sym.symbol.attributes.alias], sym.weight) : sym)
+            .map(sym => {
+                // skip for enum member completions (eg "AnimalMob."" should have "Chicken", not "CHICKEN")
+                if (sym.symbol.attributes.alias && !(isMemberCompletion && sym.symbol.kind === SymbolKind.EnumMember)) {
+                    return completionSymbol(lastApiInfo.apis.byQName[sym.symbol.attributes.alias], sym.weight);
+                } else {
+                    return sym;
+                }
+            })
             .filter(shouldUseSymbol)
             .forEach(sym => {
                 entries[sym.symbol.qName] = sym


### PR DESCRIPTION
I think the symbol aliases are only used for these enum constants right now but I'm checking the symbol type anyway in case we want to use them for anything else later. Could cause problems later if we decided we wanted to do something like assign "AnimalMob.Turtle" as an alias for "AnimalMob.SeaTurtle"... not quite sure if that's a thing we intend to support with this alias property?

Fixes https://github.com/microsoft/pxt-minecraft/issues/2005