### PR TITLE
Fix gallery asset duplication, tile names

### DIFF
--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -307,9 +307,11 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                 }
                 else {
                     const tileWidth = (state.store.present as TilemapState).tileset.tileWidth;
+                    const emptyTile =  createNewImageAsset(pxt.AssetType.Tile, tileWidth, tileWidth) as pxt.Tile;
+                    emptyTile.meta = { displayName: lf("tile") } // always generate a display name for tiles
                     this.setState({
                         editingTile: true,
-                        tileToEdit: createNewImageAsset(pxt.AssetType.Tile, tileWidth, tileWidth) as pxt.Tile
+                        tileToEdit: emptyTile
                     });
                 }
                 if (this.props.onTileEditorOpenClose) this.props.onTileEditorOpenClose(true);

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -96,9 +96,12 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
     protected duplicateAssetHandler = () => {
         pxt.tickEvent("assets.duplicate", { type: this.props.asset.type.toString(), gallery: this.props.isGalleryAsset.toString() });
 
+        const asset = this.props.asset;
+        if (!asset.meta?.displayName) asset.meta = { ...asset.meta, displayName: getDisplayNameForAsset(asset, this.props.isGalleryAsset) }
+
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        const { type, id } = project.duplicateAsset(this.props.asset);
+        const { type, id } = project.duplicateAsset(asset);
         this.updateAssets().then(() => {
             this.props.dispatchChangeGalleryView(GalleryView.User);
             this.props.dispatchChangeSelectedAsset(type, id);
@@ -170,7 +173,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
             { asset && <div className="asset-editor-sidebar-controls">
                 {canEdit && <sui.MenuItem name={lf("Edit")} className="asset-editor-button" icon="edit" onClick={this.editAssetHandler}/>}
                 <sui.MenuItem name={lf("Duplicate")} className="asset-editor-button" icon="copy" onClick={this.duplicateAssetHandler}/>
-                {canCopy && <sui.MenuItem name={lf("Clipboard")} className="asset-editor-button" icon="paste" onClick={this.copyAssetHandler}/>}
+                {canCopy && <sui.MenuItem name={lf("Copy")} className="asset-editor-button" icon="paste" onClick={this.copyAssetHandler}/>}
                 <sui.MenuItem name={lf("Delete")}
                     className={`asset-editor-button delete-asset ${!canDelete ? "disabled" : ""}`}
                     icon="trash"
@@ -204,7 +207,7 @@ function getDisplayNameForAsset(asset: pxt.Asset, isGalleryAsset?: boolean) {
     } else if (asset?.meta?.displayName) {
         return asset.meta.displayName;
     } else {
-        return isGalleryAsset ? pxt.getShortIDForAsset(asset) : lf("Temporary asset");
+        return isGalleryAsset ? asset.id.split('.').pop() : lf("Temporary asset");
     }
 }
 


### PR DESCRIPTION
- Rename 'Clipboard' -> 'Copy'
- Give duplicated gallery assets a default displayName (parsed from qName)
- Give tiles created in the tilemap a default display name (no such thing as a temporary tile)

Fixes https://github.com/microsoft/pxt-arcade/issues/2818
Fixes https://github.com/microsoft/pxt-arcade/issues/2754