### PR TITLE
Conflict resolution for loosely versioned dependencies.

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -407,16 +407,17 @@ namespace pxt {
                             }
                             if (!foundYottaConflict
                                 && pkgCfg.name === depPkg.id
-                                && depPkg._verspec != version
-                                && !/^file:/.test(depPkg._verspec) && !/^file:/.test(version)) {
+                                && depPkg._verspec !== version
+                                && !/^file:/.test(depPkg._verspec)
+                                && !/^file:/.test(version)) {
                                 // we have a potential version mistmatch here
                                 // check if versions are semver compatible for github refs
                                 const ghCurrent = /^github:/.test(depPkg._verspec)
                                     && pxt.github.parseRepoId(depPkg._verspec);
                                 const ghNew = /^github:/.test(version)
                                     && pxt.github.parseRepoId(version);
-                                if (!ghCurrent || !ghNew
-                                    || ghCurrent.fullName !== ghNew.fullName
+                                if (!ghCurrent || !ghNew // only for github refs
+                                    || ghCurrent.fullName !== ghNew.fullName // must be same extension
                                     // if newversion does not have tag, it's ok
                                     // note: we are upgrade major versions as well
                                     || (ghNew.tag && pxt.semver.strcmp(ghCurrent.tag, ghNew.tag) < 0)) {


### PR DESCRIPTION
When add a new github dependency without a tag, default to existing tag if already reference. Eg if adding "foo/bar", but "foo/bar#0.0.0" is already reference, use "foo/bar#0.0.0".