### PR TITLE
Fix gallery duplication, hide 'Report Abuse' for trusted content, temporary asset CSS

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -870,9 +870,9 @@ namespace pxt.github {
             return true;
 
         if (!repo || !config) return false;
-        if (repo.fullName
+        if (repo.slug
             && config.approvedRepos
-            && config.approvedRepos.some(fn => fn.toLowerCase() == repo.fullName.toLowerCase()))
+            && config.approvedRepos.some(fn => fn.toLowerCase() == repo.slug.toLowerCase()))
             return true;
         return false;
     }

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -25,7 +25,6 @@
 
 .asset-editor-sidebar-temp {
     display: flex;
-    align-items: center;
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
     background-color: @assetUnselected;
@@ -33,7 +32,7 @@
     i {
         width: 1.5rem;
         height: 1.5rem;
-        margin-right: 0.5rem;
+        margin-right: 0.3rem;
     }
 }
 

--- a/webapp/src/components/assetEditor/actions/dispatch.ts
+++ b/webapp/src/components/assetEditor/actions/dispatch.ts
@@ -2,6 +2,6 @@ import * as actions from './types'
 import { GalleryView } from '../store/assetEditorReducer';
 
 export const dispatchChangeSelectedAsset = (assetType?: pxt.AssetType, assetId?: string) => ({ type: actions.CHANGE_SELECTED_ASSET, assetType, assetId });
-export const dispatchChangeGalleryView = (view: GalleryView) => ({ type: actions.CHANGE_GALLERY_VIEW, view });
+export const dispatchChangeGalleryView = (view: GalleryView, assetType?: pxt.AssetType, assetId?: string) => ({ type: actions.CHANGE_GALLERY_VIEW, view, assetType, assetId });
 export const dispatchUpdateUserAssets = () => ({ type: actions.UPDATE_USER_ASSETS });
 export const dispatchUpdateGalleryAssets = () => ({ type: actions.UPDATE_GALLERY_ASSETS });

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -169,7 +169,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                     ? <div className="asset-editor-sidebar-name">{ name }</div>
                     : <div className="asset-editor-sidebar-temp">
                         <i className="icon exclamation triangle" />
-                        <span>{lf("No saved asset name!")}</span>
+                        <span>{lf("No asset name")}</span>
                     </div>
                 }
                 {details.map(el => {

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -18,7 +18,7 @@ interface AssetSidebarProps {
     asset?: pxt.Asset;
     isGalleryAsset?: boolean;
     showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
-    dispatchChangeGalleryView: (view: GalleryView) => void;
+    dispatchChangeGalleryView: (view: GalleryView, assetType?: pxt.AssetType, assetId?: string) => void;
     dispatchChangeSelectedAsset: (assetType?: pxt.AssetType, assetId?: string) => void;
     dispatchUpdateUserAssets: () => void;
 }
@@ -103,8 +103,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         const { type, id } = project.duplicateAsset(asset);
         this.updateAssets().then(() => {
-            this.props.dispatchChangeGalleryView(GalleryView.User);
-            this.props.dispatchChangeSelectedAsset(type, id);
+            this.props.dispatchChangeGalleryView(GalleryView.User, type, id);
         });
     }
 
@@ -146,7 +145,6 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         project.removeAsset(this.props.asset);
         this.props.dispatchChangeSelectedAsset();
-        this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets();
     }
 

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -26,9 +26,11 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
                 selectedAsset: getSelectedAsset(state, action.assetType, action.assetId)
             };
         case actions.CHANGE_GALLERY_VIEW:
+            const selectedAsset = !!action.assetId ? getSelectedAsset(state, action.assetType, action.assetId) : state.selectedAsset;
             return {
                 ...state,
-                view: action.view
+                view: action.view,
+                selectedAsset
             };
         case actions.UPDATE_USER_ASSETS:
             const assets = getAssets();


### PR DESCRIPTION
one fix per commit:

- https://github.com/microsoft/pxt/commit/b9f6cd81bf494cb06f89ccdaaefdf30efe50f90f fixes https://github.com/microsoft/pxt-arcade/issues/3077, will address https://github.com/microsoft/pxt-arcade/issues/3078 but leaving that one open as we don't actually check trusted/untrusted for individual tutorials and we should think about that maybe
- https://github.com/microsoft/pxt/commit/e6ea2d73bf6c60ceeda91f6295038d4db13a21c5 CSS feedback for temporary asset warning from design office hours
- https://github.com/microsoft/pxt/commit/9d8060e24db9cea1a26b51ca2b8361e7b319581d fixes https://github.com/microsoft/pxt-arcade/issues/3071