### PR TITLE
Only auto-display completion modal once, load Arcade beta from skillmap beta

### DIFF
--- a/skillmap/src/components/SkillCarousel.tsx
+++ b/skillmap/src/components/SkillCarousel.tsx
@@ -86,9 +86,14 @@ class SkillCarouselImpl extends React.Component<SkillCarouselProps> {
     }
 
     protected getEndCard(completed: boolean): JSX.Element {
-        return <div className={`end-card ${this.props.completionState === "completed" ? "spin" : ""}`} key="end">
+        const { completionState } = this.props;
+
+        return <div className={`end-card ${completionState === "completed" ? "spin" : ""}`} key="end">
             <div className="end-card-icon" onClick={completed ? this.handleEndCardClick : undefined} role="button">
-                <i className="icon trophy" onTransitionEnd={this.handleEndCardTransition} />
+                {completionState === "transitioning" || completionState === "completed"
+                    ? <i className="icon trophy" onTransitionEnd={this.handleEndCardTransition} />
+                    : <div className="end-card-placeholder" />
+                }
             </div>
         </div>
     }

--- a/skillmap/src/styles/skillcard.css
+++ b/skillmap/src/styles/skillcard.css
@@ -234,15 +234,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-left: 2rem;
+    margin-left: 1.5rem;
+}
+
+.end-card-placeholder {
+    width: 3rem;
+    height: 3rem;
 }
 
 .end-card-icon {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 6rem;
-    height: 6rem;
     margin-right: 3rem;
     border-radius: 50%;
 
@@ -251,22 +254,26 @@
 }
 
 .end-card i.icon {
+    opacity: 0;
     font-size: 4rem;
     line-height: 4rem;
-    margin: 0;
+    margin: 0.35rem 0;
+    transition-delay: 0.5s;
     transition: all 1.5s ease;
 }
 
 .end-card:before {
     content: '';
     position: absolute;
-    left: -2.5rem;
+    left: -1.5rem;
     width: 2.5rem;
     height: 0.75rem;
     background-color: var(--primary-color);
 }
 
 .end-card.spin i.icon {
+    opacity: 1;
     cursor: pointer;
     transform: rotateZ(720deg);
+    margin: 1rem 0.7rem;
 }


### PR DESCRIPTION
we load the markdown before user progress, so maps load in as "incomplete" then become "completed" once the user state is loaded. before, we only added the end trophy once a map was completed so we didn't run into the CSS transition over-triggering; now the DOM element is always present. did a little shifting around of elements to make it so this wasn't the case, and also updated the rendering so it's easier to tell when a map is completed (trophy) vs not (dot):

![image](https://user-images.githubusercontent.com/34112083/105116217-2602db80-5a7f-11eb-9c5c-25f95e0dbf27.png)

fixes https://github.com/microsoft/pxt-arcade/issues/2899