### PR TITLE
[stable6.2] cherry picks for prebuilt simjs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4859,6 +4859,42 @@ export function buildAsync(parsed: commandParser.ParsedCommand) {
         }).then((compileOpts) => { });
 }
 
+export async function buildShareSimJsAsync(parsed: commandParser.ParsedCommand) {
+    const id = parsed.args[0];
+    console.log(`Building sim js for ${id}`);
+    const cwd = process.cwd();
+    const builtFolder = path.join("temp", id);
+    nodeutil.mkdirP(builtFolder);
+    process.chdir(builtFolder);
+
+    const mainPkg = new pxt.MainPackage(new Host());
+    mainPkg._verspec = `pub:${id}`;
+
+    await mainPkg.host().downloadPackageAsync(mainPkg);
+    await mainPkg.installAllAsync();
+    const opts = await mainPkg.getCompileOptionsAsync();
+    const compileResult = pxtc.compile(opts);
+    if (compileResult.diagnostics && compileResult.diagnostics.length > 0) {
+        compileResult.diagnostics.forEach(diag => {
+            console.error(diag.messageText)
+        })
+        throw new Error(`Failed to compile share id: ${id}`);
+    }
+
+    const builtJsInfo = pxtc.buildSimJsInfo(compileResult);
+
+    const outdir = parsed.flags["output"] as string || path.join(cwd, "docs", "static", "builtjs");
+    nodeutil.mkdirP(outdir);
+    const outputLocation = path.join(outdir, `${id}v${pxt.appTarget.versions.target}.json`);
+    fs.writeFileSync(
+        outputLocation,
+        JSON.stringify(builtJsInfo)
+    );
+
+    process.chdir(cwd);
+    console.log(`saved prebuilt ${id} to ${outputLocation}`);
+}
+
 export function gendocsAsync(parsed: commandParser.ParsedCommand) {
     const docs = !!parsed.flags["docs"];
     const locs = !!parsed.flags["locs"];
@@ -6042,6 +6078,20 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
             }
         }
     }, buildAsync);
+
+    p.defineCommand({
+        name: "buildsimjs",
+        help: "build sim js for a share link",
+        argString: "<share id>",
+        flags: {
+            output: {
+                description: "Specifies the output folder for the generated files",
+                argument: "output",
+                type: "string",
+                aliases: ["o"]
+            },
+        },
+    }, buildShareSimJsAsync)
 
     simpleCmd("clean", "removes built folders", cleanAsync);
     advancedCommand("cleangen", "remove generated files", cleanGenAsync);

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4379,7 +4379,7 @@ function buildCoreAsync(buildOpts: BuildCoreOptions): Promise<pxtc.CompileResult
 
             if (buildOpts.mode === BuildOption.DebugSim) {
                 mainPkg.host().writeFile(mainPkg, "built/debug/debugInfo.json", JSON.stringify({
-                    usedParts: pxtc.computeUsedParts(res, true),
+                    usedParts: pxtc.computeUsedParts(res, "ignorebuiltin"),
                     usedArguments: res.usedArguments,
                     breakpoints: res.breakpoints
                 }));

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -839,6 +839,14 @@ declare namespace ts.pxtc {
         ignoreFileResolutionErrors?: boolean; // ignores triple-slash directive errors; debug only
     }
 
+    interface BuiltSimJsInfo {
+        js: string;
+        targetVersion: string;
+        fnArgs?: pxt.Map<String[]>;
+        parts?: string[];
+        usedBuiltinParts?: string[];
+    }
+
     interface UpgradePolicy {
         type: "api" | "blockId" | "missingPackage" | "package" | "blockValue" | "userenum";
         map?: pxt.Map<string>;

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -107,7 +107,7 @@ namespace pxt.Cloud {
             return apiRequestWithCdnAsync({ url }).then(r => r.json)
     }
 
-    export function downloadScriptFilesAsync(id: string) {
+    export function downloadScriptFilesAsync(id: string): Promise<Map<string>> {
         return privateRequestAsync({ url: id + "/text", forceLiveEndpoint: true }).then(resp => {
             return JSON.parse(resp.text)
         })

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -336,7 +336,7 @@ namespace ts.pxtc {
         endingToken?: string;
     }
 
-    export function computeUsedParts(resp: CompileResult, ignoreBuiltin = false): string[] {
+    export function computeUsedParts(resp: CompileResult, filter?: "onlybuiltin" | "ignorebuiltin"): string[] {
         if (!resp.usedSymbols || !pxt.appTarget.simulator || !pxt.appTarget.simulator.parts)
             return [];
 
@@ -356,10 +356,15 @@ namespace ts.pxtc {
             }
         });
 
-        if (ignoreBuiltin) {
+        if (filter) {
             const builtinParts = pxt.appTarget.simulator.boardDefinition.onboardComponents;
-            if (builtinParts)
-                parts = parts.filter(p => builtinParts.indexOf(p) < 0);
+            if (builtinParts) {
+                if (filter === "ignorebuiltin") {
+                    parts = parts.filter(p => builtinParts.indexOf(p) === -1);
+                } else if (filter === "onlybuiltin") {
+                    parts = parts.filter(p => builtinParts.indexOf(p) >= 0);
+                }
+            }
         }
 
         //sort parts (so breadboarding layout is stable w.r.t. code ordering)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -376,6 +376,16 @@ namespace ts.pxtc {
         return parts;
     }
 
+    export function buildSimJsInfo(compileResult: pxtc.CompileResult): pxtc.BuiltSimJsInfo {
+        return {
+            js: compileResult.outfiles[pxtc.BINARY_JS],
+            targetVersion: pxt.appTarget.versions.target,
+            fnArgs: compileResult.usedArguments,
+            parts: pxtc.computeUsedParts(compileResult, "ignorebuiltin"),
+            usedBuiltinParts: pxtc.computeUsedParts(compileResult, "onlybuiltin"),
+        };
+    }
+
     /**
      * Unlocalized category name for a symbol
      */

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -355,6 +355,16 @@ namespace pxt.runner {
             .then(() => compileAsync(false, opts => {
                 if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
 
+                // Api info needed for py2ts conversion, if project is shared in Python
+                if (opts.target.preferredEditor === pxt.PYTHON_PROJECT_NAME) {
+                    opts.target.preferredEditor = pxt.JAVASCRIPT_PROJECT_NAME;
+                    opts.ast = true;
+                    const resp = pxtc.compile(opts)
+                    const apis = getApiInfo(resp.ast, opts);
+                    opts.apisInfo = apis;
+                    opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME;
+                }
+
                 // Apply upgrade rules if necessary
                 const sharedTargetVersion = mainPkg.config.targetVersions.target;
                 const currentTargetVersion = pxt.appTarget.versions.target;

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -13,7 +13,8 @@ namespace pxt.runner {
         highContrast?: boolean;
         light?: boolean;
         fullScreen?: boolean;
-        dependencies?: string[]
+        dependencies?: string[];
+        builtJsInfo?: pxtc.BuiltSimJsInfo;
     }
 
     class EditorPackage {
@@ -348,90 +349,100 @@ namespace pxt.runner {
             })
     }
 
-    export function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
-        let didUpgrade = false;
+    export async function simulateAsync(container: HTMLElement, simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
+        const builtSimJS = simOptions.builtJsInfo || await buildSimJsInfo(simOptions);
+        const {
+            js,
+            fnArgs,
+            parts,
+            usedBuiltinParts,
+        } = builtSimJS;
 
-        return loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies)
-            .then(() => compileAsync(false, opts => {
-                if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+        if (!js) {
+            console.error("Program failed to compile");
+            return undefined;
+        }
 
-                // Api info needed for py2ts conversion, if project is shared in Python
-                if (opts.target.preferredEditor === pxt.PYTHON_PROJECT_NAME) {
-                    opts.target.preferredEditor = pxt.JAVASCRIPT_PROJECT_NAME;
-                    opts.ast = true;
-                    const resp = pxtc.compile(opts)
-                    const apis = getApiInfo(resp.ast, opts);
-                    opts.apisInfo = apis;
-                    opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME;
+        let options: pxsim.SimulatorDriverOptions = {};
+        options.onSimulatorCommand = msg => {
+            if (msg.command === "restart") {
+                runOptions.storedState = getStoredState(simOptions.id)
+                driver.run(js, runOptions);
+            }
+            if (msg.command == "setstate") {
+                if (msg.stateKey && msg.stateValue) {
+                    setStoredState(simOptions.id, msg.stateKey, msg.stateValue)
                 }
+            }
+        };
 
-                // Apply upgrade rules if necessary
-                const sharedTargetVersion = mainPkg.config.targetVersions.target;
-                const currentTargetVersion = pxt.appTarget.versions.target;
+        let driver = new pxsim.SimulatorDriver(container, options);
 
-                if (sharedTargetVersion && currentTargetVersion &&
-                    pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), pxt.semver.parse(currentTargetVersion)) < 0) {
-                    for (const fileName of Object.keys(opts.fileSystem)) {
-                        if (!pxt.Util.startsWith(fileName, "pxt_modules") && pxt.Util.endsWith(fileName, ".ts")) {
-                            didUpgrade = true;
-                            opts.fileSystem[fileName] = pxt.patching.patchJavaScript(sharedTargetVersion, opts.fileSystem[fileName]);
-                        }
+        let board = pxt.appTarget.simulator.boardDefinition;
+        let storedState: Map<string> = getStoredState(simOptions.id)
+        let runOptions: pxsim.SimulatorRunOptions = {
+            boardDefinition: board,
+            parts: parts,
+            builtinParts: usedBuiltinParts,
+            fnArgs: fnArgs,
+            cdnUrl: pxt.webConfig.commitCdnUrl,
+            localizedStrings: Util.getLocalizedStrings(),
+            highContrast: simOptions.highContrast,
+            storedState: storedState,
+            light: simOptions.light,
+        };
+        if (pxt.appTarget.simulator && !simOptions.fullScreen)
+            runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio
+                ? pxt.appTarget.simulator.partsAspectRatio
+                : pxt.appTarget.simulator.aspectRatio;
+        driver.run(js, runOptions);
+        return builtSimJS;
+    }
+
+    export async function buildSimJsInfo(simOptions: SimulateOptions): Promise<pxtc.BuiltSimJsInfo> {
+        await loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies);
+
+        let didUpgrade = false;
+        const currentTargetVersion = pxt.appTarget.versions.target;
+        let compileResult = await compileAsync(false, opts => {
+            if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+
+            // Api info needed for py2ts conversion, if project is shared in Python
+            if (opts.target.preferredEditor === pxt.PYTHON_PROJECT_NAME) {
+                opts.target.preferredEditor = pxt.JAVASCRIPT_PROJECT_NAME;
+                opts.ast = true;
+                const resp = pxtc.compile(opts);
+                const apis = getApiInfo(resp.ast, opts);
+                opts.apisInfo = apis;
+                opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME;
+            }
+
+            // Apply upgrade rules if necessary
+            const sharedTargetVersion = mainPkg.config.targetVersions?.target;
+
+            if (sharedTargetVersion && currentTargetVersion &&
+                pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), pxt.semver.parse(currentTargetVersion)) < 0) {
+                for (const fileName of Object.keys(opts.fileSystem)) {
+                    if (!pxt.Util.startsWith(fileName, "pxt_modules") && pxt.Util.endsWith(fileName, ".ts")) {
+                        didUpgrade = true;
+                        opts.fileSystem[fileName] = pxt.patching.patchJavaScript(sharedTargetVersion, opts.fileSystem[fileName]);
                     }
                 }
-            }))
-            .then(resp => {
-                if (resp.diagnostics?.length > 0 && didUpgrade) {
-                    pxt.log("Compile with upgrade rules failed, trying again with original code");
-                    return compileAsync(false, opts => {
-                        if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
-                    });
-                }
-                return resp;
-            })
-            .then(resp => {
-                if (resp.diagnostics && resp.diagnostics.length > 0) {
-                    console.error("Diagnostics", resp.diagnostics)
-                }
-                let js = resp.outfiles[pxtc.BINARY_JS];
-                if (js) {
-                    let options: pxsim.SimulatorDriverOptions = {};
-                    options.onSimulatorCommand = msg => {
-                        if (msg.command === "restart") {
-                            runOptions.storedState = getStoredState(simOptions.id)
-                            driver.run(js, runOptions);
-                        }
-                        if (msg.command == "setstate") {
-                            if (msg.stateKey && msg.stateValue) {
-                                setStoredState(simOptions.id, msg.stateKey, msg.stateValue)
-                            }
-                        }
-                    };
+            }
+        });
 
-                    let driver = new pxsim.SimulatorDriver(container, options);
+        if (compileResult.diagnostics?.length > 0 && didUpgrade) {
+            pxt.log("Compile with upgrade rules failed, trying again with original code");
+            compileResult = await compileAsync(false, opts => {
+                if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+            });
+        }
 
-                    let fnArgs = resp.usedArguments;
-                    let board = pxt.appTarget.simulator.boardDefinition;
-                    let parts = pxtc.computeUsedParts(resp, "ignorebuiltin");
-                    const usedBuiltinParts = pxtc.computeUsedParts(resp, "onlybuiltin");
-                    let storedState: Map<string> = getStoredState(simOptions.id)
-                    let runOptions: pxsim.SimulatorRunOptions = {
-                        boardDefinition: board,
-                        parts: parts,
-                        builtinParts: usedBuiltinParts,
-                        fnArgs: fnArgs,
-                        cdnUrl: pxt.webConfig.commitCdnUrl,
-                        localizedStrings: Util.getLocalizedStrings(),
-                        highContrast: simOptions.highContrast,
-                        storedState: storedState,
-                        light: simOptions.light
-                    };
-                    if (pxt.appTarget.simulator && !simOptions.fullScreen)
-                        runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio
-                            ? pxt.appTarget.simulator.partsAspectRatio
-                            : pxt.appTarget.simulator.aspectRatio;
-                    driver.run(js, runOptions);
-                }
-            })
+        if (compileResult.diagnostics && compileResult.diagnostics.length > 0) {
+            console.error("Diagnostics", compileResult.diagnostics);
+        }
+
+        return pxtc.buildSimJsInfo(compileResult);
     }
 
     function getStoredState(id: string) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -401,11 +401,13 @@ namespace pxt.runner {
 
                     let fnArgs = resp.usedArguments;
                     let board = pxt.appTarget.simulator.boardDefinition;
-                    let parts = pxtc.computeUsedParts(resp, true);
+                    let parts = pxtc.computeUsedParts(resp, "ignorebuiltin");
+                    const usedBuiltinParts = pxtc.computeUsedParts(resp, "onlybuiltin");
                     let storedState: Map<string> = getStoredState(simOptions.id)
                     let runOptions: pxsim.SimulatorRunOptions = {
                         boardDefinition: board,
                         parts: parts,
+                        builtinParts: usedBuiltinParts,
                         fnArgs: fnArgs,
                         cdnUrl: pxt.webConfig.commitCdnUrl,
                         localizedStrings: Util.getLocalizedStrings(),

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -53,8 +53,6 @@ namespace pxt.runner {
         }
 
         writeFile(module: pxt.Package, filename: string, contents: string): void {
-            if (filename == pxt.CONFIG_NAME)
-                return; // ignore config writes
             const epkg = getEditorPkg(module);
             epkg.files[filename] = contents;
         }
@@ -351,10 +349,35 @@ namespace pxt.runner {
     }
 
     export function simulateAsync(container: HTMLElement, simOptions: SimulateOptions) {
+        let didUpgrade = false;
+
         return loadPackageAsync(simOptions.id, simOptions.code, simOptions.dependencies)
             .then(() => compileAsync(false, opts => {
                 if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+
+                // Apply upgrade rules if necessary
+                const sharedTargetVersion = mainPkg.config.targetVersions.target;
+                const currentTargetVersion = pxt.appTarget.versions.target;
+
+                if (sharedTargetVersion && currentTargetVersion &&
+                    pxt.semver.cmp(pxt.semver.parse(sharedTargetVersion), pxt.semver.parse(currentTargetVersion)) < 0) {
+                    for (const fileName of Object.keys(opts.fileSystem)) {
+                        if (!pxt.Util.startsWith(fileName, "pxt_modules") && pxt.Util.endsWith(fileName, ".ts")) {
+                            didUpgrade = true;
+                            opts.fileSystem[fileName] = pxt.patching.patchJavaScript(sharedTargetVersion, opts.fileSystem[fileName]);
+                        }
+                    }
+                }
             }))
+            .then(resp => {
+                if (resp.diagnostics?.length > 0 && didUpgrade) {
+                    pxt.log("Compile with upgrade rules failed, trying again with original code");
+                    return compileAsync(false, opts => {
+                        if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+                    });
+                }
+                return resp;
+            })
             .then(resp => {
                 if (resp.diagnostics && resp.diagnostics.length > 0) {
                     console.error("Diagnostics", resp.diagnostics)

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -10,6 +10,7 @@ namespace pxsim {
         refCountingDebug?: boolean;
         options?: any;
         parts?: string[];
+        builtinParts?: string[];
         partDefinitions?: Map<PartDefinition>
         fnArgs?: any;
         code: string;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -43,6 +43,7 @@ namespace pxsim {
         trace?: boolean;
         boardDefinition?: pxsim.BoardDefinition;
         parts?: string[];
+        builtinParts?: string[];
         fnArgs?: any;
         aspectRatio?: number;
         partDefinitions?: pxsim.Map<PartDefinition>;

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -112,6 +112,7 @@
         var light = !!/light(?:[:=])1/i.exec(window.location.href);
         var fullScreen = !!/fullscreen(?:[:=])1/i.exec(window.location.href);
         var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
+        var prebuiltSimJs = /prebuilt(?:[:=])1/i.test(window.location.href);
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var codeFromData = undefined;
@@ -162,6 +163,19 @@
             }
         });
 
+        var prebuiltCodePromise = Promise.resolve(undefined);
+        if (prebuiltSimJs) {
+            var versionsuff = /localhost:/.test(window.location.href) ? "" : "@versionsuff@";
+            var builtSimJsUrl = "/static/builtjs/" + id[1] + versionsuff + ".json"
+            // kick off fetch immediately, no need to wait for ksrunnerready
+            prebuiltCodePromise = fetch(builtSimJsUrl)
+                .then(resp => resp.json())
+                .catch(e => {
+                    // TODO: send tick that something broke :(
+                    console.error("Failed to get prebuilt code")
+                });
+        }
+
         ksRunnerReady(function() {
             var theme = pxt.appTarget.appTheme;
             document.title = theme.title;
@@ -180,19 +194,22 @@
                 })
             }
             else if (!debugSim) {
-                var options = {
-                    id: id ? id[1] : undefined,
-                    code: code ? decodeURIComponent(code) : undefined,
-                    highContrast: highContrast,
-                    light: light,
-                    fullScreen: fullScreen,
-                    dependencies: deps ? decodeURIComponent(deps[1]).split(",") : undefined
-                };
-                console.log('simulating script')
-                pxt.runner.simulateAsync(sims, options).done(function() {
-                    console.log('simulator started...')
-                    $(loading).remove();
-                })
+                prebuiltCodePromise.then(builtSimJs => {
+                    var options = {
+                        id: id ? id[1] : undefined,
+                        code: code ? decodeURIComponent(code) : undefined,
+                        highContrast: highContrast,
+                        light: light,
+                        fullScreen: fullScreen,
+                        dependencies: deps ? decodeURIComponent(deps[1]).split(",") : undefined,
+                        builtJsInfo: builtSimJs,
+                    };
+                    console.log('simulating script')
+                    pxt.runner.simulateAsync(sims, options).done(function() {
+                        console.log('simulator started...')
+                        $(loading).remove();
+                    })
+                });
             }
             else {
                 $(loading).remove();

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -267,7 +267,8 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
     res: pxtc.CompileResult, options: RunOptions, trace: boolean) {
     const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
-    const parts = pxtc.computeUsedParts(res, true);
+    const parts = pxtc.computeUsedParts(res, "ignorebuiltin");
+    const usedBuiltinParts = pxtc.computeUsedParts(res, "onlybuiltin");
     const fnArgs = res.usedArguments;
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
@@ -276,6 +277,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         boardDefinition: boardDefinition,
         mute,
         parts,
+        builtinParts: usedBuiltinParts,
         debug,
         trace,
         fnArgs,

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -265,11 +265,13 @@ export interface RunOptions {
 
 export function run(pkg: pxt.MainPackage, debug: boolean,
     res: pxtc.CompileResult, options: RunOptions, trace: boolean) {
-    const js = res.outfiles[pxtc.BINARY_JS]
     const boardDefinition = pxt.appTarget.simulator.boardDefinition;
-    const parts = pxtc.computeUsedParts(res, "ignorebuiltin");
-    const usedBuiltinParts = pxtc.computeUsedParts(res, "onlybuiltin");
-    const fnArgs = res.usedArguments;
+    const {
+        js,
+        fnArgs,
+        parts,
+        usedBuiltinParts,
+    } = pxtc.buildSimJsInfo(res);
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
 


### PR DESCRIPTION
For speeding up asphodel ~

Original prs:
* share page upgrade rules https://github.com/microsoft/pxt/pull/7463 (note there's a 1 line fix to this pr I added to 7681 to fix doc page sims)
* parts change was for microbit v2 sim support, already released there https://github.com/microsoft/pxt/pull/7544 
* fix share page for python projects https://github.com/microsoft/pxt/pull/7555
* prebuilt sim https://github.com/microsoft/pxt/pull/7681

All cherry-picked cleanly / no changes specific to this pr. Most of the code for the other two share page fixes was refactored into a separate function in the prebuilt sim pr, so the green portion is very similar in that vs this.