### PR TITLE
check shortId as well when creating new id

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -714,7 +714,10 @@ namespace pxt {
                 }
             }
 
-            return isTaken(name) || isTaken(getShortIDCore(assetType, name));
+            const shortId = getShortIDCore(assetType, name);
+            const checkShortId = shortId && shortId !== name;
+
+            return isTaken(name) || (checkShortId && isTaken(shortId));
         }
 
         /**

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1195,7 +1195,7 @@ namespace pxt {
             varPrefix = varPrefix.replace(/\d+$/, "");
             const prefix = namespaceString ? namespaceString + "." + varPrefix : varPrefix;
             let index = 1;
-            while (this.isNameTaken(type, prefix + index)) {
+            while (this.isNameTaken(type, prefix + index) || this.isNameTaken(type, getShortIDCore(type, prefix + index))) {
                 ++index;
             }
             return prefix + index;

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -427,7 +427,7 @@ namespace pxt {
         public createNewTile(data: pxt.sprite.BitmapData, id?: string, displayName?: string) {
             this.onChange();
 
-            if (!id || this.state.tiles.isIDTaken(id)) {
+            if (!id || this.isNameTaken(AssetType.Tile, id)) {
                 id = this.generateNewID(AssetType.Tile, pxt.sprite.TILE_PREFIX, pxt.sprite.TILE_NAMESPACE);
             }
 
@@ -701,16 +701,20 @@ namespace pxt {
         }
 
         public isNameTaken(assetType: AssetType, name: string) {
-            switch (assetType) {
-                case AssetType.Image:
-                    return this.state.images.isIDTaken(name) || this.gallery.images.isIDTaken(name);
-                case AssetType.Tile:
-                    return this.state.tiles.isIDTaken(name) || this.gallery.tiles.isIDTaken(name);
-                case AssetType.Tilemap:
-                    return this.state.tilemaps.isIDTaken(name) || this.gallery.tilemaps.isIDTaken(name);
-                case AssetType.Animation:
-                    return this.state.animations.isIDTaken(name) || this.gallery.animations.isIDTaken(name);
+            const isTaken = (id: string) => {
+                switch (assetType) {
+                    case AssetType.Image:
+                        return this.state.images.isIDTaken(id) || this.gallery.images.isIDTaken(id);
+                    case AssetType.Tile:
+                        return this.state.tiles.isIDTaken(id) || this.gallery.tiles.isIDTaken(id);
+                    case AssetType.Tilemap:
+                        return this.state.tilemaps.isIDTaken(id) || this.gallery.tilemaps.isIDTaken(id);
+                    case AssetType.Animation:
+                        return this.state.animations.isIDTaken(id) || this.gallery.animations.isIDTaken(id);
+                }
             }
+
+            return isTaken(name) || isTaken(getShortIDCore(assetType, name));
         }
 
         /**
@@ -1195,7 +1199,7 @@ namespace pxt {
             varPrefix = varPrefix.replace(/\d+$/, "");
             const prefix = namespaceString ? namespaceString + "." + varPrefix : varPrefix;
             let index = 1;
-            while (this.isNameTaken(type, prefix + index) || this.isNameTaken(type, getShortIDCore(type, prefix + index))) {
+            while (this.isNameTaken(type, prefix + index)) {
                 ++index;
             }
             return prefix + index;

--- a/webapp/src/assets.ts
+++ b/webapp/src/assets.ts
@@ -2,11 +2,11 @@ export function isNameTaken(name: string) {
     return pxt.react.getTilemapProject().isNameTaken(pxt.AssetType.Image, name);
 }
 
-export function createNewImageAsset(type: pxt.AssetType.Tile | pxt.AssetType.Image | pxt.AssetType.Animation, width: number, height: number) {
+export function createNewImageAsset(type: pxt.AssetType.Tile | pxt.AssetType.Image | pxt.AssetType.Animation, width: number, height: number, displayName?: string) {
     const project = pxt.react.getTilemapProject();
     switch (type) {
         case pxt.AssetType.Tile:
-            return project.createNewTile(new pxt.sprite.Bitmap(width, height).data());
+            return project.createNewTile(new pxt.sprite.Bitmap(width, height).data(), null, displayName);
         case pxt.AssetType.Image:
             return project.createNewImage(width, height);
         case pxt.AssetType.Animation:

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -308,8 +308,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                 }
                 else {
                     const tileWidth = (state.store.present as TilemapState).tileset.tileWidth;
-                    const emptyTile =  createNewImageAsset(pxt.AssetType.Tile, tileWidth, tileWidth) as pxt.Tile;
-                    emptyTile.meta = { displayName: lf("tile") } // always generate a display name for tiles
+                    const emptyTile = createNewImageAsset(pxt.AssetType.Tile, tileWidth, tileWidth, lf("customTile")) as pxt.Tile;
                     this.setState({
                         editingTile: true,
                         tileToEdit: emptyTile

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -308,7 +308,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                 }
                 else {
                     const tileWidth = (state.store.present as TilemapState).tileset.tileWidth;
-                    const emptyTile = createNewImageAsset(pxt.AssetType.Tile, tileWidth, tileWidth, lf("customTile")) as pxt.Tile;
+                    const emptyTile = createNewImageAsset(pxt.AssetType.Tile, tileWidth, tileWidth, lf("myTile")) as pxt.Tile;
                     this.setState({
                         editingTile: true,
                         tileToEdit: emptyTile

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -102,7 +102,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             case pxt.AssetType.Image:
                 return lf("image");
             case pxt.AssetType.Tile:
-                return lf("tile");
+                return lf("customTile");
             case pxt.AssetType.Tilemap:
                 return lf("level");
             case pxt.AssetType.Animation:

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -100,13 +100,13 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
     protected getEmptyAssetDisplayName(type: pxt.AssetType): string {
         switch (type) {
             case pxt.AssetType.Image:
-                return lf("image");
+                return lf("myImage");
             case pxt.AssetType.Tile:
-                return lf("customTile");
+                return lf("myTile");
             case pxt.AssetType.Tilemap:
                 return lf("level");
             case pxt.AssetType.Animation:
-                return lf("anim");
+                return lf("myAnim");
             default:
                 return lf("asset")
         }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/3026, easy repro in https://github.com/microsoft/pxt-arcade/issues/3026#issuecomment-772104528

Check the shortId as well when generating checking whether a name is taken, to avoid overlapping between shortId & display names

![image](https://user-images.githubusercontent.com/5615930/106684359-28832c00-657b-11eb-9562-8a362d505b40.png)

Also changes default display name from `tile` to ~`customTile`~ see comment \\/, to minimize overlapping between displayName & shortId when possible

![image](https://user-images.githubusercontent.com/5615930/106686486-3470ed00-657f-11eb-9db4-03e43d8fb39d.png)
