### PR TITLE
[stable6.8] Cherry-pick image editor colors, asset duplication, github slug fixes

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -983,9 +983,9 @@ namespace pxt.github {
         }
     }
 
-    export function toGithubDependencyPath(id: ParsedRepo): string {
-        let r = "github:" + id.fullName;
-        if (id.tag) r += "#" + id.tag;
+    export function toGithubDependencyPath(path: string, tag?: string): string {
+        let r = "github:" + path;
+        if (tag) r += "#" + tag;
         return r;
     }
 

--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -74,7 +74,9 @@ export async function getMarkdownAsync(source: MarkdownSource, url: string): Pro
 async function fetchSkillMapFromGithub(path: string): Promise<MarkdownFetchResult | undefined> {
     const ghid = pxt.github.parseRepoId(path)
     const config = await pxt.packagesConfigAsync();
-    const repoStatus = pxt.github.repoStatus(ghid, config);
+
+    const baseRepo = pxt.github.parseRepoId(ghid.slug);
+    const repoStatus = pxt.github.repoStatus(baseRepo, config);
     let status: PageSourceStatus = "unknown";
 
     let reportId: string | undefined;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3547,7 +3547,7 @@ export class ProjectView
             // add as a dependency itself
             if (pxtJson.files.find(f => /\.ts$/.test(f))) {
                 dependencies = {}
-                dependencies[ghid.project] = pxt.github.toGithubDependencyPath(ghid);
+                dependencies[ghid.project] = pxt.github.toGithubDependencyPath(ghid.slug, ghid.tag);
             }
             else {// just use dependencies from the tutorial
                 pxt.Util.jsonMergeFrom(dependencies, pxtJson.dependencies);

--- a/webapp/src/components/ImageEditor/sprite/Palette.tsx
+++ b/webapp/src/components/ImageEditor/sprite/Palette.tsx
@@ -53,14 +53,18 @@ class PaletteImpl extends React.Component<PaletteProps,{}> {
                 </g>
             </svg>
             <div className="image-editor-color-buttons" onContextMenu={this.preventContextMenu}>
-                {this.props.colors.map((color, index) =>
-                    <div key={index}
+                {this.props.colors.map((color, index) => {
+                    const namedColor = index === 0 ? lf("transparency") : hexToNamedColor(color);
+                    const title = namedColor ?
+                                    lf("Color {0} ({1})", index, namedColor)
+                                    : lf("Color {0}", index);
+                    return <div key={index}
                         className={`image-editor-button ${index === 0 ? "checkerboard" : ""}`}
                         role="button"
-                        title={lf("Color {0}", index)}
+                        title={title}
                         onMouseDown={this.clickHandler(index)}
                         style={index === 0 ? null : { backgroundColor: color }} />
-                )}
+                })}
             </div>
         </div>;
     }
@@ -81,6 +85,49 @@ class PaletteImpl extends React.Component<PaletteProps,{}> {
     }
 
     protected preventContextMenu = (ev: React.MouseEvent<any>) => ev.preventDefault();
+}
+
+function hexToNamedColor(color: string) {
+    /**
+     * Default colors for arcade; match the default colors set as palette in
+     * https://github.com/microsoft/pxt-arcade/blob/master/libs/device/pxt.json#L32
+     * and names for those colors described in
+     * https://arcade.makecode.com/reference/scene/background-color#color-number
+     */
+    switch (color?.toLowerCase()) {
+        case "#ffffff":
+            return lf("white");
+        case "#ff2121":
+            return lf("red");
+        case "#ff93c4":
+            return lf("pink");
+        case "#ff8135":
+            return lf("orange");
+        case "#fff609":
+            return lf("yellow");
+        case "#249ca3":
+            return lf("teal");
+        case "#78dc52":
+            return lf("green");
+        case "#003fad":
+            return lf("blue");
+        case "#87f2ff":
+            return lf("light blue");
+        case "#8e2ec4":
+            return lf("purple");
+        case "#a4839f":
+            return lf("light purple");
+        case "#5c406c":
+            return lf("dark purple");
+        case "#e5cdc4":
+            return lf("tan")
+        case "#91463d":
+            return lf("brown");
+        case "#000000":
+            return lf("black");
+        default:
+            return undefined;
+    }
 }
 
 function mapStateToProps({ store: { present }, editor }: ImageEditorStore, ownProps: any) {

--- a/webapp/src/components/assetEditor/actions/dispatch.ts
+++ b/webapp/src/components/assetEditor/actions/dispatch.ts
@@ -2,6 +2,6 @@ import * as actions from './types'
 import { GalleryView } from '../store/assetEditorReducer';
 
 export const dispatchChangeSelectedAsset = (assetType?: pxt.AssetType, assetId?: string) => ({ type: actions.CHANGE_SELECTED_ASSET, assetType, assetId });
-export const dispatchChangeGalleryView = (view: GalleryView) => ({ type: actions.CHANGE_GALLERY_VIEW, view });
+export const dispatchChangeGalleryView = (view: GalleryView, assetType?: pxt.AssetType, assetId?: string) => ({ type: actions.CHANGE_GALLERY_VIEW, view, assetType, assetId });
 export const dispatchUpdateUserAssets = () => ({ type: actions.UPDATE_USER_ASSETS });
 export const dispatchUpdateGalleryAssets = () => ({ type: actions.UPDATE_GALLERY_ASSETS });

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -18,7 +18,7 @@ interface AssetSidebarProps {
     asset?: pxt.Asset;
     isGalleryAsset?: boolean;
     showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
-    dispatchChangeGalleryView: (view: GalleryView) => void;
+    dispatchChangeGalleryView: (view: GalleryView, assetType?: pxt.AssetType, assetId?: string) => void;
     dispatchChangeSelectedAsset: (assetType?: pxt.AssetType, assetId?: string) => void;
     dispatchUpdateUserAssets: () => void;
 }
@@ -103,8 +103,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         const { type, id } = project.duplicateAsset(asset);
         this.updateAssets().then(() => {
-            this.props.dispatchChangeGalleryView(GalleryView.User);
-            this.props.dispatchChangeSelectedAsset(type, id);
+            this.props.dispatchChangeGalleryView(GalleryView.User, type, id);
         });
     }
 
@@ -146,7 +145,6 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         project.removeAsset(this.props.asset);
         this.props.dispatchChangeSelectedAsset();
-        this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets();
     }
 

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -26,9 +26,11 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
                 selectedAsset: getSelectedAsset(state, action.assetType, action.assetId)
             };
         case actions.CHANGE_GALLERY_VIEW:
+            const selectedAsset = !!action.assetId ? getSelectedAsset(state, action.assetType, action.assetId) : state.selectedAsset;
             return {
                 ...state,
-                view: action.view
+                view: action.view,
+                selectedAsset
             };
         case actions.UPDATE_USER_ASSETS:
             const assets = getAssets();


### PR DESCRIPTION
- Fix hash loading of github tutorials with typescript files in the repo (#7890)
- Speed up asset gallery duplication (#7893) 
- Hides report abuse on trusted skillmaps (#7894) 
- Name the default colors in the image editor for accessibility (#7898)