### PR TITLE
add example of using handlerStatement to playground

### DIFF
--- a/docs/static/playground/samples/language/events/sample.js
+++ b/docs/static/playground/samples/language/events/sample.js
@@ -4,11 +4,11 @@
 //% color="#AA278D"
 namespace language {
     /**
-     * A simple event taking an function handler
+     * A simple event taking a function handler
      */
     //% block="on event"
     export function onEvent(handler: () => void) {
-
+        handler();
     }
 
     /**
@@ -16,7 +16,7 @@ namespace language {
      */
     //% block="on event with $color"
     export function onEventWithArgs(color: number, handler: () => void) {
-
+        handler();
     }
 
     /**
@@ -25,7 +25,7 @@ namespace language {
     //% block="on rare $handlerArg1 event"
     //% draggableParameters
     export function onEventWithHandlerArgs(handler: (handlerArg: string) => void) {
-
+        handler("Hello world!");
     }
 
     /**
@@ -35,7 +35,7 @@ namespace language {
     //% block="on some event $handlerArg from $arg"
     //% draggableParameters
     export function onEventWithHandlerArgsShuffle(arg: number, handler: (handlerArg: string) => void) {
-
+        handler("Hello world!");
     }
 
     /**
@@ -43,9 +43,19 @@ namespace language {
      * also be special "reporter" blocks that can only be used inside the event
      * handler itself, mimicking the behavior of locally scoped variables.
      */
-    //% block="on some event $handlerArg from $arg"
+    //% block="on some event $handlerStringArg $handlerBoolArg from $arg"
     //% draggableParameters="reporter"
     export function onEventWithHandlerReporterArgs(arg: number, handler: (handlerStringArg: string, handlerBoolArg: boolean) => void) {
+        handler("Hello world", true);
+    }
 
+    /**
+     * Events can be made into statements that can be put in line with other events,
+     * similar to loops or conditions.
+     */
+    //% block="on an inline event"
+    //% handlerStatement
+    export function onEventAsStatement(handler: () => void) {
+        handler();
     }
 }


### PR DESCRIPTION
Add example to the playground using handlerStatement to make an event you can put inline:

![image](https://user-images.githubusercontent.com/5615930/94973049-8addfa00-04bf-11eb-9089-a36509f22c5a.png)

I also made it so each of the examples calls the handlers; something similar to that will need to show up in their block anyways, and someone who's new might not understand how to get the code to actually run / treating a function as a parameter might be non-obvious

This issue did stand out a bit https://github.com/microsoft/pxt-microbit/issues/3303 as it causes the blocks in the toolbox to be reversed from their definitions, which feels odd. I can take a look at what's going on unless we know where / why that happened?
