### PR TITLE
Updated Delete asset button styling

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -179,9 +179,11 @@
 }
 
 .delete-asset {
-    color: @white;
-    background-color: @red;
-    font-weight: 700;
+    margin: 0.5rem;
+    text-align: center;
+    font-size: 0.9rem;
+    cursor: pointer;
+    opacity: 0.9;
 }
 
 .asset-editor-create-options {

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -174,11 +174,10 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                 {canEdit && <sui.MenuItem name={lf("Edit")} className="asset-editor-button" icon="edit" onClick={this.editAssetHandler}/>}
                 <sui.MenuItem name={lf("Duplicate")} className="asset-editor-button" icon="copy" onClick={this.duplicateAssetHandler}/>
                 {canCopy && <sui.MenuItem name={lf("Copy")} className="asset-editor-button" icon="paste" onClick={this.copyAssetHandler}/>}
-                <sui.MenuItem name={lf("Delete")}
-                    className={`asset-editor-button delete-asset ${!canDelete ? "disabled" : ""}`}
-                    icon="trash"
+                {canDelete && <sui.MenuItem name={lf("Delete Asset")}
+                    className="delete-asset"
                     dataTooltip={!canDelete ? (isGalleryAsset ? lf("Can't delete gallery item") : lf("Asset is used in your project")) : undefined}
-                    onClick={canDelete ? this.showDeleteModal : undefined}/>
+                    onClick={canDelete ? this.showDeleteModal : undefined}/>}
             </div>}
             <textarea className="asset-editor-sidebar-copy" ref={this.copyTextAreaRefHandler} ></textarea>
             <sui.Modal className="asset-editor-delete-dialog" isOpen={showDeleteModal} onClose={this.hideDeleteModal} closeIcon={true} dimmer={true} header={lf("Delete Asset")} buttons={actions}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/107451694-aa83cf80-6afc-11eb-9206-441ca5dc7fb7.png)

render delete button as smaller text, hide button if asset is not deletable