### PR TITLE
Add skillmap highlight color for reward nodes + selected stroke

### DIFF
--- a/skillmap/src/components/GraphNode.tsx
+++ b/skillmap/src/components/GraphNode.tsx
@@ -62,11 +62,11 @@ export class GraphNode extends React.Component<GraphNodeProps> {
         switch (status) {
             case "completed":
                 return <g transform={`translate(${(width / 2) - (3 * nudgeUnit)} ${(-width / 2) + (3 * nudgeUnit)})`}>
-                    <circle cx={0} cy={0} r={(width / 4) - nudgeUnit} stroke={theme.strokeColor} strokeWidth="2" fill={theme.rewardNodeColor}/>
+                    <circle cx={0} cy={0} r={(width / 4) - nudgeUnit} stroke={theme.strokeColor} strokeWidth="2" fill={theme.lockedNodeColor}/>
                     <text dy="2"
                         textAnchor="middle"
                         alignmentBaseline="middle"
-                        fill={theme.rewardNodeForeground}
+                        fill={theme.lockedNodeForeground}
                         className="graph-status-icon">
                             {"\uf00c"}
                         </text>
@@ -92,13 +92,13 @@ export class GraphNode extends React.Component<GraphNodeProps> {
         let fill = theme.unlockedNodeColor;
         let foreground = theme.unlockedNodeForeground;
 
-        if (kind !== "activity") {
-            fill = theme.rewardNodeColor;
-            foreground = theme.rewardNodeForeground;
-        }
-        else if (status === "locked") {
+        if (status === "locked") {
             fill = theme.lockedNodeColor;
             foreground = theme.lockedNodeForeground;
+        }
+        else if (kind !== "activity") {
+            fill = theme.rewardNodeColor;
+            foreground = theme.rewardNodeForeground;
         }
 
         const selectedUnit = width / 8;
@@ -106,8 +106,8 @@ export class GraphNode extends React.Component<GraphNodeProps> {
         return  <g className={`graph-activity ${selected ? "selected" : ""}`} transform={`translate(${position.x} ${position.y})`} onClick={this.handleClick}>
             { selected &&
                 (kind !== "activity" ?
-                    <circle className="highlight" cx={0} cy={0} r={width / 2 + selectedUnit} /> :
-                    <rect className="highlight" x={-width / 2 - selectedUnit} y={-width / 2 - selectedUnit} width={width + 2 * selectedUnit} height={width + 2 * selectedUnit} rx={width / 6} />)
+                    <circle className="highlight" cx={0} cy={0} r={width / 2 + selectedUnit} stroke={theme.selectedStrokeColor} /> :
+                    <rect className="highlight" x={-width / 2 - selectedUnit} y={-width / 2 - selectedUnit} width={width + 2 * selectedUnit} height={width + 2 * selectedUnit} rx={width / 6} stroke={theme.selectedStrokeColor} />)
             }
             { kind !== "activity" ?
                 <circle cx={0} cy={0} r={width / 2} fill={fill} stroke={theme.strokeColor} strokeWidth="2" /> :

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -312,9 +312,10 @@ function isFalse(value: string | undefined) {
 }
 
 function inflateMetadata(section: MarkdownSection): PageMetadata {
-    const tertiary = section.attributes["tertiarycolor"];
     const primary = section.attributes["primarycolor"];
     const secondary = section.attributes["secondarycolor"];
+    const tertiary = section.attributes["tertiarycolor"];
+    const highlight = section.attributes["highlightcolor"];
 
     return {
         title: section.attributes["name"] || section.header,
@@ -326,13 +327,13 @@ function inflateMetadata(section: MarkdownSection): PageMetadata {
             backgroundColor: tertiary || "var(--body-background-color)",
             pathColor: primary || "#BFBFBF",
             strokeColor: "#000000",
-            rewardNodeColor: tertiary || "var(--tertiary-color)",
-            rewardNodeForeground: tertiary ? getContrastingColor(tertiary) : "#000000",
+            rewardNodeColor: highlight || "var(--primary-color)",
+            rewardNodeForeground: highlight ? getContrastingColor(highlight) : "#000000",
             unlockedNodeColor: secondary || "var(--secondary-color)",
             unlockedNodeForeground: secondary ? getContrastingColor(secondary) : "#000000",
             lockedNodeColor: primary || "#BFBFBF",
             lockedNodeForeground: primary ? getContrastingColor(primary) : "#000000",
-            selectedStrokeColor: "var(--hover-color)",
+            selectedStrokeColor: highlight || "var(--primary-color)",
             pathOpacity: 0.5,
         }
     }

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -54,7 +54,7 @@ const initialState: SkillMapState = {
         backgroundColor: "var(--body-background-color)",
         pathColor: "#BFBFBF",
         strokeColor: "#000000",
-        rewardNodeColor: "var(--tertiary-color)",
+        rewardNodeColor: "var(--primary-color)",
         rewardNodeForeground: "#000000",
         unlockedNodeColor: "var(--secondary-color)",
         unlockedNodeForeground: "#000000",

--- a/skillmap/src/styles/graphnode.css
+++ b/skillmap/src/styles/graphnode.css
@@ -1,5 +1,4 @@
 .selected .highlight {
-    stroke: var(--hover-color);
     stroke-width: 4px;
     fill: transparent;
 }

--- a/skillmap/src/styles/infopanel.css
+++ b/skillmap/src/styles/infopanel.css
@@ -43,8 +43,9 @@
     margin-bottom: 0.5rem;
 }
 
+.info-panel-content > .info-panel-title,
 .info-panel-content > .info-panel-label {
-    margin: 1rem 0;
+    margin-bottom: 1rem;
 }
 
 /* Component Styles */


### PR DESCRIPTION
shifting colors around a bit:
- primary: path, locked node 
- secondary: unlocked node
- tertiary: background
- highlight: selected stroke, reward node

exclamation point badge is the color of the reward node (highlight), completed checkmark is the color of the locked nodes (primary)

![image](https://user-images.githubusercontent.com/34112083/110842766-62bba980-825c-11eb-8c9d-898e2a60227a.png)
![image](https://user-images.githubusercontent.com/34112083/110842833-7404b600-825c-11eb-9896-0890275de69c.png)

default settings:
![image](https://user-images.githubusercontent.com/34112083/110842941-98f92900-825c-11eb-9719-ce693e8e0ee4.png)
