### PR TITLE
Add code card 'directOpen' property to skip the details view, add 'link' CodeCardType

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -1,6 +1,6 @@
 declare namespace pxt {
 
-    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw" | "forumUrl" | "forumExample" | "sharedExample";
+    type CodeCardType = "file" | "example" | "codeExample" | "tutorial" | "side" | "template" | "package" | "hw" | "forumUrl" | "forumExample" | "sharedExample" | "link";
     type CodeCardEditorType = "blocks" | "js" | "py";
 
     interface Map<T> {
@@ -159,6 +159,7 @@ declare namespace pxt {
         cardType?: CodeCardType;
         editor?: CodeCardEditorType;
         otherActions?: CodeCardAction[];
+        directOpen?: boolean; // skip the details view, directly do the card action
 
         header?: string;
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -129,6 +129,9 @@ export class Projects extends data.Component<ISettingsProps, ProjectsState> {
                     window.location.hash = "pub:" + id;
                 }
                 break;
+            case "link":
+                window.open(((/^https:\/\//i.test(url)) || (/^\//i.test(url)) ? url : ''), "_blank");
+                break;
             default:
                 const m = /^\/#tutorial:([a-z0A-Z0-9\-\/]+)$/.exec(url); // Tutorial
                 if (m) this.props.parent.startActivity("tutorial", m[1]);
@@ -656,7 +659,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
 
     handleCardClick(e: any, scr: any, index?: number) {
         const { name } = this.props;
-        if (this.props.setSelected) {
+        if (this.props.setSelected && !scr.directOpen) {
             // Set this item as selected
             pxt.tickEvent("projects.detail.open");
             this.props.setSelected(name, index);

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -659,7 +659,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
 
     handleCardClick(e: any, scr: any, index?: number) {
         const { name } = this.props;
-        if (this.props.setSelected && !scr.directOpen) {
+        if (this.props.setSelected && !(scr && scr.directOpen)) {
             // Set this item as selected
             pxt.tickEvent("projects.detail.open");
             this.props.setSelected(name, index);


### PR DESCRIPTION
Small change to support skipping the details view from a homescreen card:

- 'directOpen' property specifies that a card should launch it's primary action directly (open tutorial, show instructions, etc) instead of expanding the details view
- adding "link" CardType--previously our default "Action" was a link (stylized <a> tag) so to support the "CodeCard as a link" I'm adding an extra case to the chgGallery function (set as the onClick for the CodeCard as well as the onClick for the details action)