### PR TITLE
Allow naming of temporary assets (image literals) from monaco field

### DIFF
--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -35,8 +35,14 @@ namespace pxt.editor {
         }
 
         protected resultToText(result: pxt.ProjectImage): string {
-            if (this.isAsset && result.meta.displayName) {
-                result = pxt.react.getTilemapProject().updateAsset(result)
+            if (result.meta?.displayName) {
+                const project = pxt.react.getTilemapProject();
+                if (this.isAsset) {
+                    result = project.updateAsset(result)
+                } else {
+                    this.isAsset = true;
+                    result = project.createNewProjectImage(result.bitmap, result.meta.displayName);
+                }
                 return `assets.image\`${result.meta.displayName}\``
             }
             return pxt.sprite.bitmapToImageLiteral(pxt.sprite.Bitmap.fromData(result.bitmap), this.isPython ? "python" : "typescript");

--- a/webapp/src/assets.ts
+++ b/webapp/src/assets.ts
@@ -1,11 +1,9 @@
-import * as pkg from "./package";
-
 export function isNameTaken(name: string) {
-    return pkg.mainEditorPkg().tilemapProject.isNameTaken(pxt.AssetType.Image, name);
+    return pxt.react.getTilemapProject().isNameTaken(pxt.AssetType.Image, name);
 }
 
 export function createNewImageAsset(type: pxt.AssetType.Tile | pxt.AssetType.Image | pxt.AssetType.Animation, width: number, height: number) {
-    const project = pkg.mainEditorPkg().tilemapProject;
+    const project = pxt.react.getTilemapProject();
     switch (type) {
         case pxt.AssetType.Tile:
             return project.createNewTile(new pxt.sprite.Bitmap(width, height).data());
@@ -18,21 +16,21 @@ export function createNewImageAsset(type: pxt.AssetType.Tile | pxt.AssetType.Ima
 }
 
 export function createProjectImage(bitmap: pxt.sprite.BitmapData) {
-    const project = pkg.mainEditorPkg().tilemapProject;
+    const project = pxt.react.getTilemapProject();
     return project.createNewProjectImage(bitmap);
 }
 
 export function createTile(bitmap: pxt.sprite.BitmapData) {
-    const project = pkg.mainEditorPkg().tilemapProject;
+    const project = pxt.react.getTilemapProject();
     return project.createNewTile(bitmap);
 }
 
 export function lookupAsset(type: pxt.AssetType, id: string) {
-    const project = pkg.mainEditorPkg().tilemapProject;
+    const project = pxt.react.getTilemapProject();
     return project.lookupAsset(type, id);
 }
 
 export function getNewInternalID() {
-    const project = pkg.mainEditorPkg().tilemapProject;
+    const project = pxt.react.getTilemapProject();
     return project.getNewInternalId();
 }


### PR DESCRIPTION
- Replace image literals with `assets.image\`name\`` if the user types a display name into the sprite editor
- Also fixes JS console error that happens if you refresh while in monaco and open the sprite editor and try to rename a sprite (tilemapProject isn't loaded)

Fixes https://github.com/microsoft/pxt-arcade/issues/2813