### PR TITLE
Add Immersive Reader for skillmap and recipes, add hover text

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -826,6 +826,14 @@
         background-position: center!important;
     }
 
+    // skillmap embedded tutorials
+    .tutorial.tutorial-embed {
+        .immersive-reader-button.ui.item,
+        .immersive-reader-button.ui.item:focus {
+            background-size: 1.7rem;
+        }
+    }
+
     /* github */
     #githubEditor {
         background-color: @HCbackground !important;

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -33,11 +33,6 @@
     background: @invertedBackground;
 }
 
-#mainmenu .menu {
-    display: flex;
-    align-items: center;
-}
-
 #mainmenu > .menu > .ui.item:hover > .icon {
     transform: scale(1.2);
 }

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -59,6 +59,12 @@
     padding-right: 1.3rem !important;
 }
 
+#mainmenu .tutorial-menu {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .tutorial #tutorialcard {
     position: relative;
     z-index: @tutorialCardZIndex;
@@ -650,12 +656,12 @@ code.lang-filterblocks {
             height: @tutorialEmbedMenuHeight;
             width: 100%;
         }
-        .ui.item {
-            margin-left: auto;
-            margin-right: auto;
-        }
         .ui.item.tutorial-menuitem {
             background: none !important;
+        }
+
+        .immersive-reader-button.ui.item {
+            background-size: 1.7rem;
         }
 
         // In the embedded view, always show the navigation dots even in mobile

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -539,9 +539,6 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const homeEnabled = !lockedEditor && !isController;
         const sandbox = pxt.shell.isSandboxMode();
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
-        const tutorialCardContent = inTutorial ? tutorialOptions.tutorialStepInfo?.[tutorialOptions.tutorialStep].headerContentMd :
-            undefined;
-        const immersiveReaderEnabled = pxt.appTarget.appTheme.immersiveReader;
 
         const activityName = tutorialOptions && tutorialOptions.tutorialActivityInfo ?
             tutorialOptions.tutorialActivityInfo[tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity].name :
@@ -596,7 +593,6 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
             </div>}
             {inTutorial && activityName && <div className="ui item">{activityName}</div>}
             {inTutorial && !hideIteration && <tutorial.TutorialMenu parent={this.props.parent} />}
-            {inTutorial && immersiveReaderEnabled && <ImmersiveReader.ImmersiveReaderButton content={tutorialCardContent} tutorialOptions={tutorialOptions}/>}
             {debugging && !inTutorial ? <sui.MenuItem className="debugger-menu-item centered" icon="large bug" name="Debug Mode" /> : undefined}
             {tsOnly && !sandbox && <sui.MenuItem className="centered" icon="xicon js" name="JavaScript" />}
             {pyOnly && !sandbox && <sui.MenuItem className="centered" icon="xicon python" name="Python" />}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -10,6 +10,7 @@ import * as auth from "./auth";
 import * as identity from "./identity";
 import * as cloudsync from "./cloudsync";
 import * as pkg from "./package";
+import * as ImmersiveReader from "./immersivereader";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -538,6 +539,10 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const homeEnabled = !lockedEditor && !isController;
         const sandbox = pxt.shell.isSandboxMode();
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
+        const tutorialCardContent = inTutorial ? tutorialOptions.tutorialStepInfo?.[tutorialOptions.tutorialStep].headerContentMd :
+            undefined;
+        const immersiveReaderEnabled = pxt.appTarget.appTheme.immersiveReader;
+
         const activityName = tutorialOptions && tutorialOptions.tutorialActivityInfo ?
             tutorialOptions.tutorialActivityInfo[tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity].name :
             null;
@@ -591,6 +596,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
             </div>}
             {inTutorial && activityName && <div className="ui item">{activityName}</div>}
             {inTutorial && !hideIteration && <tutorial.TutorialMenu parent={this.props.parent} />}
+            {inTutorial && immersiveReaderEnabled && <ImmersiveReader.ImmersiveReaderButton content={tutorialCardContent} tutorialOptions={tutorialOptions}/>}
             {debugging && !inTutorial ? <sui.MenuItem className="debugger-menu-item centered" icon="large bug" name="Debug Mode" /> : undefined}
             {tsOnly && !sandbox && <sui.MenuItem className="centered" icon="xicon js" name="JavaScript" />}
             {pyOnly && !sandbox && <sui.MenuItem className="centered" icon="xicon python" name="Python" />}

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -120,6 +120,7 @@ export class ImmersiveReaderButton extends data.Component<ImmersiveReaderProps, 
 
     render() {
         return <div className='immersive-reader-button ui item' onClick={this.buttonClickHandler}
-            aria-label={lf("Launch Immersive Reader")} role="button" onKeyDown={sui.fireClickOnEnter} tabIndex={0}/>
+            aria-label={lf("Launch Immersive Reader")} role="button" onKeyDown={sui.fireClickOnEnter} tabIndex={0}
+            title={lf("Launch Immersive Reader")}/>
     }
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1358,7 +1358,8 @@ class ModalButtonElement extends data.PureComponent<ModalButton, {}> {
             className={`approve ${action.icon ? `icon ${action.labelPosition ? action.labelPosition : 'right'} labeled` : ''} ${action.className || ''} ${action.loading ? "loading disabled" : ""} ${action.disabled ? "disabled" : ""}`}
             onClick={this.handleClick}
             onKeyDown={fireClickOnEnter}
-            ariaLabel={this.props.ariaLabel ? this.props.ariaLabel : this.props.label}/>
+            ariaLabel={this.props.ariaLabel ? this.props.ariaLabel : this.props.label}
+            title={this.props.title}/>
     }
 }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -100,15 +100,24 @@ export class TutorialMenu extends data.Component<ISettingsProps, {}> {
 
     renderCore() {
         let tutorialOptions = this.props.parent.state.tutorialOptions;
+        const tutorialCardContent = tutorialOptions.tutorialStepInfo?.[tutorialOptions.tutorialStep].headerContentMd
+        const immersiveReaderEnabled = pxt.appTarget.appTheme.immersiveReader;
 
         if (this.hasActivities) {
-            return <TutorialStepCircle parent={this.props.parent} />;
+            return <div className="menu tutorial-menu">
+                <TutorialStepCircle parent={this.props.parent} />
+                {immersiveReaderEnabled && <ImmersiveReader.ImmersiveReaderButton content={tutorialCardContent} tutorialOptions={tutorialOptions}/>}
+            </div>;
         } else if (tutorialOptions.tutorialStepInfo.length < 8) {
-            return <TutorialMenuItem parent={this.props.parent} />;
+            return <div className="menu tutorial-menu">
+                <TutorialMenuItem parent={this.props.parent} />
+                {immersiveReaderEnabled && <ImmersiveReader.ImmersiveReaderButton content={tutorialCardContent} tutorialOptions={tutorialOptions}/>}
+            </div>;
         } else {
-            return <div className="menu">
+            return <div className="menu tutorial-menu">
                 <TutorialMenuItem parent={this.props.parent} className="mobile hide" />
                 <TutorialStepCircle parent={this.props.parent} className="mobile only" />
+                {immersiveReaderEnabled && <ImmersiveReader.ImmersiveReaderButton content={tutorialCardContent} tutorialOptions={tutorialOptions}/>}
             </div>
         }
     }
@@ -299,7 +308,8 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
                 actions.push({
                     className: "immersive-reader-button",
                     onclick: () => {ImmersiveReader.launchImmersiveReader(fullText, options)},
-                    ariaLabel: lf("Launch Immersive Reader")
+                    ariaLabel: lf("Launch Immersive Reader"),
+                    title: lf("Launch Immersive Reader")
                 })
             }
             actions.push({

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -100,8 +100,6 @@ export class TutorialMenu extends data.Component<ISettingsProps, {}> {
 
     renderCore() {
         let tutorialOptions = this.props.parent.state.tutorialOptions;
-        const tutorialCardContent = tutorialOptions.tutorialStepInfo?.[tutorialOptions.tutorialStep].headerContentMd
-        const immersiveReaderEnabled = pxt.appTarget.appTheme.immersiveReader;
 
         if (this.hasActivities) {
             return <TutorialStepCircle parent={this.props.parent} />;
@@ -111,8 +109,6 @@ export class TutorialMenu extends data.Component<ISettingsProps, {}> {
             return <div className="menu">
                 <TutorialMenuItem parent={this.props.parent} className="mobile hide" />
                 <TutorialStepCircle parent={this.props.parent} className="mobile only" />
-
-                {immersiveReaderEnabled && <ImmersiveReader.ImmersiveReaderButton content={tutorialCardContent} tutorialOptions={tutorialOptions}/>}
             </div>
         }
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3317 tooltip says "Launch Immersive Reader"

uploadtrg! https://arcade.makecode.com/app/2bf8ddd106e873c066702f4ea6e3ee00aca4b2e5-72e4c2c947


skillmap:
![skillmap](https://user-images.githubusercontent.com/18712271/111740964-e79d5900-8842-11eb-9f22-d84e51dde549.gif)

recipe:
![recipe](https://user-images.githubusercontent.com/18712271/111741061-10255300-8843-11eb-8f7f-9993b2e7530f.gif)

ALSO fixes this bug, sorry guys >>
![image](https://user-images.githubusercontent.com/18712271/111740932-d9e7d380-8842-11eb-972e-e0b0da1498ff.png)
