### PR TITLE
Skill map V2 instrumentation pass

### DIFF
--- a/skillmap/src/components/ActivityActions.tsx
+++ b/skillmap/src/components/ActivityActions.tsx
@@ -57,12 +57,14 @@ export class ActivityActionsImpl extends React.Component<ActivityActionsProps> {
     }
 
     protected handleRestartButtonClick = () => {
-        const { mapId, activityId, dispatchShowRestartActivityWarning } = this.props;
+        const { mapId, activityId, status, dispatchShowRestartActivityWarning } = this.props;
+        tickEvent("skillmap.sidebar.restart", { path: mapId, activity: activityId, status: status || "" });
         dispatchShowRestartActivityWarning(mapId, activityId);
     }
 
     protected handleShareButtonClick = () => {
-        const { mapId, activityId, dispatchShowShareModal } = this.props;
+        const { mapId, activityId, status, dispatchShowShareModal } = this.props;
+        tickEvent("skillmap.sidebar.share", { path: mapId, activity: activityId, status: status || "" });
         dispatchShowShareModal(mapId, activityId);
     }
 

--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -93,7 +93,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
 
         const actions = [
             { label: this.getRewardText(reward.type),  onClick: () => {
-                tickEvent("skillmap.certificate", { path: mapId });
+                tickEvent("skillmap.reward", { path: mapId, activity: reward.activityId });
                 window.open(reward.url || skillMap.completionUrl);
             } }
         ]
@@ -181,7 +181,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
 
         const actions = [
             { label: lf("START FRESH"), onClick: async () => {
-                tickEvent("skillmap.startfresh");
+                tickEvent("skillmap.startfresh", { path: skillMap!.mapId, activity: activity!.activityId, previousActivity: previous.activityId });
 
                 dispatchSetReloadHeaderState("reloading")
 
@@ -191,7 +191,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
                 dispatchHideModal();
             } },
             { label: lf("KEEP CODE"), onClick: async () => {
-                tickEvent("skillmap.keepcode");
+                tickEvent("skillmap.keepcode", { path: skillMap!.mapId, activity: activity!.activityId, previousActivity: previous.activityId });
 
                 dispatchSetReloadHeaderState("reloading")
 
@@ -209,6 +209,8 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
 
     protected handleShareInputClick = (evt: any) => { evt.target.select() }
     protected handleShareCopyClick = () => {
+        const { mapId, activity } = this.props;
+        tickEvent("skillmap.share.copy", { path: mapId, activity: activity!.activityId });
         const input = document.querySelector(".share-input input") as HTMLInputElement;
         if (input) {
             input.select();
@@ -225,7 +227,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
         if (!data?.shortId) {
             actions.push({ label: lf("Cancel"), onClick: () => this.handleOnClose });
             actions.push({ label: lf("Publish"), onClick: async () => {
-                tickEvent("skillmap.share");
+                tickEvent("skillmap.share", { path: mapId, activity: activity!.activityId });
                 this.setState({ loading: true });
 
                 const progress = lookupActivityProgress(userState!, pageSourceUrl!, mapId!, activity!.activityId);

--- a/skillmap/src/components/RewardActions.tsx
+++ b/skillmap/src/components/RewardActions.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { dispatchOpenActivity, dispatchShowCompletionModal } from '../actions/dispatch';
 
 import { ActivityStatus } from '../lib/skillMapUtils';
+import { tickEvent } from "../lib/browserUtils";
 
 interface OwnProps {
     mapId: string;
@@ -35,6 +36,7 @@ export class RewardActionsImpl extends React.Component<RewardActionsProps> {
             case "locked":
                 break;
             default:
+                tickEvent("skillmap.sidebar.reward", { path: mapId, activity: activityId })
                 return dispatchShowCompletionModal(mapId, activityId)
         }
     }

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -8,6 +8,7 @@ import { GraphPath } from "./GraphPath";
 
 import { getActivityStatus, isActivityUnlocked } from '../lib/skillMapUtils';
 import { SvgCoord, orthogonalGraph } from '../lib/skillGraphUtils';
+import { tickEvent } from "../lib/browserUtils";
 
 interface SvgGraphItem {
     activity: MapActivity;
@@ -81,12 +82,15 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
 
         const { status } = getActivityStatus(user, pageSourceUrl, map, activityId);
         if (kind === "completion" && status === "completed") {
+            tickEvent("skillmap.graph.reward.select", { path: map.mapId, activity: activityId})
             dispatchChangeSelectedItem(map.mapId, activityId);
             dispatchShowCompletionModal(map.mapId, activityId)
         } else {
             if (activityId !== selectedActivityId) {
+                tickEvent("skillmap.graph.item.select", { path: map.mapId, activity: activityId })
                 dispatchChangeSelectedItem(map.mapId, activityId);
             } else {
+                tickEvent("skillmap.graph.item.deselect", { path: map.mapId, activity: activityId })
                 dispatchChangeSelectedItem(undefined);
             }
         }
@@ -108,6 +112,7 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
     componentDidUpdate(props: SkillGraphProps) {
         if (props.completionState === "transitioning") {
             setTimeout(() => {
+                tickEvent("skillmap.graph.reward.auto", { path: props.map.mapId, activity: props.selectedActivityId || "" })
                 props.dispatchSetSkillMapCompleted(props.map.mapId)
                 props.dispatchShowCompletionModal(props.map.mapId, props.selectedActivityId)
             }, 400);


### PR DESCRIPTION
@abchatra @Jaqster Skill map V2 telemetry

`skillmap.sidebar.restart` - Restart button clicked on the sidebar (displays modal -> there's a separate tick for actually restarting)
`skillmap.sidebar.share` - Share button clicked on sidebar (displays modal)
`skillmap.sidebar.reward` - Reward button clicked on sidebar (modal)

`skillmap.reward` - Previously `skillmap.certificate`

`skillmap.share` - "Publish" button clicked in the share dialog
`skillmap.share.copy` - "Copy" button clicked in the share dialog (after publishing)

`skillmap.startfresh` - Start fresh (in the code carryover modal)
`skillmap.keepcode` - Keep code from previous activity

Our previous select/deselect ticks are `skillmap.carousel.item.select` -- I made new ticks for the graph/V2 layout but I can rename these to match the carousel ticks as well if that's better:
`skillmap.graph.reward.select`
`skillmap.graph.item.select`
`skillmap.graph.item.deselect`
`skillmap.graph.reward.auto`

The old ticks for activity start, complete, restart and the header buttons are all the same: https://github.com/microsoft/pxt/pull/7630