### PR TITLE
try adding UTF-8 BOM on sha miss

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -919,8 +919,11 @@ async function githubUpdateToAsync(hd: Header, options: UpdateOptions) {
         }
         text = await pxt.github.downloadTextAsync(parsed.fullName, sha, path)
         treeEnt.blobContent = text
-        if (gitsha(text) != treeEnt.sha)
+        if (gitsha(text) != treeEnt.sha
+                // Try adding UTF-8 BOM; this can be stripped over web requests
+                && gitsha(`\uFEFF${text}`) !== treeEnt.sha) {
             U.userError(lf("Corrupt SHA1 on download of '{0}'.", path))
+        }
         if (options.tryDiff3 && hasChanges) {
             if (path == pxt.CONFIG_NAME) {
                 text = pxt.diff.mergeDiff3Config(files[path], oldEnt.blobContent, treeEnt.blobContent);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1999

This seems to behave fine to me? Causes the project to load properly (both the one from the issue and the other one I ran into today), and doesn't show the files in the diff. I suppose we'd need to check for utf16 big / little endian BOM as well if we wanted to be fully thorough, but notepad produces UTF-8 + BOM which I believe was the issue here / before as well?