### PR TITLE
Pass referenced tiles into tilemap editor

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -96,11 +96,16 @@ namespace pxtblockly {
                     break;
                 case pxt.AssetType.Tilemap:
                     editorKind = "tilemap-editor";
-                    const allTiles = pxt.react.getTilemapProject().getProjectTiles(this.asset.data.tileset.tileWidth, true);
+                    const project = pxt.react.getTilemapProject();
+                    const allTiles = project.getProjectTiles(this.asset.data.tileset.tileWidth, true);
+                    this.asset.data.projectReferences = [];
 
                     for (const tile of allTiles.tiles) {
                         if (!this.asset.data.tileset.tiles.some(t => t.id === tile.id)) {
                             this.asset.data.tileset.tiles.push(tile);
+                        }
+                        if (project.isAssetUsed(tile)) {
+                            this.asset.data.projectReferences.push(tile.id);
                         }
                     }
                     break;

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -11,11 +11,16 @@ namespace pxt.editor {
         protected textToValue(text: string): pxt.ProjectTilemap {
             const tm = this.readTilemap(text);
 
-            const allTiles = pxt.react.getTilemapProject().getProjectTiles(tm.data.tileset.tileWidth, true);
+            const project = pxt.react.getTilemapProject();
+            const allTiles = project.getProjectTiles(tm.data.tileset.tileWidth, true);
+            tm.data.projectReferences = [];
 
             for (const tile of allTiles.tiles) {
                 if (!tm.data.tileset.tiles.some(t => t.id === tile.id)) {
                     tm.data.tileset.tiles.push(tile);
+                }
+                if (project.isAssetUsed(tile)) {
+                    tm.data.projectReferences.push(tile.id);
                 }
             }
 

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -101,13 +101,20 @@ export class AssetEditor extends Editor {
                 });
                 break;
             case pxt.AssetType.Tilemap:
+                const project = pxt.react.getTilemapProject();
                 // for tilemaps, fill in all project tiles
-                const allTiles = pxt.react.getTilemapProject().getProjectTiles(asset.data.tileset.tileWidth, true);
+                const allTiles = project.getProjectTiles(asset.data.tileset.tileWidth, true);
+                const referencedTiles = [];
                 for (const tile of allTiles.tiles) {
                     if (!asset.data.tileset.tiles.some(t => t.id === tile.id)) {
                         asset.data.tileset.tiles.push(tile);
                     }
+                    if (project.isAssetUsed(tile)) {
+                        referencedTiles.push(tile.id);
+                    }
                 }
+
+                asset.data.projectReferences = referencedTiles;
 
                 fieldView = pxt.react.getFieldEditorView("tilemap-editor", asset as pxt.ProjectTilemap, {
                     initWidth: 16,


### PR DESCRIPTION
One more late game fix! Pass used tiles into blockly/monaco/asseteditor ImageEditor so you can't delete them from inside the tilemap editor.