### PR TITLE
Add warning icon for temp assets, update sidebar name display

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -15,15 +15,25 @@
     margin: 1rem;
 }
 
-.asset-editor-sidebar-name {
+.asset-editor-sidebar-name,
+.asset-editor-sidebar-temp {
     overflow: hidden;
     text-overflow: ellipsis;
     margin-bottom: 0.5rem;
     font-weight: 700;
+}
 
-    &.unnamed {
-        font-weight: 400;
-        font-style: italic;
+.asset-editor-sidebar-temp {
+    display: flex;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    background-color: @assetUnselected;
+
+    i {
+        width: 1.5rem;
+        height: 1.5rem;
+        margin-right: 0.5rem;
     }
 }
 
@@ -105,14 +115,21 @@
 }
 
 .asset-editor-card-label {
+    display: flex;
     position: relative;
     margin-top: -2rem;
+    z-index: 2;
+}
+
+.asset-editor-card-icon {
     height: 2rem;
     width: 2rem;
-    background: @white;
-    z-index: 2;
     line-height: 2rem;
     text-align: center;
+    background: @white;
+    margin-right: 0.25rem;
+
+    i { margin: 0; }
 }
 
 .asset-editor-preview {

--- a/webapp/src/components/assetEditor/assetCard.tsx
+++ b/webapp/src/components/assetEditor/assetCard.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect } from 'react-redux';
 
-import { AssetEditorState } from './store/assetEditorReducer';
+import { AssetEditorState, isGalleryAsset } from './store/assetEditorReducer';
 import { dispatchChangeSelectedAsset } from './actions/dispatch';
 
 import { AssetPreview } from "./assetPreview";
@@ -52,11 +52,18 @@ export class AssetCardView extends React.Component<AssetCardCoreProps> {
 
     render() {
         const { asset, selected } = this.props;
+        const inGallery = isGalleryAsset(asset);
         const icon = this.getDisplayIconForAsset(asset.type);
+        const showIcons = icon || !asset.meta?.displayName;
         return <div className={`asset-editor-card ${selected ? "selected" : ""}`} onClick={this.clickHandler} role="listitem">
             <AssetPreview asset={asset} />
-            {icon && <div className="asset-editor-card-label">
-                <i className={`icon ${icon}`} />
+            {showIcons && <div className="asset-editor-card-label">
+                {icon && <div className="asset-editor-card-icon">
+                    <i className={`icon ${icon}`} />
+                </div>}
+                {!asset.meta?.displayName && !inGallery && <div className="asset-editor-card-icon">
+                    <i className="icon exclamation triangle" />
+                </div>}
             </div>}
         </div>
     }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -4,7 +4,7 @@ import * as simulator from "../../simulator";
 import * as sui from "../../sui";
 import { connect } from 'react-redux';
 
-import { AssetEditorState, GalleryView } from './store/assetEditorReducer';
+import { AssetEditorState, GalleryView, isGalleryAsset } from './store/assetEditorReducer';
 import { dispatchChangeGalleryView, dispatchChangeSelectedAsset, dispatchUpdateUserAssets } from './actions/dispatch';
 
 import { AssetPreview } from "./assetPreview";
@@ -165,7 +165,13 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                 <div className="asset-editor-sidebar-preview">
                     { asset && <AssetPreview asset={asset} />  }
                 </div>
-                <div className={`asset-editor-sidebar-name ${!isNamed ? 'unnamed' : ''}`}>{ name }</div>
+                {isNamed || !asset
+                    ? <div className="asset-editor-sidebar-name">{ name }</div>
+                    : <div className="asset-editor-sidebar-temp">
+                        <i className="icon exclamation triangle" />
+                        <span>{lf("No saved asset name!")}</span>
+                    </div>
+                }
                 {details.map(el => {
                     return <div key={el.name} className="asset-editor-sidebar-detail">{`${el.name}: ${el.value}`}</div>
                 })}
@@ -215,7 +221,7 @@ function mapStateToProps(state: AssetEditorState, ownProps: any) {
     if (!state) return {};
     return {
         asset: state.selectedAsset,
-        isGalleryAsset: state.selectedAsset?.id.startsWith("sprites.")
+        isGalleryAsset: isGalleryAsset(state.selectedAsset)
     };
 }
 

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -111,4 +111,8 @@ export function assetToGalleryItem(asset: pxt.Asset, imgConv = new pxt.ImageConv
     }
 }
 
+export function isGalleryAsset(asset?: pxt.Asset) {
+    return asset?.id.startsWith("sprites.");
+}
+
 export default topReducer;


### PR DESCRIPTION
![fix-temp-asset](https://user-images.githubusercontent.com/34112083/107408494-ea789180-6abf-11eb-8f9d-bdf4bf34b17f.gif)

build: https://arcade.makecode.com/app/ead5a05a47849e1603b61860ea0f340eb0b24e8f-405477fb68

i clicked around the asset editor and sprite/tilemap editor galleries and everything seemed okay to me, but uploading a build just in case anyone else can think of any other edge cases to try