### PR TITLE
mono-repo 2

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1136,7 +1136,13 @@ namespace pxt.github {
         // patch depdencies
         U.values(slugVersions)
             .forEach(v => v.deps
-                .forEach(dep => deps[dep.id] = pxt.github.stringifyRepo(dep.ghid)))
+                .forEach(dep => {
+                    if (dep.ghid.tag !== v.tag) {
+                        pxt.debug(`dep: ${pxt.github.stringifyRepo(dep.ghid)} -> ${v.tag}`);
+                        dep.ghid.tag = v.tag;
+                        deps[dep.id] = pxt.github.stringifyRepo(dep.ghid);
+                    }
+                }))
 
         return deps;
     }

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -646,6 +646,7 @@ namespace pxt {
                 if (!deps) deps = from.dependencies(isCpp)
                 for (let id of Object.keys(deps)) {
                     let ver = deps[id] || "*"
+                    pxt.debug(`dep: load ${from.id}.${id}${isCpp ? "++" : ""}: ${ver}`)
                     if (id == "hw" && pxt.hwVariant)
                         id = "hw---" + pxt.hwVariant
                     let mod = from.resolveDep(id)

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -616,7 +616,7 @@ namespace pxt {
                         // this may be an issue if the user does not create releases
                         // and pulls from master
                         const modtag = modid?.tag || mod.config?.version;
-                        const c= pxt.semver.strcmp(modtag, verid.tag);
+                        const c = pxt.semver.strcmp(modtag, verid.tag);
                         if (c == 0) {
                             // turns out to be the same versions
                             pxt.debug(`resolved version are ${modtag}`)

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -615,7 +615,7 @@ namespace pxt {
                         // if modid does not have a tag, try sniffing it from config
                         // this may be an issue if the user does not create releases
                         // and pulls from master
-                        const modtag = modid?.tag || mod?.config.version;
+                        const modtag = modid?.tag || mod.config?.version;
                         const c= pxt.semver.strcmp(modtag, verid.tag);
                         if (c == 0) {
                             // turns out to be the same versions

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -603,15 +603,59 @@ namespace pxt {
                 })
             }
 
+            const handleVerMismatch = (mod: Package, ver: string) => {
+                pxt.debug(`version spec mismatch: ${mod._verspec} != ${ver}`)
+
+                // if both are github, try to pick the higher semver
+                if (/^github:/.test(mod._verspec) && /^github:/.test(ver)) {
+                    const modid = pxt.github.parseRepoId(mod._verspec);
+                    const verid = pxt.github.parseRepoId(ver);
+                    // same repo
+                    if (modid?.slug && modid?.slug === verid?.slug) {
+                        // if modid does not have a tag, try sniffing it from config
+                        // this may be an issue if the user does not create releases
+                        // and pulls from master
+                        const modtag = modid?.tag || mod?.config.version;
+                        const c= pxt.semver.strcmp(modtag, verid.tag);
+                        if (c == 0) {
+                            // turns out to be the same versions
+                            pxt.debug(`resolved version are ${modtag}`)
+                            return;
+                        }
+                        else if (c < 0) {
+                            // already loaded version of dependencies is greater
+                            // than current version, use it instead
+                            pxt.debug(`auto-upgraded ${ver} to ${modtag}`)
+                            return;
+                        }
+                    }
+                }
+
+                // ignore, file: protocol
+                if (/^file:/.test(mod._verspec) || /^file:/.test(ver)) {
+                    pxt.debug(`ignore file: mismatch issues`)
+                    return;
+                }
+
+                // crashing if really really not good
+                // so instead we just ignore and continute
+                mod.configureAsInvalidPackage(lf("version mismatch"))
+            }
 
             const loadDepsRecursive = async (deps: pxt.Map<string>, from: Package, isCpp = false) => {
                 if (!deps) deps = from.dependencies(isCpp)
                 for (let id of Object.keys(deps)) {
-                    const ver = deps[id] || "*"
+                    let ver = deps[id] || "*"
                     if (id == "hw" && pxt.hwVariant)
                         id = "hw---" + pxt.hwVariant
                     let mod = from.resolveDep(id)
                     if (mod) {
+                        // check if the current dependecy matches the ones
+                        // loaded in parent
+                        if (!mod.invalid() && mod._verspec !== ver)
+                            handleVerMismatch(mod, ver);
+
+                        // bail out if invalid
                         if (mod.invalid()) {
                             // failed to resolve dependency, ignore
                             mod.level = Math.min(mod.level, from.level + 1)
@@ -619,8 +663,6 @@ namespace pxt {
                             continue
                         }
 
-                        if (mod._verspec != ver && !/^file:/.test(mod._verspec) && !/^file:/.test(ver))
-                            U.userError("Version spec mismatch on " + id)
                         if (!isCpp) {
                             mod.level = Math.min(mod.level, from.level + 1)
                             mod.addedBy.push(from)

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -662,8 +662,12 @@ namespace pxt {
             }
 
             const loadDepsRecursive = async (deps: pxt.Map<string>, from: Package, isCpp = false) => {
-                if (!deps) deps = from.dependencies(isCpp)
+                if (!deps) deps = from.dependencies(isCpp);
+
                 pxt.debug(`deps: ${from.id}->${Object.keys(deps).join(", ")}`);
+                deps = pxt.github.resolveMonoRepoVersions(deps);
+                pxt.debug(`deps: resolved ${from.id}->${Object.keys(deps).join(", ")}`);
+
                 for (let id of Object.keys(deps)) {
                     let ver = deps[id] || "*"
                     pxt.debug(`dep: load ${from.id}.${id}${isCpp ? "++" : ""}: ${ver}`)

--- a/theme/common.less
+++ b/theme/common.less
@@ -194,8 +194,8 @@ pre {
     margin-top: 0;
     margin-bottom: 0;
     width: 100%;
-    background-color: @simulatorBackground;
-    z-index: @simulatorZIndex;
+    background-color: @filelistBackgroundColor;
+    z-index: @filelistZIndex;
 }
 
 #filelist .simtoolbar {
@@ -241,11 +241,19 @@ pre {
 
 #filelist .nested.item {
     padding: .92857143em 1.14285714em;
-    padding-left: 2rem;
+    padding-left: 1rem;
 }
 
-#filelist .header {
-    background: rgba(0,0,0,0.05);
+#filelist .header.item {
+    background: @filelistHeaderBackground;
+}
+
+#filelist .folder.item {
+    font-weight: bold;
+}
+
+#filelist .folderitem.item {
+    padding-left: 2rem;
 }
 
 #simulators {

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -216,6 +216,12 @@
 @serialConsoleBackground: @simulatorBackground;
 
 /*-------------------
+   Filelist
+--------------------*/
+@filelistBackgroundColor: @simulatorBackground;
+@filelistHeaderBackground:  rgba(0,0,0,0.05);
+
+/*-------------------
    Github Diff editor
 --------------------*/
 @githubBackgroundColor: @serialBackgroundColor;

--- a/theme/themes/pxt/globals/zindex.variables
+++ b/theme/themes/pxt/globals/zindex.variables
@@ -52,6 +52,8 @@
 @simulatorZIndex: @editorToolsZIndex+1; /* Needs to be on top of @editorToolsZIndex for mobile/tablet view */
 @editorLogoZIndex: ((@blocklyFlyoutZIndex)-1); /* Should be below the flyouts blocklyFlyout and @monacoFlyoutZIndex */
 
+@filelistZIndex: @simulatorZIndex;
+
 /* Tutorial */
 @tutorialCardZIndex: @simulatorZIndex+2;
 @tutorialLightboxCardZIndex: @tutorialCardZIndex+1;

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -163,24 +163,25 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
 
     private packageOf(p: pkg.EditorPackage) {
         const expandedPkg = this.state.expandedPkg;
+        const pkgid = p.getPkgId();
         const del = !pxt.shell.isReadOnly()
-            && p.getPkgId() != pxt.appTarget.id
-            && p.getPkgId() != "built"
-            && p.getPkgId() != "assets"
-            && p.getPkgId() != pxt.appTarget.corepkg
+            && pkgid != pxt.appTarget.id
+            && pkgid != "built"
+            && pkgid != "assets"
+            && pkgid != pxt.appTarget.corepkg
             && p.getKsPkg().config && !p.getKsPkg().config.core
             && p.getKsPkg().level <= 1;
-        const upd = p.getKsPkg() && p.getKsPkg().verProtocol() == "github";
+        const upd = del && p.getKsPkg()?.verProtocol() == "github";
         const meta: pkg.PackageMeta = this.getData("open-pkg-meta:" + p.getPkgId());
         let version = upd ? p.getKsPkg().verArgument().split('#')[1] : undefined; // extract github tag
         if (version && version.length > 20) version = version.substring(0, 7);
-        return [<PackgeTreeItem key={"hd-" + p.getPkgId()}
-            pkg={p} isActive={expandedPkg == p.getPkgId()} onItemClick={this.togglePkg}
+        return [<PackgeTreeItem key={"hd-" + pkgid}
+            pkg={p} isActive={expandedPkg == pkgid} onItemClick={this.togglePkg}
             hasDelete={del} onItemRemove={this.removePkg}
             version={version} hasRefresh={upd} onItemRefresh={this.updatePkg} >
             {!meta.numErrors ? null : <span className='ui label red'>{meta.numErrors}</span>}
-            {p.getPkgId()}
-            {expandedPkg == p.getPkgId() ?
+            {pkgid}
+            {expandedPkg == pkgid ?
                 <div role="group" className="menu">
                     {this.filesOf(p)}
                 </div> : undefined}
@@ -498,13 +499,13 @@ class PackgeTreeItem extends sui.StatelessUIElement<PackageTreeItemProps> {
     }
 
     handleRefresh(e: React.MouseEvent<HTMLElement>) {
-        this.props.onItemRefresh(this.props.pkg);
         e.stopPropagation();
+        this.props.onItemRefresh(this.props.pkg);
     }
 
     handleRemove(e: React.MouseEvent<HTMLElement>) {
-        this.props.onItemRemove(this.props.pkg);
         e.stopPropagation();
+        this.props.onItemRemove(this.props.pkg);
     }
 
     private handleButtonKeydown(e: React.KeyboardEvent<HTMLElement>) {

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -404,7 +404,7 @@ class FolderTreeItem extends sui.StatelessUIElement<FolderTreeItemProps> {
             return children;
 
         return <>
-            <div className="folder item" role="treeitem" 
+            <div className="folder item" role="treeitem"
                 aria-selected={false}
                 aria-label={lf("Files in folder {0}", folder)}>
                 <i className="folder open outline icon"></i>

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -119,11 +119,11 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
 
     private folderOf(pkg: pkg.EditorPackage, folder: string, files: pkg.File[]): JSX.Element {
         return <>
-            {folder && <div className="folder item" role="treeitem"
+            {folder && <div className="folder item" key={"folder" + folder} role="treeitem"
                 aria-label={lf("Files in folder {0}", folder)}>
-                    <i className="folder open outline icon"></i>
-                    {folder}
-                    </div>}
+                <i className="folder open outline icon"></i>
+                {folder}
+            </div>}
             {this.filesFolderOf(pkg, folder, files)}
         </>
     }
@@ -165,7 +165,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                 && !file.isReadonly();
             const nameStart = folder.length ? folder.length + 1 : 0;
             return (
-                <FileTreeItem key={"file" + file.getName()}
+                <FileTreeItem
+                    key={"file" + file.getName()}
                     file={file}
                     meta={meta}
                     onItemClick={this.setFile}
@@ -178,7 +179,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
                     shareUrl={shareUrl}
                     addLocalizedFile={addLocale && localized}
                     className={(currentFile == file ? "active " : "") + (pkg.isTopLevel() ? "" : "nested ") + (folder ? "folderitem " : "") + "item"}
-                 >
+                >
                     {file.name.slice(nameStart)}
                     {showStar ? "*" : ""}
                     {meta.isGitModified ? " ↑" : ""}

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -113,22 +113,13 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             ffiles.push(f);
         })
         return Object.keys(folders)
-            .map(folder => this.folderOf(pkg, folder, folders[folder]))
+            .map(folder => <FolderTreeItem key={folder} folder={folder}>
+                {this.folderFilesOf(pkg, folder, files)}
+            </FolderTreeItem>)
             .reduce((l, r) => l.concat(r), [])
     }
 
-    private folderOf(pkg: pkg.EditorPackage, folder: string, files: pkg.File[]): JSX.Element {
-        return <>
-            {folder && <div className="folder item" key={"folder" + folder} role="treeitem"
-                aria-label={lf("Files in folder {0}", folder)}>
-                <i className="folder open outline icon"></i>
-                {folder}
-            </div>}
-            {this.filesFolderOf(pkg, folder, files)}
-        </>
-    }
-
-    private filesFolderOf(pkg: pkg.EditorPackage, folder: string, files: pkg.File[]): JSX.Element[] {
+    private folderFilesOf(pkg: pkg.EditorPackage, folder: string, files: pkg.File[]): JSX.Element[] {
         const { currentFile } = this.state;
         const header = this.props.parent.state.header;
         const topPkg = pkg.isTopLevel();
@@ -396,6 +387,28 @@ namespace custom {
     }
 }
 
+interface FolderTreeItemProps {
+    folder: string;
+    children: any;
+}
+
+class FolderTreeItem extends sui.StatelessUIElement<FolderTreeItemProps> {
+    constructor(props: FolderTreeItemProps) {
+        super(props);
+    }
+
+    renderCore() {
+        const { folder, children } = this.props;
+        return <>
+            {folder && <div className="folder item" key={"folder" + folder} role="treeitem"
+                aria-label={lf("Files in folder {0}", folder)}>
+                <i className="folder open outline icon"></i>
+                {folder}
+            </div>}
+            {children}
+        </>
+    }
+}
 interface FileTreeItemProps {
     file: pkg.File;
     meta: pkg.FileMeta;

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -113,8 +113,8 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             ffiles.push(f);
         })
         return Object.keys(folders)
-            .map(folder => <FolderTreeItem key={folder} folder={folder}>
-                {this.folderFilesOf(pkg, folder, files)}
+            .map(folder => <FolderTreeItem key={"folder-" + folder} folder={folder}>
+                {this.folderFilesOf(pkg, folder, folders[folder])}
             </FolderTreeItem>)
             .reduce((l, r) => l.concat(r), [])
     }
@@ -157,7 +157,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
             const nameStart = folder.length ? folder.length + 1 : 0;
             return (
                 <FileTreeItem
-                    key={"file" + file.getName()}
+                    key={"file-" + file.getName()}
                     file={file}
                     meta={meta}
                     onItemClick={this.setFile}
@@ -399,13 +399,17 @@ class FolderTreeItem extends sui.StatelessUIElement<FolderTreeItemProps> {
 
     renderCore() {
         const { folder, children } = this.props;
+
+        if (!folder)
+            return children;
+
         return <>
-            {folder && <div className="folder item" key={"folder" + folder} role="treeitem" 
+            <div className="folder item" role="treeitem" 
                 aria-selected={false}
                 aria-label={lf("Files in folder {0}", folder)}>
                 <i className="folder open outline icon"></i>
                 {folder}
-            </div>}
+            </div>
             {children}
         </>
     }

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -400,7 +400,8 @@ class FolderTreeItem extends sui.StatelessUIElement<FolderTreeItemProps> {
     renderCore() {
         const { folder, children } = this.props;
         return <>
-            {folder && <div className="folder item" key={"folder" + folder} role="treeitem"
+            {folder && <div className="folder item" key={"folder" + folder} role="treeitem" 
+                aria-selected={false}
                 aria-label={lf("Files in folder {0}", folder)}>
                 <i className="folder open outline icon"></i>
                 {folder}

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -394,8 +394,8 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         try {
             const ghid = this.parsedRepoId();
             const tags = await pxt.github.listRefsAsync(ghid.slug, "tags")
-            pxt.semver.sortLatestTags(tags)
-            currv = tags[0];
+            const stags = pxt.semver.sortLatestTags(tags)
+            currv = stags[0];
         } catch (e) {
             console.log(e)
         }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -414,6 +414,7 @@ export class ProjectsMenu extends data.Component<ISettingsProps, {}> {
 
 interface HeroBannerState {
     cardIndex?: number;
+    paused?: boolean;
 }
 
 const HERO_BANNER_DELAY = 10000; // 10 seconds per card
@@ -437,7 +438,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
 
     private handleSetCardIndex(index: number) {
         this.stopRefresh();
-        this.setState({ cardIndex: index });
+        this.setState({ cardIndex: index, paused: true });
     }
 
     private handleCardClick() {
@@ -452,7 +453,8 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
     }
 
     private startRefresh() {
-        if (!this.carouselInterval && this.prevGalleries && this.prevGalleries.length) {
+        const { paused } = this.state;
+        if (!paused && !this.carouselInterval && this.prevGalleries && this.prevGalleries.length) {
             pxt.debug(`start refreshing hero carousel`)
             this.carouselInterval = setInterval(this.handleRefreshCard, HERO_BANNER_DELAY);
             this.handleRefreshCard();
@@ -524,7 +526,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
                 </sui.Link>
             </div>}
             {cardIndex !== undefined && cards?.length > 1 && <div key="cards" className="dots">
-                {cards.map((card, i) => <button key={i} className={`ui button empty circular label  clear ${i === cardIndex && "active"}`} onClick={handleSetCard(i)}>
+                {cards.map((_, i) => <button key={"dot" + i} className={`ui button empty circular label  clear ${i === cardIndex && "active"}`} onClick={handleSetCard(i)}>
                 </button>)}
             </div>}
         </div>

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -667,16 +667,17 @@ export async function bumpAsync(hd: Header, newVer = "") {
     cfg.version = newVer || bumpedVersion(cfg)
     const releaseTag = "v" + cfg.version;
 
-    // if any other github repo is referenced, also patch their version
-    // since those extensions are part of the same repo and share the same versions
+    // if any other github repo is referenced, unbound their version
+    // those extensions are part of the same repo and their version will be resolved
+    // at load time
     if (cfg.dependencies) {
         const gh = pxt.github.parseRepoId(hd.githubId);
         Object.keys(cfg.dependencies).forEach(k => {
             const ver = cfg.dependencies[k];
             const ghid = /^github:/.test(ver) && pxt.github.parseRepoId(ver);
             if (ghid && gh.slug === ghid.slug) {
-                cfg.dependencies[k] = `github:${pxt.github.join(gh.slug, ghid.fileName)}#${releaseTag}`
-                pxt.log(`patching dep ${k} to ${cfg.dependencies[k]}`)
+                cfg.dependencies[k] = `github:${pxt.github.join(gh.slug, ghid.fileName)}`
+                pxt.debug(`patching dep ${k} to ${cfg.dependencies[k]}`)
             }
         })
     }


### PR DESCRIPTION
Handles package version resolution when using interdependent github repositories that are unbound. This happens a lot in mono-repo.

Let's look at a simple example of a root extension with nested extension reference the root.

```
parent/
parent/child <-- reference jacdac
```

When creating a release, all extensions within the repo share the tag, so we should leave the version tag of ``parent`` unbound in the ``child`` dependecy list to avoid versioning conflicts.

If a script references ``child``, when a ``parent`` is resolve, we first check if we've already found a tag for that ``child`` - hence thta repo. We use that tag for ``parent`` as well.

If a script reference ``parent`` and ``child`` is already referenced from the top level script dependency list, we will try to resolve the version using semver. Depending on the load order, the resolution might fail on the repo is marked as invalid.

When a script references multiple nested mono-repo extensions with different release tags, we align all nested extensions to the latest tag.

```
parent/
parent/child#v0.0.0
parent/child2#v1.0.0 <-- this version wins
```

Extra: 
- [x] nicer folder rendering in filelist
![image](https://user-images.githubusercontent.com/4175913/101880574-6ffcc580-3b93-11eb-9eed-905881258f5a.png)
- [x] fix in dot click in hero banner