### PR TITLE
Tick event for 'exiting' a recipe

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3487,7 +3487,7 @@ export class ProjectView
         // custom tick for recipe "completion". recipes use links in the markdown to
         // progress, so we track when a user "exits" a recipe by loading a new one
         if (this.state.header?.tutorial?.tutorialRecipe) {
-            pxt.tickEvent("recipe.exit", { id: this.state.header?.tutorial?.tutorial, goto: tutorialId });
+            pxt.tickEvent("recipe.exit", { tutorial: this.state.header?.tutorial?.tutorial, goto: tutorialId });
         }
 
         core.hideDialog();
@@ -3545,7 +3545,7 @@ export class ProjectView
     }
 
     completeTutorialAsync(): Promise<void> {
-        pxt.tickEvent("tutorial.complete");
+        pxt.tickEvent("tutorial.complete", { tutorial: this.state.header?.tutorial?.tutorial });
         core.showLoading("leavingtutorial", lf("leaving tutorial..."));
 
         // clear tutorial field

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3484,6 +3484,12 @@ export class ProjectView
     }
 
     private startTutorialAsync(tutorialId: string, tutorialTitle?: string, recipe?: boolean, editorProjectName?: string): Promise<void> {
+        // custom tick for recipe "completion". recipes use links in the markdown to
+        // progress, so we track when a user "exits" a recipe by loading a new one
+        if (this.state.header?.tutorial?.tutorialRecipe) {
+            pxt.tickEvent("recipe.exit", { id: this.state.header?.tutorial?.tutorial, goto: tutorialId });
+        }
+
         core.hideDialog();
         core.showLoading("tutorial", lf("starting tutorial..."));
         sounds.initTutorial(); // pre load sounds


### PR DESCRIPTION
Current approach is that "finishing" a recipe is the same as loading a new recipe into a project that already has a recipe open. When users are done with the entire chain of recipes, they would hit the "Finish" button which would be a different tick that represents being done with all the recipes in that progression path.