### PR TITLE
Hide reward text if no rewards present

### DIFF
--- a/skillmap/src/components/InfoPanel.tsx
+++ b/skillmap/src/components/InfoPanel.tsx
@@ -116,7 +116,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
             })
 
             details.push(`${completed}/${total} ${lf("Complete")}`);
-            details.push(`${rewards} ${lf("Reward(s)")}`)
+            details.push(rewards ? `${rewards} ${lf("Reward(s)")}` : "")
         }
     }
 


### PR DESCRIPTION
hide the "# rewards" text if there are no rewards present in the map! otherwise the text shows the total number of rewards

![image](https://user-images.githubusercontent.com/34112083/111544510-cf89e480-8731-11eb-94a3-a1d272ffb0db.png)

fixes https://github.com/microsoft/pxt-arcade/issues/3294