### PR TITLE
Check in parent package for source of pkg: dependencies

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -137,7 +137,8 @@ namespace pxt {
                 return Promise.resolve(resp)
             } else if (proto == "pkg") {
                 // the package source is serialized in a file in the package itself
-                const pkgFilesSrc = this.readFile(this.verArgument());
+                const src = this.parent || this; // fall back to current package if no parent
+                const pkgFilesSrc = src.readFile(this.verArgument());
                 const pkgFilesJson = ts.pxtc.Util.jsonTryParse(pkgFilesSrc) as Map<string>;
                 if (!pkgFilesJson)
                     pxt.log(`unable to find ${this.verArgument()}`)


### PR DESCRIPTION
This project: https://makecode.com/_JKC4gAc2xc0H was not loading in the share page because it had a "pkg:" depenency and was checking for the source in the epkg of the dependency itself. Small change to check the parent package, falling back to current behavior if there is no parent. 

This matches [here](https://github.com/microsoft/pxt/blob/master/webapp/src/package.ts#L686) where it reads the source from mainPkg, but I don't have any other examples of pkg: dependencies in the wild so it'd be great to verify that this is the intended behavior