### PR TITLE
Clear editor filters when opening a new empty project

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2165,7 +2165,8 @@ export class ProjectView
             filesOverride: { "main.blocks": `<xml xmlns="http://www.w3.org/1999/xhtml"></xml>` },
             name,
             documentation,
-            preferredEditor
+            preferredEditor,
+            filters: {}
         })
     }
 


### PR DESCRIPTION
We carryover filters from the previous editor state in internalLoadHeaderAsync which means if you call newEmptyProject from inside a tutorial, the toolbox filters are not cleared. 

@abchatra can we take this as a patch fix for Minecraft? i think it will help the Prodigy Learning folks with the tutorial thing they're doing