### PR TITLE
Adding empty card shadows in the asset editor gallery

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -104,6 +104,12 @@
     border-width: 2px;
 }
 
+.asset-editor-card.empty-card {
+    background-color: #000000;
+    opacity: 0.05;
+    border: none;
+}
+
 .asset-editor-card-label {
     position: relative;
     margin-top: -2rem;

--- a/webapp/src/components/assetEditor/assetCardList.tsx
+++ b/webapp/src/components/assetEditor/assetCardList.tsx
@@ -76,7 +76,7 @@ export class AssetCardList extends React.Component<AssetCardListProps> {
         this.hasUpdatedCards = true;
 
         const columns = Math.floor(parentBounds.width / elementWidth);
-        const rows = Math.floor(this.container.parentElement.getBoundingClientRect().height/ elementWidth)
+        const rows = Math.floor(this.container.parentElement.getBoundingClientRect().height / elementWidth)
 
         let current = this.container.firstElementChild;
         let count = 0;

--- a/webapp/src/components/assetEditor/assetCardList.tsx
+++ b/webapp/src/components/assetEditor/assetCardList.tsx
@@ -8,11 +8,117 @@ interface AssetCardListProps {
 }
 
 export class AssetCardList extends React.Component<AssetCardListProps> {
+    container: HTMLDivElement;
+    emptyCards: HTMLDivElement[];
+    hasUpdatedCards = false;
+
+    componentDidUpdate() {
+        this.updateEmptyCards();
+    }
+
+    componentDidMount() {
+        window.addEventListener("resize", this.updateEmptyCards);
+
+        let interval = () => {
+            if (this.hasUpdatedCards) return;
+            this.updateEmptyCards();
+            if (!this.hasUpdatedCards) requestAnimationFrame(interval);
+        }
+
+        requestAnimationFrame(interval);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("resize", this.updateEmptyCards);
+    }
+
     render() {
         const { assets } = this.props;
-        return <div>
+
+        return <div ref={this.handleContainerRef}>
             {this.props.children}
             {assets.map(asset => <AssetCard asset={asset} key={asset.id} />)}
         </div>
     }
+
+    handleContainerRef = (div: HTMLDivElement) => {
+        if (div) {
+            this.container = div;
+            this.updateEmptyCards();
+        }
+    }
+
+    protected updateEmptyCards = pxtc.Util.throttle(() => {
+        if (!this.container) return;
+
+        const child = this.container.firstElementChild;
+        if (!child) return;
+
+        if (!this.emptyCards) this.emptyCards = [];
+
+        const childBounds = child.getBoundingClientRect();
+        const parentBounds = this.container.getBoundingClientRect();
+
+        // Check if we are actually visible and in DOM
+        if (!childBounds.width || !childBounds.height || !parentBounds.width || !parentBounds.height) return;
+
+        let elementWidth = childBounds.width;
+
+        // The bounding rect width does not include all padding/margin so if there is a sibling,
+        // figure out the more accurate number by subtracting their lefts
+        if (child.nextElementSibling) {
+            const siblingBounds = child.nextElementSibling.getBoundingClientRect();
+
+            // Guard against a single column
+            elementWidth = Math.max(elementWidth, siblingBounds.left - childBounds.left);
+        }
+
+        this.hasUpdatedCards = true;
+
+        const columns = Math.floor(parentBounds.width / elementWidth);
+        const rows = Math.floor(this.container.parentElement.getBoundingClientRect().height/ elementWidth)
+
+        let current = this.container.firstElementChild;
+        let count = 0;
+        let firstEmptyCard: HTMLDivElement;
+
+        // Count the number of non-empty cards and also sort them so that the empty
+        // cards are always at the end.
+        while (current) {
+            if (!current.classList.contains("empty-card")) {
+                count++;
+                if (firstEmptyCard) {
+                    this.container.insertBefore(current, firstEmptyCard);
+                }
+            }
+            else if (!firstEmptyCard) firstEmptyCard = current as HTMLDivElement;
+            current = current.nextElementSibling;
+        }
+
+
+        let emptyCards: number;
+        if (columns * rows > count) {
+            // Always make sure we fill up the full space even if we don't scroll
+            emptyCards = columns * rows - count;
+        }
+        else {
+            emptyCards = columns - (count % columns);
+        }
+
+        if (emptyCards !== this.emptyCards.length) {
+            if (this.emptyCards.length > emptyCards) {
+                while (this.emptyCards.length > emptyCards) {
+                    this.emptyCards.pop().remove();
+                }
+            }
+            else {
+                for (let i = this.emptyCards.length; i < emptyCards; i++) {
+                    const div = document.createElement("div");
+                    div.setAttribute("class", "asset-editor-card empty-card");
+                    this.container.appendChild(div);
+                    this.emptyCards.push(div);
+                }
+            }
+        }
+    }, 100);
 }


### PR DESCRIPTION
<img width="1439" alt="Screen Shot 2021-02-11 at 11 11 56 AM" src="https://user-images.githubusercontent.com/13754588/107686419-0b74ea00-6c5a-11eb-92a5-c59d9ff319ff.png">

Don't love doing this in JavaScript but @shakao and I couldn't think of a clever way to do it in css. Originally I tried putting the number of empty cards in the react state but it was pretty buggy.