### PR TITLE
Updated profile delete ui

### DIFF
--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -168,7 +168,9 @@ export interface DialogOptions {
     modalContext?: string;
     hasCloseIcon?: boolean;
     helpUrl?: string;
-    confirmationText?: string;
+    confirmationText?: string;      // Display a text input the user must type to confirm.
+    confirmationCheckbox?: string;  // Display a checkbox the user must check to confirm.
+    confirmationGranted?: boolean;
 }
 
 export function dialogAsync(options: DialogOptions): Promise<void> {

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -8,6 +8,7 @@ interface CoreDialogState {
     inputValue?: string;
     inputError?: string;
     confirmationText?: string;
+    confirmationGranted?: boolean;
 }
 
 export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogState> {
@@ -23,13 +24,15 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
         super(props);
         this.state = {
             inputValue: props.initialValue,
-            inputError: undefined
+            inputError: undefined,
+            confirmationGranted: (props.confirmationText || props.confirmationCheckbox) ? false : undefined
         }
 
         this.hide = this.hide.bind(this);
         this.modalDidOpen = this.modalDidOpen.bind(this);
         this.handleInputChange = this.handleInputChange.bind(this);
-        this.handleConfirmationChange = this.handleConfirmationChange.bind(this);
+        this.handleConfirmationTextChange = this.handleConfirmationTextChange.bind(this);
+        this.handleConfirmationCheckboxChange = this.handleConfirmationCheckboxChange.bind(this);
     }
 
     hide() {
@@ -80,8 +83,18 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
         this.setState({ inputValue: v.target.value, inputError });
     }
 
-    handleConfirmationChange(v: string) {
-        this.setState({ confirmationText: v })
+    handleConfirmationTextChange(v: string) {
+        this.setState({
+            confirmationText: v,
+            confirmationGranted: this.state.confirmationText === this.props.confirmationText
+
+        })
+    }
+
+    handleConfirmationCheckboxChange(b: boolean) {
+        this.setState({
+            confirmationGranted: b
+        });
     }
 
     render() {
@@ -110,10 +123,9 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
         // if we have confirmation text (e.g. enter your name), disable the approve button until the
         //  text matches
         options.buttons?.forEach(b => {
-            if (b.approveButton && !!options.confirmationText) {
-                const match = this.state.confirmationText === this.props.confirmationText
+            if (b.approveButton && this.state.confirmationGranted !== undefined) {
                 const disabledClass = " disabled"
-                if (match)
+                if (this.state.confirmationGranted)
                     b.className = b.className.replace(disabledClass, "")
                 else
                     b.className += b.className.indexOf(disabledClass) >= 0 ? "" : disabledClass
@@ -157,9 +169,12 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
                         <p>Type '{options.confirmationText}' to confirm:</p>
                         <sui.Input ref="confirmationInput" id="confirmationInput"
                             ariaLabel={lf("Type your name to confirm")} autoComplete={false}
-                            value={this.state.confirmationText || ''} onChange={this.handleConfirmationChange}
+                            value={this.state.confirmationText || ''} onChange={this.handleConfirmationTextChange}
                             selectOnMount={!mobile} autoFocus={!mobile} />
                     </>
+                }
+                {!!options.confirmationCheckbox &&
+                    <sui.PlainCheckbox label={options.confirmationCheckbox} isChecked={this.state.confirmationGranted} onChange={this.handleConfirmationCheckboxChange} />
                 }
             </sui.Modal >)
         /* tslint:enable:react-no-dangerous-html */

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -52,7 +52,7 @@ export class LoginDialog extends auth.Component<LoginDialogProps, LoginDialogSta
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>
                 <div className="description">
                     <p>{lf("Connect an existing account in order to sign in or signup for the first time.")}</p>
-                    <p><div className="warning">{lf("WARNING: Experimental feature ahead! Before you sign in, please backup any projects you don't want to lose.")}</div></p>
+                    <div className="warning"><p>{lf("WARNING: Experimental feature ahead! Before you sign in, please backup any projects you don't want to lose.")}</p></div>
                 </div>
                 <div className="container">
                     <div className="prompt">

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1523,6 +1523,7 @@ export class ProgressCircle extends React.Component<ProgressCircleProps, {}> {
 
 export interface PlainCheckboxProps {
     label: string;
+    isChecked?: boolean;
     onChange: (v: boolean) => void;
 }
 
@@ -1534,7 +1535,7 @@ export class PlainCheckbox extends data.Component<PlainCheckboxProps, PlainCheck
     constructor(props: PlainCheckboxProps) {
         super(props);
         this.state = {
-            isChecked: false
+            isChecked: this.props.isChecked
         }
         this.setCheckedBit = this.setCheckedBit.bind(this);
     }

--- a/webapp/src/user.tsx
+++ b/webapp/src/user.tsx
@@ -81,17 +81,19 @@ class AccountPanel extends sui.UIElement<AccountPanelProps, {}> {
         const profile = this.getData<auth.UserProfile>(auth.PROFILE)
         const result = await core.confirmAsync({
             header: lf("Delete Profile"),
-            body: lf("You are about to delete your MakeCode profile. Please note that you cannot undo this. Once you delete, your cloud-saved projects will be converted to local projects on this device."),
+            body: lf("Are you sure? This cannot be reversed! Your cloud-saved projects will be converted to local projects on this device."),
             agreeClass: "red",
-            agreeIcon: "delete",
-            agreeLbl: lf("Delete my profile"),
-            confirmationText: profile?.idp?.displayName || profile?.idp?.username || lf("User")
+            agreeIcon: "trash",
+            agreeLbl: lf("Confirm"),
+            disagreeLbl: lf("Back to safety"),
+            disagreeIcon: "arrow right",
+            confirmationCheckbox: lf("I understand this is permanent. No undo.")
         });
         if (result) {
             await auth.deleteAccount();
             // Exit out of the profile screen.
             this.props.parent.hide();
-            core.infoNotification(lf("Account deleted!"));
+            core.infoNotification(lf("Profile deleted!"));
         }
     }
 
@@ -132,9 +134,7 @@ class AccountPanel extends sui.UIElement<AccountPanelProps, {}> {
                     <sui.Button text={lf("Sign out")} icon={`xicon ${profile?.idp?.provider}`} ariaLabel={lf("Sign out {0}", profile?.idp?.provider)} onClick={this.handleSignoutClicked} />
                 </div>
                 <div className="row-span-two">
-                    <label className="title">{lf("Delete Profile")}</label>
-                    <p>{lf("Permanently delete your MakeCode profile. Your cloud-saved projects will be converted to local projects on this device.")}</p>
-                    <sui.Button ariaLabel={lf("Delete Profile")} className="red" text={lf("Delete Profile")} onClick={this.handleDeleteAccountClick} />
+                    <sui.Link className="ui" text={lf("I want to delete my profile")} ariaLabel={lf("delete profile")} onClick={this.handleDeleteAccountClick} />
                 </div>
             </div>
         );


### PR DESCRIPTION

Delete flow starts with a subtle link.
![image](https://user-images.githubusercontent.com/12176807/106538024-610a0380-64b0-11eb-9bf4-64508bed2d43.png)

Simplified language.
Replaced confirmation text input with a checkbox.
Updated button icons (trash can and arrow).
![image](https://user-images.githubusercontent.com/12176807/106538035-65ceb780-64b0-11eb-8e48-565e594ca7b3.png)



