### PR TITLE
win10 flash: make sure to reconnect dap wrapper

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -412,7 +412,7 @@ export async function initAsync() {
     if (pxt.winrt.isWinRT()) {
         log(`deploy: init winrt`)
         pxt.winrt.initWinrtHid(
-            () => pxt.packetio.initAsync(true).then(() => { }),
+            () => pxt.packetio.initAsync(true).then(wrap => wrap?.reconnectAsync()),
             () => pxt.packetio.disconnectAsync()
         );
     }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -223,7 +223,7 @@ function pairBootloaderAsync(): Promise<void> {
 function winrtDeployCoreAsync(r: pxtc.CompileResult, d: pxt.commands.DeployOptions): Promise<void> {
     log(`winrt deploy`)
     return hidDeployCoreAsync(r, d)
-        .timeout(60000)
+        .timeout(180000)
         .catch((e) => {
             return pxt.packetio.disconnectAsync()
                 .catch((e) => {


### PR DESCRIPTION
We need to run reconnectAsync after detecting a new device so that we can detect which hardware is connected.
+ increase timeout for winrt deployment.