### PR TITLE
[stable6.0] support for Markdown codecards

### DIFF
--- a/docfiles/macros.html
+++ b/docfiles/macros.html
@@ -49,6 +49,10 @@
     </div>
 </aside>
 
+<aside id=codecard class=box>
+    <pre><code class="lang-codecard">@BODY@</code></pre>
+</aside>
+
 <aside id=tutorialhint class=box>
     <div class="ui hint message">
         <div class="content">

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -124,6 +124,11 @@ code.lang-apis
     background-color: rgba(0,0,0,0.04);
     color:transparent;
 }
+code.lang-codecard > ul,
+code.lang-codecard > hr {
+    display: none
+}
+
 
 /* wrap cards header */
 .ui.card > .content > .header {

--- a/docs/writing-docs/macros.md
+++ b/docs/writing-docs/macros.md
@@ -380,13 +380,40 @@ To render one or more code cards as JSON into cards, use **codecard**.
 
     ```codecard
     [{
-        "title": "A card",
+        "name": "A card",
         "url": "...."
     }, {
-        "title": "Another card",
+        "name": "Another card",
         "url": "...."
     }]
     ```
+
+Code cards also support a text based format:
+
+    ### ~ codecard
+    * name: A card
+    * url: ...
+    ---
+    * name: Another card
+    * url: ...
+    ---
+    * name: Yet another card
+    * url: ...
+    ### ~
+
+where each card is a sequence of ``KEY: VALUE`` pairs bullet points separated by a ``---`` line.
+
+If you need to specify ``otherActions``, add multiple line of ``otherAction`` (singular)
+with a ``URL, EDITOR, CARD_TYPE`` format.
+
+    ### ~ codecard
+    ...
+    ---
+    * name: Yet another card
+    * url: ...
+    * otherAction: URL, js, example
+    * otherAction: URL, py, example
+    ### ~
 
 ### apis
 

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -101,36 +101,43 @@ namespace pxt.gallery {
     }
 
     export function parseCodeCardsHtml(el: HTMLElement) {
-        const cards: pxt.CodeCard[] = []
-        let card: any;
-        Array.from(el.children)
-            .forEach(child => {
-                if (child.tagName === "UL" || child.tagName === "OL") {
-                    if (!card)
-                        card = {};
-                    // read fields into card
-                    Array.from(child.querySelectorAll("li"))
-                        .forEach(field => {
-                            const text = field.innerText;
-                            const m = /^\s*(\w+)\s*:\s*(.*)$/.exec(text);
-                            if (m) {
-                                const k = m[1]
-                                card[k] = m[2].trim();
-                                if (k === "flags")
-                                    card[k] = card[k].split(/,\s*/);
-                            }
-                        });
-                } else if (child.tagName == "HR") {
-                    // flush current card
-                    if (card)
-                        cards.push(card)
-                    card = undefined;
-                }
-            })
-        // flush last card
-        if (card)
-            cards.push(card);
-        return !!cards.length && cards;
+        let cards: pxt.CodeCard[] = []
+
+        if (el.tagName === "CODE") {
+            // legacy JSON format
+            cards = pxt.Util.jsonTryParse(el.textContent);
+        }
+        else {
+            let card: any;
+            Array.from(el.children)
+                .forEach(child => {
+                    if (child.tagName === "UL" || child.tagName === "OL") {
+                        if (!card)
+                            card = {};
+                        // read fields into card
+                        Array.from(child.querySelectorAll("li"))
+                            .forEach(field => {
+                                const text = field.innerText;
+                                const m = /^\s*(\w+)\s*:\s*(.*)$/.exec(text);
+                                if (m) {
+                                    const k = m[1]
+                                    card[k] = m[2].trim();
+                                    if (k === "flags")
+                                        card[k] = card[k].split(/,\s*/);
+                                }
+                            });
+                    } else if (child.tagName == "HR") {
+                        // flush current card
+                        if (card)
+                            cards.push(card)
+                        card = undefined;
+                    }
+                })
+            // flush last card
+            if (card)
+                cards.push(card);
+        }
+        return !!cards?.length && cards;
     }
 
     export function parseGalleryMardown(md: string): Gallery[] {

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -62,6 +62,77 @@ namespace pxt.gallery {
         return prj;
     }
 
+    export function parseCodeCards(md: string): pxt.CodeCard[] {
+        // try to parse code cards as JSON
+        let cards = Util.jsonTryParse(md) as pxt.CodeCard[];
+        if (cards && !Array.isArray(cards))
+            cards = [cards];
+        if (cards?.length)
+            return cards;
+
+        // not json, try parsing as sequence of key,value pairs, with line splits
+        cards = md.split(/^---$/gm)
+            .filter(cmd => !!cmd)
+            .map(cmd => {
+                let cc: any = {};
+                cmd.replace(/^\s*(?:-|\*)\s+(\w+)\s*:\s*(.*)$/gm, (m, n, v) => {
+                    if (n == "flags")
+                        cc[n] = v.split(',')
+                    else if (n === "otherAction") {
+                        const parts: string[] = v.split(',').map((p: string) => p?.trim())
+                        const oas = (cc["otherActions"] || (cc["otherActions"] = []));
+                        oas.push({
+                            url: parts[0],
+                            editor: parts[1],
+                            cardType: parts[2]
+                        })
+                    }
+                    else
+                        cc[n] = v
+                    return ''
+                })
+                return !!Object.keys(cc).length && cc as pxt.CodeCard;
+            })
+            .filter(cc => !!cc);
+        if (cards?.length)
+            return cards;
+
+        return undefined;
+    }
+
+    export function parseCodeCardsHtml(el: HTMLElement) {
+        const cards: pxt.CodeCard[] = []
+        let card: any;
+        Array.from(el.children)
+            .forEach(child => {
+                if (child.tagName === "UL" || child.tagName === "OL") {
+                    if (!card)
+                        card = {};
+                    // read fields into card
+                    Array.from(child.querySelectorAll("li"))
+                        .forEach(field => {
+                            const text = field.innerText;
+                            const m = /^\s*(\w+)\s*:\s*(.*)$/.exec(text);
+                            if (m) {
+                                const k = m[1]
+                                card[k] = m[2].trim();
+                                if (k === "flags")
+                                    card[k] = card[k].split(/,\s*/);
+                            }
+                        });
+                } else if (child.tagName == "HR") {
+                    // flush current card
+                    if (card)
+                        cards.push(card)
+                    card = undefined;
+                }
+            })
+        // flush last card
+        if (card)
+            cards.push(card);
+        return !!cards.length && cards;
+    }
+
     export function parseGalleryMardown(md: string): Gallery[] {
         if (!md) return [];
 
@@ -71,28 +142,26 @@ namespace pxt.gallery {
         const galleries: { name: string; cards: pxt.CodeCard[] }[] = [];
         let incard = false;
         let name: string = undefined;
-        let cards: string = "";
+        let cardsSource: string = "";
         md.split(/\r?\n/).forEach(line => {
             // new category
-            if (/^##/.test(line)) {
+            if (/^## /.test(line)) {
                 name = line.substr(2).trim();
-            } else if (/^```codecard$/.test(line)) {
+            } else if (/^(### ~ |```)codecard$/.test(line)) {
                 incard = true;
-            } else if (/^```$/.test(line)) {
+            } else if (/^(### ~|```)$/.test(line)) {
                 incard = false;
-                if (name && cards) {
-                    try {
-                        const cardsJSON = JSON.parse(cards) as pxt.CodeCard[];
-                        if (cardsJSON && cardsJSON.length > 0)
-                            galleries.push({ name, cards: cardsJSON });
-                    } catch (e) {
-                        pxt.log('invalid card format in gallery');
-                    }
+                if (name && cardsSource) {
+                    const cards = parseCodeCards(cardsSource);
+                    if (cards?.length)
+                        galleries.push({ name, cards });
+                    else
+                        pxt.log(`invalid gallery format`)
                 }
-                cards = "";
+                cardsSource = "";
                 name = undefined;
             } else if (incard)
-                cards += line + '\n';
+                cardsSource += line + '\n';
         })
         // apply transformations
         galleries.forEach(gallery => gallery.cards.forEach(card => {

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -837,7 +837,7 @@ namespace pxt.runner {
                     const csymbols = symbols.filter(symbol => !!namespaces[symbol.namespace])
                     if (!csymbols.length) return;
 
-                    csymbols.sort((l,r) => {
+                    csymbols.sort((l, r) => {
                         // render cards first
                         const lcard = !l.attributes.blockHidden && Blockly.Blocks[l.attributes.blockId];
                         const rcard = !r.attributes.blockHidden && Blockly.Blocks[r.attributes.blockId]
@@ -1079,14 +1079,10 @@ namespace pxt.runner {
         if (!$el[0]) return Promise.resolve();
 
         $el.removeClass(cls);
-        let cards: pxt.CodeCard[];
-        try {
-            let js: any = JSON.parse($el.text());
-            if (!Array.isArray(js)) js = [js];
-            cards = js as pxt.CodeCard[];
-        } catch (e) {
-            pxt.reportException(e);
-            $el.append($('<div/>').addClass("ui segment warning").text(e.messageText));
+        // try parsing the card as json
+        const cards = pxt.gallery.parseCodeCardsHtml($el[0]);
+        if (!cards) {
+            $el.append($('<div/>').addClass("ui segment warning").text("invalid codecard format"));
         }
 
         if (options.snippetReplaceParent) $el = $el.parent();

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -794,6 +794,10 @@ ${linkString}
     </div>
 </aside>
 
+<aside id=codecard class=box>
+    <pre><code class="lang-codecard">@BODY@</code></pre>
+</aside>
+
 <aside id=tutorialhint class=box>
     <div class="ui hint message">
         <div class="content">


### PR DESCRIPTION
- The markdown-based format is optimized for crowdin and make its much easier to localize. 
- The changes are easily testable: if the gallery render in the home screen and on the docs pages; they still work
- We have a CLI too to batch convert all codecards into markdown once this is live.