### PR TITLE
Add system for locking/unlocking keyboard shortcuts in the image editor

### DIFF
--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -6,6 +6,7 @@ import { dispatchChangeImageDimensions, dispatchUndoImageEdit, dispatchRedoImage
 import { IconButton } from "./Button";
 import { fireClickOnlyOnEnter } from "./util";
 import { isNameTaken } from "../../assets";
+import { obtainShortcutLock, releaseShortcutLock } from "./keyboardShortcuts";
 
 export interface BottomBarProps {
     dispatchChangeImageDimensions: (dimensions: [number, number]) => void;
@@ -40,6 +41,8 @@ export interface BottomBarState {
 }
 
 export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarState> {
+    protected shortcutLock: number;
+
     constructor(props: BottomBarProps) {
         super(props);
         this.state = {};
@@ -79,6 +82,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                             value={width}
                             tabIndex={0}
                             onChange={this.handleWidthChange}
+                            onFocus={this.disableShortcutsOnFocus}
                             onBlur={this.handleDimensionalBlur}
                             onKeyDown={this.handleDimensionalKeydown}
                         />
@@ -96,6 +100,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                             value={height}
                             tabIndex={0}
                             onChange={this.handleHeightChange}
+                            onFocus={this.disableShortcutsOnFocus}
                             onBlur={this.handleDimensionalBlur}
                             onKeyDown={this.handleDimensionalKeydown}
                         />
@@ -121,6 +126,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                         placeholder={lf("Asset Name")}
                         tabIndex={0}
                         onChange={this.handleAssetNameChange}
+                        onFocus={this.disableShortcutsOnFocus}
                         onBlur={this.handleAssetNameBlur}
                         onKeyDown={this.handleDimensionalKeydown}
                     />
@@ -167,6 +173,10 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
                 </div>
             </div>
         );
+    }
+
+    protected disableShortcutsOnFocus = () => {
+        this.setShortcutsEnabled(false);
     }
 
     protected handleWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -220,6 +230,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
             width: null,
             height: null
         });
+        this.setShortcutsEnabled(true);
     }
 
     protected handleDimensionalKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -251,6 +262,7 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
             dispatchChangeAssetName(newName);
         }
         this.setState({ assetName: null, assetNameMessage: null });
+        this.setShortcutsEnabled(true);
     }
 
     protected zoomIn = () => {
@@ -259,6 +271,16 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
 
     protected zoomOut = () => {
         this.props.dispatchChangeZoom(-1)
+    }
+
+    protected setShortcutsEnabled(enabled: boolean) {
+        if (enabled && this.shortcutLock) {
+            releaseShortcutLock(this.shortcutLock);
+            this.shortcutLock = undefined;
+        }
+        else if (!enabled && !this.shortcutLock) {
+            this.shortcutLock = obtainShortcutLock();
+        }
     }
 }
 

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -11,6 +11,7 @@ import { GestureTarget, ClientCoordinates, bindGestureEvents, TilemapPatch, crea
 
 import { Edit, EditState, getEdit, getEditState, ToolCursor, tools } from './toolDefinitions';
 import { createTile } from '../../assets';
+import { areShortcutsEnabled } from './keyboardShortcuts';
 
 const IMAGE_MIME_TYPE = "image/x-mkcd-f4"
 
@@ -255,7 +256,8 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
     }
 
     protected onKeyDown = (ev: KeyboardEvent): void => {
-        // TODO: we should bail out of this when gallery is open.
+        if (!areShortcutsEnabled()) return;
+
         this.hasInteracted = true;
 
         if (this.shouldHandleCanvasShortcut() && this.editState?.floating?.image) {

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -5,7 +5,10 @@ import { dispatchChangeZoom, dispatchUndoImageEdit, dispatchRedoImageEdit, dispa
 import { mainStore } from './store/imageStore';
 let store = mainStore;
 
+let lockRefs: number[] = [];
+
 export function addKeyListener() {
+    lockRefs = [];
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keydown", handleUndoRedo, true);
     document.addEventListener("keydown", overrideBlocklyShortcuts, true);
@@ -15,6 +18,26 @@ export function removeKeyListener() {
     document.removeEventListener("keydown", handleKeyDown);
     document.removeEventListener("keydown", handleUndoRedo, true);
     document.removeEventListener("keydown", overrideBlocklyShortcuts, true);
+}
+
+// Disables shortcuts and returns a ref. Enable by passing the ref to release shortcut lock
+export function obtainShortcutLock(): number {
+    let ref = 0;
+    while (!ref) ref = Math.random() * Number.MAX_SAFE_INTEGER
+    lockRefs.push(ref);
+    return ref;
+}
+
+// Enables shortcuts using the ref obtained from obtainShortcutLock
+export function releaseShortcutLock(ref: number) {
+    const index = lockRefs.indexOf(ref)
+    if (index !== -1) {
+        lockRefs.splice(index, 1);
+    }
+}
+
+export function areShortcutsEnabled() {
+    return !lockRefs.length;
 }
 
 export function setStore(newStore?: Store<ImageEditorStore>) {
@@ -41,6 +64,7 @@ function overrideBlocklyShortcuts(event: KeyboardEvent) {
 }
 
 function handleKeyDown(event: KeyboardEvent) {
+    if (!areShortcutsEnabled()) return;
     // Mostly copied from the photoshop shortcuts
     switch (event.key) {
         case "e":

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -4,6 +4,7 @@ import { FieldEditorComponent } from '../blocklyFieldView';
 import { AssetCardView } from "./assetEditor/assetCard";
 import { getAssets } from "./assetEditor/store/assetEditorReducer";
 import { ImageEditor } from "./ImageEditor/ImageEditor";
+import { obtainShortcutLock, releaseShortcutLock } from "./ImageEditor/keyboardShortcuts";
 import { GalleryTile, setTelemetryFunction } from './ImageEditor/store/imageReducer';
 
 export interface ImageFieldEditorProps {
@@ -33,6 +34,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     protected galleryAssets: pxt.Asset[];
     protected userAssets: pxt.Asset[];
     protected asset: pxt.Asset;
+    protected shortcutLock: number;
 
     constructor(props: ImageFieldEditorProps) {
         super(props);
@@ -244,6 +246,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     }
 
     protected showEditor = () => {
+        this.setImageEditorShortcutsEnabled(true);
         tickImageEditorEvent("gallery-editor");
         this.setState({
             currentView: "editor",
@@ -252,6 +255,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     }
 
     protected showGallery = () => {
+        this.setImageEditorShortcutsEnabled(false);
         tickImageEditorEvent("gallery-builtin");
         this.setState({
             currentView: "gallery",
@@ -260,6 +264,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     }
 
     protected showMyAssets = () => {
+        this.setImageEditorShortcutsEnabled(false);
         tickImageEditorEvent("gallery-my-assets");
         this.userAssets = getAssets();
         this.setState({
@@ -301,6 +306,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             currentView: "editor",
             tileGalleryVisible: false
         });
+        this.setImageEditorShortcutsEnabled(true);
     }
 
     protected onTileEditorOpenClose = (open: boolean) => {
@@ -322,6 +328,16 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     protected onDoneClick = () => {
         if (this.closeEditor) this.closeEditor();
         if (this.props.doneButtonCallback) this.props.doneButtonCallback();
+    }
+
+    protected setImageEditorShortcutsEnabled(enabled: boolean) {
+        if (enabled && this.shortcutLock) {
+            releaseShortcutLock(this.shortcutLock);
+            this.shortcutLock = undefined;
+        }
+        else if (!enabled && !this.shortcutLock) {
+            this.shortcutLock = obtainShortcutLock();
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2800
and takes care of an old todo