### PR TITLE
Don't infinite load when on error in loading path

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -865,6 +865,10 @@ export class ProjectView
 
     // Add an error guard for the entire application
     componentDidCatch(error: any, info: any) {
+        this.handleCriticalError(error, info);
+    }
+
+    handleCriticalError(error: any, info?: any) {
         try {
             core.killLoadingQueue();
             pxsim.U.remove(document.getElementById('loading'));
@@ -872,10 +876,10 @@ export class ProjectView
             // Log critical error
             pxt.tickEvent('pxt.criticalerror', { error: error || '', info: info || '' });
             // Reload the page in 2 seconds
-            const lastCriticalError = pxt.storage.getLocal("lastcriticalerror") ?
-                Date.parse(pxt.storage.getLocal("lastcriticalerror")) : Date.now();
+            const lastCriticalError = pxt.storage.getLocal("lastcriticalerror") &&
+                Date.parse(pxt.storage.getLocal("lastcriticalerror"));
             // don't refresh if we refreshed in the last minute
-            if (!lastCriticalError || (!isNaN(lastCriticalError) && Date.now() - lastCriticalError > 60 * 1000)) {
+            if (!lastCriticalError || isNaN(lastCriticalError) || Date.now() - lastCriticalError > 60 * 1000) {
                 pxt.storage.setLocal("lastcriticalerror", new Date().toISOString());
                 setTimeout(() => {
                     this.reloadEditor();
@@ -4544,11 +4548,15 @@ document.addEventListener("DOMContentLoaded", () => {
             else theEditor.newProject();
             return Promise.resolve();
         })
+        .catch(e => {
+            theEditor.handleCriticalError(e, "Failure in DOM loaded handler");
+            throw e;
+        })
         .then(() => {
             pxsim.U.remove(document.getElementById('loading'));
             return workspace.loadedAsync();
         })
-        .done()
+        .done();
 
     document.addEventListener("visibilitychange", ev => {
         if (theEditor)

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -481,6 +481,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private prepareBlockly(forceHasCategories?: boolean) {
         pxt.perf.measureStart("prepareBlockly")
         let blocklyDiv = document.getElementById('blocksEditor');
+        if (!blocklyDiv)
+            return;
         pxsim.U.clear(blocklyDiv);
         this.editor = Blockly.inject(blocklyDiv, this.getBlocklyOptions(forceHasCategories)) as Blockly.WorkspaceSvg;
         const hasCategories = (this.editor.options as any).hasCategories;


### PR DESCRIPTION
If we hit an error while loading in the DOMContentLoaded event, right now we just infinite load in the home screen. These aren't necessarily recoverable -- e.g. the case this last came up in was a crash in the targets editor/extension.ts's `initExtensionsAsync` (https://github.com/microsoft/pxt-minecraft/pull/2031), and a failure there will mean editor specific behavior didn't get loaded / something is very wrong.

It uses the same one as when the main app fails to load, which pops this message and tries to refresh once in case the error was just random.

![image](https://user-images.githubusercontent.com/5615930/95375214-2989a280-0894-11eb-9795-1cfcc92274db.png)

A few small fixes along the way, I'll add a few comments pointing at them