### PR TITLE
Set toggle position based on number of toggle elements

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -329,6 +329,8 @@ div.simframe > iframe {
     background: none;
     color: @mainMenuInvertedBackground !important;
 }
+
+/* toggle style */
 .ui.item.editor-menuitem .item.toggle {
     z-index: 1 !important;
     margin: 1px;
@@ -346,40 +348,30 @@ div.simframe > iframe {
     transition-timing-function: ease-in;
 }
 
-.active.item.javascript-menuitem ~ .toggle,
-.active.item.python-menuitem ~ .toggle,
-.active.item.blocks-menuitem ~ .toggle {
-    margin-left: 0 !important;
-    box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
-    background: @editorToggleColor !important;
+/* active toggle */
+.ui.item.editor-menuitem .active ~ .item.toggle {
+    box-shadow: 2px 0 0 rgba(0,0,0,.1)!important;
+    background: #fff!important;
 }
 
-.javascript-menuitem ~ .active.item.assets-menuitem ~ .toggle,
-.python-menuitem ~ .active.item.assets-menuitem ~ .toggle,
-.blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
-.blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
-    margin-left: 140px !important;
-    box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
-    background: @editorToggleColor !important;
-}
-
-#editordropdown ~ .active.item.assets-menuitem ~ .toggle  {
-    margin-left: 185px!important;
-}
-
-.blocks-menuitem ~ #editordropdown ~ .active.item.assets-menuitem ~ .toggle {
-    margin-left: 326px !important;
-    box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
-    background: @editorToggleColor !important;
-}
-
-#editortoggle .active.item.javascript-menuitem ~ .toggle.hasdropdown,
-#editortoggle .active.item.python-menuitem ~ .toggle.hasdropdown  {
-    border-top-right-radius: 0px!important;
-    border-bottom-right-radius: 0px!important;
-}
 #editortoggle > .link {
     justify-content: center;
+}
+
+#editortoggle {
+    /* toggle positioning, no dropdown */
+    .base-menuitem:nth-of-type(1).active ~ .toggle { margin-left: 0!important; }
+    .base-menuitem:nth-of-type(2).active ~ .toggle { margin-left: 140px!important; }
+    .base-menuitem:nth-of-type(3).active ~ .toggle { margin-left: 280px!important; }
+
+    /* toggle positioning after dropdown */
+    & > #editordropdown:nth-of-type(2) ~ .active ~ .toggle { margin-left: 185px!important; }
+    & > #editordropdown:nth-of-type(3) ~ .active ~ .toggle { margin-left: 326px!important; }
+
+    .toggle.dropdown-attached {
+        border-top-right-radius: 0!important;
+        border-bottom-right-radius: 0!important;
+    }
 }
 
 #editordropdown {
@@ -869,32 +861,6 @@ p.ui.font.small {
 
 /* Mobile + Tablet */
 @media only screen and (max-width: @largestTabletScreen) {
-    #root.sandbox:not(.headless) {
-        .active.item.sim-menuitem ~ .toggle {
-            margin-left: 0 !important;
-            box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
-            background: @editorToggleColor !important;
-        }
-        .active.item.blocks-menuitem ~ .toggle {
-            margin-left: 40px !important;
-            box-shadow: 2px 0px 0px rgba(0,0,0,0.1), -2px 0px 0px rgba(0,0,0,0.1) !important;
-            background: @editorToggleColor !important;
-        }
-        .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
-        .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
-            margin-left: 80px !important;
-            box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
-            background: @editorToggleColor !important;
-        }
-
-        .blocks-menuitem ~ .active.item.assets-menuitem ~ .toggle {
-            margin-left: 120px !important;
-            box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
-            background: @editorToggleColor !important;
-        }
-
-    }
-
     .simView #boardview {
         padding-top: @sandboxMobileMenuHeight;
     }
@@ -1426,19 +1392,16 @@ p.ui.font.small {
         width: 40px;
         height: 38px;
     }
-    .javascript-menuitem ~ .active.item.assets-menuitem ~ .toggle,
-    .python-menuitem ~ .active.item.assets-menuitem ~ .toggle,
-    .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
-    .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
-        margin-left: 40px !important;
-    }
 
-    #editordropdown ~ .active.item.assets-menuitem ~ .toggle {
-        margin-left: 80px !important;
-    }
+    #editortoggle {
+        /* toggle positioning, no dropdown */
+        .base-menuitem:nth-of-type(1).active ~ .toggle { margin-left: 0!important; }
+        .base-menuitem:nth-of-type(2).active ~ .toggle { margin-left: 40px!important; }
+        .base-menuitem:nth-of-type(3).active ~ .toggle { margin-left: 80px!important; }
 
-    .blocks-menuitem ~ #editordropdown ~ .active.item.assets-menuitem ~ .toggle {
-        margin-left: 120px !important;
+        /* toggle positioning after dropdown */
+        & > #editordropdown:nth-of-type(2) ~ .active ~ .toggle { margin-left: 80px!important; }
+        & > #editordropdown:nth-of-type(3) ~ .active ~ .toggle { margin-left: 120px!important; }
     }
 
     /* Top Menu */
@@ -1715,36 +1678,6 @@ div.simframe.ui.embed {
 
     #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #editortools, #msg {
         bottom: 1.5rem !important;
-    }
-
-    &:not(.headless) .active.item.sim-menuitem ~ .toggle {
-        margin-left: 0 !important;
-        box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
-        background: @editorToggleColor !important;
-    }
-    &:not(.headless) .active.item.blocks-menuitem ~ .toggle {
-        margin-left: 140px !important;
-        box-shadow: 2px 0px 0px rgba(0,0,0,0.1) !important;
-        background: @editorToggleColor !important;
-    }
-    &:not(.headless) .blocks-menuitem ~ .active.item.javascript-menuitem ~ .toggle,
-    &:not(.headless) .blocks-menuitem ~ .active.item.python-menuitem ~ .toggle {
-        margin-left: 280px !important;
-        box-shadow: -2px 0px 0px rgba(0,0,0,0.1) !important;
-        background: @editorToggleColor !important;
-    }
-
-    .one-language {
-        .active.item.javascript-menuitem ~ .toggle,
-        .active.item.python-menuitem ~ .toggle {
-            margin-left: 0px !important;
-        }
-    }
-    &:not(.headless) .one-language {
-        .active.item.javascript-menuitem ~ .toggle,
-        .active.item.python-menuitem ~ .toggle {
-            margin-left: 140px !important;
-        }
     }
 }
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -326,7 +326,7 @@ class BaseMenuItemProps extends data.Component<IBaseMenuItemProps, {}> {
 
     renderCore() {
         const active = this.props.isActive();
-        return <sui.Item className={`${this.props.className} ${active ? "selected" : ""}`} role="menuitem" textClass="landscape only" text={this.props.text} icon={this.props.icon} active={active} onClick={this.props.onClick} title={this.props.title} />
+        return <sui.Item className={`base-menuitem ${this.props.className} ${active ? "selected" : ""}`} role="menuitem" textClass="landscape only" text={this.props.text} icon={this.props.icon} active={active} onClick={this.props.onClick} title={this.props.title} />
     }
 }
 
@@ -445,24 +445,25 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         const dropdownActive = python && (parent.isJavaScriptActive() || parent.isPythonActive());
         const tsOnly = languageRestriction === pxt.editor.LanguageRestriction.JavaScriptOnly;
         const pyOnly = languageRestriction === pxt.editor.LanguageRestriction.PythonOnly;
-        // show python in toggle if: python editor currently active, or blocks editor active & saved language pref is python
-        const showPython = (parent.isPythonActive() || pxt.shell.isPyLangPref()) && !tsOnly;
-        const showBlocks = !!pkg.mainEditorPkg().files["main.blocks"];
-        const showAssets = pxt.appTarget.appTheme.assetEditor;
 
-        const hasDropdown = python && languageRestriction === pxt.editor.LanguageRestriction.Standard;
+        // show python in toggle if: python editor currently active, or blocks editor active & saved language pref is python
+        const showPython = python && !tsOnly && (parent.isPythonActive() || pxt.shell.isPyLangPref());
+        const showBlocks = !pyOnly && !tsOnly && !!pkg.mainEditorPkg().files["main.blocks"];
+        const showSandbox = sandbox && !headless;
+        const showDropdown = !pyOnly && !tsOnly && python;
+        const showAssets = pxt.appTarget.appTheme.assetEditor && !sandbox;
 
         return (
             <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`}>
-                {sandbox && !headless && <SandboxMenuItem parent={parent} />}
-                {!pyOnly && !tsOnly && showBlocks && <BlocksMenuItem parent={parent} />}
-                {python && showPython ? <PythonMenuItem parent={parent} /> : <JavascriptMenuItem parent={parent} />}
-                {!pyOnly && !tsOnly && python && <sui.DropdownMenu id="editordropdown" role="menuitem" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
+                {showSandbox && <SandboxMenuItem parent={parent} />}
+                {showBlocks && <BlocksMenuItem parent={parent} />}
+                {showPython ? <PythonMenuItem parent={parent} /> : <JavascriptMenuItem parent={parent} />}
+                {showDropdown && <sui.DropdownMenu id="editordropdown" role="menuitem" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
                     <JavascriptMenuItem parent={parent} />
                     <PythonMenuItem parent={parent} />
                 </sui.DropdownMenu>}
                 {showAssets && <AssetMenuItem parent={parent} />}
-                <div className={`ui item toggle ${hasDropdown ? 'hasdropdown' : ''}`}></div>
+                <div className={`ui item toggle ${dropdownActive ? 'dropdown-attached' : ''}`}></div>
             </div>
         )
     }


### PR DESCRIPTION
Build: https://arcade.makecode.com/app/497f26dff3463a0cb641fec965a062b57bc34850-5ffe727f79

Cleans up the various cases we had and positions the toggle strictly based on the number of children in the toggle and which child is active. Elements after the dropdown are slightly special-cased since the dropdown changes the offset amount. container.tsx changes are mostly just shifting those conditionals around, but I also added base-editormenuitem CSS class.