### PR TITLE
Render API request render to png

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -363,7 +363,7 @@ namespace pxt.blocks.layout {
                 let pngUri = imageIconCache[svgUri];
 
                 return (pngUri ? Promise.resolve(pngUri)
-                    : pxt.BrowserUtils.encodeToPngAsync(svgUri, { width, height, pixelDensity: 4 }))
+                    : pxt.BrowserUtils.encodeToPngAsync(svgUri, { width, height, pixelDensity: 2 }))
                     .then(href => {
                         imageIconCache[svgUri] = href;
                         image.setAttributeNS(XLINK_NAMESPACE, "href", href);

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -186,55 +186,17 @@ namespace pxt.blocks.layout {
         return toSvgAsync(ws)
             .then(sg => {
                 if (!sg) return Promise.resolve<string>(undefined);
-                return toPngAsyncInternal(
-                    sg.width, sg.height, (pixelDensity | 0) || 4, sg.xml,
-                    encodeBlocks ? JSON.stringify(blockSnippet, null, 2) : null);
+                return pxt.BrowserUtils.encodeToPngAsync(sg.xml,
+                    {
+                        width: sg.width,
+                        height: sg.height,
+                        pixelDensity: (pixelDensity | 0) || 4,
+                        text: encodeBlocks ? JSON.stringify(blockSnippet, null, 2) : null
+                    });
             }).catch(e => {
                 pxt.reportException(e);
                 return undefined;
             })
-    }
-
-    const MAX_SCREENSHOT_SIZE = 1e6; // max 1Mb
-    function toPngAsyncInternal(width: number, height: number, pixelDensity: number, data: string, text?: string): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            const cvs = document.createElement("canvas") as HTMLCanvasElement;
-            const ctx = cvs.getContext("2d");
-            const img = new Image;
-
-            cvs.width = width * pixelDensity;
-            cvs.height = height * pixelDensity;
-            img.onload = function () {
-                if (text) {
-                    ctx.fillStyle = "#fff";
-                    ctx.fillRect(0, 0, cvs.width, cvs.height);
-                }
-                ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
-                let canvasdata = cvs.toDataURL("image/png");
-                // if the generated image is too big, shrink image
-                while (canvasdata.length > MAX_SCREENSHOT_SIZE) {
-                    cvs.width = (cvs.width / 2) >> 0;
-                    cvs.height = (cvs.height / 2) >> 0;
-                    pxt.log(`screenshot size ${canvasdata.length}b, shrinking to ${cvs.width}x${cvs.height}`)
-                    ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
-                    canvasdata = cvs.toDataURL("image/png");
-                }
-                if (text) {
-                    let p = pxt.lzmaCompressAsync(text).then(blob => {
-                        const datacvs = pxt.Util.encodeBlobAsync(cvs, blob);
-                        resolve(datacvs.toDataURL("image/png"));
-                    });
-                    p.done();
-                } else {
-                    resolve(canvasdata);
-                }
-            };
-            img.onerror = ev => {
-                pxt.reportError("blocks", "blocks screenshot failed");
-                resolve(undefined)
-            }
-            img.src = data;
-        })
     }
 
     const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
@@ -401,7 +363,7 @@ namespace pxt.blocks.layout {
                 let pngUri = imageIconCache[svgUri];
 
                 return (pngUri ? Promise.resolve(pngUri)
-                    : toPngAsyncInternal(width, height, 4, svgUri))
+                    : pxt.BrowserUtils.encodeToPngAsync(svgUri, { width, height, pixelDensity: 4 }))
                     .then(href => {
                         imageIconCache[svgUri] = href;
                         image.setAttributeNS(XLINK_NAMESPACE, "href", href);

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -482,10 +482,10 @@ namespace pxt.BrowserUtils {
                 ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
                 let canvasdata = cvs.toDataURL("image/png");
                 // if the generated image is too big, shrink image
-                while (canvasdata.length > MAX_SCREENSHOT_SIZE) {
+                while (canvasdata.length > maxSize) {
                     cvs.width = (cvs.width / 2) >> 0;
                     cvs.height = (cvs.height / 2) >> 0;
-                    pxt.log(`screenshot size ${canvasdata.length}b, shrinking to ${cvs.width}x${cvs.height}`)
+                    pxt.debug(`screenshot size ${canvasdata.length}b, shrinking to ${cvs.width}x${cvs.height}`)
                     ctx.drawImage(img, 0, 0, width, height, 0, 0, cvs.width, cvs.height);
                     canvasdata = cvs.toDataURL("image/png");
                 }

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -396,7 +396,7 @@ namespace pxt.BrowserUtils {
                 } else {
                     window.setTimeout(() => window.URL.revokeObjectURL(downloadurl), 0);
                 }
-            } else  {
+            } else {
                 downloadurl = toDownloadDataUri(b64, name);
                 browserDownloadDataUri(downloadurl, name, userContextWindow);
             }
@@ -456,14 +456,14 @@ namespace pxt.BrowserUtils {
     }
 
     const MAX_SCREENSHOT_SIZE = 1e6; // max 1Mb
-    export function encodeToPngAsync(dataUri: string, 
+    export function encodeToPngAsync(dataUri: string,
         options?: {
             width?: number,
             height?: number,
             pixelDensity?: number,
             maxSize?: number,
             text?: string
-    } ): Promise<string> {
+        }): Promise<string> {
         const { width, height, pixelDensity = 4, maxSize = MAX_SCREENSHOT_SIZE, text } = options || {};
 
         return new Promise<string>((resolve, reject) => {
@@ -473,7 +473,7 @@ namespace pxt.BrowserUtils {
                 const cvs = document.createElement("canvas") as HTMLCanvasElement;
                 const ctx = cvs.getContext("2d");
                 cvs.width = (width || img.width) * pixelDensity;
-                cvs.height = (height || img.height) * pixelDensity;    
+                cvs.height = (height || img.height) * pixelDensity;
 
                 if (text) {
                     ctx.fillStyle = "#fff";
@@ -505,7 +505,7 @@ namespace pxt.BrowserUtils {
             }
             img.src = dataUri;
         })
-    }    
+    }
 
     export function resolveCdnUrl(path: string): string {
         // don't expand full urls
@@ -1042,7 +1042,7 @@ namespace pxt.BrowserUtils {
 
     export interface ITutorialInfoDb {
         getAsync(filename: string, code: string[], branch?: string): Promise<TutorialInfoIndexedDbEntry>;
-        setAsync(filename: string, blocks: Map<number>, code: string[], branch?: string ): Promise<void>;
+        setAsync(filename: string, blocks: Map<number>, code: string[], branch?: string): Promise<void>;
         clearAsync(): Promise<void>;
     }
 
@@ -1095,14 +1095,14 @@ namespace pxt.BrowserUtils {
                 });
         }
 
-        setAsync(filename: string, blocks: Map<number>, code: string[], branch?: string ): Promise<void> {
+        setAsync(filename: string, blocks: Map<number>, code: string[], branch?: string): Promise<void> {
             pxt.perf.measureStart("tutorial info db setAsync")
             const key = getTutorialInfoKey(filename, branch);
             const hash = getTutorialInfoHash(code);
             return this.setWithHashAsync(filename, blocks, hash);
         }
 
-        setWithHashAsync(filename: string, blocks: Map<number>, hash: string, branch?: string ): Promise<void> {
+        setWithHashAsync(filename: string, blocks: Map<number>, hash: string, branch?: string): Promise<void> {
             pxt.perf.measureStart("tutorial info db setAsync")
             const key = getTutorialInfoKey(filename, branch);
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -566,22 +566,22 @@ namespace pxt.runner {
 
             const doWork = async () => {
                 await pxt.BrowserUtils.loadBlocklyAsync();
-                const result = isXml 
-                    ? await pxt.runner.compileBlocksAsync(msg.code, options) 
+                const result = isXml
+                    ? await pxt.runner.compileBlocksAsync(msg.code, options)
                     : await runner.decompileSnippetAsync(msg.code, msg.options);
                 const blocksSvg = result.blocksSvg as SVGSVGElement;
-                    const width = blocksSvg.viewBox.baseVal.width;
-                    const height = blocksSvg.viewBox.baseVal.height;
-                const res = blocksSvg 
-                    ? await pxt.blocks.layout.blocklyToSvgAsync(blocksSvg, 0, 0, width, height) 
+                const width = blocksSvg.viewBox.baseVal.width;
+                const height = blocksSvg.viewBox.baseVal.height;
+                const res = blocksSvg
+                    ? await pxt.blocks.layout.blocklyToSvgAsync(blocksSvg, 0, 0, width, height)
                     : undefined;
                 // try to render to png
                 let png: string;
                 try {
-                    png = res 
-                    ? await pxt.BrowserUtils.encodeToPngAsync(res.xml, { width, height })
-                    : undefined;
-                } catch(e) {
+                    png = res
+                        ? await pxt.BrowserUtils.encodeToPngAsync(res.xml, { width, height })
+                        : undefined;
+                } catch (e) {
                     console.warn(e);
                 }
                 window.parent.postMessage(<pxsim.RenderBlocksResponseMessage>{

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -588,12 +588,11 @@ namespace pxt.runner {
                     source: "makecode",
                     type: "renderblocks",
                     id: msg.id,
-                    width: res ? res.width : undefined,
-                    height: res ? res.height : undefined,
-                    svg: res ? res.svg : undefined,
-                    uri: res ? res.xml : undefined,
-                    css: res ? res.css : undefined,
-                    png
+                    width: res?.width,
+                    height: res?.height,
+                    svg: res?.svg,
+                    uri: png || res?.xml,
+                    css: res?.css
                 }, "*");
             }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -1029,6 +1029,8 @@ ${linkString}
     let apiCache: pxt.Map<pxtc.ApisInfo>;
 
     export function decompileSnippetAsync(code: string, options?: blocks.BlocksRenderOptions): Promise<DecompileResult> {
+        const { assets, forceCompilation, snippetMode, generateSourceMap } = options || {};
+
         // code may be undefined or empty!!!
         const packageid = options && options.packageId ? "pub:" + options.packageId :
             options && options.package ? "docs:" + options.package
@@ -1041,18 +1043,18 @@ ${linkString}
                     opts.fileSystem["main.ts"] = code;
                 opts.ast = true
 
-                if (options.assets) {
-                    for (const key of Object.keys(options.assets)) {
+                if (assets) {
+                    for (const key of Object.keys(assets)) {
                         if (opts.sourceFiles.indexOf(key) < 0) {
                             opts.sourceFiles.push(key);
                         }
-                        opts.fileSystem[key] = options.assets[key];
+                        opts.fileSystem[key] = assets[key];
                     }
                 }
 
                 let compileJS: pxtc.CompileResult = undefined;
                 let program: ts.Program;
-                if (options && options.forceCompilation) {
+                if (forceCompilation) {
                     compileJS = pxtc.compile(opts);
                     program = compileJS && compileJS.ast;
                 } else {
@@ -1072,8 +1074,8 @@ ${linkString}
                     .then(() => {
                         let blocksInfo = pxtc.getBlocksInfo(apis);
                         pxt.blocks.initializeAndInject(blocksInfo);
-                        const tilemapJres = options.assets?.[pxt.TILEMAP_JRES];
-                        const assetsJres = options.assets?.[pxt.IMAGES_JRES];
+                        const tilemapJres = assets?.[pxt.TILEMAP_JRES];
+                        const assetsJres = assets?.[pxt.IMAGES_JRES];
                         if (tilemapJres || assetsJres) {
                             tilemapProject = new TilemapProject();
                             tilemapProject.loadPackage(mainPkg);
@@ -1086,8 +1088,8 @@ ${linkString}
                             blocksInfo,
                             program.getSourceFile("main.ts"),
                             {
-                                snippetMode: options && options.snippetMode,
-                                generateSourceMap: options && options.generateSourceMap
+                                snippetMode,
+                                generateSourceMap
                             });
                         if (bresp.diagnostics && bresp.diagnostics.length > 0)
                             bresp.diagnostics.forEach(diag => console.error(diag.messageText));
@@ -1131,6 +1133,8 @@ ${linkString}
     }
 
     export function compileBlocksAsync(code: string, options?: blocks.BlocksRenderOptions): Promise<DecompileResult> {
+        const { assets } = options || {};
+
         const packageid = options && options.packageId ? "pub:" + options.packageId :
             options && options.package ? "docs:" + options.package
                 : null;
@@ -1138,12 +1142,12 @@ ${linkString}
             .then(() => getCompileOptionsAsync(appTarget.compile ? appTarget.compile.hasHex : false))
             .then(opts => {
                 opts.ast = true
-                if (options.assets) {
-                    for (const key of Object.keys(options.assets)) {
+                if (assets) {
+                    for (const key of Object.keys(assets)) {
                         if (opts.sourceFiles.indexOf(key) < 0) {
                             opts.sourceFiles.push(key);
                         }
-                        opts.fileSystem[key] = options.assets[key];
+                        opts.fileSystem[key] = assets[key];
                     }
                 }
                 const resp = pxtc.compile(opts)
@@ -1153,8 +1157,8 @@ ${linkString}
                         const blocksInfo = pxtc.getBlocksInfo(apis);
                         pxt.blocks.initializeAndInject(blocksInfo);
 
-                        const tilemapJres = options.assets?.[pxt.TILEMAP_JRES];
-                        const assetsJres = options.assets?.[pxt.IMAGES_JRES];
+                        const tilemapJres = assets?.[pxt.TILEMAP_JRES];
+                        const assetsJres = assets?.[pxt.IMAGES_JRES];
                         if (tilemapJres || assetsJres) {
                             tilemapProject = new TilemapProject();
                             tilemapProject.loadPackage(mainPkg);

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -68,18 +68,10 @@
                         img = svg.childNodes.item(0)
                         code.parentElement.insertBefore(img, code)
                     } 
-                    // inject as data uri svg
+                    // inject as data uri
                     {
                         var img = document.createElement("img");
                         img.src = msg.uri;
-                        img.width = msg.width;
-                        img.height = msg.height;
-                        code.parentElement.insertBefore(img, code)
-                    }
-                    // inject as png
-                    {
-                        var img = document.createElement("img");
-                        img.src = msg.png;
                         img.width = msg.width;
                         img.height = msg.height;
                         code.parentElement.insertBefore(img, code)

--- a/webapp/public/rendertest.html
+++ b/webapp/public/rendertest.html
@@ -1,5 +1,11 @@
 <html>
-
+<head>
+    <style>
+        img {
+            display: block;
+        }
+    </style>
+</head>
 <body>
     <pre id="mycode">
     <code>basic.showString("hello!")</code>
@@ -47,27 +53,37 @@
             switch (msg.type) {
                 case "renderready":
                  //   makeCodeRenderPre(document.getElementById("mycode"))
-                   // makeCodeRenderPre(document.getElementById("mycode2"))
+                    makeCodeRenderPre(document.getElementById("mycode2"))
                     makeCodeRenderPre(document.getElementById("mycode3"))
                     break;
                 case "renderblocks":
                     console.log(msg);
 
                     var id = msg.id;
-                    var img;
+                    var code = document.getElementById(id)
 
-                    var injectAsSvg = true;
-                    if (injectAsSvg) {
+                    // inject as svg
+                    {
                         var svg = new DOMParser().parseFromString(msg.svg, "image/svg+xml");
                         img = svg.childNodes.item(0)
-                    } else {
-                        img = document.createElement("img");
+                        code.parentElement.insertBefore(img, code)
+                    } 
+                    // inject as data uri svg
+                    {
+                        var img = document.createElement("img");
                         img.src = msg.uri;
                         img.width = msg.width;
                         img.height = msg.height;
+                        code.parentElement.insertBefore(img, code)
                     }
-                    var code = document.getElementById(id)
-                    code.parentElement.insertBefore(img, code)
+                    // inject as png
+                    {
+                        var img = document.createElement("img");
+                        img.src = msg.png;
+                        img.width = msg.width;
+                        img.height = msg.height;
+                        code.parentElement.insertBefore(img, code)
+                    }
                     code.parentElement.removeChild(code);
                     break;
             }


### PR DESCRIPTION
Support for generating png in "renderblocks" javascript API.

It turns out that the franken-SVG we generated using "renderblocks" does not work with popular SVG rendering engine like Sharp. This SVG currently bundles the entire semantic.css so it's always at least 1.2Mb thick. This PR also generates PNGs from the iframe process so that all fonts resolved, etc...

To test: run http://localhost:3232/rendertest.html from the microbit target.

- [x] render URI field as png instead of encoded SVG (as it is so hugesque)
- [x] fix some missing guards on accessing options
- [x] refactoring logic to generate png with encoded data into browser utils