### PR TITLE
Add list of IDs to skip when checking if a tile is used

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -104,7 +104,7 @@ namespace pxtblockly {
                         if (!this.asset.data.tileset.tiles.some(t => t.id === tile.id)) {
                             this.asset.data.tileset.tiles.push(tile);
                         }
-                        if (project.isAssetUsed(tile)) {
+                        if (project.isAssetUsed(tile, null, [this.asset.id])) {
                             this.asset.data.projectReferences.push(tile.id);
                         }
                     }

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -19,7 +19,7 @@ namespace pxt.editor {
                 if (!tm.data.tileset.tiles.some(t => t.id === tile.id)) {
                     tm.data.tileset.tiles.push(tile);
                 }
-                if (project.isAssetUsed(tile)) {
+                if (project.isAssetUsed(tile, null, [tm.id])) {
                     tm.data.projectReferences.push(tile.id);
                 }
             }

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -501,7 +501,6 @@ namespace pxt {
     export const BLOCKS_PROJECT_NAME = "blocksprj";
     export const JAVASCRIPT_PROJECT_NAME = "tsprj";
     export const PYTHON_PROJECT_NAME = "pyprj";
-    export const ASSETS_PROJECT_NAME = "assetsprj"
     export const DEFAULT_GROUP_NAME = "other"; // used in flyout, for snippet groups
     export const TILEMAP_CODE = "tilemap.g.ts";
     export const TILEMAP_JRES = "tilemap.g.jres";

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -729,13 +729,18 @@ namespace pxt {
          *
          * TILEMAPS:
          * tilemap`shortId`
+         *
+         * @param skipIDs string[] a list of string ids (block id, asset id, or file name) to ignore
          **/
-        public isAssetUsed(asset: Asset, files?: pxt.Map<{content: string}>): boolean {
-            if (asset.meta?.blockIDs?.length > 0) return true;
+        public isAssetUsed(asset: Asset, files?: pxt.Map<{content: string}>, skipIDs?: string[]): boolean {
+            let blockIds = asset.meta?.blockIDs?.filter(id => !skipIDs || skipIDs?.indexOf(id) < 0) || [];
+            if (blockIds.length > 0) return true;
 
             if (asset.type == pxt.AssetType.Tile) {
                 for (const tm of this.getAssets(AssetType.Tilemap)) {
-                    if (tm.data.tileset.tiles.some(t => t.internalID === asset.internalID)) {
+                    if (skipIDs?.indexOf(tm.id) >= 0) {
+                        continue;
+                    } else if (tm.data.tileset.tiles.some(t => t.internalID === asset.internalID)) {
                         return true;
                     }
                 }
@@ -786,6 +791,8 @@ namespace pxt {
                 const assetPyRegex = new RegExp(assetPyRefs, "gm");
 
                 for (let filename of Object.keys(files)) {
+                    if (skipIDs?.indexOf(filename) >= 0) continue;
+
                     const f = files[filename];
                     // Match .ts files that are not generated (.g.ts)
                     if (filename.match(/((?!\.g).{2}|^.{0,1})\.ts$/i)) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2117,10 +2117,6 @@ export class ProjectView
             }
         }
 
-        if (this.editor == this.assetEditor) {
-            return pxt.ASSETS_PROJECT_NAME
-        }
-
         // no preferred editor
         return undefined;
     }

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -129,7 +129,7 @@ export class AssetEditor extends Editor {
                     if (!asset.data.tileset.tiles.some(t => t.id === tile.id)) {
                         asset.data.tileset.tiles.push(tile);
                     }
-                    if (project.isAssetUsed(tile)) {
+                    if (project.isAssetUsed(tile, null, [asset.id])) {
                         referencedTiles.push(tile.id);
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2481 

Also removes "assetprj" entirely, not necessary any more.