### PR TITLE
use react@16.3 unsafe aliases for componentWill(Mount|ReceiveProps|Update)

### DIFF
--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -54,7 +54,7 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
         this.props.parent.showExitAndSaveDialog();
     }
 
-    componentWillReceiveProps(nextProps: EditorAccessibilityMenuProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: EditorAccessibilityMenuProps) {
         const newState: EditorAccessibilityMenuState = {};
         if (nextProps.highContrast != undefined) {
             newState.highContrast = nextProps.highContrast;
@@ -123,7 +123,7 @@ export class HomeAccessibilityMenu extends data.Component<HomeAccessibilityMenuP
         this.props.parent.toggleHighContrast();
     }
 
-    componentWillReceiveProps(nextProps: HomeAccessibilityMenuProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: HomeAccessibilityMenuProps) {
         const newState: HomeAccessibilityMenuState = {};
         if (nextProps.highContrast != undefined) {
             newState.highContrast = nextProps.highContrast;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -798,7 +798,7 @@ export class ProjectView
         this.editor = this.allEditors[this.allEditors.length - 1]
     }
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         this.initEditors()
         this.initDragAndDrop();
     }

--- a/webapp/src/carousel.tsx
+++ b/webapp/src/carousel.tsx
@@ -59,7 +59,7 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
         this.onRightArrowClick = this.onRightArrowClick.bind(this);
     }
 
-    componentWillReceiveProps(nextProps: ICarouselProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: ICarouselProps) {
         if (nextProps.selectedIndex != undefined) {
             this.setIndex(nextProps.selectedIndex);
         }

--- a/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
+++ b/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
@@ -133,7 +133,7 @@ class TilePaletteImpl extends React.Component<TilePaletteProps,{}> {
         this.redrawCanvas();
     }
 
-    componentWillReceiveProps(nextProps: TilePaletteProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: TilePaletteProps) {
         if (this.props.selected != nextProps.selected) {
             this.jumpToPageContaining(nextProps.selected);
         } else if (this.props.backgroundColor != nextProps.backgroundColor) {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -233,7 +233,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         }
     }
 
-    componentWillReceiveProps(nextProps: SettingsMenuProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: SettingsMenuProps) {
         const newState: SettingsMenuState = {};
         if (nextProps.highContrast != undefined) {
             newState.highContrast = nextProps.highContrast;
@@ -687,7 +687,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
         }
     }
 
-    componentWillReceiveProps(nextProps: SideDocsProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: SideDocsProps) {
         const newState: SideDocsState = {};
         if (nextProps.sideDocsCollapsed != undefined) {
             newState.sideDocsCollapsed = nextProps.sideDocsCollapsed;

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -146,7 +146,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
         }, 0);
     }
 
-    componentWillUpdate(nextProps: any, nextState: ExtensionsState) {
+    UNSAFE_componentWillUpdate(nextProps: any, nextState: ExtensionsState) {
         if (nextState.extension && nextState.visible) {
             // Start rendering the iframe earlier
             const frame = Extensions.getFrame(nextState.extension, true);

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -33,7 +33,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
         this.navigateToError = this.navigateToError.bind(this);
     }
 
-    componentWillReceiveProps(nextProps: ISettingsProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: ISettingsProps) {
         const currentFile = nextProps.parent.state.currFile;
         // Set the current package as expanded
         if (this.state.currentFile != currentFile) {

--- a/webapp/src/hinttooltip.tsx
+++ b/webapp/src/hinttooltip.tsx
@@ -19,7 +19,7 @@ export class HintTooltip extends data.Component<HintTooltipProps, HintTooltipSta
         super(props);
     }
 
-    componentWillReceiveProps(nextProps: HintTooltipProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: HintTooltipProps) {
         if (nextProps.pokeUser != this.state.show) {
             this.setState({ show: nextProps.pokeUser });
         }

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -359,7 +359,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
         this.renderMarkdown(markdown);
     }
 
-    componentWillReceiveProps(newProps: MarkedContentProps) {
+    UNSAFE_componentWillReceiveProps(newProps: MarkedContentProps) {
         const { markdown } = newProps;
         if (this.props.markdown != newProps.markdown) {
             this.renderMarkdown(markdown);

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -536,7 +536,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
         e.preventDefault();
     }
 
-    componentWillReceiveProps(nextProps?: ProjectsCarouselProps) {
+    UNSAFE_componentWillReceiveProps(nextProps?: ProjectsCarouselProps) {
         if (nextProps.selectedIndex != undefined) {
             document.addEventListener('keydown', this.closeDetailOnEscape);
         }

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -164,7 +164,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         }
     }
 
-    componentWillReceiveProps(newProps: ShareEditorProps) {
+    UNSAFE_componentWillReceiveProps(newProps: ShareEditorProps) {
         const newState: ShareEditorState = {}
         if (!this.state.projectNameChanged &&
             newProps.parent.state.projectName != this.state.projectName) {

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -709,7 +709,7 @@ export class Input extends data.Component<InputProps, InputState> {
         }
     }
 
-    componentWillReceiveProps(newProps: InputProps) {
+    UNSAFE_componentWillReceiveProps(newProps: InputProps) {
         this.setState({ value: newProps.value });
     }
 

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -264,7 +264,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         parent.moveFocusToFlyout();
     }
 
-    componentWillReceiveProps(props: ToolboxProps) {
+    UNSAFE_componentWillReceiveProps(props: ToolboxProps) {
         // if leaving monaco, mark toolbox animation as shown. also
         // handles full screen sim, where we hide the toolbox via css
         // without re-rendering, which will trigger the animation again
@@ -523,7 +523,7 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
         return this.treeRowElement;
     }
 
-    componentWillReceiveProps(nextProps: CategoryItemProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: CategoryItemProps) {
         const newState: CategoryItemState = {};
         if (nextProps.selected != undefined) {
             newState.selected = nextProps.selected;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -385,7 +385,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.props.parent.hideLightbox();
     }
 
-    componentWillUpdate() {
+    UNSAFE_componentWillUpdate() {
         document.documentElement.addEventListener("keydown", this.closeLightboxOnEscape);
     }
 
@@ -615,7 +615,7 @@ export class WorkspaceHeader extends data.Component<any, {}> {
         super(props);
     }
 
-    componentWillUpdate() {
+    UNSAFE_componentWillUpdate() {
         let flyout = document.querySelector('.blocklyFlyout');
         if (flyout) {
             this.flyoutWidth = flyout.clientWidth;


### PR DESCRIPTION
Whenever you load a page on a dev build of react (localhost, uploadtrg), these flood the console with warnings that the methods aren't ideal. This makes it easy to miss other warnings / errors, and it's just not ideal to get used to ignoring warnings :). This should remove all but these two instances of the warning:

![image](https://user-images.githubusercontent.com/5615930/95258992-5c239480-07db-11eb-9f48-90080b50769d.png)

as those will require updating our version of `react-modal`, and there have been a number of minor bumps in that package since our current version / would require more testing, where this is just a quick renaming.

These are usually easy enough to fix to use other recommended apis, but generally that require a bit of context / more changes than just a rename, so I figured just swapping them over to start / acknowledge the warning was good.

Worth a note, the `UNSAFE_` prefix is about likelihood for bugs, not an indication of any particular issue / etc. Details https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html