### PR TITLE
Remove cookie banner from makecode frame

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -282,7 +282,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         url = editorUrl.substr(0, editorUrl.length - 1);
     }
 
-    url += `?controller=1&skillsMap=1`;
+    url += `?controller=1&skillsMap=1&nocookiebanner=1`;
     title = activity.displayName;
 
     return {


### PR DESCRIPTION
Gets rid of the inner cookie banner on the skills map. The outer one will go away once I update pxtweb in the deployment config