### PR TITLE
Use tile id if no display name present

### DIFF
--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -94,7 +94,7 @@ namespace pxtblockly {
         getValue() {
             if (this.selectedOption_) {
                 const tile = this.selectedOption_[2];
-                return isGalleryTile(tile) || !(tile.meta?.displayName) ? tile.id : `assets.tile\`${displayName(tile)}\``
+                return (isGalleryTile(tile) || !(tile.meta?.displayName)) ? tile.id : `assets.tile\`${displayName(tile)}\``
             }
             const v = super.getValue();
 

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -94,7 +94,7 @@ namespace pxtblockly {
         getValue() {
             if (this.selectedOption_) {
                 const tile = this.selectedOption_[2];
-                return isGalleryTile(tile) ? tile.id : `assets.tile\`${displayName(tile)}\``
+                return isGalleryTile(tile) || !(tile.meta?.displayName) ? tile.id : `assets.tile\`${displayName(tile)}\``
             }
             const v = super.getValue();
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3018

the tilemap extension doesn't have display names for tiles and it was filling in eg assets.tile\`tiles.util.door2\` which is not a real tile