### PR TITLE
Fixing toggle css for asset editor

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -323,14 +323,24 @@ div.simframe > iframe {
     transition-timing-function: ease-in;
 }
 
+.active.item.javascript-menuitem ~ .toggle,
+.active.item.python-menuitem ~ .toggle,
 .active.item.blocks-menuitem ~ .toggle {
     margin-left: 0 !important;
     box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
     background: @editorToggleColor !important;
 }
+.javascript-menuitem ~ .active.item.assets-menuitem ~ .toggle,
+.python-menuitem ~ .active.item.assets-menuitem ~ .toggle,
 .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
 .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
     margin-left: 140px !important;
+    box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
+    background: @editorToggleColor !important;
+}
+
+.blocks-menuitem ~ .active.item.assets-menuitem ~ .toggle {
+    margin-left: 326px !important;
     box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
     background: @editorToggleColor !important;
 }
@@ -848,6 +858,13 @@ p.ui.font.small {
             box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
             background: @editorToggleColor !important;
         }
+
+        .blocks-menuitem ~ .active.item.assets-menuitem ~ .toggle {
+            margin-left: 120px !important;
+            box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
+            background: @editorToggleColor !important;
+        }
+
     }
 
     .simView #boardview {
@@ -1381,10 +1398,16 @@ p.ui.font.small {
         width: 40px;
         height: 38px;
     }
+    .javascript-menuitem ~ .active.item.assets-menuitem ~ .toggle,
+    .python-menuitem ~ .active.item.assets-menuitem ~ .toggle,
     .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
     .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
         margin-left: 40px !important;
     }
+    .blocks-menuitem ~ .active.item.assets-menuitem ~ .toggle {
+        margin-left: 120px !important;
+    }
+
     /* Top Menu */
     #maineditor {
         top: @mobileMenuHeight;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -450,6 +450,8 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         const showBlocks = !!pkg.mainEditorPkg().files["main.blocks"];
         const showAssets = !!pkg.mainEditorPkg().files[pxt.ASSETS_FILE];
 
+        const hasDropdown = python && languageRestriction === pxt.editor.LanguageRestriction.Standard;
+
         return (
             <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`}>
                 {sandbox && !headless && <SandboxMenuItem parent={parent} />}
@@ -460,7 +462,7 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
                     <PythonMenuItem parent={parent} />
                 </sui.DropdownMenu>}
                 {showAssets && pxt.appTarget.appTheme.assetEditor && <AssetMenuItem parent={parent} />}
-                <div className={`ui item toggle ${python ? 'hasdropdown' : ''}`}></div>
+                <div className={`ui item toggle ${hasDropdown ? 'hasdropdown' : ''}`}></div>
             </div>
         )
     }
@@ -566,8 +568,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const languageRestriction = cfg && cfg.languageRestriction;
 
         const inAltEditor = debugging || inTutorial;
-        const tsOnly = !inAltEditor && languageRestriction === pxt.editor.LanguageRestriction.JavaScriptOnly;
-        const pyOnly = !inAltEditor && languageRestriction === pxt.editor.LanguageRestriction.PythonOnly;
+        const showAssets = !!pkg.mainEditorPkg().files[pxt.ASSETS_FILE];
+        const tsOnly = !inAltEditor && !showAssets && languageRestriction === pxt.editor.LanguageRestriction.JavaScriptOnly;
+        const pyOnly = !inAltEditor && !showAssets && languageRestriction === pxt.editor.LanguageRestriction.PythonOnly;
         const showToggle = !inAltEditor && !targetTheme.blocksOnly
             && (sandbox || !(tsOnly || pyOnly)); // show if sandbox or not single language
         const editor = this.props.parent.isPythonActive() ? "Python" : (this.props.parent.isJavaScriptActive() ? "JavaScript" : "Blocks");


### PR DESCRIPTION
Here it is in the full editor for normal projects and javascript/python only:

![2020-10-14 18 15 34](https://user-images.githubusercontent.com/13754588/96061985-6253e980-0e49-11eb-96d4-456bbd423a91.gif)

And it's hidden in sandbox