### PR TITLE
flag to supress bundled pkg from default extensions view

### DIFF
--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -81,6 +81,7 @@ declare namespace pxt {
         };
         features?: string[];
         hidden?: boolean; // hide package from package selection dialog
+        searchOnly?: boolean; // do not show by default, only as search result
         skipLocalization?: boolean;
         snippetBuilders?: SnippetConfig[];
         experimentalHw?: boolean;

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -189,6 +189,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         return Object.keys(bundled).filter(k => !/prj$/.test(k))
             .map(k => JSON.parse(bundled[k]["pxt.json"]) as pxt.PackageConfig)
             .filter(pk => !pk.hidden)
+            .filter(pk => !(!query && pk.searchOnly)) // Hide these unless user has started search
             .filter(pk => !query || pk.name.toLowerCase().indexOf(query.toLowerCase()) > -1) // search filter
             .filter(pk => boards || !pkg.mainPkg.deps[pk.name] || pkg.mainPkg.deps[pk.name].cppOnly) // don't show package already referenced in extensions
             .filter(pk => !/---/.test(pk.name)) //filter any package with ---, these are part of common-packages such as core---linux or music---pwm


### PR DESCRIPTION
For https://github.com/microsoft/pxt-microbit/issues/3854 we don't want the extension to show up by default, but it should be available for people who have content based around it / that it actually works for. Adds a flag to suppress bundled packages from the default extensions view, while still leaving them available if you search for them.