### PR TITLE
fix race condition when starting sim runtime

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -308,13 +308,18 @@ namespace pxsim {
             if (msg.localizedStrings)
                 pxsim.localization.setLocalizedStrings(msg.localizedStrings);
 
-            runtime = new Runtime(msg);
-            runtime.board.initAsync(msg)
+            const rt = new Runtime(msg);
+            runtime = rt;
+            rt.board.initAsync(msg)
                 .done(() => {
-                    runtime.run((v) => {
-                        pxsim.dumpLivePointers();
-                        Runtime.postMessage({ type: "toplevelcodefinished" })
-                    });
+                    if (rt === runtime) {
+                        rt.run((v) => {
+                            pxsim.dumpLivePointers();
+                            Runtime.postMessage({ type: "toplevelcodefinished" });
+                        });
+                    }
+                    // else: a new runtime was started while this one was still initializing.
+                    // This runtime has already been stopped by the beginning of this function.
                 });
         }
 


### PR DESCRIPTION
fix race condition when starting new runtimes quickly. The outcome seems similar to the issue from shannons last comment in https://github.com/microsoft/pxt-minecraft/issues/2057#issuecomment-719727197, but I haven't been able to repro with those steps so far / have to test a bit more to see if it's actually related.

easiest way to repro the issue is a build of minecraft where you increase the delay in `board.initAsync` from 300ms to ~2.5 seconds. Then, click outside the window to run code, c to open code again immediately, then close again. The first runtimes `initAsync` will complete after the 2.5second delay, and then `runtime.run` will be called on the newer runtime before that one has finished initializing. Whenever the current runtime finishes initializing it crashes on https://github.com/microsoft/pxt/blob/aea68dbbadb99de8453981aea686eb9bcf5cc2dc/pxtsim/runtime.ts#L1326

The result is a bit inconsistent in my debug build, most of the time the error just pops up in the console without any obvious effect, but it has caused stop button to show up for me in code builder once or twice my computer was running a bit slower -- in that case it seemed like the error was only showing up when the window regained focused, maybe due to throttling under low perf / etc. When that happened, the stop button does get shown / you have to stop and then press play again for things to work.