### PR TITLE
Set isProjectTile true to tiles returned from asset field editor

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -746,7 +746,7 @@ namespace pxt {
                 for (const tm of this.getAssets(AssetType.Tilemap)) {
                     if (skipIDs?.indexOf(tm.id) >= 0) {
                         continue;
-                    } else if (tm.data.tileset.tiles.some(t => t.internalID === asset.internalID)) {
+                    } else if (tm.data.tileset.tiles.some(t => t.id === asset.id)) {
                         return true;
                     }
                 }

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -186,6 +186,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
         return {
             id: state.asset?.id,
             internalID: state.asset ? state.asset.internalID : getNewInternalID(),
+            isProjectTile: true,
             type: pxt.AssetType.Tile,
             bitmap: data,
             jresData: pxt.sprite.base64EncodeBitmap(data),


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2907

\+ check ID instead of internalID for seeing if a tile asset is being used in a tilemap