### PR TITLE
Upgrade tutorial tiles from old tilemaps into user's project

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -545,6 +545,9 @@ namespace pxt.editor {
         blockId?: string;
     }
 
+
+    export let upgradeXml: (code: string) => void;
+
     export let initExtensionsAsync: (opts: ExtensionOptions) => Promise<ExtensionResult>
         = opts => Promise.resolve<ExtensionResult>({});
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -545,9 +545,6 @@ namespace pxt.editor {
         blockId?: string;
     }
 
-
-    export let upgradeXml: (code: string) => void;
-
     export let initExtensionsAsync: (opts: ExtensionOptions) => Promise<ExtensionResult>
         = opts => Promise.resolve<ExtensionResult>({});
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -816,6 +816,9 @@ namespace pxt {
                 case AssetType.Image:
                     return this.state.images.getByID(name) || this.gallery.images.getByID(name);
                 case AssetType.Tile:
+                    if (name == "myTiles.tile0") {
+                        return this.getTransparency(16);
+                    }
                     return this.state.tiles.getByID(name) || this.gallery.tiles.getByID(name);
                 case AssetType.Tilemap:
                     return this.state.tilemaps.getByID(name) || this.gallery.tilemaps.getByID(name);

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -552,13 +552,6 @@ namespace pxt {
             return new pxt.sprite.TilemapData(tilemap, tileset, layers.data());
         }
 
-        public getTileWidth(): number {
-            const tilemaps = this.state.tilemaps.getSnapshot();
-            if (tilemaps.length == 0)
-                return 16; // default tile size
-            return tilemaps[0].data.tileset.tileWidth; // Assuming that all tilemaps have the same size tiles
-        }
-
         public resolveTile(id: string): Tile {
             return this.lookupAsset(AssetType.Tile, id) as Tile;
         }
@@ -823,9 +816,6 @@ namespace pxt {
                 case AssetType.Image:
                     return this.state.images.getByID(name) || this.gallery.images.getByID(name);
                 case AssetType.Tile:
-                    if (name == "myTiles.tile0") {
-                        return this.getTransparency(this.getTileWidth());
-                    }
                     return this.state.tiles.getByID(name) || this.gallery.tiles.getByID(name);
                 case AssetType.Tilemap:
                     return this.state.tilemaps.getByID(name) || this.gallery.tilemaps.getByID(name);

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -816,6 +816,16 @@ namespace pxt {
                 case AssetType.Image:
                     return this.state.images.getByID(name) || this.gallery.images.getByID(name);
                 case AssetType.Tile:
+                    const matchTransparency = /^myTiles\.transparency([0-9]+)$/
+                    const ret = name.match(matchTransparency);
+                    if (ret) {
+                        const tile = this.state.tiles.getByID(name);
+                        if (!tile) {
+                            return this.getTransparency(parseInt(ret[1]));
+                        } else {
+                            return tile;
+                        }
+                    }
                     return this.state.tiles.getByID(name) || this.gallery.tiles.getByID(name);
                 case AssetType.Tilemap:
                     return this.state.tilemaps.getByID(name) || this.gallery.tilemaps.getByID(name);

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -552,6 +552,13 @@ namespace pxt {
             return new pxt.sprite.TilemapData(tilemap, tileset, layers.data());
         }
 
+        public getTileWidth(): number {
+            const tilemaps = this.state.tilemaps.getSnapshot();
+            if (tilemaps.length == 0)
+                return 16; // default tile size
+            return tilemaps[0].data.tileset.tileWidth; // Assuming that all tilemaps have the same size tiles
+        }
+
         public resolveTile(id: string): Tile {
             return this.lookupAsset(AssetType.Tile, id) as Tile;
         }
@@ -817,7 +824,7 @@ namespace pxt {
                     return this.state.images.getByID(name) || this.gallery.images.getByID(name);
                 case AssetType.Tile:
                     if (name == "myTiles.tile0") {
-                        return this.getTransparency(16);
+                        return this.getTransparency(this.getTileWidth());
                     }
                     return this.state.tiles.getByID(name) || this.gallery.tiles.getByID(name);
                 case AssetType.Tilemap:

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1470,6 +1470,7 @@ export class ProjectView
         return this.loadBlocklyAsync()
             .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.tutorial, t.language))
             .then((usedBlocks) => {
+                tutorial.xmlUpgrades(t.tutorialCode, t.language);
                 let editorState: pxt.editor.EditorState = {
                     searchBar: false
                 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1468,9 +1468,9 @@ export class ProjectView
 
         const t = header.tutorial;
         return this.loadBlocklyAsync()
+            .then(() => tutorial.xmlUpgrades(t.tutorialCode, t.language))
             .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.tutorial, t.language))
             .then((usedBlocks) => {
-                tutorial.xmlUpgrades(t.tutorialCode, t.language);
                 let editorState: pxt.editor.EditorState = {
                     searchBar: false
                 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1526,8 +1526,9 @@ export class ProjectView
         else {
             decompilePromise = compiler.decompileBlocksSnippetAsync(template)
                 .then(resp => {
-                    const blockXML = tutorial.upgradeTutorialXml(resp.outfiles["main.blocks"], header.targetVersion);
+                    let blockXML = resp.outfiles["main.blocks"];
                     if (blockXML) {
+                        blockXML = tutorial.upgradeTutorialXml(blockXML, header.targetVersion)
                         pkg.mainEditorPkg().setFile("main.blocks", blockXML);
                     }
                 })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1468,7 +1468,6 @@ export class ProjectView
 
         const t = header.tutorial;
         return this.loadBlocklyAsync()
-            .then(() => tutorial.xmlUpgrades(t.tutorialCode, t.language))
             .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.tutorial, t.language))
             .then((usedBlocks) => {
                 let editorState: pxt.editor.EditorState = {
@@ -1527,7 +1526,7 @@ export class ProjectView
         else {
             decompilePromise = compiler.decompileBlocksSnippetAsync(template)
                 .then(resp => {
-                    const blockXML = resp.outfiles["main.blocks"];
+                    const blockXML = tutorial.upgradeTutorialXml(resp.outfiles["main.blocks"], header.targetVersion);
                     if (blockXML) {
                         pkg.mainEditorPkg().setFile("main.blocks", blockXML);
                     }
@@ -3141,7 +3140,9 @@ export class ProjectView
         return compiler.getBlocksAsync()
             .then(blocksInfo => compiler.decompileBlocksSnippetAsync(req.ts, blocksInfo, req))
             .then(resp => {
-                const svg = pxt.blocks.render(resp.outfiles["main.blocks"], {
+                const header = pkg.mainEditorPkg().header;
+                const blocksXml = tutorial.upgradeTutorialXml(resp.outfiles["main.blocks"], header.targetVersion);
+                const svg = pxt.blocks.render(blocksXml, {
                     snippetMode: req.snippetMode || false,
                     layout: req.layout !== undefined ? req.layout : pxt.blocks.BlockLayout.Align,
                     splitSvg: false

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1528,7 +1528,7 @@ export class ProjectView
                 .then(resp => {
                     let blockXML = resp.outfiles["main.blocks"];
                     if (blockXML) {
-                        blockXML = tutorial.upgradeTutorialXml(blockXML, header.targetVersion)
+                        blockXML = tutorial.upgradeTutorialXml(blockXML, header.targetVersion);
                         pkg.mainEditorPkg().setFile("main.blocks", blockXML);
                     }
                 })

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -16,6 +16,21 @@ import * as editortoolbar from "./editortoolbar";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
+export function xmlUpgrades(code: string[], language?: string,) {
+    compiler.getBlocksAsync()
+        .then(blocksInfo => {
+            pxt.blocks.initializeAndInject(blocksInfo);
+            if (language == "python")
+                return compiler.pySnippetArrayToBlocksAsync(code, blocksInfo);
+            return compiler.decompileBlocksSnippetAsync(code.join("\n"), blocksInfo);
+        }).then(resp => {
+            const blocksXml = resp.outfiles["main.blocks"];
+            if (pxt.editor.upgradeXml) {
+                pxt.editor.upgradeXml(blocksXml);
+            }
+        })
+}
+
 /**
  * We'll run this step when we first start the tutorial to figure out what blocks are used so we can
  * filter the toolbox.

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -16,8 +16,9 @@ import * as editortoolbar from "./editortoolbar";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
-export function xmlUpgrades(code: string[], language?: string,) {
-    compiler.getBlocksAsync()
+export function xmlUpgrades(code: string[], language?: string): Promise<void> {
+    if (pxt.editor.upgradeXml) {
+        return compiler.getBlocksAsync()
         .then(blocksInfo => {
             pxt.blocks.initializeAndInject(blocksInfo);
             if (language == "python")
@@ -25,10 +26,11 @@ export function xmlUpgrades(code: string[], language?: string,) {
             return compiler.decompileBlocksSnippetAsync(code.join("\n"), blocksInfo);
         }).then(resp => {
             const blocksXml = resp.outfiles["main.blocks"];
-            if (pxt.editor.upgradeXml) {
-                pxt.editor.upgradeXml(blocksXml);
-            }
+            pxt.editor.upgradeXml(blocksXml);
         })
+    }
+
+    return Promise.resolve();
 }
 
 /**


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2568

corresponding pxt-arcade PR: https://github.com/microsoft/pxt-arcade/pull/2727

The issue was when we initiate the tilemap block, we try to decode all the tiles, but the tiles don't exist in the project. This will add all the custom tiles to the user's tileset -- it looks like this for Side Scroller:
![image](https://user-images.githubusercontent.com/18712271/102120018-d1709e80-3df6-11eb-9c69-4bf4f3fdc426.png)

Questions I have:
- Should I be worried about adding another decompile in? Should I try to store what we had before and use that?
- Is it best to separate out the XML upgrade logic into pxt-arcade? Or should I move it to here? 


Try out the upload hereee: https://arcade.makecode.com/app/5f84aab6ae563167ac13981b277805cda8157511-9d50993b91

The tutorials we have with the old tilemaps are: 

- Barrel Dodger
- Simple Extensions
- Maze
- Side Scroller
- Setting the Scene
- Breadcrumb Trail
