### PR TITLE
Add non-rendered 'layout' node for graph control

### DIFF
--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -72,7 +72,7 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
         }
     }
 
-    const nodes = dfsArray(graphNode);
+    const nodes = dfsArray(graphNode).filter(node => node.kind !== "layout");
 
     // Get map of node offsets at each level of the graph
     const offsetMap: { [key: number]: number[] } = {};
@@ -171,7 +171,7 @@ export function treeGraph(root: BaseNode): GraphNode[] {
         }
     }
 
-    const nodes = bfsArray(graphNode);
+    const nodes = bfsArray(graphNode).filter(node => node.kind !== "layout");
     nodes.forEach(n => {
         if (n.parents) {
             n.edges = [];

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -34,9 +34,9 @@ interface MapFinishedPrerequisite {
     mapId: string;
 }
 
-type MapNodeKind = "activity" | "reward" | "completion";
+type MapNodeKind = "activity" | "reward" | "completion" | "layout";
 
-type MapNode = MapActivity | MapReward | MapCompletionNode
+type MapNode = MapActivity | MapReward | MapCompletionNode | MapLayoutNode
 
 interface BaseNode {
     kind: MapNodeKind;
@@ -74,6 +74,10 @@ interface MapReward extends BaseNode {
 
 interface MapCompletionNode extends MapReward {
     kind: "completion";
+}
+
+interface MapLayoutNode extends BaseNode {
+    kind: "layout";
 }
 
 type CompletedTags = {[index: string]: number}

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -206,10 +206,21 @@ function inflateMapNode(section: MarkdownSection): MapNode {
 
     if (section.attributes.kind === "reward" || section.attributes.kind === "completion") {
         return inflateMapReward(section, base as Partial<MapReward>);
-    }
-    else {
+    } else if (section.attributes.kind === "layout") {
+        return inflateMapLayout(section, base as Partial<MapLayoutNode>);
+    } else {
         return inflateActivity(section, base as Partial<MapActivity>);
     }
+}
+
+function inflateMapLayout(section: MarkdownSection, base: Partial<MapLayoutNode>): MapLayoutNode {
+    const result: Partial<MapLayoutNode> = {
+        ...base,
+        kind: "layout",
+        next: []
+    };
+
+    return result as MapLayoutNode;
 }
 
 function inflateMapReward(section: MarkdownSection, base: Partial<MapReward>): MapReward {


### PR DESCRIPTION
per kiki's request for more graph layout customizability, this is a blank node that is used in layout but not actually rendered. defined in markdown as:

```
### layout-a
* name: Blank Node
* kind: layout
```

it's the graph algorithm's responsibility to process the layout nodes however and discard them before emitting edges