### PR TITLE
don't broadcast random messages to iframes + dev token fix

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -269,10 +269,11 @@ namespace pxsim {
             }
 
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
-            const depEditors = this.dependentEditors();
-            let frames = this.simFrames();
-            const simUrl = U.isLocalHost() ? "*" : this.getSimUrl();
             if (source && broadcastmsg && !!broadcastmsg.broadcast) {
+                const depEditors = this.dependentEditors();
+                let frames = this.simFrames();
+                const simUrl = U.isLocalHost() ? "*" : this.getSimUrl();
+
                 // the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const parentWindow = window.parent && window.parent !== window.window
@@ -298,22 +299,22 @@ namespace pxsim {
                         this.startFrame(frames[1]);
                     }
                 }
-            }
 
-            // dispatch message to other frames
-            for (let i = 0; i < frames.length; ++i) {
-                const frame = frames[i] as HTMLIFrameElement
-                // same frame as source
-                if (source && frame.contentWindow == source) continue;
-                // frame not in DOM
-                if (!frame.contentWindow) continue;
+                // dispatch message to other frames
+                for (let i = 0; i < frames.length; ++i) {
+                    const frame = frames[i] as HTMLIFrameElement
+                    // same frame as source
+                    if (source && frame.contentWindow == source) continue;
+                    // frame not in DOM
+                    if (!frame.contentWindow) continue;
 
-                frame.contentWindow.postMessage(msg, simUrl);
+                    frame.contentWindow.postMessage(msg, simUrl);
 
-                // don't start more than 1 recorder
-                if (msg.type == 'recorder'
-                    && (<pxsim.SimulatorRecorderMessage>msg).action == "start")
-                    break;
+                    // don't start more than 1 recorder
+                    if (msg.type == 'recorder'
+                        && (<pxsim.SimulatorRecorderMessage>msg).action == "start")
+                        break;
+                }
             }
         }
 

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -118,7 +118,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
                 </ol>}
                 {useToken && <div className="ui field">
                     <label id="selectUrlToOpenLabel">{lf("Paste GitHub token here:")}</label>
-                    <input type="url" tabIndex={0} autoFocus aria-labelledby="selectUrlToOpenLabel" placeholder="0123abcd..." className="ui blue fluid"></input>
+                    <input id="githubTokenInput" type="url" tabIndex={0} autoFocus aria-labelledby="selectUrlToOpenLabel" placeholder="0123abcd..." className="ui blue fluid"></input>
                 </div>}
             </div>,
         }).then(res => {
@@ -127,8 +127,8 @@ export class GithubProvider extends cloudsync.ProviderBase {
                 return Promise.resolve()
             } else {
                 if (useToken) {
-                    const input = form.querySelectorAll('input')[0] as HTMLInputElement;
-                    const hextoken = input.value.trim();
+                    const input = form.querySelector(`#githubTokenInput`) as HTMLInputElement;
+                    const hextoken = input?.value?.trim();
                     return this.saveAndValidateTokenAsync(hextoken, rememberMe);
                 }
                 else {


### PR DESCRIPTION
- [x] when receiving messages, make sure to only broadcast message that have .broadcast = true. Not every messages like react debugging stuff...
- [x] dev token lookup is broken due to "remember me " feature. We used to lookup the first input in the dialog.