### PR TITLE
Sort headers consistently when cloud saved

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -128,7 +128,11 @@ export function getHeaders(withDeleted = false) {
         (withDeleted || !h.isDeleted) &&
         !h.isBackup &&
         (!h.cloudUserId || h.cloudUserId === cloudUserId))
-    r.sort((a, b) => b.recentUse - a.recentUse)
+    r.sort((a, b) => {
+        const aTime = a.cloudUserId ? Math.min(a.cloudLastSyncTime, a.modificationTime) : a.modificationTime
+        const bTime = b.cloudUserId ? Math.min(b.cloudLastSyncTime, b.modificationTime) : b.modificationTime
+        return bTime - aTime
+    })
     return r
 }
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/3232

We used to always sort by "recent use". Instead, we now sort by either the last cloud save time or the modification time.

For non-cloud projects, this is a slight change since we're showing by mod time instead of view time (but I think we agreed on this.)

For cloud projects, the reason we chose the min(lastCloudSave, mod time) is because that is the safest time to show: it'll never show a timestamp beyond when it was last saved so that the user can trust that the timestamp means "it was saved no older than this time".