### PR TITLE
Don't save non-tutorial headers and wait until load is complete

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -144,6 +144,10 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
                 });
             }
         }
+
+        if (original.action === "importproject" || original.action === "startactivity") {
+            this.onEditorLoaded();
+        }
     }
 
     protected sendMessage(message: any, response = false) {
@@ -188,7 +192,9 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             }
         };
 
-        await saveProjectAsync(project);
+        if (project.header.tutorial || project.header.tutorialCompleted) {
+            await saveProjectAsync(project);
+        }
 
         if (project.header!.tutorial) {
             dispatchSetHeaderIdForActivity(
@@ -213,7 +219,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
                 type: "pxteditor",
                 action: "importproject",
                 project: project
-            } as pxt.editor.EditorMessageImportProjectRequest)
+            } as pxt.editor.EditorMessageImportProjectRequest, true)
         }
         else {
             this.sendMessage({
@@ -221,7 +227,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
                 action: "startactivity",
                 path: this.props.tutorialPath,
                 activityType: "tutorial"
-            } as pxt.editor.EditorMessageStartActivity);
+            } as pxt.editor.EditorMessageStartActivity, true);
         }
     }
 
@@ -229,7 +235,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         switch (event.tick) {
             // FIXME: add a better tick; app.editor fires too early
             case "app.editor":
-                this.onEditorLoaded();
+                // this.onEditorLoaded();
                 break;
             case "tutorial.complete":
                 this.onTutorialFinished();

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -18,6 +18,7 @@ interface MakeCodeFrameProps {
     tutorialPath: string;
     completed: boolean;
     activityHeaderId?: string;
+    activityType: MapActivityType;
     dispatchSetHeaderIdForActivity: (headerId: string, currentStep: number, maxSteps: number) => void;
     dispatchCloseActivity: (finished?: boolean) => void;
     dispatchSaveAndCloseActivity: () => void;
@@ -182,7 +183,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     }
 
     protected async handleWorkspaceSaveRequestAsync(request: pxt.editor.EditorWorkspaceSaveRequest) {
-        const { dispatchSetHeaderIdForActivity, activityHeaderId } = this.props;
+        const { dispatchSetHeaderIdForActivity, activityHeaderId, activityType } = this.props;
 
         const project = {
             ...request.project,
@@ -192,7 +193,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             }
         };
 
-        if (project.header.tutorial || project.header.tutorialCompleted) {
+        if (activityType !== "tutorial" || project.header.tutorial || project.header.tutorialCompleted) {
             await saveProjectAsync(project);
         }
 
@@ -281,6 +282,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         activityId: currentActivityId,
         activityHeaderId: currentHeaderId,
         completed: lookupActivityProgress(state.user, currentMapId, currentActivityId)?.isCompleted,
+        activityType: activity.type,
         save: saveState === "saving"
     }
 }

--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -195,5 +195,5 @@ export function resolvePath(path: string) {
 }
 
 export function tickEvent(id: string, data?: { [key: string] : string | number }) {
-    (window as any).pxtTickEvent(id, data);
+    (window as any).pxtTickEvent?.(id, data);
 }

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -28,6 +28,8 @@ interface MapFinishedPrerequisite {
     mapId: string;
 }
 
+type MapActivityType = "tutorial";
+
 interface MapActivity {
     activityId: string;
 
@@ -35,7 +37,7 @@ interface MapActivity {
     description?: string;
     tags: string[];
 
-    type: "tutorial";
+    type: MapActivityType;
     editor: "blocks" | "js" | "py";
 
     url: string;


### PR DESCRIPTION
Hopefully fixes https://github.com/microsoft/pxt-arcade/issues/2595 and https://github.com/microsoft/pxt-arcade/issues/2597

I was finally able to repro this by turning on the maximum cpu throttling in Chrome.

The other part of the change is to make it so that we wait until the activity/project is started instead of using the editor load event because when it's slow the editor loads an empty project and *then* loads the actual thing.