### PR TITLE
add styling for tutorial hovertext

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -168,6 +168,11 @@ body#docs.tutorial {
     padding: 0.5rem;
     height: calc(@tutorialCardHeight - 1.5rem);
     overflow: hidden;
+
+    a:not([href]), a[href^="#"] {
+        color: @black;
+        text-decoration: underline;
+    }
 }
 
 .tutorial #tutorialcard.hasHint .tutorialmessage {


### PR DESCRIPTION
Looks like this as written, but the selector is the more interesting part / easy to swap any styling in:

![image](https://user-images.githubusercontent.com/5615930/107269804-fb150300-69fe-11eb-910c-336539c17034.png)

Always underlined + black + italic without any hover effect reads as "hover but don't click" to me :)