### PR TITLE
fix default length for string.substr

### DIFF
--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -299,7 +299,7 @@ declare interface String {
      * @param start first character index; can be negative from counting from the end, eg:0
      * @param length number of characters to extract, eg: 10
      */
-    //% shim=String_::substr
+    //% helper=stringSubstr
     //% help=text/substr
     //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
     substr(start: number, length?: number): string;

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -297,9 +297,9 @@ declare interface String {
     /**
      * Return a substring of the current string.
      * @param start first character index; can be negative from counting from the end, eg:0
-     * @param length number of characters to extract
+     * @param length number of characters to extract, eg: 10
      */
-    //% shim=String_::substr length.defl=10
+    //% shim=String_::substr
     //% help=text/substr
     //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
     substr(start: number, length?: number): string;

--- a/libs/pxt-common/pxt-helpers.ts
+++ b/libs/pxt-common/pxt-helpers.ts
@@ -374,6 +374,13 @@ namespace helpers {
         }
     }
 
+    //% shim=String_::substr
+    declare function stringSubstrHelper(s: string, start: number, length?: number): string;
+
+    export function stringSubstr(s: string, start: number, length?: number): string {
+        length = length === undefined ? s.length : length || 0;
+        return stringSubstrHelper(s, start, length);
+    }
 
     export function stringSlice(s: string, start: number, end?: number): string {
         const len = s.length;
@@ -382,15 +389,17 @@ namespace helpers {
             start = Math.max(len + start, 0);
         }
 
-        if (end == null) {
+        if (end === undefined) {
             end = len;
+        } else if (end === null) {
+            end = 0;
         }
 
         if (end < 0) {
             end = len + end;
         }
 
-        return s.substr(start, end - start);
+        return stringSubstrHelper(s, start, end - start);
     }
 
     // TODO move to PXT


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3356

`param.defl` defines a default for the api, not just the block. The `eg: {default}` format for setting default values for blocks is a bit less obvious / more surprising behavior, but does what we want it to (set the default length for blocks without breaking effecting ts code).

Few other edge case bugs bugs too:
* substr: passing length null was getting treated as length 3 on hardware as null was getting coerced
* substr: passing length undefined explicitly was not equivalent to not passing a value (I suppose this might be considered a bug with defl itself as well?)
* slice: passing null gets treated as 0 in js, but was being treated as passing undefined

quick test case to show differences

```
game.consoleOverlay.setVisible(true)

function test(a: string) {
    console.log(a.length + " " + a);
}

test("abcdefhasdfasdf".substr(2))
test("abcdefhasdfasdf".substr(2, null))
test("abcdefhasdfasdf".substr(2, undefined))
test("abcdefhasdfasdf".slice(0))
test("abcdefhasdfasdf".slice(0, null))
test("abcdefhasdfasdf".slice(0, undefined))
```