### PR TITLE
Markdown format for codecard

### DIFF
--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -49,6 +49,10 @@
     </div>
 </aside>
 
+<aside id=codecard class=box>
+    <pre><code class="lang-codecard">@BODY@</code></pre>
+</aside>
+
 <aside id=tutorialhint class=box>
     <div class="ui hint message">
         <div class="content">

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -124,6 +124,11 @@ code.lang-apis
     background-color: rgba(0,0,0,0.04);
     color:transparent;
 }
+code.lang-codecard > ul,
+code.lang-codecard > hr {
+    display: none
+}
+
 
 /* wrap cards header */
 .ui.card > .content > .header {

--- a/docs/writing-docs/macros.md
+++ b/docs/writing-docs/macros.md
@@ -394,18 +394,18 @@ To render one or more code cards as JSON into cards, use **codecard**.
 
 Code cards also support a text based format:
 
-    ```codecard
-    name: A card
-    url: ...
+    ### ~ codecard
+    * name: A card
+    * url: ...
     ---
-    name: Another card
-    url: ...
+    * name: Another card
+    * url: ...
     ---
-    name: Yet another card
-    url: ...
-    ```
+    * name: Yet another card
+    * url: ...
+    ### ~
 
-where each card is a sequence of ``KEY: VALUE`` pairs separate by an ``---`` line.
+where each card is a sequence of ``KEY: VALUE`` pairs bullet points separated by a ``---`` line.
 
 ### apis
 

--- a/docs/writing-docs/macros.md
+++ b/docs/writing-docs/macros.md
@@ -407,6 +407,18 @@ Code cards also support a text based format:
 
 where each card is a sequence of ``KEY: VALUE`` pairs bullet points separated by a ``---`` line.
 
+If you need to specify ``otherActions``, add multiple line of ``otherAction`` (singular)
+with a ``URL, EDITOR, CARD_TYPE`` format.
+
+    ### ~ codecard
+    ...
+    ---
+    * name: Yet another card
+    * url: ...
+    * otherAction: URL, js, example
+    * otherAction: URL, py, example
+    ### ~
+
 ### apis
 
 Render all blocks from a given set of namespaces as code cards.

--- a/docs/writing-docs/macros.md
+++ b/docs/writing-docs/macros.md
@@ -384,13 +384,28 @@ To render one or more code cards as JSON into cards, use **codecard**.
 
     ```codecard
     [{
-        "title": "A card",
+        "name": "A card",
         "url": "...."
     }, {
-        "title": "Another card",
+        "name": "Another card",
         "url": "...."
     }]
     ```
+
+Code cards also support a text based format:
+
+    ```codecard
+    name: A card
+    url: ...
+    ---
+    name: Another card
+    url: ...
+    ---
+    name: Yet another card
+    url: ...
+    ```
+
+where each card is a sequence of ``KEY: VALUE`` pairs separate by an ``---`` line.
 
 ### apis
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -98,7 +98,7 @@ namespace pxt.gallery {
             .filter(cmd => !!cmd)
             .map(cmd => {
                 let cc: any = {};
-                cmd.replace(/^\s*\*\s+(\w+)\s*:\s*(.*)$/gm, (m, n, v) => {
+                cmd.replace(/^\s*(-|\*)\s+(\w+)\s*:\s*(.*)$/gm, (m, n, v) => {
                     if (n == "flags")
                         cc[n] = v.split(',')
                     else
@@ -119,7 +119,7 @@ namespace pxt.gallery {
         let card: any;
         Array.from(el.children)
             .forEach(child => {
-                if (child.tagName === "UL") {
+                if (child.tagName === "UL" || child.tagName === "OL") {
                     if (!card)
                         card = {};
                     // read fields into card

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -85,6 +85,53 @@ namespace pxt.gallery {
         return prj;
     }
 
+    export function parseCodeCards(md: string): pxt.CodeCard[] {
+        // try to parse code cards as JSON
+        let cards = Util.jsonTryParse(md) as pxt.CodeCard[];
+        if (cards && !Array.isArray(cards))
+            cards = [cards];
+        if (cards?.length)
+            return cards;
+
+        // not json, try parsing as sequence of key,value pairs, with line splits
+        cards = md.split(/^---$/gm)
+            .filter(cmd => !!cmd)
+            .map(cmd => {
+                let cc: any = {};
+                cmd.replace(/^\s*\*\s+(\w+)\s*:\s*(.*)$/gm, (m, n, v) => {
+                    if (n == "flags")
+                        cc[n] = v.split(',')
+                    else
+                        cc[n] = v
+                    return ''
+                })
+                return Object.keys(cc).length && cc as pxt.CodeCard;
+            })
+            .filter(cc => !!cc);
+        if (cards?.length)
+            return cards;
+
+        return undefined;
+    }
+
+    export function parseCodeCardsHtml(el: HTMLElement) {
+        const cards: pxt.CodeCard[] =
+            Array.from(el.querySelectorAll("ul"))
+                .map(ul => {
+                    const card: any = {};
+                    Array.from(ul.querySelectorAll("li"))
+                        .forEach(field => {
+                            const text = field.innerText;
+                            const m = /^\s*\*\s+(\w+)\s*:\s*(.*)$/.exec(text);
+                            if (m) {
+                                card[m[1]] = m[2].trim();
+                            }
+                        });
+                    return Object.keys(card).length && card;
+                })
+        return cards.length && cards;
+    }
+
     export function parseGalleryMardown(md: string): Gallery[] {
         if (!md) return [];
 
@@ -94,28 +141,26 @@ namespace pxt.gallery {
         const galleries: { name: string; cards: pxt.CodeCard[] }[] = [];
         let incard = false;
         let name: string = undefined;
-        let cards: string = "";
+        let cardsSource: string = "";
         md.split(/\r?\n/).forEach(line => {
             // new category
             if (/^##/.test(line)) {
                 name = line.substr(2).trim();
-            } else if (/^```codecard$/.test(line)) {
+            } else if (/^(### ~ |```)codecard$/.test(line)) {
                 incard = true;
-            } else if (/^```$/.test(line)) {
+            } else if (/^(### ~|```)$/.test(line)) {
                 incard = false;
-                if (name && cards) {
-                    try {
-                        const cardsJSON = JSON.parse(cards) as pxt.CodeCard[];
-                        if (cardsJSON && cardsJSON.length > 0)
-                            galleries.push({ name, cards: cardsJSON });
-                    } catch (e) {
-                        pxt.log('invalid card format in gallery');
-                    }
+                if (name && cardsSource) {
+                    const cards = parseCodeCards(cardsSource);
+                    if (cards?.length)
+                        galleries.push({ name, cards });
+                    else
+                        pxt.log(`invalid gallery format`)
                 }
-                cards = "";
+                cardsSource = "";
                 name = undefined;
             } else if (incard)
-                cards += line + '\n';
+                cardsSource += line + '\n';
         })
         // apply transformations
         galleries.forEach(gallery => gallery.cards.forEach(card => {

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -159,7 +159,7 @@ namespace pxt.gallery {
         let cardsSource: string = "";
         md.split(/\r?\n/).forEach(line => {
             // new category
-            if (/^##/.test(line)) {
+            if (/^## /.test(line)) {
                 name = line.substr(2).trim();
             } else if (/^(### ~ |```)codecard$/.test(line)) {
                 incard = true;

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -98,9 +98,18 @@ namespace pxt.gallery {
             .filter(cmd => !!cmd)
             .map(cmd => {
                 let cc: any = {};
-                cmd.replace(/^\s*(-|\*)\s+(\w+)\s*:\s*(.*)$/gm, (m, n, v) => {
+                cmd.replace(/^\s*(?:-|\*)\s+(\w+)\s*:\s*(.*)$/gm, (m, n, v) => {
                     if (n == "flags")
                         cc[n] = v.split(',')
+                    else if (n === "otherAction") {
+                        const parts: string[] = v.split(',').map((p: string) => p?.trim())
+                        const oas = (cc["otherActions"] || (cc["otherActions"] = []));
+                        oas.push({
+                            url: parts[0],
+                            editor: parts[1],
+                            cardType: parts[2]
+                        })
+                    }
                     else
                         cc[n] = v
                     return ''

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -1098,8 +1098,6 @@ namespace pxt.runner {
         // try parsing the card as json
         const cards = pxt.gallery.parseCodeCardsHtml($el[0]);
         if (!cards) {
-            // try parsing nested HTML structure
-
             $el.append($('<div/>').addClass("ui segment warning").text("invalid codecard format"));
         }
 

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -853,7 +853,7 @@ namespace pxt.runner {
                     const csymbols = symbols.filter(symbol => !!namespaces[symbol.attributes.blockNamespace || symbol.namespace])
                     if (!csymbols.length) return;
 
-                    csymbols.sort((l,r) => {
+                    csymbols.sort((l, r) => {
                         // render cards first
                         const lcard = !l.attributes.blockHidden && Blockly.Blocks[l.attributes.blockId];
                         const rcard = !r.attributes.blockHidden && Blockly.Blocks[r.attributes.blockId]
@@ -1095,14 +1095,12 @@ namespace pxt.runner {
         if (!$el[0]) return Promise.resolve();
 
         $el.removeClass(cls);
-        let cards: pxt.CodeCard[];
-        try {
-            let js: any = JSON.parse($el.text());
-            if (!Array.isArray(js)) js = [js];
-            cards = js as pxt.CodeCard[];
-        } catch (e) {
-            pxt.reportException(e);
-            $el.append($('<div/>').addClass("ui segment warning").text(e.messageText));
+        // try parsing the card as json
+        const cards = pxt.gallery.parseCodeCardsHtml($el[0]);
+        if (!cards) {
+            // try parsing nested HTML structure
+
+            $el.append($('<div/>').addClass("ui segment warning").text("invalid codecard format"));
         }
 
         if (options.snippetReplaceParent) $el = $el.parent();

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -875,6 +875,10 @@ ${linkString}
     </div>
 </aside>
 
+<aside id=codecard class=box>
+    <pre><code class="lang-codecard">@BODY@</code></pre>
+</aside>
+
 <aside id=tutorialhint class=box>
     <div class="ui hint message">
         <div class="content">


### PR DESCRIPTION
Backward compatible support for a markdown codecard section.

Our current code card format is cumbersome: it is really easy to create invalid json, it does not integrate well at all in crowdin. I was trying to translate the micro:bit cards... and it's impossible.

    ```codecard
    [{
        "name": "A card",
        "url": "...."
    }, {
        "name": "Another card",
        "url": "...."
    }]
    ```
Crowdin decides to chunk it randomly.

![image](https://user-images.githubusercontent.com/4175913/97579179-fc21a780-19ae-11eb-8a9f-16bc934cc162.png)

The new format is based on markdown and guarantees a smooth integration in crowdin (screenshot below).

```
    ### ~ codecard
    * name: A card
    * url: ...
    ---
    * name: Another card
    * url: ...
    ---
    * name: Yet another card
    * url: ...
    ### ~
```
![image](https://user-images.githubusercontent.com/4175913/97576921-f9718300-19ab-11eb-9ed6-6b1d4a2cbb05.png)

To support this format, we will also need to update the backend renderer.