### PR TITLE
Use base repo when checking for approved/banned status from skillmap

### DIFF
--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -74,7 +74,9 @@ export async function getMarkdownAsync(source: MarkdownSource, url: string): Pro
 async function fetchSkillMapFromGithub(path: string): Promise<MarkdownFetchResult | undefined> {
     const ghid = pxt.github.parseRepoId(path)
     const config = await pxt.packagesConfigAsync();
-    const repoStatus = pxt.github.repoStatus(ghid, config);
+
+    const baseRepo = pxt.github.parseRepoId(ghid.slug);
+    const repoStatus = pxt.github.repoStatus(baseRepo, config);
     let status: PageSourceStatus = "unknown";
 
     let reportId: string | undefined;


### PR DESCRIPTION
skillmap does not have subpackage support, so we use the slug when checking against the list of approved repos (fullName will include the skillmap file itself)

fixes microsoft/pxt-arcade#3077