### PR TITLE
don't ignore sim msgs

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -268,39 +268,38 @@ namespace pxsim {
                 return
             }
 
-            const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
-            if (!source || !broadcastmsg?.broadcast)
-                return; // not our message, ignore
-
             const depEditors = this.dependentEditors();
             let frames = this.simFrames();
             const simUrl = U.isLocalHost() ? "*" : this.getSimUrl();
 
-            // if the editor is hosted in a multi-editor setting
-            // don't start extra frames
-            const parentWindow = window.parent && window.parent !== window.window
-                ? window.parent : window.opener;
-            if (this.options.nestedEditorSim && parentWindow) {
-                // if message comes from parent already, don't echo
-                if (source !== parentWindow) {
-                    const parentOrigin = this.options.parentOrigin || window.location.origin
-                    parentWindow.postMessage(msg, parentOrigin);
-                }
-                // send message to other editors
-            } else if (depEditors) {
-                depEditors.forEach(w => {
-                    if (source !== w)
-                        // dependant editors should be in the same origin
-                        w.postMessage(msg, window.location.origin)
-                })
-                // start second simulator
-            } else {
-                // start secondary frame if needed
-                if (frames.length < 2) {
-                    this.container.appendChild(this.createFrame());
-                    frames = this.simFrames();
-                } else if (frames[1].dataset['runid'] != this.runId) {
-                    this.startFrame(frames[1]);
+            const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
+            if (source && broadcastmsg?.broadcast) {
+                // if the editor is hosted in a multi-editor setting
+                // don't start extra frames
+                const parentWindow = window.parent && window.parent !== window.window
+                    ? window.parent : window.opener;
+                if (this.options.nestedEditorSim && parentWindow) {
+                    // if message comes from parent already, don't echo
+                    if (source !== parentWindow) {
+                        const parentOrigin = this.options.parentOrigin || window.location.origin
+                        parentWindow.postMessage(msg, parentOrigin);
+                    }
+                    // send message to other editors
+                } else if (depEditors) {
+                    depEditors.forEach(w => {
+                        if (source !== w)
+                            // dependant editors should be in the same origin
+                            w.postMessage(msg, window.location.origin)
+                    })
+                    // start second simulator
+                } else {
+                    // start secondary frame if needed
+                    if (frames.length < 2) {
+                        this.container.appendChild(this.createFrame());
+                        frames = this.simFrames();
+                    } else if (frames[1].dataset['runid'] != this.runId) {
+                        this.startFrame(frames[1]);
+                    }
                 }
             }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2459
fix https://github.com/microsoft/pxt-arcade/issues/2460
fix https://github.com/microsoft/pxt-microbit/issues/3413
fix mute button

mostly reverts the change in https://github.com/microsoft/pxt/pull/7509; that prevented sending any messages (besides broadcasts) to the simulator. I'm not sure I understand the case the PR said it was fixing, but it'll definitely need a narrower fix for those / if you want to give me a few examples I can see where to cull them @pelikhan 