### PR TITLE
Set blocksinfo in asset editor for tilemap/image editor

### DIFF
--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -29,7 +29,11 @@ export class AssetEditor extends Editor {
         // force refresh to ensure we have a view
 
         return super.loadFileAsync(file, hc)
-            .then(() => this.updateGalleryAssets())
+            .then(() => compiler.getBlocksAsync()) // make sure to load block definitions
+            .then(info => {
+                this.blocksInfo = info;
+                this.updateGalleryAssets();
+            })
             .then(() => store.dispatch(dispatchUpdateUserAssets()))
             .then(() => this.parent.forceUpdate());
     }


### PR DESCRIPTION
I removed this when updating the gallery to use shared code but we still need blocksInfo for the tilemap editor 