### PR TITLE
CSS for asset editor, fix issues with naming

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -410,7 +410,7 @@ namespace pxt {
             return this.state.tiles.add(newTile);
         }
 
-        public createNewProjectImage(data: pxt.sprite.BitmapData) {
+        public createNewProjectImage(data: pxt.sprite.BitmapData, displayName?: string) {
             this.onChange();
 
             const newImage: ProjectImage = {
@@ -418,7 +418,9 @@ namespace pxt {
                 id: this.generateNewID(AssetType.Image, pxt.sprite.IMAGE_PREFIX, pxt.sprite.IMAGES_NAMESPACE),
                 type: AssetType.Image,
                 jresData: pxt.sprite.base64EncodeBitmap(data),
-                meta: {},
+                meta: {
+                    displayName
+                },
                 bitmap: data
             };
 

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -15,6 +15,11 @@
     margin: 1rem;
 }
 
+.asset-editor-sidebar-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .asset-editor-sidebar-preview {
     width: ~"calc(@{blocklyRowWidthWide} - 2rem)";
     height: ~"calc(@{blocklyRowWidthWide} - 2rem)";
@@ -128,5 +133,20 @@
 }
 
 .create-new {
+    color: @white;
+    background-color: @green;
     margin-left: auto;
+    font-weight: 700;
+}
+
+.delete-asset {
+    color: @white;
+    background-color: @red;
+    font-weight: 700;
+}
+
+.asset-editor-create-dialog .actions,
+.asset-editor-delete-dialog .actions {
+    display: flex;
+    justify-content: space-between;
 }

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -38,7 +38,8 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
         super(props);
 
         this.state = {
-            currentView: "editor"
+            currentView: "editor",
+            headerVisible: true
         };
         setTelemetryFunction(tickImageEditorEvent);
     }
@@ -124,8 +125,8 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
                 });
             }
 
-            if (options.headerVisible === false) {
-                this.setState({ headerVisible: false })
+            if (options.headerVisible != undefined) {
+                this.setState({ headerVisible: options.headerVisible })
             }
         }
     }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -119,7 +119,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         const { asset, isGalleryAsset } = this.props;
         const { showDeleteModal } = this.state;
         const details = this.getAssetDetails();
-        const name = asset ? asset.meta?.displayName || asset.id || lf("Unnamed") : lf("No asset selected");
+        const name = asset ? asset.meta?.displayName || pxt.getShortIDForAsset(asset) || lf("Unnamed") : lf("No asset selected");
 
         const actions: sui.ModalButton[] = [
             { label: lf("Cancel"), onclick: this.hideDeleteModal, icon: 'cancel' },

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -119,7 +119,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         const { asset, isGalleryAsset } = this.props;
         const { showDeleteModal } = this.state;
         const details = this.getAssetDetails();
-        const name = asset?.meta?.displayName || lf("No asset selected");
+        const name = asset ? asset.meta?.displayName || asset.id || lf("Unnamed") : lf("No asset selected");
 
         const actions: sui.ModalButton[] = [
             { label: lf("Cancel"), onclick: this.hideDeleteModal, icon: 'cancel' },
@@ -141,11 +141,10 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                 {!isGalleryAsset && <sui.MenuItem name={lf("Edit")} className="asset-editor-button" icon="edit" onClick={this.editAssetHandler}/>}
                 <sui.MenuItem name={lf("Duplicate")} className="asset-editor-button" icon="copy" onClick={this.duplicateAssetHandler}/>
                 <sui.MenuItem name={lf("Copy")} className="asset-editor-button" icon="paste" onClick={this.copyAssetHandler}/>
-                {!isGalleryAsset && <sui.MenuItem name={lf("Delete")} className="asset-editor-button" icon="trash" onClick={this.showDeleteModal}/>}
+                {!isGalleryAsset && <sui.MenuItem name={lf("Delete")} className="asset-editor-button delete-asset" icon="trash" onClick={this.showDeleteModal}/>}
             </div>}
             <textarea className="asset-editor-sidebar-copy" ref={this.copyTextAreaRefHandler} ></textarea>
-            <sui.Modal isOpen={showDeleteModal} onClose={this.hideDeleteModal} closeIcon={false}
-                dimmer={true} header={lf("Delete Asset")} buttons={actions}>
+            <sui.Modal className="asset-editor-delete-dialog" isOpen={showDeleteModal} onClose={this.hideDeleteModal} closeIcon={false} dimmer={true} header={lf("Delete Asset")} buttons={actions}>
                 <div>{lf("Are you sure you want to delete {0}? Deleted assets cannot be recovered.", name)}</div>
             </sui.Modal>
         </div>

--- a/webapp/src/components/assetEditor/assetTopbar.tsx
+++ b/webapp/src/components/assetEditor/assetTopbar.tsx
@@ -41,9 +41,9 @@ class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState
                 const name = result.meta?.displayName;
                 switch (type) {
                     case pxt.AssetType.Image:
-                        project.createNewProjectImage(result.bitmap); break;
+                        project.createNewProjectImage(result.bitmap, name); break;
                     case pxt.AssetType.Tile:
-                        project.createNewTile(result.bitmap); break;
+                        project.createNewTile(result.bitmap, null, name); break;
                     case pxt.AssetType.Tilemap:
                         project.createNewTilemapFromData(result.data, name); break;
                 }
@@ -55,7 +55,7 @@ class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState
 
     protected getEmptyAsset(type: pxt.AssetType): pxt.Asset {
         const project = pxt.react.getTilemapProject();
-        const asset = { type, id: "", internalID: 0, meta: {} } as pxt.Asset;
+        const asset = { type, id: "", internalID: 0, meta: { displayName: this.getEmptyAssetDisplayName(type) } } as pxt.Asset;
         switch (type) {
             case pxt.AssetType.Image:
             case pxt.AssetType.Tile:
@@ -64,6 +64,19 @@ class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState
                 (asset as pxt.ProjectTilemap).data = project.blankTilemap(16, 16, 16);
         }
         return asset;
+    }
+
+    protected getEmptyAssetDisplayName(type: pxt.AssetType): string {
+        switch (type) {
+            case pxt.AssetType.Image:
+                return lf("image");
+            case pxt.AssetType.Tile:
+                return lf("tile");
+            case pxt.AssetType.Tilemap:
+                return lf("level");
+            default:
+                return lf("asset")
+        }
     }
 
     render() {
@@ -79,7 +92,7 @@ class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState
             <AssetGalleryTab title={lf("My Assets")} view={GalleryView.User} />
             <AssetGalleryTab title={lf("Gallery")} view={GalleryView.Gallery} />
             <div className="asset-editor-button create-new" onClick={this.showCreateModal} role="button">{lf("Create New")}</div>
-            <sui.Modal isOpen={showCreateModal} onClose={this.hideCreateModal} closeIcon={false} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
+            <sui.Modal className="asset-editor-create-dialog" isOpen={showCreateModal} onClose={this.hideCreateModal} closeIcon={false} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
                 <div>{lf("Choose your asset type from the options below.")}</div>
             </sui.Modal>
         </div>

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -29,9 +29,11 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
                 view: action.view
             };
         case actions.UPDATE_USER_ASSETS:
+            const assets = getUserAssets()
             return {
                 ...state,
-                assets: getUserAssets()
+                selectedAsset: state.selectedAsset ? assets.find(el => el.id == state.selectedAsset.id) : undefined,
+                assets
             }
         default:
             return state


### PR DESCRIPTION
Fixes:
- Update sidebar preview after asset edit
- Show asset id if displayName not present
- Default names for new assets
- Restore gallery header to regular image editor
- CSS for button colors, button spacing in modals, overflow for asset name

Todo: 
- CSS for toggle
- Fix/integrate with recent tile changes