### PR TITLE
Fix hang in safari when dragging a png from the gallery

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1370,6 +1370,7 @@ namespace ts.pxtc.Util {
                 const imgdat = ctx.getImageData(0, 0, canvas.width, canvas.height)
                 const d = imgdat.data
                 const bpp = (d[0] & 1) | ((d[1] & 1) << 1) | ((d[2] & 1) << 2)
+                // Safari sometimes just reads a buffer full of 0's so we also need to bail if bpp == 0
                 if (bpp > 5 || bpp == 0)
                     return Promise.reject(new Error(lf("Invalid encoded PNG format")))
 

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1370,7 +1370,7 @@ namespace ts.pxtc.Util {
                 const imgdat = ctx.getImageData(0, 0, canvas.width, canvas.height)
                 const d = imgdat.data
                 const bpp = (d[0] & 1) | ((d[1] & 1) << 1) | ((d[2] & 1) << 2)
-                if (bpp > 5)
+                if (bpp > 5 || bpp == 0)
                     return Promise.reject(new Error(lf("Invalid encoded PNG format")))
 
                 function decode(ptr: number, bpp: number, trg: Uint8Array) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2802

For some reason, Safari is just reading the gallery png as a buffer full of 0's. Handle that case