### PR TITLE
Unify recipe 'Exit Tutorial' behavior with tutorial

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3659,14 +3659,11 @@ export class ProjectView
     exitTutorial(removeProject?: boolean) {
         pxt.tickEvent("tutorial.exit", { tutorial: this.state.header?.tutorial?.tutorial });
         core.showLoading("leavingtutorial", lf("leaving tutorial..."));
-        const tutorial = this.state.header && this.state.header.tutorial;
-        const stayInEditor = tutorial && !!tutorial.tutorialRecipe;
 
         this.exitTutorialAsync(removeProject)
             .finally(() => {
                 core.hideLoading("leavingtutorial");
-                if (!stayInEditor)
-                    this.openHome();
+                this.openHome();
             })
     }
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -513,10 +513,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
     exitTutorial() {
         const tutorialOptions = this.props.parent.state.tutorialOptions;
         pxt.tickEvent("menu.exitTutorial", { tutorial: tutorialOptions?.tutorial }, { interactiveConsent: true });
-        if (tutorialOptions?.tutorialRecipe)
-            this.props.parent.completeTutorialAsync().done();
-        else
-            this.props.parent.exitTutorial();
+        this.props.parent.exitTutorial();
     }
 
     showReportAbuse() {


### PR DESCRIPTION
the "Exit Tutorial" button in the menu bar now takes the user to the homescreen (preserving the tutorial header) in both recipes and tutorials. we got teacher feedback that students were clicking "Exit" in the middle of Shark Attack and it was bumping them out of the recipe entirely. the "Finish" button at the end of the recipe still allows the user to exit while remaining in the editor.

fixes https://github.com/microsoft/pxt-arcade/issues/2676