### PR TITLE
Scale screenshots / gifs to display on social media better

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -429,14 +429,17 @@ namespace pxt.BrowserUtils {
             })
     }
 
-    export function imageDataToPNG(img: ImageData): string {
+    export function imageDataToPNG(img: ImageData, scale = 1): string {
         if (!img) return undefined;
 
         const canvas = document.createElement("canvas")
-        canvas.width = img.width
-        canvas.height = img.height
+        canvas.width = img.width * scale
+        canvas.height = img.height * scale
         const ctx = canvas.getContext("2d")
         ctx.putImageData(img, 0, 0);
+        ctx.imageSmoothingEnabled = false;
+        ctx.scale(scale, scale);
+        ctx.drawImage(canvas, 0, 0);
         return canvas.toDataURL("image/png");
     }
 

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -429,6 +429,18 @@ namespace pxt.BrowserUtils {
             })
     }
 
+    export function scaleImageData(img: ImageData, scale: number): ImageData {
+        const cvs = document.createElement("canvas");
+        cvs.width = img.width * scale;
+        cvs.height = img.height * scale;
+        const ctx = cvs.getContext("2d")
+        ctx.putImageData(img, 0, 0);
+        ctx.imageSmoothingEnabled = false;
+        ctx.scale(scale, scale);
+        ctx.drawImage(cvs, 0, 0);
+        return ctx.getImageData(0, 0, img.width * scale, img.height * scale);
+    }
+
     export function imageDataToPNG(img: ImageData, scale = 1): string {
         if (!img) return undefined;
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1967,7 +1967,7 @@ export class ProjectView
         this.setState({ screenshoting: true });
         simulator.driver.postMessage({ type: "screenshot" } as pxsim.SimulatorScreenshotMessage);
         return this.requestScreenshotPromise = new Promise<string>((resolve, reject) => {
-            this.pushScreenshotHandler(msg => resolve(pxt.BrowserUtils.imageDataToPNG(msg.data)));
+            this.pushScreenshotHandler(msg => resolve(pxt.BrowserUtils.imageDataToPNG(msg.data, 3)));
         }).timeout(1000) // simulator might be stopped or in bad shape
             .catch(e => {
                 pxt.tickEvent('screenshot.timeout');

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -334,7 +334,7 @@ export function loadGifEncoderAsync(): Promise<GifEncoder> {
         transparent: pxt.appTarget.appTheme.simGifTransparent,
         maxFrames: pxt.appTarget.appTheme.simGifMaxFrames || 64,
         maxLength: pxt.appTarget.appTheme.simScreenshotMaxUriLength || 300000,
-        scale: 2
+        scale: 3
     };
     return pxt.BrowserUtils.loadScriptAsync("gifjs/gif.js")
         .then(() => new GifEncoder(options));

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -97,18 +97,6 @@ function chromifyAsync(canvas: HTMLCanvasElement, title: string): HTMLCanvasElem
     return work;
 }
 
-function scaleImageData(img: ImageData, scale: number): ImageData {
-    const cvs = document.createElement("canvas");
-    cvs.width = img.width * scale;
-    cvs.height = img.height * scale;
-    const ctx = cvs.getContext("2d")
-    ctx.putImageData(img, 0, 0);
-    ctx.imageSmoothingEnabled = false;
-    ctx.scale(scale, scale);
-    ctx.drawImage(cvs, 0, 0);
-    return ctx.getImageData(0, 0, img.width * scale, img.height * scale);
-}
-
 function defaultCanvasAsync(): Promise<HTMLCanvasElement> {
     const cvs = document.createElement("canvas");
     cvs.width = 160;
@@ -258,7 +246,7 @@ export class GifEncoder {
         if (delay === undefined)
             delay = t - this.time;
         if (this.scale != 1) {
-            dataUri = scaleImageData(dataUri, this.scale);
+            dataUri = pxt.BrowserUtils.scaleImageData(dataUri, this.scale);
         }
         pxt.debug(`gif: frame ${delay}ms`);
         this.gif.addFrame(dataUri, { delay });

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -257,7 +257,6 @@ export class GifEncoder {
 
     renderAsync(): Promise<string> {
         if (this.cancellationToken.isCancelled()) return Promise.resolve(undefined);
-
         // keep trying to render until size is small enough
         const tryRenderGifAsync: () => Promise<string> = () => {
             return this.renderGifAsync()
@@ -267,7 +266,9 @@ export class GifEncoder {
                     if (this.options.maxLength && imageUri.length > this.options.maxLength) {
                         const nframes = Math.floor(this.gif.frames.length * this.options.maxLength / imageUri.length) - 1;
                         pxt.log(`gif: size too large (${(imageUri.length / 1000) | 0}kb) reducing frames to ${nframes}`);
+                        console.log("VVN: gif size too big");
                         if (nframes <= 0) {
+                            console.log("WAAAAAY too big...");
                             pxt.log(`gif: simulator image too large, cannot have a single frame`);
                             return undefined;
                         }
@@ -322,7 +323,7 @@ export function loadGifEncoderAsync(): Promise<GifEncoder> {
         transparent: pxt.appTarget.appTheme.simGifTransparent,
         maxFrames: pxt.appTarget.appTheme.simGifMaxFrames || 64,
         maxLength: pxt.appTarget.appTheme.simScreenshotMaxUriLength || 300000,
-        scale: 3
+        scale: 2
     };
     return pxt.BrowserUtils.loadScriptAsync("gifjs/gif.js")
         .then(() => new GifEncoder(options));

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -156,7 +156,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 this.gifRender();
         } else if (this.state.recordingState == ShareRecordingState.ScreenshotSnap || this.state.recordingState === ShareRecordingState.None) {
             // received a screenshot
-            this.setState({ screenshotUri: pxt.BrowserUtils.imageDataToPNG(msg.data), recordingState: ShareRecordingState.None, recordError: undefined })
+            this.setState({ screenshotUri: pxt.BrowserUtils.imageDataToPNG(msg.data, 4), recordingState: ShareRecordingState.None, recordError: undefined })
         } else {
             // ignore
             // make sure simulator is stopped

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -156,7 +156,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                 this.gifRender();
         } else if (this.state.recordingState == ShareRecordingState.ScreenshotSnap || this.state.recordingState === ShareRecordingState.None) {
             // received a screenshot
-            this.setState({ screenshotUri: pxt.BrowserUtils.imageDataToPNG(msg.data, 4), recordingState: ShareRecordingState.None, recordError: undefined })
+            this.setState({ screenshotUri: pxt.BrowserUtils.imageDataToPNG(msg.data), recordingState: ShareRecordingState.None, recordError: undefined })
         } else {
             // ignore
             // make sure simulator is stopped


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2600

The issue was that Facebook won't show images if they're too small (less than 200x200 px), so I added an optional scaling factor to converting the screenshot image -> PNG and also when we make the gifs. Are we worried about this taking too much storage?

[edit] I had a screenshot that I forgot to share!
![image](https://user-images.githubusercontent.com/18712271/103808096-49a03d80-500c-11eb-95e3-64c982a24b2e.png)
it's a little blurry still, but I think that's on FB's end not liking pixel art. better than having part of the microsoft logo?