### PR TITLE
Use checkerboard background for asset preview

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -111,7 +111,7 @@
     display: flex;
     width: 100%;
     height: 100%;
-    background: @assetPreviewBackground;
+    background-image: @assetPreviewBackground;
 
     img {
         max-width: 100%;

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -378,7 +378,7 @@
 @assetSidebarBorder: #dedede;
 @assetSidebarButton: #f8f8f8;
 @assetSidebarButtonHover: #dedede;
-@assetPreviewBackground: #dedede;
+@assetPreviewBackground: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10px' height='10px'%3E%3Crect x='0' y='0' width='10px' height='10px' fill='white'%3E%3C/rect%3E%3Crect x='0' y='0' width='5px' height='5px' fill='%23dedede'%3E%3C/rect%3E%3Crect x='5' y='5' width='5px' height='5px' fill='%23dedede'%3E%3C/rect%3E%3C/svg%3E");
 @assetUnselected: #e3ddd0;
 @assetTypeButton: @teal;
 


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/issues/2605#issuecomment-760701673

bringing back the checkerboard!

![image](https://user-images.githubusercontent.com/34112083/104760502-50b70200-5716-11eb-8c8b-ae2bcea92951.png)
