### PR TITLE
more immersive reader beautification

### DIFF
--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -15,7 +15,13 @@ export type ImmersiveReaderToken = {
 }
 
 function beautifyText(content: string): string {
-    const cleaningFuncs = [cleanImages, cleanBlockAnnotation, cleanBold];
+    const cleaningFuncs = [
+        cleanImages,
+        cleanBlockAnnotation,
+        cleanBold,
+        cleanHorizontalRule,
+        cleanNewLines,
+    ];
     let contentWIP = content;
 
     cleaningFuncs.forEach(clean => {
@@ -24,31 +30,44 @@ function beautifyText(content: string): string {
 
     return contentWIP;
 
-    // Change ``|| around blocks to {}
+    // Change ``|| around blocks to ""
     function cleanBlockAnnotation(content: string): string {
-        const blockLiteral = /``\|\|([\w|\s]+:[\w|\s]+)\|\|``/
-        const blockRegex = new RegExp(blockLiteral, "g");
-        const blocksRemoved = content.replace(blockRegex, (matched, word, offset, s) => {
-            return "{" + word + "}";
-        })
-        return blocksRemoved;
+        return content.replace(
+            /`?`\|\|[\w|\s]+:(.+?)\|\|``?/gu,
+            (matched, word, offset, s) => lf("\"{0}\"", word)
+        );
     }
 
     // Don't show any images
     function cleanImages(content: string): string {
-        const imageRegEx = /(!\[.*\]\(.*\))/g;
-        const imagesRemoved = content.replace(imageRegEx, "");
-        return imagesRemoved;
+        return content.replace(
+            /(!\w*\[[^\]]*\]\w*\([^)]*\))/gu,
+            ""
+        );
     }
 
     // Remove ** around bold text, replace with "
     function cleanBold(content: string): string {
-        const boldLiteral = /\*\*([\w|\s]+)\*\*/
-        const boldRegex = new RegExp(boldLiteral, "g");
-        const boldRemoved = content.replace(boldRegex, (matched, word, offset, s) => {
-            return "\"" + word + "\""
-        })
-        return boldRemoved;
+        return content.replace(
+            /\*\*([^*]+)\*\*/gu,
+            (matched, word, offset, s) => lf("\"{0}\"", word)
+        );
+    }
+
+    // replace horizontal rules with new lines
+    function cleanHorizontalRule(content: string): string {
+        return content.replace(
+            /^\* \* \*$/gum,
+            "- - -"
+        );
+    }
+
+    // replace new lines with break tags so that they don't get smooshed
+    function cleanNewLines(content: string): string {
+        return content.replace(
+            /[\r\n]+/gum,
+            `<br />`
+        );
     }
 }
 

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -62,10 +62,10 @@ function beautifyText(content: string): string {
         );
     }
 
-    // replace new lines with break tags so that they don't get smooshed
+    // replace consecutive new lines with break tags so that they don't get smooshed
     function cleanNewLines(content: string): string {
         return content.replace(
-            /[\r\n]+/gum,
+            /[\r\n]{2,}/gum,
             `<br />`
         );
     }


### PR DESCRIPTION
My sister-in-law came over so I had her check over chase the pizza in japanese, and these are mainly changes to accommodate / fix that -- had to do a few before hand to get it to to a testable state in japanese as some of the snippets weren't showing up properly. She said the immersive reader experience in japanese was good / made sense ~ (also included one or two small things I noticed while waiting for builds / looking at galga)

Here's a build https://arcade.makecode.com/app/d3e0f1ceb8df0f341f308138eff658bc9052a990-2daf2fa76b

(@livcheerful feel free to change anything or tell me to change anything at your judgement for the replacements~)

* For block snippet replacements, the {} really stood out / didn't make any sense to her. Swapped that with quotation marks, and removed the `namespace:` portion as that's just hinting for our blocks styling / shouldn't be translated so it also stands out (and it doesn't get read out in the typical hints either as it is intended to map to the toolbox color).
* block snippets and images; relax the match a bit to allow more characters -- handle replacements when there is only one \` on block snippets, allow spaces as the markdown replacements for images is fairly generous, and also allow non-space / latin characters (e.g. plus symbol, foreign language characters, emoji that are used to imitate the blocks)
* horizontal rules become `* * *`, so swap them to `- - -` which looks a bit more like a line break (I thought the `* * *` was a misparsed italic or bold at first)
* replace new lines with break tags so they don't get smooshed to all be on same line.
* Lf the quotations marks, as they can be different on a langauge to language basis

Probably should handle normal links and the 'hover tooltip' links as they stand out, but I didn't look at that too much