### PR TITLE
 Add 'Edit', 'Create' asset functionality, tilemap preview

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -238,7 +238,7 @@ namespace pxtblockly {
                         dataURI = bitmapToImageURI(pxt.sprite.Bitmap.fromData(this.asset.frames[0]), PREVIEW_WIDTH, this.lightMode);
                         break;
                     case pxt.AssetType.Tilemap:
-                        dataURI = tilemapToImageURI(this.asset.data, PREVIEW_WIDTH, this.lightMode, this.blocksInfo);
+                        dataURI = tilemapToImageURI(this.asset.data, PREVIEW_WIDTH, this.lightMode);
                         break;
                 }
                 const img = new svg.Image()

--- a/pxtblocks/fields/field_utils.ts
+++ b/pxtblocks/fields/field_utils.ts
@@ -69,7 +69,7 @@ namespace pxtblockly {
         return canvas.toDataURL();
     }
 
-    export function tilemapToImageURI(data: pxt.sprite.TilemapData, sideLength: number, lightMode: boolean, blocksInfo: pxtc.BlocksInfo) {
+    export function tilemapToImageURI(data: pxt.sprite.TilemapData, sideLength: number, lightMode: boolean) {
         const colors = pxt.appTarget.runtime.palette.slice();
         const canvas = document.createElement("canvas");
         canvas.width = sideLength;

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -286,6 +286,7 @@ namespace pxt {
         }
 
         protected generateNewDisplayName(prefix: string) {
+            prefix = prefix.replace(/\d+$/, "");
             let index = 0;
             while (this.takenNames[prefix + index]) {
                 ++index;
@@ -768,19 +769,24 @@ namespace pxt {
             this.onChange();
             const newAsset = cloneAsset(asset);
             newAsset.internalID = this.getNewInternalId();
-            const name = newAsset.id.substr(newAsset.id.lastIndexOf(".") + 1).replace(/\d*$/, "");
+            const id = newAsset.id.substr(newAsset.id.lastIndexOf(".") + 1).replace(/\d*$/, "");
+            if (!newAsset.meta?.displayName) {
+                if (!newAsset.meta) newAsset.meta = {};
+                newAsset.meta.displayName = id;
+            }
+
             switch (newAsset.type) {
                 case AssetType.Image:
-                    newAsset.id = this.generateNewID(AssetType.Image, name, pxt.sprite.IMAGES_NAMESPACE);
+                    newAsset.id = this.generateNewID(AssetType.Image, id, pxt.sprite.IMAGES_NAMESPACE);
                     this.state.images.add(newAsset); break;
                 case AssetType.Tile:
-                    newAsset.id = this.generateNewID(AssetType.Tile, name, pxt.sprite.TILE_NAMESPACE);
+                    newAsset.id = this.generateNewID(AssetType.Tile, id, pxt.sprite.TILE_NAMESPACE);
                     this.state.tiles.add(newAsset); break;
                 case AssetType.Tilemap:
-                    newAsset.id = this.generateNewID(AssetType.Tilemap, name);
+                    newAsset.id = this.generateNewID(AssetType.Tilemap, id);
                     this.state.tilemaps.add(newAsset); break;
                 case AssetType.Animation:
-                    newAsset.id = this.generateNewID(AssetType.Animation, name);
+                    newAsset.id = this.generateNewID(AssetType.Animation, id);
                     this.state.animations.add(newAsset); break;
             }
             return newAsset;
@@ -952,6 +958,7 @@ namespace pxt {
         }
 
         protected generateNewID(type: AssetType, varPrefix: string, namespaceString?: string) {
+            varPrefix = varPrefix.replace(/\d+$/, "");
             const prefix = namespaceString ? namespaceString + "." + varPrefix : varPrefix;
             let index = 1;
             while (this.isNameTaken(type, prefix + index)) {
@@ -1148,6 +1155,7 @@ namespace pxt {
     }
 
     function cloneAsset<U extends Asset>(asset: U): U {
+        asset.meta = Object.assign({}, asset.meta);
         switch (asset.type) {
             case AssetType.Tile:
             case AssetType.Image:

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -13,6 +13,7 @@ export interface ImageFieldEditorProps {
 export interface ImageFieldEditorState {
     currentView: "editor" | "gallery" | "my-assets";
     tileGalleryVisible?: boolean;
+    headerVisible?: boolean;
     galleryFilter?: string;
 }
 
@@ -44,7 +45,7 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
 
     render() {
         const { showTiles } = this.props;
-        const { currentView } = this.state;
+        const { currentView, headerVisible } = this.state;
 
         if (this.blocksInfo && !this.extensionGallery) {
             this.extensionGallery = pxt.sprite.getGalleryItems(this.blocksInfo, "Image")
@@ -61,7 +62,7 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
         const toggleClass = currentView === "editor" ? "left" : (currentView === "gallery" ? "center" : "right");
 
         return <div className="image-editor-wrapper">
-            <div className="gallery-editor-header">
+            {headerVisible && <div className="gallery-editor-header">
                 <div className={`gallery-editor-toggle ${toggleClass} ${pxt.BrowserUtils.isEdge() ? "edge" : ""}`}>
                     <div className="gallery-editor-toggle-label gallery-editor-toggle-left" onClick={this.showEditor} role="button">
                         {lf("Editor")}
@@ -75,7 +76,7 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
                     <div className="gallery-editor-toggle-handle"/>
                 </div>
                 { showTiles && <button className="gallery-editor-show-tiles" onClick={this.toggleTileGallery}>{lf("Tile Gallery")}</button>}
-            </div>
+            </div>}
             <div className="image-editor-gallery-content">
                 <ImageEditor ref="image-editor" singleFrame={this.props.singleFrame} onDoneClicked={this.onDoneClick} />
                 <ImageEditorGallery
@@ -121,6 +122,10 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
                 this.setState({
                     galleryFilter: options.filter
                 });
+            }
+
+            if (options.headerVisible === false) {
+                this.setState({ headerVisible: false })
             }
         }
     }

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -10,13 +10,14 @@ interface AssetGalleryProps {
     view: GalleryView;
     galleryAssets: pxt.Asset[];
     userAssets: pxt.Asset[];
+    showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
 }
 
 class AssetGalleryImpl extends React.Component<AssetGalleryProps> {
     render() {
-        const { view, galleryAssets, userAssets } = this.props;
+        const { view, galleryAssets, userAssets, showAssetFieldView } = this.props;
         return <div className="asset-editor-gallery">
-            <AssetTopbar />
+            <AssetTopbar showAssetFieldView={showAssetFieldView} />
             <div className={`asset-editor-card-list ${view !== GalleryView.User ? "hidden" : ""}`}>
                 <AssetCardList assets={userAssets} />
             </div>

--- a/webapp/src/components/assetEditor/assetGalleryTab.tsx
+++ b/webapp/src/components/assetEditor/assetGalleryTab.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { connect } from 'react-redux';
+
+import { AssetEditorState, GalleryView } from './store/assetEditorReducer';
+import { dispatchChangeGalleryView } from './actions/dispatch';
+
+interface AssetGalleryTabProps {
+    title: string;
+    view: GalleryView;
+    selected: boolean;
+    dispatchChangeGalleryView: (view: GalleryView) => void;
+}
+
+class AssetGalleryTabImpl extends React.Component<AssetGalleryTabProps> {
+    handleClick = () => {
+        this.props.dispatchChangeGalleryView(this.props.view);
+    }
+
+    render() {
+        const { title, selected } = this.props;
+
+        return <div className={`asset-editor-gallery-tab ${selected ? "selected" : ""}`} onClick={this.handleClick} role="navigation">
+            {title}
+        </div>
+    }
+}
+
+function mapStateToProps(state: AssetEditorState, ownProps: any) {
+    if (!state) return {};
+    return {
+        selected: state.view == ownProps.view
+    };
+}
+
+const mapDispatchToProps = {
+    dispatchChangeGalleryView
+};
+
+export const AssetGalleryTab = connect(mapStateToProps, mapDispatchToProps)(AssetGalleryTabImpl);

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -3,8 +3,8 @@ import * as pkg from "../../package";
 import * as sui from "../../sui";
 import { connect } from 'react-redux';
 
-import { AssetEditorState } from './store/assetEditorReducer';
-import { dispatchChangeSelectedAsset, dispatchUpdateUserAssets } from './actions/dispatch';
+import { AssetEditorState, GalleryView } from './store/assetEditorReducer';
+import { dispatchChangeGalleryView, dispatchChangeSelectedAsset, dispatchUpdateUserAssets } from './actions/dispatch';
 
 import { AssetPreview } from "./assetPreview";
 
@@ -15,6 +15,9 @@ interface AssetDetail {
 
 interface AssetSidebarProps {
     asset?: pxt.Asset;
+    isGalleryAsset?: boolean;
+    showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
+    dispatchChangeGalleryView: (view: GalleryView) => void;
     dispatchChangeSelectedAsset: (asset: pxt.Asset) => void;
     dispatchUpdateUserAssets: () => void;
 }
@@ -23,11 +26,19 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps> {
     protected copyTextAreaRef: HTMLTextAreaElement;
 
     protected getAssetDetails(): AssetDetail[] {
-        const asset = this.props.asset as pxt.ProjectImage; // TODO generalize
+        const asset = this.props.asset;
         const details: AssetDetail[] = [];
         if (asset) {
             details.push({ name: lf("Type"), value: getDisplayTextForAsset(asset.type)});
-            details.push({ name: lf("Size"), value: `${asset.bitmap.width} x ${asset.bitmap.height}`});
+
+            switch (asset.type) {
+                case pxt.AssetType.Image:
+                case pxt.AssetType.Tile:
+                    details.push({ name: lf("Size"), value: `${asset.bitmap.width} x ${asset.bitmap.height}`});
+                    break;
+                case pxt.AssetType.Tilemap:
+                    details.push({ name: lf("Size"), value: `${asset.data.tilemap.width} x ${asset.data.tilemap.height}`});
+            }
         }
 
         return details;
@@ -39,7 +50,14 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps> {
     }
 
     protected editAssetHandler = () => {
+        this.props.showAssetFieldView(this.props.asset, this.editAssetDoneHandler);
+    }
 
+    protected editAssetDoneHandler = (result: any) => {
+        const project = pxt.react.getTilemapProject();
+        project.pushUndo();
+        project.updateAsset(result);
+        this.updateAssets();
     }
 
     protected duplicateAssetHandler = () => {
@@ -47,6 +65,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps> {
         project.pushUndo();
         const newAsset = project.duplicateAsset(this.props.asset);
         this.props.dispatchChangeSelectedAsset(newAsset);
+        if (this.props.isGalleryAsset) this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets();
     }
 
@@ -79,7 +98,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps> {
     }
 
     render() {
-        const { asset } = this.props;
+        const { asset, isGalleryAsset } = this.props;
         const details = this.getAssetDetails();
 
         return <div className="asset-editor-sidebar">
@@ -89,17 +108,17 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps> {
                     { asset && <AssetPreview asset={asset} />  }
                 </div>
                 <div className="asset-editor-sidebar-name">
-                    { asset ? asset.id : lf("No asset selected") }
+                    { asset?.meta?.displayName || lf("No asset selected") }
                 </div>
                 {details.map(el => {
                     return <div key={el.name} className="asset-editor-sidebar-detail">{`${el.name}: ${el.value}`}</div>
                 })}
             </div>
             { asset && <div className="asset-editor-sidebar-controls">
-                <sui.MenuItem name={lf("Edit")} className="asset-editor-button" icon="edit" onClick={this.editAssetHandler}/>
+                {!isGalleryAsset && <sui.MenuItem name={lf("Edit")} className="asset-editor-button" icon="edit" onClick={this.editAssetHandler}/>}
                 <sui.MenuItem name={lf("Duplicate")} className="asset-editor-button" icon="copy" onClick={this.duplicateAssetHandler}/>
                 <sui.MenuItem name={lf("Copy")} className="asset-editor-button" icon="paste" onClick={this.copyAssetHandler}/>
-                <sui.MenuItem name={lf("Delete")} className="asset-editor-button" icon="delete" onClick={this.deleteAssetHandler}/>
+                {!isGalleryAsset && <sui.MenuItem name={lf("Delete")} className="asset-editor-button" icon="delete" onClick={this.deleteAssetHandler}/>}
             </div>}
             <textarea className="asset-editor-sidebar-copy" ref={this.copyTextAreaRefHandler} ></textarea>
         </div>
@@ -122,11 +141,13 @@ function getDisplayTextForAsset(type: pxt.AssetType) {
 function mapStateToProps(state: AssetEditorState, ownProps: any) {
     if (!state) return {};
     return {
-        asset: state.selectedAsset
+        asset: state.selectedAsset,
+        isGalleryAsset: state.selectedAsset?.internalID == -1
     };
 }
 
 const mapDispatchToProps = {
+    dispatchChangeGalleryView,
     dispatchChangeSelectedAsset,
     dispatchUpdateUserAssets
 };

--- a/webapp/src/components/assetEditor/assetTopbar.tsx
+++ b/webapp/src/components/assetEditor/assetTopbar.tsx
@@ -1,53 +1,98 @@
 import * as React from "react";
+import * as pkg from "../../package";
+import * as sui from "../../sui";
 import { connect } from 'react-redux';
 
 import { AssetEditorState, GalleryView } from './store/assetEditorReducer';
-import { dispatchChangeGalleryView } from './actions/dispatch';
+import { dispatchUpdateUserAssets } from './actions/dispatch';
+import { AssetGalleryTab } from './assetGalleryTab'
 
-interface AssetGalleryTabProps {
-    title: string;
-    view: GalleryView;
-    selected: boolean;
-    dispatchChangeGalleryView: (view: GalleryView) => void;
+interface AssetTopbarProps {
+    showAssetFieldView: (asset: pxt.Asset, cb: (result: any) => void) => void;
+    dispatchUpdateUserAssets?: () => void;
 }
 
-class AssetGalleryTabImpl extends React.Component<AssetGalleryTabProps> {
-    handleClick = () => {
-        this.props.dispatchChangeGalleryView(this.props.view);
+interface AssetTopbarState {
+    showCreateModal?: boolean;
+}
+
+class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState> {
+    constructor(props: AssetTopbarProps) {
+        super(props);
+        this.state = { showCreateModal: false };
+    }
+
+    protected showCreateModal = () => {
+        this.setState({ showCreateModal: true });
+    }
+
+    protected hideCreateModal = () => {
+        this.setState({ showCreateModal: false });
+    }
+
+    protected getCreateAssetHandler = (type: pxt.AssetType) => {
+        return () => {
+            const project = pxt.react.getTilemapProject();
+            const asset = this.getEmptyAsset(type);
+
+            this.hideCreateModal();
+            this.props.showAssetFieldView(asset, (result: any) => {
+                project.pushUndo();
+                const name = result.meta?.displayName;
+                switch (type) {
+                    case pxt.AssetType.Image:
+                        project.createNewProjectImage(result.bitmap); break;
+                    case pxt.AssetType.Tile:
+                        project.createNewTile(result.bitmap); break;
+                    case pxt.AssetType.Tilemap:
+                        project.createNewTilemapFromData(result.data, name); break;
+                }
+                pkg.mainEditorPkg().buildAssetsAsync()
+                    .then(() => this.props.dispatchUpdateUserAssets());
+            });
+        }
+    }
+
+    protected getEmptyAsset(type: pxt.AssetType): pxt.Asset {
+        const project = pxt.react.getTilemapProject();
+        const asset = { type, id: "", internalID: 0, meta: {} } as pxt.Asset;
+        switch (type) {
+            case pxt.AssetType.Image:
+            case pxt.AssetType.Tile:
+                (asset as pxt.ProjectImage).bitmap = new pxt.sprite.Bitmap(16, 16).data(); break
+            case pxt.AssetType.Tilemap:
+                (asset as pxt.ProjectTilemap).data = project.blankTilemap(16, 16, 16);
+        }
+        return asset;
     }
 
     render() {
-        const { title, selected } = this.props;
+        const { showCreateModal } = this.state;
 
-        return <div className={`asset-editor-gallery-tab ${selected ? "selected" : ""}`} onClick={this.handleClick} role="navigation">
-            {title}
+        const actions: sui.ModalButton[] = [
+            { label: lf("Image"), onclick: this.getCreateAssetHandler(pxt.AssetType.Image) },
+            { label: lf("Tile"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tile) },
+            { label: lf("Tilemap"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tilemap) }
+        ]
+
+        return <div className="asset-editor-topbar">
+            <AssetGalleryTab title={lf("My Assets")} view={GalleryView.User} />
+            <AssetGalleryTab title={lf("Gallery")} view={GalleryView.Gallery} />
+            <div className="asset-editor-button create-new" onClick={this.showCreateModal}>{lf("Create New")}</div>
+            <sui.Modal isOpen={showCreateModal} onClose={this.hideCreateModal} closeIcon={false} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
+                <div>{lf("Choose your asset type from the options below.")}</div>
+            </sui.Modal>
         </div>
     }
 }
 
 function mapStateToProps(state: AssetEditorState, ownProps: any) {
     if (!state) return {};
-    return {
-        selected: state.view == ownProps.view
-    };
+    return ownProps;
 }
 
 const mapDispatchToProps = {
-    dispatchChangeGalleryView
+    dispatchUpdateUserAssets
 };
 
-const AssetGalleryTab = connect(mapStateToProps, mapDispatchToProps)(AssetGalleryTabImpl);
-
-
-interface AssetTopbarProps {
-}
-
-export class AssetTopbar extends React.Component<AssetTopbarProps> {
-    render() {
-        return <div className="asset-editor-topbar">
-            <AssetGalleryTab title={lf("My Assets")} view={GalleryView.User} />
-            <AssetGalleryTab title={lf("Gallery")} view={GalleryView.Gallery} />
-            <div className="asset-editor-button create-new">{lf("Create New")}</div>
-        </div>
-    }
-}
+export const AssetTopbar = connect(mapStateToProps, mapDispatchToProps)(AssetTopbarImpl);

--- a/webapp/src/components/assetEditor/assetTopbar.tsx
+++ b/webapp/src/components/assetEditor/assetTopbar.tsx
@@ -78,7 +78,7 @@ class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState
         return <div className="asset-editor-topbar">
             <AssetGalleryTab title={lf("My Assets")} view={GalleryView.User} />
             <AssetGalleryTab title={lf("Gallery")} view={GalleryView.Gallery} />
-            <div className="asset-editor-button create-new" onClick={this.showCreateModal}>{lf("Create New")}</div>
+            <div className="asset-editor-button create-new" onClick={this.showCreateModal} role="button">{lf("Create New")}</div>
             <sui.Modal isOpen={showCreateModal} onClose={this.hideCreateModal} closeIcon={false} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
                 <div>{lf("Choose your asset type from the options below.")}</div>
             </sui.Modal>

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -47,7 +47,7 @@ export class AssetEditor extends Editor {
         return <Provider store={store}>
             <div className="asset-editor-outer">
                 <AssetSidebar showAssetFieldView={this.showAssetFieldView} />
-                <AssetGallery galleryAssets={this.galleryAssets} />
+                <AssetGallery galleryAssets={this.galleryAssets} showAssetFieldView={this.showAssetFieldView} />
             </div>
         </Provider>
     }

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -48,8 +48,15 @@ function getUserAssets() {
         return asset;
     };
 
+    const tilemapToGalleryItem = (asset: pxt.ProjectTilemap) => {
+        let tilemap = asset.data.tilemap;
+        asset.previewURI = pxtblockly.tilemapToImageURI(asset.data, Math.max(tilemap.width, tilemap.height), false);
+        return asset;
+    };
+
     return project.getAssets(pxt.AssetType.Image).map(imageToGalleryItem)
-        .concat(project.getAssets(pxt.AssetType.Tile).map(imageToGalleryItem));
+        .concat(project.getAssets(pxt.AssetType.Tile).map(imageToGalleryItem))
+        .concat(project.getAssets(pxt.AssetType.Tilemap).map(tilemapToGalleryItem));
 }
 
 export default topReducer;


### PR DESCRIPTION
- Hook 'Edit' and 'Create' up to image/tilemap editor
- Add tilemaps to user assets, add preview image for tilemaps (minimap view/same as blocks)
- Add warning modal for delete, asset type selection modal for create
- Small tweak to asset displayName/id generation (strip trailing digits)

TODO:
- CSS pass
- Fix bugs