### PR TITLE
Fixes for tile creation/edit/update in asset editor view

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -433,7 +433,7 @@ namespace pxt {
             if (existing) {
                 this.state.tiles.update(existing.id, tile);
 
-                if (existing.id !== tile.id) {
+                if (existing.id !== tile.id || !pxt.sprite.bitmapEquals(existing.bitmap, tile.bitmap)) {
                     for (const tm of this.getAssets(AssetType.Tilemap)) {
                         if (tm.data.tileset.tiles.some(t => t.internalID === tile.internalID)) {
 
@@ -566,6 +566,10 @@ namespace pxt {
                     displayName: id
                 },
                 data: data
+            });
+
+            data.tileset.tiles.forEach(t => {
+                this.resolveTile(t.id) ? this.updateTile(t) : this.createNewTile(t.bitmap, t.id, t.meta?.displayName);
             });
 
             return [id, data];
@@ -754,6 +758,7 @@ namespace pxt {
                 case AssetType.Tile:
                     return this.updateTile(asset);
                 case AssetType.Tilemap:
+                    asset.data.tileset.tiles.forEach(t => this.updateTile(t));
                     return this.state.tilemaps.update(asset.id, asset);
                 case AssetType.Animation:
                     return this.state.animations.update(asset.id, asset);

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -142,6 +142,20 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
         return imageStateToBitmap(currentFrame);
     }
 
+    getAsset(): pxt.Asset {
+        const type = this.editingAsset.type;
+        switch (type) {
+            case pxt.AssetType.Tile:
+                return this.getTile();
+            case pxt.AssetType.Animation:
+                return this.getAnimation();
+            case pxt.AssetType.Tilemap:
+                return this.getTilemap();
+            default:
+                return this.getImage();
+        }
+    }
+
     getImage(): pxt.ProjectImage {
         const state = this.getStore().getState();
         const data = this.getCurrentFrame().data();
@@ -294,19 +308,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
 
     protected onDoneClick = () => {
         if (this.props.onDoneClicked) {
-            let value: pxt.Asset;
-
-            if (this.getStore().getState().editor.isTilemap) {
-                value = this.getTilemap();
-            }
-            else if (this.props.singleFrame) {
-                value = this.props.nested ? this.getTile() : this.getImage();
-            }
-            else {
-                value = this.getAnimation()
-            }
-
-            this.props.onDoneClicked(value);
+            this.props.onDoneClicked(this.getAsset());
         }
     }
 

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -132,7 +132,7 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
 
     getValue() {
         if (this.ref) {
-            return (this.props.singleFrame ? this.ref.getImage() : this.ref.getAnimation()) as U;
+            return this.ref.getAsset() as U;
         }
         return null;
     }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -59,6 +59,18 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
     }
 
     protected editAssetHandler = () => {
+        const { asset } = this.props;
+
+        // for tilemaps, fill in all project tiles
+        if (asset.type == pxt.AssetType.Tilemap) {
+            const allTiles = pxt.react.getTilemapProject().getProjectTiles(asset.data.tileset.tileWidth, true);
+            for (const tile of allTiles.tiles) {
+                if (!asset.data.tileset.tiles.some(t => t.id === tile.id)) {
+                    asset.data.tileset.tiles.push(tile);
+                }
+            }
+        }
+
         this.props.showAssetFieldView(this.props.asset, this.editAssetDoneHandler);
     }
 

--- a/webapp/src/components/assetEditor/assetTopbar.tsx
+++ b/webapp/src/components/assetEditor/assetTopbar.tsx
@@ -61,7 +61,10 @@ class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState
             case pxt.AssetType.Tile:
                 (asset as pxt.ProjectImage).bitmap = new pxt.sprite.Bitmap(16, 16).data(); break
             case pxt.AssetType.Tilemap:
-                (asset as pxt.ProjectTilemap).data = project.blankTilemap(16, 16, 16);
+                const tilemap = asset as pxt.ProjectTilemap;
+                tilemap.data = project.blankTilemap(16, 16, 16);
+                tilemap.data.tileset = project.getProjectTiles(tilemap.data.tileset.tileWidth, true);
+
         }
         return asset;
     }


### PR DESCRIPTION
- Previously the only way you could create a tile was from inside the tilemap editor, but now you could be editing a tile from the standalone image editor so I unified the getTile/getImage/getAnimation to return based on asset type
- When updating a tilemap, also iterate over all tiles in the tileset (user may have created new ones or edited existing ones)
- When editing a tile (standalone) also update in all tilemaps if the bitmap has changed
- Show all custom tiles in the tile palette when opening the tilemap editor