### PR TITLE
Add certificate card at the end of a completed skills carousel

### DIFF
--- a/skillsmap/src/actions/dispatch.ts
+++ b/skillsmap/src/actions/dispatch.ts
@@ -11,5 +11,5 @@ export const dispatchSetPageTitle = (title: string) => ({ type: actions.SET_PAGE
 export const dispatchSetPageDescription = (description: string) => ({ type: actions.SET_PAGE_DESCRIPTION, description });
 export const dispatchSetPageInfoUrl = (infoUrl: string) => ({ type: actions.SET_PAGE_INFO_URL, infoUrl });
 
-export const dispatchShowCompletionModal = (mapId: string, activityId: string) => ({ type: actions.SHOW_COMPLETION_MODAL, mapId, activityId });
+export const dispatchShowCompletionModal = (mapId: string, activityId?: string) => ({ type: actions.SHOW_COMPLETION_MODAL, mapId, activityId });
 export const dispatchHideCompletionModal = () => ({ type: actions.HIDE_COMPLETION_MODAL });

--- a/skillsmap/src/components/Carousel.tsx
+++ b/skillsmap/src/components/Carousel.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
-import { connect } from 'react-redux';
 
-import { SkillsMapState } from '../store/reducer';
 import { Item, CarouselItem } from './CarouselItem';
-import { dispatchChangeSelectedItem } from '../actions/dispatch';
 
 import '../styles/carousel.css'
+import { ComponentClass } from "react-redux";
 
 interface CarouselProps {
     title?: string;
     items: Item[];
     selectedItem?: string;
-    itemTemplate?: (props: Item) => JSX.Element;
     itemClassName?: string;
-    dispatchChangeSelectedItem: (id: string) => void;
+    itemTemplate?: ((props: Item) => JSX.Element) | ComponentClass<any>;
+    onItemSelect?: (id: string) => void;
+    prependChildren?: JSX.Element[];
+    appendChildren?: JSX.Element[];
 }
 
 interface CarouselState {
@@ -21,7 +21,7 @@ interface CarouselState {
     showRight: boolean;
 }
 
-class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
+export class Carousel extends React.Component<CarouselProps, CarouselState> {
     protected carouselRef: any;
     constructor(props: CarouselProps) {
         super(props);
@@ -51,7 +51,7 @@ class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
     }
 
     render() {
-        const { title, items, selectedItem, itemTemplate, itemClassName } = this.props;
+        const { title, items, selectedItem, itemTemplate, itemClassName, onItemSelect, prependChildren, appendChildren } = this.props;
         const { showLeft, showRight } = this.state;
 
         return <div className="carousel">
@@ -61,9 +61,11 @@ class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
             </div>}
             <div className="carousel-items">
                 <div className="carousel-items-inner" onScroll={this.handleScroll} ref={(el) => this.carouselRef = el}>
+                    {prependChildren}
                     {items.map((el, i) => {
-                        return <CarouselItem key={i} className={itemClassName} item={el} itemTemplate={itemTemplate} selected={selectedItem === el.id} />
+                        return <CarouselItem key={i} className={itemClassName} item={el} itemTemplate={itemTemplate} selected={selectedItem === el.id} onSelect={onItemSelect} />
                     })}
+                    {appendChildren}
                 </div>
             </div>
             {showRight && <div className="carousel-arrow right" onClick={this.handleRightArrowClick}>
@@ -72,16 +74,3 @@ class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
         </div>
     }
 }
-
-function mapStateToProps(state: SkillsMapState, ownProps: any) {
-    if (!state) return {};
-    return {
-        selectedItem: state.selectedItem
-    }
-}
-
-const mapDispatchToProps = {
-    dispatchChangeSelectedItem
-};
-
-export const Carousel = connect(mapStateToProps, mapDispatchToProps)(CarouselImpl);

--- a/skillsmap/src/components/CarouselItem.tsx
+++ b/skillsmap/src/components/CarouselItem.tsx
@@ -1,8 +1,4 @@
 import * as React from "react";
-import { connect } from 'react-redux';
-
-import { SkillsMapState } from '../store/reducer';
-import { dispatchChangeSelectedItem } from '../actions/dispatch';
 
 export interface Item {
     id: string;
@@ -24,31 +20,16 @@ interface CarouselItemProps {
     itemTemplate?: any;
     selected?: boolean;
     className?: string;
-    dispatchChangeSelectedItem: (id: string) => void;
+    onSelect?: (id: string) => void;
 }
 
-class CarouselItemImpl extends React.Component<CarouselItemProps> {
-    handleClick = () => {
-        const { item, dispatchChangeSelectedItem } = this.props;
-        dispatchChangeSelectedItem(item.id);
-    }
+export function CarouselItem(props: CarouselItemProps) {
+    const { item, itemTemplate, selected, className, onSelect } = props;
+    const Inner = itemTemplate || CarouselItemTemplate;
 
-    render() {
-        const { item, itemTemplate, selected, className } = this.props;
-        const Inner = itemTemplate || CarouselItemTemplate;
+    const handleClick = () => { if (onSelect) onSelect(item.id); };
 
-        return <div className={`carousel-item ${selected ? 'selected' : ''} ${className || ''}`} onClick={this.handleClick}>
-            <Inner {...item} />
-        </div>
-    }
+    return <div className={`carousel-item ${selected ? 'selected' : ''} ${className || ''}`} onClick={handleClick}>
+        <Inner {...item} />
+    </div>
 }
-
-function mapStateToProps(state: SkillsMapState, ownProps: any) {
-    return {};
-}
-
-const mapDispatchToProps = {
-    dispatchChangeSelectedItem
-};
-
-export const CarouselItem = connect(mapStateToProps, mapDispatchToProps)(CarouselItemImpl);

--- a/skillsmap/src/components/CompletionModal.tsx
+++ b/skillsmap/src/components/CompletionModal.tsx
@@ -4,31 +4,42 @@ import * as React from "react";
 import { connect } from 'react-redux';
 
 import { SkillsMapState } from '../store/reducer';
-import { dispatchHideCompletionModal } from '../actions/dispatch';
+import { dispatchOpenActivity, dispatchHideCompletionModal } from '../actions/dispatch';
 
-import { Modal } from './Modal';
+import { Modal, ModalAction } from './Modal';
+
+type CompletionModalType = "map" | "activity";
 
 interface CompletionModalProps {
-    activity?: MapActivity;
+    type?: CompletionModalType;
+    mapId?: string;
+    displayName?: string;
+    nextActivityId?: string;
+    dispatchOpenActivity: (mapId: string, activityId: string) => void;
     dispatchHideCompletionModal: () => void;
 }
 
 export class CompletionModalImpl extends React.Component<CompletionModalProps> {
     render() {
-        const  { activity, dispatchHideCompletionModal } = this.props;
-        if (!activity) return <div />
+        const  { type, mapId, displayName, nextActivityId, dispatchOpenActivity, dispatchHideCompletionModal } = this.props;
+        if (!type) return <div />
 
-        const completionModalTitle = "Activity Complete!";
-        const completionModalText = "Good work! You've completed {0}. Keep going?";
+        const completionModalTitle = type === "activity" ? "Activity Complete!" : "Path Complete!";
+        const completionModalText = "Good work! You've completed {0}. Keep going!";
         const completionModalTextSegments = completionModalText.split("{0}");
 
-        const hasNext = !!activity?.next;
-        const actions = [
-            { label: hasNext ? "NEXT" : "DONE", onClick: () => console.log(activity?.next?.[0]?.activityId || "Done") }
-        ]
+        const actions: ModalAction[] = [];
+        if (type === "activity" && mapId && nextActivityId) {
+            actions.push({ label:"NEXT", onClick: () => {
+                dispatchHideCompletionModal();
+                dispatchOpenActivity(mapId, nextActivityId);
+             } });
+        } else {
+            actions.push({ label: "CERTIFICATE", onClick: () => {} });
+        }
 
         return <Modal title={completionModalTitle} actions={actions} onClose={() => dispatchHideCompletionModal()}>
-            {completionModalTextSegments[0]}{<strong>{activity.displayName}</strong>}{completionModalTextSegments[1]}
+            {completionModalTextSegments[0]}{<strong>{displayName}</strong>}{completionModalTextSegments[1]}
         </Modal>
     }
 }
@@ -36,12 +47,28 @@ export class CompletionModalImpl extends React.Component<CompletionModalProps> {
 function mapStateToProps(state: SkillsMapState, ownProps: any) {
     if (!state) return {};
     const { currentMapId, currentActivityId } = state.modal || {};
-    return {
-        activity: currentMapId && currentActivityId ? state.maps[currentMapId].activities[currentActivityId] : undefined
+    let type: CompletionModalType | undefined;
+    let displayName: string | undefined;
+    let nextActivityId: string | undefined;
+
+    if (currentMapId) {
+        const map = state.maps[currentMapId];
+        if (currentActivityId) {
+            const activity = map.activities[currentActivityId];
+            type = "activity";
+            displayName = activity.displayName;
+            nextActivityId = activity.next?.[0].activityId;
+        } else {
+            type = "map";
+            displayName = map.displayName;
+        }
     }
+
+    return { type, mapId: currentMapId, displayName, nextActivityId }
 }
 
 const mapDispatchToProps = {
+    dispatchOpenActivity,
     dispatchHideCompletionModal
 };
 

--- a/skillsmap/src/components/Modal.tsx
+++ b/skillsmap/src/components/Modal.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import '../styles/modal.css'
 
-interface ModalAction {
+export interface ModalAction {
     label: string;
     className?: string;
     onClick: () => void;

--- a/skillsmap/src/lib/skillMapUtils.ts
+++ b/skillsmap/src/lib/skillMapUtils.ts
@@ -1,4 +1,9 @@
 
+export function isMapCompleted(user: UserState, map: SkillsMap) {
+    if (Object.keys(map?.activities).some(k => !user?.mapProgress[map.mapId]?.activityState[k]?.isCompleted)) return false;
+    return true;
+}
+
 export function isActivityCompleted(user: UserState, mapId: string, activityId: string) {
     return !!(lookupActivityProgress(user, mapId, activityId)?.isCompleted);
 }

--- a/skillsmap/src/store/reducer.ts
+++ b/skillsmap/src/store/reducer.ts
@@ -43,7 +43,7 @@ const topReducer = (state: SkillsMapState = initialState, action: any): SkillsMa
                     ...state.user,
                     mapProgress: {
                         ...state.user.mapProgress,
-                        [action.id]: { mapId: action.map.id, activityState: {} }
+                        [action.map.mapId]: { mapId: action.map.mapId, activityState: { } }
                     }
                 },
                 maps: {

--- a/skillsmap/src/styles/skillcard.css
+++ b/skillsmap/src/styles/skillcard.css
@@ -181,3 +181,41 @@
 .completed i.xicon.redo:before {
     vertical-align: bottom;
 }
+
+/* END CARD DISPLAY (TROPHY) */
+.end-card {
+    position: relative;
+    flex-grow: 0;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 2rem;
+}
+
+.end-card-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 6rem;
+    height: 6rem;
+    margin-right: 3rem;
+    border-radius: 50%;
+
+    background-color: #ddd;
+}
+
+.end-card i.icon {
+    font-size: 4rem;
+    line-height: 4rem;
+    margin: 0;
+}
+
+.end-card:before {
+    content: '';
+    position: absolute;
+    left: -2.5rem;
+    width: 2.5rem;
+    height: 0.75rem;
+    background-color: #000;
+}


### PR DESCRIPTION
- Small cleanup for generic Carousel/CarouselItem components to remove redux dependencies
- Hook completion modal "Next" button up to next activity
- Push end certificate card (triggers completion modal for entire skill map) if all activities in a map are completed