### PR TITLE
Unite asset emitting code paths and fix tile parsing

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -73,11 +73,8 @@ namespace pxtblockly {
             const project = pxt.react.getTilemapProject();
 
             if (text) {
-                const match = /^\s*assets\s*\.\s*animation\s*`([^`]+)`\s*$/.exec(text);
-                if (match) {
-                    const asset = project.lookupAssetByName(pxt.AssetType.Animation, match[1].trim());
-                    if (asset) return asset;
-                }
+                const existing = pxt.lookupProjectAssetByTSReference(text, project);
+                if (existing) return existing;
 
                 const frames = parseImageArrayString(text);
 
@@ -105,7 +102,7 @@ namespace pxtblockly {
                 ).join(",") + "]"
             }
 
-            return `assets.animation\`${this.asset.meta.displayName || pxt.getShortIDForAsset(this.asset)}\``
+            return pxt.getTSReferenceForAsset(this.asset);
         }
 
         protected redrawPreview() {

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -34,18 +34,9 @@ namespace pxtblockly {
         protected createNewAsset(text?: string): pxt.Asset {
             const project = pxt.react.getTilemapProject();
             if (text) {
-                const match = /^\s*assets\s*\.\s*(image|tile)\s*`([^`]+)`\s*$/.exec(text);
-                if (match) {
-                    const asset = project.lookupAssetByName(
-                        match[1] === "image" ? pxt.AssetType.Image : pxt.AssetType.Tile, match[2].trim()
-                    );
-                    if (asset) return asset;
-                    else if (!this.getBlockData()) {
-                        this.isGreyBlock = true;
-                        this.valueText = text;
-                        return undefined;
-                    }
-                }
+                const asset = pxt.lookupProjectAssetByTSReference(text, project);
+
+                if (asset) return asset;
             }
 
             if (this.getBlockData()) {
@@ -66,9 +57,7 @@ namespace pxtblockly {
 
         protected getValueText(): string {
             if (this.asset && !this.isTemporaryAsset()) {
-                const id = this.asset.meta.displayName || this.asset.id.substr(this.asset.id.lastIndexOf(".") + 1);
-                const type = this.asset.type === pxt.AssetType.Image ? "image" : "tile";
-                return `assets.${type}\`${id}\``;
+                return pxt.getTSReferenceForAsset(this.asset);
             }
             return pxt.sprite.bitmapToImageLiteral(this.asset && pxt.sprite.Bitmap.fromData((this.asset as pxt.ProjectImage).bitmap), pxt.editor.FileType.TypeScript);
         }

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -34,9 +34,11 @@ namespace pxtblockly {
         protected createNewAsset(text?: string): pxt.Asset {
             const project = pxt.react.getTilemapProject();
             if (text) {
-                const match = /^\s*assets\s*\.\s*image\s*`([^`]+)`\s*$/.exec(text);
+                const match = /^\s*assets\s*\.\s*(image|tile)\s*`([^`]+)`\s*$/.exec(text);
                 if (match) {
-                    const asset = project.lookupAssetByName(pxt.AssetType.Image, match[1].trim());
+                    const asset = project.lookupAssetByName(
+                        match[1] === "image" ? pxt.AssetType.Image : pxt.AssetType.Tile, match[2].trim()
+                    );
                     if (asset) return asset;
                     else if (!this.getBlockData()) {
                         this.isGreyBlock = true;
@@ -63,7 +65,11 @@ namespace pxtblockly {
         }
 
         protected getValueText(): string {
-            if (this.asset && !this.isTemporaryAsset()) return `assets.image\`${this.asset.meta.displayName || this.asset.id.substr(this.asset.id.lastIndexOf(".") + 1)}\``;
+            if (this.asset && !this.isTemporaryAsset()) {
+                const id = this.asset.meta.displayName || this.asset.id.substr(this.asset.id.lastIndexOf(".") + 1);
+                const type = this.asset.type === pxt.AssetType.Image ? "image" : "tile";
+                return `assets.${type}\`${id}\``;
+            }
             return pxt.sprite.bitmapToImageLiteral(this.asset && pxt.sprite.Bitmap.fromData((this.asset as pxt.ProjectImage).bitmap), pxt.editor.FileType.TypeScript);
         }
 

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -42,20 +42,9 @@ namespace pxtblockly {
             }
 
             const project = pxt.react.getTilemapProject();
-            const match = /^\s*tilemap\s*`([^`]*)`\s*$/.exec(newText);
 
-            if (match) {
-                const tilemapId = match[1].trim();
-                let resolved = project.lookupAssetByName(pxt.AssetType.Tilemap, tilemapId);
-
-                if (!resolved) {
-                    resolved = project.lookupAsset(pxt.AssetType.Tilemap, tilemapId);
-                }
-
-                if (resolved) {
-                    return resolved;
-                }
-            }
+            const existing = pxt.lookupProjectAssetByTSReference(newText, project);
+            if (existing) return existing;
 
             const tilemap = pxt.sprite.decodeTilemap(newText, "typescript", project) || project.blankTilemap(this.params.tileWidth, this.params.initWidth, this.params.initHeight);
             let newAsset: pxt.ProjectTilemap;
@@ -111,16 +100,10 @@ namespace pxtblockly {
             if (this.isGreyBlock) return pxt.Util.htmlUnescape(this.valueText);
 
             if (this.asset) {
-                return `tilemap\`${this.asset.meta.displayName || this.asset.id}\``;
+                return pxt.getTSReferenceForAsset(this.asset);
             }
 
-            try {
-                return pxt.sprite.encodeTilemap(this.asset.data, "typescript");
-            }
-            catch (e) {
-                // If encoding failed, this is a legacy tilemap. Should get upgraded when the project is loaded
-                return this.getInitText();
-            }
+            return this.getInitText();
         }
 
         protected parseFieldOptions(opts: FieldTilemapOptions): ParsedFieldTilemapOptions {

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -94,7 +94,7 @@ namespace pxtblockly {
         getValue() {
             if (this.selectedOption_) {
                 const tile = this.selectedOption_[2];
-                return isGalleryTile(tile) ? tile.id : `assets.tile\`${displayName(tile)}\``
+                return pxt.getTSReferenceForAsset(tile);
             }
             const v = super.getValue();
 

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -148,10 +148,12 @@ namespace pxtblockly {
 
             if (newValue) {
                 // If it's an expression, pull out the id
-                const match = /^\s*assets\s*\.\s*tile\s*`([^`]+)`\s*$/.exec(newValue);
+                const match = pxt.parseAssetTSReference(newValue);
                 if (match) {
-                    newValue = match[1];
+                    newValue = match.name;
                 }
+
+                newValue = newValue.trim();
 
                 for (const option of options) {
                     if (newValue === option[2].id || newValue === option[2].meta.displayName || newValue === pxt.getShortIDForAsset(option[2])) {

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -254,8 +254,4 @@ namespace pxtblockly {
     function displayName(tile: pxt.Tile) {
         return tile.meta.displayName || pxt.getShortIDForAsset(tile);
     }
-
-    function isGalleryTile(tile: pxt.Tile) {
-        return tile.id.startsWith("sprites.");
-    }
 }

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -11,16 +11,16 @@ namespace pxt.editor {
         protected textToValue(text: string): pxt.ProjectImage {
             this.isPython = text.indexOf("`") === -1
 
-            const match = /^\s*assets\s*\.\s*image\s*`([^`]*)`\s*$/.exec(text);
+            const match = pxt.parseAssetTSReference(text);
             if (match) {
+                const { type, name } = match;
                 const project = pxt.react.getTilemapProject();
                 this.isAsset = true;
-                const asset = project.lookupAssetByName(pxt.AssetType.Image, match[1].trim());
+                const asset = project.lookupAssetByName(pxt.AssetType.Image, name);
                 if (asset) {
                     return asset;
                 }
                 else {
-                    const name = match[1].trim();
                     const newAsset = project.createNewImage();
 
                     if (name && !project.isNameTaken(pxt.AssetType.Image, name) && pxt.validateAssetName(name)) {

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -43,7 +43,7 @@ namespace pxt.editor {
                     this.isAsset = true;
                     result = project.createNewProjectImage(result.bitmap, result.meta.displayName);
                 }
-                return `assets.image\`${result.meta.displayName}\``
+                return pxt.getTSReferenceForAsset(result, this.isPython);
             }
             return pxt.sprite.bitmapToImageLiteral(pxt.sprite.Bitmap.fromData(result.bitmap), this.isPython ? "python" : "typescript");
         }

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -116,7 +116,7 @@ namespace pxt.editor {
 
             if (this.isTilemapLiteral) {
                 project.updateAsset(asset);
-                return this.fileType === "typescript" ? `tilemap\`${asset.id}\`` : `tilemap("""${asset.id}""")`;
+                return pxt.getTSReferenceForAsset(asset, this.fileType === "python");
             }
             else {
                 return pxt.sprite.encodeTilemap(result, this.fileType === "typescript" ? "typescript" : "python");

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1278,7 +1278,7 @@ namespace pxt {
                 out += `${indent}//% fixedInstance jres blockIdentity=images._tile\n`
                 out += `${indent}export const ${key} = image.ofBuffer(hex\`\`);\n`
 
-                tileEntries.push({ keys: [entry.displayName, getShortIDCore(AssetType.Tile, key)], expression: key})
+                tileEntries.push({ keys: [entry.displayName, getShortIDCore(AssetType.Tile, key, true)], expression: key})
             }
 
             if (entry.mimeType === TILEMAP_MIME_TYPE) {
@@ -1316,7 +1316,7 @@ namespace pxt {
 
             if (typeof entry === "string" || entry.mimeType === IMAGE_MIME_TYPE) {
                 let expression: string;
-                let factoryKeys = [getShortIDCore(AssetType.Image, key)]
+                let factoryKeys = [getShortIDCore(AssetType.Image, key, true)]
                 if (typeof entry === "string") {
                     expression = sprite.bitmapToImageLiteral(sprite.getBitmapFromJResURL(entry), "typescript");
                 }
@@ -1333,7 +1333,7 @@ namespace pxt {
                 const animation = decodeAnimation(entry);
 
                 animationEntries.push({
-                    keys: [entry.displayName, getShortIDCore(AssetType.Animation, key)],
+                    keys: [entry.displayName, getShortIDCore(AssetType.Animation, key, true)],
                     expression: `[${animation.frames.map(f =>
                             sprite.bitmapToImageLiteral(sprite.Bitmap.fromData(f), "typescript")
                         ).join(", ")}]`
@@ -1542,7 +1542,7 @@ namespace pxt {
         return getShortIDCore(asset.type, asset.id);
     }
 
-    function getShortIDCore(assetType: pxt.AssetType, id: string) {
+    function getShortIDCore(assetType: pxt.AssetType, id: string, allowNoPrefix = false) {
         let prefix: string;
         switch (assetType) {
             case AssetType.Image:
@@ -1564,7 +1564,7 @@ namespace pxt {
                 const short = id.substr(prefix.length);
                 if (short.indexOf(".") === -1) return short;
             }
-            else {
+            else if (!allowNoPrefix) {
                 return null;
             }
         }

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1516,12 +1516,26 @@ namespace pxt {
         }
     }
 
-    export function lookupProjectAssetByTSReference(ts: string, project: TilemapProject) {
-        const match = /^\s*(?:(?:assets\s*\.\s*(image|tile|animation|tilemap))|(tilemap))\s*(?:`|\(""")([^`"]+)(?:`|"""\))\s*$/.exec(ts);
+    export function parseAssetTSReference(ts: string) {
+        const match = /^\s*(?:(?:assets\s*\.\s*(image|tile|animation|tilemap))|(tilemap))\s*(?:`|\(""")([^`"]+)(?:`|"""\))\s*$/m.exec(ts);
 
         if (match) {
             const type = match[1] || match[2];
-            const name = match[3];
+            const name = match[3].trim();
+
+            return {
+                type, name
+            }
+        }
+
+        return undefined;
+    }
+
+    export function lookupProjectAssetByTSReference(ts: string, project: TilemapProject) {
+        const match = parseAssetTSReference(ts);
+
+        if (match) {
+            const { type, name } = match;
 
             switch (type) {
                 case "tile":

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1517,7 +1517,7 @@ namespace pxt {
     }
 
     export function lookupProjectAssetByTSReference(ts: string, project: TilemapProject) {
-        const match = /^\s*(?:(?:assets\s*\.\s*(image|tile|animation|tilemap))|(tilemap))\s*`([^`]+)`\s*$/.exec(ts);
+        const match = /^\s*(?:(?:assets\s*\.\s*(image|tile|animation|tilemap))|(tilemap))\s*(?:`|\(""")([^`"]+)(?:`|"""\))\s*$/.exec(ts);
 
         if (match) {
             const type = match[1] || match[2];


### PR DESCRIPTION
Fixes  microsoft/pxt-arcade#2986
Fixes microsoft/pxt-arcade#3018

This unites all of the asset emitting and all of the parsing except in the monaco fields (which have some special behavior around creating new assets if the name does not exist)

@shakao you should be able to close https://github.com/microsoft/pxt/pull/7855

@jwunderl this might conflict with https://github.com/microsoft/pxt/pull/7858 because getShortIDCore can now return undefined.

I think I tested this pretty thoroughly, but please review carefully because it touches some key stuff

