### PR TITLE
Support projects that use assets from the asset editor in tutorials

### DIFF
--- a/docs/writing-docs/tutorials/resources.md
+++ b/docs/writing-docs/tutorials/resources.md
@@ -1,6 +1,6 @@
 # Resource sections
 
-Resource sections allow tutorials to have complex objects included as part of the tutorial document. In a normal project, these would be in a separate source file among the set of other files contained in the project. As a convenience, these resource objects (such tilemaps for game programs) can be added to a tutorial document for use in the hints and the user code for the tutorial activity. 
+Resource sections allow tutorials to have complex objects included as part of the tutorial document. In a normal project, these would be in a separate source file among the set of other files contained in the project. As a convenience, these resource objects (such tilemaps for game programs) can be added to a tutorial document for use in the hints and the user code for the tutorial activity.
 
 ## jres
 
@@ -74,7 +74,16 @@ Now, put in an event to detect when button **A** is pressed.
 ```blocks
 tiles.setTilemap(tilemap`level`)
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
-	
+
 })
 ```
 ````
+
+
+## Custom assets (Arcade beta only)
+
+To import all assets (Tilemaps, Images, Animations, and Tiles) into the tutorial at once, use the ```` ```assetsjson ``` ```` language block. You can get the assets for your project by adding `?savetemplate=1` to the end of your URL. For example, the URL for arcade's beta editor would be:
+
+https://arcade.makecode.com/beta?savetemplate=1
+
+With the correct URL entered, you can click the save button (the floppy disk) in the editor to download your project as a `.txt.mkcd` file. The contents of this file can be opened in a text editor and pasted into the ```` ```assetsjson ``` ```` block to configure the tutorial. To reopen and edit the project, simply drag the original `.txt.mkcd` into the editor and repeat the process to download it again.

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -43,7 +43,7 @@ declare namespace pxt {
         // "acme-corp/pxt-widget": "min:v0.1.2" - auto-upgrade to that version
         // "acme-corp/pxt-widget": "dv:foo,bar" - add "disablesVariant": ["foo", "bar"] to pxt.json
         upgrades?: pxt.Map<string>;
-        // list of trusted custom editor extension urls 
+        // list of trusted custom editor extension urls
         // that can bypass consent and send/receive messages
         approvedEditorExtensionUrls?: string[];
     }
@@ -945,6 +945,7 @@ declare namespace pxt.tutorial {
         language?: string; // language of code snippet (ts or python)
         templateCode?: string;
         metadata?: TutorialMetadata;
+        assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
     }
 
@@ -995,6 +996,7 @@ declare namespace pxt.tutorial {
         autoexpandStep?: boolean; // autoexpand tutorial card if instruction text overflows
         metadata?: TutorialMetadata; // metadata about the tutorial parsed from the markdown
         language?: string; // native language of snippets ("python" for python, otherwise defaults to typescript)
+        assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
     }
     interface TutorialCompletionInfo {

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -54,6 +54,16 @@ namespace pxt.gallery {
         return undefined;
     }
 
+    export function parseTemplateProjectJSON(md: string): pxt.Map<string> {
+        const pm = /```assetjson\s+((.|\s)+?)\s*```/i.exec(md);
+
+        if (pm) {
+            pxt.tutorial.parseAssetJson(pm[1]);
+        }
+
+        return {};
+    }
+
     export function parseExampleMarkdown(name: string, md: string): GalleryProject {
         if (!md) return undefined;
 
@@ -77,6 +87,11 @@ namespace pxt.gallery {
             snippetType,
             source
         };
+
+        prj.filesOverride = {
+            ...prj.filesOverride,
+            ...parseTemplateProjectJSON(md)
+        }
 
         if (jres) {
             prj.filesOverride[pxt.TILEMAP_JRES] = jres.jres;

--- a/pxtlib/gallery.ts
+++ b/pxtlib/gallery.ts
@@ -58,7 +58,7 @@ namespace pxt.gallery {
         const pm = /```assetjson\s+((.|\s)+?)\s*```/i.exec(md);
 
         if (pm) {
-            pxt.tutorial.parseAssetJson(pm[1]);
+            return pxt.tutorial.parseAssetJson(pm[1]);
         }
 
         return {};

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -10,7 +10,7 @@ namespace pxt.tutorial {
             return undefined; // error parsing steps
 
         // collect code and infer editor
-        const { code, templateCode, editor, language, jres } = computeBodyMetadata(body);
+        const { code, templateCode, editor, language, jres, assetJson } = computeBodyMetadata(body);
 
         // noDiffs legacy
         if (metadata.diffs === true // enabled in tutorial
@@ -22,6 +22,8 @@ namespace pxt.tutorial {
         ) {
             diffify(steps, activities);
         }
+
+        const assetFiles = parseAssetJson(assetJson);
 
         // strip hidden snippets
         steps.forEach(step => {
@@ -39,19 +41,21 @@ namespace pxt.tutorial {
             templateCode,
             metadata,
             language,
-            jres
+            jres,
+            assetFiles
         };
     }
 
     function computeBodyMetadata(body: string) {
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres)?\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson)?\s*\n([\s\S]*?)\n```/gmi;
         let jres: string;
         let code: string[] = [];
         let templateCode: string;
         let language: string;
         let idx = 0;
+        let assetJson: string;
         // Concatenate all blocks in separate code blocks and decompile so we can detect what blocks are used (for the toolbox)
         body
             .replace(/((?!.)\s)+/g, "\n")
@@ -83,6 +87,10 @@ namespace pxt.tutorial {
                     case "jres":
                         jres = m2;
                         break;
+                    case "assetjson":
+                        assetJson = m2;
+                        break;
+
                 }
                 code.push(m1 == "python" ? `\n${m2}\n` : `{\n${m2}\n}`);
                 idx++
@@ -90,7 +98,7 @@ namespace pxt.tutorial {
             });
         // default to blocks
         editor = editor || pxt.BLOCKS_PROJECT_NAME
-        return { code, templateCode, editor, language, jres }
+        return { code, templateCode, editor, language, jres, assetJson }
 
         function checkTutorialEditor(expected: string) {
             if (editor && editor != expected) {
@@ -267,7 +275,7 @@ ${code}
     /* Remove hidden snippets from text */
     function stripHiddenSnippets(str: string): string {
         if (!str) return str;
-        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson)\s*\n([\s\S]*?)\n```/gmi;
         return str.replace(hiddenSnippetRegex, '').trim();
     }
 
@@ -352,7 +360,8 @@ ${code}
             autoexpandStep: true,
             metadata: tutorialInfo.metadata,
             language: tutorialInfo.language,
-            jres: tutorialInfo.jres
+            jres: tutorialInfo.jres,
+            assetFiles: tutorialInfo.assetFiles
         };
 
         return { options: tutorialOptions, editor: tutorialInfo.editor };
@@ -395,5 +404,19 @@ ${code}
         }
         md = md || files[mfn];
         return md;
+    }
+
+
+    export function parseAssetJson(json: string): pxt.Map<string> {
+        if (!json) return undefined;
+
+        const files: pxt.Map<string> = JSON.parse(json);
+
+        return {
+            [pxt.TILEMAP_JRES]: files[pxt.TILEMAP_JRES],
+            [pxt.TILEMAP_CODE]: files[pxt.TILEMAP_CODE],
+            [pxt.IMAGES_JRES]: files[pxt.IMAGES_JRES],
+            [pxt.IMAGES_CODE]: files[pxt.IMAGES_CODE]
+        }
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3747,7 +3747,7 @@ export class ProjectView
         return pkg.mainEditorPkg().buildAssetsAsync()
             .then(() => pkg.mainPkg.saveToJsonAsync())
             .then(project => {
-                pxt.BrowserUtils.browserDownloadText(project.source, pkg.genFileName(".txt.mkcd"))
+                pxt.BrowserUtils.browserDownloadText(project.source, pkg.genFileName(".assets.mkcd"))
             })
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3747,7 +3747,7 @@ export class ProjectView
         return pkg.mainEditorPkg().buildAssetsAsync()
             .then(() => pkg.mainPkg.saveToJsonAsync())
             .then(project => {
-                pxt.BrowserUtils.browserDownloadText(project.source, pkg.genFileName(".json"))
+                pxt.BrowserUtils.browserDownloadText(project.source, pkg.genFileName(".txt.mkcd"))
             })
     }
 


### PR DESCRIPTION
I've added documentation on how to use this to the docs section on tutorials.

This is definitely not ideal, but it will serve as a stopgap until we have time to make a better solution (right now you can't write tutorials with the asset editor at all 😦). @abchatra and I brainstormed a few options earlier today that we'll discuss with the team.