### PR TITLE
Additional telemetry data for various tutorial ticks

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1439,7 +1439,7 @@ export class ProjectView
             })
             .catch(e => {
                 // Failed to decompile
-                pxt.tickEvent('tutorial.faileddecompile', { tutorialId: t.tutorial });
+                pxt.tickEvent('tutorial.faileddecompile', { tutorial: t.tutorial });
                 core.errorNotification(lf("Oops, an error occured as we were loading the tutorial."));
                 // Reset state (delete the current project and exit the tutorial)
                 this.exitTutorial(true);
@@ -3532,14 +3532,19 @@ export class ProjectView
     }
 
     startActivity(activity: pxt.editor.Activity, path: string, title?: string, editorProjectName?: string, focus = true) {
-        pxt.tickEvent(activity + ".start", { activity, path, editor: editorProjectName });
         switch (activity) {
             case "tutorial":
-                this.startTutorialAsync(path, title, false, editorProjectName); break;
+                pxt.tickEvent("tutorial.start", { tutorial: path, editor: editorProjectName });
+                this.startTutorialAsync(path, title, false, editorProjectName);
+                break;
             case "recipe":
-                this.startTutorialAsync(path, title, true, editorProjectName); break;
+                pxt.tickEvent("recipe.start", { recipe: path, editor: editorProjectName });
+                this.startTutorialAsync(path, title, true, editorProjectName);
+                break;
             case "example":
-                this.importExampleAsync({ name, path, loadBlocks: false, preferredEditor: editorProjectName }); break;
+                pxt.tickEvent("example.start", { example: path, editor: editorProjectName });
+                this.importExampleAsync({ name, path, loadBlocks: false, preferredEditor: editorProjectName });
+                break;
         }
         this.textEditor.giveFocusOnLoading = focus;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3365,7 +3365,7 @@ export class ProjectView
                     return processMarkdown(md);
                 });
         } else if (scriptId) {
-            pxt.tickEvent("tutorial.shared");
+            pxt.tickEvent("tutorial.shared", { tutorial: scriptId });
             p = workspace.downloadFilesByIdAsync(scriptId)
                 .then(files => {
                     const pxtJson = pxt.Package.parseAndValidConfig(files["pxt.json"]);
@@ -3532,7 +3532,7 @@ export class ProjectView
     }
 
     startActivity(activity: pxt.editor.Activity, path: string, title?: string, editorProjectName?: string, focus = true) {
-        pxt.tickEvent(activity + ".start", { editor: editorProjectName });
+        pxt.tickEvent(activity + ".start", { activity, path, editor: editorProjectName });
         switch (activity) {
             case "tutorial":
                 this.startTutorialAsync(path, title, false, editorProjectName); break;
@@ -3588,7 +3588,7 @@ export class ProjectView
     }
 
     exitTutorial(removeProject?: boolean) {
-        pxt.tickEvent("tutorial.exit");
+        pxt.tickEvent("tutorial.exit", { tutorial: this.state.header?.tutorial?.tutorial });
         core.showLoading("leavingtutorial", lf("leaving tutorial..."));
         const tutorial = this.state.header && this.state.header.tutorial;
         const stayInEditor = tutorial && !!tutorial.tutorialRecipe;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -491,9 +491,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
     }
 
     exitTutorial() {
-        pxt.tickEvent("menu.exitTutorial", undefined, { interactiveConsent: true });
-        if (this.props.parent.state.tutorialOptions
-            && this.props.parent.state.tutorialOptions.tutorialRecipe)
+        const tutorialOptions = this.props.parent.state.tutorialOptions;
+        pxt.tickEvent("menu.exitTutorial", { tutorial: tutorialOptions?.tutorial }, { interactiveConsent: true });
+        if (tutorialOptions?.tutorialRecipe)
             this.props.parent.completeTutorialAsync().done();
         else
             this.props.parent.exitTutorial();


### PR DESCRIPTION
- `tutorial.start` will have `{ activity: ["tutorial"|"recipe"|"example"], path: "/tutorials/chase-the-pizza", editor: ["blocksprj"|"tsprj"|"pyprj"] }`
- `tutorial.shared` has the script id under "tutorial"
- `tutorial.faileddecompile` (not modified in this PR) has the tutorial name/path under "tutorialId"

@abchatra do we want the "tutorial id" dimension to have the same key in all of our ticks? not sure if it matters