### PR TITLE
Fix large hex downloads on chrome <=79

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -383,7 +383,6 @@ namespace pxt.BrowserUtils {
             if (!!createObjectURL) {
                 const b = new Blob([Util.stringToUint8Array(atob(b64))], { type: contentType });
                 const objUrl = createObjectURL(b);
-                // TODO: revoke after dialog closed to help gc underlying blob window.URL.revokeObjectURL()
                 browserDownloadDataUri(objUrl, name, userContextWindow);
                 if (maintainObjectURL) {
                     downloadurl = objUrl;

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -367,27 +367,23 @@ namespace pxt.BrowserUtils {
     }
 
     export function browserDownloadBase64(b64: string, name: string, contentType: string = "application/octet-stream", userContextWindow?: Window, onError?: (err: any) => void): string {
-        pxt.debug('trigger download')
+        pxt.debug('trigger download');
 
-        const hasMsSaveOrOpenBlob = (<any>window).navigator.msSaveOrOpenBlob && !pxt.BrowserUtils.isMobile();
-        const createObjectUrl = window.URL?.createObjectURL;
-        let downloadurl = toDownloadDataUri(b64, name);
+        const createObjectURL = window.URL?.createObjectURL;
+        let downloadurl: string;
         try {
-            if (hasMsSaveOrOpenBlob || !!createObjectUrl) {
-                const b = new Blob([Util.stringToUint8Array(atob(b64))], { type: contentType })
-                if (!!createObjectUrl) {
-                    downloadurl = createObjectUrl(b);
-                    // TODO: revoke after dialog closed to help gc underlying blob window.URL.revokeObjectURL()
-                    browserDownloadDataUri(downloadurl, name, userContextWindow);
-                } else {
-                    const result = (<any>window).navigator.msSaveOrOpenBlob(b, name);
-                }
+            if (!!createObjectURL) {
+                const b = new Blob([Util.stringToUint8Array(atob(b64))], { type: contentType });
+                downloadurl = createObjectURL(b);
+                // TODO: revoke after dialog closed to help gc underlying blob window.URL.revokeObjectURL()
+                browserDownloadDataUri(downloadurl, name, userContextWindow);
             } else  {
+                downloadurl = toDownloadDataUri(b64, name);
                 browserDownloadDataUri(downloadurl, name, userContextWindow);
             }
         } catch (e) {
             if (onError) onError(e);
-            pxt.debug("saving failed")
+            pxt.debug("saving failed");
         }
         return downloadurl;
     }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -285,12 +285,12 @@ namespace pxt.BrowserUtils {
         return 1;
     }
 
-    export function browserDownloadBinText(text: string, name: string, contentType: string = "application/octet-stream", opt?: BrowserDownloadOptions): string {
-        return browserDownloadBase64(ts.pxtc.encodeBase64(text), name, contentType, opt)
+    export function browserDownloadBinText(text: string, name: string, opt?: BrowserDownloadOptions): string {
+        return browserDownloadBase64(ts.pxtc.encodeBase64(text), name, opt)
     }
 
-    export function browserDownloadText(text: string, name: string, contentType: string = "application/octet-stream", opt?: BrowserDownloadOptions): string {
-        return browserDownloadBase64(ts.pxtc.encodeBase64(Util.toUTF8(text)), name, contentType, opt);
+    export function browserDownloadText(text: string, name: string, opt?: BrowserDownloadOptions): string {
+        return browserDownloadBase64(ts.pxtc.encodeBase64(Util.toUTF8(text)), name, opt);
     }
 
     export function isBrowserDownloadInSameWindow(): boolean {
@@ -352,8 +352,8 @@ namespace pxt.BrowserUtils {
         }
     }
 
-    export function browserDownloadUInt8Array(buf: Uint8Array, name: string, contentType: string = "application/octet-stream", opt?: BrowserDownloadOptions): string {
-        return browserDownloadBase64(ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf)), name, contentType, opt);
+    export function browserDownloadUInt8Array(buf: Uint8Array, name: string, opt?: BrowserDownloadOptions): string {
+        return browserDownloadBase64(ts.pxtc.encodeBase64(Util.uint8ArrayToString(buf)), name, opt);
     }
 
     export function toDownloadDataUri(b64: string, contentType: string): string {
@@ -367,15 +367,21 @@ namespace pxt.BrowserUtils {
     }
 
     export interface BrowserDownloadOptions {
-        userContextWindow?: Window,
+        contentType?: string; // defl: application/octet-stream
+        userContextWindow?: Window;
         onError?: (err: any) => void;
         maintainObjectURL?: boolean;
     }
 
-    export function browserDownloadBase64(b64: string, name: string, contentType: string = "application/octet-stream", opt: BrowserDownloadOptions = {}): string {
+    export function browserDownloadBase64(b64: string, name: string, opt: BrowserDownloadOptions = {}): string {
         pxt.debug('trigger download');
 
-        const { userContextWindow, onError, maintainObjectURL } = opt;
+        const {
+            contentType = "application/octet-stream",
+            userContextWindow,
+            onError,
+            maintainObjectURL
+        } = opt;
 
         const createObjectURL = window.URL?.createObjectURL;
         let downloadurl: string;

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -275,7 +275,7 @@ namespace pxt.runner {
         if (woptions.hexname && woptions.hex) {
             let $hexBtn = snippetBtn(lf("Download"), "download icon").click(() => {
                 pxt.tickEvent("docs.btn", { button: "hex" });
-                BrowserUtils.browserDownloadBinText(woptions.hex, woptions.hexname, pxt.appTarget.compile.hexMimeType);
+                BrowserUtils.browserDownloadBinText(woptions.hex, woptions.hexname, { contentType: pxt.appTarget.compile.hexMimeType });
             })
             $menu.append($hexBtn);
         }

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -163,7 +163,7 @@
                 pxt.runner.generateHexFileAsync(options).done(function(hex) {
                     $(loading).remove();
                     var name = pxt.appTarget.id + '-' + ts.pxt.BINARY_HEX;
-                    var uri = pxt.BrowserUtils.browserDownloadBinText(hex, name, undefined, { maintainObjectURL: true });
+                    var uri = pxt.BrowserUtils.browserDownloadBinText(hex, name, { maintainObjectURL: true });
                     var a = document.createElement("a");
                     a.href = uri;
                     a.download = name;

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -119,7 +119,7 @@
             codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
         } catch (e) {
             /**
-             *  Internet Explorer 11 and Microsoft Edge throw an exception when checking 
+             *  Internet Explorer 11 and Microsoft Edge throw an exception when checking
              *  if the frame element exists when the iframe is on a different origin
              */
         }
@@ -163,7 +163,7 @@
                 pxt.runner.generateHexFileAsync(options).done(function(hex) {
                     $(loading).remove();
                     var name = pxt.appTarget.id + '-' + ts.pxt.BINARY_HEX;
-                    var uri = pxt.BrowserUtils.browserDownloadBinText(hex, name)
+                    var uri = pxt.BrowserUtils.browserDownloadBinText(hex, name, undefined, { maintainObjectURL: true });
                     var a = document.createElement("a");
                     a.href = uri;
                     a.download = name;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1968,8 +1968,8 @@ export class ProjectView
     saveProjectToFileAsync(): Promise<void> {
         const mpkg = pkg.mainPkg;
         if (saveAsBlocks()) {
-            pxt.BrowserUtils.browserDownloadText(mpkg.readFile("main.blocks"), pkg.genFileName(".blocks"), 'application/xml');
-            return Promise.resolve();;
+            pxt.BrowserUtils.browserDownloadText(mpkg.readFile("main.blocks"), pkg.genFileName(".blocks"), { contentType: 'application/xml' });
+            return Promise.resolve();
         }
         if (pxt.commands.saveProjectAsync) {
             core.infoNotification(lf("Saving..."))
@@ -1981,7 +1981,7 @@ export class ProjectView
         else return this.exportProjectToFileAsync()
             .then((buf: Uint8Array) => {
                 const fn = pkg.genFileName(".mkcd");
-                pxt.BrowserUtils.browserDownloadUInt8Array(buf, fn, 'application/octet-stream');
+                pxt.BrowserUtils.browserDownloadUInt8Array(buf, fn, { contentType: 'application/octet-stream' });
             })
     }
 

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -65,7 +65,6 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
     }
 
     if (!userContext && (resp.saveOnly || pxt.BrowserUtils.isBrowserDownloadInSameWindow())) {
-        window.URL?.revokeObjectURL(url)
         return Promise.resolve()
             .then(() => window.URL?.revokeObjectURL(url));
     } else {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -17,8 +17,8 @@ function browserDownloadAsync(text: string, name: string, contentType: string): 
     pxt.BrowserUtils.browserDownloadBinText(
         text,
         name,
-        contentType,
         {
+            contentType: contentType,
             onError: (e: any) => core.errorNotification(lf("saving file failed..."))
         }
     );
@@ -39,8 +39,8 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
         url = pxt.BrowserUtils.browserDownloadBase64(
             out,
             fn,
-            "application/x-uf2",
             {
+                contentType: "application/x-uf2",
                 userContextWindow: resp.userContextWindow,
                 onError: e => core.errorNotification(lf("saving file failed...")),
                 maintainObjectURL: true,
@@ -51,8 +51,8 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
         url = pxt.BrowserUtils.browserDownloadBinText(
             out,
             fn,
-            pxt.appTarget.compile.hexMimeType,
             {
+                contentType: pxt.appTarget.compile.hexMimeType,
                 userContextWindow: resp.userContextWindow,
                 onError: e => core.errorNotification(lf("saving file failed...")),
                 maintainObjectURL: true,


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3417 - the dataurl was just too long for older versions of chrome to handle it. `createObjectURL` is listed as a working draft but browser support is good https://caniuse.com/bloburls

~I added a TODO for it, but will want to look at this a bit more and `revokeObjectUrl` -- as written the blob will persist in memory until refresh most likely~ added handling to revoke url when it goes out of use. Mainly wanted initial thoughts as this part of the code hasn't changed much / in case there is something known that I'm overlooking about `createObjectURL`

here's a build since I'm using it for browserstack anyways https://makecode.microbit.org/app/662dfecbb1be03dc15f0348e51683672c8e02097-64245805e1