### PR TITLE
remove version suffix from builtsimjsurl

### DIFF
--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -120,7 +120,7 @@
             codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
         } catch (e) {
             /**
-             *  Internet Explorer 11 and Microsoft Edge throw an exception when checking 
+             *  Internet Explorer 11 and Microsoft Edge throw an exception when checking
              *  if the frame element exists when the iframe is on a different origin
              */
         }
@@ -165,8 +165,7 @@
 
         var prebuiltCodePromise = Promise.resolve(undefined);
         if (prebuiltSimJs) {
-            var versionsuff = /localhost:/.test(window.location.href) ? "" : "@versionsuff@";
-            var builtSimJsUrl = "/static/builtjs/" + id[1] + versionsuff + ".json"
+            var builtSimJsUrl = "/static/builtjs/" + id[1] + ".json"
             // kick off fetch immediately, no need to wait for ksrunnerready
             prebuiltCodePromise = fetch(builtSimJsUrl)
                 .then(resp => resp.json())


### PR DESCRIPTION
Right now it's not getting replaced as run.html is a special cased html page, and `pxtConfig` is just getting '?' for the target version, so just remove the version suffix. For now, drop the `@versionsuff@` and just point to `builtjs/{share-id}.json`, and when we get the next release I'll version it then (as my future change wouldn't require a backend update, as it's not using run.html)