### PR TITLE
Fix false conflicts when doing multi-tab editting

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -337,12 +337,13 @@ export class ProjectView
             this.saveFileAsync().done();
         } else if (active) {
             data.invalidate("header:*")
-            if (workspace.isHeadersSessionOutdated()
+            let hdrId = this.state.header ? this.state.header.id : '';
+            const inEditor = !this.state.home && hdrId
+            if ((!inEditor && workspace.isHeadersSessionOutdated())
                 || workspace.isHeaderSessionOutdated(this.state.header)) {
                 pxt.debug('workspace: changed, reloading...')
-                let id = this.state.header ? this.state.header.id : '';
                 workspace.syncAsync()
-                    .done(() => !this.state.home && id ? this.loadHeaderAsync(workspace.getHeader(id), this.state.editorState) : Promise.resolve());
+                    .done(() => inEditor ? this.loadHeaderAsync(workspace.getHeader(hdrId), this.state.editorState) : Promise.resolve());
                 // device scanning restarts in loadheader
             } else if (this.state.resumeOnVisibility) {
                 this.setState({ resumeOnVisibility: false });

--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -12,6 +12,7 @@ type ScriptText = pxt.workspace.ScriptText;
 type WorkspaceProvider = pxt.workspace.WorkspaceProvider;
 
 import U = pxt.Util;
+import { dbgHdrToString, isHeaderSessionOutdated } from "./workspace";
 
 type CloudProject = {
     id: string;
@@ -116,7 +117,7 @@ function updateCloudTempMetadata(headerId: string, props: Partial<CloudTempMetad
     data.invalidate(`${HEADER_CLOUDSTATE}:${headerId}`);
 }
 
-function setAsync(h: Header, prevVersion: Version, text?: ScriptText): Promise<Version> {
+function setAsync(h: Header, prevVersion: string, text?: ScriptText): Promise<string> {
     return new Promise(async (resolve, reject) => {
         const userId = auth.user()?.id;
         h.cloudUserId = userId;
@@ -508,6 +509,9 @@ async function onHeaderChangeDebouncer(h: Header) {
     // do we actually have a significant change?
     const hasCloudChange = h.cloudUserId === auth.user().id && !h.cloudCurrent;
     if (!hasCloudChange)
+        return;
+    // is another tab responsible for this project?
+    if (isHeaderSessionOutdated(h))
         return;
 
     // we have a change to sync

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -319,8 +319,9 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
                 {/* TODO: consider make this cloud state indicator a seperate React component so we don't need to update
                     the whole toolbar when there are cloud state changes. However so far, this doesn't seem to be a
                     performance concern. */}
-                {(cloudState === "syncing" || cloudState === "offline" || cloudState === "conflict" || cloudState === "justSaved")
+                {(cloudState === "syncing" || cloudState === "offline" || cloudState === "conflict" || cloudState === "justSaved" || cloudState === "localEdits")
                     && <i className="ui large right floated icon cloud cloudState"></i>}
+                {cloudState === "localEdits" && <span className="ui cloudState">{lf("saving...")}</span>}
                 {cloudState === "syncing" && <span className="ui cloudState">{lf("saving...")}</span>}
                 {cloudState === "justSaved" && <span className="ui cloudState">{lf("saved!")}</span>}
                 {cloudState === "offline" && <span className="ui cloudState">{lf("offline.")}</span>}


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/3118
Fixes: https://github.com/microsoft/pxt-arcade/issues/3167

We use the "cloudCurrent" flag on Headers to determine if work needs to be pushed to the cloud. The problem is that each tab was assuming it should push changes for all headers that have cloudCurrent == false.
The fix was to not bother saving to cloud projects that aren't owned by this tab during the normal save loop.

Also, we were too aggressively reloading the whole editor in multi-tab scenarios. Instead we only need to reload the editor if the specific header we're editing is being edited by another tab.