### PR TITLE
Fix race condition between multi-tab syncAsync and partialSaveAsync

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -434,7 +434,7 @@ export async function partialSaveAsync(id: string, filename: string, content: st
         pxt.tickEvent(`workspace.invalidSaveToUnknownProject`);
         return;
     }
-    const newTxt = {...prev.text}
+    const newTxt = {...await getTextAsync(id)}
     newTxt[filename] = content;
     return saveAsync(prev.header, newTxt);
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/3207

What I didn't realize is that our in memory cache in workspace.ts gets wiped rather aggressively by the multi-tab sync code even when there aren't any multi-tab changes.. we should fix that but for now if we just work with the assumption that u might need to rehydrate the cache from disk at any moment, things seem to work again. 