### PR TITLE
Small CSS fixes for skillmap

### DIFF
--- a/skillmap/src/App.css
+++ b/skillmap/src/App.css
@@ -109,6 +109,10 @@ code {
     height: 100%;
 }
 
+.header-org-logo .header-org-logo-small {
+    display: none;
+}
+
 .header i.icon {
     line-height: 2rem;
     cursor: pointer;
@@ -253,5 +257,13 @@ code {
 @media only screen and (max-width: 767px) {
     .header-button .header-button-label {
         display: none;
+    }
+
+    .header-org-logo .header-org-logo-large {
+        display: none;
+    }
+
+    .header-org-logo .header-org-logo-small {
+        display: block;
     }
 }

--- a/skillmap/src/App.css
+++ b/skillmap/src/App.css
@@ -133,7 +133,7 @@ code {
     user-select: none;
 }
 
-.header-button span {
+.header-button .header-button-label {
     line-height: 2rem;
 }
 
@@ -242,5 +242,16 @@ code {
     .usabilla_live_button_container {
         top: 10rem !important;
         bottom: unset !important;
+    }
+}
+
+
+/*******************************/
+/*****     MOBILE VIEW     *****/
+/*******************************/
+
+@media only screen and (max-width: 767px) {
+    .header-button .header-button-label {
+        display: none;
     }
 }

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -77,7 +77,8 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
                 }
                 { items?.length > 0 && <Dropdown icon="setting" className="header-settings" items={items} /> }
                 <div className="header-org-logo">
-                    <img src={resolvePath("assets/microsoft.png")} alt={organizationLogoAlt} />
+                    <img className="header-org-logo-large" src={resolvePath("assets/microsoft.png")} alt={organizationLogoAlt} />
+                    <img className="header-org-logo-small" src={resolvePath("assets/microsoft-square.png")} alt={organizationLogoAlt} />
                 </div>
             </div>
         </div>

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -113,7 +113,7 @@ const HeaderBarButton = (props: HeaderBarButtonProps) => {
 
     return <div className="header-button" title={title} role="button" onClick={onClick}>
         <i className={icon} />
-        <span>{label}</span>
+        <span className="header-button-label">{label}</span>
     </div>
 }
 

--- a/skillmap/src/styles/graphnode.css
+++ b/skillmap/src/styles/graphnode.css
@@ -19,3 +19,12 @@
     font-family: Icons;
     font-size: 1rem;
 }
+
+.graph-activity {
+    cursor: pointer;
+    user-select: none;
+}
+
+.graph-activity:hover .graph-icon, .graph-activity:hover .graph-icon-x {
+    opacity: 0.6;
+}

--- a/skillmap/src/styles/skillgraph.css
+++ b/skillmap/src/styles/skillgraph.css
@@ -19,16 +19,19 @@
 }
 
 .skill-graph-background {
-    display: flex;
     position: absolute;
-    align-items: center;
-    justify-content: center;
     width: 100%;
     height: 100%;
     z-index: var(--graph-backround-zindex);
+    user-select: none;
+    text-align: center;
 }
 
 .skill-graph-background img {
     max-width: 80%;
     max-height: 80%;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3266
Fixes https://github.com/microsoft/pxt-arcade/issues/3267
Requires https://github.com/microsoft/pxt-arcade/pull/3282

Also fixes the skillmap background stretching in Safari (Safari doesn't like it if you put images in flexboxes).

Also includes a bunch of mobile fixes for the header. We still have lots of problems on mobile, but at least the header looks nice now:

<img width="318" alt="Screen Shot 2021-03-15 at 6 12 30 PM" src="https://user-images.githubusercontent.com/13754588/111241364-2cfb2580-85ba-11eb-825e-902848cf51b0.png">
