### PR TITLE
Be stricter when parsing image literals

### DIFF
--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -38,6 +38,11 @@ namespace pxtblockly {
                 if (match) {
                     const asset = project.lookupAssetByName(pxt.AssetType.Image, match[1].trim());
                     if (asset) return asset;
+                    else if (!this.getBlockData()) {
+                        this.isGreyBlock = true;
+                        this.valueText = text;
+                        return undefined;
+                    }
                 }
             }
 
@@ -46,6 +51,13 @@ namespace pxtblockly {
             }
 
             const bmp = text ? pxt.sprite.imageLiteralToBitmap(text) : new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight);
+
+            if (!bmp) {
+                this.isGreyBlock = true;
+                this.valueText = text;
+                return undefined;
+            }
+
             const newAsset = project.createNewProjectImage(bmp.data());
             return newAsset;
         }

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -580,16 +580,13 @@ namespace pxt.sprite {
         return result;
     }
 
-    export function imageLiteralToBitmap(text: string, defaultPattern?: string): Bitmap {
+    export function imageLiteralToBitmap(text: string): Bitmap {
         // Strip the tagged template string business and the whitespace. We don't have to exhaustively
         // replace encoded characters because the compiler will catch any disallowed characters and throw
         // an error before the decompilation happens. 96 is backtick and 9 is tab
         text = text.replace(/[ `]|(?:&#96;)|(?:&#9;)|(?:img)/g, "").trim();
         text = text.replace(/^["`\(\)]*/, '').replace(/["`\(\)]*$/, '');
         text = text.replace(/&#10;/g, "\n");
-
-        if (!text && defaultPattern)
-            text = defaultPattern;
 
         const rows = text.split("\n");
 
@@ -620,6 +617,8 @@ namespace pxt.sprite {
                     case "d": case "D": case "O": rowValues.push(13); break;
                     case "e": case "E": case "Y": rowValues.push(14); break;
                     case "f": case "F": case "W": rowValues.push(15); break;
+                    default:
+                        if (!/\s/.test(row[c])) return undefined;
                 }
             }
 


### PR DESCRIPTION
I doubt this will solve the underlying issue in https://github.com/microsoft/pxt-arcade/issues/2986 (which I cannot repro) but this will at least stop the sprite field editor from destroying the evidence when it occurs.

That bug is caused when we try to read the image literal from the asset string (e.g. ```assets.image`hello` ```) and you end up getting a single line of random pixels. Error out and make it a grey block instead.