### PR TITLE
cfg-check: do not issue spurious error on tags pushed

### DIFF
--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -143,7 +143,10 @@ jobs:
             ".github/workflows/cfg-check.yml": `name: Check pxt.json
 
 on:
-  push
+  push:
+    branches:
+      - 'master'
+      - 'main'
 
 jobs:
   check-cfg:

--- a/pxtlib/initprj.ts
+++ b/pxtlib/initprj.ts
@@ -172,6 +172,7 @@ jobs:
         run: pxt checkpkgcfg
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+        continue-on-error: true
         with:
           title: 'Removing missing files from pxt.json'
           commit-message: 'Removing missing files from pxt.json'


### PR DESCRIPTION
fix https://forum.makecode.com/t/error-on-github-actions-for-makecode-arcade/6616/2, it shouldn't be running on tags getting pushed :(