### PR TITLE
fixes for idb workspaces

### DIFF
--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -97,6 +97,7 @@ export class Table {
                 pxt.log(`table: set failed, cleaning translation db`)
                 // clean up translation and try again
                 return pxt.BrowserUtils.clearTranslationDbAsync()
+                    .then(() => pxt.BrowserUtils.clearTutorialInfoDbAsync())
                     .then(() => this.setAsyncNoRetry(obj))
                     .catch(e => {
                         pxt.reportException(e);

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -22,39 +22,32 @@ let _db: pxt.BrowserUtils.IDBWrapper;
 
 // This function migrates existing projectes in pouchDb to indexDb
 // From browserworkspace to idbworkspace
-function migrateBrowserWorkspaceAsync(): Promise<void> {
-    return getDbAsync()
-        .then((db) => {
-            return db.getAllAsync<pxt.workspace.Header>(HEADERS_TABLE);
-        })
-        .then((allDbHeaders) => {
-                if (allDbHeaders.length) {
-                    // There are already scripts using the idbworkspace, so a migration has already happened
-                    return Promise.resolve();
-                }
+async function migrateBrowserWorkspaceAsync(): Promise<void> {
+    const db = await getDbAsync();
+    const allDbHeaders = await db.getAllAsync<pxt.workspace.Header>(HEADERS_TABLE);
+    if (allDbHeaders.length) {
+        // There are already scripts using the idbworkspace, so a migration has already happened
+        return;
+    }
 
-                const copyProject = (h: pxt.workspace.Header): Promise<string> => {
-                    return browserworkspace.provider.getAsync(h)
-                        .then((resp) => {
-                            // Ignore metadata of the previous script so they get re-generated for the new copy
-                            delete (<any>h)._id;
-                            delete (<any>h)._rev;
-                            return setAsync(h, undefined, resp.text);
-                        })
-                };
+    const copyProject = async (h: pxt.workspace.Header): Promise<string> => {
+        const resp = await browserworkspace.provider.getAsync(h);
 
-                return browserworkspace.provider.listAsync()
-                    .then((previousHeaders: pxt.workspace.Header[]) => {
-                        return Promise.map(previousHeaders, (h) => copyProject(h));
-                    })
-                    .then(() => { });
-        });
+        // Ignore metadata of the previous script so they get re-generated for the new copy
+        delete (resp as any)._id;
+        delete (resp as any)._rev;
 
+        return setAsync(h, undefined, resp.text);
+    };
+
+    const previousHeaders = await browserworkspace.provider.listAsync();
+
+    await Promise.all(previousHeaders.map(h => copyProject(h)));
 }
 
-function getDbAsync(): Promise<pxt.BrowserUtils.IDBWrapper> {
+async function getDbAsync(): Promise<pxt.BrowserUtils.IDBWrapper> {
     if (_db) {
-        return Promise.resolve(_db);
+        return _db;
     }
 
     _db = new pxt.BrowserUtils.IDBWrapper("__pxt_idb_workspace", 1, (ev, r) => {
@@ -63,71 +56,58 @@ function getDbAsync(): Promise<pxt.BrowserUtils.IDBWrapper> {
         db.createObjectStore(HEADERS_TABLE, { keyPath: KEYPATH });
     });
 
-    return _db.openAsync()
-        .catch((e) => {
-            pxt.reportException(e);
-            return Promise.reject(e);
-        })
-        .then(() => _db);
+    try {
+        await _db.openAsync();
+    } catch (e) {
+        pxt.reportException(e);
+        return Promise.reject(e);
+    }
+
+    return _db;
 }
 
-function listAsync(): Promise<pxt.workspace.Header[]> {
-    return migrateBrowserWorkspaceAsync()
-        .then (() => {
-            return getDbAsync();
-        })
-        .then((db) => {
-            return db.getAllAsync<pxt.workspace.Header>(HEADERS_TABLE);
-        });
+async function listAsync(): Promise<pxt.workspace.Header[]> {
+    await migrateBrowserWorkspaceAsync();
+    const db = await getDbAsync();
+    return db.getAllAsync<pxt.workspace.Header>(HEADERS_TABLE);
 }
 
-function getAsync(h: Header): Promise<pxt.workspace.File> {
-    return getDbAsync()
-        .then((db) => {
-            return db.getAsync<StoredText>(TEXTS_TABLE, h.id);
-        })
-        .then((res) => {
-            return Promise.resolve({
-                header: h,
-                text: res.files,
-                version: res._rev
-            });
-        });
+async function getAsync(h: Header): Promise<pxt.workspace.File> {
+    const db = await getDbAsync();
+    const res = await db.getAsync<StoredText>(TEXTS_TABLE, h.id);
+    return {
+        header: h,
+        text: res.files,
+        version: res._rev
+    };
 }
 
-function setAsync(h: Header, prevVer: any, text?: ScriptText): Promise<pxt.workspace.Version> {
-    return getDbAsync()
-        .then((db) => {
-            const dataToStore: StoredText = {
-                id: h.id,
-                files: text,
-                _rev: prevVer
-            };
-            return (text ? db.setAsync(TEXTS_TABLE, dataToStore) : Promise.resolve())
-                .then(() => {
-                    return db.setAsync(HEADERS_TABLE, h);
-                });
-        });
+// TODO: this return type is very misleading; pxt.workspace.Version is any so this is accepting a void return
+async function setAsync(h: Header, prevVer: any, text?: ScriptText): Promise<pxt.workspace.Version> {
+    const db = await getDbAsync();
+    const dataToStore: StoredText = {
+        id: h.id,
+        files: text,
+        _rev: prevVer
+    };
+
+    if (text) {
+        await db.setAsync(TEXTS_TABLE, dataToStore);
+    }
+
+    await db.setAsync(HEADERS_TABLE, h);
 }
 
-function deleteAsync(h: Header, prevVer: any): Promise<void> {
-    return getDbAsync()
-        .then((db) => {
-            return db.deleteAsync(TEXTS_TABLE, h.id)
-                .then(() => {
-                    return db.deleteAsync(HEADERS_TABLE, h.id);
-                });
-        });
+async function deleteAsync(h: Header, prevVer: any): Promise<void> {
+    const db = await getDbAsync();
+    await db.deleteAsync(TEXTS_TABLE, h.id);
+    await db.deleteAsync(HEADERS_TABLE, h.id);
 }
 
-function resetAsync(): Promise<void> {
-    return getDbAsync()
-        .then((db) => {
-            return db.deleteAllAsync(TEXTS_TABLE)
-                .then(() => {
-                    return db.deleteAllAsync(HEADERS_TABLE);
-                });
-        });
+async function resetAsync(): Promise<void> {
+    const db = await getDbAsync();
+    await db.deleteAllAsync(TEXTS_TABLE);
+    await db.deleteAllAsync(HEADERS_TABLE);
 }
 
 export const provider: WorkspaceProvider = {

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -103,7 +103,7 @@ async function setAsync(h: Header, prevVer: any, text?: ScriptText): Promise<voi
         }
 
         pxt.reportException(e);
-        pxt.log(`idb: set failed, cleaning cached dbs`)
+        pxt.log(`idb: set failed, cleaning cache dbs`);
 
         // clean up cache dbs and try again
         await pxt.BrowserUtils.clearTranslationDbAsync();

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -58,6 +58,9 @@ async function getDbAsync(): Promise<pxt.BrowserUtils.IDBWrapper> {
             const db = r.result as IDBDatabase;
             db.createObjectStore(TEXTS_TABLE, { keyPath: KEYPATH });
             db.createObjectStore(HEADERS_TABLE, { keyPath: KEYPATH });
+        }, async () => {
+            await pxt.BrowserUtils.clearTranslationDbAsync();
+            await pxt.BrowserUtils.clearTutorialInfoDbAsync();
         });
 
         try {

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -86,7 +86,7 @@ async function setAsync(h: Header, prevVer: any, text?: ScriptText): Promise<voi
     const db = await getDbAsync();
 
     try {
-        setCoreAsync(db, h, prevVer, text);
+        await setCoreAsync(db, h, prevVer, text);
     } catch (e) {
         if (e.status == 409) {
             // conflict while writing key, ignore.
@@ -102,16 +102,13 @@ async function setAsync(h: Header, prevVer: any, text?: ScriptText): Promise<voi
         await pxt.BrowserUtils.clearTutorialInfoDbAsync();
 
         try {
-            return await setCoreAsync(db, h, prevVer, text);
+            await setCoreAsync(db, h, prevVer, text);
         } catch (e) {
             pxt.reportException(e, {
-                db: "idb",
+                ws: "idb",
             });
-            pxt.log(`idb: we are out of space...`)
-            // TODO: We should probably catch this failure in workspace.ts && switch to in mem db;
-            // there's no obvious way that we can recover here if there's no more room.
-            // Maybe toast notification to the user and still allow fetching from here.
-            return;
+            pxt.log(`idb: we are out of space...`);
+            throw e;
         }
     }
 

--- a/webapp/src/idbworkspace.ts
+++ b/webapp/src/idbworkspace.ts
@@ -30,14 +30,14 @@ async function migrateBrowserWorkspaceAsync(): Promise<void> {
         return;
     }
 
-    const copyProject = async (h: pxt.workspace.Header): Promise<string> => {
+    const copyProject = async (h: pxt.workspace.Header): Promise<void> => {
         const resp = await browserworkspace.provider.getAsync(h);
 
         // Ignore metadata of the previous script so they get re-generated for the new copy
         delete (resp as any)._id;
         delete (resp as any)._rev;
 
-        return setAsync(h, undefined, resp.text);
+        await setAsync(h, undefined, resp.text);
     };
 
     const previousHeaders = await browserworkspace.provider.listAsync();
@@ -82,8 +82,7 @@ async function getAsync(h: Header): Promise<pxt.workspace.File> {
     };
 }
 
-// TODO: this return type is very misleading; pxt.workspace.Version is any so this is accepting a void return
-async function setAsync(h: Header, prevVer: any, text?: ScriptText): Promise<pxt.workspace.Version> {
+async function setAsync(h: Header, prevVer: any, text?: ScriptText): Promise<void> {
     const db = await getDbAsync();
 
     try {

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -90,17 +90,13 @@ export function setupWorkspace(id: string) {
     }
 }
 
-function switchToMemoryWorkspace(reason: string = "syncerror") {
-    if (impl === memoryworkspace.provider) {
-        return;
-    }
-
+function switchToMemoryWorkspace(reason: string) {
     pxt.tickEvent(`workspace.syncerror`, {
         ws: implType,
         reason: reason
     });
 
-    pxt.log("workspace: error, switching to memory workspace");
+    pxt.log(`workspace: error, switching from ${implType} to memory workspace`);
     impl = memoryworkspace.provider;
 }
 


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-minecraft/issues/1936
closes https://github.com/microsoft/pxt-minecraft/issues/1893

Handful of fixes for idb workspaces (I awaitified it in the first commit as I was reading through all the code to make sure I had context on everything).

* If we fail to write in idb workspace, try again after clearing translation / tutorial info caches to clear up some room. This behavior is largely the same as https://github.com/microsoft/pxt/blob/76381d21d3f3574e7bd1bee1459e80af2dea9690/webapp/src/db.ts#L84
* If writing still fails, we're out of space / something is wrong and we can't continue to store stuff. bubble up the error to workspace `saveAsync`, and transition to using the in memory db so it at least works for the session / e.g. you can at least load tutorials still. (this is the fix for 1936 above).
* Fix race condition in getDbAsync -- This was immediately setting `_db`, and then going on to open it in a promise; if something else tried called `getDbAsync` it would get immediate access, potentially before `openAsync` finished. Worth a note it looks like we have a similar problem in db.ts (though I don't think this one breaks anything really): https://github.com/microsoft/pxt/blob/76381d21d3f3574e7bd1bee1459e80af2dea9690/webapp/src/db.ts#L43
This one defers setting it at until after the test get is complete, so it's possible multiple pouchdbs will get instantiated simultaneously / could probably be better of storing memoryDb if there's an error here. Can look at that more, but didn't want to make this PR any bigger right away.

I think it's worth discussing the in memory db behavior in a design meeting; feels like there needs to be some way we can convey that they need to make other plans to persist their projects -- at least something like an icon maybe? 