### PR TITLE
Add 'x' button to image/tilemap editor top bar, saves & closes

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -98,12 +98,34 @@
     display: flex;
 }
 
+.image-editor-header-left,
+.image-editor-header-right {
+    flex: 1;
+}
+
+.image-editor-header-right {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+
+    & > div {
+        margin-right: 0.5rem;
+    }
+}
+
 .image-editor-gallery-content {
     flex-grow: 1;
     overflow: hidden;
     position: relative;
     height: 100%;
     flex: 9;
+}
+
+.image-editor-close-button {
+    color: @white;
+    font-size: 1.5rem;
+    line-height: 1.5rem;
+    cursor: pointer;
 }
 
 // Tablet + Mobile
@@ -125,6 +147,10 @@
         flex: 3!important;
     }
 
+    .image-editor-header-left {
+        display: none;
+    }
+
     .gallery-editor-toggle {
         margin-left: .25rem!important;
         flex-shrink: 1;
@@ -138,7 +164,6 @@
         flex-shrink: 1;
         width: 2em!important;
         right: .9em!important;
-        margin-right: 0!important;
         justify-content: center!important;
         padding: 0!important;
     }
@@ -287,14 +312,10 @@
 }
 
 .gallery-filter-button {
-    position: absolute;
-    right: 0;
     width: 7em;
     height: 2.25rem;
     cursor: pointer;
     display: flex;
-    margin-right: 2em;
-    margin-top: 0.25rem;
     padding: 0 1em;
     border-radius: 5px;
     background-color: white;

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -106,12 +106,20 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
         return <div className="image-editor-wrapper">
             {showHeader && <div className="gallery-editor-header">
-                <ImageEditorToggle options={toggleOptions} view={currentView} />
-                <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={sui.fireClickOnEnter}>
-                    <div className="gallery-filter-button-icon">
-                        <i className="icon filter" />
+                <div className="image-editor-header-left" />
+                <div className="image-editor-header-center">
+                    <ImageEditorToggle options={toggleOptions} view={currentView} />
+                </div>
+                <div className="image-editor-header-right">
+                    <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={sui.fireClickOnEnter}>
+                        <div className="gallery-filter-button-icon">
+                            <i className="icon filter" />
+                        </div>
+                        <div className="gallery-filter-button-label">{lf("Filter")}</div>
                     </div>
-                    <div className="gallery-filter-button-label">{lf("Filter")}</div>
+                    {!editingTile && <div className="image-editor-close-button" role="button" onClick={this.onDoneClick}>
+                        <i className="ui icon close"/>
+                    </div>}
                 </div>
             </div>}
             <div className="image-editor-gallery-window">


### PR DESCRIPTION
the 'X' button will save the user's progress and close. 

it's fine on desktop/tablet:
![image](https://user-images.githubusercontent.com/34112083/111238930-5e252700-85b5-11eb-839a-0375a5bfb901.png)
![image](https://user-images.githubusercontent.com/34112083/111238935-61201780-85b5-11eb-954c-f32de467e433.png)

pretty tight on mobile though. i could hide the x button entirely here, since they still have the done button at the bottom?
![image](https://user-images.githubusercontent.com/34112083/111238943-667d6200-85b5-11eb-87b1-5fa1d92fd052.png)
