### PR TITLE
fix code stop / minecraft hour of code

### DIFF
--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -133,10 +133,10 @@ namespace ts.pxtc {
         }
 
         // run post-processing code last, if present
-        const postIdx = opts.sourceFiles.indexOf("_onCodeStop.ts")
+        const postIdx = opts.sourceFiles.indexOf(pxt.TUTORIAL_CODE_STOP)
         if (postIdx >= 0) {
             opts.sourceFiles.splice(postIdx, 1)
-            opts.sourceFiles.push("_onCodeStop.ts")
+            opts.sourceFiles.push(pxt.TUTORIAL_CODE_STOP)
         }
 
         res.times["conversions"] = U.cpuUs() - startTime
@@ -365,10 +365,10 @@ namespace ts.pxtc {
         }
 
         // run post-processing code last, if present
-        const post_idx = tsFiles.indexOf("_onCodeStop.ts")
+        const post_idx = tsFiles.indexOf(pxt.TUTORIAL_CODE_STOP);
         if (post_idx >= 0) {
             tsFiles.splice(post_idx, 1)
-            tsFiles.push("_onCodeStop.ts")
+            tsFiles.push(pxt.TUTORIAL_CODE_STOP);
         }
 
         // TODO: ensure that main.ts is last???

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -1018,10 +1018,16 @@ namespace ts.pxtc {
             let files = program.getSourceFiles().slice();
 
             const main = files.find(sf => sf.fileName === "main.ts");
-
             if (main) {
                 files = files.filter(sf => sf.fileName !== "main.ts");
                 files.push(main);
+            }
+
+            // run post-processing code last, if present
+            const postProcessing = files.find(sf => sf.fileName === pxt.TUTORIAL_CODE_STOP);
+            if (postProcessing) {
+                files = files.filter(sf => sf.fileName !== pxt.TUTORIAL_CODE_STOP);
+                files.push(postProcessing);
             }
 
             files.forEach(f => {


### PR DESCRIPTION
hot fix for hour of code tutorials

~I'm fairly confident this will work but waiting for my local build to test real quick, putting up now to get build started~ tested and appears to work, though that's just comparing the generated code / haven't got an easy way to test in game at the moment.

For reference, generated code with current release (important bit is relative position of `pxsim._control._onCodeStop` vs on start / main.ts code):

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/5615930/98314307-88713300-1f8a-11eb-8308-8269803769ee.png)

vs with previous release

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/5615930/98314285-7c857100-1f8a-11eb-904b-30001a65dc47.png)

and with this change:

![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/5615930/98314329-96bf4f00-1f8a-11eb-8758-879954f6c8b5.png)

