### PR TITLE
Add certificate 'card' at the end of a carousel after skill map completed

### DIFF
--- a/skillmap/src/actions/dispatch.ts
+++ b/skillmap/src/actions/dispatch.ts
@@ -11,5 +11,5 @@ export const dispatchSetPageTitle = (title: string) => ({ type: actions.SET_PAGE
 export const dispatchSetPageDescription = (description: string) => ({ type: actions.SET_PAGE_DESCRIPTION, description });
 export const dispatchSetPageInfoUrl = (infoUrl: string) => ({ type: actions.SET_PAGE_INFO_URL, infoUrl });
 
-export const dispatchShowCompletionModal = (mapId: string, activityId: string) => ({ type: actions.SHOW_COMPLETION_MODAL, mapId, activityId });
+export const dispatchShowCompletionModal = (mapId: string, activityId?: string) => ({ type: actions.SHOW_COMPLETION_MODAL, mapId, activityId });
 export const dispatchHideCompletionModal = () => ({ type: actions.HIDE_COMPLETION_MODAL });

--- a/skillmap/src/components/Carousel.tsx
+++ b/skillmap/src/components/Carousel.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
-import { connect } from 'react-redux';
 
-import { SkillMapState } from '../store/reducer';
 import { Item, CarouselItem } from './CarouselItem';
-import { dispatchChangeSelectedItem } from '../actions/dispatch';
 
 import '../styles/carousel.css'
+import { ComponentClass } from "react-redux";
 
 interface CarouselProps {
     title?: string;
     items: Item[];
     selectedItem?: string;
-    itemTemplate?: (props: Item) => JSX.Element;
     itemClassName?: string;
-    dispatchChangeSelectedItem: (id: string) => void;
+    itemTemplate?: ((props: Item) => JSX.Element) | ComponentClass<any>;
+    onItemSelect?: (id: string) => void;
+    prependChildren?: JSX.Element[];
+    appendChildren?: JSX.Element[];
 }
 
 interface CarouselState {
@@ -21,7 +21,7 @@ interface CarouselState {
     showRight: boolean;
 }
 
-class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
+export class Carousel extends React.Component<CarouselProps, CarouselState> {
     protected carouselRef: any;
     constructor(props: CarouselProps) {
         super(props);
@@ -51,7 +51,7 @@ class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
     }
 
     render() {
-        const { title, items, selectedItem, itemTemplate, itemClassName } = this.props;
+        const { title, items, selectedItem, itemTemplate, itemClassName, onItemSelect, prependChildren, appendChildren } = this.props;
         const { showLeft, showRight } = this.state;
 
         return <div className="carousel">
@@ -61,9 +61,11 @@ class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
             </div>}
             <div className="carousel-items">
                 <div className="carousel-items-inner" onScroll={this.handleScroll} ref={(el) => this.carouselRef = el}>
+                    {prependChildren}
                     {items.map((el, i) => {
-                        return <CarouselItem key={i} className={itemClassName} item={el} itemTemplate={itemTemplate} selected={selectedItem === el.id} />
+                        return <CarouselItem key={i} className={itemClassName} item={el} itemTemplate={itemTemplate} selected={selectedItem === el.id} onSelect={onItemSelect} />
                     })}
+                    {appendChildren}
                 </div>
             </div>
             {showRight && <div className="carousel-arrow right" onClick={this.handleRightArrowClick}>
@@ -72,16 +74,3 @@ class CarouselImpl extends React.Component<CarouselProps, CarouselState> {
         </div>
     }
 }
-
-function mapStateToProps(state: SkillMapState, ownProps: any) {
-    if (!state) return {};
-    return {
-        selectedItem: state.selectedItem
-    }
-}
-
-const mapDispatchToProps = {
-    dispatchChangeSelectedItem
-};
-
-export const Carousel = connect(mapStateToProps, mapDispatchToProps)(CarouselImpl);

--- a/skillmap/src/components/CarouselItem.tsx
+++ b/skillmap/src/components/CarouselItem.tsx
@@ -1,8 +1,4 @@
 import * as React from "react";
-import { connect } from 'react-redux';
-
-import { SkillMapState } from '../store/reducer';
-import { dispatchChangeSelectedItem } from '../actions/dispatch';
 
 export interface Item {
     id: string;
@@ -24,31 +20,16 @@ interface CarouselItemProps {
     itemTemplate?: any;
     selected?: boolean;
     className?: string;
-    dispatchChangeSelectedItem: (id: string) => void;
+    onSelect?: (id: string) => void;
 }
 
-class CarouselItemImpl extends React.Component<CarouselItemProps> {
-    handleClick = () => {
-        const { item, dispatchChangeSelectedItem } = this.props;
-        dispatchChangeSelectedItem(item.id);
-    }
+export function CarouselItem(props: CarouselItemProps) {
+    const { item, itemTemplate, selected, className, onSelect } = props;
+    const Inner = itemTemplate || CarouselItemTemplate;
 
-    render() {
-        const { item, itemTemplate, selected, className } = this.props;
-        const Inner = itemTemplate || CarouselItemTemplate;
+    const handleClick = () => { if (onSelect) onSelect(item.id); };
 
-        return <div className={`carousel-item ${selected ? 'selected' : ''} ${className || ''}`} onClick={this.handleClick}>
-            <Inner {...item} />
-        </div>
-    }
+    return <div className={`carousel-item ${selected ? 'selected' : ''} ${className || ''}`} onClick={handleClick}>
+        <Inner {...item} />
+    </div>
 }
-
-function mapStateToProps(state: SkillMapState, ownProps: any) {
-    return {};
-}
-
-const mapDispatchToProps = {
-    dispatchChangeSelectedItem
-};
-
-export const CarouselItem = connect(mapStateToProps, mapDispatchToProps)(CarouselItemImpl);

--- a/skillmap/src/components/Modal.tsx
+++ b/skillmap/src/components/Modal.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import '../styles/modal.css'
 
-interface ModalAction {
+export interface ModalAction {
     label: string;
     className?: string;
     onClick: () => void;

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -1,4 +1,9 @@
 
+export function isMapCompleted(user: UserState, map: SkillMap) {
+    if (Object.keys(map?.activities).some(k => !user?.mapProgress[map.mapId]?.activityState[k]?.isCompleted)) return false;
+    return true;
+}
+
 export function isActivityCompleted(user: UserState, mapId: string, activityId: string) {
     return !!(lookupActivityProgress(user, mapId, activityId)?.isCompleted);
 }

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -43,7 +43,7 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
                     ...state.user,
                     mapProgress: {
                         ...state.user.mapProgress,
-                        [action.id]: { mapId: action.map.id, activityState: {} }
+                        [action.map.mapId]: { mapId: action.map.mapId, activityState: { } }
                     }
                 },
                 maps: {

--- a/skillmap/src/styles/skillcard.css
+++ b/skillmap/src/styles/skillcard.css
@@ -181,3 +181,41 @@
 .completed i.xicon.redo:before {
     vertical-align: bottom;
 }
+
+/* END CARD DISPLAY (TROPHY) */
+.end-card {
+    position: relative;
+    flex-grow: 0;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 2rem;
+}
+
+.end-card-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 6rem;
+    height: 6rem;
+    margin-right: 3rem;
+    border-radius: 50%;
+
+    background-color: #ddd;
+}
+
+.end-card i.icon {
+    font-size: 4rem;
+    line-height: 4rem;
+    margin: 0;
+}
+
+.end-card:before {
+    content: '';
+    position: absolute;
+    left: -2.5rem;
+    width: 2.5rem;
+    height: 0.75rem;
+    background-color: #000;
+}


### PR DESCRIPTION
- Small cleanup for generic Carousel/CarouselItem components to remove redux dependencies
- Hook completion modal "Next" button up to next activity
- Push end certificate card (triggers completion modal for entire skill map) if all activities in a map are completed