### PR TITLE
Fix skillmap for localized languages

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -179,7 +179,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         this.queryFlags = parseQuery();
         let config = await pxt.targetConfigAsync();
         let hash = parseHash(window.location.hash || config.skillMap?.defaultPath);
-        // await this.initLocalizationAsync();
+        await this.initLocalizationAsync();
         this.fetchAndParseSkillMaps(hash.cmd as MarkdownSource, hash.arg);
     }
 

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -179,7 +179,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         this.queryFlags = parseQuery();
         let config = await pxt.targetConfigAsync();
         let hash = parseHash(window.location.hash || config.skillMap?.defaultPath);
-        await this.initLocalizationAsync();
+        // await this.initLocalizationAsync();
         this.fetchAndParseSkillMaps(hash.cmd as MarkdownSource, hash.arg);
     }
 

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -110,11 +110,6 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     protected onMessageReceived = (event: MessageEvent) => {
         const data = event.data as pxt.editor.EditorMessageRequest;
 
-        if ((data.type as string) === "ready") {
-            this.handleWorkspaceReadyEventAsync();
-            return;
-        }
-
         if (data.type === "pxteditor" && data.id && this.pendingMessages[data.id]) {
             this.onResponseReceived(this.pendingMessages[data.id], event.data as pxt.editor.EditorMessageResponse);
             delete this.pendingMessages[data.id];
@@ -130,6 +125,11 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
                 break;
             case "workspacesave":
                 this.handleWorkspaceSaveRequestAsync(data as pxt.editor.EditorWorkspaceSaveRequest);
+                break;
+            case "workspaceevent":
+                if ((data as pxt.editor.EditorWorkspaceEvent).event.type === "createproject") {
+                    this.handleWorkspaceReadyEventAsync();
+                }
                 break;
             default:
                 // console.log(JSON.stringify(data, null, 4));


### PR DESCRIPTION
Looks like we had a timing issue when the editor pauses to load localizations. Switching to the event that Shannon added which should fix the skillmap in localized languages.