### PR TITLE
Try loading the latest cloud version when opening a project; skip it if it takes too long

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -880,7 +880,7 @@ namespace ts.pxtc.Util {
     }
 
     export function timeout(ms: number): Promise<void> {
-        return new Promise(resolve => setTimeout(resolve, ms))
+        return new Promise(resolve => setTimeout(() => resolve(), ms))
     }
 
     // node.js overrides this to use process.cpuUsage()

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -879,6 +879,10 @@ namespace ts.pxtc.Util {
         return Math.round(now() / 1000)
     }
 
+    export function timeout(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms))
+    }
+
     // node.js overrides this to use process.cpuUsage()
     export let cpuUs = (): number => {
         // current time in microseconds

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -44,6 +44,7 @@ import * as socketbridge from "./socketbridge";
 import * as webusb from "./webusb";
 import * as keymap from "./keymap";
 import * as auth from "./auth";
+import * as cloud from "./cloud";
 import * as user from "./user";
 
 import * as monaco from "./monaco"
@@ -1304,26 +1305,37 @@ export class ProjectView
         if (checkAsync)
             return checkAsync.then(() => this.openHome());
 
-        let doSync = false
+        let p = Promise.resolve();
         // check our multi-tab session
         if (workspace.isHeadersSessionOutdated()) {
              // reload header before loading
             pxt.log(`multi-tab sync before load`)
-            doSync = true;
-        }
-        // check our cloud sync
-        const RESYNC_TIME_SEC = 5 * 60 // 5 minutes
-        const headerCloudSyncOutdated = auth.loggedInSync()
-            && Util.nowSeconds() - workspace.getHeaderLastCloudSync(h) > RESYNC_TIME_SEC
-        if (headerCloudSyncOutdated) {
-            pxt.log(`cloud sync before load`)
-            doSync = true;
-        }
-
-        let p = Promise.resolve();
-        if (doSync) {
             p = p.then(() => workspace.syncAsync().then(() => { }))
         }
+
+        // Try a quick cloud fetch. If it doesn't complete within X second(s),
+        // continue on.
+        const timeout = Util.timeout(1500/*1.5 seconds*/)
+        p = p.then(() => {
+            return Promise.any([
+                timeout,
+                // start a partial cloud sync
+                cloud.syncAsync([h])
+                    .then((changes) => {
+                        if (changes.length) {
+                            if (timeout.isResolved()) {
+                                // We are too late; the editor has already been loaded.
+                                // Call the onChanges handler to update the editor.
+                                cloud.onChangesSynced(changes)
+                            } else {
+                                // We're not too late, update the local var so that the
+                                // first load has the new info.
+                                h = workspace.getHeader(h.id)
+                            }
+                        }
+                    })
+            ])
+        })
 
         return p.then(() => {
             workspace.acquireHeaderSession(h);

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1505,7 +1505,10 @@ export async function saveToCloudAsync(h: Header) {
     pxt.debug(`cloud save to ${h.name} (${h.id})`)
     checkHeaderSession(h);
     const text = await getTextAsync(h.id)
-    return cloud.saveAsync(h, text)
+    const res = await cloud.saveAsync(h, text)
+    // TODO: update UX to indicate a save finished
+    pxt.log(`Project ${h.name} (${h.id.substr(0,4)}...) saved to cloud.`)
+    return res;
 }
 
 // this promise is set while a sync is in progress


### PR DESCRIPTION
Try loading the latest cloud version when opening a project; skip it if it takes too long
Adds support for partial synchronizations.

The new behavior is:
When opening a cloud project,
Start fetching that project's latest state from the cloud,
If the fetch completes with 1.5 seconds, great, load that,
Else, load the local project and if the sync comes back with changes, refresh the editor

Fixes: https://github.com/microsoft/pxt-arcade/issues/2866

![2021-01-13 16 12 15](https://user-images.githubusercontent.com/6453828/104528701-d030be00-55bc-11eb-8fed-80f5c56c7a6d.gif)
