### PR TITLE
Fixing rotate logic for square marquee selections

### DIFF
--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -745,7 +745,9 @@ export function rotateEdit(image: EditState, clockwise: boolean, isTilemap: bool
         }
     }
 
-    if ((toFloatingLayer || hasFloatingLayer) && (newImage.width !== newImage.height)) {
+    const isSquareFullImageRotate = newImage.width === newImage.height && newImage.width === image.image.width && image.image.width === image.image.height;
+
+    if ((toFloatingLayer || hasFloatingLayer) && !isSquareFullImageRotate) {
         if (!hasFloatingLayer) {
             for (let x = 0; x < image.width; x++) {
                 for (let y = 0; y < image.height; y++) {


### PR DESCRIPTION
Tiny fix for square marquee selections, which were getting cropped when rotating. Need to check that it's square *and* the full image