### PR TITLE
Default animation interval, copy duplicated tile display name, disable resize fix

### DIFF
--- a/webapp/src/assets.ts
+++ b/webapp/src/assets.ts
@@ -20,9 +20,9 @@ export function createProjectImage(bitmap: pxt.sprite.BitmapData) {
     return project.createNewProjectImage(bitmap);
 }
 
-export function createTile(bitmap: pxt.sprite.BitmapData) {
+export function createTile(bitmap: pxt.sprite.BitmapData, id?: string, displayName?: string) {
     const project = pxt.react.getTilemapProject();
-    return project.createNewTile(bitmap);
+    return project.createNewTile(bitmap, id, displayName);
 }
 
 export function lookupAsset(type: pxt.AssetType, id: string) {

--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -294,7 +294,7 @@ function mapStateToProps({store: { present: state, past, future }, editor}: Imag
         aspectRatioLocked: state.aspectRatioLocked,
         onionSkinEnabled: editor.onionSkinEnabled,
         cursorLocation: editor.cursorLocation,
-        resizeDisabled: editor.resizeDisabled,
+        resizeDisabled: state.asset?.type === pxt.AssetType.Tile,
         assetName: state.asset?.meta?.displayName,
         hasUndo: !!past.length,
         hasRedo: !!future.length

--- a/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
+++ b/webapp/src/components/ImageEditor/tilemap/TilePalette.tsx
@@ -368,7 +368,8 @@ class TilePaletteImpl extends React.Component<TilePaletteProps,{}> {
 
         if (!tileset.tiles[selected] || !tileset.tiles[selected].isProjectTile || selected === 0) return;
 
-        dispatchCreateNewTile(createTile(tileset.tiles[selected].bitmap), tileset.tiles.length, backgroundColor);
+        const tile = tileset.tiles[selected];
+        dispatchCreateNewTile(createTile(tile.bitmap, null, tile.meta?.displayName), tileset.tiles.length, backgroundColor);
     }
 
     protected tileDeleteAlertHandler = () => {

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -90,6 +90,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             case pxt.AssetType.Animation:
                 const animation = asset as pxt.Animation;
                 animation.frames = [new pxt.sprite.Bitmap(16, 16).data()];
+                animation.interval = 200;
                 break;
 
         }


### PR DESCRIPTION
fixes:
- set default interval when creating animation (bug: second animation created in the editor has empty interval)
- copy display name when duplicating a tile INSIDE the tilemap (bug: duplicated tiles in tilemap have no display names and are listed as "temporary asset")
- disable resize for tiles only (bug: editing a tile in the asset editor then opening a tilemap will disable resize for that tilemap)