### PR TITLE
don't log spurious sim url error on localhost

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -92,7 +92,9 @@ namespace pxsim {
                 const simUrl = new URL(this.getSimUrl())
                 this._allowedOrigins.push(simUrl.origin)
             } catch (e) {
-                console.error(`Invalid sim url ${this.getSimUrl()}`)
+                if (!U.isLocalHost()) {
+                    console.error(`Invalid sim url ${this.getSimUrl()}`)
+                }
             }
         }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -92,9 +92,7 @@ namespace pxsim {
                 const simUrl = new URL(this.getSimUrl())
                 this._allowedOrigins.push(simUrl.origin)
             } catch (e) {
-                if (!U.isLocalHost()) {
-                    console.error(`Invalid sim url ${this.getSimUrl()}`)
-                }
+                console.error(`Invalid sim url ${this.getSimUrl()}`)
             }
         }
 
@@ -261,7 +259,7 @@ namespace pxsim {
         }
 
         private getSimUrl(): string {
-            return this.options.simUrl || ((window as any).pxtConfig || {}).simUrl || "/sim/simulator.html"
+            return this.options.simUrl || ((window as any).pxtConfig || {}).simUrl || `${location.origin}/sim/simulator.html`;
         }
 
         public postMessage(msg: pxsim.SimulatorMessage, source?: Window) {


### PR DESCRIPTION
This currently logs an error message on localhost as `new URL("/sim/simulator.html")` is invalid. No functional difference, just avoids an unnecessary error 

I suppose it could also just return before adding any of the _allowedOrigins on localhost since they are ignored here anyways https://github.com/microsoft/pxt/blob/981db6465023458f99506bf73be4cb57b8013c40/pxtsim/simdriver.ts#L626-L630 but that feels like a bug waiting to happen if someone wants to add something to the simdriver constructor in the future


edit: I suppose this also closes https://github.com/microsoft/pxt-microbit/issues/3410 now ~