### PR TITLE
Make sure the rendering blockly workspace is always cleaned up

### DIFF
--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -105,8 +105,10 @@ namespace pxt.blocks {
             return renderWorkspace(options);
         } catch (e) {
             pxt.reportException(e);
-            cleanRenderingWorkspace();
             return undefined;
+        }
+        finally {
+            cleanRenderingWorkspace();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2755

The temporary assets should be cleaned up when the fields are disposed, but the workspace we use for hints was apparently not always getting cleaned up