### PR TITLE
Dont lose tick events, attach target

### DIFF
--- a/docfiles/tickevent.html
+++ b/docfiles/tickevent.html
@@ -18,7 +18,7 @@
                     }, 1000);
                 }
 
-                if (queuedTicks.length >= 10) {
+                if (queuedTicks.length >= 100) {
                     queuedTicks.shift();
                 }
 

--- a/docfiles/tickevent.html
+++ b/docfiles/tickevent.html
@@ -32,7 +32,11 @@
                         else if (typeof data[k] == "number") measures[k] = data[k];
                         else props[k] = JSON.stringify(data[k] || '');
                     });
+                } else {
+                    data = {};
                 }
+                data["target"] = "@targetid@";
+                data["cookie"] = "true";
                 window.appInsights.trackEvent(id, data, measures);
             }
         }

--- a/docfiles/tickevent.html
+++ b/docfiles/tickevent.html
@@ -1,16 +1,40 @@
 <script type="text/javascript">
-    window.pxtTickEvent = function(id, data) {
-        if (window.appInsights && window.appInsights.trackEvent) {
-            const props = {};
-            const measures = {};
-            if (data) {
-                Object.keys(data).forEach(k => {
-                    if (typeof data[k] == "string") props[k] = data[k];
-                    else if (typeof data[k] == "number") measures[k] = data[k];
-                    else props[k] = JSON.stringify(data[k] || '');
+    if (!window.pxtTickEvent) {
+        let queuedTicks;
+        window.pxtTickEvent = function(id, data) {
+            if (window.appInsights && window.appInsights.trackEvent) {
+                sendTick(id, data);
+            } else {
+                if (!queuedTicks) {
+                    queuedTicks = [];
+                    var interval = window.setInterval(function() {
+                        if (window.appInsights && window.appInsights.trackEvent) {
+                            window.clearInterval(interval);
+                            for (var i = 0; i < queuedTicks.length; i++) {
+                                queuedTicks[i]();
+                            }
+                            queuedTicks = undefined;
+                        }
+                    }, 1000);
+                }
+
+                queuedTicks.push(function () {
+                    sendTick(id, data);
                 });
             }
-            window.appInsights.trackEvent(id, data, measures);
+
+            function sendTick(id, data) {
+                const props = {};
+                const measures = {};
+                if (data) {
+                    Object.keys(data).forEach(k => {
+                        if (typeof data[k] == "string") props[k] = data[k];
+                        else if (typeof data[k] == "number") measures[k] = data[k];
+                        else props[k] = JSON.stringify(data[k] || '');
+                    });
+                }
+                window.appInsights.trackEvent(id, data, measures);
+            }
         }
     }
 </script>

--- a/docfiles/tickevent.html
+++ b/docfiles/tickevent.html
@@ -18,6 +18,10 @@
                     }, 1000);
                 }
 
+                if (queuedTicks.length >= 10) {
+                    queuedTicks.shift();
+                }
+
                 queuedTicks.push(function () {
                     sendTick(id, data);
                 });


### PR DESCRIPTION
setting up window.appInsights.trackEvent is async, so it's possible for tick events to be fired before that gets loaded; in particular this happens for https://github.com/microsoft/pxt-arcade/blob/master/docfiles/script.html#L174 on my machine.

This queues the events in that case, and checks every second until trackEvent is loaded / fires off all the ticks at that point.

Also updated the tick posting portion so https://github.com/microsoft/pxt-arcade/pull/2587 would be unnecessary (though not really sure if we want cookie = true for sure? Not sure where it landed on whether we should be setting that or not now that when the cookie banner is gone).