### PR TITLE
Skill map v2 components, basic layout

### DIFF
--- a/skillmap/src/App.css
+++ b/skillmap/src/App.css
@@ -38,6 +38,7 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     background-color: var(--body-background-color);
+    overflow: hidden;
 }
 
 code {
@@ -46,6 +47,7 @@ code {
 
 #root {
     width: 100%;
+    height: 100%;
 }
 
 #root.editor {
@@ -180,7 +182,8 @@ code {
 .skill-map-container {
     flex-grow: 1;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    justify-content: center;
 }
 
 .skill-map-error {

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -17,9 +17,8 @@ import {
 } from './actions/dispatch';
 import { PageSourceStatus, SkillMapState } from './store/reducer';
 import { HeaderBar } from './components/HeaderBar';
-import { Banner } from './components/Banner';
 import { AppModal } from './components/AppModal';
-import { SkillCarousel } from './components/SkillCarousel';
+import { SkillGraphContainer } from './components/SkillGraphContainer';
 
 import { parseSkillMap } from './lib/skillMapParser';
 import { parseHash, getMarkdownAsync, MarkdownSource, parseQuery,
@@ -34,7 +33,7 @@ import './App.css';
 
 // TODO: this file needs to read colors from the target
 import './arcade.css';
-import { SkillGraph } from './components/SkillGraph';
+import { InfoPanel } from './components/InfoPanel';
 /* tslint:enable:no-import-side-effect */
 
 (window as any).Promise = Promise;
@@ -206,16 +205,13 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const maps = Object.keys(skillMaps).map((id: string) => skillMaps[id]);
         return (<div className={`app-container ${pxt.appTarget.id}`}>
                 <HeaderBar />
-                { activityOpen ? <MakeCodeFrame /> : <div>
-                    <Banner icon="map" />
+                { activityOpen ? <MakeCodeFrame /> :
                     <div className="skill-map-container">
                         { error
                             ? <div className="skill-map-error">{error}</div>
-                            : maps?.map((el, i) => {
-                                return <SkillCarousel map={el} key={i} /> // <SkillGraph map={el} key={i} />
-                            })}
+                            : <SkillGraphContainer maps={maps} />}
+                        { !error && <InfoPanel />}
                     </div>
-                </div>
                 }
                 <AppModal />
             </div>);

--- a/skillmap/src/components/InfoPanel.tsx
+++ b/skillmap/src/components/InfoPanel.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { connect } from 'react-redux';
+
+import { SkillMapState } from '../store/reducer';
+
+/* tslint:disable:no-import-side-effect */
+import '../styles/infopanel.css'
+/* tslint:enable:no-import-side-effect */
+
+interface InfoPanelProps {
+    selectedItem: string;
+}
+
+export class InfoPanelImpl extends React.Component<InfoPanelProps> {
+    render() {
+        const  { selectedItem } = this.props;
+        return <div className="info-panel">
+            <h1>Info Panel</h1>
+        </div>
+    }
+}
+
+function mapStateToProps(state: SkillMapState, ownProps: any) {
+    return {
+        selectedItem: state.selectedItem
+    };
+}
+
+export const InfoPanel = connect(mapStateToProps)(InfoPanelImpl);

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -27,6 +27,7 @@ interface SkillGraphProps {
 }
 
 const UNIT = 10;
+const PADDING = 4;
 
 class SkillGraphImpl extends React.Component<SkillGraphProps> {
     protected items: GraphItem[];
@@ -81,35 +82,38 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
 
     // This function converts graph position (no units) to x/y (SVG units)
     protected getPosition(depth: number, offset: number): SvgCoord {
-        return { x: (depth + 1) * 12 * UNIT, y: (offset * 8 + 6) * UNIT}
+        return { x: this.getX(depth), y: this.getY(offset) }
+    }
+
+    protected getX(position: number) {
+        return ((position * 12) + PADDING) * UNIT;
+    }
+
+    protected getY(position: number) {
+        return ((position * 8) + PADDING) * UNIT;
     }
 
     render() {
         const { map, user, selectedItem, pageSourceUrl } = this.props;
-        return <div className="skill-graph">
-            {map.displayName && <div className="graph-title">
-                <span>{map.displayName}</span>
-            </div>}
-            <div className="graph">
-                <svg xmlns="http://www.w3.org/2000/svg" width={(this.size.width + 2) * 12 * UNIT} height={(this.size.height + 2) * 8 * UNIT}>
-                    {this.paths.map((el, i) => {
-                        return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT} color="#000" points={el.points} />
-                    })}
-                    {this.paths.map((el, i) => {
-                         return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT - 4} color="#BFBFBF" points={el.points} />
-                    })}
-                    {this.items.map((el, i) => {
-                        return <SkillGraphNode key={`graph-activity-${i}`}
-                            activityId={el.activity.activityId}
-                            position={el.position}
-                            width={5 * UNIT}
-                            selected={el.activity.activityId === selectedItem}
-                            onItemSelect={this.onItemSelect}
-                            status={isActivityUnlocked(user, pageSourceUrl, map, el.activity.activityId) ? "notstarted" : "locked"} /> // TODO shakao needs "completed/inprogress"
-                    })}
-                </svg>
-            </div>
-        </div>
+        const width = this.getX(this.size.width) + UNIT * PADDING;
+        const height = this.getY(this.size.height) + UNIT * PADDING;
+        return <svg className="skill-graph" xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+            {this.paths.map((el, i) => {
+                return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT} color="#000" points={el.points} />
+            })}
+            {this.paths.map((el, i) => {
+                return <SkillGraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT - 4} color="#BFBFBF" points={el.points} />
+            })}
+            {this.items.map((el, i) => {
+                return <SkillGraphNode key={`graph-activity-${i}`}
+                    activityId={el.activity.activityId}
+                    position={el.position}
+                    width={5 * UNIT}
+                    selected={el.activity.activityId === selectedItem}
+                    onItemSelect={this.onItemSelect}
+                    status={isActivityUnlocked(user, pageSourceUrl, map, el.activity.activityId) ? "notstarted" : "locked"} /> // TODO shakao needs "completed/inprogress"
+            })}
+        </svg>
     }
 }
 

--- a/skillmap/src/components/SkillGraphContainer.tsx
+++ b/skillmap/src/components/SkillGraphContainer.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+import { SkillGraph } from "./SkillGraph";
+
+/* tslint:disable:no-import-side-effect */
+import '../styles/skillgraph.css'
+/* tslint:enable:no-import-side-effect */
+
+interface SkillGraphContainerProps {
+    maps: SkillMap[];
+}
+
+export class SkillGraphContainer extends React.Component<SkillGraphContainerProps> {
+    render() {
+        const { maps } = this.props;
+
+        return <div className="skill-graph-wrapper">
+            <div className={`skill-graph-content`}>
+                {maps.map((el, i) => {
+                        return <SkillGraph map={el} key={i} />
+                    })}
+            </div>
+            <div className="skill-graph-background">
+                {/* TEMP: this div will be replaced by the background image url from markdown */}
+                <div className="background-img"></div>
+            </div>
+        </div>
+    }
+}

--- a/skillmap/src/components/SkillGraphPath.tsx
+++ b/skillmap/src/components/SkillGraphPath.tsx
@@ -2,10 +2,6 @@ import * as React from "react";
 
 import { SvgCoord } from '../lib/skillGraphUtils';
 
-/* tslint:disable:no-import-side-effect */
-import '../styles/skillnode.css'
-/* tslint:enable:no-import-side-effect */
-
 interface SkillGraphPathProps {
     points: SvgCoord[];
     strokeWidth: number;

--- a/skillmap/src/styles/infopanel.css
+++ b/skillmap/src/styles/infopanel.css
@@ -1,0 +1,8 @@
+.info-panel {
+    display: flex;
+    justify-content: center;
+    width: 20rem;
+    margin: 1rem;
+
+    border: 1px solid #000; /* TEMP */
+}

--- a/skillmap/src/styles/skillgraph.css
+++ b/skillmap/src/styles/skillgraph.css
@@ -1,0 +1,36 @@
+.skill-graph {
+    display: block;
+    max-width: 100%;
+}
+
+.skill-graph-content {
+    display: flex;
+    flex-direction: column;
+    z-index: 50;
+}
+
+.skill-graph-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+}
+
+.skill-graph-background {
+    display: flex;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    z-index: 10;
+}
+
+/* TEMP */
+.background-img {
+    background-color: var(--primary-color);
+    opacity: 0.2;
+    width: 800px;
+    height: 600px;
+}

--- a/skillmap/src/styles/skillnode.css
+++ b/skillmap/src/styles/skillnode.css
@@ -1,17 +1,6 @@
-.graph {
-    width: 100%;
-    position: relative;
-}
-
 .graph-activity.selected rect {
     stroke: var(--primary-color);
     stroke-width: 4px;
-}
-
-.graph-title {
-    font-size: 1.2rem;
-    margin: 1rem 0 0 1rem;
-    font-weight: 700;
 }
 
 .graph-icon {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/109563046-16ba7900-7a94-11eb-8bf3-15456babedd0.png)

Stubbing out the info panel, general page restructuring to support the branching layout. The orange square is just a placeholder until we have the background image URL in the markdown. 