### PR TITLE
Asset creation fix

### DIFF
--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -49,8 +49,7 @@ namespace pxt.editor {
             return {
                 initWidth: 16,
                 initHeight: 16,
-                blocksInfo: this.host.blocksInfo(),
-                showTiles: true
+                blocksInfo: this.host.blocksInfo()
             };
         }
     }

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -142,6 +142,9 @@ namespace pxt {
                     asset = this.add(newValue);
                     this.notifyListener(newValue.internalID);
                 }
+                else {
+                    asset = newValue;
+                }
             }
             else {
                 asset = this.add(newValue);

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -197,7 +197,7 @@ export function init() {
 
         switch (fieldEditorId) {
             case "image-editor":
-                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} showTiles={options?.showTiles} />);
+                current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={true} />);
                 break;
             case "animation-editor":
                 current.injectElement(<ImageFieldEditor ref={ refHandler } singleFrame={false} />);

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -9,7 +9,6 @@ import { GalleryTile, setTelemetryFunction } from './ImageEditor/store/imageRedu
 export interface ImageFieldEditorProps {
     singleFrame: boolean;
     doneButtonCallback?: () => void;
-    showTiles?: boolean;
 }
 
 export interface ImageFieldEditorState {
@@ -25,9 +24,7 @@ interface ProjectGalleryItem extends pxt.sprite.GalleryItem {
     id: string;
 }
 
-export type ImageType = pxt.ProjectImage | pxt.Animation | pxt.ProjectTilemap;
-
-export class ImageFieldEditor<U extends ImageType> extends React.Component<ImageFieldEditorProps, ImageFieldEditorState> implements FieldEditorComponent<U> {
+export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<ImageFieldEditorProps, ImageFieldEditorState> implements FieldEditorComponent<U> {
     protected blocksInfo: pxtc.BlocksInfo;
     protected ref: ImageEditor;
     protected closeEditor: () => void;
@@ -48,7 +45,6 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
     }
 
     render() {
-        const { showTiles } = this.props;
         const { currentView, headerVisible, editingTile } = this.state;
 
         if (this.asset && !this.galleryAssets) {
@@ -76,7 +72,6 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
                     </div>
                     <div className="gallery-editor-toggle-handle"/>
                 </div>
-                { showTiles && <button className="gallery-editor-show-tiles" onClick={this.toggleTileGallery}>{lf("Tile Gallery")}</button>}
             </div>}
             <div className="image-editor-gallery-content">
                 <ImageEditor ref="image-editor" singleFrame={this.props.singleFrame} onDoneClicked={this.onDoneClick} onTileEditorOpenClose={this.onTileEditorOpenClose} />
@@ -84,10 +79,6 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
                     items={currentView === "my-assets" ? this.filterAssets(this.userAssets) : this.filterAssets(this.galleryAssets, editingTile ? pxt.AssetType.Tile : this.asset?.type, true)}
                     hidden={currentView === "editor"}
                     onAssetSelected={this.onAssetSelected} />
-                { showTiles && <ImageEditorGallery
-                    items={this.filterAssets(this.galleryAssets, pxt.AssetType.Tile)}
-                    hidden={currentView !== "editor" || !this.state.tileGalleryVisible}
-                    onAssetSelected={this.onAssetSelected} /> }
             </div>
         </div>
     }
@@ -109,6 +100,10 @@ export class ImageFieldEditor<U extends ImageType> extends React.Component<Image
 
         switch (value.type) {
             case pxt.AssetType.Image:
+                this.initSingleFrame(value as pxt.ProjectImage, options);
+                break;
+            case pxt.AssetType.Tile:
+                options.disableResize = true;
                 this.initSingleFrame(value as pxt.ProjectImage, options);
                 break;
             case pxt.AssetType.Animation:

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -114,8 +114,7 @@ export class AssetEditor extends Editor {
                 fieldView = pxt.react.getFieldEditorView("image-editor", asset as pxt.ProjectImage, {
                     initWidth: 16,
                     initHeight: 16,
-                    showTiles: true,
-                    headerVisible: false,
+                    headerVisible: true,
                     blocksInfo: this.blocksInfo
                 });
                 break;
@@ -138,7 +137,7 @@ export class AssetEditor extends Editor {
                 fieldView = pxt.react.getFieldEditorView("tilemap-editor", asset as pxt.ProjectTilemap, {
                     initWidth: 16,
                     initHeight: 16,
-                    headerVisible: false,
+                    headerVisible: true,
                     blocksInfo: this.blocksInfo
                 });
                 break;
@@ -146,8 +145,7 @@ export class AssetEditor extends Editor {
                 fieldView = pxt.react.getFieldEditorView("animation-editor", asset as pxt.Animation, {
                     initWidth: 16,
                     initHeight: 16,
-                    showTiles: true,
-                    headerVisible: false,
+                    headerVisible: true,
                     blocksInfo: this.blocksInfo
                 });
                 break;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2464

This fixes a few things:

1. Fixes the new asset button in the asset editor which got broken at some point and wouldn't open up the editor after selecting an asset type. The editors also now have the gallery header enabled
2. Removes the "show tile gallery" button which is no longer needed because of https://github.com/microsoft/pxt/pull/7737
3. Fixes exception when closing the image/tilemap editor without making any edits