### PR TITLE
only special case edge download if uri is actually a datauri

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -332,7 +332,7 @@ namespace pxt.BrowserUtils {
                 document.body.appendChild(iframe);
             }
             iframe.src = uri;
-        } else if (pxt.BrowserUtils.isEdge() || pxt.BrowserUtils.isIE()) {
+        } else if (/^data:/i.test(uri) && (pxt.BrowserUtils.isEdge() || pxt.BrowserUtils.isIE())) {
             //Fix for edge
             let byteString = atob(uri.split(',')[1]);
             let ia = Util.stringToUint8Array(byteString);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3553

In https://github.com/microsoft/pxt/pull/7557 I didn't notice this old special case https://github.com/microsoft/pxt/pull/646 for fixing datauris in edge. We use this function directly in a few other spots where we generate svgs thoughout the app, so just check that it actually is a datauri before chopping it up for now.