### PR TITLE
Hide my assets option when editing a tile or in asset editor

### DIFF
--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -84,6 +84,7 @@ export class AssetEditor extends Editor {
                     initWidth: 16,
                     initHeight: 16,
                     headerVisible: true,
+                    hideMyAssets: true,
                     blocksInfo: this.blocksInfo
                 });
                 break;
@@ -107,6 +108,7 @@ export class AssetEditor extends Editor {
                     initWidth: 16,
                     initHeight: 16,
                     headerVisible: true,
+                    hideMyAssets: true,
                     blocksInfo: this.blocksInfo
                 });
                 break;
@@ -115,6 +117,7 @@ export class AssetEditor extends Editor {
                     initWidth: 16,
                     initHeight: 16,
                     headerVisible: true,
+                    hideMyAssets: true,
                     blocksInfo: this.blocksInfo
                 });
                 break;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2963

The "My Assets" tab only really makes sense when you are in a block, because it replaces the current thing you're editing with a reference to the asset you selected. We don't really have a concept of references in the asset editor, so remove the tab altogether. This also removes it when editing a tile in the tilemap editor which has the same issue.