### PR TITLE
Allow prebuilt js in run.html links

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5014,21 +5014,14 @@ export async function buildShareSimJsAsync(parsed: commandParser.ParsedCommand) 
         throw new Error(`Failed to compile share id: ${id}`);
     }
 
-    // todo: this is duped from runner.ts, maybe move to pxtc so can just keep in one loc?
-    const builtJs = {
-        js: compileResult.outfiles[pxtc.BINARY_JS],
-        targetVersion: targetVersion,
-        fnArgs: compileResult.usedArguments,
-        parts: pxtc.computeUsedParts(compileResult, "ignorebuiltin"),
-        usedBuiltinParts: pxtc.computeUsedParts(compileResult, "onlybuiltin"),
-    };
+    const builtJsInfo = pxtc.buildSimJsInfo(compileResult);
 
     const outdir = parsed.flags["output"] as string || path.join(cwd, "docs", "static", "builtjs");
     nodeutil.mkdirP(outdir);
     const outputLocation = path.join(outdir, `${id}v${targetVersion}.json`);
     fs.writeFileSync(
         outputLocation,
-        JSON.stringify(builtJs)
+        JSON.stringify(builtJsInfo)
     );
 
     process.chdir(cwd);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4994,7 +4994,6 @@ export function buildAsync(parsed: commandParser.ParsedCommand) {
 export async function buildShareSimJsAsync(parsed: commandParser.ParsedCommand) {
     const id = parsed.args[0];
     console.log(`Building sim js for ${id}`);
-    const targetVersion = pxt.appTarget.versions.target;
     const cwd = process.cwd();
     const builtFolder = path.join("temp", id);
     nodeutil.mkdirP(builtFolder);
@@ -5018,7 +5017,7 @@ export async function buildShareSimJsAsync(parsed: commandParser.ParsedCommand) 
 
     const outdir = parsed.flags["output"] as string || path.join(cwd, "docs", "static", "builtjs");
     nodeutil.mkdirP(outdir);
-    const outputLocation = path.join(outdir, `${id}v${targetVersion}.json`);
+    const outputLocation = path.join(outdir, `${id}v${pxt.appTarget.versions.target}.json`);
     fs.writeFileSync(
         outputLocation,
         JSON.stringify(builtJsInfo)

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -859,6 +859,14 @@ declare namespace ts.pxtc {
         ignoreFileResolutionErrors?: boolean; // ignores triple-slash directive errors; debug only
     }
 
+    interface BuiltSimJsInfo {
+        js: string;
+        targetVersion: string;
+        fnArgs?: pxt.Map<String[]>;
+        parts?: string[];
+        usedBuiltinParts?: string[];
+    }
+
     interface UpgradePolicy {
         type: "api" | "blockId" | "missingPackage" | "package" | "blockValue" | "userenum";
         map?: pxt.Map<string>;

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -107,7 +107,7 @@ namespace pxt.Cloud {
             return apiRequestWithCdnAsync({ url }).then(r => r.json)
     }
 
-    export function downloadScriptFilesAsync(id: string) {
+    export function downloadScriptFilesAsync(id: string): Promise<Map<string>> {
         return privateRequestAsync({ url: id + "/text", forceLiveEndpoint: true }).then(resp => {
             return JSON.parse(resp.text)
         })

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -376,6 +376,16 @@ namespace ts.pxtc {
         return parts;
     }
 
+    export function buildSimJsInfo(compileResult: pxtc.CompileResult): pxtc.BuiltSimJsInfo {
+        return {
+            js: compileResult.outfiles[pxtc.BINARY_JS],
+            targetVersion: pxt.appTarget.versions.target,
+            fnArgs: compileResult.usedArguments,
+            parts: pxtc.computeUsedParts(compileResult, "ignorebuiltin"),
+            usedBuiltinParts: pxtc.computeUsedParts(compileResult, "onlybuiltin"),
+        };
+    }
+
     /**
      * Unlocalized category name for a symbol
      */

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -13,7 +13,16 @@ namespace pxt.runner {
         highContrast?: boolean;
         light?: boolean;
         fullScreen?: boolean;
-        dependencies?: string[]
+        dependencies?: string[];
+        builtJsInfo?: BuiltSimJsInfo;
+    }
+
+    export interface BuiltSimJsInfo {
+        js: string;
+        simVersion?: semver.Version;
+        fnArgs?: Map<String[]>;
+        parts?: string[];
+        usedBuiltinParts?: string[];
     }
 
     class EditorPackage {
@@ -349,17 +358,67 @@ namespace pxt.runner {
     }
 
     export async function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
-        let didUpgrade = false;
+        const builtSimJS = simOptions.builtJsInfo || await buildSimJsInfo(simOptions);
+        const {
+            js,
+            fnArgs,
+            parts,
+            usedBuiltinParts
+        } = builtSimJS;
 
+        if (!js) {
+            console.error("Program failed to compile");
+            return;
+        }
+
+        let options: pxsim.SimulatorDriverOptions = {};
+        options.onSimulatorCommand = msg => {
+            if (msg.command === "restart") {
+                runOptions.storedState = getStoredState(simOptions.id)
+                driver.run(js, runOptions);
+            }
+            if (msg.command == "setstate") {
+                if (msg.stateKey && msg.stateValue) {
+                    setStoredState(simOptions.id, msg.stateKey, msg.stateValue)
+                }
+            }
+        };
+
+        let driver = new pxsim.SimulatorDriver(container, options);
+
+        let board = pxt.appTarget.simulator.boardDefinition;
+        let storedState: Map<string> = getStoredState(simOptions.id)
+        let runOptions: pxsim.SimulatorRunOptions = {
+            boardDefinition: board,
+            parts: parts,
+            builtinParts: usedBuiltinParts,
+            fnArgs: fnArgs,
+            cdnUrl: pxt.webConfig.commitCdnUrl,
+            localizedStrings: Util.getLocalizedStrings(),
+            highContrast: simOptions.highContrast,
+            storedState: storedState,
+            light: simOptions.light,
+        };
+        if (pxt.appTarget.simulator && !simOptions.fullScreen)
+            runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio
+                ? pxt.appTarget.simulator.partsAspectRatio
+                : pxt.appTarget.simulator.aspectRatio;
+        driver.run(js, runOptions);
+    }
+
+    export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<BuiltSimJsInfo> {
         await loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies);
-        let resp = await compileAsync(false, opts => {
+
+        let didUpgrade = false;
+        const currentTargetVersion = pxt.appTarget.versions.target && pxt.semver.parse(pxt.appTarget.versions.target);
+        let compileResult = await compileAsync(false, opts => {
             if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
 
             // Api info needed for py2ts conversion, if project is shared in Python
             if (opts.target.preferredEditor === pxt.PYTHON_PROJECT_NAME) {
                 opts.target.preferredEditor = pxt.JAVASCRIPT_PROJECT_NAME;
                 opts.ast = true;
-                const resp = pxtc.compile(opts)
+                const resp = pxtc.compile(opts);
                 const apis = getApiInfo(resp.ast, opts);
                 opts.apisInfo = apis;
                 opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME;
@@ -367,10 +426,9 @@ namespace pxt.runner {
 
             // Apply upgrade rules if necessary
             const sharedTargetVersion = mainPkg.config.targetVersions.target;
-            const currentTargetVersion = pxt.appTarget.versions.target;
 
             if (sharedTargetVersion && currentTargetVersion &&
-                pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), pxt.semver.parse(currentTargetVersion)) < 0) {
+                pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), currentTargetVersion) < 0) {
                 for (const fileName of Object.keys(opts.fileSystem)) {
                     if (!pxt.Util.startsWith(fileName, "pxt_modules") && pxt.Util.endsWith(fileName, ".ts")) {
                         didUpgrade = true;
@@ -380,55 +438,24 @@ namespace pxt.runner {
             }
         });
 
-        if (resp.diagnostics?.length > 0 && didUpgrade) {
+        if (compileResult.diagnostics?.length > 0 && didUpgrade) {
             pxt.log("Compile with upgrade rules failed, trying again with original code");
-            resp = await compileAsync(false, opts => {
+            compileResult = await compileAsync(false, opts => {
                 if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
             });
         }
 
-        if (resp.diagnostics && resp.diagnostics.length > 0) {
-            console.error("Diagnostics", resp.diagnostics)
+        if (compileResult.diagnostics && compileResult.diagnostics.length > 0) {
+            console.error("Diagnostics", compileResult.diagnostics);
         }
-        let js = resp.outfiles[pxtc.BINARY_JS];
-        if (js) {
-            let options: pxsim.SimulatorDriverOptions = {};
-            options.onSimulatorCommand = msg => {
-                if (msg.command === "restart") {
-                    runOptions.storedState = getStoredState(simOptions.id)
-                    driver.run(js, runOptions);
-                }
-                if (msg.command == "setstate") {
-                    if (msg.stateKey && msg.stateValue) {
-                        setStoredState(simOptions.id, msg.stateKey, msg.stateValue)
-                    }
-                }
-            };
 
-            let driver = new pxsim.SimulatorDriver(container, options);
-
-            let fnArgs = resp.usedArguments;
-            let board = pxt.appTarget.simulator.boardDefinition;
-            let parts = pxtc.computeUsedParts(resp, "ignorebuiltin");
-            const usedBuiltinParts = pxtc.computeUsedParts(resp, "onlybuiltin");
-            let storedState: Map<string> = getStoredState(simOptions.id)
-            let runOptions: pxsim.SimulatorRunOptions = {
-                boardDefinition: board,
-                parts: parts,
-                builtinParts: usedBuiltinParts,
-                fnArgs: fnArgs,
-                cdnUrl: pxt.webConfig.commitCdnUrl,
-                localizedStrings: Util.getLocalizedStrings(),
-                highContrast: simOptions.highContrast,
-                storedState: storedState,
-                light: simOptions.light
-            };
-            if (pxt.appTarget.simulator && !simOptions.fullScreen)
-                runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio
-                    ? pxt.appTarget.simulator.partsAspectRatio
-                    : pxt.appTarget.simulator.aspectRatio;
-            driver.run(js, runOptions);
-        }
+        return {
+            js: compileResult.outfiles[pxtc.BINARY_JS],
+            simVersion: currentTargetVersion,
+            fnArgs: compileResult.usedArguments,
+            parts: pxtc.computeUsedParts(compileResult, "ignorebuiltin"),
+            usedBuiltinParts: pxtc.computeUsedParts(compileResult, "onlybuiltin"),
+        };
     }
 
     function getStoredState(id: string) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -14,15 +14,7 @@ namespace pxt.runner {
         light?: boolean;
         fullScreen?: boolean;
         dependencies?: string[];
-        builtJsInfo?: BuiltSimJsInfo;
-    }
-
-    export interface BuiltSimJsInfo {
-        js: string;
-        targetVersion: string;
-        fnArgs?: Map<String[]>;
-        parts?: string[];
-        usedBuiltinParts?: string[];
+        builtJsInfo?: pxtc.BuiltSimJsInfo;
     }
 
     class EditorPackage {
@@ -406,7 +398,7 @@ namespace pxt.runner {
         driver.run(js, runOptions);
     }
 
-    export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<BuiltSimJsInfo> {
+    export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
         await loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies);
 
         let didUpgrade = false;
@@ -449,13 +441,7 @@ namespace pxt.runner {
             console.error("Diagnostics", compileResult.diagnostics);
         }
 
-        return {
-            js: compileResult.outfiles[pxtc.BINARY_JS],
-            targetVersion: currentTargetVersion,
-            fnArgs: compileResult.usedArguments,
-            parts: pxtc.computeUsedParts(compileResult, "ignorebuiltin"),
-            usedBuiltinParts: pxtc.computeUsedParts(compileResult, "onlybuiltin"),
-        };
+        return pxtc.buildSimJsInfo(compileResult);
     }
 
     function getStoredState(id: string) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -417,7 +417,7 @@ namespace pxt.runner {
             }
 
             // Apply upgrade rules if necessary
-            const sharedTargetVersion = mainPkg.config.targetVersions.target;
+            const sharedTargetVersion = mainPkg.config.targetVersions?.target;
 
             if (sharedTargetVersion && currentTargetVersion &&
                 pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), pxt.semver.parse(currentTargetVersion)) < 0) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -349,7 +349,7 @@ namespace pxt.runner {
             })
     }
 
-    export async function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
+    export async function simulateAsync(container: HTMLElement, simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
         const builtSimJS = simOptions.builtJsInfo || await buildSimJsInfo(simOptions);
         const {
             js,
@@ -360,7 +360,7 @@ namespace pxt.runner {
 
         if (!js) {
             console.error("Program failed to compile");
-            return;
+            return undefined;
         }
 
         let options: pxsim.SimulatorDriverOptions = {};
@@ -396,6 +396,7 @@ namespace pxt.runner {
                 ? pxt.appTarget.simulator.partsAspectRatio
                 : pxt.appTarget.simulator.aspectRatio;
         driver.run(js, runOptions);
+        return builtSimJS;
     }
 
     export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -19,7 +19,7 @@ namespace pxt.runner {
 
     export interface BuiltSimJsInfo {
         js: string;
-        simVersion?: semver.Version;
+        targetVersion: string;
         fnArgs?: Map<String[]>;
         parts?: string[];
         usedBuiltinParts?: string[];
@@ -363,7 +363,7 @@ namespace pxt.runner {
             js,
             fnArgs,
             parts,
-            usedBuiltinParts
+            usedBuiltinParts,
         } = builtSimJS;
 
         if (!js) {
@@ -410,7 +410,7 @@ namespace pxt.runner {
         await loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies);
 
         let didUpgrade = false;
-        const currentTargetVersion = pxt.appTarget.versions.target && pxt.semver.parse(pxt.appTarget.versions.target);
+        const currentTargetVersion = pxt.appTarget.versions.target;
         let compileResult = await compileAsync(false, opts => {
             if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
 
@@ -428,7 +428,7 @@ namespace pxt.runner {
             const sharedTargetVersion = mainPkg.config.targetVersions.target;
 
             if (sharedTargetVersion && currentTargetVersion &&
-                pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), currentTargetVersion) < 0) {
+                pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), pxt.semver.parse(currentTargetVersion)) < 0) {
                 for (const fileName of Object.keys(opts.fileSystem)) {
                     if (!pxt.Util.startsWith(fileName, "pxt_modules") && pxt.Util.endsWith(fileName, ".ts")) {
                         didUpgrade = true;
@@ -451,7 +451,7 @@ namespace pxt.runner {
 
         return {
             js: compileResult.outfiles[pxtc.BINARY_JS],
-            simVersion: currentTargetVersion,
+            targetVersion: currentTargetVersion,
             fnArgs: compileResult.usedArguments,
             parts: pxtc.computeUsedParts(compileResult, "ignorebuiltin"),
             usedBuiltinParts: pxtc.computeUsedParts(compileResult, "onlybuiltin"),

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -112,7 +112,7 @@
         var light = !!/light(?:[:=])1/i.exec(window.location.href);
         var fullScreen = !!/fullscreen(?:[:=])1/i.exec(window.location.href);
         var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
-        var prebuiltSimJs = /prebuilt(?:[:=])([^&?]+)/i.exec(window.location.href);
+        var prebuiltSimJs = /prebuilt(?:[:=])1/i.test(window.location.href);
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var codeFromData = undefined;
@@ -165,8 +165,10 @@
 
         var prebuiltCodePromise = Promise.resolve(undefined);
         if (prebuiltSimJs) {
+            var versionsuff = /localhost:/.test(window.location.href) ? "" : "@versionsuff@";
+            var builtSimJsUrl = "/static/builtjs/" + id[1] + versionsuff + ".json"
             // kick off fetch immediately, no need to wait for ksrunnerready
-            prebuiltCodePromise = fetch(prebuiltSimJs[1])
+            prebuiltCodePromise = fetch(builtSimJsUrl)
                 .then(resp => resp.json())
                 .catch(e => {
                     // TODO: send tick that something broke :(

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -112,6 +112,7 @@
         var light = !!/light(?:[:=])1/i.exec(window.location.href);
         var fullScreen = !!/fullscreen(?:[:=])1/i.exec(window.location.href);
         var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
+        var prebuiltSimJs = /prebuilt(?:[:=])([^&?]+)/i.exec(window.location.href);
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var codeFromData = undefined;
@@ -162,6 +163,17 @@
             }
         });
 
+        var prebuiltCodePromise = Promise.resolve(undefined);
+        if (prebuiltSimJs) {
+            // kick off fetch immediately, no need to wait for ksrunnerready
+            prebuiltCodePromise = fetch(prebuiltSimJs[1])
+                .then(resp => resp.json())
+                .catch(e => {
+                    // TODO: send tick that something broke :(
+                    console.error("Failed to get prebuilt code")
+                });
+        }
+
         ksRunnerReady(function() {
             var theme = pxt.appTarget.appTheme;
             document.title = theme.title;
@@ -180,19 +192,22 @@
                 })
             }
             else if (!debugSim) {
-                var options = {
-                    id: id ? id[1] : undefined,
-                    code: code ? decodeURIComponent(code) : undefined,
-                    highContrast: highContrast,
-                    light: light,
-                    fullScreen: fullScreen,
-                    dependencies: deps ? decodeURIComponent(deps[1]).split(",") : undefined
-                };
-                console.log('simulating script')
-                pxt.runner.simulateAsync(sims, options).done(function() {
-                    console.log('simulator started...')
-                    $(loading).remove();
-                })
+                prebuiltCodePromise.then(builtSimJs => {
+                    var options = {
+                        id: id ? id[1] : undefined,
+                        code: code ? decodeURIComponent(code) : undefined,
+                        highContrast: highContrast,
+                        light: light,
+                        fullScreen: fullScreen,
+                        dependencies: deps ? decodeURIComponent(deps[1]).split(",") : undefined,
+                        builtJsInfo: builtSimJs,
+                    };
+                    console.log('simulating script')
+                    pxt.runner.simulateAsync(sims, options).done(function() {
+                        console.log('simulator started...')
+                        $(loading).remove();
+                    })
+                });
             }
             else {
                 $(loading).remove();

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -281,11 +281,13 @@ export interface RunOptions {
 
 export function run(pkg: pxt.MainPackage, debug: boolean,
     res: pxtc.CompileResult, options: RunOptions, trace: boolean) {
-    const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
-    const parts = pxtc.computeUsedParts(res, "ignorebuiltin");
-    const usedBuiltinParts = pxtc.computeUsedParts(res, "onlybuiltin");
-    const fnArgs = res.usedArguments;
+    const {
+        js,
+        fnArgs,
+        parts,
+        usedBuiltinParts,
+    } = pxtc.buildSimJsInfo(res);
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
     const isIpcRenderer = pxt.BrowserUtils.isIpcRenderer() || undefined;


### PR DESCRIPTION
Add option to use prebuilt js on share page in arcade to speed up loading; this is mainly just an intermediary step towards prebuilding sim js in general (hopefully!)

(also added a quick fix for docs sims, which is crashing off master right now: https://github.com/microsoft/pxt/pull/7681/commits/b534fe7d608177a368f830aab6fa009cd0ddf1a4)

![loading-loading-loading](https://user-images.githubusercontent.com/5615930/100972560-daf03180-34ed-11eb-8b39-18c22ad1a584.gif)

asphodel diff:
time from page load -> first asphodel paint on my work computer:
![image](https://user-images.githubusercontent.com/5615930/100972154-26eea680-34ed-11eb-8027-bdc62db84d40.png)

with this (worth noting this is local serve / loading time may vary):
![image](https://user-images.githubusercontent.com/5615930/100971878-9f089c80-34ec-11eb-81f3-3e6d6fd916b6.png)

other notes:
* I'm appending version suffixes so any bump would need to rebuild the source -- this isn't usually necessary except for major releases, but 
* plays a bit weirdly with local host, as we replace `@versionsuff@` with "" there; for testing locally I just renamed the file without the suffix
* I only made the cli command to build one share link's js at a time (instead of all approved sharelinks), but it'll be easy enough to add one that builds all approved links + a github action to handle checking out the right release / build all / make a pr; just a few other improvements I wanted to look at before the release / it's not a big deal to manually update when there's only one approved link at the moment anyways
* There's not a clean point between pxt.runner and the cli where we can get the compilation portion the same, so I left off the upgrade rules + python support from the cli for this PR so it's easier to port; will see about getting that cleaned up in follow afterwards~

and example built off current arcade (not stable branch): https://github.com/microsoft/pxt-arcade/pull/2622