### PR TITLE
Fix rename not working w/ cloud save

### DIFF
--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -350,7 +350,7 @@ export class EditorPackage {
     /**
      * Sets a dependency without conflict validation
      * @param pkgid
-     * @param pkgversion 
+     * @param pkgversion
      */
     setDependencyAsync(pkgid: string, pkgversion: string) {
         return this.updateConfigAsync(cfg => cfg.dependencies[pkgid] = pkgversion)
@@ -430,6 +430,10 @@ export class EditorPackage {
     saveFileAsync(filename: string) {
         if (!this.header) return Promise.resolve();
         const content = this.files[filename]?.content
+        if (filename === pxt.CONFIG_NAME) {
+            // cfg file changes can cause other changes in the header
+            return this.saveFilesAsync();
+        }
         return workspace.partialSaveAsync(this.header.id, filename, content);
     }
 
@@ -583,9 +587,9 @@ export class EditorPackage {
 
     /**
      * Adds the dependency while handling conflicts, return true the dependency was added
-     * @param config 
-     * @param version 
-     * @param skipConfirm 
+     * @param config
+     * @param version
+     * @param skipConfirm
      */
     addDependencyAsync(config: pxt.PackageConfig, version: string, skipConfirm?: boolean): Promise<boolean> {
         if (this.topPkg !== this)

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -506,8 +506,7 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
     if (!fromCloudSync)
         h.recentUse = U.nowSeconds()
 
-    if (!newSave)
-    {
+    if (!newSave) {
         // persist header changes to our local cache, but keep the old
         // reference around because (unfortunately) other layers (e.g. package.ts)
         // assume the reference is stable per id.

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -459,12 +459,6 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
             version: null
         }
         allScripts.push(e)
-    } else {
-        // persist header changes to our local cache, but keep the old
-        // reference around because (unfortunately) other layers (e.g. package.ts)
-        // assume the reference is stable per id.
-        Object.assign(e.header, h)
-        h = e.header;
     }
 
     const hasUserFileChanges = async () => {
@@ -512,6 +506,14 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
     if (!fromCloudSync)
         h.recentUse = U.nowSeconds()
 
+    if (!newSave)
+    {
+        // persist header changes to our local cache, but keep the old
+        // reference around because (unfortunately) other layers (e.g. package.ts)
+        // assume the reference is stable per id.
+        Object.assign(e.header, h)
+        h = e.header;
+    }
     if (text)
         e.text = text
     if (text || h.isDeleted) {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/3233

The problem was that the package layer was responsible for keeping the pxt.json changes in sync with the header fields, and they became desync'ed when using the single file save path.

Also there was an issue with diffing previous and new project state for the purpose of determining which changes are worth syncing to the cloud. We were updating the in-memory cache before doing the diff so we had no way to actually compare the header.