### PR TITLE
Filter assets by tag in gallery

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -412,6 +412,7 @@ namespace pxt.sprite {
     }
 
     export function filterItems(target: GalleryItem[], tags: string[]) {
+        // Keep this unified with ImageFieldEditor:filterAssets
         tags = tags
             .filter(el => !!el)
             .map(el => el.toLowerCase());

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -189,9 +189,10 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         if (filterString) {
             assets.forEach(a => {
                 if (!a.meta.tags && this.options) {
-                    a.meta.tags = this.blocksInfo.apis.byQName[a.id]?.attributes.tags?.split(" ") || [""];
+                    a.meta.tags = this.blocksInfo.apis.byQName[a.id]?.attributes.tags?.split(" ") || [];
                 }})
 
+        // Keep tag filtering unified with pxtlib/spriteutils:filterItems
             const tags = filterString.split(" ")
                 .filter(el => !!el)
                 .map(el => el.toLowerCase());
@@ -202,6 +203,22 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                 .map(tag => tag.substring(1));
 
             assets = assets.filter(t => checkInclude(t, includeTags) && checkExclude(t, excludeTags))
+        }
+        function checkInclude(item: pxt.Asset, includeTags: string[]) {
+            const tags = item.meta.tags ? item.meta.tags : [];
+            return includeTags.every(filterTag => {
+                const optFilterTag = `?${filterTag}`;
+                return tags.some(tag =>
+                    tag === filterTag || tag === optFilterTag
+                )
+            });
+        }
+
+        function checkExclude(item: pxt.Asset, excludeTags: string[]) {
+            const tags = item.meta.tags ? item.meta.tags : [];
+            return excludeTags.every(filterTag =>
+                !tags.some(tag => tag === filterTag)
+            );
         }
 
         if (isGallery) {
@@ -227,23 +244,6 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                 case pxt.AssetType.Tilemap:
                     return assets.filter(t => t.type === pxt.AssetType.Tilemap);
             }
-        }
-
-        function checkInclude(item: pxt.Asset, includeTags: string[]) {
-            const tags = item.meta.tags ? item.meta.tags: [""];
-            return includeTags.every(filterTag => {
-                const optFilterTag = `?${filterTag}`;
-                return tags.some(tag =>
-                    tag === filterTag || tag === optFilterTag
-                )
-            });
-        }
-
-        function checkExclude(item: pxt.Asset, excludeTags: string[]) {
-            const tags = item.meta.tags? item.meta.tags: [""];
-            return excludeTags.every(filterTag =>
-                !tags.some(tag => tag === filterTag)
-            );
         }
     }
 

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -78,7 +78,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             <div className="image-editor-gallery-content">
                 <ImageEditor ref="image-editor" singleFrame={this.props.singleFrame} onDoneClicked={this.onDoneClick} onTileEditorOpenClose={this.onTileEditorOpenClose} />
                 <ImageEditorGallery
-                    items={currentView === "my-assets" ? this.filterAssets(this.userAssets) : this.filterAssets(this.galleryAssets, editingTile ? pxt.AssetType.Tile : this.asset?.type, true, this.state.galleryFilter)}
+                    items={currentView === "my-assets" ? this.filterAssets(this.userAssets) : this.filterAssets(this.galleryAssets, editingTile ? pxt.AssetType.Tile : this.asset?.type, true)}
                     hidden={currentView === "editor"}
                     onAssetSelected={this.onAssetSelected} />
             </div>
@@ -177,7 +177,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         this.galleryAssets = getAssets(true, this.asset.type);
     }
 
-    protected filterAssets(assets: pxt.Asset[], type: pxt.AssetType = this.asset?.type, isGallery = false, filterString?: string) {
+    protected filterAssets(assets: pxt.Asset[], type: pxt.AssetType = this.asset?.type, isGallery = false) {
         if (type === undefined) {
             return assets;
         }
@@ -186,14 +186,14 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             assets = assets.map(t => (t.type !== this.asset.type || t.id !== this.asset.id) ? t : assetToGalleryItem(this.getValue()))
         }
 
-        if (filterString) {
+        if (this.state.galleryFilter) {
             assets.forEach(a => {
                 if (!a.meta.tags && this.options) {
                     a.meta.tags = this.blocksInfo.apis.byQName[a.id]?.attributes.tags?.split(" ") || [];
                 }})
 
         // Keep tag filtering unified with pxtlib/spriteutils:filterItems
-            const tags = filterString.split(" ")
+            const tags = this.state.galleryFilter.split(" ")
                 .filter(el => !!el)
                 .map(el => el.toLowerCase());
             const includeTags = tags


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2901

- Added fetching tags for assets
- Added filtering by tags 

I copied the tag filtering from https://github.com/microsoft/pxt/blob/9e24403a17e2df8aa2261572b653662dbc9cbf5d/pxtlib/spriteutils.ts#L414

Also the dialogs gallery looks like this now, I can't remember if that's how it was before or if this is what we want?
![image](https://user-images.githubusercontent.com/18712271/105223603-d836b380-5b10-11eb-88ea-c94dbf52d834.png)
