### PR TITLE
Don't request all files at once when building course book

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -847,6 +847,28 @@ namespace ts.pxtc.Util {
         }
     }
 
+    export async function promisePoolAsync<T, V>(maxConcurrent: number, inputValues: T[], handler: (input: T) => Promise<V>) {
+        let curr = 0;
+        const promises = [];
+        const output: V[] = [];
+
+        for (let i = 0; i < maxConcurrent; i++) {
+            const thread = (async () => {
+                while (curr < inputValues.length) {
+                    const id = curr++;
+                    const input = inputValues[id];
+                    output[id] = await handler(input);
+                }
+            })();
+
+            promises.push(thread);
+        }
+
+        await Promise.all(promises);
+
+        return output;
+    }
+
     export function now(): number {
         return Date.now();
     }

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -847,7 +847,7 @@ namespace ts.pxtc.Util {
         }
     }
 
-    export async function promisePoolAsync<T, V>(maxConcurrent: number, inputValues: T[], handler: (input: T) => Promise<V>) {
+    export async function promisePoolAsync<T, V>(maxConcurrent: number, inputValues: T[], handler: (input: T) => Promise<V>): Promise<V[]> {
         let curr = 0;
         const promises = [];
         const output: V[] = [];

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -790,19 +790,20 @@ ${linkString}
             .then(summary => {
                 toc = pxt.docs.buildTOC(summary);
                 pxt.log(`TOC: ${JSON.stringify(toc, null, 2)}`)
-                const tocsp: Promise<void>[] = [];
+                const tocsp: TOCMenuEntry[] = [];
                 pxt.docs.visitTOC(toc, entry => {
-                    if (!/^\//.test(entry.path) || /^\/pkg\//.test(entry.path)) return;
-                    tocsp.push(
-                        pxt.Cloud.markdownAsync(entry.path)
-                            .then(md => {
-                                entry.markdown = md;
-                            }, e => {
-                                entry.markdown = `_${entry.path} failed to load._`;
-                            })
-                    )
+                    if (/^\//.test(entry.path) && !/^\/pkg\//.test(entry.path))
+                        tocsp.push(entry);
                 });
-                return Promise.all(tocsp);
+
+                return U.promisePoolAsync(4, tocsp, async entry => {
+                    try {
+                        const md = await pxt.Cloud.markdownAsync(entry.path);
+                        entry.markdown = md;
+                    } catch (e) {
+                        entry.markdown = `_${entry.path} failed to load._`;
+                    }
+                });
             })
             .then(pages => {
                 let md = toc[0].name;


### PR DESCRIPTION
Right now, when building a course using `--docs#book`, we fetch all pages at once; when this is done in a language other than english, this means we need to fetch translations for all those files (which is ~~ 40-50+ md files per course). This will result in some of the requests for updating translations getting rejected, and the user getting out of date / possibly no translations for random entries

testing this is a bit tedious as localhost 403s on `/api/md/arcade/courses/...` when trying to build the book locally, so here's a link to a course in a build: https://arcade.makecode.com/app/5be2b998acd9bb6b02c82e20bef342be8d2acc7a-841de5f31f--docs#book:/courses/csintro1/SUMMARY It doesn't appear to be significantly slower than it currently is, as a significant portion of the time is spent rendering the page after fetching everything

worth a note, `pxtc.Util.promisePoolAsync` is a slight generalization of the implementation I added in pxt-translations to build translations in parallel.