### PR TITLE
fix string.trim

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -374,6 +374,7 @@ declare interface String {
     /**
      * Return a substring of the current string with whitespace removed from both ends
      */
+    //% helper=stringTrim
     trim(): string;
 
     /**


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/2395#issuecomment-698446759

I had added trim as a side effect when fixing parseInt, and in one of the commits we dropped the block for trim, and I accidentally cut the helper annotation too (which says which function is used to implement this method). Quarter for the 'forgot to call the function' jar!

actual implementation is here:

https://github.com/microsoft/pxt/blob/b587c496504c846d86cd52299b878137465dfceb/libs/pxt-common/pxt-helpers.ts#L469-L479