### PR TITLE
add field to sim iframe to indicate inside ipcrenderer

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -338,6 +338,10 @@ namespace pxsim {
             frame.frameBorder = "0";
             frame.dataset['runid'] = this.runId;
 
+            if (!!(window as any).ipcRenderer) {
+                frame.dataset['ipcRenderer'] = "true";
+            }
+
             wrapper.appendChild(frame);
 
             const i = document.createElement("i");


### PR DESCRIPTION
~so we can see if we're inside minecraft without the query parameter~

Nevermind, approaching this another way as browser support is inconsistent with accessing frameElement