### PR TITLE
Check slug instead of full name for repo status

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -870,9 +870,9 @@ namespace pxt.github {
             return true;
 
         if (!repo || !config) return false;
-        if (repo.fullName
+        if (repo.slug
             && config.approvedRepos
-            && config.approvedRepos.some(fn => fn.toLowerCase() == repo.fullName.toLowerCase()))
+            && config.approvedRepos.some(fn => fn.toLowerCase() == repo.slug.toLowerCase()))
             return true;
         return false;
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3077, will address https://github.com/microsoft/pxt-arcade/issues/3078 but leaving that one open as we don't actually check trusted/untrusted for individual tutorials and we should consider that