### PR TITLE
Keep track of hints we've seen

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -247,6 +247,7 @@ namespace pxt.editor {
         pokeUserActivity(): void;
         stopPokeUserActivity(): void;
         clearUserPoke(): void;
+        setHintSeen(step: number): void;
 
         anonymousPublishAsync(screenshotUri?: string): Promise<string>;
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1786,6 +1786,7 @@ export class ProjectView
         try {
             const { options, editor } = pxt.tutorial.getTutorialOptions(md, "untitled", "untitled", "", false);
             const dependencies = pxt.gallery.parsePackagesFromMarkdown(md);
+            this.hintManager.clearViewedHints();
 
             return this.createProjectAsync({
                 name: "untitled",
@@ -3527,6 +3528,7 @@ export class ProjectView
                     throw new Error(lf("Tutorial {0} not found", tutorialId));
 
                 const { options, editor: parsedEditor } = pxt.tutorial.getTutorialOptions(md, tutorialId, filename, reportId, !!recipe);
+                this.hintManager.clearViewedHints();
 
                 // pick tutorial editor
                 const editor = editorProjectName || parsedEditor;
@@ -3676,7 +3678,7 @@ export class ProjectView
     pokeUserActivity() {
         if (!!this.state.tutorialOptions && !!this.state.tutorialOptions.tutorial) {
             // animate tutorial hint after some time of user inactivity
-            this.hintManager.pokeUserActivity(ProjectView.tutorialCardId, this.state.tutorialOptions.tutorialHintCounter);
+            this.hintManager.pokeUserActivity(ProjectView.tutorialCardId, this.state.tutorialOptions.tutorialStep, this.state.tutorialOptions.tutorialHintCounter);
         }
     }
 
@@ -3686,6 +3688,10 @@ export class ProjectView
 
     clearUserPoke() {
         this.setState({ pokeUserComponent: null });
+    }
+
+    setHintSeen(step: number) {
+        this.hintManager.viewedHint(step);
     }
 
     private tutorialCardHintCallback() {

--- a/webapp/src/hinttooltip.tsx
+++ b/webapp/src/hinttooltip.tsx
@@ -40,6 +40,16 @@ export class HintManager {
     private defaultDuration: number = 10000;
     private defaultDisplayCount: number = 3;
     private hints: { [key: string]: any } = {};
+    private seenHints: { [key: number]: boolean} = {};
+
+    public viewedHint(step: number) {
+        // Mark this hint as seen, don't wiggle the hint button
+        this.seenHints[step] = true;
+    }
+
+    public clearViewedHints() {
+        this.seenHints = {};
+    }
 
     public addHint(id: string, callback: any, duration?: number) {
         this.hints[id] = pxt.Util.debounce(() => {
@@ -50,8 +60,9 @@ export class HintManager {
 
     // starts a timer, overwriting current timer
     // TODO: if/when we add more hints, should discuss whether this count is across all hints or per-hint
-    public pokeUserActivity(id: string, displayCount?: number) {
-        if (displayCount == undefined || displayCount < this.defaultDisplayCount) {
+    public pokeUserActivity(id: string, step: number, displayCount?: number) {
+        if ((displayCount == undefined || displayCount < this.defaultDisplayCount) &&
+             !this.seenHints[step]) {
             this.stopPokeUserActivity();
             this.timer = this.hints[id]();
         }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -534,6 +534,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
 
         const th = this.refs["tutorialhint"] as TutorialHint;
         if (!th) return;
+        const currentStep = this.props.parent.state.tutorialOptions.tutorialStep;
 
         if (!visible) {
             if (th.elementRef) th.elementRef.removeEventListener('click', this.expandedHintOnClick);
@@ -548,6 +549,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             if (!options.tutorialStepInfo[options.tutorialStep].showDialog)
                 document.addEventListener('click', this.closeHint); // add close listener if not modal
             pxt.tickEvent(`tutorial.showhint`, { tutorial: options.tutorial, step: options.tutorialStep });
+            this.props.parent.setHintSeen(currentStep);
         }
         th.showHint(visible, showFullText);
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2080

Keep track of all the hints we've seen so we don't jiggle the hint button if it's already been used.
the path is basically:

**hintManager** is in charge of the wiggling and also keeps track of who has/hasn't been seen
**app** prompts **hintManager** to start the timer to jiggle
**tutorial** tells **app** when we've seen a hint who then passes it along to **hintManager**


This plays nicely with having multiple tutorials