### PR TITLE
fix checkdocs with autoexpandOff flag

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -26,7 +26,8 @@ namespace pxt.docs {
         "hideIteration": "<!-- iter -->",
         "codeStart": "<!-- start -->",
         "codeStop": "<!-- stop -->",
-        "autoOpen": "<!-- autoOpen -->"
+        "autoOpen": "<!-- autoOpen -->",
+        "autoexpandOff": "<!-- autoexpandOff -->",
     }
 
     function replaceAll(replIn: string, x: string, y: string) {


### PR DESCRIPTION
Looks like checkdocs is failing the docs view of tutorials with the `autoexpandOff` flag: https://github.com/microsoft/pxt-arcade/runs/1884371908#step:6:280 from https://github.com/microsoft/pxt-arcade/pull/3105 ends up getting noted as a broken link https://github.com/microsoft/pxt-arcade/runs/1884371908?check_suite_focus=true#step:6:297 . 

Also noticed the skillmap tutorials aren't currently getting checked during checkdocs; if you want them to be then you'll want to add a summary under docs/skillmap that points to each tutorial, like https://github.com/microsoft/pxt-arcade/blob/master/docs/physics-tests/SUMMARY.md does to all in physics-tests, . That said, we do already have a 30min build for arcade so maybe leaving those off until we speed up the build wouldn't be the worst thing in the world