### PR TITLE
return editor versions in renderready callback

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -607,7 +607,8 @@ namespace pxt.runner {
                 }, false);
                 window.parent.postMessage(<pxsim.RenderReadyResponseMessage>{
                     source: "makecode",
-                    type: "renderready"
+                    type: "renderready",
+                    versions: pxt.appTarget.versions
                 }, "*");
             })
     }

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -221,7 +221,8 @@ namespace pxsim {
 
     export interface RenderReadyResponseMessage extends SimulatorMessage {
         source: "makecode",
-        type: "renderready"
+        type: "renderready",
+        versions: pxt.TargetVersions
     }
 
     export interface RenderBlocksRequestMessage extends SimulatorMessage {


### PR DESCRIPTION
Allows to use versions when creating hashes of rendered blocks for caching.