### PR TITLE
fixes for error reporting on block localizations

### DIFF
--- a/cli/crowdin.ts
+++ b/cli/crowdin.ts
@@ -182,7 +182,6 @@ export async function buildAllTranslationsAsync(langToStringsHandlerAsync: (file
         const crowdinDir = pxt.appTarget.id;
         const locs: pxt.Map<pxt.Map<string>> = {};
         for (const filePath of files) {
-            const errors: pxt.Map<number> = {};
             const fn = path.basename(filePath);
             const crowdf = path.join(crowdinDir, fn);
             const locdir = path.dirname(filePath);
@@ -195,32 +194,12 @@ export async function buildAllTranslationsAsync(langToStringsHandlerAsync: (file
                 if (!dataLang || !stringifyTranslations(dataLang))
                     continue;
 
-                // validate translations
-                if (/-strings\.json$/.test(fn) && !/jsdoc-strings\.json$/.test(fn)) {
-                    // block definitions
-                    for (const id of Object.keys(dataLang)) {
-                        const tr = dataLang[id];
-                        pxt.blocks.normalizeBlock(tr, err => {
-                            const errid = `${fn}.${lang}`;
-                            errors[`${fn}.${lang}`] = 1;
-                            pxt.log(`error ${errid}: ${err}`);
-                        });
-                    }
-                }
-
                 // merge translations
                 let strings = locs[lang];
                 if (!strings) strings = locs[lang] = {};
                 Object.keys(dataLang)
                     .filter(k => !!dataLang[k] && !strings[k])
                     .forEach(k => strings[k] = dataLang[k]);
-            }
-
-            const errorIds = Object.keys(errors);
-            if (errorIds.length) {
-                pxt.log(`${errorIds.length} errors`);
-                errorIds.forEach(blockid => pxt.log(`error in ${blockid}`));
-                pxt.reportError("loc.errors", "invalid translation", errors);
             }
         }
 

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -82,15 +82,15 @@ namespace pxt.blocks {
         if (!b) return b;
         // normalize and validate common errors
         // made while translating
-        let nb = b.replace(/[^\\]%\s+/g, '%');
+        let nb = b.replace(/(?:^|[^\\])([%$])\s+/g, '$1');
         if (nb != b) {
             err(`block has extra spaces: ${b}`);
-            return b;
+            b = nb;
         }
 
         // remove spaces around %foo = ==> %foo=
         b = nb;
-        nb = b.replace(/(%\w+)\s*=\s*(\w+)/, '$1=$2');
+        nb = b.replace(/([%$]\w+)\s*=\s*(\w+)/, '$1=$2');
         if (nb != b) {
             err(`block has space between %name and = : ${b}`)
             b = nb;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -686,11 +686,13 @@ namespace ts.pxtc {
             })))
             .then(() => cleanLocalizations(apis))
             .finally(() => {
-                if (errors.length)
+                for (const bId of errors) {
                     pxt.reportError(`loc.errors`, `invalid translations`, {
-                        blockIds: errors.join("|"),
+                        block: bId,
                         lang: lang,
                     });
+                }
+
             })
     }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -610,7 +610,6 @@ namespace ts.pxtc {
         const lang = pxtc.Util.userLanguage();
         if (pxtc.Util.userLanguage() == "en") return Promise.resolve(cleanLocalizations(apis));
 
-        const errors: string[] = [];
         const langLower = lang.toLowerCase();
         const attrJsLocsKey = langLower + "|jsdoc";
         const attrBlockLocsKey = langLower + "|block";
@@ -674,7 +673,10 @@ namespace ts.pxtc {
                             const locps = pxt.blocks.compileInfo(fn);
                             if (!hasEquivalentParameters(ps, locps)) {
                                 pxt.log(`block has non matching arguments: ${oldBlock} vs ${fn.attributes.block}`);
-                                errors.push(fn.attributes.blockId);
+                                pxt.reportError(`loc.errors`, `invalid translations`, {
+                                    block: fn.attributes.blockId,
+                                    lang: lang,
+                                });
                                 fn.attributes.block = oldBlock;
                                 updateBlockDef(fn.attributes);
                             }
@@ -685,15 +687,6 @@ namespace ts.pxtc {
                 })
             })))
             .then(() => cleanLocalizations(apis))
-            .finally(() => {
-                for (const bId of errors) {
-                    pxt.reportError(`loc.errors`, `invalid translations`, {
-                        block: bId,
-                        lang: lang,
-                    });
-                }
-
-            })
     }
 
     function cleanLocalizations(apis: ApisInfo) {


### PR DESCRIPTION
Right now we're getting a ton of errors from these that aren't easily investigated, as it's sending each block id as a separate property in the object, and sending the error in a lot of cases where we actually fix the block. 

two fixes for the errors:

* Send a tick event instead of an error when `normalizeBlock` has modified a block -- this isn't really an error case as we are theoretically fixing these with the replaces, so if it parses properly through the `hasEquivalentParameters` check below then in theory the block is fine / just trivia differences

* changing the shape of the error reporting - I believe these should be easier to investigate, as we can get all the info we need to find the errors from the target, version, & language id as that's enough to load in and view the errors in the console (I also included the broken block id as a pipe delimited list)

Also drops the logic from cli/crowdin; this wasn't actually changing the blocks, and these will get the ticks sent whenever users load them. Can add them back in with the tickevent behavior in pxtlib/service.ts if we still want to send those tickevents when packaging the app instead of on use.

also a few minor fixes to block normalization logic, will add notes explaining inline