### PR TITLE
Fix reloads of same xml for temporary assets

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -229,10 +229,12 @@ namespace pxtblockly {
                 const project = pxt.react.getTilemapProject();
 
                 const id = this.getBlockData();
-                if (id) {
-                    this.asset = project.lookupAsset(this.getAssetType(), id);
+                const existing = project.lookupAsset(this.getAssetType(), id);
+                if (existing) {
+                    this.asset = existing;
                 }
                 else {
+                    this.setBlockData(null);
                     if (this.asset) {
                         if (this.sourceBlock_ && this.asset.meta.blockIDs) {
                             this.asset.meta.blockIDs = this.asset.meta.blockIDs.filter(id => id !== this.sourceBlock_.id);


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2815
Fixes https://github.com/microsoft/pxt-arcade/issues/2809

We store the asset id on the xml of the block. That works well, but when we switch to javascript we delete the asset. This is a problem if we switch back to the blocks with no changes; no decompile happens so the xml is the same and it tries to load the deleted asset. This just checks to make sure it actually exists. 