### PR TITLE
Clean up temporary asset when exiting field editor

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -113,6 +113,8 @@ namespace pxtblockly {
                     if (pxt.assetEquals(this.asset, result)) return;
 
                     this.pendingEdit = true;
+
+                    if (result.meta?.displayName) this.disposeOfTemporaryAsset();
                     this.asset = result;
                     const lastRevision = project.revision();
 


### PR DESCRIPTION
When going from temporary asset -> named asset in the image/animation editor, clean up the previous temporary asset. This will delete it from the project but you can get it back using undo/redo if it was a mistake.

Fixes https://github.com/microsoft/pxt-arcade/issues/2987