### PR TITLE
Add support for basic cloud save

### DIFF
--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -135,6 +135,17 @@ function loadState() {
     }
 }
 
+/**
+ * Clear all auth state.
+ * Direct access to state$ allowed.
+ */
+function clearState() {
+    state$ = {};
+    pxt.storage.removeLocal(AUTH_USER_STATE);
+    data.invalidate("auth:*");
+    //data.invalidate("user-prefs:*"); // Should we invalidate this? Or would it be jarring visually?
+}
+
 export type CallbackState = {
     hash?: string;
     params?: pxt.Map<string>;
@@ -588,17 +599,6 @@ function authApiHandler(p: string) {
         case FIELD_LOGGED_IN: return loggedInSync();
     }
     return null;
-}
-
-/**
- * Clear all auth state.
- * Direct access to state$ allowed.
- */
-function clearState() {
-    state$ = {};
-    pxt.storage.removeLocal(AUTH_USER_STATE);
-    data.invalidate("auth:*");
-    //data.invalidate("user-prefs:*"); // should we clear this?
 }
 
 function internalUserPreferencesHandler(path: string): UserPreferences | boolean | string {

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -13,14 +13,15 @@ const FIELD_LOGGED_IN = "logged-in";
 export const USER = `${MODULE}:${FIELD_USER}`;
 export const LOGGED_IN = `${MODULE}:${FIELD_LOGGED_IN}`;
 
-const CSRF_TOKEN = "csrf-token";
-const AUTH_STATE = "auth-login-state";
-
 const USER_PREF_MODULE = "user-pref";
 const FIELD_HIGHCONTRAST = "high-contrast";
 const FIELD_LANGUAGE = "language";
 export const HIGHCONTRAST = `${USER_PREF_MODULE}:${FIELD_HIGHCONTRAST}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
+
+const CSRF_TOKEN = "csrf-token";
+const AUTH_STATE = "auth-login-state";
+const X_PXT_TARGET = "x-pxt-target";
 
 export type UserProfile = {
     id?: string;
@@ -378,9 +379,6 @@ export async function initialUserPreferences(): Promise<UserPreferences | undefi
     return initialUserPreferences_;
 }
 
-/**
- * Private functions
- */
 function loggedInSync(): boolean {
     if (!hasIdentity()) { return false; }
     const state = getState();
@@ -454,7 +452,7 @@ function setUser(user: UserProfile) {
     }
 }
 
-type ApiResult<T> = {
+export type ApiResult<T> = {
     resp: T;
     statusCode: number;
     success: boolean;
@@ -470,12 +468,14 @@ const DEV_BACKEND_LOCALHOST_SSL = "https://localhost:5500";
 
 const DEV_BACKEND = DEV_BACKEND_LOCALHOST;
 
-async function apiAsync<T = any>(url: string, data?: any, method?: string): Promise<ApiResult<T>> {
+export async function apiAsync<T = any>(url: string, data?: any, method?: string): Promise<ApiResult<T>> {
     const headers: pxt.Map<string> = {};
     const csrfToken = pxt.storage.getLocal(CSRF_TOKEN);
     if (csrfToken) {
         headers["authorization"] = `mkcd ${csrfToken}`;
     }
+    headers[X_PXT_TARGET] = pxt.appTarget?.id;
+
     url = pxt.BrowserUtils.isLocalHostDev() ? `${DEV_BACKEND}${url}` : url;
 
     return U.requestAsync({

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -1,4 +1,3 @@
-import { loginCheck } from "./cloudsync";
 import * as core from "./core";
 import * as data from "./data";
 
@@ -8,9 +7,9 @@ import U = pxt.Util;
  * Virtual API keys
  */
 const MODULE = "auth";
-const FIELD_USER = "user";
+const FIELD_PROFILE = "profile";
 const FIELD_LOGGED_IN = "logged-in";
-export const USER = `${MODULE}:${FIELD_USER}`;
+export const PROFILE = `${MODULE}:${FIELD_PROFILE}`;
 export const LOGGED_IN = `${MODULE}:${FIELD_LOGGED_IN}`;
 
 const USER_PREF_MODULE = "user-pref";
@@ -20,7 +19,8 @@ export const HIGHCONTRAST = `${USER_PREF_MODULE}:${FIELD_HIGHCONTRAST}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
 
 const CSRF_TOKEN = "csrf-token";
-const AUTH_STATE = "auth-login-state";
+const AUTH_LOGIN_STATE = "auth:login-state";
+const AUTH_USER_STATE = "auth:user-state";
 const X_PXT_TARGET = "x-pxt-target";
 
 export type UserProfile = {
@@ -56,16 +56,84 @@ const DEFAULT_USER_PREFERENCES: () => UserPreferences = () => ({
  * In-memory auth state. Changes to this state trigger virtual API subscription callbacks.
  */
 export type State = {
-    user?: UserProfile;
+    profile?: UserProfile;
     preferences?: UserPreferences;
 };
 
-let state_: State = {};
+/**
+ * In-memory cache of user profile state. This is persisted in local storage.
+ * DO NOT ACCESS DIRECTLY UNLESS YOU KNOW IT IS OK. Functions allowed direct
+ * access are marked as such below.
+ */
+let state$: Readonly<State> = null;;
 
 /**
  * Read-only access to current state.
+ * Direct access to state$ allowed.
  */
-export const getState = (): Readonly<State> => state_;
+export function getState(): Readonly<State> {
+    if (!state$) {
+        loadState();
+        if (state$) {
+            generateUserProfilePicDataUrl(state$.profile);
+            data.invalidate("auth:*");
+            data.invalidate("user-pref:*");
+        }
+    }
+    if (!state$) {
+        state$ = {};
+    }
+    return state$;
+};
+
+/**
+ * Updates user profile state and writes it to local storage.
+ * Direct access to state$ allowed.
+ */
+function transformUserProfile(profile: UserProfile) {
+    state$ = {
+        ...state$,
+        profile: {
+            ...profile
+        }
+    };
+    saveState();
+}
+
+/**
+ * Updates user preference state and writes it to local storage.
+ * Direct access to state$ allowed.
+ */
+function transformUserPreferences(preferences: UserPreferences) {
+    state$ = {
+        ...state$,
+        preferences: {
+            ...preferences
+        }
+    };
+    saveState();
+}
+
+/**
+ * Write auth state to local storage.
+ * Direct access to state$ allowed.
+ */
+function saveState() {
+    pxt.storage.setLocal(AUTH_USER_STATE, JSON.stringify(state$));
+}
+
+/**
+ * Read cached auth state from local storage.
+ * Direct access to state$ allowed.
+ */
+function loadState() {
+    const str = pxt.storage.getLocal(AUTH_USER_STATE);
+    if (str) {
+        try {
+            state$ = JSON.parse(str);
+        } catch { }
+    }
+}
 
 export type CallbackState = {
     hash?: string;
@@ -108,11 +176,11 @@ export async function loginAsync(idp: pxt.IdentityProviderId, persistent: boolea
     const state = getState();
 
     // See if we have a valid access token already.
-    if (!state.user) {
+    if (!state.profile) {
         await authCheck();
     }
 
-    const currIdp = state.user?.idp;
+    const currIdp = state.profile?.idp;
 
     // Check if we're already signed into this identity provider.
     if (currIdp === idp) {
@@ -132,7 +200,7 @@ export async function loginAsync(idp: pxt.IdentityProviderId, persistent: boolea
         idp,
     };
     const stateStr = JSON.stringify(stateObj);
-    pxt.storage.setLocal(AUTH_STATE, stateStr);
+    pxt.storage.setLocal(AUTH_LOGIN_STATE, stateStr);
 
     // Redirect to the login endpoint.
     const loginUrl = core.stringifyQueryString('/api/auth/login', {
@@ -185,11 +253,13 @@ export async function authCheck(): Promise<UserProfile | undefined> {
     // Fail fast if we don't have csrf token.
     if (!pxt.storage.getLocal(CSRF_TOKEN)) { return undefined; }
 
-    if (state_.user) {
+    const state = getState();
+
+    if (state.profile) {
         if (!initialAuthCheck_) {
-            initialAuthCheck_ = Promise.resolve(state_.user)
+            initialAuthCheck_ = Promise.resolve(state.profile);
         }
-        return state_.user
+        return state.profile;
     }
     if (!initialAuthCheck_) {
         // Optimistically try to fetch user profile. It will succeed if we have a valid
@@ -208,12 +278,12 @@ export async function loginCallback(qs: pxt.Map<string>) {
 
     do {
         // Read and remove auth state from local storage
-        const stateStr = pxt.storage.getLocal(AUTH_STATE);
+        const stateStr = pxt.storage.getLocal(AUTH_LOGIN_STATE);
         if (!stateStr) {
             pxt.debug("Auth state not found in storge.");
             break;
         }
-        pxt.storage.removeLocal(AUTH_STATE);
+        pxt.storage.removeLocal(AUTH_LOGIN_STATE);
 
         state = JSON.parse(stateStr);
         if (typeof state !== 'object') {
@@ -270,7 +340,7 @@ export async function loginCallback(qs: pxt.Map<string>) {
 }
 
 export function identityProviders(): pxt.AppCloudProvider[] {
-    return Object.keys(pxt.appTarget.cloud?.cloudProviders)
+    return Object.keys(pxt.appTarget?.cloud?.cloudProviders || {})
         .map(id => pxt.appTarget.cloud.cloudProviders[id])
         .filter(prov => prov.identity)
         .sort((a, b) => a.order - b.order);
@@ -299,13 +369,13 @@ export async function updateUserProfile(opts: {
     if (!await loggedIn()) { return false; }
     const state = getState();
     const result = await apiAsync<UserProfile>('/api/user/profile', {
-        id: state.user.id,
+        id: state.profile.id,
         username: opts.username,
         avatarUrl: opts.avatarUrl
     } as UserProfile);
     if (result.success) {
         // Set user profile from returned value
-        setUser(result.resp);
+        setUserProfile(result.resp);
     }
     return result.success;
 }
@@ -324,7 +394,7 @@ export async function deleteAccount() {
 
 export class Component<TProps, TState> extends data.Component<TProps, TState> {
     public getUser(): UserProfile {
-        return this.getData<UserProfile>(USER);
+        return this.getData<UserProfile>(PROFILE);
     }
     public isLoggedIn(): boolean {
         return this.getData<boolean>(LOGGED_IN);
@@ -353,15 +423,20 @@ function internalPrefUpdateAndInvalidate(newPref: Partial<UserPreferences>) {
     // TODO is there a generic way to do this so we don't need to add new branches
     //  for each field that changes?
 
+    const state = getState();
+
     // remember old
-    const oldPref = state_.preferences ?? DEFAULT_USER_PREFERENCES()
+    const oldPref = state.preferences ?? DEFAULT_USER_PREFERENCES()
     // update
-    state_.preferences = { ...oldPref, ...newPref }
+    transformUserPreferences({
+        ...oldPref,
+        ...newPref
+    });
     // invalidate fields that change
-    if (oldPref?.highContrast !== state_.preferences?.highContrast) {
+    if (oldPref?.highContrast !== state.preferences?.highContrast) {
         data.invalidate(HIGHCONTRAST)
     }
-    if (oldPref?.language !== state_.preferences?.language) {
+    if (oldPref?.language !== state.preferences?.language) {
         data.invalidate(LANGUAGE)
     }
 }
@@ -382,40 +457,44 @@ export async function initialUserPreferences(): Promise<UserPreferences | undefi
 function loggedInSync(): boolean {
     if (!hasIdentity()) { return false; }
     const state = getState();
-    return !!state.user?.id;
+    return !!state.profile?.id;
 }
 
 async function fetchUserAsync(): Promise<UserProfile | undefined> {
     const state = getState();
 
     // We already have a user, no need to get it again.
-    if (state.user) {
-        return state.user;
+    if (state.profile) {
+        return state.profile;
     }
 
     const result = await apiAsync('/api/user/profile');
     if (result.success) {
-        const user: UserProfile = result.resp;
-        if (user?.idp?.picture?.encoded) {
-            const url = window.URL || window.webkitURL;
-            try {
-                // Decode the base64 image to a data URL.
-                const decoded = U.stringToUint8Array(atob(user.idp.picture.encoded));
-                const blob = new Blob([decoded], { type: user.idp.picture.mimeType });
-                user.idp.picture.dataUrl = url.createObjectURL(blob);
-                // This is a pretty big buffer and we don't need it anymore so free it.
-                delete user.idp.picture.encoded;
-            } catch { }
-        }
-        setUser(user);
-        return user
+        const profile: UserProfile = result.resp;
+        generateUserProfilePicDataUrl(profile);
+        setUserProfile(profile);
+        return profile;
     }
     return undefined
+}
+
+function generateUserProfilePicDataUrl(profile: UserProfile) {
+    if (profile?.idp?.picture?.encoded) {
+        const url = window.URL || window.webkitURL;
+        try {
+            // Decode the base64 image to a data URL.
+            const decoded = U.stringToUint8Array(atob(profile.idp.picture.encoded));
+            const blob = new Blob([decoded], { type: profile.idp.picture.mimeType });
+            profile.idp.picture.dataUrl = url.createObjectURL(blob);
+        } catch { }
+    }
 }
 
 async function fetchUserPreferencesAsync(): Promise<UserPreferences | undefined> {
     // Wait for the initial auth
     if (!await loggedIn()) return undefined;
+
+    const state = getState();
 
     const api = '/api/user/preferences';
     const result = await apiAsync<Partial<UserPreferences>>('/api/user/preferences');
@@ -428,7 +507,7 @@ async function fetchUserPreferencesAsync(): Promise<UserPreferences | undefined>
             internalPrefUpdateAndInvalidate(result.resp);
 
             // update our one-time promise for the initial load
-            return state_.preferences
+            return state.preferences
         }
     } else {
         pxt.reportError("identity", `fetch ${api} failed:\n${JSON.stringify(result)}`)
@@ -441,14 +520,14 @@ function idpEnabled(idp: pxt.IdentityProviderId): boolean {
     return identityProviders().filter(prov => prov.id === idp).length > 0;
 }
 
-function setUser(user: UserProfile) {
+function setUserProfile(profile: UserProfile) {
     const wasLoggedIn = loggedInSync();
-    state_.user = user;
+    transformUserProfile(profile);
     const isLoggedIn = loggedInSync();
-    data.invalidate(USER);
+    data.invalidate(PROFILE);
     data.invalidate(LOGGED_IN);
     if (isLoggedIn && !wasLoggedIn) {
-        core.infoNotification(`Signed in: ${user.idp.displayName}`);
+        core.infoNotification(`Signed in: ${profile.idp.displayName}`);
     }
 }
 
@@ -505,36 +584,44 @@ function authApiHandler(p: string) {
     const field = data.stripProtocol(p);
     const state = getState();
     switch (field) {
-        case FIELD_USER: return state.user;
+        case FIELD_PROFILE: return state.profile;
         case FIELD_LOGGED_IN: return loggedInSync();
     }
     return null;
 }
 
+/**
+ * Clear all auth state.
+ * Direct access to state$ allowed.
+ */
 function clearState() {
-    state_ = {};
-    data.invalidate(USER);
-    data.invalidate(LOGGED_IN);
+    state$ = {};
+    pxt.storage.removeLocal(AUTH_USER_STATE);
+    data.invalidate("auth:*");
+    //data.invalidate("user-prefs:*"); // should we clear this?
 }
 
 function internalUserPreferencesHandler(path: string): UserPreferences | boolean | string {
+    const state = getState();
     const field = data.stripProtocol(path);
     switch (field) {
-        case FIELD_HIGHCONTRAST: return state_.preferences.highContrast;
-        case FIELD_LANGUAGE: return state_.preferences.language;
+        case FIELD_HIGHCONTRAST: return state.preferences.highContrast;
+        case FIELD_LANGUAGE: return state.preferences.language;
     }
-    return state_.preferences
+    return state.preferences
 }
 function userPreferencesHandlerSync(path: string): UserPreferences | boolean | string {
-    if (!state_.preferences) {
-        state_.preferences = DEFAULT_USER_PREFERENCES();
+    const state = getState();
+    if (!state.preferences) {
+        transformUserPreferences(DEFAULT_USER_PREFERENCES());
         /* await */ initialUserPreferences();
     }
     return internalUserPreferencesHandler(path);
 }
 async function userPreferencesHandlerAsync(path: string): Promise<UserPreferences | boolean | string> {
-    if (!state_.preferences) {
-        state_.preferences = DEFAULT_USER_PREFERENCES();
+    const state = getState();
+    if (!state.preferences) {
+        transformUserPreferences(DEFAULT_USER_PREFERENCES());
         await initialUserPreferences();
     }
     return internalUserPreferencesHandler(path);
@@ -547,3 +634,8 @@ data.mountVirtualApi(USER_PREF_MODULE, {
 });
 
 data.mountVirtualApi(MODULE, { getSync: authApiHandler });
+
+
+// ClouddWorkspace must be included after we mount our virtual APIs.
+import * as cloudWorkspace from "./cloudworkspace";
+cloudWorkspace.init();

--- a/webapp/src/cloudworkspace.ts
+++ b/webapp/src/cloudworkspace.ts
@@ -1,0 +1,132 @@
+import * as core from "./core";
+import * as auth from "./auth";
+import * as ws from "./workspace";
+import * as data from "./data";
+import * as workspace from "./workspace";
+
+type Version = pxt.workspace.Version;
+type File = pxt.workspace.File;
+type Header = pxt.workspace.Header;
+type Project = pxt.workspace.Project;
+type ScriptText = pxt.workspace.ScriptText;
+type WorkspaceProvider = pxt.workspace.WorkspaceProvider;
+
+import U = pxt.Util;
+
+const state = {
+    uploadCount: 0,
+    downloadCount: 0
+};
+
+type CloudProject = {
+    id: string;
+    header: string;
+    text: string;
+    version: string;
+};
+
+function listAsync(): Promise<Header[]> {
+    return new Promise(async (resolve, reject) => {
+        const result = await auth.apiAsync<CloudProject[]>("/api/user/project");
+        if (result.success) {
+            const headers = result.resp.map(proj => JSON.parse(proj.header));
+            resolve(headers);
+        } else {
+            reject(new Error(result.errmsg));
+        }
+    });
+}
+
+function getAsync(h: Header): Promise<File> {
+    return new Promise(async (resolve, reject) => {
+        const result = await auth.apiAsync<CloudProject>(`/api/user/project/${h.id}`);
+        if (result.success) {
+            const project = result.resp;
+            const header = JSON.parse(project.header);
+            const text = JSON.parse(project.text);
+            const version = project.version;
+            const file: File = {
+                header,
+                text,
+                version
+            };
+            resolve(file);
+        } else {
+            reject(new Error(result.errmsg));
+        }
+    });
+}
+
+function setAsync(h: Header, prevVersion: Version, text?: ScriptText): Promise<Version> {
+    return new Promise(async (resolve, reject) => {
+        const project: CloudProject = {
+            id: h.id,
+            header: JSON.stringify(h),
+            text: text ? JSON.stringify(text) : undefined,
+            version: prevVersion
+        }
+        const result = await auth.apiAsync<string>('/api/user/project', project);
+        if (result.success) {
+            resolve(result.resp);
+        } else {
+            // TODO: Handle reject due to version conflict
+            reject(new Error(result.errmsg));
+        }
+    });
+}
+
+function deleteAsync(h: Header, prevVersion: Version, text?: ScriptText): Promise<void> {
+    return Promise.resolve();
+}
+
+function resetAsync(): Promise<void> {
+    return Promise.resolve();
+}
+
+export const provider: WorkspaceProvider = {
+    getAsync,
+    setAsync,
+    deleteAsync,
+    listAsync,
+    resetAsync,
+}
+
+/**
+ * Virtual API
+ */
+
+const MODULE = "cloud";
+const FIELD_UPLOADING = "uploading";
+const FIELD_DOWNLOADING = "downloading";
+const FIELD_WORKING = "working";
+export const UPLOADING = `${MODULE}:${FIELD_UPLOADING}`;
+export const DOWNLOADING = `${MODULE}:${FIELD_DOWNLOADING}`;
+export const WORKING = `${MODULE}:${FIELD_WORKING}`;
+
+function cloudApiHandler(p: string): any {
+    switch (data.stripProtocol(p)) {
+        case FIELD_UPLOADING: return state.uploadCount > 0;
+        case FIELD_DOWNLOADING: return state.downloadCount > 0;
+        case WORKING: return cloudApiHandler(UPLOADING) || cloudApiHandler(DOWNLOADING);
+    }
+    return null;
+}
+
+data.mountVirtualApi("cloudws", { getSync: cloudApiHandler });
+
+let prevWorkspaceType: string;
+
+const userSubscriber: data.DataSubscriber = {
+    subscriptions: [],
+    onDataChanged: async () => {
+        const loggedIn = await auth.loggedIn();
+        if (loggedIn) {
+            prevWorkspaceType = workspace.switchToCloudWorkspce();
+        } else if (prevWorkspaceType) {
+            workspace.switchToWorkspace(prevWorkspaceType);
+        }
+        await workspace.syncAsync();
+    }
+};
+
+data.subscribe(userSubscriber, auth.LOGGED_IN);

--- a/webapp/src/user.tsx
+++ b/webapp/src/user.tsx
@@ -93,17 +93,17 @@ class AccountPanel extends sui.UIElement<AccountPanelProps, {}> {
     }
 
     renderCore() {
-        const user = this.getData<auth.UserProfile>(auth.USER);
-        const provider = auth.identityProvider(user.idp.provider);
+        const profile = this.getData<auth.UserProfile>(auth.PROFILE);
+        const provider = auth.identityProvider(profile.idp?.provider);
 
         const avatarElem = (
             <div className="profile-pic avatar">
-                <img src={user?.idp?.picture?.dataUrl} alt={lf("User")} />
+                <img src={profile?.idp?.picture?.dataUrl} alt={lf("User")} />
             </div>
         );
         const initialsElem = (
             <div className="profile-pic avatar">
-                <span>{cloudsync.userInitials(user?.idp?.displayName)}</span>
+                <span>{cloudsync.userInitials(profile?.idp?.displayName)}</span>
             </div>
         );
 
@@ -112,21 +112,21 @@ class AccountPanel extends sui.UIElement<AccountPanelProps, {}> {
                 <div className="header-text">
                     <label>{lf("Account")}</label>
                 </div>
-                {user?.idp?.picture?.dataUrl ? avatarElem : initialsElem}
+                {profile?.idp?.picture?.dataUrl ? avatarElem : initialsElem}
                 <div className="row">
                     <label className="title">{lf("Name")}</label>
-                    <p className="value">{user?.idp?.displayName}</p>
+                    <p className="value">{profile?.idp?.displayName}</p>
                 </div>
                 <div className="row">
                     <label className="title">{lf("Username")}</label>
-                    <p className="value">{user?.idp?.username}</p>
+                    <p className="value">{profile?.idp?.username}</p>
                 </div>
                 <div className="row">
                     <label className="title">{lf("Provider")}</label>
                     <p className="value">{provider.name}</p>
                 </div>
                 <div className="row">
-                    <sui.Button text={lf("Sign out")} icon={`xicon ${user?.idp?.provider}`} ariaLabel={lf("Sign out {0}", user?.idp?.provider)} onClick={this.handleSignoutClicked} />
+                    <sui.Button text={lf("Sign out")} icon={`xicon ${profile?.idp?.provider}`} ariaLabel={lf("Sign out {0}", profile?.idp?.provider)} onClick={this.handleSignoutClicked} />
                 </div>
                 <div className="row">
                     <label className="title">{lf("Delete Account")}</label>

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -93,7 +93,7 @@ export function setupWorkspace(id: string) {
     }
 }
 
-export function switchToCloudWorkspce(): string {
+export function switchToCloudWorkspace(): string {
     U.assert(implType !== "cloud", "workspace already cloud");
     const prevType = implType;
     impl = cloudWorkspace.provider;


### PR DESCRIPTION
* Add `CloudWorkspace` provider. Signed in users are switched to this workspace.
* Cache user profile in local storage, and optimistically assume they're logged in on app load.

TODO:
- Handle promotion of locally stored levels to cloud. Review Sam's design.
- Handle eTag conflicts on save.

Although there's more to do, I think this is fine to merge at this stage.