### PR TITLE
Removing edit options from workspace in debug mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.29",
+    "pxt-blockly": "3.0.32",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1208,23 +1208,6 @@ namespace pxt.blocks {
                 if (Blockly.Names.equals(oldName, varField.getText())) {
                     varField.setValue(newName);
                 }
-            },
-            /**
-             * Add menu option to create getter block for loop variable.
-             * @param {!Array} options List of menu options to add to.
-             * @this Blockly.Block
-             */
-            customContextMenu: function (options: any[]) {
-                if (!this.isCollapsed()) {
-                    let option: any = { enabled: true };
-                    option.text = lf("Create 'get {0}'", name);
-                    let xmlField = goog.dom.createDom('field', null, name);
-                    xmlField.setAttribute('name', 'VAR');
-                    let xmlBlock = goog.dom.createDom('block', null, xmlField) as HTMLElement;
-                    xmlBlock.setAttribute('type', 'variables_get');
-                    option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
-                    options.push(option);
-                }
             }
         };
 
@@ -1301,7 +1284,7 @@ namespace pxt.blocks {
              * @this Blockly.Block
              */
             customContextMenu: function (options: any[]) {
-                if (!this.isCollapsed()) {
+                if (!this.isCollapsed() && !this.inDebugWorkspace()) {
                     let option: any = { enabled: true };
                     let name = this.getField('VAR').getText();
                     option.text = lf("Create 'get {0}'", name);
@@ -2225,19 +2208,21 @@ namespace pxt.blocks {
              * @this Blockly.Block
              */
             customContextMenu: function (options: any[]) {
-                let option: any = {
-                    enabled: this.workspace.remainingCapacity() > 0
-                };
+                if (!(this.inDebugWorkspace())) {
+                    let option: any = {
+                        enabled: this.workspace.remainingCapacity() > 0
+                    };
 
-                let name = this.getField("VAR").getText();
-                option.text = lf("Create 'get {0}'", name)
+                    let name = this.getField("VAR").getText();
+                    option.text = lf("Create 'get {0}'", name)
 
-                let xmlField = goog.dom.createDom('field', null, name);
-                xmlField.setAttribute('name', 'VAR');
-                let xmlBlock = goog.dom.createDom('block', null, xmlField);
-                xmlBlock.setAttribute('type', "variables_get");
-                option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
-                options.push(option);
+                    let xmlField = goog.dom.createDom('field', null, name);
+                    xmlField.setAttribute('name', 'VAR');
+                    let xmlBlock = goog.dom.createDom('block', null, xmlField);
+                    xmlBlock.setAttribute('type', "variables_get");
+                    option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
+                    options.push(option);
+                }
             }
         };
 

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1480,10 +1480,13 @@ namespace pxt.blocks {
             let eventGroup = Blockly.utils.genUid();
             let topComments = this.getTopComments();
             let ws = this;
+            const editable = !(this.options.debugMode || this.options.readOnly);
 
             // Option to add a workspace comment.
             if (this.options.comments && !BrowserUtils.isIE()) {
-                options.push(Blockly.ContextMenu.workspaceCommentOption(ws, e));
+                const commentOption = Blockly.ContextMenu.workspaceCommentOption(ws, e) as any;
+                commentOption.enabled = commentOption.enabled && editable;
+                options.push(commentOption);
             }
 
 
@@ -1515,7 +1518,7 @@ namespace pxt.blocks {
 
             const deleteOption = {
                 text: deleteCount == 1 ? msg.DELETE_BLOCK : msg.DELETE_ALL_BLOCKS,
-                enabled: deleteCount > 0,
+                enabled: deleteCount > 0 && editable,
                 callback: () => {
                     pxt.tickEvent("blocks.context.delete", undefined, { interactiveConsent: true });
                     if (deleteCount < 2) {
@@ -1533,7 +1536,7 @@ namespace pxt.blocks {
 
             const formatCodeOption = {
                 text: lf("Format Code"),
-                enabled: true,
+                enabled: editable,
                 callback: () => {
                     pxt.tickEvent("blocks.context.format", undefined, { interactiveConsent: true });
                     pxt.blocks.layout.flow(this, { useViewWidth: true });
@@ -1545,7 +1548,7 @@ namespace pxt.blocks {
                 // Option to collapse all top-level (enabled) blocks
                 const collapseAllOption = {
                     text: lf("Collapse Blocks"),
-                    enabled: topBlocks.length && topBlocks.find((b: Blockly.Block) => b.isEnabled() && !b.isCollapsed()),
+                    enabled: topBlocks.length && topBlocks.find((b: Blockly.Block) => b.isEnabled() && !b.isCollapsed()) && editable,
                     callback: () => {
                         pxt.tickEvent("blocks.context.collapse", undefined, { interactiveConsent: true });
                         pxt.blocks.layout.setCollapsedAll(this, true);
@@ -1556,7 +1559,7 @@ namespace pxt.blocks {
                 // Option to expand all collapsed blocks
                 const expandAllOption = {
                     text: lf("Expand Blocks"),
-                    enabled: topBlocks.length && topBlocks.find((b: Blockly.Block) => b.isEnabled() && b.isCollapsed()),
+                    enabled: topBlocks.length && topBlocks.find((b: Blockly.Block) => b.isEnabled() && b.isCollapsed()) && editable,
                     callback: () => {
                         pxt.tickEvent("blocks.context.expand", undefined, { interactiveConsent: true });
                         pxt.blocks.layout.setCollapsedAll(this, false);


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt-blockly/pull/341
Fixes https://github.com/microsoft/pxt-arcade/issues/3220

Removes the remaining context menu edit options and also the "create get 'var'" option on for-loops which does not work and hasn't ever since we switched it to be draggable. I guess we just never noticed.