### PR TITLE
Add border to help distinguish selected/unselected asset tab

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -55,18 +55,26 @@
     width: 100%;
     display: flex;
     flex-direction: row;
+    border-bottom: 1px solid @assetTopbarBorder;
 }
 
 .asset-editor-gallery-tab {
+    height: 3rem;
     background-color: @assetUnselected;
+    color: @grey;
     padding: .7em 2em .85em;
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
+    border-color: @assetTopbarBorder;
+    border-style: solid;
+    border-width: 0 1px 1px 0;
 }
 
 .asset-editor-gallery-tab.selected {
     background-color: transparent;
+    border-bottom-color: @blocklySvgColor;
+    color: @black;
 }
 .asset-editor-card-list {
     width: 100%;

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -375,9 +375,10 @@
 /*-------------------
    Asset Editor
 -------------------*/
-@assetSidebarBorder: #dedede;
+@assetSidebarBorder: #c6c6c6;
 @assetSidebarButton: #f8f8f8;
 @assetSidebarButtonHover: #dedede;
+@assetTopbarBorder: #c6c6c6;
 @assetPreviewBackground: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10px' height='10px'%3E%3Crect x='0' y='0' width='10px' height='10px' fill='white'%3E%3C/rect%3E%3Crect x='0' y='0' width='5px' height='5px' fill='%23dedede'%3E%3C/rect%3E%3Crect x='5' y='5' width='5px' height='5px' fill='%23dedede'%3E%3C/rect%3E%3C/svg%3E");
 @assetUnselected: #e3ddd0;
 @assetTypeButton: @teal;


### PR DESCRIPTION
![fix-asset-tab](https://user-images.githubusercontent.com/34112083/105776670-e07e5c80-5f1d-11eb-954c-63ad8c31f31f.gif)

@soniakandah we've gotten some user feedback that the current tab design is a bit confusing; i added some borders as a (hopefully low-impact) fix for the current release, until we get to the full redesign later, happy to make adjustments if you have feedback

fixes https://github.com/microsoft/pxt-arcade/issues/2978
fixes https://github.com/microsoft/pxt-arcade/issues/2879