### PR TITLE
name the default colors in the image editor for accessibility

### DIFF
--- a/webapp/src/components/ImageEditor/sprite/Palette.tsx
+++ b/webapp/src/components/ImageEditor/sprite/Palette.tsx
@@ -53,14 +53,18 @@ class PaletteImpl extends React.Component<PaletteProps,{}> {
                 </g>
             </svg>
             <div className="image-editor-color-buttons" onContextMenu={this.preventContextMenu}>
-                {this.props.colors.map((color, index) =>
-                    <div key={index}
+                {this.props.colors.map((color, index) => {
+                    const namedColor = index === 0 ? lf("transparency") : hexToNamedColor(color);
+                    const title = namedColor ?
+                                    lf("Color {0} ({1})", index, namedColor)
+                                    : lf("Color {0}", index);
+                    return <div key={index}
                         className={`image-editor-button ${index === 0 ? "checkerboard" : ""}`}
                         role="button"
-                        title={lf("Color {0}", index)}
+                        title={title}
                         onMouseDown={this.clickHandler(index)}
                         style={index === 0 ? null : { backgroundColor: color }} />
-                )}
+                })}
             </div>
         </div>;
     }
@@ -81,6 +85,43 @@ class PaletteImpl extends React.Component<PaletteProps,{}> {
     }
 
     protected preventContextMenu = (ev: React.MouseEvent<any>) => ev.preventDefault();
+}
+
+function hexToNamedColor(color: string) {
+    switch (color?.toLowerCase()) {
+        case "#ffffff":
+            return lf("white");
+        case "#ff2121":
+            return lf("red");
+        case "#ff93c4":
+            return lf("pink");
+        case "#ff8135":
+            return lf("orange");
+        case "#fff609":
+            return lf("yellow");
+        case "#249ca3":
+            return lf("teal");
+        case "#78dc52":
+            return lf("green");
+        case "#003fad":
+            return lf("blue");
+        case "#87f2ff":
+            return lf("light blue");
+        case "#8e2ec4":
+            return lf("purple");
+        case "#a4839f":
+            return lf("light purple");
+        case "#5c406c":
+            return lf("dark purple");
+        case "#e5cdc4":
+            return lf("tan")
+        case "#91463d":
+            return lf("brown");
+        case "#000000":
+            return lf("black");
+        default:
+            return undefined;
+    }
 }
 
 function mapStateToProps({ store: { present }, editor }: ImageEditorStore, ownProps: any) {

--- a/webapp/src/components/ImageEditor/sprite/Palette.tsx
+++ b/webapp/src/components/ImageEditor/sprite/Palette.tsx
@@ -88,6 +88,12 @@ class PaletteImpl extends React.Component<PaletteProps,{}> {
 }
 
 function hexToNamedColor(color: string) {
+    /**
+     * Default colors for arcade; match the default colors set as palette in
+     * https://github.com/microsoft/pxt-arcade/blob/master/libs/device/pxt.json#L32
+     * and names for those colors described in
+     * https://arcade.makecode.com/reference/scene/background-color#color-number
+     */
     switch (color?.toLowerCase()) {
         case "#ffffff":
             return lf("white");


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/3135

![colors colors colors](https://user-images.githubusercontent.com/5615930/108265170-4759f480-711d-11eb-9154-65c95b267409.gif)

mouse is only huge due to gif maker / it doesn't overlap normally

Took the names from https://arcade.makecode.com/reference/scene/background-color

(I think there's still value in showing the number as it corresponds to shortcut / etc so I just appended the name of the color to the end if present)

There are some node packages that will translate hexcode -> nearest named color, but that seems like a lot for now (the ones that pop up right away include like 28k colors), especially when changing the palette isn't used too much.