### PR TITLE
Filter out hide iteration tutorials

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -623,6 +623,10 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
             const headers = this.fetchLocalData()
             const showNewProject = pxt.appTarget.appTheme && !pxt.appTarget.appTheme.hideNewProjectButton;
             const showScriptManagerCard = targetTheme.scriptManager && headers.length > ProjectsCarousel.NUM_PROJECTS_HOMESCREEN;
+
+            const headersToShow = headers
+                .filter(h => !h.tutorial?.metadata?.hideIteration)
+                .slice(0, ProjectsCarousel.NUM_PROJECTS_HOMESCREEN);
             return <carousel.Carousel bleedPercent={20}>
                 {showNewProject ? <div role="button" className="ui card link buttoncard newprojectcard" title={lf("Creates a new empty project")}
                     onClick={this.newProject} onKeyDown={sui.fireClickOnEnter} >
@@ -631,7 +635,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                         <span className="header">{lf("New Project")}</span>
                     </div>
                 </div> : undefined}
-                {headers.slice(0, ProjectsCarousel.NUM_PROJECTS_HOMESCREEN).map((scr, index) => {
+                {headersToShow.map((scr, index) => {
                     const tutorialStep =
                         scr.tutorial ? scr.tutorial.tutorialStep
                             : scr.tutorialCompleted ? scr.tutorialCompleted.steps - 1

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -289,7 +289,8 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
 
     private getSortedHeaders() {
         const { sortedBy, sortedAsc } = this.state;
-        const headers = this.fetchLocalData() || [];
+        const headers = (this.fetchLocalData() || [])
+            .filter(h => !h.tutorial?.metadata?.hideIteration);
         return headers.sort(this.getSortingFunction(sortedBy, sortedAsc))
     }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -666,7 +666,7 @@ export class WorkspaceHeader extends data.Component<any, WorkspaceHeaderState> {
     renderCore() {
         return <div id="headers">
             <div id="flyoutHeader" style={this.headerStyle()}>
-                <div id="flyoutHeaderTitle">{this.flyoutTitle}</div>
+                <div id="flyoutHeaderTitle" className="no-select">{this.flyoutTitle}</div>
             </div>
             <div id="workspaceHeader" style={this.workspaceStyle()}>
                 <editortoolbar.SmallEditorToolbar parent={this.props.parent}/>


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/2051

the hideIteration tutorial flag hides the home button / makes tutorials inescapable. Don't show those under my projects so users can't get stuck.

As an alternative I took a look at doing it with the [temporary header flag](https://github.com/microsoft/pxt/blob/c73b189198b392ab371beab46a57f030c12ca51f/localtypings/projectheader.d.ts#L15) so the project wouldn't just sit around in local storage in perpetuity, but that will lose the project on refresh, and drop you into the normal editor.

I think one better thing we could do would be to change the behavior of the `temporary` flag to make the project have a lifespan of one day instead of not storing it at all, hide them the carousels, and then clear old ones in [`migratePrefixesAsync`](https://github.com/microsoft/pxt/blob/c73b189198b392ab371beab46a57f030c12ca51f/webapp/src/browserworkspace.ts#L10) and on oom errors -- where I've seen it used I actually would want the project to persist past a refresh, just not indefinitely. If that sounds alright with everyone, I'll do that after I finish the other stuff needed for release~

@livcheerful quick fix while I was looking through in tutorials.tsx, the flyout header is a part of the ui / not something the user will intend to copy so I disabled selection on it ~