### PR TITLE
Fixing some bugs in temporary assets

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -332,12 +332,19 @@ namespace pxtblockly {
             if (!this.asset.meta) {
                 this.asset.meta = {};
             }
+
             if (!this.asset.meta.blockIDs) {
                 this.asset.meta.blockIDs = [];
             }
 
             if (this.sourceBlock_) {
                 if (this.asset.meta.blockIDs.indexOf(this.sourceBlock_.id) === -1) {
+                    const blockIDs = this.asset.meta.blockIDs;
+                    if (blockIDs.length && this.isTemporaryAsset() && blockIDs.some(id => this.sourceBlock_.workspace.getBlockById(id))) {
+                        // This temporary asset is already used, so we should clone a copy for ourselves
+                        this.asset = pxt.react.getTilemapProject().duplicateAsset(this.asset, true);
+                        this.asset.meta.blockIDs = [];
+                    }
                     this.asset.meta.blockIDs.push(this.sourceBlock_.id);
                 }
                 this.setBlockData(this.asset.id);

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -58,7 +58,7 @@ namespace pxtblockly {
         protected abstract getValueText(): string;
 
         init() {
-            if (this.fieldGroup_) {
+            if (this.isInitialized()) {
                 // Field has already been initialized once.
                 return;
             }
@@ -188,23 +188,25 @@ namespace pxtblockly {
                 return;
             }
             this.value_ = newValue;
-            this.parseValueText(newValue);
-            this.redrawPreview();
 
-            super.doValueUpdate_(newValue);
+            if (this.isInitialized()) {
+                this.parseValueText(newValue);
+                this.redrawPreview();
+
+                super.doValueUpdate_(newValue);
+            }
         }
 
         dispose() {
             super.dispose();
 
             pxt.react.getTilemapProject().removeChangeListener(this.getAssetType(), this.assetChangeListener);
-
-            this.disposeOfTemporaryAsset();
         }
 
         disposeOfTemporaryAsset() {
             if (this.isTemporaryAsset()) {
                 pxt.react.getTilemapProject().removeAsset(this.asset);
+                this.setBlockData("");
                 this.asset = undefined;
             }
         }
@@ -258,7 +260,7 @@ namespace pxtblockly {
             if (this.sourceBlock_ && !this.sourceBlock_.isInFlyout) {
                 const project = pxt.react.getTilemapProject();
 
-                const id = pxt.blocks.getBlockDataForField(this.sourceBlock_, this.name);
+                const id = this.getBlockData();
                 if (id) {
                     this.asset = project.lookupAsset(this.getAssetType(), id);
                 }
@@ -312,12 +314,12 @@ namespace pxtblockly {
             if (!this.asset && this.sourceBlock_ && !this.sourceBlock_.isInFlyout) {
                 const project = pxt.react.getTilemapProject();
 
-                const id = pxt.blocks.getBlockDataForField(this.sourceBlock_, this.name);
+                const id = this.getBlockData();
                 if (id) {
                     this.asset = project.lookupAsset(this.getAssetType(), id);
                 }
                 if (!this.asset) {
-                    this.asset = this.createNewAsset();
+                    this.asset = this.createNewAsset(this.value_);
                 }
                 this.updateAssetListener();
             }
@@ -338,7 +340,7 @@ namespace pxtblockly {
                 if (this.asset.meta.blockIDs.indexOf(this.sourceBlock_.id) === -1) {
                     this.asset.meta.blockIDs.push(this.sourceBlock_.id);
                 }
-                pxt.blocks.setBlockDataForField(this.sourceBlock_, this.name, this.asset.id);
+                this.setBlockData(this.asset.id);
             }
 
             pxt.react.getTilemapProject().updateAsset(this.asset);
@@ -353,7 +355,7 @@ namespace pxtblockly {
 
         protected assetChangeListener = () => {
             if (this.pendingEdit) return;
-            const id = pxt.blocks.getBlockDataForField(this.sourceBlock_, this.name);
+            const id = this.getBlockData();
             if (id) {
                 this.asset = pxt.react.getTilemapProject().lookupAsset(this.getAssetType(), id);
             }
@@ -362,6 +364,18 @@ namespace pxtblockly {
 
         protected isTemporaryAsset() {
             return this.asset && !this.asset.meta.displayName;
+        }
+
+        protected getBlockData() {
+            return pxt.blocks.getBlockDataForField(this.sourceBlock_, this.name);
+        }
+
+        protected setBlockData(value: string) {
+            pxt.blocks.setBlockDataForField(this.sourceBlock_, this.name, value);
+        }
+
+        protected isInitialized() {
+            return !!this.fieldGroup_;
         }
     }
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -41,6 +41,10 @@ namespace pxtblockly {
                 }
             }
 
+            if (this.getBlockData()) {
+                return project.lookupAsset(pxt.AssetType.Image, this.getBlockData());
+            }
+
             const bmp = text ? pxt.sprite.imageLiteralToBitmap(text) : new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight);
             const newAsset = project.createNewProjectImage(bmp.data());
             return newAsset;

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -178,12 +178,7 @@ namespace pxtblockly {
 
         menuGenerator_ = () => {
             if (this.sourceBlock_?.workspace && needsTilemapUpgrade(this.sourceBlock_?.workspace)) {
-                return [[{
-                    src: mkTransparentTileImage(16),
-                    width: PREVIEW_SIDE_LENGTH,
-                    height: PREVIEW_SIDE_LENGTH,
-                    alt: this.getValue()
-                }, this.getValue(), this.getValue()]]
+                return [constructTransparentTile()]
             }
             return FieldTileset.getReferencedTiles(this.sourceBlock_.workspace);
         }

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -884,19 +884,22 @@ namespace pxt {
             }
         }
 
-        public duplicateAsset(asset: ProjectImage): ProjectImage;
-        public duplicateAsset(asset: Tile): Tile;
-        public duplicateAsset(asset: ProjectTilemap): ProjectTilemap;
-        public duplicateAsset(asset: Animation): Animation;
-        public duplicateAsset(asset: Asset): Asset;
-        public duplicateAsset(asset: Asset) {
+        public duplicateAsset(asset: ProjectImage, temporary?: boolean): ProjectImage;
+        public duplicateAsset(asset: Tile, temporary?: boolean): Tile;
+        public duplicateAsset(asset: ProjectTilemap, temporary?: boolean): ProjectTilemap;
+        public duplicateAsset(asset: Animation, temporary?: boolean): Animation;
+        public duplicateAsset(asset: Asset, temporary?: boolean): Asset;
+        public duplicateAsset(asset: Asset, temporary = false) {
             this.onChange();
             const newAsset = cloneAsset(asset);
             newAsset.internalID = this.getNewInternalId();
             const id = newAsset.id.substr(newAsset.id.lastIndexOf(".") + 1).replace(/\d*$/, "");
-            if (!newAsset.meta?.displayName) {
-                if (!newAsset.meta) newAsset.meta = {};
-                newAsset.meta.displayName = id;
+
+            if (!temporary) {
+                if (!newAsset.meta?.displayName) {
+                    if (!newAsset.meta) newAsset.meta = {};
+                    newAsset.meta.displayName = id;
+                }
             }
 
             switch (newAsset.type) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1028,9 +1028,6 @@ export class ProjectView
                     header.editor = pxt.PYTHON_PROJECT_NAME
                     header.pubCurrent = false
                     isCodeFile = true;
-                } else if (fn.name == pxt.ASSETS_FILE) {
-                    header.editor = pxt.ASSETS_PROJECT_NAME
-                    header.pubCurrent = false
                 } else {
                     // some other file type
                 }


### PR DESCRIPTION
We were losing references to temporary assets when switching between the asset editor and blocks editor. This fixes that and also makes it so that the source of truth for assets is the block data and not the field value (though that still gets used if the data doesn't exist)