### PR TITLE
Support for tutorial card in asset editor view

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -959,6 +959,7 @@ declare namespace pxt.tutorial {
         codeStart?: string; // command to run when code starts (MINECRAFT HOC ONLY)
         codeStop?: string; // command to run when code stops (MINECRAFT HOC ONLY)
         autoexpandOff?: boolean // INTERNAL TESTING ONLY
+        preferredEditor?: string // preferred editor for opening the tutorial
     }
 
     interface TutorialStepInfo {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -28,6 +28,7 @@ namespace pxt.docs {
         "codeStop": "<!-- stop -->",
         "autoOpen": "<!-- autoOpen -->",
         "autoexpandOff": "<!-- autoexpandOff -->",
+        "preferredEditor": "<!-- preferredEditor -->"
     }
 
     function replaceAll(replIn: string, x: string, y: string) {

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -239,3 +239,7 @@
     }
 
 }
+
+.image-editor-open #tutorialcard {
+    z-index: @blocklyDropdownDivZIndex + 1
+}

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -12,6 +12,8 @@ export interface EditorBounds {
     left: number;
     width: number;
     height: number;
+    horizontalPadding?: number;
+    verticalPadding?: number;
 }
 
 export interface FieldEditorComponent<U> extends React.Component {
@@ -130,7 +132,6 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
         let horizontalPadding = 25;
         let verticalPadding = 25;
 
-
         if (bounds.width - (horizontalPadding * 2) < 500) {
             horizontalPadding = 0;
             verticalPadding = 0;
@@ -140,6 +141,10 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
             verticalPadding = Math.min(bounds.height - 610, 0) / 2;
             horizontalPadding = 0;
         }
+
+        // Override calculated padding if specific values passed in
+        horizontalPadding = (bounds.horizontalPadding != undefined) ? bounds.horizontalPadding : horizontalPadding;
+        verticalPadding = (bounds.horizontalPadding != undefined) ? bounds.verticalPadding : verticalPadding;
 
         this.contentBounds = {
             left: bounds.left + horizontalPadding,


### PR DESCRIPTION
the metadata flag is:

```
### @preferredEditor assets
```

this specifies the default file to open with the tutorial, overriding our inferred editor. i'm not setting the editor in the header because the asset editor is not a real "project type" the way blocks/js/python are (eg wouldn't make sense to have "preferred language" be assets, you can't have an "assets-only" project). this flag just says to open a specific file regardless of the language the tutorial snippets are in.

build loading an example tutorial: https://arcade.makecode.com/app/b415899eacdee5361fa4f112034a8cee240d3776-f4f28bddc2#tutorial:71543-65938-99537-55249