### PR TITLE
no more simulator flickering

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "@types/react-dom": "16.0.3",
     "@types/react-redux": "5.0.0",
     "@types/request": "2.48.2",
+    "@types/resize-observer-browser": "^0.1.5",
     "@types/web-bluetooth": "0.0.4"
   },
   "scripts": {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1268,22 +1268,4 @@ namespace pxt.BrowserUtils {
         if (/[?&]rnd=/.test(url)) return url; // already busted
         return `${url}${url.indexOf('?') > 0 ? "&" : "?"}rnd=${Math.random()}`
     }
-
-    let _browserSrollbarWidth: number;
-    export function browserScrollbarWidth() {
-        if (!_browserSrollbarWidth) {
-            const el = document.createElement('div');
-            try {
-                el.style.overflow = 'scroll';
-                el.style.zIndex = '-100';
-                el.style.position = 'absolute';
-                el.style.left = '2000px';
-                document.body.appendChild(el);
-                _browserSrollbarWidth = el.offsetWidth - el.clientWidth;
-            } finally {
-                document.body.removeChild(el);
-            }
-        }
-        return _browserSrollbarWidth;
-    }
 }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1270,7 +1270,7 @@ namespace pxt.BrowserUtils {
     }
 
     let _browserSrollbarWidth: number;
-    export function browserSrollbarWidth() {
+    export function browserScrollbarWidth() {
         if (!_browserSrollbarWidth) {
             const el = document.createElement('div');
             try {

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1268,4 +1268,22 @@ namespace pxt.BrowserUtils {
         if (/[?&]rnd=/.test(url)) return url; // already busted
         return `${url}${url.indexOf('?') > 0 ? "&" : "?"}rnd=${Math.random()}`
     }
+
+    let _browserSrollbarWidth: number;
+    export function browserSrollbarWidth() {
+        if (!_browserSrollbarWidth) {
+            const el = document.createElement('div');
+            try {
+                el.style.overflow = 'scroll';
+                el.style.zIndex = '-100';
+                el.style.position = 'absolute';
+                el.style.left = '2000px';
+                document.body.appendChild(el);
+                _browserSrollbarWidth = el.offsetWidth - el.clientWidth;
+            } finally {
+                document.body.removeChild(el);
+            }
+        }
+        return _browserSrollbarWidth;
+    }
 }

--- a/theme/common.less
+++ b/theme/common.less
@@ -188,15 +188,31 @@ pre {
 }
 
 #filelist {
-    padding: 1em 2em 1em 2em;
+    padding-top: 1em;
+    padding-right: ~"calc(2em - @{customScrollbarWidth})";
+    padding-bottom: 1em;
+    padding-left: 2em;
     overflow-x: hidden;
-    overflow-y: auto;
     margin-top: 0;
     margin-bottom: 0;
     width: 100%;
     background-color: @filelistBackgroundColor;
     z-index: @filelistZIndex;
+
+    // the scroll bar is always visible, but we hide it when needed
+    overflow-y: scroll; 
 }
+
+.invisibleScrollbar::-webkit-scrollbar { 
+    background: transparent !important; 
+}    
+.invisibleScrollbar::-webkit-scrollbar-thumb { 
+    display: none !important;
+}    
+.invisibleScrollbar::-webkit-scrollbar-track { 
+    background: transparent !important; 
+}    
+
 
 #filelist .simtoolbar {
     -webkit-transition: opacity 0.2s; /* Safari */

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -269,8 +269,9 @@
     line-height: 2.25rem;
 }
 
+// this impacts all scrollbars in pxt
 ::-webkit-scrollbar {
-    width: 10px;
+    width: @customScrollbarWidth;
 }
 
 ::-webkit-scrollbar-track {

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -83,7 +83,7 @@
 --------------------*/
 
 @useCustomScrollbars: false;
-@customScrollbarWidth: 7px;
+@customScrollbarWidth: 10px;
 
 @thumbBackground: rgba(0, 0, 0, 0.25);
 @thumbInvertedBackground: rgba(255, 255, 255, 0.25);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3919,13 +3919,12 @@ export class ProjectView
     private _filelistResizeObserver: ResizeObserver;
     private handleFileListRef = (c: HTMLDivElement) => {
         this.fileListRef = c;
-        const scrollbarWidth = pxt.BrowserUtils.browserScrollbarWidth(); // cache size
-        console.debug({ scrollbarWidth })
         this._filelistResizeObserver = new ResizeObserver(() => {
-            console.log(`filelist resize`)
             const scrollVisible = c.scrollHeight > c.clientHeight;
-            const padding = scrollVisible ? `calc(2em - ${scrollbarWidth}px)` : undefined;
-            this.fileListRef.style.paddingRight = padding;
+            if (scrollVisible)
+                this.fileListRef.classList.remove("invisibleScrollbar");
+            else
+                this.fileListRef.classList.add("invisibleScrollbar");
         })
         this._filelistResizeObserver.observe(c);
     }
@@ -4045,7 +4044,7 @@ export class ProjectView
                 </div>}
 
                 <div id="simulator" className="simulator">
-                    <div id="filelist" ref={this.handleFileListRef} className="ui items">
+                    <div id="filelist" ref={this.handleFileListRef} className="ui items invisibleScrollbar">
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0}>
                         </div>
                         <simtoolbar.SimulatorToolbar

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -126,6 +126,7 @@ export class ProjectView
     chooseHwDialog: projects.ChooseHwDialog;
     prevEditorId: string;
     screenshotHandlers: ((msg: pxt.editor.ScreenshotData) => void)[] = [];
+    fileListRef: HTMLDivElement;
 
     private lastChangeTime: number;
     private reload: boolean;
@@ -1314,7 +1315,7 @@ export class ProjectView
         let p = Promise.resolve();
         // check our multi-tab session
         if (workspace.isHeadersSessionOutdated()) {
-             // reload header before loading
+            // reload header before loading
             pxt.log(`multi-tab sync before load`)
             p = p.then(() => workspace.syncAsync().then(() => { }))
         }
@@ -1334,7 +1335,7 @@ export class ProjectView
                             if (timeout.isResolved()) {
                                 // We are too late; the editor has already been loaded.
                                 // Call the onChanges handler to update the editor.
-                                pxt.tickEvent(`identity.syncOnProjectOpen.timedout`, { 'elapsedSec': elapsed})
+                                pxt.tickEvent(`identity.syncOnProjectOpen.timedout`, { 'elapsedSec': elapsed })
                                 if (changes.some(header => header.id === h.id))
                                     cloud.forceReloadForCloudSync()
                             } else {
@@ -3915,6 +3916,20 @@ export class ProjectView
         this.profileDialog = c;
     }
 
+    private _filelistResizeObserver: ResizeObserver;
+    private handleFileListRef = (c: HTMLDivElement) => {
+        this.fileListRef = c;
+        const scrollbarWidth = pxt.BrowserUtils.browserScrollbarWidth(); // cache size
+        console.debug({ scrollbarWidth })
+        this._filelistResizeObserver = new ResizeObserver(() => {
+            console.log(`filelist resize`)
+            const scrollVisible = c.scrollHeight > c.clientHeight;
+            const padding = scrollVisible ? `calc(2em - ${scrollbarWidth}px)` : undefined;
+            this.fileListRef.style.paddingRight = padding;
+        })
+        this._filelistResizeObserver.observe(c);
+    }
+
     ///////////////////////////////////////////////////////////
     ////////////             RENDER               /////////////
     ///////////////////////////////////////////////////////////
@@ -4030,7 +4045,7 @@ export class ProjectView
                 </div>}
 
                 <div id="simulator" className="simulator">
-                    <div id="filelist" className="ui items">
+                    <div id="filelist" ref={this.handleFileListRef} className="ui items">
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0}>
                         </div>
                         <simtoolbar.SimulatorToolbar

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3916,17 +3916,18 @@ export class ProjectView
         this.profileDialog = c;
     }
 
-    private _filelistResizeObserver: ResizeObserver;
     private handleFileListRef = (c: HTMLDivElement) => {
         this.fileListRef = c;
-        this._filelistResizeObserver = new ResizeObserver(() => {
-            const scrollVisible = c.scrollHeight > c.clientHeight;
-            if (scrollVisible)
-                this.fileListRef.classList.remove("invisibleScrollbar");
-            else
-                this.fileListRef.classList.add("invisibleScrollbar");
-        })
-        this._filelistResizeObserver.observe(c);
+        if (typeof ResizeObserver !== "undefined") {
+            const observer = new ResizeObserver(() => {
+                const scrollVisible = c.scrollHeight > c.clientHeight;
+                if (scrollVisible)
+                    this.fileListRef.classList.remove("invisibleScrollbar");
+                else
+                    this.fileListRef.classList.add("invisibleScrollbar");
+            })
+            observer.observe(c);
+        }
     }
 
     ///////////////////////////////////////////////////////////
@@ -4044,7 +4045,7 @@ export class ProjectView
                 </div>}
 
                 <div id="simulator" className="simulator">
-                    <div id="filelist" ref={this.handleFileListRef} className="ui items invisibleScrollbar">
+                    <div id="filelist" ref={this.handleFileListRef} className="ui items">
                         <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0}>
                         </div>
                         <simtoolbar.SimulatorToolbar

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -25,7 +25,8 @@
         "types": [
             "react",
             "react-dom",
-            "bluebird"
+            "bluebird",
+            "resize-observer-browser"
         ],
         "incremental": false
     },


### PR DESCRIPTION
In certain sizes, our simulators are just at the limit of displaying the scrollbar. At this point, a bunch of resize flickering may happen.

The solution here is to always have a vertical scrollbar, but unhide only when it is needed. So, no more resizing and flickering.

![scroll](https://user-images.githubusercontent.com/4175913/109507367-82302680-7a53-11eb-9e14-8887e4103d42.gif)

ps: the scrollbar customizations for the image editor impact the whole of PXT.
