### PR TITLE
Hide skillmap reset option in iframe, show trophy always

### DIFF
--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -35,14 +35,16 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
             })
         }
 
-        items.push({
-            id: "reset",
-            label: lf("Reset All"),
-            onClick: () => {
-                tickEvent("skillmap.reset.warning");
-                this.props.dispatchShowResetUserModal();
-            }
-        })
+        if (!this.props.activityOpen) {
+            items.push({
+                id: "reset",
+                label: lf("Reset All"),
+                onClick: () => {
+                    tickEvent("skillmap.reset.warning");
+                    this.props.dispatchShowResetUserModal();
+                }
+            })
+        }
 
         return items;
     }

--- a/skillmap/src/components/SkillCarousel.tsx
+++ b/skillmap/src/components/SkillCarousel.tsx
@@ -85,9 +85,9 @@ class SkillCarouselImpl extends React.Component<SkillCarouselProps> {
         this.carouselRef = el;
     }
 
-    protected getEndCard(): JSX.Element {
+    protected getEndCard(completed: boolean): JSX.Element {
         return <div className={`end-card ${this.props.completionState === "completed" ? "spin" : ""}`} key="end">
-            <div className="end-card-icon" onClick={this.handleEndCardClick} role="button">
+            <div className="end-card-icon" onClick={completed ? this.handleEndCardClick : undefined} role="button">
                 <i className="icon trophy" onTransitionEnd={this.handleEndCardTransition} />
             </div>
         </div>
@@ -141,7 +141,8 @@ class SkillCarouselImpl extends React.Component<SkillCarouselProps> {
 
     render() {
         const { map, user, selectedItem, pageSourceUrl } = this.props;
-        const endCard = isMapCompleted(user, pageSourceUrl, map) ? [this.getEndCard()] : [];
+        const completed = isMapCompleted(user, pageSourceUrl, map);
+        const endCard = [this.getEndCard(completed)];
         const requirments = this.renderRequirements();
 
         return <Carousel title={map.displayName} items={this.items} itemTemplate={SkillCard} itemClassName="linked"

--- a/skillmap/src/styles/skillcard.css
+++ b/skillmap/src/styles/skillcard.css
@@ -245,14 +245,12 @@
     height: 6rem;
     margin-right: 3rem;
     border-radius: 50%;
-    cursor: pointer;
 
     color: var(--inverted-text-color);
     background-color: var(--primary-color);
 }
 
 .end-card i.icon {
-    opacity: 0;
     font-size: 4rem;
     line-height: 4rem;
     margin: 0;
@@ -269,6 +267,6 @@
 }
 
 .end-card.spin i.icon {
-    opacity: 1;
+    cursor: pointer;
     transform: rotateZ(720deg);
 }


### PR DESCRIPTION
- Hide "Reset All" option if you are in an activity
- Always display trophy icon (unclickable). After learning path is completed, icon will spin, auto-display the completion modal, and become clickable

Fixes https://github.com/microsoft/pxt-arcade/issues/2791
Fixes https://github.com/microsoft/pxt-arcade/issues/2742