### PR TITLE
Check for "cloudCurrent" field when comparing local vs cloud

### DIFF
--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -67,7 +67,6 @@ export function getCloudSummary(h: pxt.workspace.Header, md: CloudTempMetadata):
 
 async function listAsync(): Promise<Header[]> {
     return new Promise(async (resolve, reject) => {
-        // Note: Cosmos & our backend does not return e-tags each individual item in a list operation
         const result = await auth.apiAsync<CloudProject[]>("/api/user/project");
         if (result.success) {
             const syncTime = U.nowSeconds()

--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -270,7 +270,7 @@ async function resolveConflict(local: Header, remoteFile: File) {
         //  since this is a bad case (may lead to repeat duplication).
         pxt.reportException(e);
         pxt.tickEvent(`identity.sync.conflict.overwriteLocalFailed`, { exception: e });
-        anyError = true;
+        pxt.tickEvent(`identity.sync.conflict.failed`);
         throw e;
     }
 


### PR DESCRIPTION
Our sync algorithm wasn't pushing local changes in all cases.
Also improves our ticks during conflict resolution.

Fixes: https://github.com/microsoft/pxt-arcade/issues/3254

_might_ fix this too: https://github.com/microsoft/pxt-arcade/issues/3228
but since I don't have a consistent repro it's hard to say. Certainly the window for conflicts is larger without this PR since changes are synced less often.