### PR TITLE
Use pxt-game-maker-guide in stable6.8 instead of reading targetconfig

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -68,7 +68,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
     protected handleHashChange = async (e: HashChangeEvent) => {
         let config = await pxt.targetConfigAsync();
-        let hash = parseHash(window.location.hash || config.skillMap?.defaultPath);
+        let hash = parseHash(window.location.hash || "#github:https://github.com/microsoft/pxt-game-maker-guide");
         this.fetchAndParseSkillMaps(hash.cmd as MarkdownSource, hash.arg);
 
         e.stopPropagation();
@@ -187,7 +187,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         this.unsubscribeChangeListener = store.subscribe(this.onStoreChange);
         this.queryFlags = parseQuery();
         let config = await pxt.targetConfigAsync();
-        let hash = parseHash(window.location.hash || config.skillMap?.defaultPath);
+        let hash = parseHash(window.location.hash || "#github:https://github.com/microsoft/pxt-game-maker-guide");
         await this.initLocalizationAsync();
         this.fetchAndParseSkillMaps(hash.cmd as MarkdownSource, hash.arg);
     }


### PR DESCRIPTION
requires https://github.com/microsoft/pxt/pull/7972

after we merge in these two, i'll bump pxt stable6.8 and pxt-arcade stable1.3, and the http://arcade.makecode.com/v1.3--skillmap url should be pinned to always load the old v1 skillmap 