### PR TITLE
Delete obsolete "remove it?" SW_SINE comment

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -367,7 +367,7 @@ namespace pxsim {
         /*
         #define SW_TRIANGLE 1
         #define SW_SAWTOOTH 2
-        #define SW_SINE 3 // TODO remove it? it takes space
+        #define SW_SINE 3
         #define SW_TUNEDNOISE 4
         #define SW_NOISE 5
         #define SW_SQUARE_10 11


### PR DESCRIPTION
To avoid confusion, refresh the comments copied from
pxt-common-packages's libs/mixer/melody.h. The sine waveform
no longer needs a lot of space after the merge of
https://github.com/microsoft/pxt-common-packages/pull/1178