### PR TITLE
always show translate button in docs

### DIFF
--- a/docfiles/langpicker.html
+++ b/docfiles/langpicker.html
@@ -13,11 +13,9 @@
                 How do I add a new language?
             </a>
 
-            <!-- @ifdef crowdinproject -->
             <a id="translatebtn" class="ui button" role="button" tabindex="0">
                 Translate this page
             </a>
-            <!-- @endif -->
         </div>
     </div>
 </div>


### PR DESCRIPTION
Always show the translate button now that in-context is supported.