### PR TITLE
[stable6.8] Pin stable V1 skillmap default to pxt-skillmap-sample

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -68,7 +68,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
     protected handleHashChange = async (e: HashChangeEvent) => {
         let config = await pxt.targetConfigAsync();
-        let hash = parseHash(window.location.hash || config.skillMap?.defaultPath);
+        let hash = parseHash(window.location.hash || "github:microsoft/pxt-skillmap-sample/skillmap.md");
         this.fetchAndParseSkillMaps(hash.cmd as MarkdownSource, hash.arg);
 
         e.stopPropagation();
@@ -187,7 +187,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         this.unsubscribeChangeListener = store.subscribe(this.onStoreChange);
         this.queryFlags = parseQuery();
         let config = await pxt.targetConfigAsync();
-        let hash = parseHash(window.location.hash || config.skillMap?.defaultPath);
+        let hash = parseHash(window.location.hash || "github:microsoft/pxt-skillmap-sample/skillmap.md");
         await this.initLocalizationAsync();
         this.fetchAndParseSkillMaps(hash.cmd as MarkdownSource, hash.arg);
     }


### PR DESCRIPTION
Don't read the URL from the targetconfig, so that we can update the default in the targetconfig