### PR TITLE
Update simulator from asset editor view, fix for tileset block

### DIFF
--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -94,7 +94,7 @@ namespace pxtblockly {
         getValue() {
             if (this.selectedOption_) {
                 const tile = this.selectedOption_[2];
-                return `assets.tile\`${displayName(tile)}\``
+                return isGalleryTile(tile) ? tile.id : `assets.tile\`${displayName(tile)}\``
             }
             const v = super.getValue();
 
@@ -251,5 +251,9 @@ namespace pxtblockly {
 
     function displayName(tile: pxt.Tile) {
         return tile.meta.displayName || pxt.getShortIDForAsset(tile);
+    }
+
+    function isGalleryTile(tile: pxt.Tile) {
+        return tile.id.startsWith("sprites.");
     }
 }

--- a/pxtblocks/fields/field_utils.ts
+++ b/pxtblocks/fields/field_utils.ts
@@ -252,7 +252,7 @@ namespace pxtblockly {
 
         for (const projectMap of projectMaps) {
             for (const tile of projectMap.data.tileset.tiles) {
-                all[tile.id] = project.lookupAsset(pxt.AssetType.Tile, tile.id);;
+                all[tile.id] = project.lookupAsset(pxt.AssetType.Tile, tile.id);
             }
         }
 
@@ -264,7 +264,7 @@ namespace pxtblockly {
             if (match) {
                 const tile = project.lookupAssetByName(pxt.AssetType.Tile, match[1]);
 
-                if (!all[tile.id]) {
+                if (tile && !all[tile.id]) {
                     all[tile.id] = tile;
                 }
             }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as pkg from "../../package";
+import * as simulator from "../../simulator";
 import * as sui from "../../sui";
 import { connect } from 'react-redux';
 
@@ -73,10 +74,9 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         return details;
     }
 
-    protected updateAssets(select?: pxt.Asset): void {
-        pkg.mainEditorPkg().buildAssetsAsync()
-            .then(() => this.props.dispatchUpdateUserAssets())
-            .then(() => select && this.props.dispatchChangeSelectedAsset(select.type, select.id));
+    protected updateAssets(): Promise<void> {
+        return pkg.mainEditorPkg().buildAssetsAsync()
+            .then(() => this.props.dispatchUpdateUserAssets());
     }
 
     protected editAssetHandler = () => {
@@ -88,15 +88,17 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         project.updateAsset(result);
         this.props.dispatchChangeGalleryView(GalleryView.User);
-        this.updateAssets();
+        this.updateAssets().then(() => simulator.setDirty());
     }
 
     protected duplicateAssetHandler = () => {
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        const asset = project.duplicateAsset(this.props.asset);
-        this.props.dispatchChangeGalleryView(GalleryView.User);
-        this.updateAssets(asset);
+        const { type, id } = project.duplicateAsset(this.props.asset);
+        this.updateAssets().then(() => {
+            this.props.dispatchChangeGalleryView(GalleryView.User);
+            this.props.dispatchChangeSelectedAsset(type, id);
+        });
     }
 
     protected copyAssetHandler = () => {

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -159,7 +159,12 @@ export class AssetEditor extends Editor {
         fieldView.onHide(() => {
             const result = fieldView.getResult();
             if (asset.type == pxt.AssetType.Tilemap) result.data = this.updateTilemapTiles(result.data);
-            cb(result);
+
+            Promise.resolve(cb(result)).then(() => {
+                this.parent.saveBlocksToTypeScriptAsync().then((src) => {
+                    pkg.mainEditorPkg().setContentAsync("main.ts", src)
+                })
+            });
         });
         fieldView.show();
     }

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -161,9 +161,12 @@ export class AssetEditor extends Editor {
             if (asset.type == pxt.AssetType.Tilemap) result.data = this.updateTilemapTiles(result.data);
 
             Promise.resolve(cb(result)).then(() => {
-                this.parent.saveBlocksToTypeScriptAsync().then((src) => {
-                    pkg.mainEditorPkg().setContentAsync("main.ts", src)
-                })
+                // for temporary (unnamed) assets, update the underlying typescript image literal
+                if (!result.meta?.displayName) {
+                    this.parent.saveBlocksToTypeScriptAsync().then((src) => {
+                        if (src) pkg.mainEditorPkg().setContentAsync("main.ts", src)
+                    })
+                }
             });
         });
         fieldView.show();


### PR DESCRIPTION
https://github.com/microsoft/pxt/commit/026a824a30ff8d5c4041cf0026fa730b593c60b5 - mark simulator as dirty, update main.ts for unnamed/temporary assets since they're emitted as literals in the case of images and animations (second half of fix for https://github.com/microsoft/pxt-arcade/issues/2488)
https://github.com/microsoft/pxt/commit/4a6d4be6d8f2df822b5d63a4f606c073f6d09da1 - null check, emit id directly for gallery tiles (fixes https://github.com/microsoft/pxt-arcade/issues/2512)