### PR TITLE
Error message on workspace db failure

### DIFF
--- a/common-docs/browsers/no-auto-save.md
+++ b/common-docs/browsers/no-auto-save.md
@@ -13,3 +13,4 @@ There are several ways to do this depending on the editor you are using:
 
 * Private browsing: If you open makecode in your browsers 'private browsing' mode, it will often fail to be able to save projects - depending on the browser, they might be saved only until the browser window is closed, or only until the window is refreshed.
 * Storage full: The browser allocates a certain amount of space for each website, so it's possible that you have run out of memory. If this is the case, you might need to try to clear space on your hard drive, or delete old projects.
+* Storage disabled: Many browsers have options to disable local storage or cookies entirely. If these settings are enabled in your browser, you may need to disable them for auto save to work again.

--- a/common-docs/browsers/no-auto-save.md
+++ b/common-docs/browsers/no-auto-save.md
@@ -1,6 +1,6 @@
 # No auto save
 
-In some cases, MakeCode is unable to save your project on it's own.
+In some cases, MakeCode is unable to save your project on its own.
 When this happens, you should be careful to back up your projects before leaving the window to make sure you do not lose any progress.
 There are several ways to do this depending on the editor you are using:
 
@@ -11,6 +11,6 @@ There are several ways to do this depending on the editor you are using:
 
 ## Common causes of auto save being disabled
 
-* Private browsing: If you open makecode in your browsers 'private browsing' mode, it will often fail to be able to save projects - depending on the browser, they might be saved only until the browser window is closed, or only until the window is refreshed.
+* Private browsing: If you open MakeCode in your browsers 'private browsing' mode, it will often fail to be able to save projects - depending on the browser, they might be saved only until the browser window is closed, or only until the window is refreshed.
 * Storage full: The browser allocates a certain amount of space for each website, so it's possible that you have run out of memory. If this is the case, you might need to try to clear space on your hard drive, or delete old projects.
 * Storage disabled: Many browsers have options to disable local storage or cookies entirely. If these settings are enabled in your browser, you may need to disable them for auto save to work again.

--- a/common-docs/browsers/no-auto-save.md
+++ b/common-docs/browsers/no-auto-save.md
@@ -1,0 +1,15 @@
+# No auto save
+
+In some cases, MakeCode is unable to save your project on it's own.
+When this happens, you should be careful to back up your projects before leaving the window to make sure you do not lose any progress.
+There are several ways to do this depending on the editor you are using:
+
+* Create a share link for project, which will store it in the cloud.
+* Save your project using the "Save Project" option in the project settings menu.
+* Save your project as a PNG
+* For editors that include hardware, a downloaded hex file can be loaded back into the editor
+
+## Common causes of auto save being disabled
+
+* Private browsing: If you open makecode in your browsers 'private browsing' mode, it will often fail to be able to save projects - depending on the browser, they might be saved only until the browser window is closed, or only until the window is refreshed.
+* Storage full: The browser allocates a certain amount of space for each website, so it's possible that you have run out of memory. If this is the case, you might need to try to clear space on your hard drive, or delete old projects.

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -394,6 +394,7 @@ declare namespace pxt {
         embedBlocksInSnapshot?: boolean; // embed blocks xml in right-click snapshot
         blocksErrorList?: boolean; // blocks error list experiment
         assetEditor?: boolean; // enable asset editor view (in blocks/text toggle)
+        disableMemoryWorkspaceWarning?: boolean; // do not warn the user when switching to in memory workspace
     }
 
     interface SocialOptions {

--- a/theme/common.less
+++ b/theme/common.less
@@ -1794,3 +1794,9 @@ select.ui.dropdown {
         font-size: 12px !important;
     }
 }
+
+.ui.modal.auto-save-disabled-warning {
+    .header {
+        background-color: lighten(@red, 25%);
+    }
+}

--- a/theme/common.less
+++ b/theme/common.less
@@ -1842,6 +1842,6 @@ select.ui.dropdown {
 
 .ui.modal.auto-save-disabled-warning {
     .header {
-        background-color: lighten(@red, 25%);
+        background-color: #F5BC5F;
     }
 }

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -155,6 +155,7 @@ export interface DialogOptions {
     logos?: string[];
     className?: string;
     header: string;
+    headerIcon?: string;
     body?: string;
     jsx?: JSX.Element;
     jsxd?: () => JSX.Element; // dynamic-er version of jsx

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -106,6 +106,7 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
                 defaultOpen={true} buttons={buttons}
                 dimmer={true} closeIcon={options.hasCloseIcon}
                 header={options.header}
+                headerIcon={options.headerIcon}
                 closeOnDimmerClick={!options.hideCancel}
                 closeOnDocumentClick={!options.hideCancel}
                 closeOnEscape={!options.hideCancel}

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -80,9 +80,8 @@ export class Table {
                     .then(() => pxt.BrowserUtils.clearTutorialInfoDbAsync())
                     .then(() => this.setAsyncNoRetry(obj))
                     .catch(e => {
-                        pxt.reportException(e);
                         pxt.log(`table: we are out of space...`)
-                        return undefined;
+                        throw e;
                     })
             })
     }

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -12,23 +12,28 @@ const PouchDB = require("pouchdb")
     }
 });
 
-let _db: any = undefined;
-
+let _db: Promise<any> = undefined;
 export function getDbAsync(): Promise<any> {
-    if (_db) return Promise.resolve(_db);
+    if (_db) return _db;
 
-    const opts: any = {
-        revs_limit: 2
-    };
+    return _db = Promise.resolve()
+        .then(() => {
+            const opts: any = {
+                revs_limit: 2
+            };
 
-    _db = new PouchDB("pxt-" + pxt.storage.storageId(), opts);
-    pxt.log(`PouchDB adapter: ${_db.adapter}`)
+            const db = new PouchDB("pxt-" + pxt.storage.storageId(), opts);
+            pxt.log(`PouchDB adapter: ${db.adapter}`);
 
-    return Promise.resolve(_db);
+            return db;
+        });
 }
 
 export function destroyAsync(): Promise<void> {
-    return !_db ? Promise.resolve() : _db.destroy();
+    return !_db ? Promise.resolve() : _db.then((db: any) => {
+        db.destroy();
+        _db = undefined;
+    });
 }
 
 export class Table {

--- a/webapp/src/db.ts
+++ b/webapp/src/db.ts
@@ -13,38 +13,18 @@ const PouchDB = require("pouchdb")
 });
 
 let _db: any = undefined;
-let inMemory = false;
-
-function memoryDb(): Promise<any> {
-    pxt.debug('db: in memory...')
-    inMemory = true;
-    _db = new PouchDB("pxt-" + pxt.storage.storageId(), {
-        adapter: 'memory'
-    })
-    return Promise.resolve(_db);
-}
 
 export function getDbAsync(): Promise<any> {
     if (_db) return Promise.resolve(_db);
-
-    if (pxt.shell.isSandboxMode() || pxt.shell.isReadOnly())
-        return memoryDb();
 
     const opts: any = {
         revs_limit: 2
     };
 
-    let temp = new PouchDB("pxt-" + pxt.storage.storageId(), opts);
-    return temp.get('pouchdbsupportabletest')
-        .catch(function (error: any) {
-            if (error && error.error && error.name == 'indexed_db_went_bad') {
-                return memoryDb();
-            } else {
-                _db = temp;
-                return Promise.resolve(_db);
-            }
-        })
-        .finally(() => { pxt.log(`PouchDB adapter: ${_db.adapter}`) });
+    _db = new PouchDB("pxt-" + pxt.storage.storageId(), opts);
+    pxt.log(`PouchDB adapter: ${_db.adapter}`)
+
+    return Promise.resolve(_db);
 }
 
 export function destroyAsync(): Promise<void> {

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1135,6 +1135,7 @@ export interface ModalProps extends ReactModal.Props {
     longer?: boolean;
 
     header?: string;
+    headerIcon?: string;
     headerClass?: string;
     description?: string;
 
@@ -1244,7 +1245,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     render() {
         const { isOpen, size, longer, basic, className,
             onClose, closeIcon, children, onKeyDown,
-            header, headerClass, headerActions, helpUrl, description,
+            header, headerIcon, headerClass, headerActions, helpUrl, description,
             closeOnDimmerClick, closeOnDocumentClick, closeOnEscape,
             shouldCloseOnEsc, shouldCloseOnOverlayClick, shouldFocusAfterRender, overlayClassName, ...rest } = this.props;
         const { marginTop, scrolling, mountClasses } = this.state;
@@ -1287,6 +1288,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
             role="dialog"
             aria={aria} {...rest}>
             {header || showBack || helpUrl ? <div id={this.id + 'title'} className={"header " + (headerClass || "")}>
+                {headerIcon && <Icon icon={headerIcon} />}
                 <span className="header-title" style={{ margin: `0 ${helpUrl ? '-20rem' : '0'} 0 ${showBack ? '-20rem' : '0'}` }}>{header}</span>
                 {showBack ? <div className="header-close">
                     <Button className="back-button large" title={lf("Go back")} onClick={onClose} tabIndex={0} onKeyDown={fireClickOnEnter}>

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -97,9 +97,9 @@ async function switchToMemoryWorkspace(reason: string): Promise<void> {
     });
 
     pxt.log(`workspace: error, switching from ${implType} to memory workspace`);
-    const expectedMemWs = pxt.shell.isSandboxMode() || pxt.shell.isReadOnly() || pxt.BrowserUtils.isIFrame();
+    const expectedMemWs = pxt.appTarget.appTheme.disableMemoryWorkspaceWarning
+                            || pxt.shell.isSandboxMode() || pxt.shell.isReadOnly() || pxt.BrowserUtils.isIFrame();
     if (!expectedMemWs && impl !== memoryworkspace.provider) {
-        // TODO; probably don't want this in HOC
         await core.confirmAsync({
             header: lf("Unable to save projects"),
             body: lf("We are unable to save your projects at this time; be sure to save your project by downloading or sharing it, as they will go after you refresh!"),

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -91,15 +91,16 @@ export function setupWorkspace(id: string) {
 }
 
 async function switchToMemoryWorkspace(reason: string): Promise<void> {
-    pxt.tickEvent(`workspace.syncerror`, {
-        ws: implType,
-        reason: reason
-    });
-
     pxt.log(`workspace: error, switching from ${implType} to memory workspace`);
+
     const expectedMemWs = pxt.appTarget.appTheme.disableMemoryWorkspaceWarning
-                            || pxt.shell.isSandboxMode() || pxt.shell.isReadOnly() || pxt.BrowserUtils.isIFrame();
+        || pxt.shell.isSandboxMode() || pxt.shell.isReadOnly() || pxt.BrowserUtils.isIFrame();
     if (!expectedMemWs && impl !== memoryworkspace.provider) {
+        pxt.tickEvent(`workspace.syncerror`, {
+            ws: implType,
+            reason: reason
+        });
+
         await core.confirmAsync({
             header: lf("Unable to save projects"),
             body: lf("We are unable to save your projects at this time; be sure to save your project by downloading or sharing it, as they will go after you refresh!"),

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -102,11 +102,14 @@ async function switchToMemoryWorkspace(reason: string): Promise<void> {
         });
 
         await core.confirmAsync({
-            header: lf("Unable to save projects"),
-            body: lf("We are unable to save your projects at this time; be sure to save your project by downloading or sharing it, as they will go after you refresh!"),
-            agreeLbl: lf("Done"),
+            header: lf("Warning! Project Auto-Save Disabled"),
+            body: lf("We are unable to save your projects at this time. You can still manually save your project via direct download, or sharing your project."),
+            agreeLbl: lf("Continue"),
+            headerIcon: "warning",
             agreeClass: "cancel",
             agreeIcon: "cancel",
+            helpUrl: "/browsers/no-auto-save",
+            className: "auto-save-disabled-warning",
             hasCloseIcon: true,
         });
     }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -94,13 +94,16 @@ async function switchToMemoryWorkspace(reason: string): Promise<void> {
     pxt.log(`workspace: error, switching from ${implType} to memory workspace`);
 
     const expectedMemWs = pxt.appTarget.appTheme.disableMemoryWorkspaceWarning
+        || impl === memoryworkspace.provider
         || pxt.shell.isSandboxMode() || pxt.shell.isReadOnly() || pxt.BrowserUtils.isIFrame();
-    if (!expectedMemWs && impl !== memoryworkspace.provider) {
-        pxt.tickEvent(`workspace.syncerror`, {
-            ws: implType,
-            reason: reason
-        });
 
+    pxt.tickEvent(`workspace.syncerror`, {
+        ws: implType,
+        reason: reason,
+        expected: expectedMemWs ? 1 : 0
+    });
+
+    if (!expectedMemWs) {
         await core.confirmAsync({
             header: lf("Warning! Project Auto-Save Disabled"),
             body: lf("We are unable to save your projects at this time. You can still manually save your project via direct download, or sharing your project."),
@@ -113,6 +116,7 @@ async function switchToMemoryWorkspace(reason: string): Promise<void> {
             hasCloseIcon: true,
         });
     }
+
     impl = memoryworkspace.provider;
 }
 


### PR DESCRIPTION
Pop an error message when we transition into an in memory workspace; no issue but some discussion here: https://github.com/microsoft/pxt/pull/7505 and offline

pouch db had a separate form of the in memory db (using pouch dbs apis) -- no reason to split up, so I made it just use the same memoryworkspace as others. also incidentally fixes the minor race condition mentioned in the pr above where we'd potentially make more than one db object

the `disableMemoryWorkspaceWarning` flag is so we can disable this warning in situations like hour of code where we don't really care to notify user we couldn't save.

![can't save anything modal](https://user-images.githubusercontent.com/5615930/96068096-ff198580-0e4f-11eb-9de0-20a216e3d142.gif)

(I'm not too attached to the wording, and we can always throw in a sad emoji to the header if we want!)