### PR TITLE
Store skillmap progress for page source url rather than carousel name

### DIFF
--- a/pxtlib/skillmap.ts
+++ b/pxtlib/skillmap.ts
@@ -28,8 +28,10 @@ namespace pxt.skillmap {
             this.db = new BrowserUtils.IDBWrapper(IndexedDBWorkspace.databaseName, IndexedDBWorkspace.version, (ev, result) => {
                 const db = result.result as IDBDatabase;
 
-                db.createObjectStore(IndexedDBWorkspace.projectTable, { keyPath: IndexedDBWorkspace.projectKey });
-                db.createObjectStore(IndexedDBWorkspace.userTable, { keyPath: IndexedDBWorkspace.userKey });
+                if (ev.oldVersion < 1) {
+                    db.createObjectStore(IndexedDBWorkspace.projectTable, { keyPath: IndexedDBWorkspace.projectKey });
+                    db.createObjectStore(IndexedDBWorkspace.userTable, { keyPath: IndexedDBWorkspace.userKey });
+                }
             });
         }
 

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -146,6 +146,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
                         this.props.dispatchAddSkillMap(map);
                     })
                 }
+
                 if (metadata) {
                     const { title, description, infoUrl } = metadata;
                     setPageTitle(title);
@@ -219,9 +220,10 @@ class AppImpl extends React.Component<AppProps, AppState> {
     }
 
     protected applyQueryFlags(user: UserState, maps?: SkillMap[], sourceUrl?: string) {
+        const pageSource = sourceUrl || "default";
         if (this.queryFlags["debugNewUser"] === "true") {
             user.isDebug = true;
-            user.mapProgress = {};
+            user.mapProgress = { [pageSource]: {} };
             user.completedTags = {};
         }
 
@@ -230,7 +232,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
             if (maps) {
                 for (const map of maps) {
-                    user.mapProgress[map.mapId] = {
+                    user.mapProgress[pageSource][map.mapId] = {
                         completionState: "completed",
                         mapId: map.mapId,
                         activityState: {}
@@ -238,14 +240,14 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
                     for (const key of Object.keys(map.activities)) {
                         const activity = map.activities[key];
-                        if (!user.mapProgress[map.mapId].activityState[activity.activityId]) {
-                            user.mapProgress[map.mapId].activityState[activity.activityId] = {
+                        if (!user.mapProgress[pageSource][map.mapId].activityState[activity.activityId]) {
+                            user.mapProgress[pageSource][map.mapId].activityState[activity.activityId] = {
                                 activityId: activity.activityId,
                                 isCompleted: true
                             };
                         }
                         else {
-                            user.mapProgress[map.mapId].activityState[activity.activityId].isCompleted = true;
+                            user.mapProgress[pageSource][map.mapId].activityState[activity.activityId].isCompleted = true;
                         }
 
                         if (activity.tags?.length && sourceUrl) {

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -95,7 +95,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
 
     let completedHeaderId: string | undefined;
     if (state.editorView?.currentHeaderId) {
-        if (isActivityCompleted(state.user, state.editorView.currentMapId, state.editorView.currentActivityId)) {
+        if (isActivityCompleted(state.user, state.pageSourceUrl, state.editorView.currentMapId, state.editorView.currentActivityId)) {
             completedHeaderId = state.editorView.currentHeaderId;
         }
     }

--- a/skillmap/src/components/SkillCard.tsx
+++ b/skillmap/src/components/SkillCard.tsx
@@ -116,7 +116,7 @@ export class SkillCardImpl extends React.Component<SkillCardProps> {
 
 function mapStateToProps(state: SkillMapState, ownProps: any) {
     const map = state.maps?.[ownProps.mapId];
-    const isUnlocked = state.user && map && isActivityUnlocked(state.user, map, ownProps.id);
+    const isUnlocked = state.user && map && isActivityUnlocked(state.user, state.pageSourceUrl, map, ownProps.id);
 
     let status: SkillCardStatus = isUnlocked ? "notstarted" : "locked";
     let currentStep: number | undefined;
@@ -127,7 +127,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
             status = "locked";
         }
         else {
-            const progress = lookupActivityProgress(state.user, ownProps.mapId, ownProps.id);
+            const progress = lookupActivityProgress(state.user, state.pageSourceUrl, ownProps.mapId, ownProps.id);
 
             if (progress) {
                 if (progress.isCompleted) {

--- a/skillmap/src/components/SkillCarousel.tsx
+++ b/skillmap/src/components/SkillCarousel.tsx
@@ -22,7 +22,7 @@ interface SkillCarouselProps {
     requiredMaps: SkillMap[];
     user: UserState;
     selectedItem?: string;
-    pageSourceUrl?: string;
+    pageSourceUrl: string;
     completionState: "incomplete" | "transitioning" | "completed";
     dispatchChangeSelectedItem: (id?: string) => void;
     dispatchShowCompletionModal: (mapId: string, activityId?: string) => void;
@@ -140,8 +140,8 @@ class SkillCarouselImpl extends React.Component<SkillCarouselProps> {
     }
 
     render() {
-        const { map, user, selectedItem } = this.props;
-        const endCard = isMapCompleted(user, map) ? [this.getEndCard()] : [];
+        const { map, user, selectedItem, pageSourceUrl } = this.props;
+        const endCard = isMapCompleted(user, pageSourceUrl, map) ? [this.getEndCard()] : [];
         const requirments = this.renderRequirements();
 
         return <Carousel title={map.displayName} items={this.items} itemTemplate={SkillCard} itemClassName="linked"
@@ -155,6 +155,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     if (!state) return {};
 
     const map: SkillMap = ownProps.map;
+    const mapProgress = state.user?.mapProgress?.[state.pageSourceUrl];
     let requiredMaps: SkillMap[] = [];
 
     if (map.prerequisites?.length && state.pageSourceUrl) {
@@ -168,7 +169,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         user: state.user,
         requiredMaps,
         pageSourceUrl: state.pageSourceUrl,
-        completionState: state.user?.mapProgress?.[map.mapId]?.completionState,
+        completionState: mapProgress?.[map.mapId]?.completionState,
         selectedItem: state.selectedItem && ownProps.map?.activities?.[state.selectedItem] ? state.selectedItem : undefined
     }
 }

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -326,7 +326,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         mapId: currentMapId,
         activityId: currentActivityId,
         activityHeaderId: currentHeaderId,
-        completed: lookupActivityProgress(state.user, currentMapId, currentActivityId)?.isCompleted,
+        completed: lookupActivityProgress(state.user, state.pageSourceUrl, currentMapId, currentActivityId)?.isCompleted,
         activityType: activity.type,
         save: saveState === "saving"
     }

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -52,9 +52,9 @@ type CompletedTags = {[index: string]: number}
 interface UserState {
     isDebug?: boolean;
     id: string;
-    mapProgress: {[index: string]: MapState};
 
     // Indexed by the skillmap page url
+    mapProgress: {[index: string]: {[mapId: string]: MapState}};
     completedTags: {[index: string]: CompletedTags};
 }
 

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -50,6 +50,7 @@ interface MapActivity {
 type CompletedTags = {[index: string]: number}
 
 interface UserState {
+    version: string;
     isDebug?: boolean;
     id: string;
 

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -1,3 +1,4 @@
+
 /// <reference path="./skillMap.d.ts" />
 
 const testMap = ``

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -1,11 +1,10 @@
-
-export function isMapCompleted(user: UserState, map: SkillMap, skipActivity?: string) {
-    if (Object.keys(map?.activities).some(k => !user?.mapProgress[map.mapId]?.activityState[k]?.isCompleted && k !== skipActivity)) return false;
+export function isMapCompleted(user: UserState, pageSource: string, map: SkillMap, skipActivity?: string) {
+    if (Object.keys(map?.activities).some(k => !lookupMapProgress(user, pageSource, map.mapId)?.activityState[k]?.isCompleted && k !== skipActivity)) return false;
     return true;
 }
 
-export function isActivityCompleted(user: UserState, mapId: string, activityId: string) {
-    return !!(lookupActivityProgress(user, mapId, activityId)?.isCompleted);
+export function isActivityCompleted(user: UserState, pageSource: string, mapId: string, activityId: string) {
+    return !!(lookupActivityProgress(user, pageSource, mapId, activityId)?.isCompleted);
 }
 
 export function isMapUnlocked(user: UserState, map: SkillMap, pageSource: string) {
@@ -17,20 +16,20 @@ export function isMapUnlocked(user: UserState, map: SkillMap, pageSource: string
             if (numCompleted === undefined || numCompleted < pre.numberCompleted) return false;
         }
         else if (pre.type === "map") {
-            if (!isMapCompleted(user, map)) return false;
+            if (!isMapCompleted(user, pageSource, map)) return false;
         }
     }
 
     return true;
 }
 
-export function getCompletedTags(user: UserState, maps: SkillMap[]) {
+export function getCompletedTags(user: UserState, pageSource: string, maps: SkillMap[]) {
     const completed: CompletedTags = {};
 
     for (const map of maps) {
         for (const activityId of Object.keys(map.activities)) {
             const activity = map.activities[activityId];
-            if (isActivityCompleted(user, map.mapId, activity.activityId)) {
+            if (isActivityCompleted(user, pageSource, map.mapId, activity.activityId)) {
                 for (const tag of activity.tags) {
                     if (!completed[tag]) completed[tag] = 0;
                     completed[tag] ++;
@@ -42,13 +41,13 @@ export function getCompletedTags(user: UserState, maps: SkillMap[]) {
     return completed;
 }
 
-export function isActivityUnlocked(user: UserState, map: SkillMap, activityId: string) {
+export function isActivityUnlocked(user: UserState, pageSource: string, map: SkillMap, activityId: string) {
     if (map.root.activityId === activityId) return true;
 
     return checkRecursive(map.root);
 
     function checkRecursive(root: MapActivity) {
-        if (isActivityCompleted(user, map.mapId, root.activityId)) {
+        if (isActivityCompleted(user, pageSource, map.mapId, root.activityId)) {
             if (root.next.some(activity => activity.activityId === activityId)) {
                 return true;
             }
@@ -62,6 +61,10 @@ export function isActivityUnlocked(user: UserState, map: SkillMap, activityId: s
     }
 }
 
-export function lookupActivityProgress(user: UserState, mapId: string, activityId: string) {
-    return user.mapProgress[mapId]?.activityState[activityId]
+export function lookupMapProgress(user: UserState, pageSource: string, mapId: string): MapState | undefined {
+    return user.mapProgress[pageSource] ? user.mapProgress[pageSource][mapId] : undefined;
+}
+
+export function lookupActivityProgress(user: UserState, pageSource: string, mapId: string, activityId: string) {
+    return lookupMapProgress(user, pageSource, mapId)?.activityState[activityId]
 }

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -1,6 +1,6 @@
 import * as actions from '../actions/types'
 import { guidGen } from '../lib/browserUtils';
-import { getCompletedTags, lookupActivityProgress, isMapCompleted } from '../lib/skillMapUtils';
+import { getCompletedTags, lookupActivityProgress, isMapCompleted, applyUserUpgrades } from '../lib/skillMapUtils';
 
 export type ModalType = "restart-warning" | "completion" | "report-abuse" | "reset";
 export type PageSourceStatus = "approved" | "banned" | "unknown";
@@ -33,12 +33,14 @@ interface ModalState {
     currentActivityId?: string;
 }
 
+const userVersion = "0.0.1";
 const initialState: SkillMapState = {
     title: lf("Game Maker Guide"),
     description: lf("Level up your game making skills by completing the tutorials in this guide."),
     pageSourceStatus: "unknown",
     pageSourceUrl: "default",
     user: {
+        version: userVersion,
         isDebug: true,
         id: guidGen(),
         mapProgress: {},
@@ -163,7 +165,7 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
         case actions.SET_USER:
             return {
                 ...state,
-                user: action.user
+                user: applyUserUpgrades(action.user, userVersion, state.pageSourceUrl, state.maps)
             };
         case actions.RESET_USER:
             return {


### PR DESCRIPTION
previously mapProgress was a map of carousel name to progress (per activity)--this would cause issues if different pages had the same name for a carousel. adding an extra layer where mapProgress uses the page source URL (same as completedTags, should be unique) to map to individual carousels

also makes the page source URL required (defaults to "default" if one is not found)