### PR TITLE
Support new waveforms in simulator

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -295,21 +295,21 @@ namespace pxsim {
                 const output = rectNoiseBuffer.getChannelData(0);
 
                 let x = 0xf01ba80;
-                for (let i = 0; i < bufferSize; i+=4) {
+                for (let i = 0; i < bufferSize; i += 4) {
                     // see https://en.wikipedia.org/wiki/Xorshift
                     x ^= x << 13;
                     x ^= x >> 17;
                     x ^= x << 5;
                     if (x & 0x8000) {
                         output[i] = 1.0;
-                        output[i+1] = 1.0;
-                        output[i+2] = -1.0;
-                        output[i+3] = -1.0;
+                        output[i + 1] = 1.0;
+                        output[i + 2] = -1.0;
+                        output[i + 3] = -1.0;
                     } else {
                         output[i] = 0.0;
-                        output[i+1] = 0.0;
-                        output[i+2] = 0.0;
-                        output[i+3] = 0.0;
+                        output[i + 1] = 0.0;
+                        output[i + 2] = 0.0;
+                        output[i + 3] = 0.0;
                     }
                 }
             }
@@ -328,7 +328,7 @@ namespace pxsim {
                 // "bits" must be in the range 4..6.
                 const cycle_bits: number[] = [ 0x2df0eb47, 0xc8165a93 ];
                 const mask_456: number[] = [ 0xf, 0x1f, 0x3f ];
-                for (let i = 0; i < bufferSize; i+=4) {
+                for (let i = 0; i < bufferSize; i += 4) {
                     let cycle: number = i / 4;
                     let is_on: boolean;
                     let cycle_mask = mask_456[bits - 4];
@@ -336,14 +336,14 @@ namespace pxsim {
                     is_on = (cycle_bits[cycle >> 5] & (1 << (cycle & 0x1f))) != 0;
                     if (is_on) {
                         output[i] = 1.0;
-                        output[i+1] = 1.0;
-                        output[i+2] = -1.0;
-                        output[i+3] = -1.0;
+                        output[i + 1] = 1.0;
+                        output[i + 2] = -1.0;
+                        output[i + 3] = -1.0;
                     } else {
                         output[i] = 0.0;
-                        output[i+1] = 0.0;
-                        output[i+2] = 0.0;
-                        output[i+3] = 0.0;
+                        output[i + 1] = 0.0;
+                        output[i + 2] = 0.0;
+                        output[i + 3] = 0.0;
                     }
                 }
                 cycleNoiseBuffer[bits] = buf

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -268,10 +268,6 @@ namespace pxsim {
         let squareBuffer: AudioBuffer[] = []
 
         function getNoiseBuffer() {
-            // Create a square wave filtered by a pseudorandom bit sequence.
-            // This uses four samples per cycle to create square-ish waves.
-            // The Web Audio API's frequency scaling may be using linear
-            // interpolation which would turn a two-sample wave into a triangle.
             if (!noiseBuffer) {
                 const bufferSize = 100000;
                 noiseBuffer = context().createBuffer(1, bufferSize, context().sampleRate);
@@ -289,6 +285,10 @@ namespace pxsim {
         }
 
         function getRectNoiseBuffer() {
+            // Create a square wave filtered by a pseudorandom bit sequence.
+            // This uses four samples per cycle to create square-ish waves.
+            // The Web Audio API's frequency scaling may be using linear
+            // interpolation which would turn a two-sample wave into a triangle.
             if (!rectNoiseBuffer) {
                 const bufferSize = 131072; // must be a multiple of 4
                 rectNoiseBuffer = context().createBuffer(1, bufferSize, context().sampleRate);

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -372,9 +372,9 @@ namespace pxsim {
         #define SW_NOISE 5
         #define SW_SQUARE_10 11
         #define SW_SQUARE_50 15
-        #define SW_CYCLENOISE_4 16
-        #define SW_CYCLENOISE_5 17
-        #define SW_CYCLENOISE_6 18
+        #define SW_SQUARE_CYCLE_16 16
+        #define SW_SQUARE_CYCLE_32 17
+        #define SW_SQUARE_CYCLE_64 18
         */
 
 

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -263,9 +263,15 @@ namespace pxsim {
 
         const waveForms: OscillatorType[] = [null, "triangle", "sawtooth", "sine"]
         let noiseBuffer: AudioBuffer
+        let rectNoiseBuffer: AudioBuffer
+        let cycleNoiseBuffer: AudioBuffer[] = []
         let squareBuffer: AudioBuffer[] = []
 
         function getNoiseBuffer() {
+            // Create a square wave filtered by a pseudorandom bit sequence.
+            // This uses four samples per cycle to create square-ish waves.
+            // The Web Audio API's frequency scaling may be using linear
+            // interpolation which would turn a two-sample wave into a triangle.
             if (!noiseBuffer) {
                 const bufferSize = 100000;
                 noiseBuffer = context().createBuffer(1, bufferSize, context().sampleRate);
@@ -280,6 +286,69 @@ namespace pxsim {
                 }
             }
             return noiseBuffer
+        }
+
+        function getRectNoiseBuffer() {
+            if (!rectNoiseBuffer) {
+                const bufferSize = 131072; // must be a multiple of 4
+                rectNoiseBuffer = context().createBuffer(1, bufferSize, context().sampleRate);
+                const output = rectNoiseBuffer.getChannelData(0);
+
+                let x = 0xf01ba80;
+                for (let i = 0; i < bufferSize; i+=4) {
+                    // see https://en.wikipedia.org/wiki/Xorshift
+                    x ^= x << 13;
+                    x ^= x >> 17;
+                    x ^= x << 5;
+                    if (x & 0x8000) {
+                        output[i] = 1.0;
+                        output[i+1] = 1.0;
+                        output[i+2] = -1.0;
+                        output[i+3] = -1.0;
+                    } else {
+                        output[i] = 0.0;
+                        output[i+1] = 0.0;
+                        output[i+2] = 0.0;
+                        output[i+3] = 0.0;
+                    }
+                }
+            }
+            return rectNoiseBuffer
+        }
+
+        function getCycleNoiseBuffer(bits: number) {
+            if (!cycleNoiseBuffer[bits]) {
+                // Buffer size needs to be a multiple of 4x the largest cycle length,
+                // 4*64 in this case.
+                const bufferSize = 1024;
+                const buf = context().createBuffer(1, bufferSize, context().sampleRate);
+                const output = buf.getChannelData(0);
+
+                // See pxt-common-packages's libs/mixer/melody.cpp for details.
+                // "bits" must be in the range 4..6.
+                const cycle_bits: number[] = [ 0x2df0eb47, 0xc8165a93 ];
+                const mask_456: number[] = [ 0xf, 0x1f, 0x3f ];
+                for (let i = 0; i < bufferSize; i+=4) {
+                    let cycle: number = i / 4;
+                    let is_on: boolean;
+                    let cycle_mask = mask_456[bits - 4];
+                    cycle &= cycle_mask;
+                    is_on = (cycle_bits[cycle >> 5] & (1 << (cycle & 0x1f))) != 0;
+                    if (is_on) {
+                        output[i] = 1.0;
+                        output[i+1] = 1.0;
+                        output[i+2] = -1.0;
+                        output[i+3] = -1.0;
+                    } else {
+                        output[i] = 0.0;
+                        output[i+1] = 0.0;
+                        output[i+2] = 0.0;
+                        output[i+3] = 0.0;
+                    }
+                }
+                cycleNoiseBuffer[bits] = buf
+            }
+            return cycleNoiseBuffer[bits]
         }
 
         function getSquareBuffer(param: number) {
@@ -299,9 +368,13 @@ namespace pxsim {
         #define SW_TRIANGLE 1
         #define SW_SAWTOOTH 2
         #define SW_SINE 3 // TODO remove it? it takes space
+        #define SW_TUNEDNOISE 4
         #define SW_NOISE 5
         #define SW_SQUARE_10 11
         #define SW_SQUARE_50 15
+        #define SW_CYCLENOISE_4 16
+        #define SW_CYCLENOISE_5 17
+        #define SW_CYCLENOISE_6 18
         */
 
 
@@ -317,6 +390,7 @@ namespace pxsim {
          */
 
         function getGenerator(waveFormIdx: number, hz: number): OscillatorNode | AudioBufferSourceNode {
+            console.log('getGenerator wave=' + waveFormIdx)
             let form = waveForms[waveFormIdx]
             if (form) {
                 let src = context().createOscillator()
@@ -326,17 +400,24 @@ namespace pxsim {
             }
 
             let buffer: AudioBuffer
-            if (waveFormIdx == 5)
+            if (waveFormIdx == 4)
+                buffer = getRectNoiseBuffer()
+            else if (waveFormIdx == 5)
                 buffer = getNoiseBuffer()
             else if (11 <= waveFormIdx && waveFormIdx <= 15)
                 buffer = getSquareBuffer((waveFormIdx - 10) * 10)
+            else if (16 <= waveFormIdx && waveFormIdx <= 18)
+                buffer = getCycleNoiseBuffer((waveFormIdx - 16) + 4)
             else
                 return null
 
             let node = context().createBufferSource();
             node.buffer = buffer;
             node.loop = true;
-            if (waveFormIdx != 5)
+            const isFilteredNoise = waveFormIdx == 4 || (16 <= waveFormIdx && waveFormIdx <= 18);
+            if (isFilteredNoise)
+                node.playbackRate.value = hz / (context().sampleRate / 4);
+            else if (waveFormIdx != 5)
                 node.playbackRate.value = hz / (context().sampleRate / 1024);
 
             return node
@@ -417,6 +498,7 @@ namespace pxsim {
                 const endFreq = BufferMethods.getNumber(b, BufferMethods.NumberFormat.UInt16LE, idx + 10)
 
                 const isSquareWave = 11 <= soundWaveIdx && soundWaveIdx <= 15;
+                const isFilteredNoise = soundWaveIdx == 4 || (16 <= soundWaveIdx && soundWaveIdx <= 18);
                 const scaledStart = scaleVol(startVol, isSquareWave);
                 const scaledEnd = scaleVol(endVol, isSquareWave);
 
@@ -450,7 +532,8 @@ namespace pxsim {
                         } else if ((ch.generator as any).playbackRate != undefined) {
                             // If generator is an AudioBufferSourceNode
                             const param = (ch.generator as any).playbackRate as AudioParam;
-                            param.linearRampToValueAtTime(endFreq / (context().sampleRate / 1024), ctx.currentTime + ((timeOff + duration) / 1000));
+                            const bufferSamplesPerWave = isFilteredNoise ? 4 : 1024;
+                            param.linearRampToValueAtTime(endFreq / (context().sampleRate / bufferSamplesPerWave), ctx.currentTime + ((timeOff + duration) / 1000));
                         }
                     }
 

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -390,7 +390,6 @@ namespace pxsim {
          */
 
         function getGenerator(waveFormIdx: number, hz: number): OscillatorNode | AudioBufferSourceNode {
-            console.log('getGenerator wave=' + waveFormIdx)
             let form = waveForms[waveFormIdx]
             if (form) {
                 let src = context().createOscillator()


### PR DESCRIPTION
This adds simulator support for the new waveforms added in
https://github.com/microsoft/pxt-common-packages/pull/1177

See
https://forum.makecode.com/t/testing-modifications-to-the-sound-engine/3351
for context and example sound output.