### PR TITLE
fix embed view for melody editor notes

### DIFF
--- a/theme/melodyeditor.less
+++ b/theme/melodyeditor.less
@@ -250,7 +250,8 @@
 }
 
 .melody-content-div,
-.pxt-renderer g.blocklyEditableText > & {
+.pxt-renderer g.blocklyEditableText > &,
+.pxt-renderer g.blocklyNonEditableText > & {
     .melody-red {
         fill: #A80000;
         background: #A80000;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3398
(also the rendering on the share page, which is the exact same thing but a more important version of it :P https://makecode.microbit.org/20471-20215-46152-81939)

when rendering through the embed view the blocks are locked as non-editable, so our css has to match that

(could also just drop the `.blocklyEditableText`, but there are a lot of elements matching `.pxt-renderer g`)

here's the example from their post using an uploaded trg and working https://jsfiddle.net/ntoqkdsj/ (maybe worth noting the target includes my bluebird changes)