### PR TITLE
Unconditionally allow auth callbacks to execute

### DIFF
--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -286,8 +286,6 @@ export async function authCheck(): Promise<UserProfile | undefined> {
 }
 
 export async function loginCallback(qs: pxt.Map<string>) {
-    if (!hasIdentity()) { return; }
-
     let state: AuthState;
     let callbackState: CallbackState = { ...NilCallbackState };
 


### PR DESCRIPTION
I introduced this bug when disabling auth within skillmap. The auth system now starts in a disabled state, but it's fine to always let auth callbacks execute.

Fixes: https://github.com/microsoft/pxt-arcade/issues/3195
