### PR TITLE
Patch header name to match card

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -185,7 +185,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     }
 
     protected async handleWorkspaceSaveRequestAsync(request: pxt.editor.EditorWorkspaceSaveRequest) {
-        const { dispatchSetHeaderIdForActivity, activityHeaderId, activityType } = this.props;
+        const { dispatchSetHeaderIdForActivity, activityHeaderId, activityType, title } = this.props;
 
         const project = {
             ...request.project,
@@ -194,6 +194,17 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
                 id: activityHeaderId || request.project.header!.id
             }
         };
+
+        // Patch the name, otherwise it will be the name of the GitHub repo
+        if (project.header?.name !== title) {
+            project.header!.name = title;
+            const pxtJSON = project.text!["pxt.json"];
+            if (pxtJSON) {
+                const config = JSON.parse(pxtJSON);
+                config.name = title;
+                project.text!["pxt.json"] = pxt.Package.stringifyConfig(config);
+            }
+        }
 
         if (project.header.tutorialCompleted) {
             const existing = await getProjectAsync(project.header.id);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2661

Changes it to be the name of the activity