### PR TITLE
Add autoexpandOff metadata option for tutorial testing

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -958,6 +958,7 @@ declare namespace pxt.tutorial {
         noDiffs?: boolean; // don't automatically generated diffs
         codeStart?: string; // command to run when code starts (MINECRAFT HOC ONLY)
         codeStop?: string; // command to run when code stops (MINECRAFT HOC ONLY)
+        autoexpandOff?: boolean // INTERNAL TESTING ONLY
     }
 
     interface TutorialStepInfo {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -357,7 +357,7 @@ ${code}
             tutorialCode: tutorialInfo.code,
             tutorialRecipe: !!recipe,
             templateCode: tutorialInfo.templateCode,
-            autoexpandStep: true,
+            autoexpandStep: tutorialInfo.metadata?.autoexpandOff ? false : true,
             metadata: tutorialInfo.metadata,
             language: tutorialInfo.language,
             jres: tutorialInfo.jres,


### PR DESCRIPTION
tutorial steps will default to "collapsed" ("Show more...") when the tutorial is first opened. as with current behavior, if a user clicks "Show more/less" we remember that state and will persist it with that project.

to use, add this to the start of a tutorial:

```
### @autoexpandOff true
```

for https://github.com/microsoft/pxt-arcade/issues/3047