### PR TITLE
Attach root classes to minecraft modals

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -337,7 +337,7 @@ namespace pxt.editor {
         checkForHwVariant(): boolean;
         pairAsync(): Promise<void>;
 
-        rootClasses: string[];
+        createModalClasses(classes?: string): string;
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;
 
         askForProjectCreationOptionsAsync(): Promise<ProjectCreationOptions>;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -337,6 +337,7 @@ namespace pxt.editor {
         checkForHwVariant(): boolean;
         pairAsync(): Promise<void>;
 
+        rootClasses: string[];
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;
 
         askForProjectCreationOptionsAsync(): Promise<ProjectCreationOptions>;

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -771,6 +771,12 @@
         }
     }
 
+    .ui.modal.inverted-theme {
+        border: 2px solid @HCtextColor !important;
+        border-radius: initial !important;
+        box-shadow: initial !important;
+    }
+
     .ui.modal, .ui.modal > .header, .ui.modal > .content, .ui.modal > .actions, .ui.modal > .segment {
         background: @HCbackground !important;
         color: @HCtextColor !important;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -118,7 +118,6 @@ export class ProjectView
     chooseHwDialog: projects.ChooseHwDialog;
     prevEditorId: string;
     screenshotHandlers: ((msg: pxt.editor.ScreenshotData) => void)[] = [];
-    rootClasses: string[];
 
     private lastChangeTime: number;
     private reload: boolean;
@@ -130,6 +129,7 @@ export class ProjectView
     private loadingExample: boolean;
     private openingTypeScript: boolean;
     private preserveUndoStack: boolean;
+    private rootClasses: string[];
 
     // component ID strings
     static readonly tutorialCardId = "tutorialcard";
@@ -3219,6 +3219,16 @@ export class ProjectView
     ///////////////////////////////////////////////////////////
     ////////////             Dialogs              /////////////
     ///////////////////////////////////////////////////////////
+
+    // Classes to add to modals
+    createModalClasses(classes?: string): string {
+        const rootClassList = [
+            classes,
+            this.rootClasses.indexOf("flyoutOnly") != -1 ? "flyoutOnly": "",
+            this.rootClasses.indexOf("inverted-theme") != -1 ? "inverted-theme" : "",
+        ]
+        return sui.cx(rootClassList);
+    }
 
     showReportAbuse() {
         const pubId = (this.state.tutorialOptions && this.state.tutorialOptions.tutorialReportId)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -118,6 +118,7 @@ export class ProjectView
     chooseHwDialog: projects.ChooseHwDialog;
     prevEditorId: string;
     screenshotHandlers: ((msg: pxt.editor.ScreenshotData) => void)[] = [];
+    rootClasses: string[];
 
     private lastChangeTime: number;
     private reload: boolean;
@@ -3906,6 +3907,7 @@ export class ProjectView
             this.editor == this.textEditor && this.state.errorListState,
             'full-abs',
         ];
+        this.rootClasses = rootClassList;
         const rootClasses = sui.cx(rootClassList);
 
         if (this.state.hasError) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3224,7 +3224,7 @@ export class ProjectView
     createModalClasses(classes?: string): string {
         const rootClassList = [
             classes,
-            this.rootClasses.indexOf("flyoutOnly") != -1 ? "flyoutOnly": "",
+            this.rootClasses.indexOf("flyoutOnly") != -1 ? "flyoutOnly" : "",
             this.rootClasses.indexOf("inverted-theme") != -1 ? "inverted-theme" : "",
         ]
         return sui.cx(rootClassList);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -809,7 +809,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                             .then(() => {
                                 if (!this.functionsDialog) {
                                     const wrapper = document.body.appendChild(document.createElement('div'));
-                                    this.functionsDialog = ReactDOM.render(React.createElement(CreateFunctionDialog), wrapper) as CreateFunctionDialog;
+                                    this.functionsDialog = ReactDOM.render(React.createElement(CreateFunctionDialog, {parent: this.parent}), wrapper) as CreateFunctionDialog;
                                 }
                                 this.functionsDialog.show(mutation, cb, this.editor);
                             });

--- a/webapp/src/createFunction.tsx
+++ b/webapp/src/createFunction.tsx
@@ -151,7 +151,7 @@ export class CreateFunctionDialog extends data.Component<ISettingsProps, CreateF
             }
         ];
         const types = this.getArgumentTypes().slice();
-        const classes = ["createfunction", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")].join(" ");
+        const classes =  this.props.parent.createModalClasses("createfunction");
         return (
             <sui.Modal isOpen={visible} className={classes} size="large"
                 closeOnEscape={false} closeIcon={true} closeOnDimmerClick={false} closeOnDocumentClick={false}

--- a/webapp/src/createFunction.tsx
+++ b/webapp/src/createFunction.tsx
@@ -151,9 +151,9 @@ export class CreateFunctionDialog extends data.Component<ISettingsProps, CreateF
             }
         ];
         const types = this.getArgumentTypes().slice();
-
+        const classes = ["createfunction", this.props.parent.rootClasses.filter((e:string) => e != "full-abs").join(" ")].join(" ");
         return (
-            <sui.Modal isOpen={visible} className="createfunction" size="large"
+            <sui.Modal isOpen={visible} className={classes} size="large"
                 closeOnEscape={false} closeIcon={true} closeOnDimmerClick={false} closeOnDocumentClick={false}
                 dimmer={true} buttons={actions} header={lf("Edit Function")}
                 modalDidOpen={this.modalDidOpen}

--- a/webapp/src/createFunction.tsx
+++ b/webapp/src/createFunction.tsx
@@ -151,7 +151,7 @@ export class CreateFunctionDialog extends data.Component<ISettingsProps, CreateF
             }
         ];
         const types = this.getArgumentTypes().slice();
-        const classes = ["createfunction", this.props.parent.rootClasses.filter((e:string) => e != "full-abs").join(" ")].join(" ");
+        const classes = ["createfunction", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")].join(" ");
         return (
             <sui.Modal isOpen={visible} className={classes} size="large"
                 closeOnEscape={false} closeIcon={true} closeOnDimmerClick={false} closeOnDocumentClick={false}

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -287,9 +287,13 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
             this.submitConsent();
         };
         const actions: sui.ModalButton[] = action ? [{ label: action, onclick: actionClick }] : undefined;
+        const extensionClasses = [(needsConsent?"extensionconsentdialog":"extensiondialog"),
+            this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ")].join(" ");
+        const permissionClasses = ["extensionpermissiondialog", "basic",
+            this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ")].join(" ");
         if (!needsConsent && visible) this.initializeFrame();
         return (
-            <sui.Modal isOpen={visible} className={`${needsConsent ? 'extensionconsentdialog' : 'extensiondialog'}`}
+            <sui.Modal isOpen={visible} className={extensionClasses}
                 size={needsConsent ? 'small' : 'fullscreen'} closeIcon={true}
                 onClose={this.hide} dimmer={true} buttons={actions}
                 modalDidOpen={this.updateDimensions} shouldFocusAfterRender={false}
@@ -298,7 +302,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
                 {consent ?
                     <div id="extensionWrapper" data-frame={extension} ref={this.handleExtensionWrapperRef}>
                         {permissionRequest ?
-                            <sui.Modal isOpen={true} className="extensionpermissiondialog basic" closeIcon={false} dimmer={true} dimmerClassName="permissiondimmer">
+                            <sui.Modal isOpen={true} className={permissionClasses} closeIcon={false} dimmer={true} dimmerClassName="permissiondimmer">
                                 <div className="permissiondialoginner">
                                     <div className="permissiondialogheader">
                                         {lf("Permission Request")}

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -287,7 +287,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
             this.submitConsent();
         };
         const actions: sui.ModalButton[] = action ? [{ label: action, onclick: actionClick }] : undefined;
-        const extensionClasses = [(needsConsent?"extensionconsentdialog":"extensiondialog"),
+        const extensionClasses = [(needsConsent ? "extensionconsentdialog" : "extensiondialog"),
             this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ")].join(" ");
         const permissionClasses = ["extensionpermissiondialog", "basic",
             this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ")].join(" ");

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -287,13 +287,9 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
             this.submitConsent();
         };
         const actions: sui.ModalButton[] = action ? [{ label: action, onclick: actionClick }] : undefined;
-        const extensionClasses = [(needsConsent ? "extensionconsentdialog" : "extensiondialog"),
-            this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ")].join(" ");
-        const permissionClasses = ["extensionpermissiondialog", "basic",
-            this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ")].join(" ");
         if (!needsConsent && visible) this.initializeFrame();
         return (
-            <sui.Modal isOpen={visible} className={extensionClasses}
+            <sui.Modal isOpen={visible} className={(needsConsent ? "extensionconsentdialog" : "extensiondialog")}
                 size={needsConsent ? 'small' : 'fullscreen'} closeIcon={true}
                 onClose={this.hide} dimmer={true} buttons={actions}
                 modalDidOpen={this.updateDimensions} shouldFocusAfterRender={false}
@@ -302,7 +298,7 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
                 {consent ?
                     <div id="extensionWrapper" data-frame={extension} ref={this.handleExtensionWrapperRef}>
                         {permissionRequest ?
-                            <sui.Modal isOpen={true} className={permissionClasses} closeIcon={false} dimmer={true} dimmerClassName="permissiondimmer">
+                            <sui.Modal isOpen={true} className="extensionpermissiondialog basic" closeIcon={false} dimmer={true} dimmerClassName="permissiondimmer">
                                 <div className="permissiondialoginner">
                                     <div className="permissiondialogheader">
                                         {lf("Permission Request")}

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -105,9 +105,11 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
             && !pxt.shell.isReadOnly()
             && !pxt.BrowserUtils.isPxtElectron()
             && pxt.appTarget.appTheme.crowdinProject;
+        const classes = this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ");
 
         return (
             <sui.Modal isOpen={this.state.visible}
+                className={classes}
                 size={modalSize}
                 onClose={this.hide}
                 dimmer={true} header={lf("Select Language")}

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -105,7 +105,7 @@ export class LanguagePicker extends data.Component<ISettingsProps, LanguagesStat
             && !pxt.shell.isReadOnly()
             && !pxt.BrowserUtils.isPxtElectron()
             && pxt.appTarget.appTheme.crowdinProject;
-        const classes = this.props.parent.rootClasses.filter((e) => e != "full-abs").join(" ");
+        const classes = this.props.parent.createModalClasses();
 
         return (
             <sui.Modal isOpen={this.state.visible}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1042,13 +1042,14 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const disableFileAccessinAndroid = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
         const showImport = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
+        const classes = (["importdialog", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
         const showCreateGithubRepo = targetTheme.githubEditor
             && !pxt.winrt.isWinRT() // not supported in windows 10
             && !pxt.BrowserUtils.isPxtElectron()
             && pxt.appTarget?.cloud?.cloudProviders?.github;
         /* tslint:disable:react-a11y-anchors */
         return (
-            <sui.Modal isOpen={visible} className="importdialog" size="small"
+            <sui.Modal isOpen={visible} className={classes} size="small"
                 onClose={this.close} dimmer={true}
                 closeIcon={true} header={lf("Import")}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
@@ -1168,9 +1169,10 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 onclick: this.skip
             }
         ];
+        const classes = (["exitandsave", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
 
         return (
-            <sui.Modal isOpen={visible} className="exitandsave" size="tiny"
+            <sui.Modal isOpen={visible} className={classes} size="tiny"
                 onClose={this.hide} dimmer={true} buttons={actions}
                 closeIcon={true} header={lf("Project has no name {0}", this.state.emoji)}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
@@ -1303,8 +1305,9 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
             }
         ];
 
+        const classes = "newproject" + this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ");
 
-        return <sui.Modal isOpen={visible} className="newproject" size="tiny"
+        return <sui.Modal isOpen={visible} className={classes} size="tiny"
             onClose={this.hide} dimmer={true} buttons={actions}
             closeIcon={true} header={lf("Create a Project {0}", emoji)}
             closeOnDimmerClick closeOnDocumentClick closeOnEscape

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1042,7 +1042,7 @@ export class ImportDialog extends data.Component<ISettingsProps, ImportDialogSta
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const disableFileAccessinAndroid = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
         const showImport = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
-        const classes = (["importdialog", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
+        const classes = this.props.parent.createModalClasses("importdialog");
         const showCreateGithubRepo = targetTheme.githubEditor
             && !pxt.winrt.isWinRT() // not supported in windows 10
             && !pxt.BrowserUtils.isPxtElectron()
@@ -1169,7 +1169,7 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 onclick: this.skip
             }
         ];
-        const classes = (["exitandsave", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
+        const classes = this.props.parent.createModalClasses("exitandsave");
 
         return (
             <sui.Modal isOpen={visible} className={classes} size="tiny"
@@ -1304,8 +1304,7 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
                 display: lf("{0} Only", "JavaScript")
             }
         ];
-
-        const classes = "newproject" + this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ");
+        const classes = this.props.parent.createModalClasses("newproject");
 
         return <sui.Modal isOpen={visible} className={classes} size="tiny"
             onClose={this.hide} dimmer={true} buttons={actions}

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -417,9 +417,11 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const experimentsChanged = mode == ScriptSearchMode.Experiments
             && experimentsState != pxt.editor.experiments.state();
 
+        const classes = this.props.parent.createModalClasses("searchdialog");
+
         return (
             <sui.Modal isOpen={visible} dimmer={true}
-                className="searchdialog" size="fullscreen"
+                className={classes} size="fullscreen"
                 onClose={this.hide}
                 closeIcon={closeIcon}
                 header={headerText}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -467,7 +467,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             && pxt.appTarget?.cloud?.cloudProviders?.github;
         const unknownError = sharingError && !tooBigErrorSuggestGitHub;
         const qrCodeFull = !!qrCodeUri && qrCodeExpanded;
-        const classes = (["sharedialog", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
+        const classes = this.props.parent.createModalClasses("sharedialog");
 
         return (
             <sui.Modal isOpen={visible} className={classes}

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -467,9 +467,10 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             && pxt.appTarget?.cloud?.cloudProviders?.github;
         const unknownError = sharingError && !tooBigErrorSuggestGitHub;
         const qrCodeFull = !!qrCodeUri && qrCodeExpanded;
+        const classes = (["sharedialog", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
 
         return (
-            <sui.Modal isOpen={visible} className="sharedialog"
+            <sui.Modal isOpen={visible} className={classes}
                 size={thumbnails ? "" : "small"}
                 onClose={this.hide}
                 dimmer={true} header={title || lf("Share Project")}

--- a/webapp/src/sidebarTutorial.tsx
+++ b/webapp/src/sidebarTutorial.tsx
@@ -19,6 +19,8 @@ export class SidebarTutorialHint extends TutorialHint {
         const tutorialHint = stepInfo.hintContentMd;
         const showDialog = stepInfo.showDialog;
         const fullText = stepInfo.contentMd;
+        const classes = (["hintdialog",
+            this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
 
         let onClick = tutorialStep < tutorialStepInfo.length - 1 ? this.next : this.closeHint;
         const actions: sui.ModalButton[] = [{
@@ -33,7 +35,7 @@ export class SidebarTutorialHint extends TutorialHint {
                 <div className="callout-hint-text"><md.MarkedContent markdown={tutorialHint} unboxSnippets={true} parent={this.props.parent}/></div>
             </div>
             :
-            <sui.Modal isOpen={true} className="hintdialog flyoutOnly"
+            <sui.Modal isOpen={true} className={classes}
                 closeIcon={false} header={tutorialName} buttons={actions}
                 onClose={onClick} dimmer={true} longer={true}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>

--- a/webapp/src/sidebarTutorial.tsx
+++ b/webapp/src/sidebarTutorial.tsx
@@ -19,8 +19,7 @@ export class SidebarTutorialHint extends TutorialHint {
         const tutorialHint = stepInfo.hintContentMd;
         const showDialog = stepInfo.showDialog;
         const fullText = stepInfo.contentMd;
-        const classes = (["hintdialog",
-            this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
+        const classes = this.props.parent.createModalClasses("hintdialog");
 
         let onClick = tutorialStep < tutorialStepInfo.length - 1 ? this.next : this.closeHint;
         const actions: sui.ModalButton[] = [{

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -292,7 +292,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
                 icon: 'check',
                 className: 'green'
             }]
-            const classes = (["hintdialog", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
+            const classes = this.props.parent.createModalClasses("hintdialog");
 
             return <sui.Modal isOpen={visible} className={classes}
                 closeIcon={false} header={tutorialName} buttons={actions}

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -270,7 +270,6 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
     renderCore() {
         const { visible } = this.state;
         const options = this.props.parent.state.tutorialOptions;
-        const flyoutOnly = this.props.parent.state.editorState && this.props.parent.state.editorState.hasCategories === false;
         const { tutorialReady, tutorialStepInfo, tutorialStep, tutorialName } = options;
         if (!tutorialReady) return <div />;
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -292,9 +292,9 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
                 icon: 'check',
                 className: 'green'
             }]
+            const classes = (["hintdialog", this.props.parent.rootClasses.filter((e: string) => e != "full-abs").join(" ")]).join(" ");
 
-            const modalClasses = flyoutOnly ? "hintdialog flyoutOnly" : "hintdialog";
-            return <sui.Modal isOpen={visible} className={modalClasses}
+            return <sui.Modal isOpen={visible} className={classes}
                 closeIcon={false} header={tutorialName} buttons={actions}
                 onClose={onClick} dimmer={true} longer={true}
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2076

This fix is two parts:
1. Updating the HC less so that for inverted themed editors, the modal's outline is the text color (white)
2. Make the root's classes accessible so that we can attach them to the modals when we make them

I initially updated all the modals with new classes, but changed it so that only the modals we'll see in Minecraft have the classes. I can add them back tho if you guys think that'd be better