### PR TITLE
show vars with non-ts-identifier chars in debug view

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -986,7 +986,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (!this.parent.state.debugging) return;
 
         if (this.debuggerToolbox) {
-            const visibleVars = Blockly.Variables.allUsedVarModels(this.editor).map((variable: any) => variable.name as string);
+            const visibleVars = Blockly.Variables.allUsedVarModels(this.editor)
+                    .map((variable: Blockly.VariableModel) => pxtc.escapeIdentifier(variable.name));
 
             this.debuggerToolbox.setBreakpoint(brk, visibleVars);
         }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2573

Worth noting this would show the variables with invalid chars escaped:

![image](https://user-images.githubusercontent.com/5615930/99496260-c8d89580-2928-11eb-999b-506639a8fedc.png)

as that's how they're stored in the simulator; if we want to, we could defer escaping the name till the filter is used https://github.com/microsoft/pxt/blob/d1d8cd45952216d88c79130b4c04bc926586b281/webapp/src/debuggerVariables.tsx#L189 and then use the name in `filters` instead of `updatedGlobals.variables` when displaying the variable? Not sure it's necessary so I left it as the simple fix for now