### PR TITLE
if in ipcRenderer, send that state in sim msg

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -23,6 +23,7 @@ namespace pxsim {
         clickTrigger?: boolean;
         breakOnStart?: boolean;
         storedState?: Map<any>;
+        ipc?: boolean;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -59,6 +59,7 @@ namespace pxsim {
         breakOnStart?: boolean;
         storedState?: Map<any>;
         autoRun?: boolean;
+        ipc?: boolean;
     }
 
     export interface HwDebugger {
@@ -523,7 +524,8 @@ namespace pxsim {
                 version: opts.version,
                 clickTrigger: opts.clickTrigger,
                 breakOnStart: opts.breakOnStart,
-                storedState: opts.storedState
+                storedState: opts.storedState,
+                ipc: opts.ipc,
             }
             this.start();
         }

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -288,6 +288,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
     const fnArgs = res.usedArguments;
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
+    const isIpcRenderer = pxt.BrowserUtils.isIpcRenderer() || undefined;
 
     const opts: pxsim.SimulatorRunOptions = {
         boardDefinition: boardDefinition,
@@ -308,7 +309,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         clickTrigger: clickTrigger,
         breakOnStart: debug,
         storedState: storedState,
-        autoRun
+        autoRun,
+        ipc: isIpcRenderer,
     }
     //if (pxt.options.debug)
     //    pxt.debug(JSON.stringify(opts, null, 2))


### PR DESCRIPTION
The host is implemented differently for ios / android / desktop, so loadIpc isn't guaranteed to exist in non-desktop. ipcRenderer will eventually get loaded, so include that in the run msg so we can guarantee the simulator knows it is in game~