### PR TITLE
auth: logout if we receive 401/Unauthorized

### DIFF
--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -558,7 +558,6 @@ const DEV_BACKEND_PROD = "https://www.makecode.com";
 const DEV_BACKEND_STAGING = "https://staging.pxt.io";
 // tslint:disable-next-line:no-http-string
 const DEV_BACKEND_LOCALHOST = "http://localhost:5500";
-const DEV_BACKEND_LOCALHOST_SSL = "https://localhost:5500";
 
 const DEV_BACKEND = DEV_BACKEND_LOCALHOST;
 
@@ -585,7 +584,11 @@ export async function apiAsync<T = any>(url: string, data?: any, method?: string
             success: Math.floor(r.statusCode / 100) === 2,
             errmsg: null
         }
-    }).catch(e => {
+    }).catch(async (e) => {
+        if (!/logout/.test(url) && e.statusCode == 401) {
+            // 401/Unauthorized. logout now.
+            await logout();
+        }
         return {
             statusCode: e.statusCode,
             errmsg: e.message,


### PR DESCRIPTION
If any authenticated api call returns 401/Unauthorized, logout the user. This indicates the user did something to invalidate their account such as delete their account from another browser or tab.