### PR TITLE
pass builtinParts as separate field in init message

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4403,7 +4403,7 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
 
             if (buildOpts.mode === BuildOption.DebugSim) {
                 mainPkg.host().writeFile(mainPkg, "built/debug/debugInfo.json", JSON.stringify({
-                    usedParts: pxtc.computeUsedParts(res, true),
+                    usedParts: pxtc.computeUsedParts(res, "ignorebuiltin"),
                     usedArguments: res.usedArguments,
                     breakpoints: res.breakpoints
                 }));

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -336,7 +336,7 @@ namespace ts.pxtc {
         endingToken?: string;
     }
 
-    export function computeUsedParts(resp: CompileResult, ignoreBuiltin = false): string[] {
+    export function computeUsedParts(resp: CompileResult, filter?: "onlybuiltin" | "ignorebuiltin"): string[] {
         if (!resp.usedSymbols || !pxt.appTarget.simulator || !pxt.appTarget.simulator.parts)
             return [];
 
@@ -356,10 +356,15 @@ namespace ts.pxtc {
             }
         });
 
-        if (ignoreBuiltin) {
+        if (filter) {
             const builtinParts = pxt.appTarget.simulator.boardDefinition.onboardComponents;
-            if (builtinParts)
-                parts = parts.filter(p => builtinParts.indexOf(p) < 0);
+            if (builtinParts) {
+                if (filter === "ignorebuiltin") {
+                    parts = parts.filter(p => builtinParts.indexOf(p) === -1);
+                } else if (filter === "onlybuiltin") {
+                    parts = parts.filter(p => builtinParts.indexOf(p) >= 0);
+                }
+            }
         }
 
         //sort parts (so breadboarding layout is stable w.r.t. code ordering)

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -401,11 +401,13 @@ namespace pxt.runner {
 
                     let fnArgs = resp.usedArguments;
                     let board = pxt.appTarget.simulator.boardDefinition;
-                    let parts = pxtc.computeUsedParts(resp, true);
+                    let parts = pxtc.computeUsedParts(resp, "ignorebuiltin");
+                    const usedBuiltinParts = pxtc.computeUsedParts(resp, "onlybuiltin");
                     let storedState: Map<string> = getStoredState(simOptions.id)
                     let runOptions: pxsim.SimulatorRunOptions = {
                         boardDefinition: board,
                         parts: parts,
+                        builtinParts: usedBuiltinParts,
                         fnArgs: fnArgs,
                         cdnUrl: pxt.webConfig.commitCdnUrl,
                         localizedStrings: Util.getLocalizedStrings(),

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -10,6 +10,7 @@ namespace pxsim {
         refCountingDebug?: boolean;
         options?: any;
         parts?: string[];
+        builtinParts?: string[];
         partDefinitions?: Map<PartDefinition>
         fnArgs?: any;
         code: string;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -44,7 +44,7 @@ namespace pxsim {
         trace?: boolean;
         boardDefinition?: pxsim.BoardDefinition;
         parts?: string[];
-        builtinParts?: string[]
+        builtinParts?: string[];
         fnArgs?: any;
         aspectRatio?: number;
         partDefinitions?: pxsim.Map<PartDefinition>;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -44,6 +44,7 @@ namespace pxsim {
         trace?: boolean;
         boardDefinition?: pxsim.BoardDefinition;
         parts?: string[];
+        builtinParts?: string[]
         fnArgs?: any;
         aspectRatio?: number;
         partDefinitions?: pxsim.Map<PartDefinition>;

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -283,7 +283,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
     res: pxtc.CompileResult, options: RunOptions, trace: boolean) {
     const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
-    const parts = pxtc.computeUsedParts(res, true);
+    const parts = pxtc.computeUsedParts(res, "ignorebuiltin");
+    const usedBuiltinParts = pxtc.computeUsedParts(res, "onlybuiltin");
     const fnArgs = res.usedArguments;
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
@@ -292,6 +293,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         boardDefinition: boardDefinition,
         mute,
         parts,
+        builtinParts: usedBuiltinParts,
         debug,
         trace,
         fnArgs,


### PR DESCRIPTION
Pass the builtinparts as a separate part of the message, so they're available if needed. Part of fix for micro:bit v2 sim positioning (right now they're getting counted as non-builtin parts, and causing the simulator to get double size

![image](https://user-images.githubusercontent.com/5615930/96931800-ba56a580-1472-11eb-9c13-55d5658c772c.png)

vs with this:

![image](https://user-images.githubusercontent.com/5615930/96932123-3bae3800-1473-11eb-88c5-b8955af0cb32.png)

Up for alternative approaches as well, we might need something else to handle cases like using the music blocks (assuming we want them to show as using the onboardspeaker instead of the headphones when other blocks have switched to v2 modes)