### PR TITLE
Support for adding dependencies from messagesimulators.

### DIFF
--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -593,6 +593,20 @@ namespace pxt.github {
             })
     }
 
+    export async function downloadLastestPackageAsync(repo: ParsedRepo): Promise<{ version: string, config: pxt.PackageConfig }> {
+        const packageConfig = await pxt.packagesConfigAsync()
+        const tag = await pxt.github.latestVersionAsync(repo.slug, packageConfig)
+        // download package into cache
+        const repoWithTag = `${repo.fullName}#${tag}`;
+        await pxt.github.downloadPackageAsync(repoWithTag, packageConfig)
+
+        // return config
+        const config = await pkgConfigAsync(repo.fullName, tag)
+        const version = `github:${repoWithTag}`
+        
+        return { version, config };
+    }
+
     export async function cacheProjectDependenciesAsync(cfg: pxt.PackageConfig): Promise<void> {
         const ghExtensions = Object.keys(cfg.dependencies)
             ?.filter(dep => isGithubId(cfg.dependencies[dep]));
@@ -1105,13 +1119,6 @@ namespace pxt.github {
                             return refsRes.head || tagToShaAsync(scr.slug, scr.defaultBranch)
                     })
             });
-    }
-
-    export async function downloadLastestConfigAsync(repo: ParsedRepo) {
-        const packageConfig = await pxt.packagesConfigAsync()
-        const version = await pxt.github.latestVersionAsync(repo.slug, packageConfig)
-        const config = await pxt.github.pkgConfigAsync(repo.fullName, version)
-        return { version, config };
     }
 
     export function resolveMonoRepoVersions(deps: pxt.Map<string>): pxt.Map<string> {

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -603,7 +603,7 @@ namespace pxt.github {
         // return config
         const config = await pkgConfigAsync(repo.fullName, tag)
         const version = `github:${repoWithTag}`
-        
+
         return { version, config };
     }
 

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -593,7 +593,7 @@ namespace pxt.github {
             })
     }
 
-    export async function downloadLastestPackageAsync(repo: ParsedRepo): Promise<{ version: string, config: pxt.PackageConfig }> {
+    export async function downloadLatestPackageAsync(repo: ParsedRepo): Promise<{ version: string, config: pxt.PackageConfig }> {
         const packageConfig = await pxt.packagesConfigAsync()
         const tag = await pxt.github.latestVersionAsync(repo.slug, packageConfig)
         // download package into cache

--- a/pxtlib/github.ts
+++ b/pxtlib/github.ts
@@ -1107,6 +1107,13 @@ namespace pxt.github {
             });
     }
 
+    export async function downloadLastestConfigAsync(repo: ParsedRepo) {
+        const packageConfig = await pxt.packagesConfigAsync()
+        const version = await pxt.github.latestVersionAsync(repo.slug, packageConfig)
+        const config = await pxt.github.pkgConfigAsync(repo.fullName, version)
+        return { version, config };
+    }
+
     export function resolveMonoRepoVersions(deps: pxt.Map<string>): pxt.Map<string> {
         deps = Util.clone(deps);
         // before loading dependencies, ensure that all mono-repo are in sync

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -168,6 +168,14 @@ namespace pxsim {
         query: string
     }
 
+    export interface SimulatorAddExtensionsMessage extends SimulatorMessage {
+        type: "addextensions",
+        /**
+         * List of repositories to add
+         */
+        extensions: string[]
+    }
+
     export interface SimulatorAspectRatioMessage extends SimulatorMessage {
         type: "aspectratio",
         value: number,

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -163,11 +163,6 @@ namespace pxsim {
         modalContext?: string;
     }
 
-    export interface SimulatorExtensionsDialogMessage extends SimulatorMessage {
-        type: "extensionsdialog",
-        query: string
-    }
-
     export interface SimulatorAddExtensionsMessage extends SimulatorMessage {
         type: "addextensions",
         /**

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -904,17 +904,7 @@ namespace pxsim {
                 delay: opts && opts.delay
             } as SimulatorScreenshotMessage));
         }
-
-        static requestExtensionsDialog(query: string) {
-            const r = runtime;
-            if (!r) return;
-
-            Runtime.postMessage(<SimulatorExtensionsDialogMessage>{
-                type: "extensionsdialog",
-                query
-            })
-        }
-
+        
         static requestToggleRecording() {
             const r = runtime;
             if (!r) return;

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -904,7 +904,7 @@ namespace pxsim {
                 delay: opts && opts.delay
             } as SimulatorScreenshotMessage));
         }
-        
+
         static requestToggleRecording() {
             const r = runtime;
             if (!r) return;

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -705,7 +705,6 @@ namespace pxsim {
                 case 'screenshot':
                 case 'custom':
                 case 'recorder':
-                case 'extensionsdialog':
                 case 'addextensions':
                     break; //handled elsewhere
                 case 'aspectratio': {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -706,6 +706,7 @@ namespace pxsim {
                 case 'custom':
                 case 'recorder':
                 case 'extensionsdialog':
+                case 'addextensions':
                     break; //handled elsewhere
                 case 'aspectratio': {
                     const asmsg = msg as SimulatorAspectRatioMessage;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -202,10 +202,7 @@ export class ProjectView
             let msg = ev.data as pxsim.SimulatorMessage;
             if (!msg || !this.state.header) return;
 
-            if (msg.type === "extensionsdialog") {
-                const exmsg = msg as pxsim.SimulatorExtensionsDialogMessage;
-                this.showPackageDialog(exmsg.query)
-            } else if (msg.type === "addextensions") {
+            if (msg.type === "addextensions") {
                 const exmsg = msg as pxsim.SimulatorAddExtensionsMessage;
                 const extensions = exmsg.extensions;
                 this.addOrUpdateGithubExtensions(extensions);
@@ -3458,8 +3455,8 @@ export class ProjectView
         return this.newProjectDialog.promptUserAsync();
     }
 
-    showPackageDialog(query?: string) {
-        this.scriptSearch.showExtensions(query);
+    showPackageDialog() {
+        this.scriptSearch.showExtensions();
     }
 
     showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void> {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -282,6 +282,9 @@ export class ProjectView
                 await p.setDependencyAsync(config.name, version);
             }
             this.reloadHeaderAsync();
+        }
+        catch (e) {
+            core.handleNetworkError(e);
         } finally {
             core.hideLoading("addextensions")
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -263,7 +263,7 @@ export class ProjectView
                         {lf("Add these user-provided extensions to your project?")}
                     </p>
                     <p>
-                        {ghidToBeApproved.map(scr => <a href={`https://github.com/${scr.project}`}>{scr.fullName}</a>).join(", ")}
+                        {ghidToBeApproved.map(scr => <a href={`https://github.com/${scr.project}`}>{scr.fullName}</a>)},
                     </p>
                     <hr />
                     <p>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -207,7 +207,7 @@ export class ProjectView
             } else if (msg.type === "addextensions") {
                 const exmsg = msg as pxsim.SimulatorAddExtensionsMessage;
                 const extensions = exmsg.extensions;
-                this.addGithubExtensions(extensions);
+                this.addOrUpdateGithubExtensions(extensions);
             } else if (msg.type === "screenshot") {
                 const scmsg = msg as pxsim.SimulatorScreenshotMessage;
                 if (!scmsg.data) return;
@@ -235,7 +235,7 @@ export class ProjectView
     /**
      * Add Github extensions **without** conflict resolution
      */
-    private async addGithubExtensions(extensions: string[]) {
+    private async addOrUpdateGithubExtensions(extensions: string[]) {
         pxt.tickEvent('package.addextensions')
         const p = pkg.mainEditorPkg();
         if (!p || !extensions?.length)

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -246,7 +246,7 @@ export class ProjectView
             core.showLoading("addextensions", lf("adding extensions..."))
             for (const ghid of extensions.map(ext => pxt.github.parseRepoId(ext)).filter(ghid => !!ghid)) {
                 pxt.debug(`adding ${ghid.fullName}`)
-                const { config, version } = await pxt.github.downloadLastestPackageAsync(ghid);
+                const { config, version } = await pxt.github.downloadLatestPackageAsync(ghid);
                 await p.setDependencyAsync(config.name, version);
             }
             this.reloadHeaderAsync();

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -232,6 +232,9 @@ export class ProjectView
         }, false);
     }
 
+    /**
+     * Add Github extensions **without** conflict resolution
+     */
     private async addGithubExtensions(extensions: string[]) {
         pxt.tickEvent('package.addextensions')
         const p = pkg.mainEditorPkg();
@@ -241,18 +244,12 @@ export class ProjectView
         pxt.debug(`adding extensions ${extensions}`)
         try {
             core.showLoading("addextensions", lf("adding extensions..."))
-            let needsReload = false;
             for (const ghid of extensions.map(ext => pxt.github.parseRepoId(ext)).filter(ghid => !!ghid)) {
                 pxt.debug(`adding ${ghid.fullName}`)
                 const { config, version } = await pxt.github.downloadLastestPackageAsync(ghid);
-                const added = await p.addDependencyAsync(config, version);
-                if (added) {
-                    pxt.debug(`reload needed`)
-                    needsReload = needsReload || added;
-                }
+                await p.setDependencyAsync(config.name, version);
             }
-            if (needsReload)
-                await this.reloadHeaderAsync();
+            this.reloadHeaderAsync();
         } finally {
             core.hideLoading("addextensions")
         }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -347,7 +347,12 @@ export class EditorPackage {
             .then(() => this.saveFilesAsync());
     }
 
-    addDepAsync(pkgid: string, pkgversion: string) {
+    /**
+     * Sets a dependency without conflict validation
+     * @param pkgid
+     * @param pkgversion 
+     */
+    setDependencyAsync(pkgid: string, pkgversion: string) {
         return this.updateConfigAsync(cfg => cfg.dependencies[pkgid] = pkgversion)
             .then(() => this.saveFilesAsync());
     }
@@ -630,7 +635,7 @@ export class EditorPackage {
 
                 return addDependencyPromise
                     .then(ok => ok
-                        ? this.addDepAsync(config.name, version).then(() => true)
+                        ? this.setDependencyAsync(config.name, version).then(() => true)
                         : Promise.resolve(false));
             });
     }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -577,7 +577,7 @@ export class EditorPackage {
     }
 
     /**
-     * Adds the dependency while handling conflicts, return true if reload is needed
+     * Adds the dependency while handling conflicts, return true the dependency was added
      * @param config 
      * @param version 
      * @param skipConfirm 
@@ -628,7 +628,10 @@ export class EditorPackage {
                         });
                 }
 
-                return addDependencyPromise;
+                return addDependencyPromise
+                    .then(ok => ok
+                        ? this.addDepAsync(config.name, version).then(() => true)
+                        : Promise.resolve(false));
             });
     }
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -465,7 +465,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
         }
     }
 
-    componentWillMount() {
+    componentDidMount() {
         this.startRefresh();
     }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -453,7 +453,6 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
         if (!paused && !this.carouselInterval && this.prevGalleries && this.prevGalleries.length) {
             pxt.debug(`start refreshing hero carousel`)
             this.carouselInterval = setInterval(this.handleRefreshCard, HERO_BANNER_DELAY);
-            this.handleRefreshCard();
         }
     }
 

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -289,7 +289,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         try {
             this.hide();
             core.showLoading("installingextension", lf("installing extension..."))
-            const added = await pkg.mainEditorPkg().addDependencyAsync(config, version, this.state.mode == ScriptSearchMode.Boards)
+            const added = await pkg.mainEditorPkg()
+                .addDependencyAsync(config, version, this.state.mode == ScriptSearchMode.Boards)
             if (added)  //async
                 this.props.parent.reloadHeaderAsync();
         }

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -289,8 +289,8 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         try {
             this.hide();
             core.showLoading("installingextension", lf("installing extension..."))
-            const needsReload = await pkg.mainEditorPkg().addDependencyAsync(config, version, this.state.mode == ScriptSearchMode.Boards)
-            if (needsReload)  //async
+            const added = await pkg.mainEditorPkg().addDependencyAsync(config, version, this.state.mode == ScriptSearchMode.Boards)
+            if (added)  //async
                 this.props.parent.reloadHeaderAsync();
         }
         finally {

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -275,7 +275,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         let r: { version: string, config: pxt.PackageConfig };
         try {
             core.showLoading("downloadingpackage", lf("downloading extension..."));
-            r = await pxt.github.downloadLastestConfigAsync(scr);
+            r = await pxt.github.downloadLastestPackageAsync(scr);
         } finally {
             core.hideLoading("downloadingpackage");
         }

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -276,6 +276,9 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         try {
             core.showLoading("downloadingpackage", lf("downloading extension..."));
             r = await pxt.github.downloadLastestPackageAsync(scr);
+        }
+        catch (e) {
+            core.handleNetworkError(e);
         } finally {
             core.hideLoading("downloadingpackage");
         }

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -269,81 +269,31 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             .finally(() => this.afterHide());
     }
 
-    installGh(scr: pxt.github.GitRepo) {
+    async installGh(scr: pxt.github.GitRepo) {
         pxt.tickEvent("packages.github", { name: scr.fullName });
         this.hide();
-        core.showLoading("downloadingpackage", lf("downloading extension..."));
-        pxt.packagesConfigAsync()
-            .then(config => pxt.github.latestVersionAsync(scr.slug, config))
-            .then(tag => pxt.github.pkgConfigAsync(scr.fullName, tag)
-                .then(cfg => {
-                    core.hideLoading("downloadingpackage");
-                    return cfg;
-                })
-                .then(cfg => this.addDepIfNoConflict(cfg, "github:" + scr.fullName + "#" + tag)))
-            .catch(core.handleNetworkError)
-            .finally(() => {
-                this.afterHide();
-                core.hideLoading("downloadingpackage")
-            });
+        let r: { version: string, config: pxt.PackageConfig };
+        try {
+            core.showLoading("downloadingpackage", lf("downloading extension..."));
+            r = await pxt.github.downloadLastestConfigAsync(scr);
+        } finally {
+            core.hideLoading("downloadingpackage");
+        }
+        return await this.addDepIfNoConflict(r.config, r.version)
     }
 
-    addDepIfNoConflict(config: pxt.PackageConfig, version: string) {
-        return pkg.mainPkg.findConflictsAsync(config, version)
-            .then((conflicts) => {
-                let inUse = config.core ? [] // skip conflict checking for a new core package
-                    : conflicts.filter((c) => pkg.mainPkg.isPackageInUse(c.pkg0.id));
-                let addDependencyPromise = Promise.resolve(true);
-
-                if (inUse.length) {
-                    addDependencyPromise = addDependencyPromise
-                        .then(() => core.confirmAsync({
-                            header: lf("Cannot add {0} extension", config.name),
-                            hideCancel: true,
-                            agreeLbl: lf("Ok"),
-                            body: lf("Remove all the blocks from the {0} extension and try again.", inUse[0].pkg0.id)
-                        }))
-                        .then(() => {
-                            return false;
-                        });
-                } else if (conflicts.length) {
-                    const body = conflicts.length === 1 ?
-                        // Single conflict: "Extension A is..."
-                        lf("Extension {0} is incompatible with {1}. Remove {0} and add {1}?", conflicts[0].pkg0.id, config.name) :
-                        // 2 conflicts: "Extensions A and B are..."; 3+ conflicts: "Extensions A, B, C and D are..."
-                        lf("Extensions {0} and {1} are incompatible with {2}. Remove them and add {2}?", conflicts.slice(0, -1).map((c) => c.pkg0.id).join(", "), conflicts.slice(-1)[0].pkg0.id, config.name);
-
-                    addDependencyPromise = addDependencyPromise
-                        .then(() => this.state.mode == ScriptSearchMode.Boards
-                            ? Promise.resolve(1)
-                            : core.confirmAsync({
-                                header: lf("Some extensions will be removed"),
-                                agreeLbl: lf("Remove extension(s) and add {0}", config.name),
-                                agreeClass: "pink",
-                                body
-                            }))
-                        .then((buttonPressed) => {
-                            if (buttonPressed !== 0) {
-                                let p = pkg.mainEditorPkg();
-                                return Promise.all(conflicts.map((c) => {
-                                    return p.removeDepAsync(c.pkg0.id);
-                                }))
-                                    .then(() => true);
-                            }
-                            return Promise.resolve(false);
-                        });
-                }
-
-                return addDependencyPromise
-                    .then((shouldAdd) => {
-                        if (shouldAdd) {
-                            let p = pkg.mainEditorPkg();
-                            return p.addDepAsync(config.name, version)
-                                .then(() => this.props.parent.reloadHeaderAsync());
-                        }
-                        return Promise.resolve();
-                    });
-            });
+    async addDepIfNoConflict(config: pxt.PackageConfig, version: string) {
+        try {
+            this.hide();
+            core.showLoading("installingextension", lf("installing extension..."))
+            const needsReload = await pkg.mainEditorPkg().addDependencyAsync(config, version, this.state.mode == ScriptSearchMode.Boards)
+            if (needsReload)  //async
+                this.props.parent.reloadHeaderAsync();
+        }
+        finally {
+            core.hideLoading("installingextension")
+            this.afterHide();
+        }
     }
 
     toggleExperiment(experiment: pxt.editor.experiments.Experiment) {

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -275,7 +275,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         let r: { version: string, config: pxt.PackageConfig };
         try {
             core.showLoading("downloadingpackage", lf("downloading extension..."));
-            r = await pxt.github.downloadLastestPackageAsync(scr);
+            r = await pxt.github.downloadLatestPackageAsync(scr);
         }
         catch (e) {
             core.handleNetworkError(e);

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -246,7 +246,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     addUrl(scr: pxt.Cloud.JsonScript) {
         this.hide();
         let p = pkg.mainEditorPkg();
-        return p.addDepAsync(scr.name, "pub:" + scr.id)
+        return p.setDependencyAsync(scr.name, "pub:" + scr.id)
             .then(() => this.props.parent.reloadHeaderAsync())
             .finally(() => this.afterHide());
     }


### PR DESCRIPTION
Add a new simulator message that allows adding github extensions to the project.

- Refactors the logic to add a new dependency from the scriptsearch.tsx into classes so that it can be used in other places.
- refactor scriptsearch addDepIfNoConflict into the EditorPackage class (where it belongs)
- refactor downloading github pacakge into github.ts
- (fix minor bugs with herobanner)