### PR TITLE
Remove asset editor name on mobile

### DIFF
--- a/theme/image-editor/bottomBar.less
+++ b/theme/image-editor/bottomBar.less
@@ -103,3 +103,10 @@
     display: flex;
     flex-direction: row;
 }
+
+
+@media only screen and (max-width: @largestMobileScreen) {
+    .image-editor-change-name {
+        display: none;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2855

Hide it on mobile phones