### PR TITLE
Display animations in asset editor, UI/UX fixes

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -18,6 +18,8 @@
 .asset-editor-sidebar-name {
     overflow: hidden;
     text-overflow: ellipsis;
+    margin-bottom: 0.5rem;
+    font-weight: 700;
 }
 
 .asset-editor-sidebar-preview {

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -20,6 +20,11 @@
     text-overflow: ellipsis;
     margin-bottom: 0.5rem;
     font-weight: 700;
+
+    &.unnamed {
+        font-weight: 400;
+        font-style: italic;
+    }
 }
 
 .asset-editor-sidebar-preview {

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -159,8 +159,7 @@
     font-weight: 700;
 }
 
-.asset-editor-create-dialog .actions,
-.asset-editor-delete-dialog .actions {
+.asset-editor-create-dialog .actions {
     display: flex;
-    justify-content: space-between;
+    justify-content: space-around;
 }

--- a/theme/common.less
+++ b/theme/common.less
@@ -153,7 +153,7 @@ pre {
     z-index: (@blocklyFlyoutZIndex)-1;
 }
 
-#blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #filelist {
+#blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #filelist {
     bottom: @editorToolsCollapsedHeight;
 }
 
@@ -162,6 +162,7 @@ pre {
 .hideEditorToolbar #pxtJsonEditor,
 .hideEditorToolbar #serialEditor,
 .hideEditorToolbar #githubEditor,
+.hideEditorToolbar #assetEditor,
 .hideEditorToolbar #filelist {
     bottom: 0rem !important;
 }
@@ -1288,7 +1289,7 @@ p.ui.font.small {
         height: 9rem;
     }
 
-    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #filelist {
+    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #filelist {
         bottom: @editorToolsCollapsedMobileHeight;
     }
 
@@ -1558,7 +1559,7 @@ p.ui.font.small {
         top: @thinMenuHeight;
         padding: 0.5rem 1.5rem;
     }
-    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #filelist {
+    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #filelist {
         bottom: @editorToolsThinHeight;
     }
 
@@ -1702,7 +1703,7 @@ div.simframe.ui.embed {
         display: inherit;
     }
 
-    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #editortools, #msg {
+    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #editortools, #msg {
         bottom: 1.5rem !important;
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3925,8 +3925,8 @@ export class ProjectView
         }
         const isRTL = pxt.Util.isUserLanguageRtl();
         const showRightChevron = (this.state.collapseEditorTools || isRTL) && !(this.state.collapseEditorTools && isRTL); // Collapsed XOR RTL
-        // don't show in sandbox or is blocks editor or previous editor is blocks
-        const showFileList = !sandbox && !inTutorial
+        // don't show in sandbox or is blocks editor or previous editor is blocks or assets editor
+        const showFileList = !sandbox && !inTutorial && !this.isAssetsActive()
             && !(isBlocks
                 || (pkg.mainPkg && pkg.mainPkg.config && (pkg.mainPkg.config.preferredEditor == pxt.BLOCKS_PROJECT_NAME)));
         const hasCloud = this.hasCloud();

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -118,7 +118,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
                 <AssetCardList assets={galleryAssets} />
             </div>
             <sui.Modal className="asset-editor-create-dialog" isOpen={showCreateModal} onClose={this.hideCreateModal}
-                closeIcon={false} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
+                closeIcon={true} dimmer={true} header={lf("Create New Asset")} buttons={actions}>
                 <div>{lf("Choose your asset type from the options below.")}</div>
             </sui.Modal>
         </div>

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -51,6 +51,8 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
                         project.createNewTile(result.bitmap, null, name); break;
                     case pxt.AssetType.Tilemap:
                         project.createNewTilemapFromData(result.data, name); break;
+                    case pxt.AssetType.Animation:
+                        project.createNewAnimationFromData(result.data, name); break;
                 }
                 pkg.mainEditorPkg().buildAssetsAsync()
                     .then(() => this.props.dispatchUpdateUserAssets());
@@ -68,6 +70,10 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             case pxt.AssetType.Tilemap:
                 const tilemap = asset as pxt.ProjectTilemap;
                 tilemap.data = project.blankTilemap(16, 16, 16);
+            case pxt.AssetType.Animation:
+                const animation = asset as pxt.Animation;
+                animation.frames = [new pxt.sprite.Bitmap(16, 16).data()];
+                break;
 
         }
         return asset;
@@ -81,6 +87,8 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
                 return lf("tile");
             case pxt.AssetType.Tilemap:
                 return lf("level");
+            case pxt.AssetType.Animation:
+                return lf("anim");
             default:
                 return lf("asset")
         }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -86,6 +86,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
         project.updateAsset(result);
+        this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets();
     }
 
@@ -94,7 +95,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         const newAsset = project.duplicateAsset(this.props.asset);
         this.props.dispatchChangeSelectedAsset(newAsset);
-        if (this.props.isGalleryAsset) this.props.dispatchChangeGalleryView(GalleryView.User);
+        this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets();
     }
 
@@ -132,6 +133,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         project.removeAsset(this.props.asset);
         this.props.dispatchChangeSelectedAsset(null);
+        this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets();
     }
 

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -138,10 +138,11 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
     }
 
     render() {
-        const { asset } = this.props;
+        const { asset, isGalleryAsset } = this.props;
         const { showDeleteModal, canEdit, canCopy, canDelete } = this.state;
         const details = this.getAssetDetails();
-        const name = asset ? asset.meta?.displayName || pxt.getShortIDForAsset(asset) || lf("Unnamed") : lf("No asset selected");
+        const isNamed = asset?.meta?.displayName || isGalleryAsset;
+        const name = getDisplayNameForAsset(asset, isGalleryAsset);
 
         const actions: sui.ModalButton[] = [{ label: lf("Delete"), onclick: this.deleteAssetHandler, icon: 'trash', className: 'red' }];
 
@@ -151,7 +152,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                 <div className="asset-editor-sidebar-preview">
                     { asset && <AssetPreview asset={asset} />  }
                 </div>
-                <div className="asset-editor-sidebar-name">{ name }</div>
+                <div className={`asset-editor-sidebar-name ${!isNamed ? 'unnamed' : ''}`}>{ name }</div>
                 {details.map(el => {
                     return <div key={el.name} className="asset-editor-sidebar-detail">{`${el.name}: ${el.value}`}</div>
                 })}
@@ -180,6 +181,16 @@ function getDisplayTextForAsset(type: pxt.AssetType) {
             return lf("Animation");
         case pxt.AssetType.Tilemap:
             return lf("Tilemap");
+    }
+}
+
+function getDisplayNameForAsset(asset: pxt.Asset, isGalleryAsset?: boolean) {
+    if (!asset) {
+        return lf("No asset selected");
+    } else if (asset?.meta?.displayName) {
+        return asset.meta.displayName;
+    } else {
+        return isGalleryAsset ? pxt.getShortIDForAsset(asset) : lf("Temporary asset");
     }
 }
 

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -43,7 +43,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
 
             const project = pxt.react.getTilemapProject();
             const canEdit = !isGalleryAsset;
-            const canCopy = asset?.type != pxt.AssetType.Tilemap;
+            const canCopy = asset?.type != pxt.AssetType.Tilemap && asset?.type != pxt.AssetType.Animation;
             const canDelete = !isGalleryAsset && !project.isAssetUsed(asset, pkg.mainEditorPkg().files);
 
             this.setState({ canEdit, canCopy, canDelete });
@@ -63,6 +63,10 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                     break;
                 case pxt.AssetType.Tilemap:
                     details.push({ name: lf("Size"), value: `${asset.data.tilemap.width} x ${asset.data.tilemap.height}`});
+                    break;
+                case pxt.AssetType.Animation:
+                    details.push({ name: lf("Size"), value: `${asset.frames[0].width} x ${asset.frames[0].height}`});
+                    break;
             }
         }
 

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -143,10 +143,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         const details = this.getAssetDetails();
         const name = asset ? asset.meta?.displayName || pxt.getShortIDForAsset(asset) || lf("Unnamed") : lf("No asset selected");
 
-        const actions: sui.ModalButton[] = [
-            { label: lf("Cancel"), onclick: this.hideDeleteModal, icon: 'cancel' },
-            { label: lf("Delete"), onclick: this.deleteAssetHandler, icon: 'trash', className: 'red' }
-        ]
+        const actions: sui.ModalButton[] = [{ label: lf("Delete"), onclick: this.deleteAssetHandler, icon: 'trash', className: 'red' }];
 
         return <div className="asset-editor-sidebar">
             <div className="asset-editor-sidebar-info">
@@ -166,7 +163,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                 {canDelete && <sui.MenuItem name={lf("Delete")} className="asset-editor-button delete-asset" icon="trash" onClick={this.showDeleteModal}/>}
             </div>}
             <textarea className="asset-editor-sidebar-copy" ref={this.copyTextAreaRefHandler} ></textarea>
-            <sui.Modal className="asset-editor-delete-dialog" isOpen={showDeleteModal} onClose={this.hideDeleteModal} closeIcon={false} dimmer={true} header={lf("Delete Asset")} buttons={actions}>
+            <sui.Modal className="asset-editor-delete-dialog" isOpen={showDeleteModal} onClose={this.hideDeleteModal} closeIcon={true} dimmer={true} header={lf("Delete Asset")} buttons={actions}>
                 <div>{lf("Are you sure you want to delete {0}? Deleted assets cannot be recovered.", name)}</div>
             </sui.Modal>
         </div>

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -123,6 +123,15 @@ export class AssetEditor extends Editor {
                     blocksInfo: this.blocksInfo
                 });
                 break;
+            case pxt.AssetType.Animation:
+                fieldView = pxt.react.getFieldEditorView("animation-editor", asset as pxt.Animation, {
+                    initWidth: 16,
+                    initHeight: 16,
+                    showTiles: true,
+                    headerVisible: false,
+                    blocksInfo: this.blocksInfo
+                });
+                break;
             default:
                 break;
         }

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -17,6 +17,10 @@ export class AssetEditor extends Editor {
     protected galleryAssets: pxt.Asset[] = [];
     protected blocksInfo: pxtc.BlocksInfo;
 
+    getId() {
+        return "assetEditor";
+    }
+
     acceptsFile(file: pkg.File) {
         return file.name === pxt.ASSETS_FILE;
     }

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -60,12 +60,20 @@ function getUserAssets() {
         return asset;
     };
 
+    const animationToGalleryItem = (asset: pxt.Animation) => {
+        if (asset.frames?.length <= 0) return null;
+        let bitmap = pxt.sprite.Bitmap.fromData(asset.frames[0]);
+        asset.previewURI = imgConv.convert("data:image/x-mkcd-f," + pxt.sprite.base64EncodeBitmap(bitmap.data()));
+        return asset;
+    };
+
     const images = project.getAssets(pxt.AssetType.Image).map(imageToGalleryItem).sort(compareInternalId);
     const tiles = project.getAssets(pxt.AssetType.Tile).map(imageToGalleryItem)
         .filter(t => !t.id.match(/^myTiles.transparency(8|16|32)$/gi)).sort(compareInternalId);
     const tilemaps = project.getAssets(pxt.AssetType.Tilemap).map(tilemapToGalleryItem).sort(compareInternalId);
+    const animations = project.getAssets(pxt.AssetType.Animation).map(animationToGalleryItem);
 
-    return images.concat(tiles).concat(tilemaps);
+    return images.concat(tiles).concat(tilemaps).concat(animations);
 }
 
 export default topReducer;

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -145,7 +145,9 @@ export class File implements pxt.editor.IFile {
             this.name === pxt.TILEMAP_CODE ||
             this.name === pxt.TILEMAP_JRES ||
             this.name === pxt.IMAGES_CODE ||
-            this.name === pxt.IMAGES_JRES
+            this.name === pxt.IMAGES_JRES ||
+            this.name === pxt.TUTORIAL_INFO_FILE ||
+            this.name == pxt.ASSETS_FILE
         );
     }
 }


### PR DESCRIPTION
Stack of small asset editor changes! They are split out by commit:

https://github.com/microsoft/pxt/commit/214b9f9f051b050e49609c52502cd2b220444767 - Display animations along with other assets, open animation editor on "Edit"
https://github.com/microsoft/pxt/commit/a42c4bda509312e450b890466da0eb8636711879 - Adjust asset editor height for editor toolbar (fixes https://github.com/microsoft/pxt-arcade/issues/2500) and add font-weight + margin to asset name (fixes https://github.com/microsoft/pxt-arcade/issues/2487)
https://github.com/microsoft/pxt/commit/548367c2fe746003ba5d2cea2af64cbd8d8a535b - Switch to "My Assets" view any time an asset is duplicated, edited, or deleted (fixes https://github.com/microsoft/pxt-arcade/issues/2485)
https://github.com/microsoft/pxt/commit/0c7b372dad85e12dfe0bf4d4f79fde324a173db3 - X instead of "Cancel" in modals (fixes https://github.com/microsoft/pxt-arcade/issues/2476)
https://github.com/microsoft/pxt/commit/c305506b602c98959c7de054cd36c8ae7393726f - Display "Temporary name" instead of shortID to indicate that an asset is unnamed (fixes https://github.com/microsoft/pxt-arcade/issues/2497)
https://github.com/microsoft/pxt/commit/28db67595d049453675fccdce0d268c78efe504a - Readonly assets.json (fixes https://github.com/microsoft/pxt-arcade/issues/2480)
https://github.com/microsoft/pxt/commit/45ccb65dd9ab4f24d7707059a3f6916ab4e031fc - Hide file explorer in asset editor view (fixes https://github.com/microsoft/pxt-arcade/issues/2496)