### PR TITLE
use defaultBranch info, craft better name for reference

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -909,9 +909,9 @@ namespace pxt.github {
                     fullName: rid.fullName,
                     fileName: rid.fileName,
                     slug: rid.slug,
-                    name: meta.name,
+                    name: rid.fileName ? `${meta.name}-${rid.fileName}` : meta.name,
                     description: meta.description,
-                    defaultBranch: "master",
+                    defaultBranch: meta.defaultBranch || "master",
                     tag: rid.tag,
                     status
                 };


### PR DESCRIPTION
2 fixes:
- [x] use meta.defaultBranch returned by the cloud to support main branch
- [x] when searching for github packages in subfolders, crash a package name based on the file location too.
