### PR TITLE
Fix asset transformation bugs

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1274,9 +1274,6 @@ namespace pxt.blocks {
                     }
                 }
             }
-            else if (field instanceof pxtblockly.FieldSpriteEditor && e.options.emitTilemapLiterals) {
-                field.disposeOfTemporaryAsset();
-            }
 
             // For some enums in pxt-minecraft, we emit the members as constants that are defined in
             // libs/core. For example, Blocks.GoldBlock is emitted as GOLD_BLOCK

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -171,14 +171,16 @@ namespace pxtblockly {
         }
 
         onDispose() {
-            this.disposeOfTemporaryAsset();
+            if (this.sourceBlock_?.workspace && !this.sourceBlock_.workspace.rendered) {
+                this.disposeOfTemporaryAsset();
+            }
             pxt.react.getTilemapProject().removeChangeListener(this.getAssetType(), this.assetChangeListener);
         }
 
         disposeOfTemporaryAsset() {
             if (this.isTemporaryAsset()) {
                 pxt.react.getTilemapProject().removeAsset(this.asset);
-                this.setBlockData("");
+                this.setBlockData(null);
                 this.asset = undefined;
             }
         }
@@ -244,7 +246,13 @@ namespace pxtblockly {
                     if (this.asset) {
                         if (this.sourceBlock_ && this.asset.meta.blockIDs) {
                             this.asset.meta.blockIDs = this.asset.meta.blockIDs.filter(id => id !== this.sourceBlock_.id);
-                            project.updateAsset(this.asset);
+
+                            if (this.asset.meta.blockIDs.length === 0 && !this.asset.meta.displayName) {
+                                project.removeAsset(this.asset);
+                            }
+                            else {
+                                project.updateAsset(this.asset);
+                            }
                         }
                     }
                     this.isEmpty = !newText;

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -185,6 +185,12 @@ namespace pxtblockly {
             }
         }
 
+        clearTemporaryAssetData() {
+            if (this.isTemporaryAsset()) {
+                this.setBlockData(null);
+            }
+        }
+
         protected onEditorClose(newValue: pxt.Asset) {
             // Subclass
         }

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -200,6 +200,7 @@ namespace pxt.editor {
         saveBlocksToTypeScriptAsync(): Promise<string>;
 
         saveFileAsync(): Promise<void>;
+        saveCurrentSourceAsync(): Promise<void>;
         saveProjectAsync(): Promise<void>;
         loadHeaderAsync(h: pxt.workspace.Header): Promise<void>;
         reloadHeaderAsync(): Promise<void>;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -387,7 +387,7 @@ export class ProjectView
         if (!this.editorFile || this.loadingExample)
             return Promise.resolve()
         return this.saveTypeScriptAsync()
-            .then(() => this.setFileContentAsync());
+            .then(() => this.saveCurrentSourceAsync());
     }
 
     saveProjectAsync(): Promise<void> {
@@ -396,7 +396,7 @@ export class ProjectView
             .then(() => this.state.header && workspace.saveAsync(this.state.header))
     }
 
-    setFileContentAsync(): Promise<void> {
+    saveCurrentSourceAsync(): Promise<void> {
         let txt = this.editor.getCurrentSource()
         if (txt != this.editorFile.content)
             simulator.setDirty();
@@ -2386,7 +2386,7 @@ export class ProjectView
 
         // Python uses the virtual file and not the current editor content, so sync content
         if (fromLanguage == "py") {
-            promise = promise.then(() => this.setFileContentAsync());
+            promise = promise.then(() => this.saveCurrentSourceAsync());
         }
 
         promise = promise

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -124,7 +124,20 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 .then((compilationResult) => {
                     this.compilationResult = compilationResult;
                     pxt.tickActivity("blocks.compile");
-                    return this.compilationResult.source;
+
+                    let next = Promise.resolve();
+                    if (willOpenTypeScript && this.parent) {
+                        // If we are opening TypeScript, clean up the temporary assets
+                        // We need to do these steps in this order:
+                        //   1. Remove the block data elements for each field
+                        //   2. Save the XML with the blocks data removed (otherwise reloading the blocks will break)
+                        //   3. Dispose of the temporary assets themselves
+                        clearTemporaryAssetBlockData(this.editor)
+                        next = this.parent.saveCurrentSourceAsync()
+                            .then(() => disposeOfTemporaryAssets(this.editor))
+                    }
+
+                    return next.then(() => this.compilationResult.source)
                 });
         } catch (e) {
             pxt.reportException(e)
@@ -1763,4 +1776,27 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         });
         this.editor.setDebugModeOption(debugging);
     }
+}
+
+function forEachImageField(workspace: Blockly.Workspace, cb: (asset: pxtblockly.FieldAssetEditor<any, any>) => void) {
+    const blocks = workspace.getAllBlocks(false);
+
+    for (const block of blocks) {
+        for (const input of block.inputList) {
+            for (const field of input.fieldRow) {
+                // No need to check for tilemap editor because those are never temporary
+                if (field instanceof pxtblockly.FieldSpriteEditor || field instanceof pxtblockly.FieldAnimationEditor) {
+                    cb(field)
+                }
+            }
+        }
+    }
+}
+
+function disposeOfTemporaryAssets(workspace: Blockly.Workspace) {
+    forEachImageField(workspace, field => field.disposeOfTemporaryAsset());
+}
+
+function clearTemporaryAssetBlockData(workspace: Blockly.Workspace) {
+    forEachImageField(workspace, field => field.clearTemporaryAssetData());
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2912
Fixes https://github.com/microsoft/pxt-arcade/issues/2905
Fixes https://github.com/microsoft/pxt-arcade/issues/2894
Fixes https://github.com/microsoft/pxt-arcade/issues/2920

This fixes a host of bugs all related to the same underlying issue. When we save the image-editor fields, we also save the ID of the asset to the block XML. This is so that we can reload the asset when switching back to blocks after making changes elsewhere (like in the asset editor tab). However, we also dispose of temporary assets in a few situations without clearing that ID in the XML. Then when the XML gets loaded again, it leads to some weird behavior because the assets don't exist.

Say we have a project with two temporary assets: `myImages.image1` and `myImages.image2`

Here's a sort of timeline of how this bug could happen when loading fields pointing to those assets from XML
1. Both `myImages.image1` and `myImages.image2` are disposed when the workspace is cleaned up to make way for the new one
2. Begin load of the new blocks XML
1. Load the field that points to `myImages.image2`
2. `myImages.image2` does not exist, so create a new asset with an autogenerated name. The name `myImages.image1` isn't taken, so use that.
3. Load the field that points to `myImages.image1`
4. An asset named `myImages.image1` does exist (it was created in step 2) so load that asset and overwrite the one saved in the XML. Now the field that was originally pointing at the old `myImages.image1` is pointing to a copy of the old `myImages.image2`

TLDR: this was a huge pain to debug.