### PR TITLE
Fixes for duplicate and saving assets, resize listener

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -518,7 +518,7 @@ export class ProjectView
         if (!mainEditorPkg.lookupFile("this/" + pxt.ASSETS_FILE)) {
             mainEditorPkg.setFile(pxt.ASSETS_FILE, "\n", true);
         }
-        this.setFile(pkg.mainEditorPkg().lookupFile(`this/${pxt.ASSETS_FILE}`));
+        this.saveFileAsync().then(() => this.setFile(pkg.mainEditorPkg().lookupFile(`this/${pxt.ASSETS_FILE}`)));
     }
 
     openSettings() {

--- a/webapp/src/components/assetEditor/actions/dispatch.ts
+++ b/webapp/src/components/assetEditor/actions/dispatch.ts
@@ -1,6 +1,6 @@
 import * as actions from './types'
 import { GalleryView } from '../store/assetEditorReducer';
 
-export const dispatchChangeSelectedAsset = (asset: pxt.Asset) => ({ type: actions.CHANGE_SELECTED_ASSET, asset });
+export const dispatchChangeSelectedAsset = (assetType?: pxt.AssetType, assetId?: string) => ({ type: actions.CHANGE_SELECTED_ASSET, assetType, assetId });
 export const dispatchChangeGalleryView = (view: GalleryView) => ({ type: actions.CHANGE_GALLERY_VIEW, view });
 export const dispatchUpdateUserAssets = () => ({ type: actions.UPDATE_USER_ASSETS });

--- a/webapp/src/components/assetEditor/assetCard.tsx
+++ b/webapp/src/components/assetEditor/assetCard.tsx
@@ -10,7 +10,7 @@ import { AssetPreview } from "./assetPreview";
 interface AssetCardProps {
     asset: pxt.Asset;
     selected?: boolean;
-    dispatchChangeSelectedAsset: (asset: pxt.Asset) => void;
+    dispatchChangeSelectedAsset: (assetType?: pxt.AssetType, assetId?: string) => void;
 }
 
 class AssetCardImpl extends React.Component<AssetCardProps> {
@@ -29,7 +29,8 @@ class AssetCardImpl extends React.Component<AssetCardProps> {
     }
 
     clickHandler = () => {
-        this.props.dispatchChangeSelectedAsset(this.props.asset);
+        const { type, id } = this.props.asset;
+        this.props.dispatchChangeSelectedAsset(type, id);
     }
 
     render() {

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -52,7 +52,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
                     case pxt.AssetType.Tilemap:
                         project.createNewTilemapFromData(result.data, name); break;
                     case pxt.AssetType.Animation:
-                        project.createNewAnimationFromData(result.data, name); break;
+                        project.createNewAnimationFromData(result.frames, result.interval, name); break;
                 }
                 pkg.mainEditorPkg().buildAssetsAsync()
                     .then(() => this.props.dispatchUpdateUserAssets());
@@ -101,7 +101,8 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
         const actions: sui.ModalButton[] = [
             { label: lf("Image"), onclick: this.getCreateAssetHandler(pxt.AssetType.Image) },
             { label: lf("Tile"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tile) },
-            { label: lf("Tilemap"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tilemap) }
+            { label: lf("Tilemap"), onclick: this.getCreateAssetHandler(pxt.AssetType.Tilemap) },
+            { label: lf("Animation"), onclick: this.getCreateAssetHandler(pxt.AssetType.Animation) }
         ]
 
         return <div className="asset-editor-gallery">

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -18,7 +18,7 @@ interface AssetSidebarProps {
     isGalleryAsset?: boolean;
     showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
     dispatchChangeGalleryView: (view: GalleryView) => void;
-    dispatchChangeSelectedAsset: (asset: pxt.Asset) => void;
+    dispatchChangeSelectedAsset: (assetType?: pxt.AssetType, assetId?: string) => void;
     dispatchUpdateUserAssets: () => void;
 }
 
@@ -73,9 +73,10 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         return details;
     }
 
-    protected updateAssets(): void {
+    protected updateAssets(select?: pxt.Asset): void {
         pkg.mainEditorPkg().buildAssetsAsync()
-            .then(() => this.props.dispatchUpdateUserAssets());
+            .then(() => this.props.dispatchUpdateUserAssets())
+            .then(() => select && this.props.dispatchChangeSelectedAsset(select.type, select.id));
     }
 
     protected editAssetHandler = () => {
@@ -93,10 +94,9 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
     protected duplicateAssetHandler = () => {
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        const newAsset = project.duplicateAsset(this.props.asset);
-        this.props.dispatchChangeSelectedAsset(newAsset);
+        const asset = project.duplicateAsset(this.props.asset);
         this.props.dispatchChangeGalleryView(GalleryView.User);
-        this.updateAssets();
+        this.updateAssets(asset);
     }
 
     protected copyAssetHandler = () => {
@@ -132,7 +132,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
         project.removeAsset(this.props.asset);
-        this.props.dispatchChangeSelectedAsset(null);
+        this.props.dispatchChangeSelectedAsset();
         this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets();
     }

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import * as pkg from "../../package";
 import * as compiler from "../../compiler";
+import * as blocklyFieldView from "../../blocklyFieldView";
 
 import { Provider } from 'react-redux';
 import store from './store/assetEditorStore'
@@ -50,6 +51,16 @@ export class AssetEditor extends Editor {
     redo() {
         pxt.react.getTilemapProject().redo();
         store.dispatch(dispatchUpdateUserAssets());
+    }
+
+
+    resize(e?: Event) {
+        blocklyFieldView.setEditorBounds({
+            top: 0,
+            left: 0,
+            width: window.innerWidth,
+            height: window.innerHeight
+        });
     }
 
     display(): JSX.Element {

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -27,6 +27,7 @@ export class AssetEditor extends Editor {
 
     loadFileAsync(file: pkg.File, hc?: boolean): Promise<void> {
         // force refresh to ensure we have a view
+
         return super.loadFileAsync(file, hc)
             .then(() => compiler.getBlocksAsync()) // make sure to load block definitions
             .then(info => {
@@ -35,6 +36,10 @@ export class AssetEditor extends Editor {
             })
             .then(() => store.dispatch(dispatchUpdateUserAssets()))
             .then(() => this.parent.forceUpdate());
+    }
+
+    unloadFileAsync(): Promise<void> {
+        return pkg.mainEditorPkg().buildAssetsAsync();
     }
 
     undo() {

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -21,7 +21,7 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
         case actions.CHANGE_SELECTED_ASSET:
             return {
                 ...state,
-                selectedAsset: action.asset
+                selectedAsset: getSelectedAsset(state.assets, action.assetType, action.assetId)
             };
         case actions.CHANGE_GALLERY_VIEW:
             return {
@@ -29,7 +29,7 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
                 view: action.view
             };
         case actions.UPDATE_USER_ASSETS:
-            const assets = getUserAssets()
+            const assets = getUserAssets();
             return {
                 ...state,
                 selectedAsset: state.selectedAsset ? assets.find(el => el.id == state.selectedAsset.id) : undefined,
@@ -42,6 +42,12 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
 
 function compareInternalId(a: pxt.Asset, b: pxt.Asset) {
     return a.internalID - b.internalID;
+}
+
+function getSelectedAsset(assets: pxt.Asset[], type: pxt.AssetType, id: string) {
+    if (!type || !id) return undefined;
+
+    return assets.find(el => el.type == type && el.id == id);
 }
 
 function getUserAssets() {


### PR DESCRIPTION
https://github.com/microsoft/pxt/commit/85882d28a26143a5f65dd9b2b3d3f3762ae93d09 - Save code before entering assets editor (fixes https://github.com/microsoft/pxt-arcade/issues/2506, fixes https://github.com/microsoft/pxt-arcade/issues/2502)
https://github.com/microsoft/pxt/commit/3d7be698f02d399a52e8ddf415ff9118817e30cf - Hook up window resize listener (fixes https://github.com/microsoft/pxt-arcade/issues/2490)
https://github.com/microsoft/pxt/commit/5facfa89b3960206251d46489faa0396ba5a45d1 - Duplicate should essentially create a new asset with the same image (fixes https://github.com/microsoft/pxt-arcade/issues/2514, partial fix for https://github.com/microsoft/pxt-arcade/issues/2481)
https://github.com/microsoft/pxt/commit/4b25eed12d8f54451d87ff619320960701b88dd2 - Look up selected asset by ID (cleanup)
https://github.com/microsoft/pxt/commit/daa9d259d16ff3a18cc3551a536ef6502a9e264c - Add animation to create dialog

