### PR TITLE
Fix grey blocks for tilemap blocks

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1252,7 +1252,7 @@ namespace pxt.blocks {
             if (field instanceof pxtblockly.FieldTextInput) {
                 return H.mkStringLiteral(f);
             }
-            else if (field instanceof pxtblockly.FieldTilemap) {
+            else if (field instanceof pxtblockly.FieldTilemap && !field.isGreyBlock) {
                 const project = pxt.react.getTilemapProject();
                 const tmString = field.getValue();
 

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -134,6 +134,9 @@ namespace pxtblockly {
         }
 
         render_() {
+            if (this.isGreyBlock && !this.textElement_) {
+                this.createTextElement_();
+            }
             super.render_();
 
             if (!this.isGreyBlock) {
@@ -188,6 +191,7 @@ namespace pxtblockly {
 
             if (this.isGreyBlock) {
                 this.createTextElement_();
+                this.render_();
                 this.updateEditable();
                 return;
             }

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -70,7 +70,6 @@ namespace pxtblockly {
             else if (newText.trim()) {
                 this.isGreyBlock = true;
                 this.valueText = newText;
-                this.render_();
             }
 
             return newAsset;

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -70,6 +70,7 @@ namespace pxtblockly {
             else if (newText.trim()) {
                 this.isGreyBlock = true;
                 this.valueText = newText;
+                this.render_();
             }
 
             return newAsset;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2799

Also fixes the preview, which got broken at some point:

<img width="261" alt="Screen Shot 2021-01-11 at 2 40 31 PM" src="https://user-images.githubusercontent.com/13754588/104246492-f61e5d00-541a-11eb-9c67-7dd643186d64.png">
