### PR TITLE
Cherry-pick asset editor fixes, small UI updates to stable6.8

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -16,14 +16,17 @@ namespace pxt.blocks {
      */
     export function domToWorkspaceNoEvents(dom: Element, workspace: Blockly.Workspace): string[] {
         pxt.tickEvent(`blocks.domtow`)
+        let newBlockIds: string[] = [];
         try {
             Blockly.Events.disable();
-            const newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);
+            newBlockIds = Blockly.Xml.domToWorkspace(dom, workspace);
             applyMetaComments(workspace);
-            return newBlockIds;
+        } catch (e) {
+            pxt.reportException(e);
         } finally {
             Blockly.Events.enable();
         }
+        return newBlockIds;
     }
 
     function applyMetaComments(workspace: Blockly.Workspace) {

--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -73,11 +73,8 @@ namespace pxtblockly {
             const project = pxt.react.getTilemapProject();
 
             if (text) {
-                const match = /^\s*assets\s*\.\s*animation\s*`([^`]+)`\s*$/.exec(text);
-                if (match) {
-                    const asset = project.lookupAssetByName(pxt.AssetType.Animation, match[1].trim());
-                    if (asset) return asset;
-                }
+                const existing = pxt.lookupProjectAssetByTSReference(text, project);
+                if (existing) return existing;
 
                 const frames = parseImageArrayString(text);
 
@@ -105,7 +102,7 @@ namespace pxtblockly {
                 ).join(",") + "]"
             }
 
-            return `assets.animation\`${this.asset.meta.displayName || pxt.getShortIDForAsset(this.asset)}\``
+            return pxt.getTSReferenceForAsset(this.asset);
         }
 
         protected redrawPreview() {

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -113,6 +113,8 @@ namespace pxtblockly {
                     if (pxt.assetEquals(this.asset, result)) return;
 
                     this.pendingEdit = true;
+
+                    if (result.meta?.displayName) this.disposeOfTemporaryAsset();
                     this.asset = result;
                     const lastRevision = project.revision();
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -38,6 +38,11 @@ namespace pxtblockly {
                 if (match) {
                     const asset = project.lookupAssetByName(pxt.AssetType.Image, match[1].trim());
                     if (asset) return asset;
+                    else if (!this.getBlockData()) {
+                        this.isGreyBlock = true;
+                        this.valueText = text;
+                        return undefined;
+                    }
                 }
             }
 
@@ -46,6 +51,13 @@ namespace pxtblockly {
             }
 
             const bmp = text ? pxt.sprite.imageLiteralToBitmap(text) : new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight);
+
+            if (!bmp) {
+                this.isGreyBlock = true;
+                this.valueText = text;
+                return undefined;
+            }
+
             const newAsset = project.createNewProjectImage(bmp.data());
             return newAsset;
         }

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -34,16 +34,9 @@ namespace pxtblockly {
         protected createNewAsset(text?: string): pxt.Asset {
             const project = pxt.react.getTilemapProject();
             if (text) {
-                const match = /^\s*assets\s*\.\s*image\s*`([^`]+)`\s*$/.exec(text);
-                if (match) {
-                    const asset = project.lookupAssetByName(pxt.AssetType.Image, match[1].trim());
-                    if (asset) return asset;
-                    else if (!this.getBlockData()) {
-                        this.isGreyBlock = true;
-                        this.valueText = text;
-                        return undefined;
-                    }
-                }
+                const asset = pxt.lookupProjectAssetByTSReference(text, project);
+
+                if (asset) return asset;
             }
 
             if (this.getBlockData()) {
@@ -63,7 +56,9 @@ namespace pxtblockly {
         }
 
         protected getValueText(): string {
-            if (this.asset && !this.isTemporaryAsset()) return `assets.image\`${this.asset.meta.displayName || this.asset.id.substr(this.asset.id.lastIndexOf(".") + 1)}\``;
+            if (this.asset && !this.isTemporaryAsset()) {
+                return pxt.getTSReferenceForAsset(this.asset);
+            }
             return pxt.sprite.bitmapToImageLiteral(this.asset && pxt.sprite.Bitmap.fromData((this.asset as pxt.ProjectImage).bitmap), pxt.editor.FileType.TypeScript);
         }
 

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -42,20 +42,9 @@ namespace pxtblockly {
             }
 
             const project = pxt.react.getTilemapProject();
-            const match = /^\s*tilemap\s*`([^`]*)`\s*$/.exec(newText);
 
-            if (match) {
-                const tilemapId = match[1].trim();
-                let resolved = project.lookupAssetByName(pxt.AssetType.Tilemap, tilemapId);
-
-                if (!resolved) {
-                    resolved = project.lookupAsset(pxt.AssetType.Tilemap, tilemapId);
-                }
-
-                if (resolved) {
-                    return resolved;
-                }
-            }
+            const existing = pxt.lookupProjectAssetByTSReference(newText, project);
+            if (existing) return existing;
 
             const tilemap = pxt.sprite.decodeTilemap(newText, "typescript", project) || project.blankTilemap(this.params.tileWidth, this.params.initWidth, this.params.initHeight);
             let newAsset: pxt.ProjectTilemap;
@@ -111,16 +100,10 @@ namespace pxtblockly {
             if (this.isGreyBlock) return pxt.Util.htmlUnescape(this.valueText);
 
             if (this.asset) {
-                return `tilemap\`${this.asset.meta.displayName || this.asset.id}\``;
+                return pxt.getTSReferenceForAsset(this.asset);
             }
 
-            try {
-                return pxt.sprite.encodeTilemap(this.asset.data, "typescript");
-            }
-            catch (e) {
-                // If encoding failed, this is a legacy tilemap. Should get upgraded when the project is loaded
-                return this.getInitText();
-            }
+            return this.getInitText();
         }
 
         protected parseFieldOptions(opts: FieldTilemapOptions): ParsedFieldTilemapOptions {

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -94,7 +94,7 @@ namespace pxtblockly {
         getValue() {
             if (this.selectedOption_) {
                 const tile = this.selectedOption_[2];
-                return isGalleryTile(tile) ? tile.id : `assets.tile\`${displayName(tile)}\``
+                return pxt.getTSReferenceForAsset(tile);
             }
             const v = super.getValue();
 
@@ -148,10 +148,12 @@ namespace pxtblockly {
 
             if (newValue) {
                 // If it's an expression, pull out the id
-                const match = /^\s*assets\s*\.\s*tile\s*`([^`]+)`\s*$/.exec(newValue);
+                const match = pxt.parseAssetTSReference(newValue);
                 if (match) {
-                    newValue = match[1];
+                    newValue = match.name;
                 }
+
+                newValue = newValue.trim();
 
                 for (const option of options) {
                     if (newValue === option[2].id || newValue === option[2].meta.displayName || newValue === pxt.getShortIDForAsset(option[2])) {
@@ -251,9 +253,5 @@ namespace pxtblockly {
 
     function displayName(tile: pxt.Tile) {
         return tile.meta.displayName || pxt.getShortIDForAsset(tile);
-    }
-
-    function isGalleryTile(tile: pxt.Tile) {
-        return tile.id.startsWith("sprites.");
     }
 }

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -11,16 +11,16 @@ namespace pxt.editor {
         protected textToValue(text: string): pxt.ProjectImage {
             this.isPython = text.indexOf("`") === -1
 
-            const match = /^\s*assets\s*\.\s*image\s*`([^`]*)`\s*$/.exec(text);
+            const match = pxt.parseAssetTSReference(text);
             if (match) {
+                const { type, name } = match;
                 const project = pxt.react.getTilemapProject();
                 this.isAsset = true;
-                const asset = project.lookupAssetByName(pxt.AssetType.Image, match[1].trim());
+                const asset = project.lookupAssetByName(pxt.AssetType.Image, name);
                 if (asset) {
                     return asset;
                 }
                 else {
-                    const name = match[1].trim();
                     const newAsset = project.createNewImage();
 
                     if (name && !project.isNameTaken(pxt.AssetType.Image, name) && pxt.validateAssetName(name)) {
@@ -43,7 +43,7 @@ namespace pxt.editor {
                     this.isAsset = true;
                     result = project.createNewProjectImage(result.bitmap, result.meta.displayName);
                 }
-                return `assets.image\`${result.meta.displayName}\``
+                return pxt.getTSReferenceForAsset(result, this.isPython);
             }
             return pxt.sprite.bitmapToImageLiteral(pxt.sprite.Bitmap.fromData(result.bitmap), this.isPython ? "python" : "typescript");
         }

--- a/pxteditor/monaco-fields/field_tilemap.ts
+++ b/pxteditor/monaco-fields/field_tilemap.ts
@@ -116,7 +116,7 @@ namespace pxt.editor {
 
             if (this.isTilemapLiteral) {
                 project.updateAsset(asset);
-                return this.fileType === "typescript" ? `tilemap\`${asset.id}\`` : `tilemap("""${asset.id}""")`;
+                return pxt.getTSReferenceForAsset(asset, this.fileType === "python");
             }
             else {
                 return pxt.sprite.encodeTilemap(result, this.fileType === "typescript" ? "typescript" : "python");

--- a/pxtlib/legacyTilemap.ts
+++ b/pxtlib/legacyTilemap.ts
@@ -24,9 +24,9 @@ namespace pxt.sprite.legacy {
     }
 
     export function decodeTilemap(literal: string, fileType: "typescript" | "python"): LegacyTilemapData {
-        literal = Util.htmlUnescape(literal).trim();
+        literal = Util.htmlUnescape(literal)?.trim();
 
-        if (!literal.trim()) {
+        if (!literal?.trim()) {
             return new LegacyTilemapData(new Tilemap(16, 16), {tileWidth: 16, tiles: []}, new Bitmap(16, 16).data());
         }
 

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -580,16 +580,13 @@ namespace pxt.sprite {
         return result;
     }
 
-    export function imageLiteralToBitmap(text: string, defaultPattern?: string): Bitmap {
+    export function imageLiteralToBitmap(text: string): Bitmap {
         // Strip the tagged template string business and the whitespace. We don't have to exhaustively
         // replace encoded characters because the compiler will catch any disallowed characters and throw
         // an error before the decompilation happens. 96 is backtick and 9 is tab
         text = text.replace(/[ `]|(?:&#96;)|(?:&#9;)|(?:img)/g, "").trim();
         text = text.replace(/^["`\(\)]*/, '').replace(/["`\(\)]*$/, '');
         text = text.replace(/&#10;/g, "\n");
-
-        if (!text && defaultPattern)
-            text = defaultPattern;
 
         const rows = text.split("\n");
 
@@ -620,6 +617,8 @@ namespace pxt.sprite {
                     case "d": case "D": case "O": rowValues.push(13); break;
                     case "e": case "E": case "Y": rowValues.push(14); break;
                     case "f": case "F": case "W": rowValues.push(15); break;
+                    default:
+                        if (!/\s/.test(row[c])) return undefined;
                 }
             }
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1278,7 +1278,7 @@ namespace pxt {
                 out += `${indent}//% fixedInstance jres blockIdentity=images._tile\n`
                 out += `${indent}export const ${key} = image.ofBuffer(hex\`\`);\n`
 
-                tileEntries.push({ keys: [entry.displayName, getShortIDCore(AssetType.Tile, key)], expression: key})
+                tileEntries.push({ keys: [entry.displayName, getShortIDCore(AssetType.Tile, key, true)], expression: key})
             }
 
             if (entry.mimeType === TILEMAP_MIME_TYPE) {
@@ -1316,7 +1316,7 @@ namespace pxt {
 
             if (typeof entry === "string" || entry.mimeType === IMAGE_MIME_TYPE) {
                 let expression: string;
-                let factoryKeys = [getShortIDCore(AssetType.Image, key)]
+                let factoryKeys = [getShortIDCore(AssetType.Image, key, true)]
                 if (typeof entry === "string") {
                     expression = sprite.bitmapToImageLiteral(sprite.getBitmapFromJResURL(entry), "typescript");
                 }
@@ -1333,7 +1333,7 @@ namespace pxt {
                 const animation = decodeAnimation(entry);
 
                 animationEntries.push({
-                    keys: [entry.displayName, getShortIDCore(AssetType.Animation, key)],
+                    keys: [entry.displayName, getShortIDCore(AssetType.Animation, key, true)],
                     expression: `[${animation.frames.map(f =>
                             sprite.bitmapToImageLiteral(sprite.Bitmap.fromData(f), "typescript")
                         ).join(", ")}]`
@@ -1484,11 +1484,79 @@ namespace pxt {
         return !bannedRegex.test(name);
     }
 
+    export function getTSReferenceForAsset(asset: pxt.Asset, isPython = false) {
+        let shortId: string;
+        if (asset.meta?.displayName) {
+            shortId = asset.meta.displayName;
+        }
+        else {
+            shortId = getShortIDForAsset(asset);
+        }
+
+        if (!shortId) {
+            if (asset.type === pxt.AssetType.Image || asset.type === pxt.AssetType.Tile) {
+                // Use the qualified name
+                return asset.id;
+            }
+            return undefined;
+        }
+
+        const leftTick = isPython ? `("""` : "`";
+        const rightTick = isPython ? `""")` : "`";
+
+        switch (asset.type) {
+            case AssetType.Tile:
+                return `assets.tile${leftTick}${shortId}${rightTick}`
+            case AssetType.Image:
+                return `assets.image${leftTick}${shortId}${rightTick}`
+            case AssetType.Animation:
+                return `assets.animation${leftTick}${shortId}${rightTick}`
+            case AssetType.Tilemap:
+                return `tilemap${leftTick}${shortId}${rightTick}`
+        }
+    }
+
+    export function parseAssetTSReference(ts: string) {
+        const match = /^\s*(?:(?:assets\s*\.\s*(image|tile|animation|tilemap))|(tilemap))\s*(?:`|\(""")([^`"]+)(?:`|"""\))\s*$/m.exec(ts);
+
+        if (match) {
+            const type = match[1] || match[2];
+            const name = match[3].trim();
+
+            return {
+                type, name
+            }
+        }
+
+        return undefined;
+    }
+
+    export function lookupProjectAssetByTSReference(ts: string, project: TilemapProject) {
+        const match = parseAssetTSReference(ts);
+
+        if (match) {
+            const { type, name } = match;
+
+            switch (type) {
+                case "tile":
+                    return project.lookupAssetByName(AssetType.Tile, name);
+                case "image":
+                    return project.lookupAssetByName(AssetType.Image, name);
+                case "tilemap":
+                    return project.lookupAssetByName(AssetType.Tilemap, name) || project.lookupAsset(AssetType.Tilemap, name);
+                case "animation":
+                    return project.lookupAssetByName(AssetType.Animation, name);
+            }
+        }
+
+        return undefined
+    }
+
     export function getShortIDForAsset(asset: pxt.Asset) {
         return getShortIDCore(asset.type, asset.id);
     }
 
-    function getShortIDCore(assetType: pxt.AssetType, id: string) {
+    function getShortIDCore(assetType: pxt.AssetType, id: string, allowNoPrefix = false) {
         let prefix: string;
         switch (assetType) {
             case AssetType.Image:
@@ -1505,9 +1573,14 @@ namespace pxt {
                 break;
         }
 
-        if (prefix && id.startsWith(prefix)) {
-            const short = id.substr(prefix.length);
-            if (short.indexOf(".") === -1) return short;
+        if (prefix) {
+            if (id.startsWith(prefix)) {
+                const short = id.substr(prefix.length);
+                if (short.indexOf(".") === -1) return short;
+            }
+            else if (!allowNoPrefix) {
+                return null;
+            }
         }
 
         return id;

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -156,8 +156,8 @@ class AppImpl extends React.Component<AppProps, AppState> {
                 }
 
                 this.setState({ error: undefined });
-            } catch {
-                this.handleError();
+            } catch (err) {
+                this.handleError(err);
             }
         } else {
             this.setState({ error: lf("No content loaded.") })

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -55,18 +55,26 @@
     width: 100%;
     display: flex;
     flex-direction: row;
+    border-bottom: 1px solid @assetTopbarBorder;
 }
 
 .asset-editor-gallery-tab {
+    height: 3rem;
     background-color: @assetUnselected;
+    color: @grey;
     padding: .7em 2em .85em;
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
+    border-color: @assetTopbarBorder;
+    border-style: solid;
+    border-width: 0 1px 1px 0;
 }
 
 .asset-editor-gallery-tab.selected {
     background-color: transparent;
+    border-bottom-color: @blocklySvgColor;
+    color: @black;
 }
 .asset-editor-card-list {
     width: 100%;

--- a/theme/image-editor/tilePalette.less
+++ b/theme/image-editor/tilePalette.less
@@ -172,3 +172,18 @@
 .tile-palette-controls-outer {
     height: 2rem;
 }
+
+
+@media screen and (max-height: 720px) {
+    .image-editor-tilemap-minimap {
+        height: 7rem;
+    }
+
+    .tile-canvas {
+        padding-bottom: 0;
+    }
+
+    .tile-palette-fg-bg {
+        margin-bottom: 0;
+    }
+}

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -375,9 +375,10 @@
 /*-------------------
    Asset Editor
 -------------------*/
-@assetSidebarBorder: #dedede;
+@assetSidebarBorder: #c6c6c6;
 @assetSidebarButton: #f8f8f8;
 @assetSidebarButtonHover: #dedede;
+@assetTopbarBorder: #c6c6c6;
 @assetPreviewBackground: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10px' height='10px'%3E%3Crect x='0' y='0' width='10px' height='10px' fill='white'%3E%3C/rect%3E%3Crect x='0' y='0' width='5px' height='5px' fill='%23dedede'%3E%3C/rect%3E%3Crect x='5' y='5' width='5px' height='5px' fill='%23dedede'%3E%3C/rect%3E%3C/svg%3E");
 @assetUnselected: #e3ddd0;
 @assetTypeButton: @teal;


### PR DESCRIPTION
- Add border to help distinguish selected/unselected asset tab (#7833)
- Compress tilemap sidebar for smaller screen sizes (#7835)
- Fix tilemap upgrade path in compiler (#7839)
- Be stricter when parsing image literals (#7849)
- Clean up temporary asset when exiting field editor (#7848)
- Unite asset emitting code paths and fix tile parsing (#7489) <- @abchatra this is the one richard was talking about in standup
- Expose more informative skillmap parsing error (#7863)

@riknoll let me know if i missed any!