### PR TITLE
Mobile image editor toggle icons, hide temp asset warning

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -156,6 +156,10 @@
         flex-shrink: 1;
     }
 
+    .gallery-editor-toggle-label > span {
+        display: none;
+    }
+
     .gallery-filter-button {
         .gallery-filter-button-label {
             display: none !important;
@@ -194,7 +198,7 @@
     background-color: #4572cf;
     border: 2px solid #4067b3;
     border-radius: 5px;
-    width: 19.5rem;
+    width: 24rem;
     margin-top: 0.25rem;
 
     margin-left: auto;
@@ -202,10 +206,10 @@
     cursor: pointer;
 }
 
-
 .gallery-editor-toggle.right {
     .gallery-editor-toggle-handle {
-        transform: translateX(13rem);
+        /* Subtract small margin for rightmost element */
+        transform: translateX(calc(16rem - 0.2rem));
     }
     .gallery-editor-toggle-right {
         color: #4B7BEC;
@@ -214,7 +218,7 @@
 
 .gallery-editor-toggle.center {
     .gallery-editor-toggle-handle {
-        transform: translateX(6.5rem);
+        transform: translateX(8rem);
     }
     .gallery-editor-toggle-center {
         color: #4B7BEC;
@@ -228,7 +232,7 @@
 }
 
 .gallery-editor-toggle.no-gallery {
-    width: 13rem;
+    width: 16rem;
 
     .gallery-editor-toggle-handle {
         width: 50%;
@@ -240,7 +244,7 @@
 
 .gallery-editor-toggle.no-gallery.right {
     .gallery-editor-toggle-handle {
-        transform: translateX(6.5rem);
+        transform: translateX(8rem);
     }
 }
 
@@ -258,12 +262,21 @@
 }
 
 .gallery-editor-toggle-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     flex-basis: 33%;
     text-align: center;
     color: #ffffff;
     z-index: 1;
     transition: color 0.3s;
     user-select: none;
+
+    & > i {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
 }
 
 .gallery-editor-toggle-handle {
@@ -412,6 +425,10 @@
     .asset-editor-card {
         margin: 0.2rem 0 0 0.2rem;
     }
+
+    .asset-editor-card-icon {
+        display: none;
+    }
 }
 
 .image-editor-gallery.visible {
@@ -452,4 +469,36 @@
 
 :root {
     --editor-height: 31rem;
+}
+
+
+// Mobile Only
+@media only screen and (max-width: @largestMobileScreen) {
+    .gallery-editor-toggle {
+        width: 10rem;
+        margin-left: .25rem!important;
+        flex-shrink: 1;
+    }
+
+    .gallery-editor-toggle.no-gallery {
+        width: 6.5rem;
+    }
+
+    .gallery-editor-toggle.right {
+        .gallery-editor-toggle-handle {
+            transform: translateX(6.5rem);
+        }
+    }
+
+    .gallery-editor-toggle.center {
+        .gallery-editor-toggle-handle {
+            transform: translateX(3.25rem);
+        }
+    }
+
+    .gallery-editor-toggle.no-gallery.right {
+        .gallery-editor-toggle-handle {
+            transform: translateX(3.25rem);
+        }
+    }
 }

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -89,14 +89,17 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         const toggleOptions = [{
             label: lf("Editor"),
             view: "editor",
+            icon: "paint brush",
             onClick: this.showEditor
         }, {
             label: lf("Gallery"),
             view: "gallery",
+            icon: "picture",
             onClick: this.showGallery
         }, {
             label: lf("My Assets"),
             view: "my-assets",
+            icon: "folder",
             onClick: this.showMyAssets
         }];
 
@@ -556,6 +559,7 @@ class ImageEditorGallery extends React.Component<ImageEditorGalleryProps, {}> {
 interface ImageEditorToggleOption {
     label: string;
     view: string;
+    icon?: string;
     onClick: () => void;
 }
 
@@ -586,13 +590,16 @@ class ImageEditorToggle extends React.Component<ImageEditorToggleProps> {
 
         return <div className={`gallery-editor-toggle ${toggleClass} ${pxt.BrowserUtils.isEdge() ? "edge" : ""}`}>
             <div className="gallery-editor-toggle-label gallery-editor-toggle-left" onClick={left.onClick} role="button">
-                {left.label}
+                {left.icon && <i className={`ui icon ${left.icon}`} />}
+                <span>{left.label}</span>
             </div>
             {center && <div className="gallery-editor-toggle-label gallery-editor-toggle-center" onClick={center.onClick} role="button">
-                {center.label}
+                {center.icon && <i className={`ui icon ${center.icon}`} />}
+                <span>{center.label}</span>
             </div>}
             <div className="gallery-editor-toggle-label gallery-editor-toggle-right" onClick={right.onClick} role="button">
-                {right.label}
+                {right.icon && <i className={`ui icon ${right.icon}`} />}
+                <span>{right.label}</span>
             </div>
             <div className="gallery-editor-toggle-handle"/>
     </div>


### PR DESCRIPTION
- Add icons to image editor toggle, hide text and use icons in mobile view
- Hide the temp asset warning triangle in the image editor "My Assets" (still visible from asset editor tab) (fixes https://github.com/microsoft/pxt-arcade/issues/3284)

![image](https://user-images.githubusercontent.com/34112083/111705978-c0249d00-87fe-11eb-9a99-3d5a2de98f9c.png)
![image](https://user-images.githubusercontent.com/34112083/111705996-c74bab00-87fe-11eb-8e37-20f8328c65ca.png)

![image](https://user-images.githubusercontent.com/34112083/111705988-c3b82400-87fe-11eb-9eb8-4e4d0f7bae10.png)
