### PR TITLE
fix race condition when loading cached flyoutOnly tutorials

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -132,7 +132,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
-
     domUpdate() {
         if (this.delayLoadXml) {
             if (this.loadingXml) return
@@ -173,7 +172,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         // It's possible Blockly reloads and the loading dimmer is no longer a child of the editorDiv
                         editorDiv.removeChild(loadingDimmer);
                     } catch { }
-                    this.loadingXml = false
+                    this.loadingXml = false;
                     this.loadingXmlPromise = null;
                     pxt.perf.measureEnd("domUpdate loadBlockly")
                 });
@@ -1110,7 +1109,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     // If we're switching from no toolbox to a toolbox, mount node
                     this.renderToolbox(true);
                 }
-            }
+            };
 
             if (this.loadingXmlPromise) {
                 // enqueue refresh if currently loading


### PR DESCRIPTION
Shannon made minecraft tutorials too fast D:!!

Fix an old race condition in loading tutorials that change the toolbox style, which is currently causing template code to be overwritten in minecraft hour of code.

It looks like `loadingXmlPromise` was intended to be cancelled when `refreshToolbox` was called. However, bluebird promises aren't cancellable by default / without specifying it in the config, so trying to do so would throw a big warning in the console... if we weren't nulling out `loadingXmlPromise` immediately after it was set (maybe to avoid the warning??).

The route a failure here would follow would be approximately:

* `domUpdate` gets called with the initial content (the template code) (I'll call the promise this makes 'loadingXmlPromise1')
* `refreshToolbox` is called before `loadingXmlPromise1` is complete / while it is here ish: https://github.com/microsoft/pxt/blob/94128ce17a76dedb73fe2001fcc383e050f0b6f3/webapp/src/blocks.tsx#L153-L154
* Refresh toolbox notices we've changed from a normal toolbox to flyout only, so it tries to clear the existing update (which it cannot cancel as described above). In doing so, it...
    * tries to set xml to be loaded (`this.delayLoadXml = this.getCurrentSource();`). This works! Kind of.
    * clears the loading state to force `domUpdate` to do stuff
    * and runs `domUpdate`, which will start 'loadingXmlPromise2'
* 'loadingXmlPromise1' finishes loading blockly / getting blocks from the compiler. It renders the xml that has been enqueued https://github.com/microsoft/pxt/blob/94128ce17a76dedb73fe2001fcc383e050f0b6f3/webapp/src/blocks.tsx#L164-L165, finishes it's job, and is good to go! `this.delayLoadXml` is now null because we've finished loading.
* ... and then 'loadingXmlPromise2' also finishes and renders the blocks... which are now undefined, and clears the previous blocks :(

I believe this should fix the issue with hoc tutorials loading, but I'm still VERY suspicious of how state is managed in this file / when things are called - I think it would be valuable to spend a bit longer trying to clear up the state management / update logic in this file after this batch of releases is finished. 