### PR TITLE
Code carries over from most recently completed activity

### DIFF
--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -171,9 +171,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
     renderCodeCarryoverModal() {
         const  { skillMap, activity, pageSourceUrl, userState, dispatchHideModal, dispatchSetReloadHeaderState } = this.props;
         const carryoverModalTitle = lf("Keep code from previous activity?");
-        const carryoverModalText = lf("Do you want to start with your code from {0} \
-            or start fresh with starter code? Your images, tilemaps, \
-            tiles, and animations will stick around either way.");
+        const carryoverModalText = lf("Do you want to start with your code from {0} or start fresh with starter code? Your images, tilemaps, tiles, and animations will stick around either way.");
         const carryoverModalTextSegments = carryoverModalText.split("{0}");
 
         const previousState = lookupPreviousCompletedActivityState(userState!, pageSourceUrl!, skillMap!, activity!.activityId);

--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { ModalType, SkillMapState } from '../store/reducer';
 import { dispatchHideModal, dispatchRestartActivity, dispatchOpenActivity, dispatchResetUser, dispatchSetReloadHeaderState } from '../actions/dispatch';
 import { tickEvent, postAbuseReportAsync, postShareAsync } from "../lib/browserUtils";
-import { lookupActivityProgress } from "../lib/skillMapUtils";
+import { lookupActivityProgress, lookupPreviousCompletedActivityState } from "../lib/skillMapUtils";
 import { carryoverProjectCode } from "../lib/codeCarryover";
 import { getProjectAsync } from "../lib/workspaceProvider";
 
@@ -169,9 +169,17 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
     }
 
     renderCodeCarryoverModal() {
-        const  { dispatchHideModal, skillMap, activity, pageSourceUrl, userState, dispatchSetReloadHeaderState } = this.props;
+        const  { skillMap, activity, pageSourceUrl, userState, dispatchHideModal, dispatchSetReloadHeaderState } = this.props;
         const carryoverModalTitle = lf("Keep code from previous activity?");
-        const carryoverModalText = lf("Do you want to start with your code from the previous activity or start fresh with starter code? Your images, tilemaps, tiles, and animations will stick around either way.");
+        const carryoverModalText = lf("Do you want to start with your code from {0} \
+            or start fresh with starter code? Your images, tilemaps, \
+            tiles, and animations will stick around either way.");
+        const carryoverModalTextSegments = carryoverModalText.split("{0}");
+
+        const previousState = lookupPreviousCompletedActivityState(userState!, pageSourceUrl!, skillMap!, activity!.activityId);
+        const previous = skillMap!.activities[previousState?.activityId];
+
+        if (!previous) return <div />
 
         const actions = [
             { label: lf("START FRESH"), onClick: async () => {
@@ -197,7 +205,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
         ]
 
         return <Modal title={carryoverModalTitle} actions={actions} onClose={this.handleOnClose}>
-            {carryoverModalText}
+            {carryoverModalTextSegments[0]}{<strong>{previous!.displayName}</strong>}{carryoverModalTextSegments[1]}
         </Modal>
     }
 

--- a/skillmap/src/components/InfoPanel.tsx
+++ b/skillmap/src/components/InfoPanel.tsx
@@ -116,7 +116,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
             })
 
             details.push(`${completed}/${total} ${lf("Complete")}`);
-            details.push(`${rewards} ${lf("Rewards")}`)
+            details.push(`${rewards} ${lf("Reward(s)")}`)
         }
     }
 

--- a/skillmap/src/lib/codeCarryover.ts
+++ b/skillmap/src/lib/codeCarryover.ts
@@ -1,4 +1,4 @@
-import { lookupPreviousActivityStates } from "./skillMapUtils";
+import { lookupPreviousCompletedActivityState } from "./skillMapUtils";
 import { getProjectAsync, saveProjectAsync } from "./workspaceProvider";
 
 export async function carryoverProjectCode(user: UserState, pageSource: string, map: SkillMap, activityId: string, carryoverCode: boolean) {
@@ -6,9 +6,8 @@ export async function carryoverProjectCode(user: UserState, pageSource: string, 
 
     const headerId = progress.activityState[activityId]?.headerId;
 
-    const previous = lookupPreviousActivityStates(user, pageSource, map, activityId);
-    const previousHeaderId = previous.find(state => state?.isCompleted &&
-        state.maxSteps === state.currentStep)?.headerId;
+    const previous = lookupPreviousCompletedActivityState(user, pageSource, map, activityId);
+    const previousHeaderId = previous?.headerId;
 
     if (!headerId || !previousHeaderId) return;
 

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -105,6 +105,7 @@ interface ActivityState {
     headerId?: string;
     currentStep?: number;
     maxSteps?: number;
+    completedTime?: number;
 }
 
 interface SkillGraphTheme {

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -124,6 +124,14 @@ export function lookupPreviousActivityStates(user: UserState, pageSource: string
         .filter(a => !!a) as ActivityState[];
 }
 
+// Looks up the most recently completed (user clicked "Finish") parent
+export function lookupPreviousCompletedActivityState(user: UserState, pageSource: string, map: SkillMap, activityId: string) {
+    const previous = lookupPreviousActivityStates(user, pageSource, map, activityId)
+        .filter(state => state?.isCompleted && state.maxSteps === state.currentStep)
+        .sort((a, b) => (b.completedTime || 0) - (a.completedTime || 0));
+    return previous?.[0]
+}
+
 export function flattenRewardNodeChildren(node: MapNode): MapNode[] {
     if (!isRewardNode(node)) {
         return node.next;

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -388,6 +388,7 @@ export function setActivityFinished(user: UserState, pageSource: string, map: Sk
             currentStep: 0
         })
         completedNodes[el].isCompleted = true;
+        completedNodes[el].completedTime = Date.now();
     })
 
     const currentMapProgress = user.mapProgress?.[pageSource] || {};


### PR DESCRIPTION
there's some merge weirdness going on, but here's the carryover pulling from the latest completed activity

fixes https://github.com/microsoft/pxt-arcade/issues/3280