### PR TITLE
Always dispose of temporary asset when block is disposed

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -170,6 +170,7 @@ namespace pxtblockly {
         }
 
         onDispose() {
+            this.disposeOfTemporaryAsset();
             pxt.react.getTilemapProject().removeChangeListener(this.getAssetType(), this.assetChangeListener);
         }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -72,6 +72,8 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                     const blk = allblocks[bi];
                     if (!blk.isShadow()) usedBlocks[blk.type] = 1;
                 }
+                headless.dispose();
+
                 if (pxt.options.debug)
                     pxt.debug(JSON.stringify(usedBlocks, null, 2));
 


### PR DESCRIPTION
so the issue was, for JS/Py tutorials, running `getUsedBlocks` creates a workspace and renders all the blocks (including the assets), which never get cleaned up. this only happens the first time you load the tutorial in a session, because otherwise used blocks are cached. this change disposes of that workspace, and also disposes of the temporary asset when the block is disposed

fixes https://github.com/microsoft/pxt-arcade/issues/2807