### PR TITLE
fix fill for walls on the tile in index 2

### DIFF
--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -651,7 +651,7 @@ export class FillEdit extends Edit {
 
     protected doEditCore(state: EditState) {
         const includeActiveLayerData = state.activeLayer !== state.image;
-        const getData = (col: number, row: number) => (includeActiveLayerData ? state.activeLayer.get(col, row) << 8 : 0) + state.image.get(col, row);
+        const getData = (col: number, row: number) => (includeActiveLayerData ? (state.activeLayer.get(col, row) + 1) << 8 : 0) + state.image.get(col, row);
 
         const colorToReplace = getData(this.col, this.row);
         if (colorToReplace === this.color) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2853

The magic thing that made it fail was if the tile was in the tilemap data at index 2 (red) which is the same index we use for tiles in the tilemap image.