### PR TITLE
Disable auth in skillmap

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1335,7 +1335,7 @@ export class ProjectView
                                 // We are too late; the editor has already been loaded.
                                 // Call the onChanges handler to update the editor.
                                 pxt.tickEvent(`identity.syncOnProjectOpen.timedout`, { 'elapsedSec': elapsed})
-                                if (changes.length)
+                                if (changes.some(header => header.id === h.id))
                                     cloud.forceReloadForCloudSync()
                             } else {
                                 // We're not too late, update the local var so that the
@@ -4565,7 +4565,11 @@ document.addEventListener("DOMContentLoaded", () => {
         auth.loginCallback(query);
     }
 
-    auth.init();
+    // Disable auth in skillmap until it is properly supported.
+    // See https://github.com/microsoft/pxt-arcade/issues/3138
+    const disableAuth = query["skillsMap"] == "1";
+
+    auth.init(disableAuth);
     cloud.init(); // depends on auth.init() and workspace.ts's top level
     cloudsync.loginCheck()
     parseLocalToken();

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -24,6 +24,9 @@ const AUTH_LOGIN_STATE = "auth:login-state";
 const AUTH_USER_STATE = "auth:user-state";
 const X_PXT_TARGET = "x-pxt-target";
 
+// initialized by init() call.
+let authDisabled = true;
+
 export type UserProfile = {
     id?: string;
     idp?: {
@@ -366,7 +369,7 @@ export function hasIdentity(): boolean {
     // Must read storage for this rather than app theme because this method
     // gets called before experiments are synced to the theme.
     const experimentEnabled = pxt.editor.experiments.isEnabled("identity");
-    return !pxt.BrowserUtils.isPxtElectron() && experimentEnabled && identityProviders().length > 0;
+    return !authDisabled && !pxt.BrowserUtils.isPxtElectron() && experimentEnabled && identityProviders().length > 0;
 }
 
 export async function loggedIn(): Promise<boolean> {
@@ -643,7 +646,8 @@ async function userPreferencesHandlerAsync(path: string): Promise<UserPreference
     return internalUserPreferencesHandler(path);
 }
 
-export function init() {
+export function init(disableAuth = false) {
+    authDisabled = disableAuth;
     data.mountVirtualApi(USER_PREF_MODULE, {
         getSync: userPreferencesHandlerSync,
         // TODO: virtual apis don't support both sync & async


### PR DESCRIPTION
Disable auth in skillmap until properly supported.

Also in this PR: force editor reloaded only if current project is in the list of synced changes. @darzu tell me if this looks ok.

Fixes: https://github.com/microsoft/pxt-arcade/issues/3138
Fixes: https://github.com/microsoft/pxt-arcade/issues/3150

cc @kiki-lee 