### PR TITLE
Dont mutate type node during completions of parameters with type 'any'

### DIFF
--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -281,25 +281,26 @@ namespace ts.pxtc.service {
 
             // check for explicit default in the attributes
             if (attrs && attrs.paramDefl && attrs.paramDefl[name]) {
+                let deflKind: SyntaxKind;
                 if (typeNode.kind == SK.AnyKeyword) {
                     const defaultName = attrs.paramDefl[name].toUpperCase();
                     if (!Number.isNaN(+defaultName)) {
                         // try to parse as a number
-                        typeNode.kind = SK.NumberKeyword;
+                        deflKind = SK.NumberKeyword;
                     } else if (defaultName == "FALSE" || defaultName == "TRUE") {
                         // try to parse as a bool
-                        typeNode.kind = SK.BooleanKeyword;
+                        deflKind = SK.BooleanKeyword;
                     } else if (defaultName.includes(".")) {
                         // try to parse as an enum
-                        typeNode.kind = SK.EnumKeyword;
+                        deflKind= SK.EnumKeyword;
                     } else {
                         // otherwise it'll be a string
-                        typeNode.kind = SK.StringKeyword;
+                        deflKind = SK.StringKeyword;
                     }
                 }
-                if (typeNode.kind == SK.StringKeyword) {
+                if (typeNode.kind === SK.StringKeyword || deflKind === SK.StringKeyword) {
                     const defaultName = attrs.paramDefl[name];
-                    const snippet = typeNode.kind == SK.StringKeyword && defaultName.indexOf(`"`) != 0 ? `"${defaultName}"` : defaultName;
+                    const snippet = defaultName.indexOf(`"`) != 0 ? `"${defaultName}"` : defaultName;
                     return snippet
                 }
                 return attrs.paramDefl[name];

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -292,7 +292,7 @@ namespace ts.pxtc.service {
                         deflKind = SK.BooleanKeyword;
                     } else if (defaultName.includes(".")) {
                         // try to parse as an enum
-                        deflKind= SK.EnumKeyword;
+                        deflKind = SK.EnumKeyword;
                     } else {
                         // otherwise it'll be a string
                         deflKind = SK.StringKeyword;

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -280,7 +280,7 @@ namespace ts.pxtc.service {
             const name = param.name.kind === SK.Identifier ? (param.name as ts.Identifier).text : undefined;
 
             // check for explicit default in the attributes
-            if (attrs && attrs.paramDefl && attrs.paramDefl[name]) {
+            if (attrs?.paramDefl?.[name]) {
                 let deflKind: SyntaxKind;
                 if (typeNode.kind == SK.AnyKeyword) {
                     const defaultName = attrs.paramDefl[name].toUpperCase();
@@ -300,8 +300,7 @@ namespace ts.pxtc.service {
                 }
                 if (typeNode.kind === SK.StringKeyword || deflKind === SK.StringKeyword) {
                     const defaultName = attrs.paramDefl[name];
-                    const snippet = defaultName.indexOf(`"`) != 0 ? `"${defaultName}"` : defaultName;
-                    return snippet
+                    return defaultName.indexOf(`"`) != 0 ? `"${defaultName}"` : defaultName;
                 }
                 return attrs.paramDefl[name];
             }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-minecraft/issues/2094

When a symbol with 'any' type had a default value, this was mutating parameter node / changing it from `any` to the type of the default value. So in minecraft, currently `player.say`'s block can take numbers / any, but if you switch to typescript and happen to get a completion generated for `player.say` the apiInfo will get changed / the block will no longer accept numbers or other values until you refresh.