### PR TITLE
Render branching layout for skill maps

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -212,8 +212,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
                         { error
                             ? <div className="skill-map-error">{error}</div>
                             : maps?.map((el, i) => {
-                                // TODO shakao clean up
-                                return <SkillGraph map={el} key={i} /> //<SkillCarousel map={el} key={i} /> //
+                                return <SkillCarousel map={el} key={i} /> // <SkillGraph map={el} key={i} />
                             })}
                     </div>
                 </div>

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -34,6 +34,7 @@ import './App.css';
 
 // TODO: this file needs to read colors from the target
 import './arcade.css';
+import { SkillGraph } from './components/SkillGraph';
 /* tslint:enable:no-import-side-effect */
 
 (window as any).Promise = Promise;
@@ -211,7 +212,8 @@ class AppImpl extends React.Component<AppProps, AppState> {
                         { error
                             ? <div className="skill-map-error">{error}</div>
                             : maps?.map((el, i) => {
-                                return <SkillCarousel map={el} key={i} />
+                                // TODO shakao clean up
+                                return <SkillGraph map={el} key={i} /> //<SkillCarousel map={el} key={i} /> //
                             })}
                     </div>
                 </div>

--- a/skillmap/src/components/SkillCard.tsx
+++ b/skillmap/src/components/SkillCard.tsx
@@ -6,21 +6,19 @@ import { Item } from './CarouselItem';
 
 import { dispatchOpenActivity, dispatchShowRestartActivityWarning } from '../actions/dispatch';
 
-import { isActivityUnlocked, isMapUnlocked, lookupActivityProgress, } from '../lib/skillMapUtils';
+import { ActivityStatus, isActivityUnlocked, isMapUnlocked, lookupActivityProgress, } from '../lib/skillMapUtils';
 import { tickEvent } from '../lib/browserUtils';
 
 /* tslint:disable:no-import-side-effect */
 import '../styles/skillcard.css'
 /* tslint:enable:no-import-side-effect */
 
-type SkillCardStatus = "locked" | "notstarted" | "inprogress" | "completed" | "restarted";
-
 interface SkillCardProps extends Item {
     mapId: string;
     description?: string;
     imageUrl?: string;
     tags?: string[];
-    status?: SkillCardStatus;
+    status?: ActivityStatus;
     currentStep?: number;
     maxSteps?: number
     dispatchOpenActivity: (mapId: string, activityId: string) => void;
@@ -43,7 +41,7 @@ export class SkillCardImpl extends React.Component<SkillCardProps> {
         }
     }
 
-    protected isCompleted(status: SkillCardStatus): boolean {
+    protected isCompleted(status: ActivityStatus): boolean {
         return status === "completed" || status === "restarted";
     }
 
@@ -118,7 +116,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     const map = state.maps?.[ownProps.mapId];
     const isUnlocked = state.user && map && isActivityUnlocked(state.user, state.pageSourceUrl, map, ownProps.id);
 
-    let status: SkillCardStatus = isUnlocked ? "notstarted" : "locked";
+    let status: ActivityStatus = isUnlocked ? "notstarted" : "locked";
     let currentStep: number | undefined;
     let maxSteps: number | undefined;
 

--- a/skillmap/src/components/SkillCarousel.tsx
+++ b/skillmap/src/components/SkillCarousel.tsx
@@ -41,18 +41,21 @@ class SkillCarouselImpl extends React.Component<SkillCarouselProps> {
 
     protected getItems(mapId: string, root: MapActivity): SkillCarouselItem[] {
         const items = [];
-        let activity = root;
-        while (activity) {
-            items.push({
-                id: activity.activityId,
-                label: activity.displayName,
-                url: activity.url,
-                imageUrl: activity.imageUrl,
-                mapId,
-                description: activity.description,
-                tags: activity.tags
-            });
-            activity = activity.next[0]; // TODO still add nonlinear items to array even if we don't render graph
+        let activities: MapActivity[] = [root];
+        while (activities.length > 0) {
+            let current = activities.shift();
+            if (current) {
+                items.push({
+                    id: current.activityId,
+                    label: current.displayName,
+                    url: current.url,
+                    imageUrl: current.imageUrl,
+                    mapId,
+                    description: current.description,
+                    tags: current.tags
+                });
+                activities = activities.concat(current.next);
+            }
         }
 
         return items;

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -50,21 +50,21 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
         const paths: GraphPath[] = [];
         for (let current of nodes) {
             const { depth, offset } = current;
-                items.push({
-                    activity: current,
-                    position: this.getPosition(depth, offset)
+            items.push({
+                activity: current,
+                position: this.getPosition(depth, offset)
+            });
+
+            if (current.edges) {
+                current.edges.forEach(edge => {
+                    const points: SvgCoord[] = [];
+                    edge.forEach(n => points.push(this.getPosition(n.depth, n.offset)));
+                    paths.push({ points });
                 });
+            }
 
-                if (current.edges) {
-                    current.edges.forEach(edge => {
-                        const points: SvgCoord[] = [];
-                        edge.forEach(n => points.push(this.getPosition(n.depth, n.offset)));
-                        paths.push({ points });
-                    });
-                }
-
-                this.size.height = Math.max(this.size.height, current.offset);
-                this.size.width = Math.max(this.size.width, current.depth);
+            this.size.height = Math.max(this.size.height, current.offset);
+            this.size.width = Math.max(this.size.width, current.depth);
         }
 
         return { items, paths };

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -1,0 +1,131 @@
+import * as React from "react";
+import { connect } from 'react-redux';
+
+import { SkillMapState } from '../store/reducer';
+import { dispatchChangeSelectedItem  } from '../actions/dispatch';
+import { SkillGraphNode } from './SkillGraphNode';
+import { SkillGraphPath } from "./SkillGraphPath";
+
+import { isActivityUnlocked } from '../lib/skillMapUtils';
+import { GraphCoord, simpleGraph } from '../lib/skillGraphUtils';
+
+interface GraphItem {
+    activity: MapActivity;
+    offset: GraphCoord;
+}
+
+interface GraphPath {
+    start: GraphCoord;
+    end: GraphCoord;
+}
+
+interface SkillGraphProps {
+    map: SkillMap;
+    user: UserState;
+    selectedItem?: string;
+    pageSourceUrl: string;
+    dispatchChangeSelectedItem: (id?: string) => void;
+}
+
+const UNIT = 10;
+
+class SkillGraphImpl extends React.Component<SkillGraphProps> {
+    protected items: GraphItem[];
+    protected paths: GraphPath[];
+    protected size: { width: number, height: number };
+
+    constructor(props: SkillGraphProps) {
+        super(props);
+        this.size = { width: 0, height: 0 };
+
+        const { items, paths } = this.getItems(props.map.root);
+        this.items = items;
+        this.paths = paths;
+    }
+
+    protected getItems(root: MapActivity): { items: GraphItem[], paths: GraphPath[] } {
+        const nodes = simpleGraph(root);
+
+        // Convert into renderable items
+        const items: GraphItem[] = [];
+        const paths: GraphPath[] = [];
+        for (let current of nodes) {
+            const { layer, counter, width } = current;
+                items.push({
+                    activity: current,
+                    offset: this.getOffset(layer, counter, width)
+                });
+                if (current.parents && current.parents.length > 0) {
+                    for (let p of current.parents) {
+                        paths.push({
+                            start: this.getOffset(p.layer, p.counter, p.width),
+                            end: this.getOffset(layer, counter, width)
+                        })
+                    }
+                }
+
+                this.size.height = Math.max(this.size.height, current.counter);
+                this.size.width = Math.max(this.size.width, current.layer);
+        }
+
+        return { items, paths };
+    }
+
+    protected onItemSelect = (id: string) => {
+        const { dispatchChangeSelectedItem } = this.props;
+        if (id !== this.props.selectedItem) {
+            dispatchChangeSelectedItem(id);
+        } else {
+            dispatchChangeSelectedItem(undefined);
+        }
+    }
+
+    // This function converts graph position (no units) to x/y (SVG units)
+    protected getOffset(depth: number, counter: number, width?: number): { x: number, y: number } {
+        return { x: (depth + 1) * 12 * UNIT, y: (counter * 8 + 1) * UNIT}
+    }
+
+    render() {
+        const { map, user, selectedItem, pageSourceUrl } = this.props;
+        return <div className="skill-graph">
+            {map.displayName && <div className="graph-title">
+                <span>{map.displayName}</span>
+            </div>}
+            <div className="graph">
+                <svg xmlns="http://www.w3.org/2000/svg" width={this.size.width * 20 * UNIT} height={this.size.height * 10 * UNIT}>
+                    {this.paths.map((el, i) => {
+                        return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT} color="#000" start={el.start} end={el.end} />
+                    })}
+                    {this.paths.map((el, i) => {
+                         return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT - 4} color="#BFBFBF" start={el.start}  end={el.end} />
+                    })}
+                    {this.items.map((el, i) => {
+                        return <SkillGraphNode key={`graph-activity-${i}`}
+                            activityId={el.activity.activityId}
+                            offset={el.offset}
+                            width={5 * UNIT}
+                            selected={el.activity.activityId === selectedItem}
+                            onItemSelect={this.onItemSelect}
+                            status={isActivityUnlocked(user, pageSourceUrl, map, el.activity.activityId) ? "notstarted" : "locked"} /> // TODO shakao needs "completed/inprogress"
+                    })}
+                </svg>
+            </div>
+        </div>
+    }
+}
+
+function mapStateToProps(state: SkillMapState, ownProps: any) {
+    if (!state) return {};
+
+    return {
+        user: state.user,
+        pageSourceUrl: state.pageSourceUrl,
+        selectedItem: state.selectedItem && ownProps.map?.activities?.[state.selectedItem] ? state.selectedItem : undefined
+    }
+}
+
+const mapDispatchToProps = {
+    dispatchChangeSelectedItem
+};
+
+export const SkillGraph = connect(mapStateToProps, mapDispatchToProps)(SkillGraphImpl);

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -7,17 +7,15 @@ import { SkillGraphNode } from './SkillGraphNode';
 import { SkillGraphPath } from "./SkillGraphPath";
 
 import { isActivityUnlocked } from '../lib/skillMapUtils';
-import { GraphCoord, GraphEdgeDirection, orthogonalGraph } from '../lib/skillGraphUtils';
+import { SvgCoord, orthogonalGraph } from '../lib/skillGraphUtils';
 
 interface GraphItem {
     activity: MapActivity;
-    position: GraphCoord;
+    position: SvgCoord;
 }
 
 interface GraphPath {
-    start: GraphCoord;
-    end: GraphCoord;
-    direction?: GraphEdgeDirection;
+    points: SvgCoord[];
 }
 
 interface SkillGraphProps {
@@ -56,15 +54,13 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
                     activity: current,
                     position: this.getPosition(depth, offset)
                 });
-                if (current.parents && current.parents.length > 0) {
-                    for (let i = 0; i < current.parents.length; i++) {
-                        let p = current.parents[i];
-                        paths.push({
-                            start: this.getPosition(p.depth, p.offset),
-                            end: this.getPosition(depth, offset),
-                            direction: current.edges?.[i] || "horizontal"
-                        })
-                    }
+
+                if (current.edges) {
+                    current.edges.forEach(edge => {
+                        const points: SvgCoord[] = [];
+                        edge.forEach(n => points.push(this.getPosition(n.depth, n.offset)));
+                        paths.push({ points });
+                    });
                 }
 
                 this.size.height = Math.max(this.size.height, current.offset);
@@ -84,7 +80,7 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
     }
 
     // This function converts graph position (no units) to x/y (SVG units)
-    protected getPosition(depth: number, offset: number): { x: number, y: number } {
+    protected getPosition(depth: number, offset: number): SvgCoord {
         return { x: (depth + 1) * 12 * UNIT, y: (offset * 8 + 6) * UNIT}
     }
 
@@ -97,10 +93,10 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
             <div className="graph">
                 <svg xmlns="http://www.w3.org/2000/svg" width={(this.size.width + 2) * 12 * UNIT} height={(this.size.height + 2) * 8 * UNIT}>
                     {this.paths.map((el, i) => {
-                        return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT} color="#000" start={el.start} end={el.end} direction={el.direction}/>
+                        return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT} color="#000" points={el.points} />
                     })}
                     {this.paths.map((el, i) => {
-                         return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT - 4} color="#BFBFBF" start={el.start} end={el.end} direction={el.direction} />
+                         return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT - 4} color="#BFBFBF" points={el.points} />
                     })}
                     {this.items.map((el, i) => {
                         return <SkillGraphNode key={`graph-activity-${i}`}

--- a/skillmap/src/components/SkillGraphNode.tsx
+++ b/skillmap/src/components/SkillGraphNode.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+import { GraphCoord } from './SkillGraph';
+import { ActivityStatus } from '../lib/skillMapUtils';
+
+/* tslint:disable:no-import-side-effect */
+import '../styles/skillnode.css'
+/* tslint:enable:no-import-side-effect */
+
+interface SkillGraphNodeProps {
+    activityId: string;
+    width: number;
+    offset: GraphCoord;
+    status: ActivityStatus;
+    selected?: boolean;
+    onItemSelect?: (id: string) => void;
+}
+
+export class SkillGraphNode extends React.Component<SkillGraphNodeProps> {
+    protected handleClick = () => {
+        if (this.props.onItemSelect) this.props.onItemSelect(this.props.activityId);
+    }
+
+    protected getIcon(status: ActivityStatus): string {
+        switch (status) {
+            case "locked":
+                return "\uf023";
+            default:
+                return "\uf11b";
+        }
+    }
+
+    render() {
+        const  { width, offset, selected, status } = this.props;
+        return  <g className={`graph-activity ${selected ? "selected" : ""}`} transform={`translate(${offset.x} ${offset.y})`} onClick={this.handleClick}>
+            <rect x={-width/2} y={-width/2} width={width} height={width} rx={width/10} fill={`${status === "locked" ? "lightgrey" : "var(--tertiary-color)"}`} stroke="#000" strokeWidth="2" />
+            <text textAnchor="middle" alignmentBaseline="middle" className="graph-icon">{this.getIcon(status)}</text>
+        </g>
+    }
+}

--- a/skillmap/src/components/SkillGraphNode.tsx
+++ b/skillmap/src/components/SkillGraphNode.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { SvgCoord } from './SkillGraph';
+import { SvgCoord } from '../lib/skillGraphUtils';
 import { ActivityStatus } from '../lib/skillMapUtils';
 
 /* tslint:disable:no-import-side-effect */

--- a/skillmap/src/components/SkillGraphNode.tsx
+++ b/skillmap/src/components/SkillGraphNode.tsx
@@ -10,7 +10,7 @@ import '../styles/skillnode.css'
 interface SkillGraphNodeProps {
     activityId: string;
     width: number;
-    offset: GraphCoord;
+    position: GraphCoord;
     status: ActivityStatus;
     selected?: boolean;
     onItemSelect?: (id: string) => void;
@@ -31,10 +31,11 @@ export class SkillGraphNode extends React.Component<SkillGraphNodeProps> {
     }
 
     render() {
-        const  { width, offset, selected, status } = this.props;
-        return  <g className={`graph-activity ${selected ? "selected" : ""}`} transform={`translate(${offset.x} ${offset.y})`} onClick={this.handleClick}>
+        const  { width, position, selected, status } = this.props;
+        return  <g className={`graph-activity ${selected ? "selected" : ""}`} transform={`translate(${position.x} ${position.y})`} onClick={this.handleClick}>
             <rect x={-width/2} y={-width/2} width={width} height={width} rx={width/10} fill={`${status === "locked" ? "lightgrey" : "var(--tertiary-color)"}`} stroke="#000" strokeWidth="2" />
             <text textAnchor="middle" alignmentBaseline="middle" className="graph-icon">{this.getIcon(status)}</text>
+            <text textAnchor="middle" alignmentBaseline="middle" y="15">{this.props.activityId}</text>
         </g>
     }
 }

--- a/skillmap/src/components/SkillGraphNode.tsx
+++ b/skillmap/src/components/SkillGraphNode.tsx
@@ -33,7 +33,7 @@ export class SkillGraphNode extends React.Component<SkillGraphNodeProps> {
     render() {
         const  { width, position, selected, status } = this.props;
         return  <g className={`graph-activity ${selected ? "selected" : ""}`} transform={`translate(${position.x} ${position.y})`} onClick={this.handleClick}>
-            <rect x={-width/2} y={-width/2} width={width} height={width} rx={width/10} fill={`${status === "locked" ? "lightgrey" : "var(--tertiary-color)"}`} stroke="#000" strokeWidth="2" />
+            <rect x={-width / 2} y={-width / 2} width={width} height={width} rx={width / 10} fill={`${status === "locked" ? "lightgrey" : "var(--tertiary-color)"}`} stroke="#000" strokeWidth="2" />
             <text textAnchor="middle" alignmentBaseline="middle" className="graph-icon">{this.getIcon(status)}</text>
             <text textAnchor="middle" alignmentBaseline="middle" y="15">{this.props.activityId}</text>
         </g>

--- a/skillmap/src/components/SkillGraphNode.tsx
+++ b/skillmap/src/components/SkillGraphNode.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { GraphCoord } from './SkillGraph';
+import { SvgCoord } from './SkillGraph';
 import { ActivityStatus } from '../lib/skillMapUtils';
 
 /* tslint:disable:no-import-side-effect */
@@ -10,7 +10,7 @@ import '../styles/skillnode.css'
 interface SkillGraphNodeProps {
     activityId: string;
     width: number;
-    position: GraphCoord;
+    position: SvgCoord;
     status: ActivityStatus;
     selected?: boolean;
     onItemSelect?: (id: string) => void;

--- a/skillmap/src/components/SkillGraphPath.tsx
+++ b/skillmap/src/components/SkillGraphPath.tsx
@@ -1,31 +1,35 @@
 import * as React from "react";
 
-import { GraphCoord } from '../lib/skillGraphUtils';
+import { SvgCoord } from '../lib/skillGraphUtils';
 
 /* tslint:disable:no-import-side-effect */
 import '../styles/skillnode.css'
 /* tslint:enable:no-import-side-effect */
 
 interface SkillGraphPathProps {
-    start: GraphCoord;
-    end: GraphCoord;
+    points: SvgCoord[];
     strokeWidth: number;
     color: string;
-    direction?: "vertical" | "horizontal"
 }
 
 export class SkillGraphPath extends React.Component<SkillGraphPathProps> {
     render() {
-        const  { start, end, strokeWidth, color, direction } = this.props;
+        const  { points, strokeWidth, color } = this.props;
 
-        const xdiff = (start?.x || 0) - end.x;
-        const ydiff = (start?.y || 0) - end.y;
-        const path = direction == "vertical"
-            ? `v ${ydiff} h ${xdiff} h ${-xdiff} v ${-ydiff}`
-            : `h ${xdiff} v ${ydiff} v ${-ydiff} h ${-xdiff}`
+        let pathStart = "M 0 0";
+        let pathEnd = "";
+        let start, end: SvgCoord;
+        points.forEach(p => {
+            start = p;
+            if (end) {
+                pathStart += ` l ${(end?.x || 0) - start.x} ${(end?.y || 0) - start.y}`;
+                pathEnd = ` l ${start.x - (end?.x || 0)} ${start.y - (end?.y || 0)} ${pathEnd}`;
+            }
+            end = start;
+        })
 
-        return  <g transform={`translate(${end.x} ${end.y})`}>
-            <path stroke={color} strokeWidth={strokeWidth} d={`M 0 0 ${path}`} />
+        return  <g transform={`translate(${end!.x || 0} ${end!.y || 0})`}>
+            <path stroke={color} strokeWidth={strokeWidth} d={`${pathStart} ${pathEnd}`} />
         </g>
     }
 }

--- a/skillmap/src/components/SkillGraphPath.tsx
+++ b/skillmap/src/components/SkillGraphPath.tsx
@@ -11,16 +11,21 @@ interface SkillGraphPathProps {
     end: GraphCoord;
     strokeWidth: number;
     color: string;
+    direction?: "vertical" | "horizontal"
 }
 
 export class SkillGraphPath extends React.Component<SkillGraphPathProps> {
     render() {
-        const  { start, end, strokeWidth, color } = this.props;
+        const  { start, end, strokeWidth, color, direction } = this.props;
 
         const xdiff = (start?.x || 0) - end.x;
         const ydiff = (start?.y || 0) - end.y;
+        const path = direction == "vertical"
+            ? `v ${ydiff} h ${xdiff} h ${-xdiff} v ${-ydiff}`
+            : `h ${xdiff} v ${ydiff} v ${-ydiff} h ${-xdiff}`
+
         return  <g transform={`translate(${end.x} ${end.y})`}>
-            <path stroke={color} strokeWidth={strokeWidth} d={`M 0 0 h ${xdiff} v ${ydiff} v ${-ydiff} h ${-xdiff}`} />
+            <path stroke={color} strokeWidth={strokeWidth} d={`M 0 0 ${path}`} />
         </g>
     }
 }

--- a/skillmap/src/components/SkillGraphPath.tsx
+++ b/skillmap/src/components/SkillGraphPath.tsx
@@ -14,7 +14,7 @@ interface SkillGraphPathProps {
 
 export class SkillGraphPath extends React.Component<SkillGraphPathProps> {
     render() {
-        const  { points, strokeWidth, color } = this.props;
+        const { points, strokeWidth, color } = this.props;
 
         let pathStart = "M 0 0";
         let pathEnd = "";

--- a/skillmap/src/components/SkillGraphPath.tsx
+++ b/skillmap/src/components/SkillGraphPath.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+
+import { GraphCoord } from '../lib/skillGraphUtils';
+
+/* tslint:disable:no-import-side-effect */
+import '../styles/skillnode.css'
+/* tslint:enable:no-import-side-effect */
+
+interface SkillGraphPathProps {
+    start: GraphCoord;
+    end: GraphCoord;
+    strokeWidth: number;
+    color: string;
+}
+
+export class SkillGraphPath extends React.Component<SkillGraphPathProps> {
+    render() {
+        const  { start, end, strokeWidth, color } = this.props;
+
+        const xdiff = (start?.x || 0) - end.x;
+        const ydiff = (start?.y || 0) - end.y;
+        return  <g transform={`translate(${end.x} ${end.y})`}>
+            <path stroke={color} strokeWidth={strokeWidth} d={`M 0 0 h ${xdiff} v ${ydiff} v ${-ydiff} h ${-xdiff}`} />
+        </g>
+    }
+}

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -1,0 +1,79 @@
+export interface GraphCoord {
+    x: number;
+    y: number;
+}
+
+interface GraphNode extends MapActivity {
+    layer: number; // The layer of this node (distance from root)
+    width: number; // The maximum subtree width from this node
+    counter: number; // The offset of the node within the layer
+    parents?: GraphNode[];
+}
+
+export function simpleGraph(root: MapActivity): GraphNode[] {
+    const base = root as GraphNode;
+    base.layer = 0;
+    let activities: GraphNode[] = [base];
+
+    // Pass to set the width of each node
+    setWidths(base);
+
+    // We keep a map of how deep the graph is at this layer
+    const counterMap: { [key: number]: number } = {};
+    // BFS traversal to set the counter and layer
+    while (activities.length > 0) {
+        let current = activities.shift();
+        if (current) {
+            current.layer = current.parents ? (Math.min(...current.parents.map((el: GraphNode) => el.layer)) + 1) : 0;
+            if (counterMap[current.layer] === undefined) {
+                counterMap[current.layer] = 1;
+            }
+
+            // Set the layer offset of the node, track it in our counter map
+            if (!current.counter) {
+                const parent = current.parents?.map((el: GraphNode) => el.counter) || [0];
+                current.counter = Math.max(counterMap[current.layer], ...parent);
+                counterMap[current.layer] = current.counter + current.width;
+            }
+
+            // Assign this node as the parent of all children, set children depth
+            const next = current.next.map((el: MapActivity) => {
+                let node = el as GraphNode;
+                if (!node.parents) {
+                    node.parents = [current!];
+                } else {
+                    node.parents.push(current!);
+                }
+                return node;
+            })
+
+            activities = activities.concat(next);
+        }
+    }
+
+    return bfsArray(base);
+}
+
+function bfsArray(root: GraphNode): GraphNode[] {
+    let nodes = [];
+    let queue = [root];
+    while (queue.length > 0) {
+        let current = queue.shift();
+        if (current) {
+            nodes.push(current);
+            queue = queue.concat(current.next as any);
+        }
+    }
+
+    return nodes;
+}
+
+function setWidths(node: GraphNode) {
+    let current = node as any;
+    if (!node.next || node.next.length == 0) {
+        current.width = 1;
+    } else {
+        current.width = node.next.map((el: any) => setWidths(el)).reduce((total: number, w: number) => total + w);
+    }
+    return current.width;
+}

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -3,40 +3,150 @@ export interface GraphCoord {
     y: number;
 }
 
+export type GraphEdgeDirection = "horizontal" | "vertical";
+
 interface GraphNode extends MapActivity {
-    layer: number; // The layer of this node (distance from root)
+    depth: number; // The depth of this node (distance from root)
     width: number; // The maximum subtree width from this node
-    counter: number; // The offset of the node within the layer
+    offset: number; // The offset of the node within the layer
     parents?: GraphNode[];
+    edges?: GraphEdgeDirection[];
 }
 
+export function orthogonalGraph(root: MapActivity): GraphNode[] {
+    let activities: GraphNode[] = [root as GraphNode];
+
+    const prevChildPosition: { [key: string]: {depth: number, offset: number} } = {};
+    const visited: { [key: string]: boolean } = {};
+    let totalOffset = 0;
+    while (activities.length > 0) {
+        let current = activities.shift();
+        if (current && !visited[current.activityId]) {
+            visited[current.activityId] = true;
+            const parent = current.parents?.[0];
+            if (parent) {
+                const prevChild = prevChildPosition[parent.activityId] || { depth: 0, offset: 0 };
+                // If we can place it horizontally do so, otherwise place at bottom of the graph
+                if (prevChild.depth == 0) {
+                    prevChild.depth = 1;
+                    current.offset = parent.offset + prevChild.offset;
+                } else {
+                    totalOffset += 1
+                    prevChild.offset = totalOffset;
+                    current.offset = totalOffset;
+                }
+
+                current.depth = parent.depth + prevChild.depth;
+                prevChildPosition[parent.activityId] = prevChild;
+            } else {
+                // This is a root node
+                current.depth = 0;
+                current.offset = 0;
+            }
+
+            // Assign the current node as the parent of its children
+            const next = current.next.map((el: MapActivity) => {
+                let node = el as GraphNode;
+                if (!node.parents) {
+                    node.parents = [current!];
+                } else {
+                    node.parents.push(current!);
+                }
+                return node;
+            })
+
+            // If we have already seen this child node (attached to earlier parent)
+            // 1. Increase child offset by one unit (so it's between the parents) and adjust the total if necessary
+            // 2. Increase child depth if necessary (should be deeper than parent)
+            next.filter(n => visited[n.activityId]).forEach(n => {
+                n.offset += 1;
+                totalOffset = Math.max(totalOffset, n.offset);
+                n.depth = Math.max(n.depth, current!.depth + 1);
+            })
+            activities = next.concat(activities);
+        }
+    }
+
+
+    const nodes = dfsArray(root as GraphNode);
+
+    // Get map of node offsets at each level of the graph
+    const offsetMap: { [key: number]: number[] } = {};
+    nodes.forEach(n => {
+        if (offsetMap[n.depth] == undefined) {
+            offsetMap[n.depth] = [];
+        }
+        offsetMap[n.depth].push(n.offset);
+    })
+
+    nodes.forEach(n => {
+        if (n.parents) {
+            n.edges = [];
+            // We will try to flip the edge (draw vertical before horizontal) if
+            // there is a parent on the horizontal axis, or more than two parents
+            const tryFlipEdge = n.parents.some(p => p.offset == n.offset) || n.parents.length > 2;
+            n.parents.forEach(p => {
+                if (tryFlipEdge) {
+                    // Grab node index, check the siblings to see if there is space to draw the flipped edge
+                    const offsets = offsetMap[n.depth];
+                    const nodeIndex = offsets.indexOf(n.offset);
+                    const spaceBelow = n.offset > p.offset && !((offsets[nodeIndex + 1] - offsets[nodeIndex]) < (n.offset - p.offset));
+                    const spaceAbove = n.offset < p.offset && !((offsets[nodeIndex] - offsets[nodeIndex - 1]) < (p.offset - n.offset));
+                    if (spaceBelow || spaceAbove) {
+                        n.edges?.push("vertical")
+                    } else {
+                        n.edges?.push("horizontal")
+                    }
+                } else {
+                    n.edges?.push("horizontal")
+                }
+            })
+        }
+    })
+
+    // Shrink long leaf branches
+    nodes.forEach(node => {
+        if ((!node.next || node.next.length == 0) && node.parents?.length == 1) {
+            const parent = node.parents[0];
+            if (Math.abs(node.depth - parent.depth) + Math.abs(node.offset - parent.offset) > 2) {
+                const offsets = offsetMap[node.depth];
+                const nodeIndex = offsets.indexOf(node.offset);
+                const siblingOffset = offsets[nodeIndex - 1];
+                node.depth = parent.depth;
+                node.offset = (siblingOffset || parent.offset) + 1;
+            }
+        }
+    })
+
+    return nodes;
+}
+
+// Simple tree-like layout, does not handle loops very well
 export function simpleGraph(root: MapActivity): GraphNode[] {
-    const base = root as GraphNode;
-    base.layer = 0;
-    let activities: GraphNode[] = [base];
+    let activities: GraphNode[] = [root as GraphNode];
 
     // Pass to set the width of each node
-    setWidths(base);
+    setWidths(root as GraphNode);
 
-    // We keep a map of how deep the graph is at this layer
-    const counterMap: { [key: number]: number } = {};
-    // BFS traversal to set the counter and layer
+    // We keep a map of how deep the graph is at this depth
+    const offsetMap: { [key: number]: number } = {};
+    // BFS traversal to set the offset and depth
     while (activities.length > 0) {
         let current = activities.shift();
         if (current) {
-            current.layer = current.parents ? (Math.min(...current.parents.map((el: GraphNode) => el.layer)) + 1) : 0;
-            if (counterMap[current.layer] === undefined) {
-                counterMap[current.layer] = 1;
+            current.depth = current.parents ? (Math.min(...current.parents.map((el: GraphNode) => el.depth)) + 1) : 0;
+            if (offsetMap[current.depth] === undefined) {
+                offsetMap[current.depth] = 1;
             }
 
-            // Set the layer offset of the node, track it in our counter map
-            if (!current.counter) {
-                const parent = current.parents?.map((el: GraphNode) => el.counter) || [0];
-                current.counter = Math.max(counterMap[current.layer], ...parent);
-                counterMap[current.layer] = current.counter + current.width;
+            // Set the offset of the node, track it in our map
+            if (!current.offset) {
+                const parent = current.parents?.map((el: GraphNode) => el.offset) || [0];
+                current.offset = Math.max(offsetMap[current.depth], ...parent);
+                offsetMap[current.depth] = current.offset + current.width;
             }
 
-            // Assign this node as the parent of all children, set children depth
+            // Assign this node as the parent of all children
             const next = current.next.map((el: MapActivity) => {
                 let node = el as GraphNode;
                 if (!node.parents) {
@@ -51,15 +161,17 @@ export function simpleGraph(root: MapActivity): GraphNode[] {
         }
     }
 
-    return bfsArray(base);
+    return bfsArray(root as GraphNode);
 }
 
 function bfsArray(root: GraphNode): GraphNode[] {
     let nodes = [];
     let queue = [root];
+    let visited: { [key: string]: boolean } = {};
     while (queue.length > 0) {
         let current = queue.shift();
-        if (current) {
+        if (current && !visited[current.activityId]) {
+            visited[current.activityId] = true;
             nodes.push(current);
             queue = queue.concat(current.next as any);
         }
@@ -68,12 +180,27 @@ function bfsArray(root: GraphNode): GraphNode[] {
     return nodes;
 }
 
-function setWidths(node: GraphNode) {
-    let current = node as any;
-    if (!node.next || node.next.length == 0) {
-        current.width = 1;
-    } else {
-        current.width = node.next.map((el: any) => setWidths(el)).reduce((total: number, w: number) => total + w);
+function dfsArray(root: GraphNode): GraphNode[] {
+    let nodes = [];
+    let queue = [root];
+    let visited: { [key: string]: boolean } = {};
+    while (queue.length > 0) {
+        let current = queue.shift();
+        if (current && !visited[current.activityId]) {
+            visited[current.activityId] = true;
+            nodes.push(current);
+            queue = (current.next as any).concat(queue);
+        }
     }
-    return current.width;
+
+    return nodes;
+}
+
+function setWidths(node: GraphNode) {
+    if (!node.next || node.next.length == 0) {
+        node.width = 1;
+    } else {
+        node.width = node.next.map((el: any) => setWidths(el)).reduce((total: number, w: number) => total + w);
+    }
+    return node.width;
 }

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -144,11 +144,6 @@ function buildMapFromSections(header: MarkdownSection, sections: MarkdownSection
         visited[root.activityId] = true;
         reachable[root.activityId] = true;
 
-        // TODO shakao clean
-        // if (root.next.length > 1) {
-        //     error("Branching currently not supported")
-        // }
-
         for (const next of root.next) {
             checkForLoopsRecursive(next, {...visited});
         }

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -144,9 +144,10 @@ function buildMapFromSections(header: MarkdownSection, sections: MarkdownSection
         visited[root.activityId] = true;
         reachable[root.activityId] = true;
 
-        if (root.next.length > 1) {
-            error("Branching currently not supported")
-        }
+        // TODO shakao clean
+        // if (root.next.length > 1) {
+        //     error("Branching currently not supported")
+        // }
 
         for (const next of root.next) {
             checkForLoopsRecursive(next, {...visited});

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -1,3 +1,5 @@
+export type ActivityStatus = "locked" | "notstarted" | "inprogress" | "completed" | "restarted";
+
 export function isMapCompleted(user: UserState, pageSource: string, map: SkillMap, skipActivity?: string) {
     if (Object.keys(map?.activities).some(k => !lookupMapProgress(user, pageSource, map.mapId)?.activityState[k]?.isCompleted && k !== skipActivity)) return false;
     return true;

--- a/skillmap/src/styles/skillnode.css
+++ b/skillmap/src/styles/skillnode.css
@@ -1,0 +1,22 @@
+.graph {
+    width: 100%;
+    position: relative;
+}
+
+.graph-activity.selected rect {
+    stroke: var(--primary-color);
+    stroke-width: 4px;
+}
+
+.graph-title {
+    font-size: 1.2rem;
+    margin: 1rem 0 0 1rem;
+    font-weight: 700;
+}
+
+.graph-icon {
+    fill: var(--black);
+    font-family: Icons;
+    font-size: 1.75rem;
+    opacity: 0.5;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/109240487-6c3d1000-778c-11eb-90b4-51205d5d1245.png)

Trying to keep things cleanly split between the graph layout algorithm itself and the rendering. The React components only require a "depth" and "offset" per node (depth is distance along a primary axis--theoretically horizontal for desktop, vertical for tablet, offset is distance along the perpendicular axis) and then converts those to SVG units to draw. 

The graph layout is not bulletproof & works best for lower-degree graphs; we also don't handle edge crossings. We render the nodes in the order that the content creator has specified. If it turns out we do need a more robust algorithm to support content, it should be straightforward to swap out the layout function since it's separate from the rest of the implementation.

Basic layout:
- DFS traversal. Place node one unit horizontal (in the "depth" direction) from the parent if possible, otherwise place at the bottom of the current graph.
- If we encounter a child for the second time, increase the offset by 1 so that it is between both parents. (Previous parent will be above, given placement rules.)

Shrink long edges:
- If we have a very long leaf node with one parent, shift it back so that it is one unit below the nearest sibling (or parent, if it has no siblings). (This is for cases like the top-right graph, where otherwise the leaf nodes don't look great.)

Edges:
- Edges can have at most one bend. By default all edges extend horizontally from the child then move vertically to the parent. However, if there is a parent node on the horizontal axis or more than two parents, this will overlap, so we try to flip the edges to extend vertically from the child.

This is roughly based on: https://core.ac.uk/download/pdf/82771879.pdf (modified a bit to fit our use case)

If we need a more accurate algorithm, I thought this one also looked okay: https://www.sciencedirect.com/science/article/pii/S0925772197000266