### PR TITLE
set default color for note picker so it's not white notes on offwhite bkgd

### DIFF
--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -369,9 +369,8 @@ namespace pxtblockly {
                 this.borderColour = b.getColourTertiary();
             }
             else {
-                let b = this.sourceBlock_ as Blockly.BlockSvg;
-                this.primaryColour = b.getColourTertiary();
-                this.borderColour = b.getColourTertiary();
+                this.primaryColour = "#3D3D3D";
+                this.borderColour = "#2A2A2A";
             }
         }
 


### PR DESCRIPTION
Just before stream we tried to use the block that is the notepicker on it's own and noticed it was messed up; the default color we get for the notepicker when it isn't slotted into another block is white / light gray, which makes it hard to see / very low contrast:

![image](https://user-images.githubusercontent.com/5615930/107436029-d34a9b80-6ae1-11eb-9dc1-ae7e32d27142.png)

(sometimes as this: 
![image](https://user-images.githubusercontent.com/5615930/107443462-bb791480-6aed-11eb-828a-1161b6498d32.png))


The music category color is different depending on the color (orange in micro:bit, pink in arcade) -- I can make it try and grab the default but it's a bit tedious, and I kind of like the dark gray electric piano look anyways / the color of the piano changes whenever it's used anyways:

![image](https://user-images.githubusercontent.com/5615930/107435862-941c4a80-6ae1-11eb-8cc1-cde9adf29f1e.png)
