### PR TITLE
[stable6.4] Porting tutorial load and api gallery fix for minecraft patch

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -844,6 +844,7 @@ namespace pxt.runner {
                         && !symbol.attributes.deprecated
                         && !symbol.attributes.blockAliasFor
                         && !!symbol.attributes.jsDoc
+                        && !!symbol.attributes.block
                         && !/^__/.test(symbol.name)
                     );
                 apisEl.each((i, e) => {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -168,16 +168,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     Blockly.svgResize(this.editor);
                     this.isFirstBlocklyLoad = false;
                 }).finally(() => {
-                    this.loadingXml = false
                     try {
                         // It's possible Blockly reloads and the loading dimmer is no longer a child of the editorDiv
                         editorDiv.removeChild(loadingDimmer);
                     } catch { }
+                    this.loadingXml = false;
+                    this.loadingXmlPromise = null;
                     pxt.perf.measureEnd("domUpdate loadBlockly")
                 });
-
-            this.loadingXmlPromise.done();
-            this.loadingXmlPromise = null;
         }
     }
 
@@ -1100,20 +1098,25 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 // If we're switching from a toolbox to no toolbox, unmount node
                 ReactDOM.unmountComponentAtNode(this.getBlocklyToolboxDiv());
             }
-            // Refresh Blockly
-            this.delayLoadXml = this.getCurrentSource();
-            this.editor = undefined;
-            this.loadingXml = false;
+
+            const refreshBlockly = () => {
+                this.delayLoadXml = this.getCurrentSource();
+                this.editor = undefined;
+                this.prepareBlockly(hasCategories);
+                this.domUpdate();
+                this.editor.scrollCenter();
+                if (hasCategories) {
+                    // If we're switching from no toolbox to a toolbox, mount node
+                    this.renderToolbox(true);
+                }
+            };
+
             if (this.loadingXmlPromise) {
-                this.loadingXmlPromise.cancel();
-                this.loadingXmlPromise = null;
-            }
-            this.prepareBlockly(hasCategories);
-            this.domUpdate();
-            this.editor.scrollCenter();
-            if (hasCategories) {
-                // If we're switching from no toolbox to a toolbox, mount node
-                this.renderToolbox(true);
+                // enqueue refresh if currently loading
+                this.loadingXmlPromise
+                    .then(refreshBlockly);
+            } else {
+                refreshBlockly();
             }
         }
         pxt.perf.measureEnd("refreshToolbox")


### PR DESCRIPTION
Cherry picking for minecraft patch:

*  only show blocks in block gallery (#7605)
* fix race condition when loading cached flyoutOnly tutorials (#7600) 