### PR TITLE
Add flyoutOnly class to modal

### DIFF
--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -270,6 +270,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
     renderCore() {
         const { visible } = this.state;
         const options = this.props.parent.state.tutorialOptions;
+        const flyoutOnly = this.props.parent.state.editorState && this.props.parent.state.editorState.hasCategories === false;
         const { tutorialReady, tutorialStepInfo, tutorialStep, tutorialName } = options;
         if (!tutorialReady) return <div />;
 
@@ -292,7 +293,8 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
                 className: 'green'
             }]
 
-            return <sui.Modal isOpen={visible} className="hintdialog"
+            const modalClasses = flyoutOnly ? "hintdialog flyoutOnly" : "hintdialog";
+            return <sui.Modal isOpen={visible} className={modalClasses}
                 closeIcon={false} header={tutorialName} buttons={actions}
                 onClose={onClick} dimmer={true} longer={true}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>


### PR DESCRIPTION
Since the modal isn't created under the root, it isn't picking up the flyoutOnly stylings. Add this class back for the new HOC design 

![image](https://user-images.githubusercontent.com/18712271/97767057-e14a5280-1ad6-11eb-9971-659aa8388d41.png)
