### PR TITLE
fix pathing for local serve in docs, issue with lang picker on /pkg

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -40,7 +40,8 @@ function setupRootDir() {
         path.join(nodeutil.targetDir, "node_modules", `pxt-${pxt.appTarget.id}-sim`, "public"),
         path.join(nodeutil.pxtCoreDir, "built/web"),
         path.join(nodeutil.pxtCoreDir, "webapp/public"),
-        path.join(nodeutil.pxtCoreDir, "common-docs")
+        path.join(nodeutil.pxtCoreDir, "common-docs"),
+        path.join(nodeutil.pxtCoreDir, "docs"),
     ]
     docsDir = path.join(root, "docs")
     packagedDir = path.join(root, "built/packaged")
@@ -1094,6 +1095,8 @@ export function serveAsync(options: ServeOptions) {
         } else if (U.startsWith(pathname, "/docfiles/")) {
             pathname = pathname.slice(10)
             dd = docfilesdirs
+        } else if (U.startsWith(pathname, "./static/")) {
+            pathname = pathname.slice(1);
         }
         for (let dir of dd) {
             let filename = path.resolve(path.join(dir, pathname))

--- a/docfiles/docs.js
+++ b/docfiles/docs.js
@@ -314,6 +314,13 @@ function buildLangPicker() {
         var modalContainer = document.querySelector("#langmodal");
         var initialLang = pxt && pxt.Util.normalizeLanguageCode(pxt.BrowserUtils.getCookieLang())[0];
         var localesContainer = document.querySelector("#availablelocales");
+
+        if (!localesContainer || !modalContainer) {
+            var langPicker = document.querySelector('#langpicker');
+            if (langPicker) langPicker.remove();
+            return;
+        }
+
         appTheme.availableLocales.forEach(function(locale) {
             var card = languageOption(locale);
             localesContainer.appendChild(card);

--- a/docfiles/package.html
+++ b/docfiles/package.html
@@ -63,6 +63,7 @@
         })
     </script>
 
+    <!-- @include langpicker.html -->
     <!-- @include footer.html -->
     <!-- @include tracking.html -->
 </body>


### PR DESCRIPTION
Hassan pointed out last night that the `/pkg/{repo slug}` page on local serve was behaving poorly -- since most of our icon urls are defined as relative paths (https://github.com/microsoft/pxt-arcade/blob/1517905b5d614a77a433dd7328b6be1ae92586df/pxtarget.json#L438) they get messed up (in this case, it ended up making requests to github as it was relative under the `/pkg/` endpoint, which causes the local serve to crash.

Fix that and a few other minor issues I noticed along the way
* fix refs to images defined in `pxt/docs/static`
* patch relative links to ./static/ (these get automatically swapped out for the cdn links in the backend anyways)
* Don't error when pulling in docs.js on a page without langpicker
* add langpicker to /pkg/ so the button works (the translations don't work locally for me, but they appear to if you go to pkg/{slug}?lang=zh-CN on a live site? 