### PR TITLE
fix jres icons missing due to api caching

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -643,7 +643,6 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
 
     const result: pxtc.ApisInfo = {
         byQName: {},
-        jres: {}
     };
 
     for (const used of usedPackageInfo) {
@@ -656,11 +655,9 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
         }
 
         pxt.Util.jsonCopyFrom(result.byQName, info.apis.byQName);
-        if (info.apis.jres)
-            pxt.Util.jsonCopyFrom(result.jres, info.apis.jres);
     }
 
-    const jres = pkg.mainPkg.getJRes();
+    result.jres = pkg.mainPkg.getJRes() || {};
 
     for (const qName of Object.keys(result.byQName)) {
         let si = result.byQName[qName]
@@ -668,7 +665,7 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
         let jrname = si.attributes.jres
         if (jrname) {
             if (jrname == "true") jrname = qName
-            let jr = U.lookup(jres || {}, jrname)
+            let jr = U.lookup(result.jres, jrname)
             if (jr && jr.icon && !si.attributes.iconURL) {
                 si.attributes.iconURL = jr.icon
             }


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-minecraft/pull/2117, the icons on the blocks are missing. `info.apis.jres` doesn't ever actually get persisted, and this `pkg.mainPkg.getJRes()` is the thing keeping the jres working in other parts of the editors (the apinfo.jres isn't used much, mostly just taken from blocks directly except for in https://github.com/microsoft/pxt/blob/4a6baa87e0df5c3a982264801a6fc1e8e73bd941/pxtblocks/blocklyloader.ts#L2963-L2973)

which is the thing I was using :) It looks like it would be also be pretty easy to just grab mainpkg.getJres() when calling init in blocklyloader and remove it from apiinfo entirely if we want, but there's not much harm in leaving it as far as I can tell