### PR TITLE
Rename 'unplugged' -> 'showdialog' and 'fullscreen' -> 'showhint'

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -912,9 +912,11 @@ declare namespace pxt.tutorial {
     }
 
     interface TutorialStepInfo {
-        fullscreen?: boolean;
-        // no coding
-        unplugged?: boolean;
+        // fullscreen?: boolean; // DEPRECATED, replaced by "showHint"
+        // unplugged?: boolean: // DEPRECATED, replaced by "showDialog"
+
+        showHint?: boolean; // automatically displays hint
+        showDialog?: boolean; // no coding, displays in modal
         tutorialCompleted?: boolean;
         contentMd?: string;
         headerContentMd?: string;

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -426,7 +426,7 @@ namespace pxt.docs {
             }
             // remove tutorial macros
             if (text)
-                text = text.replace(/@(fullscreen|unplugged)/g, '');
+                text = text.replace(/@(fullscreen|unplugged|showdialog|showhint)/gi, '');
             return `<h${level} id="${(this as any).options.headerPrefix}${id}">${text}</h${level}>`
         }
     }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -216,10 +216,10 @@ ${code}
                 contentMd: step,
                 headerContentMd: header
             }
-            if (/@(fullscreen|unplugged)/.test(flags))
-                info.fullscreen = true;
-            if (/@unplugged/.test(flags))
-                info.unplugged = true;
+            if (/@(fullscreen|unplugged|showdialog|showhint)/i.test(flags))
+                info.showHint = true;
+            if (/@(unplugged|showdialog)/i.test(flags))
+                info.showDialog = true;
             if (/@tutorialCompleted/.test(flags))
                 info.tutorialCompleted = true;
             if (/@resetDiff/.test(flags))

--- a/tests/tutorial-test/baselines/activities.json
+++ b/tests/tutorial-test/baselines/activities.json
@@ -5,15 +5,15 @@
         {
             "contentMd": "Introduction text\n![Image text](/image/url.gif)",
             "headerContentMd": "Introduction text",
-            "fullscreen": true,
-            "unplugged": true,
+            "showHint": true,
+            "showDialog": true,
             "hintContentMd": "![Image text](/image/url.gif)",
             "activity": 0
         },
         {
             "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nlet x = 1;\nlet y = x + 2;\n```\n\nTry checking the blue drawer for the correct block.",
             "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
-            "fullscreen": true,
+            "showHint": true,
             "hintContentMd": "```blocks\nlet x = 1;\nlet y = x + 2;\n```\n\nTry checking the blue drawer for the correct block.",
             "activity": 1
         },

--- a/tests/tutorial-test/baselines/ghost.json
+++ b/tests/tutorial-test/baselines/ghost.json
@@ -5,7 +5,7 @@
         {
             "contentMd": "Ghost blocks do not show up in the tutorial, but display in the workspace.",
             "headerContentMd": "Ghost blocks do not show up in the tutorial, but display in the workspace.",
-            "fullscreen": true
+            "showHint": true
         },
         {
             "contentMd": "Multiple ghost sections can be included in one tutorial\n\n```blocks\nbasic.showString(\"Hello\")\n```",

--- a/tests/tutorial-test/baselines/legacyFlags.json
+++ b/tests/tutorial-test/baselines/legacyFlags.json
@@ -1,0 +1,38 @@
+{
+    "editor": "blocksprj",
+    "title": "Getting started",
+    "steps": [
+        {
+            "contentMd": "Let's get started!",
+            "headerContentMd": "Let's get started!",
+            "showHint": true,
+            "showDialog": true
+        },
+        {
+            "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nbasic.showString(\"Micro!\")\n```",
+            "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
+            "showHint": true,
+            "hintContentMd": "```blocks\nbasic.showString(\"Micro!\")\n```"
+        },
+        {
+            "contentMd": "Type your name into the input field\n\n```blocks\nbasic.showString(\"Your Name Here\")\n```",
+            "headerContentMd": "Type your name into the input field",
+            "hintContentMd": "```blocks\nbasic.showString(\"Your Name Here\")\n```"
+        },
+        {
+            "contentMd": "Now hit **Play** on the simulator to see your name appear.",
+            "headerContentMd": "Now hit **Play** on the simulator to see your name appear.",
+            "showHint": true
+        },
+        {
+            "contentMd": "Click ``|Download|`` to transfer your code to your microbit!",
+            "headerContentMd": "Click ``|Download|`` to transfer your code to your microbit!"
+        }
+    ],
+    "activities": null,
+    "code": [
+        "{\nbasic.showString(\"Micro!\")\n}",
+        "{\nbasic.showString(\"Your Name Here\")\n}"
+    ],
+    "metadata": {}
+}

--- a/tests/tutorial-test/baselines/legacySteps.json
+++ b/tests/tutorial-test/baselines/legacySteps.json
@@ -5,13 +5,13 @@
         {
             "contentMd": "Let's get started!",
             "headerContentMd": "Let's get started!",
-            "fullscreen": true,
-            "unplugged": true
+            "showHint": true,
+            "showDialog": true
         },
         {
             "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nbasic.showString(\"Micro!\")\n```",
             "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
-            "fullscreen": true,
+            "showHint": true,
             "hintContentMd": "```blocks\nbasic.showString(\"Micro!\")\n```"
         },
         {

--- a/tests/tutorial-test/baselines/python.json
+++ b/tests/tutorial-test/baselines/python.json
@@ -5,7 +5,7 @@
         {
             "contentMd": "Tutorials can be written with code in Python.\n```python\ndef on_chat():\n    # @highlight\n    player.teleport(pos(0, 100, 0))\nplayer.on_chat(\"jump\", on_chat)\n```",
             "headerContentMd": "Tutorials can be written with code in Python.",
-            "fullscreen": true,
+            "showHint": true,
             "hintContentMd": "```python\ndef on_chat():\n    # @highlight\n    player.teleport(pos(0, 100, 0))\nplayer.on_chat(\"jump\", on_chat)\n```"
         },
         {

--- a/tests/tutorial-test/baselines/singleStep.json
+++ b/tests/tutorial-test/baselines/singleStep.json
@@ -5,8 +5,8 @@
         {
             "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nbasic.showString(\"Micro!\")\n```",
             "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
-            "fullscreen": true,
-            "unplugged": true,
+            "showHint": true,
+            "showDialog": true,
             "hintContentMd": "```blocks\nbasic.showString(\"Micro!\")\n```"
         }
     ],

--- a/tests/tutorial-test/baselines/steps.json
+++ b/tests/tutorial-test/baselines/steps.json
@@ -5,13 +5,13 @@
         {
             "contentMd": "Let's get started!",
             "headerContentMd": "Let's get started!",
-            "fullscreen": true,
-            "unplugged": true
+            "showHint": true,
+            "showDialog": true
         },
         {
             "contentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.\n\n```blocks\nbasic.showString(\"Micro!\")\n```",
             "headerContentMd": "Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.",
-            "fullscreen": true,
+            "showHint": true,
             "hintContentMd": "```blocks\nbasic.showString(\"Micro!\")\n```"
         },
         {

--- a/tests/tutorial-test/baselines/template.json
+++ b/tests/tutorial-test/baselines/template.json
@@ -5,8 +5,8 @@
         {
             "contentMd": "Let's get started!",
             "headerContentMd": "Let's get started!",
-            "fullscreen": true,
-            "unplugged": true
+            "showHint": true,
+            "showDialog": true
         },
         {
             "contentMd": "The template blocks appear in the workspace at the start of the tutorials",

--- a/tests/tutorial-test/cases/activities.md
+++ b/tests/tutorial-test/cases/activities.md
@@ -5,14 +5,14 @@
 
 ## Introduction
 
-### Introduction step @unplugged
+### Introduction step @showdialog
 
 Introduction text
 ![Image text](/image/url.gif)
 
 ## Activity 1
 
-### Step 1 @fullscreen
+### Step 1 @showhint
 
 Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.
 

--- a/tests/tutorial-test/cases/ghost.md
+++ b/tests/tutorial-test/cases/ghost.md
@@ -7,7 +7,7 @@ basic.forever(() => {
 # Ghost blocks
 
 ### @diffs false
-## Step 1 @fullscreen
+## Step 1 @showdialog
 
 Ghost blocks do not show up in the tutorial, but display in the workspace.
 

--- a/tests/tutorial-test/cases/legacyFlags.md
+++ b/tests/tutorial-test/cases/legacyFlags.md
@@ -1,0 +1,27 @@
+# Getting started
+
+## Introduction @unplugged
+
+Let's get started!
+
+## Step 1 @fullscreen
+
+Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.
+
+```blocks
+basic.showString("Micro!")
+```
+## Step 2
+
+Type your name into the input field
+
+```blocks
+basic.showString("Your Name Here")
+```
+## Step 3 @fullscreen
+
+Now hit **Play** on the simulator to see your name appear.
+
+## Step 4
+
+Click ``|Download|`` to transfer your code to your microbit!

--- a/tests/tutorial-test/cases/python.md
+++ b/tests/tutorial-test/cases/python.md
@@ -1,7 +1,7 @@
 # Native python
 
 ### @diffs false
-## Step 1 @fullscreen
+## Step 1 @showdialog
 
 Tutorials can be written with code in Python.
 ```python

--- a/tests/tutorial-test/cases/singleStep.md
+++ b/tests/tutorial-test/cases/singleStep.md
@@ -1,7 +1,7 @@
 # Getting started
 
 ### @diffs false
-## Introduction @unplugged
+## Introduction @showdialog
 
 Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.
 

--- a/tests/tutorial-test/cases/steps.md
+++ b/tests/tutorial-test/cases/steps.md
@@ -1,11 +1,11 @@
 # Getting started
 
 ### @diffs false
-## Introduction @unplugged
+## Introduction @showdialog
 
 Let's get started!
 
-## Step 1 @fullscreen
+## Step 1 @showhint
 
 Welcome! Place the ``||basic:show string||`` block in the ``||basic:on start||`` slot to scroll your name.
 

--- a/tests/tutorial-test/cases/template.md
+++ b/tests/tutorial-test/cases/template.md
@@ -1,7 +1,7 @@
 # Template blocks
 
 ### @diffs false
-## Introduction @unplugged
+## Introduction @showdialog
 
 Let's get started!
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1143,14 +1143,14 @@ export class ProjectView
             tutorialOptions.tutorialStep = step;
             tutorialOptions.tutorialStepExpanded = false;
             this.setState({ tutorialOptions: tutorialOptions });
-            const fullscreen = tutorialOptions.tutorialStepInfo[step].fullscreen;
-            if (fullscreen) this.showTutorialHint();
+            const showHint = tutorialOptions.tutorialStepInfo[step].showHint;
+            if (showHint) this.showTutorialHint();
 
             const isCompleted = tutorialOptions.tutorialStepInfo[step].tutorialCompleted;
             if (isCompleted && pxt.commands.onTutorialCompleted) pxt.commands.onTutorialCompleted();
             // Hide flyouts and popouts
             this.editor.closeFlyout();
-            if (this.textEditor.giveFocusOnLoading) {
+            if (this.textEditor.giveFocusOnLoading && this.isTextEditor()) {
                 this.textEditor.editor.focus();
             }
         }
@@ -1183,8 +1183,8 @@ export class ProjectView
                         tutorialOptions.tutorialReady = true;
                         tutorialOptions.tutorialStepInfo = tt.stepInfo;
                         this.setState({ tutorialOptions: tutorialOptions });
-                        const fullscreen = tutorialOptions.tutorialStepInfo[0].fullscreen;
-                        if (fullscreen) this.showTutorialHint();
+                        const showHint = tutorialOptions.tutorialStepInfo[0].showHint;
+                        if (showHint) this.showTutorialHint();
                         //else {
                         //    this.showLightbox();
                         //}
@@ -1433,8 +1433,8 @@ export class ProjectView
                 this.setState({ editorState: editorState });
                 this.editor.filterToolbox(true);
                 const stepInfo = t.tutorialStepInfo;
-                const fullscreen = stepInfo[header.tutorial.tutorialStep].fullscreen;
-                if (fullscreen) this.showTutorialHint();
+                const showHint = stepInfo[header.tutorial.tutorialStep].showHint;
+                if (showHint) this.showTutorialHint();
                 //else this.showLightbox();
             })
             .catch(e => {

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -276,7 +276,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
         const tutorialHint = step.hintContentMd;
         const fullText = step.contentMd;
 
-        if (!step.unplugged) {
+        if (!step.showDialog) {
             if (!tutorialHint) return <div />;
 
             return <div className={`tutorialhint no-select ${!visible ? 'hidden' : ''}`} ref={this.setRef}>
@@ -323,7 +323,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
 
         this.state = {
             showSeeMore: false,
-            showHint: options.tutorialStepInfo[this.prevStep].fullscreen
+            showHint: options.tutorialStepInfo[this.prevStep].showHint
         }
 
         this.toggleHint = this.toggleHint.bind(this);
@@ -427,7 +427,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             this.prevStep = step;
 
             // on "new step", sync tutorial card state. used when exiting the modal, since that bypasses the react lifecycle
-            this.setState({ showHint: options.tutorialStepInfo[step].unplugged || options.tutorialStepInfo[step].fullscreen })
+            this.setState({ showHint: options.tutorialStepInfo[step].showDialog || options.tutorialStepInfo[step].showHint })
         }
     }
 
@@ -469,7 +469,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const { tutorialReady, tutorialStepInfo, tutorialStep } = options;
         if (!tutorialReady) return false;
         return !!tutorialStepInfo[tutorialStep].hintContentMd
-            || tutorialStepInfo[tutorialStep].unplugged;
+            || tutorialStepInfo[tutorialStep].showDialog;
     }
 
     private hintOnClick(evt?: any) {
@@ -481,11 +481,11 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         if (evt) evt.stopPropagation();
         const { tutorialStepInfo, tutorialStep } = options;
         const step = tutorialStepInfo[tutorialStep];
-        const unplugged = tutorialStep < tutorialStepInfo.length - 1 && step && !!step.unplugged;
+        const showDialog = tutorialStep < tutorialStepInfo.length - 1 && step && !!step.showDialog;
 
         this.props.parent.clearUserPoke();
 
-        if (!unplugged) {
+        if (!showDialog) {
             this.toggleHint();
         }
     }
@@ -542,7 +542,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             this.props.parent.stopPokeUserActivity();
 
             const options = this.props.parent.state.tutorialOptions;
-            if (!options.tutorialStepInfo[options.tutorialStep].unplugged)
+            if (!options.tutorialStepInfo[options.tutorialStep].showDialog)
                 document.addEventListener('click', this.closeHint); // add close listener if not modal
             pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
         }
@@ -564,7 +564,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const hasFinish = !lockedEditor && currentStep == maxSteps - 1 && !hideIteration;
         const hasHint = this.hasHint();
         const tutorialCardContent = stepInfo.headerContentMd;
-        const unplugged = stepInfo.unplugged;
+        const showDialog = stepInfo.showDialog;
 
         let tutorialAriaLabel = '',
             tutorialHintTooltip = '';
@@ -575,25 +575,25 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
 
         let hintOnClick = this.hintOnClick;
         // double-click issue on edge when closing hint from tutorial card click
-        if ((pxt.BrowserUtils.isEdge() || pxt.BrowserUtils.isIE()) && this.state.showHint && !unplugged) {
+        if ((pxt.BrowserUtils.isEdge() || pxt.BrowserUtils.isIE()) && this.state.showHint && !showDialog) {
             hintOnClick = null;
         }
 
         const isRtl = pxt.Util.isUserLanguageRtl();
         return <div id="tutorialcard" className={`ui ${tutorialStepExpanded ? 'tutorialExpanded' : ''} ${tutorialReady ? 'tutorialReady' : ''} ${this.state.showSeeMore ? 'seemore' : ''}  ${!this.state.showHint ? 'showTooltip' : ''} ${hasHint ? 'hasHint' : ''}`} style={tutorialStepExpanded ? this.getExpandedCardStyle('height') : null} >
-            {hasHint && this.state.showHint && !unplugged && <div className="mask" role="region" onClick={this.closeHint}></div>}
+            {hasHint && this.state.showHint && !showDialog && <div className="mask" role="region" onClick={this.closeHint}></div>}
             <div className='ui buttons'>
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">
                     <div ref="tutorialmessage" className={`tutorialmessage`} role="alert" aria-label={tutorialAriaLabel} tabIndex={hasHint ? 0 : -1}
                         onClick={hasHint ? hintOnClick : undefined} onKeyDown={hasHint ? sui.fireClickOnEnter : undefined}>
                         <div className="content">
-                            {!unplugged && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
+                            {!showDialog && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
                         </div>
                     </div>
                     <div className="avatar-container">
-                        {(!unplugged && hasHint) && <sui.Button className={`ui circular label blue hintbutton hidelightbox ${hasHint && this.props.pokeUser ? 'shake flash' : ''}`} icon="lightbulb outline" tabIndex={-1} onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter} />}
-                        {(!unplugged && hasHint) && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={hintOnClick} />}
+                        {(!showDialog && hasHint) && <sui.Button className={`ui circular label blue hintbutton hidelightbox ${hasHint && this.props.pokeUser ? 'shake flash' : ''}`} icon="lightbulb outline" tabIndex={-1} onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter} />}
+                        {(!showDialog && hasHint) && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={hintOnClick} />}
                         <TutorialHint ref="tutorialhint" parent={this.props.parent} />
                     </div>
                     {this.state.showSeeMore && !tutorialStepExpanded && <sui.Button className="fluid compact lightgrey" icon="chevron down" tabIndex={0} text={lf("More...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} />}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-minecraft/issues/2017

- `@unplugged` -> `@showdialog`
- `@fullscreen` -> `@showhint`

Also renaming it in the code to avoid confusion. Old flags will still work as before, just improving the naming for future content creators.