### PR TITLE
Use github slug for tutorial project dependency

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -983,9 +983,9 @@ namespace pxt.github {
         }
     }
 
-    export function toGithubDependencyPath(id: ParsedRepo): string {
-        let r = "github:" + id.fullName;
-        if (id.tag) r += "#" + id.tag;
+    export function toGithubDependencyPath(path: string, tag?: string): string {
+        let r = "github:" + path;
+        if (tag) r += "#" + tag;
         return r;
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3550,7 +3550,7 @@ export class ProjectView
             // add as a dependency itself
             if (pxtJson.files.find(f => /\.ts$/.test(f))) {
                 dependencies = {}
-                dependencies[ghid.project] = pxt.github.toGithubDependencyPath(ghid);
+                dependencies[ghid.project] = pxt.github.toGithubDependencyPath(ghid.slug, ghid.tag);
             }
             else {// just use dependencies from the tutorial
                 pxt.Util.jsonMergeFrom(dependencies, pxtJson.dependencies);


### PR DESCRIPTION
i think the monorepo stuff gets a little weird when loading non-README tutorials (many of these are in folders, etc); this change fixes tutorial loading but i think it also means if you're loading tutorials from a monorepo it'll load the entire repository?

wanted to do a small change to fix this for current arcade since i don't think anyone is using the monorepo functionality for tutorial content yet