### PR TITLE
check keys in fileDeps validation, not values

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3183,10 +3183,11 @@ export async function validateAndFixPkgConfig(parsed: commandParser.ParsedComman
         cfg.testFiles = trimmedTestFiles;
     }
 
-    const validFilesInFileDependencies = validateFileList("fileDependencies", U.values(cfg.fileDependencies));
+    const dependentFiles = Object.keys(cfg.fileDependencies);
+    const validFilesInFileDependencies = validateFileList("fileDependencies", dependentFiles);
     if (validFilesInFileDependencies) {
-        for (const key of Object.keys(cfg.fileDependencies)) {
-            if (validFilesInFileDependencies.indexOf(cfg.fileDependencies[key]) === -1) {
+        for (const key of dependentFiles) {
+            if (validFilesInFileDependencies.indexOf(key) === -1) {
                 delete cfg.fileDependencies[key];
             }
         }


### PR DESCRIPTION
Just noticed that I had the key:value swapped in https://github.com/microsoft/pxt/pull/7477/files#, as the only examples of this I had seen were ones I made to test after misreading the docs page (it was checking if the condition was a valid file)