### PR TITLE
Don't fire editorloaded too early

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -51,6 +51,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     protected nextId: number = 0;
     protected pendingMessages: {[index: string]: any} = {};
     protected isNewActivity: boolean = false;
+    protected sentReloadImportRequest: boolean = false;
 
     constructor(props: MakeCodeFrameProps) {
         super(props);
@@ -69,7 +70,8 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             } as pxt.editor.EditorMessage, true);
         }
 
-        if (this.props.reload === "reload") {
+        if (this.props.reload === "reload" && !this.sentReloadImportRequest) {
+            this.sentReloadImportRequest = true;
             const project = await getProjectAsync(this.props.activityHeaderId!);
             this.sendMessage({
                 type: "pxteditor",

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3688,7 +3688,6 @@ export class ProjectView
                     temporary: temporary
                 }).then(() => autoChooseBoard ? this.autoChooseBoardAsync(features) : Promise.resolve());
             })
-            .then(() => pxt.tickEvent("tutorial.editorLoaded"))
             .catch((e) => {
                 pxt.reportException(e, { tutorialId });
                 core.warningNotification(lf("Please check your internet connection and check the tutorial is valid."));

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -189,6 +189,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     this.loadingXml = false;
                     this.loadingXmlPromise = null;
                     pxt.perf.measureEnd("domUpdate loadBlockly")
+                    // Do Not Remove: This is used by the skillmap
+                    if (this.parent.isTutorial()) pxt.tickEvent("tutorial.editorLoaded")
                 });
         }
     }

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -36,7 +36,11 @@ export class AssetEditor extends Editor {
                 this.updateGalleryAssets();
             })
             .then(() => store.dispatch(dispatchUpdateUserAssets()))
-            .then(() => this.parent.forceUpdate());
+            .then(() => {
+                this.parent.forceUpdate()
+                // Do Not Remove: This is used by the skillmap
+                if (this.parent.isTutorial()) pxt.tickEvent("tutorial.editorLoaded")
+            });
     }
 
     unloadFileAsync(): Promise<void> {

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1444,6 +1444,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 return this.foldFieldEditorRangesAsync()
             }).finally(() => {
                 editorRightArea.removeChild(loading);
+                // Do Not Remove: This is used by the skillmap
+                if (this.parent.isTutorial()) pxt.tickEvent("tutorial.editorLoaded")
             });
     }
 


### PR DESCRIPTION
We use the tutorial.editorLoaded tick event in the skillmap to indicate when it's safe to show the code carryover dialog. We were firing it a little too early, which meant that if you made a choice in that dialog too quickly you could get an error caused by interleaving the load of two projects. Moving that event to later in the lifecycle to make sure the first load is complete.

I also added it in monaco/asset editor but did not test those.