### PR TITLE
Auto-display completion modal, populate info panel for rewards

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -236,6 +236,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
         if (this.queryFlags["debugCompleted"] === "true") {
             user.isDebug = true;
+            user.mapProgress = { [pageSource]: {} };
 
             if (maps) {
                 for (const map of maps) {

--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -10,18 +10,13 @@ import { tickEvent, postAbuseReportAsync } from "../lib/browserUtils";
 import { Modal, ModalAction } from './Modal';
 import { carryoverProjectCode } from "../lib/codeCarryover";
 
-type CompletionModalType = "map" | "activity";
-
 interface AppModalProps {
     type: ModalType;
-    completionType?: CompletionModalType;
     skillMap?: SkillMap;
     userState?: UserState;
     mapId: string;
-    activity?: MapActivity;
-    nextActivityId?: string;
+    activity?: MapNode;
     pageSourceUrl?: string;
-    displayName?: string;
     actions?: ModalAction[];
     dispatchHideModal: () => void;
     dispatchRestartActivity: (mapId: string, activityId: string) => void;
@@ -32,11 +27,11 @@ interface AppModalProps {
 
 export class AppModalImpl extends React.Component<AppModalProps> {
     render() {
-        const  { activity, type, completionType } = this.props;
+        const  { activity, type } = this.props;
 
         switch (type) {
             case "completion":
-                if (!activity && completionType !== "map") return <div />
+                if (!activity) return <div />
                 return this.renderCompletionModal();
             case "restart-warning":
                 if (!activity) return <div />
@@ -56,19 +51,36 @@ export class AppModalImpl extends React.Component<AppModalProps> {
         this.props.dispatchHideModal();
     }
 
-    renderCompletionModal() {
-        const  { type, displayName, completionType, actions } = this.props;
-        if (!type) return <div />
+    protected getRewardText(type: MapRewardType) {
+        switch (type) {
+            case "certificate":
+            default:
+                return lf("Certificate");
+        }
+    }
 
-        const completionModalTitle = completionType === "activity" ? lf("Activity Complete!") : lf("Path Complete!");
-        const completionModalText = lf("Good work! You've completed {0}. Collect your certificate and keep going!", "{0}");
+    renderCompletionModal() {
+        const  { mapId, skillMap, type, activity } = this.props;
+        if (!type || !skillMap) return <div />
+
+        const reward = activity as MapReward;
+
+        const completionModalTitle = lf("You Did It!");
+        const completionModalText = lf("Congratulations on completing {0}. Take some time to explore any activities you missed, or reset your progress to try again. But first, be sure to claim your reward using the button below.", "{0}");
         const completionModalTextSegments = completionModalText.split("{0}");
 
         const density = 100;
 
+        const actions = [
+            { label: this.getRewardText(reward.type),  onClick: () => {
+                tickEvent("skillmap.certificate", { path: mapId });
+                window.open(reward.url || skillMap.completionUrl);
+            } }
+        ]
+
         return <div className="confetti-container">
-            <Modal title={completionModalTitle} actions={actions} onClose={this.handleOnClose}>
-                {completionModalTextSegments[0]}{<strong>{displayName}</strong>}{completionModalTextSegments[1]}
+            <Modal title={completionModalTitle} actions={actions} className="completion" onClose={this.handleOnClose}>
+                {completionModalTextSegments[0]}{<strong>{skillMap.displayName}</strong>}{completionModalTextSegments[1]}
             </Modal>
             {Array(density).fill(0).map((el, i) => {
                 const style = {
@@ -174,43 +186,16 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     if (!state) return {};
     const { pageSourceUrl } = state;
     const { currentMapId, currentActivityId, type } = state.modal || {};
-    let nextActivityId: string | undefined;
-    let displayName: string | undefined;
-    let completionType: CompletionModalType | undefined;
-    let actions: ModalAction[] = [];
 
-    if (currentMapId && type !== "restart-warning") {
-        const map = state.maps[currentMapId];
-        if (currentActivityId) {
-            const activity = map.activities[currentActivityId];
-            completionType = "activity";
-            displayName = activity.displayName;
-            nextActivityId = activity.next?.[0]?.activityId;
-
-            actions.push({ label: lf("NEXT"), onClick: () => {
-                tickEvent("skillmap.activity.next", { path: currentMapId, activity: currentActivityId });
-                dispatchHideModal();
-                dispatchOpenActivity(currentMapId, nextActivityId || "");
-             } });
-        } else {
-            completionType = "map";
-            displayName = map.displayName;
-
-            actions.push({ label: lf("CERTIFICATE"), onClick: () => {
-                tickEvent("skillmap.certificate", { path: currentMapId });
-                window.open(map.completionUrl)
-            }});
-        }
-    }
+    // Set the map as currently open map (editorView), or mapId passed into modal
+    const currentMap = state.editorView ?
+        state.maps[state.editorView.currentMapId] :
+        (currentMapId && state.maps[currentMapId]);
 
     return {
         type,
-        completionType,
-        displayName,
-        nextActivityId,
         pageSourceUrl,
-        actions,
-        skillMap: state.editorView ? state.maps[state.editorView.currentMapId] : undefined,
+        skillMap: currentMap,
         userState: state.user,
 
         mapId: currentMapId,

--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -54,8 +54,9 @@ export class AppModalImpl extends React.Component<AppModalProps> {
     protected getRewardText(type: MapRewardType) {
         switch (type) {
             case "certificate":
-            default:
                 return lf("Certificate");
+            default:
+                return lf("Reward");
         }
     }
 

--- a/skillmap/src/components/GraphNode.tsx
+++ b/skillmap/src/components/GraphNode.tsx
@@ -15,12 +15,12 @@ interface GraphNodeProps {
     status: ActivityStatus;
     theme: SkillGraphTheme;
     selected?: boolean;
-    onItemSelect?: (id: string) => void;
+    onItemSelect?: (id: string, kind: MapNodeKind) => void;
 }
 
 export class GraphNode extends React.Component<GraphNodeProps> {
     protected handleClick = () => {
-        if (this.props.onItemSelect) this.props.onItemSelect(this.props.activityId);
+        if (this.props.onItemSelect) this.props.onItemSelect(this.props.activityId, this.props.kind);
     }
 
     protected getIcon(status: ActivityStatus, kind: MapNodeKind): string {

--- a/skillmap/src/components/InfoPanel.tsx
+++ b/skillmap/src/components/InfoPanel.tsx
@@ -88,10 +88,10 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
 
     if (maps) {
         if (selectedItem?.activityId) {
+            const map = maps[selectedItem.mapId];
+            const { status: activityStatus, currentStep, maxSteps } = getActivityStatus(state.user, state.pageSourceUrl, map, selectedItem.activityId);
+            status = activityStatus;
             if (isActivity) {
-                const map = maps[selectedItem.mapId];
-                const { status: activityStatus, currentStep, maxSteps } = getActivityStatus(state.user, state.pageSourceUrl, map, selectedItem.activityId);
-                status = activityStatus;
                 details.push(maxSteps ? `${currentStep}/${maxSteps} ${lf("Steps")}` : lf("Not Started"));
                 details.push(isActivity ? (node as MapActivity).type : "");
             }

--- a/skillmap/src/components/Modal.tsx
+++ b/skillmap/src/components/Modal.tsx
@@ -13,6 +13,7 @@ export interface ModalAction {
 interface ModalProps {
     title: string;
     actions?: ModalAction[];
+    className?: string;
     onClose?: () => void;
 }
 
@@ -28,9 +29,9 @@ export class Modal extends React.Component<ModalProps> {
     }
 
     render() {
-        const  { title, actions } = this.props;
+        const  { title, actions, className } = this.props;
         return <div className="modal-overlay" onClick={this.handleCloseClick} role="region">
-            <div className="modal" onClick={this.handleModalClick} role="dialog">
+            <div className={`modal ${className || ""}`} onClick={this.handleModalClick} role="dialog">
                 <div className="modal-header">
                     <div className="modal-title">{title}</div>
                     <div className="spacer" />

--- a/skillmap/src/components/RewardActions.tsx
+++ b/skillmap/src/components/RewardActions.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { connect } from 'react-redux';
+
+import { dispatchOpenActivity, dispatchShowCompletionModal } from '../actions/dispatch';
+
+import { ActivityStatus } from '../lib/skillMapUtils';
+
+interface OwnProps {
+    mapId: string;
+    activityId: string;
+    status?: ActivityStatus;
+    type?: MapRewardType;
+}
+
+interface DispatchProps {
+    dispatchOpenActivity: (mapId: string, activityId: string) => void;
+    dispatchShowCompletionModal: (mapId: string, activityId: string) => void;
+}
+
+type RewardActionsProps = OwnProps & DispatchProps;
+
+export class RewardActionsImpl extends React.Component<RewardActionsProps> {
+    protected getRewardActionText(): string {
+        switch (this.props.type) {
+            case "certificate":
+                return lf("Claim Certificate");
+            default:
+                return lf("Claim Reward");
+        }
+    }
+
+    protected handleActionButtonClick = () => {
+        const { status, mapId, activityId, dispatchShowCompletionModal } = this.props;
+        switch (status) {
+            case "locked":
+                break;
+            default:
+                return dispatchShowCompletionModal(mapId, activityId)
+        }
+    }
+
+    render() {
+        const { status } = this.props;
+
+        if (status === "locked") return <div />
+
+        return <div className="activity-actions">
+            <div className="action-button" role="button" onClick={this.handleActionButtonClick}>
+                {this.getRewardActionText()}
+            </div>
+        </div>
+    }
+}
+
+const mapDispatchToProps = {
+    dispatchOpenActivity,
+    dispatchShowCompletionModal
+}
+
+export const RewardActions = connect<{}, DispatchProps, OwnProps>(null, mapDispatchToProps)(RewardActionsImpl);

--- a/skillmap/src/components/RewardActions.tsx
+++ b/skillmap/src/components/RewardActions.tsx
@@ -41,7 +41,6 @@ export class RewardActionsImpl extends React.Component<RewardActionsProps> {
 
     render() {
         const { status } = this.props;
-
         if (status === "locked") return <div />
 
         return <div className="activity-actions">

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from 'react-redux';
 
 import { SkillMapState } from '../store/reducer';
-import { dispatchChangeSelectedItem  } from '../actions/dispatch';
+import { dispatchChangeSelectedItem, dispatchShowCompletionModal, dispatchSetSkillMapCompleted } from '../actions/dispatch';
 import { GraphNode } from './GraphNode';
 import { GraphPath } from "./GraphPath";
 
@@ -24,7 +24,10 @@ interface SkillGraphProps {
     selectedActivityId?: string;
     pageSourceUrl: string;
     theme: SkillGraphTheme;
+    completionState: "incomplete" | "transitioning" | "completed";
     dispatchChangeSelectedItem: (mapId?: string, activityId?: string) => void;
+    dispatchShowCompletionModal: (mapId: string, activityId?: string) => void;
+    dispatchSetSkillMapCompleted: (mapId: string) => void;
 }
 
 const UNIT = 10;
@@ -72,12 +75,19 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
         return { items, paths };
     }
 
-    protected onItemSelect = (activityId: string) => {
-        const { dispatchChangeSelectedItem, map } = this.props;
-        if (activityId !== this.props.selectedActivityId) {
+    protected onItemSelect = (activityId: string, kind: MapNodeKind) => {
+        const { map, completionState, selectedActivityId,
+            dispatchChangeSelectedItem, dispatchShowCompletionModal } = this.props;
+
+        if (kind === "completion" && completionState === "completed") {
             dispatchChangeSelectedItem(map.mapId, activityId);
+            dispatchShowCompletionModal(map.mapId, activityId)
         } else {
-            dispatchChangeSelectedItem(undefined);
+            if (activityId !== selectedActivityId) {
+                dispatchChangeSelectedItem(map.mapId, activityId);
+            } else {
+                dispatchChangeSelectedItem(undefined);
+            }
         }
     }
 
@@ -92,6 +102,15 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
 
     protected getY(position: number) {
         return ((position * 8) + PADDING) * UNIT;
+    }
+
+    componentDidUpdate(props: SkillGraphProps) {
+        if (props.completionState === "transitioning") {
+            setTimeout(() => {
+                props.dispatchSetSkillMapCompleted(props.map.mapId)
+                props.dispatchShowCompletionModal(props.map.mapId, props.selectedActivityId)
+            }, 400);
+        }
     }
 
     render() {
@@ -125,16 +144,20 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
 function mapStateToProps(state: SkillMapState, ownProps: any) {
     if (!state) return {};
 
+    const mapProgress = state.user?.mapProgress?.[state.pageSourceUrl];
     return {
         user: state.user,
         pageSourceUrl: state.pageSourceUrl,
         theme: state.theme,
-        selectedActivityId: state.selectedItem && ownProps.map?.mapId == state.selectedItem.mapId ? state.selectedItem.activityId : undefined
+        selectedActivityId: state.selectedItem && ownProps.map?.mapId == state.selectedItem.mapId ? state.selectedItem.activityId : undefined,
+        completionState: mapProgress?.[ownProps.map.mapId]?.completionState
     }
 }
 
 const mapDispatchToProps = {
-    dispatchChangeSelectedItem
+    dispatchChangeSelectedItem,
+    dispatchShowCompletionModal,
+    dispatchSetSkillMapCompleted
 };
 
 export const SkillGraph = connect(mapStateToProps, mapDispatchToProps)(SkillGraphImpl);

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -76,10 +76,11 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
     }
 
     protected onItemSelect = (activityId: string, kind: MapNodeKind) => {
-        const { map, completionState, selectedActivityId,
+        const { user, pageSourceUrl, map, completionState, selectedActivityId,
             dispatchChangeSelectedItem, dispatchShowCompletionModal } = this.props;
 
-        if (kind === "completion" && completionState === "completed") {
+        const { status } = getActivityStatus(user, pageSourceUrl, map, activityId);
+        if (kind === "completion" && status === "completed") {
             dispatchChangeSelectedItem(map.mapId, activityId);
             dispatchShowCompletionModal(map.mapId, activityId)
         } else {

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -50,7 +50,7 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
             }
 
             // Assign the current node as the parent of its children
-            const next = current.next.map((el: MapNode) => {
+            const next = current.next.map((el: BaseNode) => {
                 let node = el as any;
                 if (!node.parents) {
                     node.parents = [current!];
@@ -157,7 +157,7 @@ export function treeGraph(root: BaseNode): GraphNode[] {
             }
 
             // Assign this node as the parent of all children
-            const next = current.next.map((el: MapNode) => {
+            const next = current.next.map((el: BaseNode) => {
                 let node = el as GraphNode;
                 if (!node.parents) {
                     node.parents = [current!];
@@ -233,7 +233,7 @@ function cloneNode(root: BaseNode): GraphNode {
 
     // Clone all nodes, assign children to cloned nodes
     nodes.forEach(n => clones[n.activityId] = Object.assign({}, n));
-    nodes.forEach(n => n.next = n.next.map(el => clones[el.activityId] as MapNode));
+    Object.keys(clones).forEach(cloneId => clones[cloneId].next = clones[cloneId].nextIds.map(id => clones[id]));
 
     return clones[root.activityId];
 }

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -15,7 +15,7 @@ interface GraphNode extends BaseNode, GraphCoord {
 }
 
 export function orthogonalGraph(root: MapNode): GraphNode[] {
-    const graphNode = cloneNode(root);
+    const graphNode = cloneGraph(root);
     let activities: GraphNode[] = [graphNode];
 
     // Compute two coordiantes (depth, offset) for each node. The placement heuristic
@@ -51,7 +51,7 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
 
             // Assign the current node as the parent of its children
             const next = current.next.map((el: BaseNode) => {
-                let node = el as any;
+                let node = el as GraphNode;
                 if (!node.parents) {
                     node.parents = [current!];
                 } else {
@@ -132,7 +132,7 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
 
 // Simple tree-like layout, does not handle loops very well
 export function treeGraph(root: BaseNode): GraphNode[] {
-    let graphNode = cloneNode(root);
+    let graphNode = cloneGraph(root);
     let activities: GraphNode[] = [graphNode];
 
     // Pass to set the width of each node
@@ -227,13 +227,13 @@ function dfsArray(root: GraphNode): GraphNode[] {
     return nodes;
 }
 
-function cloneNode(root: BaseNode): GraphNode {
+function cloneGraph(root: BaseNode): GraphNode {
     const nodes = bfsArray(root as GraphNode);
     const clones: { [key: string]: GraphNode} = {};
 
     // Clone all nodes, assign children to cloned nodes
     nodes.forEach(n => clones[n.activityId] = Object.assign({}, n));
-    Object.keys(clones).forEach(cloneId => clones[cloneId].next = clones[cloneId].nextIds.map(id => clones[id]));
+    Object.keys(clones).forEach(cloneId => clones[cloneId].next = clones[cloneId].nextIds.map(id => clones[id] as any));
 
     return clones[root.activityId];
 }

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -8,15 +8,19 @@ interface GraphCoord {
     offset: number; // The offset of the node within the layer
 }
 
-interface GraphNode extends MapActivity, GraphCoord {
+interface GraphNode extends BaseNode, GraphCoord {
     width?: number; // The maximum subtree width from this node
     edges?: GraphCoord[][]; // Each edge is an array of (depth, offset) pairs
     parents?: GraphNode[];
 }
 
 export function orthogonalGraph(root: MapNode): GraphNode[] {
-    let activities: GraphNode[] = [root as GraphNode];
+    const graphNode = cloneNode(root);
+    let activities: GraphNode[] = [graphNode];
 
+    // Compute two coordiantes (depth, offset) for each node. The placement heuristic
+    // here is roughly based off of "The DFS-heuristic for orthogonal graph drawing"
+    // found at: https://core.ac.uk/download/pdf/82771879.pdf
     const prevChildPosition: { [key: string]: GraphCoord } = {};
     const visited: { [key: string]: boolean } = {};
     let totalOffset = 0;
@@ -47,7 +51,7 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
 
             // Assign the current node as the parent of its children
             const next = current.next.map((el: MapNode) => {
-                let node = el as GraphNode;
+                let node = el as any;
                 if (!node.parents) {
                     node.parents = [current!];
                 } else {
@@ -68,8 +72,7 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
         }
     }
 
-
-    const nodes = dfsArray(root as GraphNode);
+    const nodes = dfsArray(graphNode);
 
     // Get map of node offsets at each level of the graph
     const offsetMap: { [key: number]: number[] } = {};
@@ -128,11 +131,12 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
 }
 
 // Simple tree-like layout, does not handle loops very well
-export function treeGraph(root: MapActivity): GraphNode[] {
-    let activities: GraphNode[] = [root as GraphNode];
+export function treeGraph(root: BaseNode): GraphNode[] {
+    let graphNode = cloneNode(root);
+    let activities: GraphNode[] = [graphNode];
 
     // Pass to set the width of each node
-    setWidths(root as GraphNode);
+    setWidths(graphNode);
 
     // We keep a map of how deep the graph is at this depth
     const offsetMap: { [key: number]: number } = {};
@@ -167,7 +171,7 @@ export function treeGraph(root: MapActivity): GraphNode[] {
         }
     }
 
-    const nodes = bfsArray(root as GraphNode);
+    const nodes = bfsArray(graphNode);
     nodes.forEach(n => {
         if (n.parents) {
             n.edges = [];
@@ -221,4 +225,15 @@ function dfsArray(root: GraphNode): GraphNode[] {
     }
 
     return nodes;
+}
+
+function cloneNode(root: BaseNode): GraphNode {
+    const nodes = bfsArray(root as GraphNode);
+    const clones: { [key: string]: GraphNode} = {};
+
+    // Clone all nodes, assign children to cloned nodes
+    nodes.forEach(n => clones[n.activityId] = Object.assign({}, n));
+    nodes.forEach(n => n.next = n.next.map(el => clones[el.activityId] as MapNode));
+
+    return clones[root.activityId];
 }

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -44,7 +44,7 @@ interface BaseNode {
     displayName: string;
     imageUrl?: string;
 
-    next: MapNode[];
+    next: BaseNode[];
     nextIds: string[];
 }
 

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -11,7 +11,7 @@ interface SkillMap {
     displayName: string;
     description?: string;
     prerequisites: MapPrerequisite[];
-    completionUrl?: string;
+    completionUrl?: string; // DEPRECATED, urls should be specified on completion nodes
 
     // Indicates whether or not code can be copied from previous activity
     // for all cards in this skillmap
@@ -64,9 +64,12 @@ interface MapActivity extends BaseNode {
     allowCodeCarryover?: boolean;
 }
 
+type MapRewardType = "certificate";
+
 interface MapReward extends BaseNode {
     kind: "reward";
-
+    type: MapRewardType;
+    url: string;
 }
 
 interface MapCompletionNode extends MapReward {

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -44,7 +44,7 @@ interface BaseNode {
     displayName: string;
     imageUrl?: string;
 
-    next: BaseNode[];
+    next: MapNode[];
     nextIds: string[];
 }
 

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -311,7 +311,7 @@ function inflateMetadata(section: MarkdownSection): PageMetadata {
         infoUrl: section.attributes["infourl"],
         backgroundImageUrl: section.attributes["backgroundurl"],
         theme: {
-            backgroundColor: tertiary || "var(--tertiary-color)",
+            backgroundColor: tertiary || "var(--body-background-color)",
             pathColor: primary || "#BFBFBF",
             strokeColor: "#000000",
             rewardNodeColor: tertiary || "var(--tertiary-color)",

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -215,8 +215,18 @@ function inflateMapNode(section: MarkdownSection): MapNode {
 function inflateMapReward(section: MarkdownSection, base: Partial<MapReward>): MapReward {
     const result: Partial<MapReward> = {
         ...base,
-        kind: (section.attributes.kind || "reward") as any
+        kind: (section.attributes.kind || "reward") as any,
+        url: section.attributes.url
     };
+
+    if (section.attributes["type"]) {
+        const type = section.attributes["type"].toLowerCase();
+        switch (type) {
+            case "certificate":
+                result.type = type;
+                break;
+        }
+    }
 
     return result as MapReward;
 }

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -119,6 +119,10 @@ export function lookupPreviousActivityStates(user: UserState, pageSource: string
         .filter(a => !!a) as ActivityState[];
 }
 
+export function isRewardNode(node: MapNode) {
+    return node.kind === "reward" || node.kind === "completion";
+}
+
 export function applyUserUpgrades(user: UserState, currentVersion: string, pageSource: string, maps: { [key: string]: SkillMap }) {
     const oldVersion = pxt.semver.parse(user.version || "0.0.0");
     const newVersion = pxt.semver.parse(currentVersion);

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -108,9 +108,19 @@ export function lookupActivityProgress(user: UserState, pageSource: string, mapI
 
 export function lookupPreviousActivities(map: SkillMap, activityId: string) {
     return Object.keys(map.activities)
-        .filter(key =>
-            map.activities[key].next.some(activity => activity.activityId === activityId)
-        ).map(key => map.activities[key])
+        .filter(key => {
+            const activity = map.activities[key];
+            let nextIds: string[] = [];
+            // Replace reward node IDs with the activities following the reward node
+            activity.next.forEach(node => {
+                if (isRewardNode(node)) {
+                    nextIds = nextIds.concat(node.next.map(nextNode => nextNode.activityId))
+                } else {
+                    nextIds.push(node.activityId)
+                }
+            });
+            return nextIds.some(id => id === activityId)
+        }).map(key => map.activities[key])
 }
 
 export function lookupPreviousActivityStates(user: UserState, pageSource: string, map: SkillMap, activityId: string): ActivityState[] {

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -1,6 +1,7 @@
 import * as actions from '../actions/types'
 import { guidGen } from '../lib/browserUtils';
-import { getCompletedTags, lookupActivityProgress, isMapCompleted, applyUserUpgrades } from '../lib/skillMapUtils';
+import { getCompletedTags, lookupActivityProgress, isMapCompleted,
+    isRewardNode, applyUserUpgrades } from '../lib/skillMapUtils';
 
 export type ModalType = "restart-warning" | "completion" | "report-abuse" | "reset" | "carryover";
 export type PageSourceStatus = "approved" | "banned" | "unknown";
@@ -141,11 +142,22 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
                 }
             };
         case actions.CLOSE_ACTIVITY:
+            const currentMap = state.maps[state.editorView!.currentMapId];
+            const currentActivityId = state.editorView!.currentActivityId;
+
+            // When a node is completed, we mark any following reward nodes as complete also
+            const finishedNodes = action.finished ? getFinishedNodes(currentMap, currentActivityId) : [];
+            const selectedItem = finishedNodes.find(el => isRewardNode(el))
+
             return {
                 ...state,
+                selectedItem: selectedItem ? {
+                    mapId: currentMap.mapId,
+                    activityId: selectedItem.activityId
+                } : state.selectedItem,
                 editorView: undefined,
                 user: action.finished ?
-                    setActivityFinished(state.user, state.pageSourceUrl, state.maps[state.editorView!.currentMapId], state.editorView!.currentActivityId) :
+                    setActivityFinished(state.user, state.pageSourceUrl, currentMap, finishedNodes.map(n => n.activityId)) :
                     state.user
             };
         case actions.RESTART_ACTIVITY:
@@ -298,11 +310,7 @@ export function setHeaderIdForActivity(user: UserState, pageSource: string, map:
         }
     }
 
-    // Only transition the first time a carousel/skill path is completed: we check that the map is completed
-    // (not including the current activity), that the current activity is not YET completed, but about to be
-    const shouldTransition = isMapCompleted(user, pageSource, map, activityId) && !existing.isCompleted && isCompleted;
     const currentMapProgress = user.mapProgress?.[pageSource] || {};
-
     return {
         ...user,
         mapProgress: {
@@ -320,8 +328,7 @@ export function setHeaderIdForActivity(user: UserState, pageSource: string, map:
                             maxSteps,
                             isCompleted: existing.isCompleted || isCompleted
                         }
-                    },
-                    completionState: shouldTransition ? "transitioning" : currentMapProgress?.[mapId]?.completionState
+                    }
                 }
             }
         }
@@ -334,22 +341,24 @@ export function shouldAllowCodeCarryover(state: SkillMapState, mapId: string, ac
     return !!(activity?.kind === "activity" && activity.allowCodeCarryover);
 }
 
-export function setActivityFinished(user: UserState, pageSource: string, map: SkillMap, activityId: string) {
+export function setActivityFinished(user: UserState, pageSource: string, map: SkillMap, activityIds: string[]) {
     const mapId = map.mapId;
-    let existing = lookupActivityProgress(user, pageSource, mapId, activityId);
 
-    if (!existing) {
-        existing = {
-            isCompleted: false,
-            activityId,
+    let shouldTransition = false;
+    const completedNodes: {[key: string]: ActivityState} = { } ;
+    activityIds.forEach(el => {
+        let activity = lookupActivityProgress(user, pageSource, mapId, el);
+        // Only auto-transition the first time a completion node is reached
+        shouldTransition = shouldTransition || (isRewardNode(map.activities[el]) && !activity?.isCompleted);
+        completedNodes[el] = (activity || {
+            isCompleted: true,
+            activityId: el,
             headerId: "",
             currentStep: 0
-        }
-    }
+        })
+        completedNodes[el].isCompleted = true;
+    })
 
-    // Only transition the first time a carousel/skill path is completed: we check that the map is completed
-    // (not including the current activity) and that the current activity is not yet completed
-    const shouldTransition = isMapCompleted(user, pageSource, map, activityId) && !existing.isCompleted;
     const currentMapProgress = user.mapProgress?.[pageSource] || {};
     return {
         ...user,
@@ -361,16 +370,22 @@ export function setActivityFinished(user: UserState, pageSource: string, map: Sk
                     ...(currentMapProgress?.[mapId] || { mapId }),
                     activityState: {
                         ...(currentMapProgress?.[mapId]?.activityState || {}),
-                        [activityId]: {
-                            ...existing,
-                            isCompleted: true
-                        }
+                        ...completedNodes
                     },
                     completionState: shouldTransition ? "transitioning" : currentMapProgress?.[mapId]?.completionState
                 }
             }
         }
     };
+}
+
+function getFinishedNodes(map: SkillMap, activityId: string) {
+    const node = map.activities[activityId]
+    const completedNodes: MapNode[] = [node];
+
+    // Reward and completion nodes are automatically marked finished
+    const autoComplete = map.activities[activityId].next.filter(el => isRewardNode(el));
+    return completedNodes.concat(autoComplete);
 }
 
 export default topReducer;

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -147,11 +147,12 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
 
             // When a node is completed, we mark any following reward nodes as complete also
             const finishedNodes = action.finished ? getFinishedNodes(currentMap, currentActivityId) : [];
-            const selectedItem = finishedNodes.find(el => isRewardNode(el))
+            const selectedItem = finishedNodes.find(el => isRewardNode(el));
+            const existing = selectedItem && state.user.mapProgress[state.pageSourceUrl]?.[currentMap.mapId]?.activityState[selectedItem.activityId];
 
             return {
                 ...state,
-                selectedItem: selectedItem ? {
+                selectedItem: selectedItem && !existing ? {
                     mapId: currentMap.mapId,
                     activityId: selectedItem.activityId
                 } : state.selectedItem,

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -50,7 +50,7 @@ const initialState: SkillMapState = {
         completedTags: {}
     },
     theme: {
-        backgroundColor: "var(--tertiary-color)",
+        backgroundColor: "var(--body-background-color)",
         pathColor: "#BFBFBF",
         strokeColor: "#000000",
         rewardNodeColor: "var(--tertiary-color)",


### PR DESCRIPTION
- Clones all graph nodes before annotation
- Adds "types" for rewards (currently only supports "certificate")
- Auto-display modal the first time a reward is completed
- Properly populate the completion modal with information from that specific node (rather than the map-level completion URL)
- Fill info panel with reward info
- Update code carryover to skip reward nodes when finding previous activities (this only searches one layer down, but I think it's ok to not support the two-rewards-in-a-row scenario for now)