### PR TITLE
keep stable id for board

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -281,7 +281,8 @@ namespace pxsim {
         messageListeners: MessageListener[] = [];
 
         constructor() {
-            this.id = "b" + Math.round(Math.random() * 2147483647);
+            // use a stable board id
+            this.id = Embed.frameid || ("b" + Math.round(Math.random() * 2147483647));
             this.bus = new pxsim.EventBus(runtime);
         }
 


### PR DESCRIPTION
Instead of generating a new board id on each run, keep a stable number. The board id is used to infer the deviceSerialNumber and it reallys annoys JACDAC to have a new device each time MakeCode restarts the simulator.