### PR TITLE
Last minute fixes

### DIFF
--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -225,7 +225,6 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
             return {
                 ...state,
                 editor: toOpen.type === pxt.AssetType.Tilemap ? {
-                    ...state.editor,
                     selectedColor: -1,
                     backgroundColor: -1,
                     isTilemap: true,
@@ -237,10 +236,27 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     overlayEnabled: true,
                     tileGallery: gallery,
                     tileGalleryOpen: !!gallery,
-                    referencedTiles: toOpen.data.projectReferences
+                    referencedTiles: toOpen.data.projectReferences,
+                    previewAnimating: false,
+                    onionSkinEnabled: false,
+
+                    // Properties below this comment carry over if keep past is true
+                    tool: action.keepPast ? state.editor.tool : initialStore.editor.tool,
+                    cursorSize: action.keepPast ? state.editor.cursorSize : initialStore.editor.cursorSize,
+                    editedTiles: action.keepPast ? state.editor.editedTiles : undefined,
+                    deletedTiles: action.keepPast ? state.editor.deletedTiles : undefined
+
                 } : {
-                    ...(action.keepPast ? state.editor : initialStore.editor),
                     isTilemap: false,
+
+                    // Properties below this comment carry over if keep past is true
+                    selectedColor: action.keepPast ? state.editor.selectedColor : initialStore.editor.selectedColor,
+                    backgroundColor: action.keepPast ? state.editor.backgroundColor : initialStore.editor.backgroundColor,
+                    previewAnimating: action.keepPast ? state.editor.previewAnimating : initialStore.editor.previewAnimating,
+                    tool: action.keepPast ? state.editor.tool : initialStore.editor.tool,
+                    onionSkinEnabled: action.keepPast ? state.editor.onionSkinEnabled : initialStore.editor.onionSkinEnabled,
+                    cursorSize: action.keepPast ? state.editor.cursorSize : initialStore.editor.cursorSize,
+                    resizeDisabled: action.keepPast ? state.editor.resizeDisabled : initialStore.editor.resizeDisabled
                 },
                 store: {
                     ...state.store,

--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -789,7 +789,7 @@ export function rotateEdit(image: EditState, clockwise: boolean, isTilemap: bool
 }
 
 export function flipEdit(image: EditState, vertical: boolean, isTilemap: boolean) {
-    const source = image.floating || image;
+    const source = image.floating?.image ? image.floating : image;
 
     const newImage = isTilemap ? new pxt.sprite.Tilemap(source.image.width, source.image.height) :
         new pxt.sprite.Bitmap(source.image.width, source.image.height);
@@ -804,7 +804,7 @@ export function flipEdit(image: EditState, vertical: boolean, isTilemap: boolean
         }
     }
 
-    if (image.floating) {
+    if (image.floating?.image) {
         image.floating = {
             image: newImage,
             overlayLayers: newOverlayLayers

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -188,6 +188,16 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
         if (this.asset) {
             assets = assets.map(t => (t.type !== this.asset.type || t.id !== this.asset.id) ? t : assetToGalleryItem(this.getValue()))
+
+            if (this.state.editingTile) {
+                const tilemap = this.ref.getAsset() as pxt.ProjectTilemap;
+                assets = assets.map(a => {
+                    if (tilemap.data.editedTiles?.indexOf(a.id) >= 0) {
+                        return assetToGalleryItem(tilemap.data.tileset.tiles.find(t => t.id === a.id))
+                    }
+                    return a;
+                });
+            }
         }
 
         if (this.state.galleryFilter && useTags) {


### PR DESCRIPTION
Fixes three random bugs:

1. Fixes flip when you make a marquee selection and then clear it (already fixed for rotate, forgot to port it over)
2. Fixes the my assets tab for the tile editor so that it reflects edits made to other tiles in the tilemap editor
3. Fixes some state accidentally being carried over between tilemap editors