### PR TITLE
Update 'Report Abuse' link, hide and show based on repo status

### DIFF
--- a/skillmap/src/actions/dispatch.ts
+++ b/skillmap/src/actions/dispatch.ts
@@ -1,3 +1,4 @@
+import { PageSourceStatus } from '../store/reducer';
 import * as actions from './types'
 
 export const dispatchAddSkillMap = (map: SkillMap) => ({ type: actions.ADD_SKILL_MAP, map });
@@ -15,7 +16,7 @@ export const dispatchUpdateUserCompletedTags = () => ({ type: actions.UPDATE_USE
 export const dispatchSetPageTitle = (title: string) => ({ type: actions.SET_PAGE_TITLE, title });
 export const dispatchSetPageDescription = (description: string) => ({ type: actions.SET_PAGE_DESCRIPTION, description });
 export const dispatchSetPageInfoUrl = (infoUrl: string) => ({ type: actions.SET_PAGE_INFO_URL, infoUrl });
-export const dispatchSetPageSourceUrl = (url: string) => ({ type: actions.SET_PAGE_SOURCE_URL, url });
+export const dispatchSetPageSourceUrl = (url: string, status: PageSourceStatus) => ({ type: actions.SET_PAGE_SOURCE_URL, url, status });
 
 export const dispatchShowCompletionModal = (mapId: string, activityId?: string) => ({ type: actions.SHOW_COMPLETION_MODAL, mapId, activityId });
 export const dispatchShowRestartActivityWarning = (mapId: string, activityId: string) => ({ type: actions.SHOW_RESTART_ACTIVITY_MODAL, mapId, activityId });

--- a/skillmap/src/components/Dropdown.tsx
+++ b/skillmap/src/components/Dropdown.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import '../styles/dropdown.css'
 
-interface DropdownItem {
+export interface DropdownItem {
     id: string;
     label: string;
     onClick: (id: string) => void;

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -2,28 +2,39 @@
 import * as React from "react";
 
 import { connect } from 'react-redux';
-import { dispatchSaveAndCloseActivity, dispatchShowReportAbuseModal } from '../actions/dispatch';
+import { dispatchSaveAndCloseActivity } from '../actions/dispatch';
 import { SkillMapState } from '../store/reducer';
 import { resolvePath, tickEvent } from "../lib/browserUtils";
 
-import { Dropdown } from "./Dropdown";
+import { Dropdown, DropdownItem } from "./Dropdown";
 
 interface HeaderBarProps {
     activityOpen: boolean;
+    showReportAbuse?: boolean;
     dispatchSaveAndCloseActivity: () => void;
-    dispatchShowReportAbuseModal: () => void;
 }
 
 export class HeaderBarImpl extends React.Component<HeaderBarProps> {
+    protected reportAbuseUrl = "https://github.com/contact/report-content";
+    protected getSettingItems(): DropdownItem[] {
+        const items: DropdownItem[] = [];
+        if (this.props.showReportAbuse) {
+            items.push({
+                id: "report",
+                label: "Report Abuse",
+                onClick: (id: string) => window.open(this.reportAbuseUrl)
+            })
+        }
+
+        return items;
+    }
+
     render() {
-        const { activityOpen, dispatchShowReportAbuseModal } = this.props;
+        const { activityOpen } = this.props;
         const logoAlt = "MakeCode Logo";
         const organizationLogoAlt = "Microsoft Logo";
 
-        const reportAbuseOption = {
-            id: "report",
-            label: "Report Abuse",
-            onClick: (id: string) => dispatchShowReportAbuseModal() };
+        const items = this.getSettingItems();
 
         return <div className="header">
             <div className="header-left">
@@ -36,7 +47,7 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
             </div>
             <div className="spacer" />
             <div className="header-right">
-                <Dropdown icon="setting" className="header-settings" items={[reportAbuseOption]} />
+                { items?.length > 0 && <Dropdown icon="setting" className="header-settings" items={items} /> }
                 <div className="header-org-logo">
                     <img src={resolvePath("assets/microsoft.png")} alt={organizationLogoAlt} />
                 </div>
@@ -54,14 +65,14 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
 function mapStateToProps(state: SkillMapState, ownProps: any) {
     if (!state) return {};
     return {
-        activityOpen: !!state.editorView
+        activityOpen: !!state.editorView,
+        showReportAbuse: state.pageSourceStatus === "unknown"
     }
 }
 
 
 const mapDispatchToProps = {
-    dispatchSaveAndCloseActivity,
-    dispatchShowReportAbuseModal
+    dispatchSaveAndCloseActivity
 };
 
 export const HeaderBar = connect(mapStateToProps, mapDispatchToProps)(HeaderBarImpl);

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -2,12 +2,16 @@ import * as actions from '../actions/types'
 import { guidGen } from '../lib/browserUtils';
 import { getCompletedTags, lookupActivityProgress } from '../lib/skillMapUtils';
 
+export type ModalType = "restart-warning" | "completion" | "report-abuse";
+export type PageSourceStatus = "approved" | "banned" | "unknown";
+
 export interface SkillMapState {
     title: string;
     description: string;
     infoUrl?: string;
     user: UserState;
     pageSourceUrl?: string;
+    pageSourceStatus: PageSourceStatus;
     maps: { [key: string]: SkillMap };
     selectedItem?: string;
 
@@ -22,8 +26,6 @@ export interface EditorViewState {
     state: "active" | "saving";
 }
 
-export type ModalType = "restart-warning" | "completion" | "report-abuse";
-
 interface ModalState {
     type: ModalType;
     currentMapId?: string;
@@ -31,8 +33,9 @@ interface ModalState {
 }
 
 const initialState: SkillMapState = {
-    title: "Game Maker Guide",
-    description: "Level up your game making skills by completing the tutorials in this guide.",
+    title: lf("Game Maker Guide"),
+    description: lf("Level up your game making skills by completing the tutorials in this guide."),
+    pageSourceStatus: "unknown",
     user: {
         isDebug: true,
         id: guidGen(),
@@ -167,7 +170,8 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
         case actions.SET_PAGE_SOURCE_URL:
             return {
                 ...state,
-                pageSourceUrl: action.url
+                pageSourceUrl: action.url,
+                pageSourceStatus: action.status
             }
         case actions.SHOW_COMPLETION_MODAL:
             return {


### PR DESCRIPTION
- "Report Abuse" goes directly to Github's "Report Content" page
- Only show the link for content whose approval status is "unknown"