### PR TITLE
Trim asset names during rename

### DIFF
--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -13,7 +13,8 @@ namespace pxt.editor {
 
             const match = pxt.parseAssetTSReference(text);
             if (match) {
-                const { type, name } = match;
+                const { type, name: matchedName } = match;
+                const name = matchedName.trim();
                 const project = pxt.react.getTilemapProject();
                 this.isAsset = true;
                 const asset = project.lookupAssetByName(pxt.AssetType.Image, name);

--- a/webapp/src/components/ImageEditor/BottomBar.tsx
+++ b/webapp/src/components/ImageEditor/BottomBar.tsx
@@ -247,22 +247,25 @@ export class BottomBarImpl extends React.Component<BottomBarProps, BottomBarStat
     protected handleAssetNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         let errorMessage = null;
 
-        if (!pxt.validateAssetName(event.target.value)) {
+        const trimmedName = event.target.value.trim(); // validate using the trimmed name
+        const name = event.target.value;               // but don't trim the state otherwise they won't be able to type spaces
+
+        if (!pxt.validateAssetName(trimmedName)) {
             errorMessage = lf("Names may only contain letters, numbers, '-', '_', and space");
         }
-        else if (isNameTaken(event.target.value) && event.target.value !== this.props.assetName) {
+        else if (isNameTaken(trimmedName) && trimmedName !== this.props.assetName) {
             errorMessage = lf("This name is already used elsewhere in your project");
         }
 
-        this.setState({ assetName: event.target.value, assetNameMessage: errorMessage });
+        this.setState({ assetName: name, assetNameMessage: errorMessage });
     }
 
     protected handleAssetNameBlur = () => {
         const { dispatchChangeAssetName, assetName } = this.props;
 
-        let newName = this.state.assetName;
+        let newName = this.state.assetName.trim();
 
-        if (this.state.assetName !== assetName && pxt.validateAssetName(this.state.assetName) && !isNameTaken(this.state.assetName)) {
+        if (newName !== assetName && pxt.validateAssetName(newName) && !isNameTaken(newName)) {
             dispatchChangeAssetName(newName);
         }
         this.setState({ assetName: null, assetNameMessage: null });


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/3277

We were allowing assets to be saved with leading and trailing whitespace, which caused problems because our lookup function trims whitespace:
https://github.com/microsoft/pxt/blob/master/pxtlib/tilemap.ts#L1370

Now when we validate, lookup or commit an asset name change, we trim whitespace.