### PR TITLE
Better height responsiveness for image and tilemap editors

### DIFF
--- a/theme/image-editor/pivot.less
+++ b/theme/image-editor/pivot.less
@@ -6,7 +6,7 @@
     align-content: center;
 
     padding: 0 0.5rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.3rem;
 
     cursor: pointer;
     user-select: none;
@@ -16,7 +16,7 @@
     color: var(--sidebar-icon-inactive-color);
     transition: color 0.1s;
     font-family: sans-serif;
-    padding: .4rem .5rem .2rem;
+    padding: .2rem .5rem .1rem;
 }
 
 .image-editor-pivot-option:hover {

--- a/theme/image-editor/sideBar.less
+++ b/theme/image-editor/sideBar.less
@@ -54,3 +54,28 @@
     height: 100%;
     object-fit: contain;
 }
+
+@media only screen and (max-height: 600px) {
+    .image-editor-sidebar {
+        width: 10rem;
+    }
+
+    .image-editor-tilemap-minimap {
+        display: none;
+    }
+
+    .image-editor-colors {
+        height: 2rem;
+        width: 100%;
+    }
+
+    .image-editor-color-buttons {
+        padding-left: .5rem;
+        padding-top: 0;
+
+        .image-editor-button {
+            width: 2rem;
+            height: 2rem;
+        }
+    }
+}

--- a/theme/image-editor/tilePalette.less
+++ b/theme/image-editor/tilePalette.less
@@ -105,6 +105,7 @@
 .tile-canvas-controls {
     width: 100%;
     text-align: center;
+    margin-top: -0.5rem;
 }
 
 .tile-palette-pages {
@@ -148,7 +149,6 @@
 .tile-canvas {
     width: 100%;
     padding: 0.25rem;
-    margin-top: 0.25rem;
     position: relative;
 }
 

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -139,6 +139,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
 
         if (bounds.height - (verticalPadding * 2) < 610) {
             verticalPadding = Math.min(bounds.height - 610, 0) / 2;
+            verticalPadding = verticalPadding < 0 ? 0 : verticalPadding;
             horizontalPadding = 0;
         }
 

--- a/webapp/src/components/ImageEditor/sprite/Palette.tsx
+++ b/webapp/src/components/ImageEditor/sprite/Palette.tsx
@@ -23,7 +23,7 @@ class PaletteImpl extends React.Component<PaletteProps,{}> {
         const width = 3 * SPACER + 2 * HEIGHT;
 
         return <div>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox={`0 0 ${width} ${HEIGHT * 1.5}`} onClick={dispatchSwapBackgroundForeground}>
+            <svg xmlns="http://www.w3.org/2000/svg" className="image-editor-colors" viewBox={`0 0 ${width} ${HEIGHT * 1.5}`} onClick={dispatchSwapBackgroundForeground}>
                 <defs>
                     <pattern id="alpha-background" width="6" height="6" patternUnits="userSpaceOnUse">
                         <rect x="0" y="0" width="6px" height="6px" fill="#aeaeae" />


### PR DESCRIPTION
Should fix https://github.com/microsoft/pxt-arcade/issues/3130

Improves the vertical reponsiveness for both the image and tilemap editors.

For the image editor, the sidebar now becomes the same width as the tilemap editor sidebar on short screens.

![2021-03-15 19 04 26](https://user-images.githubusercontent.com/13754588/111246737-09d57380-85c4-11eb-846a-72b5b7c45fd4.gif)

For the tilemap editor, shaved off some padding and removed the minimap entirely at mobile-landscape heights.

![2021-03-15 19 20 10](https://user-images.githubusercontent.com/13754588/111246683-f62a0d00-85c3-11eb-90f2-048a0c5cba4b.gif)

