### PR TITLE
option to run single simulators

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -15,6 +15,8 @@ namespace pxt.runner {
         fullScreen?: boolean;
         dependencies?: string[];
         builtJsInfo?: pxtc.BuiltSimJsInfo;
+        // single simulator frame, no message simulators
+        single?: boolean;
     }
 
     class EditorPackage {
@@ -390,6 +392,7 @@ namespace pxt.runner {
             highContrast: simOptions.highContrast,
             storedState: storedState,
             light: simOptions.light,
+            single: simOptions.single,
         };
         if (pxt.appTarget.simulator && !simOptions.fullScreen)
             runOptions.aspectRatio = parts.length && pxt.appTarget.simulator.partsAspectRatio

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -24,6 +24,7 @@ namespace pxsim {
         breakOnStart?: boolean;
         storedState?: Map<any>;
         ipc?: boolean;
+        single?: boolean;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -441,7 +441,6 @@ namespace pxsim {
             this.setState(starting ? SimulatorState.Starting : SimulatorState.Stopped);
             if (unload)
                 this.unload();
-            this.removeEventListeners();
         }
 
         public suspend() {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -300,7 +300,7 @@ namespace pxsim {
 
             const single = !!this._currentRuntime.single;
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
-            if (!single && source && broadcastmsg?.broadcast) {
+            if (source && broadcastmsg?.broadcast) {
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const parentWindow = window.parent && window.parent !== window.window
@@ -319,7 +319,7 @@ namespace pxsim {
                             w.postMessage(msg, window.location.origin)
                     })
                     // start second simulator
-                } else {
+                } else if (!single) {
                     const messageChannel = msg.type === "messagepacket" && (msg as SimulatorControlMessage).channel;
                     const messageSimulator = messageChannel &&
                         this.options.messageSimulators &&

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -65,6 +65,8 @@ namespace pxsim {
         storedState?: Map<any>;
         autoRun?: boolean;
         ipc?: boolean;
+        // single iframe, no message simulators
+        single?: boolean;
     }
 
     export interface HwDebugger {
@@ -296,8 +298,9 @@ namespace pxsim {
             let frames = this.simFrames();
             const simUrl = U.isLocalHost() ? "*" : this.getSimUrl();
 
+            const single = !!this._currentRuntime.single;
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
-            if (source && broadcastmsg?.broadcast) {
+            if (!single && source && broadcastmsg?.broadcast) {
                 // if the editor is hosted in a multi-editor setting
                 // don't start extra frames
                 const parentWindow = window.parent && window.parent !== window.window
@@ -438,6 +441,7 @@ namespace pxsim {
             this.setState(starting ? SimulatorState.Starting : SimulatorState.Stopped);
             if (unload)
                 this.unload();
+            this.removeEventListeners();
         }
 
         public suspend() {
@@ -589,6 +593,7 @@ namespace pxsim {
                 breakOnStart: opts.breakOnStart,
                 storedState: opts.storedState,
                 ipc: opts.ipc,
+                single: opts.single
             }
             this.start();
         }

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -113,6 +113,7 @@
         var fullScreen = !!/fullscreen(?:[:=])1/i.exec(window.location.href);
         var deps = /deps(?:[:=])([^&?]+)/i.exec(window.location.href);
         var prebuiltSimJs = /prebuilt(?:[:=])1/i.test(window.location.href);
+        var single = !!/single(?:[:=])1/i.test(window.location.href);
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var codeFromData = undefined;
@@ -203,6 +204,7 @@
                         fullScreen: fullScreen,
                         dependencies: deps ? decodeURIComponent(deps[1]).split(",") : undefined,
                         builtJsInfo: builtSimJs,
+                        single: single
                     };
                     console.log('simulating script')
                     pxt.runner.simulateAsync(sims, options).done(function() {


### PR DESCRIPTION
With single=1, the sim runner (run.html) never spins up an additional iframe (neighter duplicate or using message packet). Use in JACDAC docs to have better control if frame being spinned up