### PR TITLE
Improve intellisense completions with complex qualifiers

### DIFF
--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -124,10 +124,12 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
                         // remove what precedes the "." in the full snippet.
                         // E.g. if the user is typing "mobs.", we want to complete with "spawn" (name) not "mobs.spawn" (qName)
                         if (completions.isMemberCompletion && snippet) {
-                            const nameStart = snippet.lastIndexOf(name);
-                            if (nameStart !== -1) {
-                                snippet = snippet.substr(nameStart)
+                            let snippetQualifiers = getQualifiers(snippet);
+                            if (qName.indexOf("anyButton") >= 0) {
+                                console.log("snippet");
+                                console.dir({ snippet, snippetQualifiers })
                             }
+                            snippet = snippet.substr(snippetQualifiers.join('.').length + 1)
                         }
                     }
                     const label = completions.isMemberCompletion ? name : qName
@@ -167,6 +169,19 @@ class CompletionProvider implements monaco.languages.CompletionItemProvider {
 
         function tosort(i: number): string {
             return ("000" + i).slice(-4);
+        }
+        function getQualifiers(str: string): string[] {
+            if (!str) return []
+            const parts = str.split('.')
+            parts.pop() // the last part is never a qualifier
+            const isValidName = (s: string) => s.match(/^[a-zA-Z_$][0-9a-zA-Z_$]*$/)
+            let quals: string[] = [];
+            for (let p of parts) {
+                if (!isValidName(p))
+                    break;
+                quals.push(p)
+            }
+            return quals;
         }
     }
     /**


### PR DESCRIPTION
Before:
![2021-01-24 17 15 26](https://user-images.githubusercontent.com/6453828/105650279-2aa50680-5e68-11eb-8728-df5a71b0cd01.gif)

After:
![2021-01-24 17 14 35](https://user-images.githubusercontent.com/6453828/105650306-43152100-5e68-11eb-9008-7362ab1664f2.gif)



It's not a perfect solution, but it's better than what was.