### PR TITLE
[stable6.0] Port monaco fixes for v2 music blocks

### DIFF
--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1883,33 +1883,44 @@ namespace ts.pxtc.service {
                             .filter(v => v.extendsTypes.reduce((x, y) => x || y.indexOf(name) != -1, false))
                             .reduce((x, y) => x.concat(y.extendsTypes), [])
                     }
-                    // if blockNamespace exists, e.g., "pins", use it for snippet
-                    // else use nsInfo.namespace, e.g., "motors"
-                    namespaceToUse = element.attributes.blockNamespace || nsInfo.namespace || "";
+
                     // all fixed instances for this namespace
                     let fixedInstances = instances.filter(value =>
                         value.kind === pxtc.SymbolKind.Variable &&
                         value.attributes.fixedInstance
                     );
+
+                    let instanceToUse: SymbolInfo;
                     // first try to get fixed instances whose retType matches nsInfo.name
                     // e.g., DigitalPin
-                    let exactInstances = fixedInstances.filter(value =>
+                    const exactInstances = fixedInstances.filter(value =>
                         value.retType == nsInfo.qName)
                         .sort((v1, v2) => v1.name.localeCompare(v2.name));
+
                     if (exactInstances.length) {
-                        snippetPrefix = `${getName(exactInstances[0])}`
+                        instanceToUse = exactInstances[0];
                     } else {
                         // second choice: use fixed instances whose retType extends type of nsInfo.name
                         // e.g., nsInfo.name == AnalogPin and instance retType == PwmPin
-                        let extendedInstances = fixedInstances.filter(value =>
+                        const extendedInstances = fixedInstances.filter(value =>
                             getExtendsTypesFor(nsInfo.qName).indexOf(value.retType) !== -1)
                             .sort((v1, v2) => v1.name.localeCompare(v2.name));
-                        if (extendedInstances.length) {
-                            snippetPrefix = `${getName(extendedInstances[0])}`
-                        }
+
+                        instanceToUse = extendedInstances[0];
                     }
+
+                    if (instanceToUse) {
+                        snippetPrefix = `${getName(instanceToUse)}`;
+                        namespaceToUse = instanceToUse.namespace;
+                    } else {
+                        namespaceToUse = nsInfo.namespace;
+                    }
+
+                    if (namespaceToUse)  {
+                        addNamespace = true;
+                    }
+
                     isInstance = true;
-                    addNamespace = true;
                 }
                 else if (element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Property) {
                     const params = pxt.blocks.compileInfo(element);

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -1717,6 +1717,10 @@ namespace ts.pxtc.service {
 
         const attrs = fn.attributes;
 
+        if (attrs.shim === "TD_ID" && recursionDepth && decl.parameters.length) {
+            return getParameterDefault(decl.parameters[0]);
+        }
+
         const checker = service && service.getProgram().getTypeChecker();
 
         const blocksInfo = blocksInfoOp(apis, runtimeOps.bannedCategories);


### PR DESCRIPTION
Porting two monaco fixes:

* Fix snippets for fixedInstances outside block namespace (#7286) 
* Fix snippets for shim=TD_ID parameters (#7284)

fix https://github.com/microsoft/pxt-microbit/issues/3501 (the second commit fixes the onboard speaker block)

![v2 music blocks](https://user-images.githubusercontent.com/5615930/98727628-106d8900-234d-11eb-8903-275ef041dd53.gif)
