### PR TITLE
Align sprite gallery rows to start of container

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -229,6 +229,7 @@
     flex-wrap: wrap;
     align-items: stretch;
     justify-content: center;
+    align-content: flex-start;
 
     visibility: hidden;
 


### PR DESCRIPTION
Fix row stretching:

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/34112083/105225424-690e8e80-5b13-11eb-90eb-0daaf48c6f21.png)
