### PR TITLE
Fix docs sims w jres, support assetjson in docs

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2243,16 +2243,19 @@ function buildTargetCoreAsync(options: BuildTargetOptions = {}) {
                             return;
                         }
 
-                        // Place the base HEX image in the hex cache if necessary
-                        let sha = options.extinfo.sha;
-                        let hex: string[] = options.extinfo.hexinfo.hex;
-                        let hexFile = path.join(hexCachePath, sha + ".hex");
+                        const hexFileExtInfo = [options.extinfo, ...(options.otherMultiVariants?.map(el => el.extinfo) || [])];
+                        for (const extinfo of hexFileExtInfo) {
+                            // Place the base HEX image in the hex cache if necessary
+                            let sha = extinfo.sha;
+                            let hex: string[] = extinfo.hexinfo.hex;
+                            let hexFile = path.join(hexCachePath, sha + ".hex");
 
-                        if (fs.existsSync(hexFile)) {
-                            pxt.debug(`native image already in offline cache for project ${dirname}: ${hexFile}`);
-                        } else {
-                            nodeutil.writeFileSync(hexFile, hex.join(os.EOL));
-                            pxt.debug(`created native image in offline cache for project ${dirname}: ${hexFile}`);
+                            if (fs.existsSync(hexFile)) {
+                                pxt.debug(`native image already in offline cache for project ${dirname}: ${hexFile}`);
+                            } else {
+                                nodeutil.writeFileSync(hexFile, hex.join(os.EOL));
+                                pxt.debug(`created native image in offline cache for project ${dirname}: ${hexFile}`);
+                            }
                         }
                     }
 

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -81,8 +81,13 @@ div.blocks-svg-list > svg {
 code {
     white-space: pre-wrap;
 }
-code.lang-ghost, code.lang-config, code.lang-package
-{ display: none;}
+code.lang-ghost,
+code.lang-config,
+code.lang-package,
+code.lang-jres,
+code.lang-assetsjson {
+    display: none;
+}
 
 code.lang-block::before,
 code.lang-blocks::before,
@@ -128,7 +133,6 @@ code.lang-codecard > ul,
 code.lang-codecard > hr {
     display: none
 }
-
 
 /* wrap cards header */
 .ui.card > .content > .header {

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -25,7 +25,7 @@ namespace pxt.blocks {
         splitSvg?: boolean;
         forceCompilation?: boolean;
         generateSourceMap?: boolean;
-        jres?: string;
+        assets?: pxt.Map<string>;
     }
 
     export function initRenderingWorkspace() {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1069,6 +1069,8 @@ namespace pxt {
         }
 
         loadAssetsJRes(jres: Map<JRes>) {
+            jres = inflateJRes(jres);
+
             for (const key of Object.keys(jres)) {
                 const entry = jres[key];
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1227,13 +1227,13 @@ namespace pxt {
                     if (needsInflation) {
                         toInflate.push(animation);
                     } else {
-                        this.state.animations.add(animation);
+                        assets.push(animation);
                     }
                 }
             }
 
             for (const animation of toInflate) {
-                this.state.animations.add(this.inflateAnimation(animation, assets));
+                assets.push(this.inflateAnimation(animation, assets));
             }
 
             return assets;

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -416,7 +416,7 @@ ${code}
             [pxt.TILEMAP_JRES]: files[pxt.TILEMAP_JRES],
             [pxt.TILEMAP_CODE]: files[pxt.TILEMAP_CODE],
             [pxt.IMAGES_JRES]: files[pxt.IMAGES_JRES],
-            [pxt.IMAGES_CODE]: files[pxt.IMAGES_CODE]
+            [pxt.IMAGES_CODE]: files[pxt.IMAGES_CODE],
         }
     }
 }

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -33,8 +33,8 @@ namespace pxt.runner {
         packageClass?: string;
         package?: string;
         jresClass?: string;
-        jres?: string;
-        assetJSON?: string;
+        assetJSONClass?: string;
+        assetJSON?: Map<string>;
         showEdit?: boolean;
         showJavaScript?: boolean; // default is to show blocks first
         split?: boolean; // split in multiple divs if too big
@@ -59,6 +59,7 @@ namespace pxt.runner {
             codeCardClass: 'lang-codecard',
             packageClass: 'lang-package',
             jresClass: 'lang-jres',
+            assetJSONClass: 'lang-assetsjson',
             projectClass: 'lang-project',
             snippetReplaceParent: true,
             simulator: true,
@@ -218,11 +219,13 @@ namespace pxt.runner {
                 pkg.setPreferredEditor(pxt.JAVASCRIPT_PROJECT_NAME);
             }
 
-            if (options.jres) {
-                host.writeFile(pkg, pxt.TILEMAP_JRES, options.jres);
-                host.writeFile(pkg, pxt.TILEMAP_CODE, pxt.emitTilemapsFromJRes(JSON.parse(options.jres)));
-                pkg.config.files.push(pxt.TILEMAP_JRES);
-                pkg.config.files.push(pxt.TILEMAP_CODE);
+            if (options.assetJSON) {
+                for (const key of Object.keys(options.assetJSON)) {
+                    if (pkg.config.files.indexOf(key) < 0) {
+                        pkg.config.files.push(key);
+                    }
+                    host.writeFile(pkg, key, options.assetJSON[key]);
+                }
             }
 
             const compressed = pkg.compressToFileAsync();
@@ -263,8 +266,7 @@ namespace pxt.runner {
                     if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
                     const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
                     const url = getRunUrl(options) + "#nofooter=1" + deps;
-                    const assetJson = mergeAssetJson(options);
-                    const assets = assetJson ? `data-assets="${encodeURIComponent(assetJson)}"` : "";
+                    const assets = options.assetJSON ? `data-assets="${encodeURIComponent(JSON.stringify(options.assetJSON))}"` : "";
                     const data = encodeURIComponent($js.text());
                     let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" data-code="${data}" ${assets} allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
                     $c.append($embed);
@@ -430,7 +432,7 @@ namespace pxt.runner {
                 if (options.snippetReplaceParent) c = c.parent();
                 const segment = $('<div class="ui segment codewidget"/>').append(s);
                 c.replaceWith(segment);
-            }, { package: options.package, snippetMode: false, aspectRatio: options.blocksAspectRatio, jres: options.jres });
+            }, { package: options.package, snippetMode: false, aspectRatio: options.blocksAspectRatio, assets: options.assetJSON });
         }
 
         let snippetCount = 0;
@@ -451,7 +453,7 @@ namespace pxt.runner {
                 hexname: hexname,
                 hex: hex,
             });
-        }, { package: options.package, aspectRatio: options.blocksAspectRatio, jres: options.jres });
+        }, { package: options.package, aspectRatio: options.blocksAspectRatio, assets: options.assetJSON });
     }
 
     function decompileCallInfo(stmt: ts.Statement): pxtc.CallInfo {
@@ -500,7 +502,7 @@ namespace pxt.runner {
                 trs.insertAfter(c);
             }
             fillWithWidget(options, c, js, py, s, r, { showJs: true, showPy: true, hideGutter: true });
-        }, { package: options.package, snippetMode: true, aspectRatio: options.blocksAspectRatio, jres: options.jres });
+        }, { package: options.package, snippetMode: true, aspectRatio: options.blocksAspectRatio, assets: options.assetJSON });
     }
 
     function renderBlocksAsync(options: ClientRenderOptions): Promise<void> {
@@ -509,7 +511,7 @@ namespace pxt.runner {
             if (options.snippetReplaceParent) c = c.parent();
             const segment = $('<div class="ui segment codewidget"/>').append(s);
             c.replaceWith(segment);
-        }, { package: options.package, snippetMode: true, aspectRatio: options.blocksAspectRatio, jres: options.jres });
+        }, { package: options.package, snippetMode: true, aspectRatio: options.blocksAspectRatio, assets: options.assetJSON });
     }
 
     function renderStaticPythonAsync(options: ClientRenderOptions): Promise<void> {
@@ -527,7 +529,7 @@ namespace pxt.runner {
                 highlight($py);
                 fillWithWidget(options, c.parent(), /* js */ $js, /* py */ $py, /* svg */ undefined, r, woptions);
             }
-        }, { package: options.package, snippetMode: true, jres: options.jres });
+        }, { package: options.package, snippetMode: true, assets: options.assetJSON });
     }
 
     function renderBlocksXmlAsync(opts: ClientRenderOptions): Promise<void> {
@@ -559,7 +561,7 @@ namespace pxt.runner {
             if (opts.snippetReplaceParent) c = c.parent();
             const segment = $('<div class="ui segment codewidget"/>').append(s);
             c.replaceWith(segment);
-        }, { package: opts.package, snippetMode: true, aspectRatio: opts.blocksAspectRatio, jres: opts.jres });
+        }, { package: opts.package, snippetMode: true, aspectRatio: opts.blocksAspectRatio, assets: opts.assetJSON });
     }
 
     function renderDiffBlocksXmlAsync(opts: ClientRenderOptions): Promise<void> {
@@ -602,7 +604,7 @@ namespace pxt.runner {
             if (opts.snippetReplaceParent) c = c.parent();
             const segment = $('<div class="ui segment codewidget"/>').append(s);
             c.replaceWith(segment);
-        }, { package: opts.package, snippetMode: true, aspectRatio: opts.blocksAspectRatio, jres: opts.jres });
+        }, { package: opts.package, snippetMode: true, aspectRatio: opts.blocksAspectRatio, assets: opts.assetJSON });
     }
 
 
@@ -1038,7 +1040,7 @@ namespace pxt.runner {
 
             if (replaceParent) c = c.parent();
             c.replaceWith(ul)
-        }, { package: options.package, aspectRatio: options.blocksAspectRatio, jres: options.jres })
+        }, { package: options.package, aspectRatio: options.blocksAspectRatio, assets: options.assetJSON })
     }
 
     function fillCodeCardAsync(c: JQuery, cards: pxt.CodeCard[], options: pxt.docs.codeCard.CodeCardRenderOptions): Promise<void> {
@@ -1136,32 +1138,36 @@ namespace pxt.runner {
         })
     }
 
-    function readJRes(options: ClientRenderOptions) {
-        if (!options.jresClass) return;
-        $('.' + options.jresClass).each((i, c) => {
-            const $c = $(c);
-            options.jres = $c.text();
-            c.parentElement.remove();
-        });
-    }
-
     function readAssetJson(options: ClientRenderOptions) {
-        $('.assetjson').each((i, c) => {
-            const $c = $(c);
-            options.assetJSON = $c.text();
-            c.parentElement.remove();
-        });
-    }
-
-    function mergeAssetJson(options: ClientRenderOptions) {
-        if (!options.assetJSON && !options.jres) return undefined;
-        const mergedJson = pxt.tutorial.parseAssetJson(options.assetJSON) || {};
-        if (options.jres) {
-            const parsedTmapJres = JSON.parse(options.jres);
-            mergedJson[pxt.TILEMAP_JRES] = JSON.stringify(parsedTmapJres);
-            mergedJson[pxt.TILEMAP_CODE] = pxt.emitTilemapsFromJRes(parsedTmapJres);
+        let assetJson: string;
+        let tilemapJres: string;
+        if (options.jresClass) {
+            $(`.${options.jresClass}`).each((i, c) => {
+                const $c = $(c);
+                tilemapJres = $c.text();
+                c.parentElement.remove();
+            });
         }
-        return JSON.stringify(mergedJson);
+        if (options.assetJSONClass) {
+            $(`.${options.assetJSONClass}`).each((i, c) => {
+                const $c = $(c);
+                assetJson = $c.text();
+                c.parentElement.remove();
+            });
+        }
+
+        options.assetJSON = mergeAssetJson(assetJson, tilemapJres);
+
+        function mergeAssetJson(assetJSON: string, tilemapJres: string) {
+            if (!assetJSON && !tilemapJres) return undefined;
+            const mergedJson = pxt.tutorial.parseAssetJson(assetJSON) || {};
+            if (tilemapJres) {
+                const parsedTmapJres = JSON.parse(tilemapJres);
+                mergedJson[pxt.TILEMAP_JRES] = JSON.stringify(parsedTmapJres);
+                mergedJson[pxt.TILEMAP_CODE] = pxt.emitTilemapsFromJRes(parsedTmapJres);
+            }
+            return mergedJson;
+        }
     }
 
     function renderDirectPython(options?: ClientRenderOptions) {
@@ -1262,16 +1268,14 @@ namespace pxt.runner {
                     </div>
                     </div></div>`)
             const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
-            const assetJson = mergeAssetJson(options);
-            const assets = assetJson ? `data-assets="${encodeURIComponent(assetJson)}"` : "";
 
             const url = getRunUrl(options) + "#nofooter=1" + deps;
             const data = encodeURIComponent($c.text().trim());
             const $simIFrame = $sim.find("iframe");
             $simIFrame.attr("src", url);
             $simIFrame.attr("data-code", data);
-            if (assetJson) {
-                $simIFrame.attr("data-assets", assetJson);
+            if (options.assetJSON) {
+                $simIFrame.attr("data-assets", JSON.stringify(options.assetJSON));
             }
             if (options.snippetReplaceParent) $c = $c.parent();
             $c.replaceWith($sim);
@@ -1285,7 +1289,6 @@ namespace pxt.runner {
         if (options.showEdit) options.showEdit = !pxt.BrowserUtils.isIFrame();
 
         mergeConfig(options);
-        readJRes(options);
         readAssetJson(options);
 
         renderQueue = [];

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -262,8 +262,9 @@ namespace pxt.runner {
                     if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio) + '%';
                     const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
                     const url = getRunUrl(options) + "#nofooter=1" + deps;
+                    const jres = options.jres ? `data-jres="${encodeURIComponent(options.jres)}"` : "";
                     const data = encodeURIComponent($js.text());
-                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" data-code="${data}" allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
+                    let $embed = $(`<div class="ui card sim"><div class="ui content"><div style="position:relative;height:0;padding-bottom:${padding};overflow:hidden;"><iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="${url}" data-code="${data}" ${jres} allowfullscreen="allowfullscreen" sandbox="allow-popups allow-forms allow-scripts allow-same-origin" frameborder="0"></iframe></div></div></div>`);
                     $c.append($embed);
 
                     scrollJQueryIntoView($embed);
@@ -1240,10 +1241,15 @@ namespace pxt.runner {
                     </div>
                     </div></div>`)
             const deps = options.package ? "&deps=" + encodeURIComponent(options.package) : "";
+            const jres = options.jres ? encodeURIComponent(options.jres) : "";
             const url = getRunUrl(options) + "#nofooter=1" + deps;
             const data = encodeURIComponent($c.text().trim());
-            $sim.find("iframe").attr("src", url);
-            $sim.find("iframe").attr("data-code", data);
+            const $simIFrame = $sim.find("iframe");
+            $simIFrame.attr("src", url);
+            $simIFrame.attr("data-code", data);
+            if (jres) {
+                $simIFrame.attr("data-jres", jres);
+            }
             if (options.snippetReplaceParent) $c = $c.parent();
             $c.replaceWith($sim);
         });

--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -34,7 +34,7 @@ namespace pxt.runner {
         package?: string;
         jresClass?: string;
         jres?: string;
-        assetjson?: string;
+        assetJSON?: string;
         showEdit?: boolean;
         showJavaScript?: boolean; // default is to show blocks first
         split?: boolean; // split in multiple divs if too big
@@ -1148,14 +1148,14 @@ namespace pxt.runner {
     function readAssetJson(options: ClientRenderOptions) {
         $('.assetjson').each((i, c) => {
             const $c = $(c);
-            options.assetjson = $c.text();
+            options.assetJSON = $c.text();
             c.parentElement.remove();
         });
     }
 
     function mergeAssetJson(options: ClientRenderOptions) {
-        if (!options.assetjson && !options.jres) return undefined;
-        const mergedJson = options.assetjson ? JSON.parse(options.assetjson) : {};
+        if (!options.assetJSON && !options.jres) return undefined;
+        const mergedJson = pxt.tutorial.parseAssetJson(options.assetJSON) || {};
         if (options.jres) {
             const parsedTmapJres = JSON.parse(options.jres);
             mergedJson[pxt.TILEMAP_JRES] = JSON.stringify(parsedTmapJres);

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -1073,16 +1073,19 @@ ${linkString}
                             };
                         pxt.debug(bresp.outfiles["main.blocks"])
 
-                        const tilemapJres = options.assets?.[TILEMAP_JRES];
-                        if (tilemapJres) {
+                        const tilemapJres = options.assets?.[pxt.TILEMAP_JRES];
+                        const assetsJres = options.assets?.[pxt.IMAGES_JRES];
+                        if (tilemapJres || assetsJres) {
                             tilemapProject = new TilemapProject();
                             tilemapProject.loadPackage(mainPkg);
-                            tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
+                            if (tilemapJres)
+                                tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
+                            if (assetsJres)
+                                tilemapProject.loadAssetsJRes(JSON.parse(assetsJres))
                         }
-
                         const blocksSvg = pxt.blocks.render(bresp.outfiles["main.blocks"], options);
 
-                        if (tilemapJres) {
+                        if (tilemapJres || assetsJres) {
                             tilemapProject = null;
                         }
 
@@ -1133,14 +1136,18 @@ ${linkString}
                         pxt.blocks.initializeAndInject(blocksInfo);
 
                         const tilemapJres = options.assets?.[pxt.TILEMAP_JRES];
-                        if (tilemapJres) {
+                        const assetsJres = options.assets?.[pxt.IMAGES_JRES];
+                        if (tilemapJres || assetsJres) {
                             tilemapProject = new TilemapProject();
                             tilemapProject.loadPackage(mainPkg);
-                            tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
+                            if (tilemapJres)
+                                tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
+                            if (assetsJres)
+                                tilemapProject.loadAssetsJRes(JSON.parse(assetsJres))
                         }
                         const blockSvg = pxt.blocks.render(code, options);
 
-                        if (tilemapJres) {
+                        if (tilemapJres || assetsJres) {
                             tilemapProject = null;
                         }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -1023,13 +1023,12 @@ ${linkString}
                     opts.fileSystem["main.ts"] = code;
                 opts.ast = true
 
-                if (options.jres) {
-                    const tilemapTS = pxt.emitTilemapsFromJRes(JSON.parse(options.jres));
-                    if (tilemapTS) {
-                        opts.fileSystem[pxt.TILEMAP_JRES] = options.jres;
-                        opts.fileSystem[pxt.TILEMAP_CODE] = tilemapTS;
-                        opts.sourceFiles.push(pxt.TILEMAP_JRES);
-                        opts.sourceFiles.push(pxt.TILEMAP_CODE);
+                if (options.assets) {
+                    for (const key of Object.keys(options.assets)) {
+                        if (opts.sourceFiles.indexOf(key) < 0) {
+                            opts.sourceFiles.push(key);
+                        }
+                        opts.fileSystem[key] = options.assets[key];
                     }
                 }
 
@@ -1074,15 +1073,16 @@ ${linkString}
                             };
                         pxt.debug(bresp.outfiles["main.blocks"])
 
-                        if (options.jres) {
+                        const tilemapJres = options.assets?.[TILEMAP_JRES];
+                        if (tilemapJres) {
                             tilemapProject = new TilemapProject();
                             tilemapProject.loadPackage(mainPkg);
-                            tilemapProject.loadTilemapJRes(JSON.parse(options.jres), true);
+                            tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
                         }
 
                         const blocksSvg = pxt.blocks.render(bresp.outfiles["main.blocks"], options);
 
-                        if (options.jres) {
+                        if (tilemapJres) {
                             tilemapProject = null;
                         }
 
@@ -1117,13 +1117,12 @@ ${linkString}
             .then(() => getCompileOptionsAsync(appTarget.compile ? appTarget.compile.hasHex : false))
             .then(opts => {
                 opts.ast = true
-                if (options.jres) {
-                    const tilemapTS = pxt.emitTilemapsFromJRes(JSON.parse(options.jres));
-                    if (tilemapTS) {
-                        opts.fileSystem[pxt.TILEMAP_JRES] = options.jres;
-                        opts.fileSystem[pxt.TILEMAP_CODE] = tilemapTS;
-                        opts.sourceFiles.push(pxt.TILEMAP_JRES);
-                        opts.sourceFiles.push(pxt.TILEMAP_CODE);
+                if (options.assets) {
+                    for (const key of Object.keys(options.assets)) {
+                        if (opts.sourceFiles.indexOf(key) < 0) {
+                            opts.sourceFiles.push(key);
+                        }
+                        opts.fileSystem[key] = options.assets[key];
                     }
                 }
                 const resp = pxtc.compile(opts)
@@ -1133,14 +1132,15 @@ ${linkString}
                         const blocksInfo = pxtc.getBlocksInfo(apis);
                         pxt.blocks.initializeAndInject(blocksInfo);
 
-                        if (options.jres) {
+                        const tilemapJres = options.assets?.[pxt.TILEMAP_JRES];
+                        if (tilemapJres) {
                             tilemapProject = new TilemapProject();
                             tilemapProject.loadPackage(mainPkg);
-                            tilemapProject.loadTilemapJRes(JSON.parse(options.jres), true);
+                            tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
                         }
                         const blockSvg = pxt.blocks.render(code, options);
 
-                        if (options.jres) {
+                        if (tilemapJres) {
                             tilemapProject = null;
                         }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -1054,6 +1054,16 @@ ${linkString}
                     .then(() => {
                         let blocksInfo = pxtc.getBlocksInfo(apis);
                         pxt.blocks.initializeAndInject(blocksInfo);
+                        const tilemapJres = options.assets?.[pxt.TILEMAP_JRES];
+                        const assetsJres = options.assets?.[pxt.IMAGES_JRES];
+                        if (tilemapJres || assetsJres) {
+                            tilemapProject = new TilemapProject();
+                            tilemapProject.loadPackage(mainPkg);
+                            if (tilemapJres)
+                                tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
+                            if (assetsJres)
+                                tilemapProject.loadAssetsJRes(JSON.parse(assetsJres))
+                        }
                         let bresp = pxtc.decompiler.decompileToBlocks(
                             blocksInfo,
                             program.getSourceFile("main.ts"),
@@ -1073,16 +1083,6 @@ ${linkString}
                             };
                         pxt.debug(bresp.outfiles["main.blocks"])
 
-                        const tilemapJres = options.assets?.[pxt.TILEMAP_JRES];
-                        const assetsJres = options.assets?.[pxt.IMAGES_JRES];
-                        if (tilemapJres || assetsJres) {
-                            tilemapProject = new TilemapProject();
-                            tilemapProject.loadPackage(mainPkg);
-                            if (tilemapJres)
-                                tilemapProject.loadTilemapJRes(JSON.parse(tilemapJres), true);
-                            if (assetsJres)
-                                tilemapProject.loadAssetsJRes(JSON.parse(assetsJres))
-                        }
                         const blocksSvg = pxt.blocks.render(bresp.outfiles["main.blocks"], options);
 
                         if (tilemapJres || assetsJres) {

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -10,6 +10,7 @@ namespace pxt.runner {
     export interface SimulateOptions {
         id?: string;
         code?: string;
+        jres?: string;
         highContrast?: boolean;
         light?: boolean;
         fullScreen?: boolean;
@@ -409,6 +410,12 @@ namespace pxt.runner {
         const currentTargetVersion = pxt.appTarget.versions.target;
         let compileResult = await compileAsync(false, opts => {
             if (simOptions.code) opts.fileSystem["main.ts"] = simOptions.code;
+            if (simOptions.jres) {
+                opts.sourceFiles.push(pxt.TILEMAP_JRES, pxt.TILEMAP_CODE)
+                opts.fileSystem[pxt.TILEMAP_JRES] = simOptions.jres;
+                opts.fileSystem[pxt.TILEMAP_CODE] = pxt.emitTilemapsFromJRes(JSON.parse(simOptions.jres));
+                opts.jres = pxt.inflateJRes(JSON.parse(simOptions.jres), opts.jres);
+            }
 
             // Api info needed for py2ts conversion, if project is shared in Python
             if (opts.target.preferredEditor === pxt.PYTHON_PROJECT_NAME) {

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -117,8 +117,10 @@
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var codeFromData = undefined;
+        var jresFromData = undefined;
         try {
             codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
+            jresFromData = window.frameElement ? window.frameElement.getAttribute('data-jres') : undefined;
         } catch (e) {
             /**
              *  Internet Explorer 11 and Microsoft Edge throw an exception when checking
@@ -199,6 +201,7 @@
                     var options = {
                         id: id ? id[1] : undefined,
                         code: code ? decodeURIComponent(code) : undefined,
+                        jres: jresFromData ? decodeURIComponent(jresFromData) : undefined,
                         highContrast: highContrast,
                         light: light,
                         fullScreen: fullScreen,

--- a/webapp/public/run.html
+++ b/webapp/public/run.html
@@ -117,10 +117,10 @@
 
         var codeFromSrc = /code(?:[:=])([^&?]+)/i.exec(window.location.href);
         var codeFromData = undefined;
-        var jresFromData = undefined;
+        var assetJsonFromData = undefined;
         try {
             codeFromData = window.frameElement ? window.frameElement.getAttribute('data-code') : undefined;
-            jresFromData = window.frameElement ? window.frameElement.getAttribute('data-jres') : undefined;
+            assetJsonFromData = window.frameElement ? window.frameElement.getAttribute('data-assets') : undefined;
         } catch (e) {
             /**
              *  Internet Explorer 11 and Microsoft Edge throw an exception when checking
@@ -201,7 +201,7 @@
                     var options = {
                         id: id ? id[1] : undefined,
                         code: code ? decodeURIComponent(code) : undefined,
-                        jres: jresFromData ? decodeURIComponent(jresFromData) : undefined,
+                        assets: assetJsonFromData ? decodeURIComponent(assetJsonFromData) : undefined,
                         highContrast: highContrast,
                         light: light,
                         fullScreen: fullScreen,


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2566 (include the jres when compiling simjs), and also support the \`\`\`assetjson snippets in docs as I noticed that was missing.

(also fix a minor bug where there was still a box where \`\`\`jres snippets used to be, you can see it at the bottom of https://arcade.makecode.com/blocks-games/jumpy-platformer)

~in the test md file I made it looks like images / animations from the jres aren't getting loaded properly into the blocks, will take a look at that (but wanted to put up PR first as I think this will be the majority of the changes / probably just need an extra line in runner.ts somewhere to patch in the images properly)~ ~Fixed images but animations are still showing up as grey blocks for some reason~ fixed all, but could use some double checking on these two commits: https://github.com/microsoft/pxt/pull/7784/files/04aac748dd41d5255fe3713ad72f6dc999c3ed84..3c3f8a281b53b7014795b8ad6ff3c54bd36ffed7 as well as https://github.com/microsoft/pxt-common-packages/pull/1214

===> test file for assetjson snippets I made
[test-asset-json.zip](https://github.com/microsoft/pxt/files/5812320/test-asset-json.zip)

