### PR TITLE
Handle null tile nicely

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -196,10 +196,14 @@ namespace pxt.sprite {
             const tm = this.tilemap.copy();
             const tileset: TileSet = {
                 tileWidth: this.tileset.tileWidth,
-                tiles: this.tileset.tiles.map(t => ({
-                    ...t,
-                    bitmap: Bitmap.fromData(t.bitmap).copy().data()
-                }))
+                tiles: this.tileset.tiles.map(t => {
+                    if (!t) {
+                        return null;
+                    }
+                    return {
+                        ...t,
+                        bitmap: Bitmap.fromData(t.bitmap).copy().data()
+                }})
             }
             const layers = Bitmap.fromData(this.layers).copy().data();
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1449,7 +1449,7 @@ namespace pxt {
             id,
             mimeType: TILEMAP_MIME_TYPE,
             data: btoa(pxt.sprite.uint8ArrayToHex(data)),
-            tileset: tilemap.tileset.tiles.map(t => t.id),
+            tileset: tilemap.tileset.tiles.map(t => t?.id),
             displayName: name
         }
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2568

The issue was trying to render any hints with a tilemap block in it, and we were trying to access things from a null value :( I'm assuming the null tile is just the transparent tile? 

I tested all the tutorials mentioned in the issue and the hints show fine now! I'm seeing this error though:
`OmittedExpression not supported`
which might just be a whole other issue? It doesn't seem to affect hint rendering though! (but i haven't looked into it at all)