### PR TITLE
clear translations before caching api info

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -709,6 +709,7 @@ declare namespace ts.pxtc {
         _def?: ParsedBlockDef;
         _expandedDef?: ParsedBlockDef;
         _untranslatedBlock?: string; // The block definition before it was translated
+        _untranslatedJsDoc?: string // the jsDoc before it was translated
         _shadowOverrides?: pxt.Map<string>;
         jsDoc?: string;
         paramHelp?: pxt.Map<string>;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -613,7 +613,9 @@ namespace ts.pxtc {
 
     export function localizeApisAsync(apis: pxtc.ApisInfo, mainPkg: pxt.MainPackage): Promise<pxtc.ApisInfo> {
         const lang = pxtc.Util.userLanguage();
-        if (pxtc.Util.userLanguage() == "en") return Promise.resolve(cleanLocalizations(apis));
+
+        if (lang == "en")
+            return Promise.resolve(cleanLocalizations(apis));
 
         const langLower = lang.toLowerCase();
         const attrJsLocsKey = langLower + "|jsdoc";
@@ -625,6 +627,7 @@ namespace ts.pxtc {
                 const attrLocs = fn.attributes.locs || {};
                 const locJsDoc = loc[fn.qName] || attrLocs[attrJsLocsKey];
                 if (locJsDoc) {
+                    fn.attributes._untranslatedJsDoc = fn.attributes.jsDoc;
                     fn.attributes.jsDoc = locJsDoc;
                     if (fn.parameters)
                         fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || attrLocs[`${langLower}|param|${pi.name}`] || pi.description);


### PR DESCRIPTION
Fix https://github.com/microsoft/pxt-microbit/issues/3655

When the user first loads an extension in non-english (and the extension has translations), it was caching the api info with the translations applied. `localizeApisAsync` doesn't do anything (besides clearing some block definition issues) when set to english, so it wouldn't be translated back to english when loaded (so worth noting this issue only applies when going from another language -> english, going to french from Dutch would still work). Need to clear those before caching.
