### PR TITLE
Null check for skill map completion state when saving header

### DIFF
--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -247,7 +247,7 @@ export function setHeaderIdForActivity(user: UserState, map: SkillMap, activityI
                         isCompleted
                     }
                 },
-                completionState: shouldTransition ? "transitioning" : user.mapProgress[mapId].completionState
+                completionState: shouldTransition ? "transitioning" : user.mapProgress[mapId]?.completionState
             }
         }
     };


### PR DESCRIPTION
Should fix the saving issues, probably not related to the defaultPath url.