### PR TITLE
move responsability of reconnect to reflashAsync

### DIFF
--- a/pxtlib/hf2.ts
+++ b/pxtlib/hf2.ts
@@ -419,6 +419,7 @@ namespace pxt.HF2 {
                 .then(() => this.flashAsync(blocks))
                 .then(() => Promise.delay(100))
                 .finally(() => this.flashing = false)
+                .then(() => this.reconnectAsync())
         }
 
         writeWordsAsync(addr: number, words: number[]) {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -170,8 +170,7 @@ export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.De
     function deployAsync(): Promise<void> {
         return pxt.packetio.initAsync(isRetry)
             .then(dev => core.showLoadingAsync(LOADING_KEY, lf("Downloading..."),
-                dev.reflashAsync(resp)
-                    .then(() => dev.reconnectAsync()), 5000))
+                dev.reflashAsync(resp), 5000))
             .then(() => core.infoNotification("Download completed!"))
             .finally(() => core.hideLoading(LOADING_KEY))
             .timeout(120000, "timeout") // packetio should time out first


### PR DESCRIPTION
For the micro:bit, don't disconnect from DAPlink after flashing -- since it stays alive anyway. This reduces the number of disconnect/reconnect.

The responsibility of reconnect is now moved to the reflashAsync function.
Tested v1/v2.