### PR TITLE
Cache namespaces that are defined in multiple packages in each of those packages

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -772,6 +772,7 @@ declare namespace ts.pxtc {
         // qualified name (e.g. "Blocks.Grass")
         qName?: string;
         pkg?: string;
+        pkgs?: string[]; // for symbols defined in multiple packages
         snippet?: string;
         snippetName?: string;
         snippetWithMarkers?: string; // TODO(dz)

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -216,7 +216,7 @@ namespace ts.pxtc {
             let hasParams = kind == SymbolKind.Function || kind == SymbolKind.Method
 
             let pkg: string = null
-            let pkgs: string[] = []
+            let pkgs: string[] = null
 
             let src = getSourceFileOfNode(stmt)
             if (src) {
@@ -531,10 +531,13 @@ namespace ts.pxtc {
                             }
                             si.attributes = parseCommentString(source);
 
+                            // Check if the colliding symbols are namespace definitions. The same namespace can be
+                            // defined in different packages/extensions, so we want to keep track of that information.
+                            // That way, we can make sure each cached extension has a copy of the namespace
                             if (existing.kind === SymbolKind.Module) {
-                                // Copy the existing package array to the new symbol info
+                                // Reference the existing array of packages where this namespace has been defined 
                                 si.pkgs = existing.pkgs || []
-                                if (existing?.pkg !== si?.pkg) {
+                                if (existing.pkg !== si.pkg) {
                                     if (!si.pkgs.find(element => element === existing.pkg)) {
                                         si.pkgs.push(existing.pkg)
                                     }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -216,6 +216,7 @@ namespace ts.pxtc {
             let hasParams = kind == SymbolKind.Function || kind == SymbolKind.Method
 
             let pkg: string = null
+            let pkgs: string[] = []
 
             let src = getSourceFileOfNode(stmt)
             if (src) {
@@ -251,6 +252,7 @@ namespace ts.pxtc {
                 fileName: stmt.getSourceFile().fileName,
                 attributes,
                 pkg,
+                pkgs,
                 extendsTypes,
                 retType:
                     stmt.kind == SyntaxKind.Constructor ? "void" :
@@ -528,6 +530,17 @@ namespace ts.pxtc {
                                 source = foundSrc;
                             }
                             si.attributes = parseCommentString(source);
+
+                            if (existing.kind === SymbolKind.Module) {
+                                // Copy the existing package array to the new symbol info
+                                si.pkgs = existing.pkgs || []
+                                if (existing?.pkg !== si?.pkg) {
+                                    if (!si.pkgs.find(element => element === existing.pkg)) {
+                                        si.pkgs.push(existing.pkg)
+                                        console.log(`${si.pkg}/${si.name} adding package ${existing.pkg} to the list of packages ${existing.pkgs}`)
+                                    }
+                                }
+                            }
                             if (existing.extendsTypes) {
                                 si.extendsTypes = si.extendsTypes || []
                                 existing.extendsTypes.forEach(t => {

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -537,7 +537,6 @@ namespace ts.pxtc {
                                 if (existing?.pkg !== si?.pkg) {
                                     if (!si.pkgs.find(element => element === existing.pkg)) {
                                         si.pkgs.push(existing.pkg)
-                                        console.log(`${si.pkg}/${si.name} adding package ${existing.pkg} to the list of packages ${existing.pkgs}`)
                                     }
                                 }
                             }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -701,10 +701,13 @@ async function cacheApiInfoAsync(project: pkg.EditorPackage, info: pxtc.ApisInfo
             for (const api of apiList) {
                 const apiInfo = info.byQName[api];
 
-                if (apiInfo.pkg === pkgId || apiInfo?.pkgs.find(element => element === pkgId)) {
+                // We include an API in the list of APIs for an external package in two cases:
+                //  1. If the API's package ID is the same as the external package
+                //  2. If any of the package IDs in the list of packages that defined the API are the same as the external package
+                if (apiInfo.pkg === pkgId || apiInfo.pkgs?.find(element => element === pkgId)) {
                     // Create a copy of the API info since we want to remove the package list.
                     // Most info objects won't have a package list
-                    entry.apis.byQName[api] = Object.assign({}, apiInfo);
+                    entry.apis.byQName[api] = U.clone(apiInfo);
                     // strip the pkg array to not store duplicate info
                     entry.apis.byQName[api].pkgs = []
                 }

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -700,8 +700,13 @@ async function cacheApiInfoAsync(project: pkg.EditorPackage, info: pxtc.ApisInfo
 
             for (const api of apiList) {
                 const apiInfo = info.byQName[api];
-                if (apiInfo.pkg === pkgId) {
-                    entry.apis.byQName[api] = apiInfo;
+
+                if (apiInfo.pkg === pkgId || apiInfo?.pkgs.find(element => element === pkgId)) {
+                    // Create a copy of the API info since we want to remove the package list.
+                    // Most info objects won't have a package list
+                    entry.apis.byQName[api] = Object.assign({}, apiInfo);
+                    // strip the pkg array to not store duplicate info
+                    entry.apis.byQName[api].pkgs = []
                 }
             }
 


### PR DESCRIPTION
# Problem
When you load multiple extensions that are in the same namespace, only one extension will have it's namespace API info cached. This means that if you load two such extensions in a project, back-out and create a new project with only one of the extensions (the one you loaded first), you will not find that extension's blocks in the toolbox. No category shows up in the toolbox for that extensions namespace since the namespace API info was not present in the cache for that extension. You can still search for the blocks, just not drag-and-drop them from the toll-box. 

# Solution
### Creating the API info list
There is already code to resolve when multiple packages define the same API info. If it's not two interface types that collided we usually make sure to either combine their sources or keep one if it contains the other. After that work is done, we'll check if we're dealing with two module (namespace) types. If so, if they come from different packages we'll add the existing namespace's package ID to a list of packages IDs on the new API info. The new API info is then stored in place of the existing.

### Caching it
We end up with a single namespace API info object that contains a list of the packages it was defined in. When caching this, we'll now check that an extension's package ID matches any of those defined in the current API's package list as well as its package ID. We make sure to remove the list of packages from the API before storing it in the cache. Now each extension will keep a copy of the namespace API info, so when they're loaded separately the namespace will show up in the toolbox.

### Reading it back from the cache
I actually don't do anything here since the namespace we save when there are duplicates are the same in all the packages/extensions we save them in. Meaning when you read back the namespaces from the cache only one of them will end up in the list of API info objects.

# Testing
Using Microbit, try loading the makerbit-lcd1602 extension. You'll see the `Makerbit` category in the toolbox along with subcategories for LCD1602 and LCD2004 blocks. Load the makerbit extension next. You'll still see the `Makerbit` category, curiously the LCD2004 subcategory no longer appears, that is a separate issue. Go back to the home screen and load a new project. If you add the LCD1602 extension again you'll see that there is no `Makerbit` category in the toolbox, though you can still search for the blocks.

After my changes, you can do the following and the `Makerbit` category will now show up. Though, much like when we loaded both the makerbit-lcd1602 and makerbit extensions together, there will be no subcategory for LCD2004. You can reverse the order that you load the extensions and then load a project with just the LCD extension and the `Makerbit` category will be present in the toolbox.

### After Loading Just the makerbit-lcd1602 extension
![JustLCD](https://user-images.githubusercontent.com/6496798/97504951-364e6300-1935-11eb-841c-10d05bd0eb73.PNG)

### After loading the makerbit extension as well
![MakerbitAndLcd](https://user-images.githubusercontent.com/6496798/97505112-80cfdf80-1935-11eb-8391-7f4a85ca3f52.PNG)

### Creating a new project with just the makerbit-lcd1602 extension after the previous step
![JustLcdAfterMakerbit](https://user-images.githubusercontent.com/6496798/97505118-84fbfd00-1935-11eb-854e-d61fd2c0c3be.PNG)


fixes microsoft/pxt-microbit#3332