### PR TITLE
Simulator tick events

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -130,12 +130,17 @@
                 window.pxtTargetConfigPromise
                     .then(function(targetConfig) {
                         var approvedShareLinks = targetConfig && targetConfig.shareLinks && targetConfig.shareLinks.approved;
-                        if (approvedShareLinks && approvedShareLinks.indexOf("@id@" >= 0)) {
+                        if (approvedShareLinks && approvedShareLinks.indexOf("@id@") >= 0) {
                             // This share link has been allow listed; remove cookie banner and allow sending of tick events
                             shareLinkIsApproved = true;
                             var abuseMessage = document.querySelector("#abuse-message");
                             if (abuseMessage)
                                 abuseMessage.remove();
+
+                            window.pxtTickEvent(
+                                'approved.shareurl.loaded',
+                                { shareurl: "@id@" },
+                            );
                         }
                     });
 

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -7,6 +7,8 @@
 
     <!-- @include meta.html -->
     <!-- @include scripthead.html -->
+    <!-- @include targetconfig.html -->
+    <!-- @include tickevent.html -->
 
     <link rel="alternate" type="application/json+oembed" href="@oembedurl@&format=json" />
     <link rel="alternate" type="text/xml+oembed" href="@oembedurl@&format=xml" />
@@ -122,6 +124,36 @@
                             .modal("show");
                     })
                 })
+
+                var shareLinkIsApproved = false;
+
+                window.pxtTargetConfigPromise
+                    .then(function(targetConfig) {
+                        var approvedShareLinks = targetConfig && targetConfig.shareLinks && targetConfig.shareLinks.approved;
+                        if (approvedShareLinks && approvedShareLinks.indexOf("@id@" >= 0)) {
+                            // This share link has been allow listed; remove cookie banner and allow sending of tick events
+                            shareLinkIsApproved = true;
+                            var abuseMessage = document.querySelector("#abuse-message");
+                            if (abuseMessage)
+                                abuseMessage.remove();
+                        }
+                    });
+
+                window.addEventListener('message', function (ev) {
+                    if (!shareLinkIsApproved)
+                        return;
+                    var d = ev.data;
+                    if (d.type == "messagepacket" && d.channel == "tick-event" && d.data) {
+                        var unpackedData = ""
+                        for (var i = 0; i < d.data.length; ++i)
+                            unpackedData += String.fromCharCode(d.data[i]);
+
+                        window.pxtTickEvent(
+                            'simulator.user.tick',
+                            d.data,
+                        );
+                    }
+                });
             </script>
         </div>
         <div class="script-bookend">

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -150,6 +150,7 @@
 
                         try {
                             const data = JSON.parse(unpackedData);
+                            data["shareurl"] = "@id@";
                             window.pxtTickEvent(
                                 'simulator.user.tick',
                                 data,

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -144,7 +144,7 @@
                         return;
                     var d = ev.data;
                     if (d.type == "messagepacket" && d.channel == "tick-event" && d.data) {
-                        var unpackedData = ""
+                        var unpackedData = "";
                         for (var i = 0; i < d.data.length; ++i)
                             unpackedData += String.fromCharCode(d.data[i]);
 

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -148,10 +148,13 @@
                         for (var i = 0; i < d.data.length; ++i)
                             unpackedData += String.fromCharCode(d.data[i]);
 
-                        window.pxtTickEvent(
-                            'simulator.user.tick',
-                            d.data,
-                        );
+                        try {
+                            const data = JSON.parse(unpackedData);
+                            window.pxtTickEvent(
+                                'simulator.user.tick',
+                                data,
+                            );
+                        } catch { /** failed to parse tick from game **/ }
                     }
                 });
             </script>

--- a/docfiles/targetconfig.html
+++ b/docfiles/targetconfig.html
@@ -1,0 +1,23 @@
+<script type="text/javascript">
+    if (!window.pxtTargetConfigPromise) {
+        // todo: check our browser support matrix, support is good for fetch
+        // but might have to promisify xmlhttprequest instead: https://caniuse.com/fetch
+
+        // This line gets patched up by the cloud
+        var pxtConfig = null;
+
+        var versionsuff = "@versionsuff@";
+        versionsuff = versionsuff ? "/" + versionsuff : "";
+
+        var targetConfigUrl = (pxtConfig && pxtConfig.isStatic) ? "targetconfig.json" : ("api/config/@targetid@/targetconfig" + versionsuff);
+        var fetchParams = !/localhost:/.test(window.location.href) ? {} : {
+            headers: {
+                "Authorization": localStorage.getItem("@targetid@/local_token"),
+                method: "GET"
+            }
+        };
+        // todo: CDN cached version?
+        window.pxtTargetConfigPromise = fetch(targetConfigUrl, fetchParams)
+            .then(resp => resp.json());
+    }
+</script>

--- a/docfiles/targetconfig.html
+++ b/docfiles/targetconfig.html
@@ -1,7 +1,5 @@
 <script type="text/javascript">
     if (!window.pxtTargetConfigPromise) {
-        // todo: check our browser support matrix, support is good for fetch
-        // but might have to promisify xmlhttprequest instead: https://caniuse.com/fetch
 
         // This line gets patched up by the cloud
         var pxtConfig = null;

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -20,6 +20,7 @@ declare namespace pxt {
     }
     interface TargetConfig {
         packages?: PackagesConfig;
+        shareLinks?: ShareConfig;
         // common galleries
         galleries?: pxt.Map<string | GalleryProps>;
         // localized galleries
@@ -41,6 +42,10 @@ declare namespace pxt {
         // "acme-corp/pxt-widget": "min:v0.1.2" - auto-upgrade to that version
         // "acme-corp/pxt-widget": "dv:foo,bar" - add "disablesVariant": ["foo", "bar"] to pxt.json
         upgrades?: pxt.Map<string>;
+    }
+
+    interface ShareConfig {
+        approved?: string[];
     }
 
     interface AppTarget {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -154,6 +154,14 @@
         }
         initAppCache();
 
+        window.addEventListener('message', msg => {
+            if (typeof window !== 'undefined' && window.parent !== window
+                && msg.data && msg.data.type == "messagepacket") {
+                // propagate message packets to parent frames
+                window.parent.postMessage(msg.data, "*");
+            }
+        })
+
         ksRunnerReady(function() {
             var theme = pxt.appTarget.appTheme;
             document.title = theme.title;

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -156,11 +156,11 @@
 
         window.addEventListener('message', msg => {
             if (typeof window !== 'undefined' && window.parent !== window
-                && msg.data && msg.data.type == "messagepacket") {
+                    && msg.data && msg.data.type == "messagepacket") {
                 // propagate message packets to parent frames
                 window.parent.postMessage(msg.data, "*");
             }
-        })
+        });
 
         ksRunnerReady(function() {
             var theme = pxt.appTarget.appTheme;


### PR DESCRIPTION
For use with https://github.com/microsoft/pxt-tick-event; adds an allowlist for scripts in targetconfig. Allowlisted scripts will drop the 'not endorsed by microsoft' banner, and listen for ticks from the simulator.

I tested it works locally / not doing anything super fancy, but I'm not certain how we'd test the share page online? Would I have to push it up to staging?

I didn't see a general way to access targetconfig.json in docs, so I added `targetconfig.html` which makes a promise to fetch the targetconfig; seems like something we could clean up with a replacement in the backend (like we do with `var pxtConfig = null;`) but this seems fine to me for now / can always add it later and just make the promise trivial?

I added the portion in script.html to check for approved links / look for tick messages if the game is approved, but that's not strictly necessary; arcade overrides that file, and the tick-event extension requires pxt-common-packages/base, which isn't in microbit, so we'd need to port base/simmessages over if we wanted it to work there. I figured it was worth including as it does give us a way to remove the abuse message from scripts we've allowlisted