### PR TITLE
Only do necessary filtering on gallery to help image editor perf

### DIFF
--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -65,20 +65,26 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         const showGallery = !this.asset || editingTile || this.asset.type !== pxt.AssetType.Tilemap;;
         const showMyAssets = !hideMyAssets && !editingTile;
 
-        if (this.asset && !this.galleryAssets) {
+        if (this.asset && !this.galleryAssets && showGallery) {
             this.updateGalleryAssets();
         }
 
-        let filteredAssets = currentView === "my-assets" ? this.filterAssetsByType(this.userAssets, editingTile ? pxt.AssetType.Tile : this.asset?.type) :
-            this.filterAssetsByType(this.galleryAssets, editingTile ? pxt.AssetType.Tile : this.asset?.type, true, true)
-
         const specialTags = ["tile", "dialog", "background"];
-        const allTags = this.getAvailableTags(filteredAssets, specialTags);
-
-        if (currentView === "gallery") {
-            filteredAssets = this.filterAssetsByTag(filteredAssets);
+        let allTags: string[] = [];
+        let filteredAssets: pxt.Asset[] = [];
+        switch (currentView) {
+            case "my-assets":
+                filteredAssets = this.filterAssetsByType(this.userAssets, editingTile ? pxt.AssetType.Tile : this.asset?.type);
+                allTags = this.getAvailableTags(filteredAssets, specialTags);
+                break;
+            case "gallery":
+                filteredAssets = this.filterAssetsByType(this.galleryAssets, editingTile ? pxt.AssetType.Tile : this.asset?.type, true, true);
+                allTags = this.getAvailableTags(filteredAssets, specialTags);
+                filteredAssets = this.filterAssetsByTag(filteredAssets);
+                break;
+            default:
+                break;
         }
-
 
         const toggleOptions = [{
             label: lf("Editor"),
@@ -309,7 +315,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             return assets;
         }
 
-        if (this.asset) {
+        if (this.asset && !isGallery) {
             assets = assets.map(t => (t.type !== this.asset.type || t.id !== this.asset.id) ? t : assetToGalleryItem(this.getValue()))
 
             if (this.state.editingTile) {
@@ -341,6 +347,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
 
             assets = assets.filter(t => checkInclude(t, includeTags) && checkExclude(t, excludeTags))
         }
+
         function checkInclude(item: pxt.Asset, includeTags: string[]) {
             const tags = item.meta.tags ? item.meta.tags : [];
             return includeTags.every(filterTag => {


### PR DESCRIPTION
the main issue was this line: https://github.com/microsoft/pxt/blob/master/webapp/src/components/ImageFieldEditor.tsx#L316 being run for every asset in the gallery, when that filtering really only needs to happen if you are in the "My Assets" view. i also did a little shifting around so the gallery stuff and general filtering in only called in the relevant views, so if you DID have a ton of very large images in my assets, at least the initial editor load will be fast

build here: https://arcade.makecode.com/app/a3691926ebf6e4f7dd0906e42b21a444a61bbce8-288c818e38

fixes https://github.com/microsoft/pxt-arcade/issues/3269