### PR TITLE
add apptheme field to use data uri instead of blob object

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -405,6 +405,7 @@ declare namespace pxt {
         identity?: boolean; // login with identity providers
         assetEditor?: boolean; // enable asset editor view (in blocks/text toggle)
         disableMemoryWorkspaceWarning?: boolean; // do not warn the user when switching to in memory workspace
+        disableBlobObjectDownload?: boolean; // use data uri downloads instead of object urls
     }
 
     interface SocialOptions {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -384,9 +384,10 @@ namespace pxt.BrowserUtils {
         } = opt;
 
         const createObjectURL = window.URL?.createObjectURL;
+        const asDataUri = pxt.appTarget.appTheme.disableBlobObjectDownload;
         let downloadurl: string;
         try {
-            if (!!createObjectURL) {
+            if (!!createObjectURL && !asDataUri) {
                 const b = new Blob([Util.stringToUint8Array(atob(b64))], { type: contentType });
                 const objUrl = createObjectURL(b);
                 browserDownloadDataUri(objUrl, name, userContextWindow);


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-microbit/issues/3674, will toggle this on with https://github.com/microsoft/pxt-microbit/blob/master/pxtarget.json#L563 (and if needed for iosapp)