### PR TITLE
Fix tilemap upgrade path in compiler

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -21,10 +21,12 @@ namespace pxt.blocks {
             Blockly.Events.disable();
             newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);
             applyMetaComments(workspace);
+        } catch (e) {
+            pxt.reportException(e);
         } finally {
             Blockly.Events.enable();
-            return newBlockIds;
         }
+        return newBlockIds;
     }
 
     function applyMetaComments(workspace: Blockly.Workspace) {

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -16,13 +16,14 @@ namespace pxt.blocks {
      */
     export function domToWorkspaceNoEvents(dom: Element, workspace: Blockly.Workspace): string[] {
         pxt.tickEvent(`blocks.domtow`)
+        let newBlockIds: string[] = [];
         try {
             Blockly.Events.disable();
-            const newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);
+            newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);
             applyMetaComments(workspace);
-            return newBlockIds;
         } finally {
             Blockly.Events.enable();
+            return newBlockIds;
         }
     }
 

--- a/pxtlib/legacyTilemap.ts
+++ b/pxtlib/legacyTilemap.ts
@@ -24,9 +24,9 @@ namespace pxt.sprite.legacy {
     }
 
     export function decodeTilemap(literal: string, fileType: "typescript" | "python"): LegacyTilemapData {
-        literal = Util.htmlUnescape(literal).trim();
+        literal = Util.htmlUnescape(literal)?.trim();
 
-        if (!literal.trim()) {
+        if (!literal?.trim()) {
             return new LegacyTilemapData(new Tilemap(16, 16), {tileWidth: 16, tiles: []}, new Bitmap(16, 16).data());
         }
 


### PR DESCRIPTION
- move domToWorkspaceNoEvents return statement into `finally` so that it returns
- wrap tilemap upgrade in try/catch so that we always re-enable blockly events after disabling them
- extra null check in decodeTilemap (was causing above error in tilemap upgrade)

fixes https://github.com/microsoft/pxt-arcade/issues/2997

cat jumper 2 works, adventures of sam & nate still doesn't upgrade properly but that looks like a separate bug with the tilemaps extension
