### PR TITLE
Upgrade codecard galleries

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3159,8 +3159,9 @@ export function downloadPlaylistsAsync(parsed: commandParser.ParsedCommand): Pro
     const fn = (parsed.args[0] as string || "playlists.json");
     if (!nodeutil.fileExistsSync(fn))
         U.userError(`File ${fn} not found`);
+    const md = !!parsed.flags["md"];
     const playlists = nodeutil.readJson(fn);
-    return youtube.renderPlaylistsAsync(playlists);
+    return youtube.renderPlaylistsAsync(playlists, md);
 }
 
 export async function validateAndFixPkgConfig(parsed: commandParser.ParsedCommand): Promise<void> {
@@ -6679,6 +6680,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
         name: "downloadplaylists",
         aliases: ["playlists"],
         help: "Download YouTube playlists and generate markdown",
+        flags: {
+            md: {
+                description: "generate markdown"
+            }
+        },
         advanced: true,
         argString: "<list>"
     }, downloadPlaylistsAsync)

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3239,7 +3239,7 @@ export function downloadDiscourseTagAsync(parsed: commandParser.ParsedCommand): 
     if (outmd && !fs.existsSync(outmd))
         U.userError(`${outmd} file not found`)
     const md: string = outmd && fs.readFileSync(outmd, { encoding: "utf8" });
-    const title = md && /^# (.)$/m.exec(md)?.[1];
+    const title = md && /^# (.*)$/m.exec(md)?.[1];
 
     nodeutil.mkdirP(out);
     let n = 0;

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5536,6 +5536,11 @@ async function upgradeCardsAsync(): Promise<void> {
     
     mds.forEach(({filename, content}) => {
         pxt.log(`patching ${filename}`)
+        const updated = content.replace(/```codecard([^`]+)```/g, (m, c: string) => {
+            const cards = pxt.gallery.parseCodeCards(c);
+            return pxt.gallery.codeCardsToMarkdown(cards);
+        })
+        nodeutil.writeFileSync(filename, updated);
     })
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3238,7 +3238,8 @@ export function downloadDiscourseTagAsync(parsed: commandParser.ParsedCommand): 
         U.userError("Target not configured for discourse");
     if (outmd && !fs.existsSync(outmd))
         U.userError(`${outmd} file not found`)
-    let md: string = outmd && fs.readFileSync(outmd, { encoding: "utf8" });
+    const md: string = outmd && fs.readFileSync(outmd, { encoding: "utf8" });
+    const title = md && /^# (.)$/m.exec(md)?.[1];
 
     nodeutil.mkdirP(out);
     let n = 0;
@@ -3303,12 +3304,12 @@ export function downloadDiscourseTagAsync(parsed: commandParser.ParsedCommand): 
                 if (lastCard)
                     cards.push(lastCard);
                 cards.forEach(card => delete (card as any).id);
-                md = md.replace(/```/g, (m, c) => {
-                    return `\`\`\`codecard
-${JSON.stringify(cards, null, 4)}
-\`\`\``;
-                })
-                nodeutil.writeFileSync(outmd, md, { encoding: "utf8" });
+               const newmd = `# ${title || "Community"}
+
+${pxt.gallery.codeCardsToMarkdown(cards)}
+
+`
+                nodeutil.writeFileSync(outmd, newmd, { encoding: "utf8" });
             }
             pxt.log(`downloaded ${n} programs (${newcards} new) from tag ${tag}`)
         })

--- a/cli/youtube.ts
+++ b/cli/youtube.ts
@@ -15,7 +15,7 @@ function checkApiKey() {
     }
 }
 
-async function renderPlaylistAsync(fn: string, id: string, useMarkdownCards: boolean): Promise<void> {
+async function renderPlaylistAsync(fn: string, id: string): Promise<void> {
     fn = fn.replace(/\.md$/i, '');
     const assets = `/static/${fn}`
     nodeutil.mkdirP("docs" + assets)
@@ -48,13 +48,7 @@ async function renderPlaylistAsync(fn: string, id: string, useMarkdownCards: boo
         "youTubePlaylistId": id,
         "imageUrl": `${assets}/playlist.png`
     });
-
-    const cardsMd = useMarkdownCards ? pxt.gallery.codeCardsToMarkdown(cards)
-        : 
-`\`\`\`codecard
-${JSON.stringify(cards, null, 4)}
-\`\`\``
-
+    const cardsMd = pxt.gallery.codeCardsToMarkdown(cards);
     const md =
         `# ${playlist.snippet.title}
 
@@ -73,8 +67,8 @@ ${cardsMd}
     nodeutil.writeFileSync(path.join('docs', fn + ".md"), md, { encoding: "utf8" });
 }
 
-export function renderPlaylistsAsync(playlists: pxt.Map<string>, useMarkdownCards: boolean): Promise<void> {
+export function renderPlaylistsAsync(playlists: pxt.Map<string>): Promise<void> {
     checkApiKey();
-    return Promise.all(Object.keys(playlists).map(fn => renderPlaylistAsync(fn, playlists[fn], useMarkdownCards)))
+    return Promise.all(Object.keys(playlists).map(fn => renderPlaylistAsync(fn, playlists[fn])))
         .then(() => { pxt.log('playlists refreshed') });
 }

--- a/cli/youtube.ts
+++ b/cli/youtube.ts
@@ -15,7 +15,7 @@ function checkApiKey() {
     }
 }
 
-async function renderPlaylistAsync(fn: string, id: string): Promise<void> {
+async function renderPlaylistAsync(fn: string, id: string, useMarkdownCards: boolean): Promise<void> {
     fn = fn.replace(/\.md$/i, '');
     const assets = `/static/${fn}`
     nodeutil.mkdirP("docs" + assets)
@@ -48,6 +48,13 @@ async function renderPlaylistAsync(fn: string, id: string): Promise<void> {
         "youTubePlaylistId": id,
         "imageUrl": `${assets}/playlist.png`
     });
+
+    const cardsMd = useMarkdownCards ? pxt.gallery.codeCardsToMarkdown(cards)
+        : 
+`\`\`\`codecard
+${JSON.stringify(cards, null, 4)}
+\`\`\``
+
     const md =
         `# ${playlist.snippet.title}
 
@@ -55,9 +62,7 @@ ${playlist.snippet.description || ""}
 
 ## Videos
 
-\`\`\`codecard
-${JSON.stringify(cards, null, 4)}
-\`\`\`
+${cardsMd}
 
 ## See Also
 
@@ -68,8 +73,8 @@ ${JSON.stringify(cards, null, 4)}
     nodeutil.writeFileSync(path.join('docs', fn + ".md"), md, { encoding: "utf8" });
 }
 
-export function renderPlaylistsAsync(playlists: pxt.Map<string>): Promise<void> {
+export function renderPlaylistsAsync(playlists: pxt.Map<string>, useMarkdownCards: boolean): Promise<void> {
     checkApiKey();
-    return Promise.all(Object.keys(playlists).map(fn => renderPlaylistAsync(fn, playlists[fn])))
+    return Promise.all(Object.keys(playlists).map(fn => renderPlaylistAsync(fn, playlists[fn], useMarkdownCards)))
         .then(() => { pxt.log('playlists refreshed') });
 }

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -214,13 +214,13 @@ namespace pxt.gallery {
 ${(cards || []).map(
             card => Object.keys(card)
                 .filter(k => !!(<any>card)[k])
-                .map(k => k === "otherActions" 
+                .map(k => k === "otherActions"
                     ? otherActionsToMd((<any>card)[k])
                     : `* ${k}: ${(<any>card)[k]}`
                 ).join('\n')
         )
                 .join(
-`
+                    `
 
 ---
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -207,4 +207,27 @@ namespace pxt.gallery {
         return pxt.Cloud.markdownAsync(name)
             .then(md => parseGalleryMardown(md))
     }
+
+    export function codeCardsToMarkdown(cards: pxt.CodeCard[]) {
+        const md = `### ~ codecard
+
+        ${(cards || []).map(
+            card => Object.keys(card)
+                .filter(k => !!(<any>card)[k])
+                .map(k => k === "otherActions" 
+                    ? otherActionsToMd((<any>card)[k])
+                    : `* ${k}: ${(<any>card)[k]}`
+                ).join('\n')
+        )
+                .join('\n---\n\n')}
+
+        ### ~
+        `
+        return md;
+
+        function otherActionsToMd(oas: pxt.CodeCardAction[]): string {
+            return oas.map(oa => `* otherAction: ${oa.url} ${oa.editor || "ts"} ${oa.cardType || ""}`)
+                .join('\n');
+        }
+    }
 }

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -211,7 +211,7 @@ namespace pxt.gallery {
     export function codeCardsToMarkdown(cards: pxt.CodeCard[]) {
         const md = `### ~ codecard
 
-        ${(cards || []).map(
+${(cards || []).map(
             card => Object.keys(card)
                 .filter(k => !!(<any>card)[k])
                 .map(k => k === "otherActions" 
@@ -219,10 +219,15 @@ namespace pxt.gallery {
                     : `* ${k}: ${(<any>card)[k]}`
                 ).join('\n')
         )
-                .join('\n---\n\n')}
+                .join(
+`
 
-        ### ~
-        `
+---
+
+`)}
+
+### ~
+`
         return md;
 
         function otherActionsToMd(oas: pxt.CodeCardAction[]): string {


### PR DESCRIPTION
CLI tool to migrate JSON-formatted codecard sections into markdown equivalents.
Here is an example: https://github.com/microsoft/pxt-maker/commit/4863e2d7274ca9ae8d07cc4ec506c2055cbb4d8f
```
pxt upgradecards
```