### PR TITLE
Use startActivity function when opening gallery examples also

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -313,7 +313,7 @@ namespace pxt.editor {
 
         editor: IEditor;
 
-        startActivity(activitity: Activity, path: string, title?: string, editor?: string): void;
+        startActivity(activitity: Activity, path: string, title?: string, editor?: string, focus?: boolean, opts?: pxt.editor.ExampleImportOptions): void;
         showLightbox(): void;
         hideLightbox(): void;
         showKeymap(show: boolean): void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3593,7 +3593,7 @@ export class ProjectView
             .finally(() => core.hideLoading("tutorial"));
     }
 
-    startActivity(activity: pxt.editor.Activity, path: string, title?: string, editorProjectName?: string, focus = true) {
+    startActivity(activity: pxt.editor.Activity, path: string, title?: string, editorProjectName?: string, focus = true, opts?: pxt.editor.ExampleImportOptions) {
         switch (activity) {
             case "tutorial":
                 pxt.tickEvent("tutorial.start", { tutorial: path, editor: editorProjectName });
@@ -3605,7 +3605,7 @@ export class ProjectView
                 break;
             case "example":
                 pxt.tickEvent("example.start", { example: path, editor: editorProjectName });
-                this.importExampleAsync({ name, path, loadBlocks: false, preferredEditor: editorProjectName });
+                this.importExampleAsync({ name: title, path, preferredEditor: editorProjectName, ...opts });
                 break;
         }
         this.textEditor.giveFocusOnLoading = focus;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -149,7 +149,7 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
     }
 
     chgCode(name: string, path: string, loadBlocks: boolean, preferredEditor?: string, template?: pxt.ProjectTemplate) {
-        return this.props.parent.importExampleAsync({ name, path, loadBlocks, preferredEditor, prj: template });
+        return this.props.parent.startActivity("example", path, name, preferredEditor, null, { path, name, loadBlocks, prj: template });
     }
 
     importProject() {


### PR DESCRIPTION
fixes issue with losing "example.start" ticks when homescreen examples are opened