### PR TITLE
Compress tilemap sidebar for smaller screen sizes

### DIFF
--- a/theme/image-editor/tilePalette.less
+++ b/theme/image-editor/tilePalette.less
@@ -172,3 +172,18 @@
 .tile-palette-controls-outer {
     height: 2rem;
 }
+
+
+@media screen and (max-height: 720px) {
+    .image-editor-tilemap-minimap {
+        height: 7rem;
+    }
+
+    .tile-canvas {
+        padding-bottom: 0;
+    }
+
+    .tile-palette-fg-bg {
+        margin-bottom: 0;
+    }
+}


### PR DESCRIPTION
mostly regains space by making the minimap a rectangle, but also shrinks some of the margins. i believe this should cover the chromebook/pixelbook case, here is a build if people want to give it a spin: https://arcade.makecode.com/app/f7f34a6a5fd79e2ad8f383f800bae690b7401b7c-acce3a0707

![image](https://user-images.githubusercontent.com/34112083/105886990-f6445e00-5fbf-11eb-99ca-3269e7563f74.png)

fixes https://github.com/microsoft/pxt-arcade/issues/2957
fixes https://github.com/microsoft/pxt-arcade/issues/2729

