### PR TITLE
Include skillmap built files in pxt package.json, clean before build

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -396,6 +396,7 @@ function pxtFileList(pref: string) {
         .concat(onlyExts(nodeutil.allFiles(pref + "built/web", 1), [".js", ".css"]))
         .concat(nodeutil.allFiles(pref + "built/web/fonts", 1))
         .concat(nodeutil.allFiles(pref + "built/web/vs", 4))
+        .concat(nodeutil.allFiles(pref + "built/web/skillmap", 4))
 
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -518,6 +518,8 @@ const copyBlockly = gulp.parallel(copyBlocklyCompressed, copyBlocklyEnJs, copyBl
 const skillmapRoot = "skillmap";
 const skillmapOut = "built/web/skillmap";
 
+const cleanSkillmap = () => rimraf(skillmapOut);
+
 const buildSkillmap =  () => exec("npm install", false, { cwd: skillmapRoot })
     .then(() => exec("npm run build", false, { cwd: skillmapRoot }));
 
@@ -533,7 +535,7 @@ const copySkillmapHtml = () => rimraf("webapp/public/skillmap.html")
                     .pipe(concat("skillmap.html"))
                     .pipe(gulp.dest("webapp/public")));
 
-const skillmap = gulp.series(buildSkillmap, gulp.parallel(copySkillmapCss, copySkillmapJs, copySkillmapHtml));
+const skillmap = gulp.series(cleanSkillmap, buildSkillmap, gulp.parallel(copySkillmapCss, copySkillmapJs, copySkillmapHtml));
 
 
 /********************************************************

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "built/web/vs/editor/editor.main.js",
     "built/web/vs/language/typescript/lib/*.js",
     "built/web/vs/language/typescript/src/*.js",
+    "built/web/skillmap/css/*.css",
+    "built/web/skillmap/js/*.js",
     "pxtcompiler/ext-typescript/lib/lib.d.ts",
     "pxtcompiler/ext-typescript/lib/typescript.js",
     "pxtcompiler/ext-typescript/lib/typescriptServices.d.ts",


### PR DESCRIPTION
including the files in the package.json so that they will be uploaded with the next bump! should be the last remaining fix for https://github.com/microsoft/pxt-arcade/issues/2584