### PR TITLE
Only adjust sidedocs top when it's visible

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -596,7 +596,7 @@ code.lang-filterblocks {
  * CSS for embedded tutorial used in the skills map
  */
 .tutorial.tutorial-embed {
-    #filelist, #maineditor, #sidedocs, .simView #simulators {
+    #filelist, #maineditor, &.sideDocs #sidedocs, .simView #simulators {
         top: @tutorialEmbedMenuHeight;
     }
     .simView #boardview {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2743

The issue was the `top` rule was being applied when the sidedocs were closed, which pushed everything down. The `sideDocs` class only appears when it's open, so I added it as a rule.

![sidedocs](https://user-images.githubusercontent.com/18712271/104050721-e6451580-519b-11eb-874a-1948d077c8ea.gif)
