### PR TITLE
Add gh action for extensions to check files exists

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3171,7 +3171,6 @@ export async function validateAndFixPkgConfig(parsed: commandParser.ParsedComman
         U.userError("Could not parse pxt.json");
     }
 
-
     const trimmedFiles = validateFileList("files", cfg.files);
     if (trimmedFiles) {
         cfg.files = trimmedFiles;
@@ -3192,13 +3191,15 @@ export async function validateAndFixPkgConfig(parsed: commandParser.ParsedComman
     }
 
     if (trimmedFiles || trimmedTestFiles || validFilesInFileDependencies) {
-        console.log("Updating pxt.json");
+        pxt.log("Updating pxt.json");
         fs.writeFileSync('pxt.json', JSON.stringify(cfg, undefined, 4));
+        pxt.log("Successfully updated pxt.json")
     } else {
-        console.log("No errors identified in pxt.json");
+        pxt.log("No errors identified in pxt.json");
     }
 
     function validateFileList(field: string, files: string[]) {
+        pxt.log(`Checking ${field}`);
         const missing: string[] = [];
         const existing: string[] = [];
 
@@ -3211,7 +3212,7 @@ export async function validateAndFixPkgConfig(parsed: commandParser.ParsedComman
         }
 
         if (missing.length) {
-            console.warn(`pxt.json lists ${field} that are missing:
+            pxt.log(`pxt.json lists ${field} that are missing:
     ${missing.join(",\n    ")}
 `);
             return existing;

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3163,6 +3163,64 @@ export function downloadPlaylistsAsync(parsed: commandParser.ParsedCommand): Pro
     return youtube.renderPlaylistsAsync(playlists);
 }
 
+export async function validateAndFixPkgConfig(parsed: commandParser.ParsedCommand): Promise<void> {
+    const file = fs.readFileSync("pxt.json", { encoding: "utf8" });
+    const cfg = pxt.Package.parseAndValidConfig(file);
+
+    if (!cfg) {
+        U.userError("Could not parse pxt.json");
+    }
+
+
+    const trimmedFiles = validateFileList("files", cfg.files);
+    if (trimmedFiles) {
+        cfg.files = trimmedFiles;
+    }
+
+    const trimmedTestFiles = validateFileList("testFiles", cfg.testFiles);
+    if (trimmedTestFiles) {
+        cfg.testFiles = trimmedTestFiles;
+    }
+
+    const validFilesInFileDependencies = validateFileList("fileDependencies", U.values(cfg.fileDependencies));
+    if (validFilesInFileDependencies) {
+        for (const key of Object.keys(cfg.fileDependencies)) {
+            if (validFilesInFileDependencies.indexOf(cfg.fileDependencies[key]) === -1) {
+                delete cfg.fileDependencies[key];
+            }
+        }
+    }
+
+    if (trimmedFiles || trimmedTestFiles || validFilesInFileDependencies) {
+        console.log("Updating pxt.json");
+        fs.writeFileSync('pxt.json', JSON.stringify(cfg, undefined, 4));
+    } else {
+        console.log("No errors identified in pxt.json");
+    }
+
+    function validateFileList(field: string, files: string[]) {
+        const missing: string[] = [];
+        const existing: string[] = [];
+
+        for (const file of (files || [])) {
+            if (fs.existsSync(file)) {
+                existing.push(file);
+            } else {
+                missing.push(file);
+            }
+        }
+
+        if (missing.length) {
+            console.warn(`pxt.json lists ${field} that are missing:
+    ${missing.join(",\n    ")}
+`);
+            return existing;
+        }
+
+        return undefined;
+    }
+}
+
 export function downloadDiscourseTagAsync(parsed: commandParser.ParsedCommand): Promise<void> {
     const rx = /```codecard((.|\s)*)```/;
     const tag = parsed.args[0] as string;
@@ -6601,6 +6659,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
         advanced: true,
         argString: "<list>"
     }, downloadPlaylistsAsync)
+
+    p.defineCommand({
+        name: "checkpkgcfg",
+        help: "Validate and attempt to fix common pxt.json issues",
+    }, validateAndFixPkgConfig);
 
     function simpleCmd(name: string, help: string, callback: (c?: commandParser.ParsedCommand) => Promise<void>, argString?: string, onlineHelp?: boolean): void {
         p.defineCommand({ name, help, onlineHelp, argString }, callback);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3167,7 +3167,9 @@ export async function validateAndFixPkgConfig(parsed: commandParser.ParsedComman
     const file = fs.readFileSync("pxt.json", { encoding: "utf8" });
     const cfg = pxt.Package.parseAndValidConfig(file);
 
-    if (!cfg) {
+    if (cfg) {
+        pxt.log("Validating pxt.json");
+    } else {
         U.userError("Could not parse pxt.json");
     }
 
@@ -3193,7 +3195,7 @@ export async function validateAndFixPkgConfig(parsed: commandParser.ParsedComman
     if (trimmedFiles || trimmedTestFiles || validFilesInFileDependencies) {
         pxt.log("Updating pxt.json");
         fs.writeFileSync('pxt.json', JSON.stringify(cfg, undefined, 4));
-        pxt.log("Successfully updated pxt.json")
+        pxt.log("Successfully updated pxt.json");
     } else {
         pxt.log("No errors identified in pxt.json");
     }

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -139,30 +139,38 @@ jobs:
           pxt build --cloud
         env:
           CI: true
+`,
+            ".github/workflows/cfg-check.yml": `name: Check pxt.json
 
+on:
+  push
+
+jobs:
   check-cfg:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [8.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js $\{{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: $\{{ matrix.node-version }}
       - name: npm install
+        run: npm install -g pxt
+      - name: Checkout current state
         run: |
-          npm install -g pxt
-          pxt target @TARGET@
+          git checkout -- .
+          git clean -fd
       - name: Fix files listed in config if necessary
         run: pxt checkpkgcfg
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: Removing missing files from pxt.json
-          title: 'missing files listed in pxt.json'
-
+          title: 'Removing missing files from pxt.json'
+          commit-message: 'Removing missing files from pxt.json'
+          delete-branch: true
 `,
             ".vscode/tasks.json":
                 `

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -139,6 +139,30 @@ jobs:
           pxt build --cloud
         env:
           CI: true
+
+  check-cfg:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [8.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js $\{{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: $\{{ matrix.node-version }}
+      - name: npm install
+        run: |
+          npm install -g pxt
+          pxt target @TARGET@
+      - name: Fix files listed in config if necessary
+        run: pxt checkpkgcfg
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Removing missing files from pxt.json
+          title: 'missing files listed in pxt.json'
+
 `,
             ".vscode/tasks.json":
                 `


### PR DESCRIPTION
And make a PR removing them from the list if they are invalid

close https://github.com/microsoft/pxt-minecraft/issues/1951

Very similar to the one I added for the minecraft content repo, e.g. of the generated pr for that: https://github.com/Mojang/EducationContent/pull/14

made a quick test repo: https://github.com/jwunderl/test-pxt-gh-action-repo/blob/master/.github/workflows/cfg-check.yml but I have that using a separate file because the checkpkgcfg isn't available without this pr

Could limit to just main/master branch, but it works for others too / doesn't seem like there's a reason to wait till the failure is fully merged?