### PR TITLE
Add new telemetry properties for isProduction and interactiveConsent (renaming "cookie")

### DIFF
--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -216,9 +216,12 @@ namespace pxt {
 
         // "cookie" does not actually correspond to whether or not we drop the cookie because we recently
         // switched to immediately dropping it rather than waiting. Instead, we maintain the legacy behavior
-        // of only setting it to true for production sites where interactive consent has been obtained
-        // so that we don't break legacy queries
-        telemetryItem.properties["cookie"] = interactiveConsent && isProduction;
+        // of only setting it to true for production sites so that we don't break legacy queries
+        telemetryItem.properties["cookie"] = isProduction;
+
+        // "interacted" corresponds to whether the user has interacted meaningfully with the site (ie
+        // the "interactiveConsent" flag is set to true). This is automatically set for native apps.
+        telemetryItem.properties["interacted"] = interactiveConsent && isProduction;
     }
 
     export function setInteractiveConsent(enabled: boolean) {

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -146,6 +146,7 @@ namespace pxt {
 
         if (isNativeApp() || shouldHideCookieBanner()) {
             initializeAppInsightsInternal(true);
+            if (isNativeApp()) setInteractiveConsent(true);
             return;
         }
 

--- a/docfiles/pxtweb/cookieCompliance.ts
+++ b/docfiles/pxtweb/cookieCompliance.ts
@@ -146,7 +146,6 @@ namespace pxt {
 
         if (isNativeApp() || shouldHideCookieBanner()) {
             initializeAppInsightsInternal(true);
-            if (isNativeApp()) setInteractiveConsent(true);
             return;
         }
 
@@ -216,12 +215,14 @@ namespace pxt {
 
         // "cookie" does not actually correspond to whether or not we drop the cookie because we recently
         // switched to immediately dropping it rather than waiting. Instead, we maintain the legacy behavior
-        // of only setting it to true for production sites so that we don't break legacy queries
-        telemetryItem.properties["cookie"] = isProduction;
+        // of only setting it to true for production sites where interactive consent has been obtained
+        // so that we don't break legacy queries
+        telemetryItem.properties["cookie"] = interactiveConsent && isProduction;
 
-        // "interacted" corresponds to whether the user has interacted meaningfully with the site (ie
-        // the "interactiveConsent" flag is set to true). This is automatically set for native apps.
-        telemetryItem.properties["interacted"] = interactiveConsent && isProduction;
+        // "interactiveConsent" corresponds to whether the user has interacted meaningfully with the site
+        // This is the same as "cookie", we are renaming it for clarity in the future.
+        telemetryItem.properties["interactiveConsent"] = interactiveConsent && isProduction;
+
     }
 
     export function setInteractiveConsent(enabled: boolean) {


### PR DESCRIPTION
Previously we were setting "cookie" to "includeCookie" which corresponds to whether or not we dropped a cookie, and not to the "interactiveConsent" flag (https://github.com/microsoft/pxt/pull/7494/files#diff-8957ba59dbfacd963c66897334cdb7040d8a10b172f100090eb857c2e7e28245L22)

We could revert to this behavior (set cookie directly equal to "isProduction" here: https://github.com/microsoft/pxt/blob/master/docfiles/pxtweb/cookieCompliance.ts#L220), but I think it's more correct to automatically set "interactiveConsent" to true for native apps (since we automatically trust them). 

@abchatra thoughts?