### PR TITLE
Square 'Create New' button as first item in asset list

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -74,7 +74,8 @@
     align-content: flex-start;
 }
 
-.asset-editor-card {
+.asset-editor-card,
+.create-new {
     width: 8rem;
     height: 8rem;
     margin: 1rem 0 0 1rem;
@@ -135,8 +136,19 @@
 .create-new {
     color: @white;
     background-color: @green;
-    margin-left: auto;
     font-weight: 700;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border-width: 0;
+
+    i.icon {
+        margin: 0;
+    }
+}
+.create-new:hover {
+    background-color: darken(@green, 10%);
 }
 
 .delete-asset {

--- a/webapp/src/components/assetEditor/assetCardList.tsx
+++ b/webapp/src/components/assetEditor/assetCardList.tsx
@@ -11,6 +11,7 @@ export class AssetCardList extends React.Component<AssetCardListProps> {
     render() {
         const { assets } = this.props;
         return <div>
+            {this.props.children}
             {assets.map(asset => <AssetCard asset={asset} key={asset.id} />)}
         </div>
     }

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
+import * as pkg from "../../package";
+import * as sui from "../../sui";
 import { connect } from 'react-redux';
 
 import { AssetEditorState, GalleryView } from "./store/assetEditorReducer";
+import { dispatchUpdateUserAssets } from './actions/dispatch';
 
 import { AssetCardList } from "./assetCardList";
 import { AssetTopbar } from "./assetTopbar";
@@ -11,19 +14,105 @@ interface AssetGalleryProps {
     galleryAssets: pxt.Asset[];
     userAssets: pxt.Asset[];
     showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
+    dispatchUpdateUserAssets?: () => void;
 }
 
-class AssetGalleryImpl extends React.Component<AssetGalleryProps> {
+interface AssetGalleryState {
+    showCreateModal?: boolean;
+}
+
+class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGalleryState> {
+    constructor(props: AssetGalleryProps) {
+        super(props);
+        this.state = { showCreateModal: false };
+    }
+
+    protected showCreateModal = () => {
+        this.setState({ showCreateModal: true });
+    }
+
+    protected hideCreateModal = () => {
+        this.setState({ showCreateModal: false });
+    }
+
+    protected getCreateAssetHandler = (type: pxt.AssetType) => {
+        return () => {
+            const project = pxt.react.getTilemapProject();
+            const asset = this.getEmptyAsset(type);
+
+            this.hideCreateModal();
+            this.props.showAssetFieldView(asset, (result: any) => {
+                project.pushUndo();
+                const name = result.meta?.displayName;
+                switch (type) {
+                    case pxt.AssetType.Image:
+                        project.createNewProjectImage(result.bitmap, name); break;
+                    case pxt.AssetType.Tile:
+                        project.createNewTile(result.bitmap, null, name); break;
+                    case pxt.AssetType.Tilemap:
+                        project.createNewTilemapFromData(result.data, name); break;
+                }
+                pkg.mainEditorPkg().buildAssetsAsync()
+                    .then(() => this.props.dispatchUpdateUserAssets());
+            });
+        }
+    }
+
+    protected getEmptyAsset(type: pxt.AssetType): pxt.Asset {
+        const project = pxt.react.getTilemapProject();
+        const asset = { type, id: "", internalID: 0, meta: { displayName: this.getEmptyAssetDisplayName(type) } } as pxt.Asset;
+        switch (type) {
+            case pxt.AssetType.Image:
+            case pxt.AssetType.Tile:
+                (asset as pxt.ProjectImage).bitmap = new pxt.sprite.Bitmap(16, 16).data(); break
+            case pxt.AssetType.Tilemap:
+                const tilemap = asset as pxt.ProjectTilemap;
+                tilemap.data = project.blankTilemap(16, 16, 16);
+
+        }
+        return asset;
+    }
+
+    protected getEmptyAssetDisplayName(type: pxt.AssetType): string {
+        switch (type) {
+            case pxt.AssetType.Image:
+                return lf("image");
+            case pxt.AssetType.Tile:
+                return lf("tile");
+            case pxt.AssetType.Tilemap:
+                return lf("level");
+            default:
+                return lf("asset")
+        }
+    }
+
     render() {
-        const { view, galleryAssets, userAssets, showAssetFieldView } = this.props;
+        const { view, galleryAssets, userAssets } = this.props;
+        const { showCreateModal } = this.state;
+
+        const actions: sui.ModalButton[] = [
+            { label: lf("Image"), onclick: this.getCreateAssetHandler(pxt.AssetType.Image) },
+            { label: lf("Tile"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tile) },
+            { label: lf("Tilemap"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tilemap) }
+        ]
+
         return <div className="asset-editor-gallery">
-            <AssetTopbar showAssetFieldView={showAssetFieldView} />
+            <AssetTopbar />
             <div className={`asset-editor-card-list ${view !== GalleryView.User ? "hidden" : ""}`}>
-                <AssetCardList assets={userAssets} />
+                <AssetCardList assets={userAssets}>
+                    <div className="create-new" role="button" onClick={this.showCreateModal}>
+                        <i className="icon huge add circle" />
+                        <span>{lf("New Asset")}</span>
+                    </div>
+                </AssetCardList>
             </div>
             <div className={`asset-editor-card-list ${view !== GalleryView.Gallery ? "hidden" : ""}`}>
                 <AssetCardList assets={galleryAssets} />
             </div>
+            <sui.Modal className="asset-editor-create-dialog" isOpen={showCreateModal} onClose={this.hideCreateModal}
+                closeIcon={false} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
+                <div>{lf("Choose your asset type from the options below.")}</div>
+            </sui.Modal>
         </div>
     }
 }
@@ -38,6 +127,7 @@ function mapStateToProps(state: AssetEditorState, ownProps: any) {
 }
 
 const mapDispatchToProps = {
+    dispatchUpdateUserAssets
 };
 
 export const AssetGallery = connect(mapStateToProps, mapDispatchToProps)(AssetGalleryImpl);

--- a/webapp/src/components/assetEditor/assetTopbar.tsx
+++ b/webapp/src/components/assetEditor/assetTopbar.tsx
@@ -1,113 +1,13 @@
 import * as React from "react";
-import * as pkg from "../../package";
-import * as sui from "../../sui";
-import { connect } from 'react-redux';
 
-import { AssetEditorState, GalleryView } from './store/assetEditorReducer';
-import { dispatchUpdateUserAssets } from './actions/dispatch';
+import { GalleryView } from './store/assetEditorReducer';
 import { AssetGalleryTab } from './assetGalleryTab'
 
-interface AssetTopbarProps {
-    showAssetFieldView: (asset: pxt.Asset, cb: (result: any) => void) => void;
-    dispatchUpdateUserAssets?: () => void;
-}
-
-interface AssetTopbarState {
-    showCreateModal?: boolean;
-}
-
-class AssetTopbarImpl extends React.Component<AssetTopbarProps, AssetTopbarState> {
-    constructor(props: AssetTopbarProps) {
-        super(props);
-        this.state = { showCreateModal: false };
-    }
-
-    protected showCreateModal = () => {
-        this.setState({ showCreateModal: true });
-    }
-
-    protected hideCreateModal = () => {
-        this.setState({ showCreateModal: false });
-    }
-
-    protected getCreateAssetHandler = (type: pxt.AssetType) => {
-        return () => {
-            const project = pxt.react.getTilemapProject();
-            const asset = this.getEmptyAsset(type);
-
-            this.hideCreateModal();
-            this.props.showAssetFieldView(asset, (result: any) => {
-                project.pushUndo();
-                const name = result.meta?.displayName;
-                switch (type) {
-                    case pxt.AssetType.Image:
-                        project.createNewProjectImage(result.bitmap, name); break;
-                    case pxt.AssetType.Tile:
-                        project.createNewTile(result.bitmap, null, name); break;
-                    case pxt.AssetType.Tilemap:
-                        project.createNewTilemapFromData(result.data, name); break;
-                }
-                pkg.mainEditorPkg().buildAssetsAsync()
-                    .then(() => this.props.dispatchUpdateUserAssets());
-            });
-        }
-    }
-
-    protected getEmptyAsset(type: pxt.AssetType): pxt.Asset {
-        const project = pxt.react.getTilemapProject();
-        const asset = { type, id: "", internalID: 0, meta: { displayName: this.getEmptyAssetDisplayName(type) } } as pxt.Asset;
-        switch (type) {
-            case pxt.AssetType.Image:
-            case pxt.AssetType.Tile:
-                (asset as pxt.ProjectImage).bitmap = new pxt.sprite.Bitmap(16, 16).data(); break
-            case pxt.AssetType.Tilemap:
-                const tilemap = asset as pxt.ProjectTilemap;
-                tilemap.data = project.blankTilemap(16, 16, 16);
-
-        }
-        return asset;
-    }
-
-    protected getEmptyAssetDisplayName(type: pxt.AssetType): string {
-        switch (type) {
-            case pxt.AssetType.Image:
-                return lf("image");
-            case pxt.AssetType.Tile:
-                return lf("tile");
-            case pxt.AssetType.Tilemap:
-                return lf("level");
-            default:
-                return lf("asset")
-        }
-    }
-
+export class AssetTopbar extends React.Component<{}> {
     render() {
-        const { showCreateModal } = this.state;
-
-        const actions: sui.ModalButton[] = [
-            { label: lf("Image"), onclick: this.getCreateAssetHandler(pxt.AssetType.Image) },
-            { label: lf("Tile"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tile) },
-            { label: lf("Tilemap"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tilemap) }
-        ]
-
         return <div className="asset-editor-topbar">
             <AssetGalleryTab title={lf("My Assets")} view={GalleryView.User} />
             <AssetGalleryTab title={lf("Gallery")} view={GalleryView.Gallery} />
-            <div className="asset-editor-button create-new" onClick={this.showCreateModal} role="button">{lf("Create New")}</div>
-            <sui.Modal className="asset-editor-create-dialog" isOpen={showCreateModal} onClose={this.hideCreateModal} closeIcon={false} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
-                <div>{lf("Choose your asset type from the options below.")}</div>
-            </sui.Modal>
         </div>
     }
 }
-
-function mapStateToProps(state: AssetEditorState, ownProps: any) {
-    if (!state) return {};
-    return ownProps;
-}
-
-const mapDispatchToProps = {
-    dispatchUpdateUserAssets
-};
-
-export const AssetTopbar = connect(mapStateToProps, mapDispatchToProps)(AssetTopbarImpl);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/96276664-296e5e80-0f88-11eb-95f5-f85539cd10e6.png)

Remove button from top bar, move all asset creation code into gallery component. This button only shows up in "My Assets" view for now, that can be changed after testing/usage if folks want.