### PR TITLE
Hero gallery: don't show dots when #cards < 2

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -520,7 +520,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
                     {card.label || card.name || lf("Start")}
                 </sui.Link>
             </div>}
-            {cardIndex !== undefined && <div key="cards" className="dots">
+            {cardIndex !== undefined && cards?.length > 1 && <div key="cards" className="dots">
                 {cards.map((card, i) => <button key={i} className={`ui button empty circular label  clear ${i === cardIndex && "active"}`} onClick={handleSetCard(i)}>
                 </button>)}
             </div>}


### PR DESCRIPTION
Small optimization, hide dots when there is only 1 item in the gallery.