### PR TITLE
Fill in skill map info panel with selected activity details

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -19,6 +19,7 @@ import { PageSourceStatus, SkillMapState } from './store/reducer';
 import { HeaderBar } from './components/HeaderBar';
 import { AppModal } from './components/AppModal';
 import { SkillGraphContainer } from './components/SkillGraphContainer';
+import { InfoPanel } from './components/InfoPanel';
 
 import { parseSkillMap } from './lib/skillMapParser';
 import { parseHash, getMarkdownAsync, MarkdownSource, parseQuery,
@@ -33,7 +34,6 @@ import './App.css';
 
 // TODO: this file needs to read colors from the target
 import './arcade.css';
-import { InfoPanel } from './components/InfoPanel';
 /* tslint:enable:no-import-side-effect */
 
 (window as any).Promise = Promise;
@@ -209,7 +209,8 @@ class AppImpl extends React.Component<AppProps, AppState> {
                     <div className="skill-map-container">
                         { error
                             ? <div className="skill-map-error">{error}</div>
-                            : <SkillGraphContainer maps={maps} />}
+                            : <SkillGraphContainer maps={maps} />
+                        }
                         { !error && <InfoPanel />}
                     </div>
                 }

--- a/skillmap/src/actions/dispatch.ts
+++ b/skillmap/src/actions/dispatch.ts
@@ -3,7 +3,7 @@ import * as actions from './types'
 
 export const dispatchAddSkillMap = (map: SkillMap) => ({ type: actions.ADD_SKILL_MAP, map });
 export const dispatchClearSkillMaps = () => ({ type: actions.CLEAR_SKILL_MAPS });
-export const dispatchChangeSelectedItem = (id?: string) => ({ type: actions.CHANGE_SELECTED_ITEM, id });
+export const dispatchChangeSelectedItem = (mapId?: string, activityId?: string) => ({ type: actions.CHANGE_SELECTED_ITEM, mapId, activityId });
 export const dispatchSetSkillMapCompleted = (mapId: string) => ({ type: actions.SET_SKILL_MAP_COMPLETED, mapId });
 
 export const dispatchSetHeaderIdForActivity = (mapId: string, activityId: string, id: string, currentStep: number, maxSteps: number, isCompleted: boolean) => ({ type: actions.SET_HEADERID_FOR_ACTIVITY, mapId, activityId, id, currentStep, maxSteps, isCompleted });

--- a/skillmap/src/components/ActionButtons.tsx
+++ b/skillmap/src/components/ActionButtons.tsx
@@ -62,7 +62,7 @@ export class ActionButtonsImpl extends React.Component<ActionButtonsProps> {
 
     render() {
         const { status } = this.props;
-        const completed = this.isCompleted(status || "notstarted");
+        const showRestart = (status && status !== "notstarted" && status !== "locked");
 
         if (status === "locked") return <div />
 
@@ -70,7 +70,7 @@ export class ActionButtonsImpl extends React.Component<ActionButtonsProps> {
             <div className="action-button" role="button" onClick={this.handleActionButtonClick}>
                 {this.getSkillCardActionText()}
             </div>
-            {completed && <div className="action-button" role="button" onClick={this.handleRestartButtonClick}>
+            {showRestart && <div className="action-button" role="button" onClick={this.handleRestartButtonClick}>
                 {lf("RESTART")}
             </div>}
         </div>

--- a/skillmap/src/components/ActionButtons.tsx
+++ b/skillmap/src/components/ActionButtons.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { connect } from 'react-redux';
+
+import { dispatchOpenActivity, dispatchShowRestartActivityWarning } from '../actions/dispatch';
+
+import { ActivityStatus } from '../lib/skillMapUtils';
+import { tickEvent } from '../lib/browserUtils';
+
+interface OwnProps {
+    mapId: string;
+    activityId: string;
+    status?: ActivityStatus;
+}
+
+interface DispatchProps {
+    dispatchOpenActivity: (mapId: string, activityId: string) => void;
+    dispatchShowRestartActivityWarning: (mapId: string, activityId: string) => void;
+}
+
+type ActionButtonsProps = OwnProps & DispatchProps;
+
+export class ActionButtonsImpl extends React.Component<ActionButtonsProps> {
+    protected getSkillCardActionText(): string {
+        switch (this.props.status) {
+            case "locked":
+                return lf("LOCKED");
+            case "completed":
+                return lf("VIEW CODE");
+            case "inprogress":
+            case "restarted":
+                return lf("CONTINUE");
+            case "notstarted":
+            default:
+                return lf("START");
+        }
+    }
+
+    protected isCompleted(status: ActivityStatus): boolean {
+        return status === "completed" || status === "restarted";
+    }
+
+    protected handleActionButtonClick = () => {
+        const { status, mapId, activityId, dispatchOpenActivity } = this.props;
+
+        switch (status) {
+            case "locked":
+                break;
+            case "completed":
+            case "inprogress":
+            case "notstarted":
+            case "restarted":
+            default:
+                tickEvent("skillmap.activity.open", { path: mapId, activity: activityId, status: status || "" });
+                return dispatchOpenActivity(mapId, activityId);
+        }
+    }
+
+    protected handleRestartButtonClick = () => {
+        const { mapId, activityId, dispatchShowRestartActivityWarning } = this.props;
+        dispatchShowRestartActivityWarning(mapId, activityId);
+    }
+
+    render() {
+        const { status } = this.props;
+        const completed = this.isCompleted(status || "notstarted");
+
+        if (status === "locked") return <div />
+
+        return <div className="activity-actions">
+            <div className="action-button" role="button" onClick={this.handleActionButtonClick}>
+                {this.getSkillCardActionText()}
+            </div>
+            {completed && <div className="action-button" role="button" onClick={this.handleRestartButtonClick}>
+                {lf("RESTART")}
+            </div>}
+        </div>
+    }
+}
+
+const mapDispatchToProps = {
+    dispatchOpenActivity,
+    dispatchShowRestartActivityWarning
+}
+
+export const ActionButtons = connect<{}, DispatchProps, OwnProps>(null, mapDispatchToProps)(ActionButtonsImpl);

--- a/skillmap/src/components/InfoPanel.tsx
+++ b/skillmap/src/components/InfoPanel.tsx
@@ -2,27 +2,89 @@ import * as React from "react";
 import { connect } from 'react-redux';
 
 import { SkillMapState } from '../store/reducer';
+import { ActionButtons } from './ActionButtons';
+
+import { ActivityStatus, isActivityUnlocked, isMapUnlocked, lookupActivityProgress, } from '../lib/skillMapUtils';
 
 /* tslint:disable:no-import-side-effect */
 import '../styles/infopanel.css'
 /* tslint:enable:no-import-side-effect */
 
 interface InfoPanelProps {
-    selectedItem: string;
+    mapId: string;
+    title: string;
+    description: string;
+    imageUrl?: string;
+    progressText?: string;
+    activity?: MapActivity;
+    status?: ActivityStatus;
 }
 
 export class InfoPanelImpl extends React.Component<InfoPanelProps> {
     render() {
-        const  { selectedItem } = this.props;
+        const  { mapId, title, description, imageUrl, progressText, activity, status  } = this.props;
         return <div className="info-panel">
-            <h1>Info Panel</h1>
+            <div className="info-panel-image">
+                {imageUrl
+                ? <img src={imageUrl} alt={lf("Preview of activity content")} />
+                : <i className={`icon image`} />}
+            </div>
+            <div className="info-panel-title">{title}</div>
+            <div className="info-panel-description">{description}</div>
+            {activity?.tags && activity.tags.length > 0 && <div className="info-panel-tags">
+                {activity.tags.map((el, i) => <div key={i}>{el}</div>)}
+            </div>}
+            {activity && <div className="info-panel-detail">
+                <div>{progressText}</div>
+                <div>{activity.type}</div>
+            </div>}
+            {activity && <ActionButtons mapId={mapId} activityId={activity.activityId} status={status} />}
         </div>
     }
 }
 
 function mapStateToProps(state: SkillMapState, ownProps: any) {
+    const item = state.selectedItem;
+    let status: ActivityStatus | undefined;
+    let currentStep: number | undefined;
+    let maxSteps: number | undefined;
+
+    if (item) {
+        const map = state.maps?.[item.mapId];
+        const isUnlocked = state.user && map && isActivityUnlocked(state.user, state.pageSourceUrl, map, item.activityId);
+
+        status = isUnlocked ? "notstarted" : "locked";
+        if (state.user) {
+            if (map && state.pageSourceUrl && !isMapUnlocked(state.user, map, state.pageSourceUrl)) {
+                status = "locked";
+            }
+            else {
+                const progress = lookupActivityProgress(state.user, state.pageSourceUrl, item.mapId, item.activityId);
+
+                if (progress) {
+                    if (progress.isCompleted) {
+                        status = (progress.currentStep && progress.maxSteps && progress.currentStep < progress.maxSteps) ?
+                            "restarted" : "completed";
+                    }
+                    else if (progress.headerId) {
+                        status = "inprogress";
+                    }
+                    currentStep = progress?.currentStep;
+                    maxSteps = progress?.maxSteps;
+                }
+            }
+        }
+    }
+
+    const activity = item && state.maps[item.mapId]?.activities[item.activityId];
     return {
-        selectedItem: state.selectedItem
+        mapId: item?.mapId,
+        title: activity ? activity.displayName : state.title,
+        description: activity ? activity.description : state.description,
+        imageUrl: activity ? activity.imageUrl : undefined,
+        activity: activity,
+        status,
+        progressText: maxSteps ? `${currentStep}/${maxSteps} ${lf("Steps")}` : lf("Not Started")
     };
 }
 

--- a/skillmap/src/components/SkillCarousel.tsx
+++ b/skillmap/src/components/SkillCarousel.tsx
@@ -24,7 +24,7 @@ interface SkillCarouselProps {
     selectedItem?: string;
     pageSourceUrl: string;
     completionState: "incomplete" | "transitioning" | "completed";
-    dispatchChangeSelectedItem: (id?: string) => void;
+    dispatchChangeSelectedItem: (mapId?: string, activityId?: string) => void;
     dispatchShowCompletionModal: (mapId: string, activityId?: string) => void;
     dispatchSetSkillMapCompleted: (mapId: string) => void;
 }
@@ -65,7 +65,7 @@ class SkillCarouselImpl extends React.Component<SkillCarouselProps> {
         const { map, dispatchChangeSelectedItem } = this.props;
         if (id !== this.props.selectedItem) {
             tickEvent("skillmap.carousel.item.select", { path: map.mapId, activity: id });
-            dispatchChangeSelectedItem(id);
+            dispatchChangeSelectedItem(map.mapId, id);
         } else {
             tickEvent("skillmap.carousel.item.deselect", { path: map.mapId, activity: id });
             dispatchChangeSelectedItem(undefined);
@@ -179,7 +179,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         requiredMaps,
         pageSourceUrl: state.pageSourceUrl,
         completionState: mapProgress?.[map.mapId]?.completionState,
-        selectedItem: state.selectedItem && ownProps.map?.activities?.[state.selectedItem] ? state.selectedItem : undefined
+        selectedItem: state.selectedItem && ownProps.map?.activities?.[state.selectedItem.activityId] ? state.selectedItem.activityId : undefined
     }
 }
 

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -21,9 +21,9 @@ interface GraphPath {
 interface SkillGraphProps {
     map: SkillMap;
     user: UserState;
-    selectedItem?: string;
+    selectedActivityId?: string;
     pageSourceUrl: string;
-    dispatchChangeSelectedItem: (id?: string) => void;
+    dispatchChangeSelectedItem: (mapId?: string, activityId?: string) => void;
 }
 
 const UNIT = 10;
@@ -71,10 +71,10 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
         return { items, paths };
     }
 
-    protected onItemSelect = (id: string) => {
-        const { dispatchChangeSelectedItem } = this.props;
-        if (id !== this.props.selectedItem) {
-            dispatchChangeSelectedItem(id);
+    protected onItemSelect = (activityId: string) => {
+        const { dispatchChangeSelectedItem, map } = this.props;
+        if (activityId !== this.props.selectedActivityId) {
+            dispatchChangeSelectedItem(map.mapId, activityId);
         } else {
             dispatchChangeSelectedItem(undefined);
         }
@@ -94,7 +94,7 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
     }
 
     render() {
-        const { map, user, selectedItem, pageSourceUrl } = this.props;
+        const { map, user, selectedActivityId, pageSourceUrl } = this.props;
         const width = this.getX(this.size.width) + UNIT * PADDING;
         const height = this.getY(this.size.height) + UNIT * PADDING;
         return <svg className="skill-graph" xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
@@ -109,7 +109,7 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
                     activityId={el.activity.activityId}
                     position={el.position}
                     width={5 * UNIT}
-                    selected={el.activity.activityId === selectedItem}
+                    selected={el.activity.activityId === selectedActivityId}
                     onItemSelect={this.onItemSelect}
                     status={isActivityUnlocked(user, pageSourceUrl, map, el.activity.activityId) ? "notstarted" : "locked"} /> // TODO shakao needs "completed/inprogress"
             })}
@@ -123,7 +123,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     return {
         user: state.user,
         pageSourceUrl: state.pageSourceUrl,
-        selectedItem: state.selectedItem && ownProps.map?.activities?.[state.selectedItem] ? state.selectedItem : undefined
+        selectedActivityId: state.selectedItem && ownProps.map?.mapId == state.selectedItem.mapId ? state.selectedItem.activityId : undefined
     }
 }
 

--- a/skillmap/src/components/SkillGraphNode.tsx
+++ b/skillmap/src/components/SkillGraphNode.tsx
@@ -35,7 +35,6 @@ export class SkillGraphNode extends React.Component<SkillGraphNodeProps> {
         return  <g className={`graph-activity ${selected ? "selected" : ""}`} transform={`translate(${position.x} ${position.y})`} onClick={this.handleClick}>
             <rect x={-width / 2} y={-width / 2} width={width} height={width} rx={width / 10} fill={`${status === "locked" ? "lightgrey" : "var(--tertiary-color)"}`} stroke="#000" strokeWidth="2" />
             <text textAnchor="middle" alignmentBaseline="middle" className="graph-icon">{this.getIcon(status)}</text>
-            <text textAnchor="middle" alignmentBaseline="middle" y="15">{this.props.activityId}</text>
         </g>
     }
 }

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -14,7 +14,7 @@ export interface SkillMapState {
     pageSourceUrl: string;
     pageSourceStatus: PageSourceStatus;
     maps: { [key: string]: SkillMap };
-    selectedItem?: string;
+    selectedItem?: { mapId: string, activityId: string };
 
     editorView?: EditorViewState;
     modal?: ModalState;
@@ -76,7 +76,10 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
         case actions.CHANGE_SELECTED_ITEM:
             return {
                 ...state,
-                selectedItem: action.id
+                selectedItem: {
+                    mapId: action.mapId,
+                    activityId: action.activityId
+                }
             };
         case actions.SET_SKILL_MAP_COMPLETED:
             return {

--- a/skillmap/src/styles/infopanel.css
+++ b/skillmap/src/styles/infopanel.css
@@ -1,8 +1,86 @@
 .info-panel {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     width: 20rem;
     margin: 1rem;
+    z-index: 60;
+    background-color: var(--body-background-color);
 
     border: 1px solid #000; /* TEMP */
+}
+
+.info-panel-image {
+    width: 100%;
+    height: 12rem;
+    text-align: center;
+    background-color: var(--inactive-color);
+}
+
+.info-panel-image i {
+    color: var(--white);
+    font-size: 5rem;
+    line-height: 12rem;
+    vertical-align: top;
+}
+
+.info-panel-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.info-panel-detail {
+    display: flex;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    justify-content: space-between;
+}
+
+.info-panel-tags {
+    display: flex;
+}
+
+.info-panel-tags > div {
+    color: var(--active-color);
+    border: 1px solid var(--active-color);
+    padding: 0.2rem 0.5rem;
+    font-size: 0.8rem;
+}
+
+.info-panel-title,
+.info-panel-description,
+.info-panel-detail,
+.info-panel-tags,
+.info-panel .activity-actions {
+    width: 100%;
+    padding: 0 1rem;
+    margin-top: 0.5rem;
+}
+
+.info-panel .action-button {
+    color: var(--active-color);
+    border: 1px solid var(--active-color);
+    padding: 0.5rem;
+    margin-top: 0.5rem;
+    font-size: 1.2rem;
+    text-align: center;
+    cursor: pointer;
+    flex: 1;
+    user-select: none;
+    text-transform: uppercase;
+}
+
+.info-panel .action-button:hover {
+    background-color: var(--hover-color);
+}
+
+.locked.action-button,
+.locked.action-button:hover {
+    color: var(--inactive-color);
+    background-color: transparent;
+    border-color: var(--inactive-color);
+    cursor: default;
 }

--- a/skillmap/src/styles/skillnode.css
+++ b/skillmap/src/styles/skillnode.css
@@ -1,5 +1,5 @@
 .graph-activity.selected rect {
-    stroke: var(--primary-color);
+    stroke: var(--hover-color);
     stroke-width: 4px;
 }
 


### PR DESCRIPTION
![skill-map-info](https://user-images.githubusercontent.com/34112083/109580353-4e82ea00-7aaf-11eb-92b0-43ff950c4b09.gif)

Filling in the info panel: displays activity info if an activity is selected, otherwise defaults to skill map (page-level) info. Right now we only support the title and description.