### PR TITLE
Use grey background for images in hints

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -217,6 +217,8 @@ text.blocklyCheckbox {
 
 /* (arcade only) Sets the correct background color for the sprite image field */
 .pxt-renderer .blocklyNonEditableText > rect.blocklySpriteField,
+.pxt-renderer .blocklyNonEditableText > rect.blocklyAnimationField,
+.pxt-renderer .blocklyNonEditableText > rect.blocklyTilemapField,
 .pxt-renderer .blocklyEditableText > rect.blocklySpriteField,
 .pxt-renderer .blocklyEditableText > rect.blocklyAnimationField,
 .pxt-renderer .blocklyEditableText > rect.blocklyTilemapField {

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -216,6 +216,7 @@ text.blocklyCheckbox {
 }
 
 /* (arcade only) Sets the correct background color for the sprite image field */
+.pxt-renderer .blocklyNonEditableText > rect.blocklySpriteField,
 .pxt-renderer .blocklyEditableText > rect.blocklySpriteField,
 .pxt-renderer .blocklyEditableText > rect.blocklyAnimationField,
 .pxt-renderer .blocklyEditableText > rect.blocklyTilemapField {


### PR DESCRIPTION
almost fixes https://github.com/microsoft/pxt-arcade/issues/2475 there's still a markdown change needed

it will look like this!
![image](https://user-images.githubusercontent.com/18712271/99749899-335a1480-2a94-11eb-8f93-23e1c0be0526.png)
