### PR TITLE
Add noproject=1 flag to open editor in controller mode without default project

### DIFF
--- a/pxteditor/shell.ts
+++ b/pxteditor/shell.ts
@@ -9,6 +9,7 @@ namespace pxt.shell {
     let layoutType: EditorLayoutType;
 
     let editorReadonly: boolean = false;
+    let noDefaultProject: boolean = false;
 
     function init() {
         if (layoutType !== undefined) return;
@@ -20,6 +21,7 @@ namespace pxt.shell {
         const controller = /controller=1/i.test(window.location.href) && pxt.BrowserUtils.isIFrame();
         const readonly = /readonly=1/i.test(window.location.href);
         const layout = /editorlayout=(widget|sandbox|ide)/i.exec(window.location.href);
+        const noproject = /noproject=1/i.test(window.location.href);
 
         layoutType = EditorLayoutType.IDE;
         if (nosandbox)
@@ -30,6 +32,7 @@ namespace pxt.shell {
             layoutType = EditorLayoutType.Sandbox;
 
         if (controller && readonly) editorReadonly = true;
+        if (controller && noproject) noDefaultProject = true;
         if (layout) {
             switch (layout[1].toLowerCase()) {
                 case "widget": layoutType = EditorLayoutType.Widget; break;
@@ -54,6 +57,10 @@ namespace pxt.shell {
         return (isSandboxMode()
             && !/[?&]edit=1/i.test(window.location.href)) ||
             (isControllerMode() && editorReadonly);
+    }
+
+    export function isNoProject() {
+        return noDefaultProject;
     }
 
     export function isControllerMode() {

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -282,7 +282,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         url = editorUrl.substr(0, editorUrl.length - 1);
     }
 
-    url += `?controller=1&skillsMap=1`;
+    url += `?controller=1&skillsMap=1&noproject=1`;
     title = activity.displayName;
 
     return {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4655,14 +4655,19 @@ document.addEventListener("DOMContentLoaded", () => {
                 // Hide the home screen
                 theEditor.setState({ home: false });
             }
+
             if (hash.cmd && handleHash(hash, true)) {
                 return Promise.resolve();
             }
             if (hasWinRTProject) {
                 return pxt.winrt.loadActivationProject();
             }
-            if (showHome)
+            if (pxt.shell.isNoProject()) {
+                pxt.tickEvent("pxt.controller.createproject");
                 return Promise.resolve();
+            }
+            if (showHome) return Promise.resolve();
+
 
             // default handlers
             const ent = theEditor.settings.fileHistory.filter(e => !!workspace.getHeader(e.id))[0];

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4663,7 +4663,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 return pxt.winrt.loadActivationProject();
             }
             if (pxt.shell.isNoProject()) {
-                pxt.tickEvent("pxt.controller.createproject");
+                workspace.fireEvent({ type: "createproject", editor: "blocks" });
                 return Promise.resolve();
             }
             if (showHome) return Promise.resolve();


### PR DESCRIPTION
Hopefully fixes https://github.com/microsoft/pxt-arcade/issues/2649

Does not create a default blank project when the editor is loaded in controller mode with this flag, instead returns an event (pxt.controller.createproject) so that the controller can choose how to handle it.

Bug is a race condition so a little hard to repro but I can pretty consistently see it in Edge without this change, and I have not seen it with this change. I also have not been able to repro the "no template code" bug with this change, but once it's merged we should probably deploy and do some stress tests.