### PR TITLE
Separate live updates from unapproved translations for md

### DIFF
--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -57,6 +57,7 @@ namespace ts.pxtc.Util {
     //let _didSetlocalizations = false;
     //let _didReportLocalizationsNotSet = false;
     export let localizeLive = false;
+    export let fetchLiveTranslations = false;
 
     /**
      * Returns the current user language, prepended by "live-" if in live mode

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -70,7 +70,7 @@ namespace ts.pxtc.Util {
      * Returns the current user language, prepended by "live-" if in live mode
      */
     export function localeInfo(): string {
-        return userLanguage();
+        return `${localizeLive ? "live-" : ""}${userLanguage()}`;
     }
     /**
      * Returns current user language iSO-code. Default is `en`.

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -56,14 +56,30 @@ namespace ts.pxtc.Util {
     let _translationsCache: pxt.Map<pxt.Map<string>> = {};
     //let _didSetlocalizations = false;
     //let _didReportLocalizationsNotSet = false;
-    export let localizeLive = false;
-    export let fetchLiveTranslations = false;
+    let localizeLive = false;
+    let allowUnapprovedTranslations = false;
+
+    export function enableLiveLocalizationUpdates() {
+        localizeLive = true;
+    }
+
+    export function liveLocalizationEnabled() {
+        return localizeLive;
+    }
+
+    export function enableUnapprovedTranslations() {
+        allowUnapprovedTranslations = true;
+    }
+
+    export function unapprovedTranslationsEnabled() {
+        return allowUnapprovedTranslations;
+    }
 
     /**
      * Returns the current user language, prepended by "live-" if in live mode
      */
     export function localeInfo(): string {
-        return `${localizeLive ? "live-" : ""}${userLanguage()}`;
+        return `${allowUnapprovedTranslations ? "live-" : ""}${userLanguage()}`;
     }
     /**
      * Returns current user language iSO-code. Default is `en`.

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -57,7 +57,6 @@ namespace ts.pxtc.Util {
     //let _didSetlocalizations = false;
     //let _didReportLocalizationsNotSet = false;
     let localizeLive = false;
-    let allowUnapprovedTranslations = false;
 
     export function enableLiveLocalizationUpdates() {
         localizeLive = true;
@@ -67,19 +66,11 @@ namespace ts.pxtc.Util {
         return localizeLive;
     }
 
-    export function enableUnapprovedTranslations() {
-        allowUnapprovedTranslations = true;
-    }
-
-    export function unapprovedTranslationsEnabled() {
-        return allowUnapprovedTranslations;
-    }
-
     /**
      * Returns the current user language, prepended by "live-" if in live mode
      */
     export function localeInfo(): string {
-        return `${allowUnapprovedTranslations ? "live-" : ""}${userLanguage()}`;
+        return userLanguage();
     }
     /**
      * Returns current user language iSO-code. Default is `en`.

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -119,7 +119,7 @@ namespace pxt.Cloud {
     const FORCE_MARKDOWN_UPDATE = MARKDOWN_EXPIRATION * 24 * 7;
     export async function markdownAsync(docid: string, locale?: string): Promise<string> {
         locale = locale || pxt.Util.userLanguage();
-        const fetchUnapproved = pxt.Util.fetchLiveTranslations;
+        const fetchUnapproved = pxt.Util.unapprovedTranslationsEnabled();
         const branch = "";
 
         const db = await pxt.BrowserUtils.translationDbAsync();

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -119,7 +119,6 @@ namespace pxt.Cloud {
     const FORCE_MARKDOWN_UPDATE = MARKDOWN_EXPIRATION * 24 * 7;
     export async function markdownAsync(docid: string, locale?: string): Promise<string> {
         locale = locale || pxt.Util.userLanguage();
-        const fetchUnapproved = pxt.Util.unapprovedTranslationsEnabled();
         const branch = "";
 
         const db = await pxt.BrowserUtils.translationDbAsync();
@@ -127,7 +126,7 @@ namespace pxt.Cloud {
 
         const downloadAndSetMarkdownAsync = async () => {
             try {
-                const r = await downloadMarkdownAsync(docid, locale, fetchUnapproved, entry?.etag);
+                const r = await downloadMarkdownAsync(docid, locale, entry?.etag);
                 await db.setAsync(locale, docid, branch, r.etag, undefined, r.md || entry?.md);
                 return r.md;
             } catch {
@@ -160,7 +159,7 @@ namespace pxt.Cloud {
         return downloadAndSetMarkdownAsync();
     }
 
-    function downloadMarkdownAsync(docid: string, locale?: string, fetchUnapproved?: boolean, etag?: string): Promise<{ md: string; etag?: string; }> {
+    function downloadMarkdownAsync(docid: string, locale?: string, etag?: string): Promise<{ md: string; etag?: string; }> {
         const packaged = pxt.webConfig?.isStatic;
         const targetVersion = pxt.appTarget.versions && pxt.appTarget.versions.target || '?';
         let url: string;
@@ -181,7 +180,6 @@ namespace pxt.Cloud {
         }
         if (!packaged && locale != "en") {
             url += `&lang=${encodeURIComponent(locale)}`
-            if (fetchUnapproved) url += "&live=1";
         }
         if (pxt.BrowserUtils.isLocalHost() && !pxt.Util.liveLocalizationEnabled()) {
             return localRequestAsync(url).then(resp => {

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -119,7 +119,7 @@ namespace pxt.Cloud {
     const FORCE_MARKDOWN_UPDATE = MARKDOWN_EXPIRATION * 24 * 7;
     export async function markdownAsync(docid: string, locale?: string): Promise<string> {
         locale = locale || pxt.Util.userLanguage();
-        const live = pxt.Util.localizeLive;
+        const fetchUnapproved = pxt.Util.fetchLiveTranslations;
         const branch = "";
 
         const db = await pxt.BrowserUtils.translationDbAsync();
@@ -127,7 +127,7 @@ namespace pxt.Cloud {
 
         const downloadAndSetMarkdownAsync = async () => {
             try {
-                const r = await downloadMarkdownAsync(docid, locale, live, entry?.etag);
+                const r = await downloadMarkdownAsync(docid, locale, fetchUnapproved, entry?.etag);
                 await db.setAsync(locale, docid, branch, r.etag, undefined, r.md || entry?.md);
                 return r.md;
             } catch {
@@ -160,7 +160,7 @@ namespace pxt.Cloud {
         return downloadAndSetMarkdownAsync();
     }
 
-    function downloadMarkdownAsync(docid: string, locale?: string, live?: boolean, etag?: string): Promise<{ md: string; etag?: string; }> {
+    function downloadMarkdownAsync(docid: string, locale?: string, fetchUnapproved?: boolean, etag?: string): Promise<{ md: string; etag?: string; }> {
         const packaged = pxt.webConfig?.isStatic;
         const targetVersion = pxt.appTarget.versions && pxt.appTarget.versions.target || '?';
         let url: string;
@@ -181,16 +181,16 @@ namespace pxt.Cloud {
         }
         if (!packaged && locale != "en") {
             url += `&lang=${encodeURIComponent(locale)}`
-            if (live) url += "&live=1"
+            if (fetchUnapproved) url += "&live=1";
         }
-        if (pxt.BrowserUtils.isLocalHost() && !live)
+        if (pxt.BrowserUtils.isLocalHost() && !fetchUnapproved) {
             return localRequestAsync(url).then(resp => {
                 if (resp.statusCode == 404)
                     return privateRequestAsync({ url, method: "GET" })
                         .then(resp => { return { md: resp.text, etag: <string>resp.headers["etag"] }; });
                 else return { md: resp.text, etag: undefined };
             });
-        else {
+        } else {
             const headers: pxt.Map<string> = etag && !useCdnApi() ? { "If-None-Match": etag } : undefined;
             return apiRequestWithCdnAsync({ url, method: "GET", headers })
                 .then(resp => { return { md: resp.text, etag: <string>resp.headers["etag"] }; });

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -183,7 +183,7 @@ namespace pxt.Cloud {
             url += `&lang=${encodeURIComponent(locale)}`
             if (fetchUnapproved) url += "&live=1";
         }
-        if (pxt.BrowserUtils.isLocalHost() && !fetchUnapproved) {
+        if (pxt.BrowserUtils.isLocalHost() && !pxt.Util.liveLocalizationEnabled()) {
             return localRequestAsync(url).then(resp => {
                 if (resp.statusCode == 404)
                     return privateRequestAsync({ url, method: "GET" })

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -844,7 +844,7 @@ namespace pxt {
                 return Promise.resolve(r);
 
             // live loc of bundled packages
-            if (pxt.Util.localizeLive && this.id != "this" && pxt.appTarget.bundledpkgs[this.id]) {
+            if (pxt.Util.liveLocalizationEnabled() && this.id != "this" && pxt.appTarget.bundledpkgs[this.id]) {
                 pxt.debug(`loading live translations for ${this.id}`)
                 return Promise.all(filenames.map(
                     fn => pxt.Util.downloadLiveTranslationsAsync(lang, `${targetId}/${fn}-strings.json`, theme.crowdinBranch)

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1044,10 +1044,9 @@ namespace ts.pxtc.Util {
         // hitting the cloud
         function downloadFromCloudAsync(strings?: pxt.Map<string>) {
             pxt.debug(`downloading translations for ${lang} ${filename} ${branch || ""}`);
-            const approvedOnly = !pxt.Util.unapprovedTranslationsEnabled();
             let host = pxt.BrowserUtils.isLocalHost() || pxt.webConfig.isStatic ? "https://makecode.com/api/" : ""
             // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
-            let url = `${host}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=${approvedOnly}`;
+            let url = `${host}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
             if (branch) url += '&branch=' + encodeURIComponent(branch);
             const headers: pxt.Map<string> = {};
             if (etag && !pxt.Cloud.useCdnApi()) headers["If-None-Match"] = etag;

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1183,9 +1183,7 @@ namespace ts.pxtc.Util {
         code: string;
         pxtBranch: string;
         targetBranch: string;
-        updateStrings?: boolean;
         force?: boolean;
-        fetchUnapproved?: boolean;
     }
 
     export function updateLocalizationAsync(opts: LocalizationUpdateOptions): Promise<void> {
@@ -1194,9 +1192,7 @@ namespace ts.pxtc.Util {
             baseUrl,
             pxtBranch,
             targetBranch,
-            updateStrings,
             force,
-            fetchUnapproved,
         } = opts;
         let { code } = opts;
         code = normalizeLanguageCode(code)[0];
@@ -1207,27 +1203,22 @@ namespace ts.pxtc.Util {
             return Promise.resolve();
         }
 
-        if (fetchUnapproved) {
-            Util.fetchLiveTranslations = true;
-        }
-
         pxt.debug(`loc: ${code}`);
+
+        const liveUpdateStrings = pxt.Util.liveLocalizationEnabled()
         return downloadTranslationsAsync(targetId, baseUrl, code,
-            pxtBranch, targetBranch, updateStrings,
+            pxtBranch, targetBranch, liveUpdateStrings,
             ts.pxtc.Util.TranslationsKind.Editor)
             .then((translations) => {
                 if (translations) {
                     setUserLanguage(code);
                     setLocalizedStrings(translations);
-                    if (updateStrings) {
-                        localizeLive = true;
-                    }
                 }
 
                 // Download api translations
-                return !updateStrings ? ts.pxtc.Util.downloadTranslationsAsync(
+                return liveUpdateStrings ? ts.pxtc.Util.downloadTranslationsAsync(
                     targetId, baseUrl, code,
-                    pxtBranch, targetBranch, updateStrings,
+                    pxtBranch, targetBranch, liveUpdateStrings,
                     ts.pxtc.Util.TranslationsKind.Apis)
                     .then(trs => {
                         if (trs)

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1044,9 +1044,10 @@ namespace ts.pxtc.Util {
         // hitting the cloud
         function downloadFromCloudAsync(strings?: pxt.Map<string>) {
             pxt.debug(`downloading translations for ${lang} ${filename} ${branch || ""}`);
+            const approvedOnly = !pxt.Util.unapprovedTranslationsEnabled();
             let host = pxt.BrowserUtils.isLocalHost() || pxt.webConfig.isStatic ? "https://makecode.com/api/" : ""
             // https://pxt.io/api/translations?filename=strings.json&lang=pl&approved=true&branch=v0
-            let url = `${host}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=true`;
+            let url = `${host}translations?lang=${encodeURIComponent(lang)}&filename=${encodeURIComponent(filename)}&approved=${approvedOnly}`;
             if (branch) url += '&branch=' + encodeURIComponent(branch);
             const headers: pxt.Map<string> = {};
             if (etag && !pxt.Cloud.useCdnApi()) headers["If-None-Match"] = etag;

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1216,14 +1216,14 @@ namespace ts.pxtc.Util {
                 }
 
                 // Download api translations
-                return liveUpdateStrings ? ts.pxtc.Util.downloadTranslationsAsync(
+                return ts.pxtc.Util.downloadTranslationsAsync(
                     targetId, baseUrl, code,
                     pxtBranch, targetBranch, liveUpdateStrings,
                     ts.pxtc.Util.TranslationsKind.Apis)
                     .then(trs => {
                         if (trs)
                             ts.pxtc.apiLocalizationStrings = trs;
-                    }) : Promise.resolve();
+                    });
             });
     }
 

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -207,31 +207,37 @@ namespace pxt.runner {
         Util.assert(!!pxt.appTarget);
 
         const href = window.location.href;
-        let live = false;
+        let updateStrings = false;
+        let fetchUnapproved = false;
         let force = false;
         let lang: string = undefined;
         if (/[&?]translate=1/.test(href) && !pxt.BrowserUtils.isIE()) {
             lang = ts.pxtc.Util.TRANSLATION_LOCALE;
-            live = true;
+            updateStrings = true;
             force = true;
+            fetchUnapproved = true;
         } else {
             const cookieValue = /PXT_LANG=(.*?)(?:;|$)/.exec(document.cookie);
             const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(href);
             lang = mlang ? mlang[3] : (cookieValue && cookieValue[1] || pxt.appTarget.appTheme.defaultLocale || (navigator as any).userLanguage || navigator.language);
-            live = !pxt.appTarget.appTheme.disableLiveTranslations || (mlang && !!mlang[1]);
+            fetchUnapproved = !!mlang?.[1]
+            updateStrings = !pxt.appTarget.appTheme.disableLiveTranslations || fetchUnapproved;
             force = !!mlang && !!mlang[2];
         }
         const versions = pxt.appTarget.versions;
 
         patchSemantic();
         const cfg = pxt.webConfig
-        return Util.updateLocalizationAsync(
-            pxt.appTarget.id,
-            cfg.commitCdnUrl, lang,
-            versions ? versions.pxtCrowdinBranch : "",
-            versions ? versions.targetCrowdinBranch : "",
-            live,
-            force)
+        return Util.updateLocalizationAsync({
+                targetId: pxt.appTarget.id,
+                baseUrl: cfg.commitCdnUrl,
+                code: lang,
+                pxtBranch: versions ? versions.pxtCrowdinBranch : "",
+                targetBranch: versions ? versions.targetCrowdinBranch : "",
+                updateStrings: updateStrings,
+                force: force,
+                fetchUnapproved: fetchUnapproved
+            })
             .then(() => {
                 mainPkg = new pxt.MainPackage(new Host());
             })
@@ -501,14 +507,16 @@ namespace pxt.runner {
         editorLanguageMode = mode;
         if (localeInfo != pxt.Util.localeInfo()) {
             const localeLiveRx = /^live-/;
-            return pxt.Util.updateLocalizationAsync(
-                pxt.appTarget.id,
-                pxt.webConfig.commitCdnUrl,
-                localeInfo.replace(localeLiveRx, ''),
-                pxt.appTarget.versions.pxtCrowdinBranch,
-                pxt.appTarget.versions.targetCrowdinBranch,
-                localeLiveRx.test(localeInfo)
-            );
+            const fetchLive = localeLiveRx.test(localeInfo);
+            return pxt.Util.updateLocalizationAsync({
+                targetId: pxt.appTarget.id,
+                baseUrl: pxt.webConfig.commitCdnUrl,
+                code: localeInfo.replace(localeLiveRx, ''),
+                pxtBranch: pxt.appTarget.versions.pxtCrowdinBranch,
+                targetBranch: pxt.appTarget.versions.targetCrowdinBranch,
+                updateStrings: fetchLive,
+                fetchUnapproved: fetchLive,
+            });
         }
 
         return Promise.resolve();

--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -213,15 +213,12 @@ namespace pxt.runner {
             lang = ts.pxtc.Util.TRANSLATION_LOCALE;
             force = true;
             pxt.Util.enableLiveLocalizationUpdates();
-            pxt.Util.enableUnapprovedTranslations();
         } else {
             const cookieValue = /PXT_LANG=(.*?)(?:;|$)/.exec(document.cookie);
             const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(href);
             lang = mlang ? mlang[3] : (cookieValue && cookieValue[1] || pxt.appTarget.appTheme.defaultLocale || (navigator as any).userLanguage || navigator.language);
-            if (!!mlang?.[1]) {
-                pxt.Util.enableUnapprovedTranslations();
-            }
-            if (!pxt.appTarget.appTheme.disableLiveTranslations || pxt.Util.unapprovedTranslationsEnabled()) {
+
+            if (!pxt.appTarget.appTheme.disableLiveTranslations || !!mlang?.[1]) {
                 pxt.Util.enableLiveLocalizationUpdates();
             }
             force = !!mlang && !!mlang[2];
@@ -509,7 +506,6 @@ namespace pxt.runner {
             const localeLiveRx = /^live-/;
             const fetchLive = localeLiveRx.test(localeInfo);
             if (fetchLive) {
-                pxt.Util.enableUnapprovedTranslations();
                 pxt.Util.enableLiveLocalizationUpdates();
             }
 

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -110,14 +110,10 @@ class AppImpl extends React.Component<AppProps, AppState> {
         let useLang: string | undefined = undefined;
         if (/[&?]translate=1/.test(href) && !pxt.BrowserUtils.isIE()) {
             useLang = ts.pxtc.Util.TRANSLATION_LOCALE;
-            pxt.Util.enableUnapprovedTranslations();
         } else {
             const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
             if (mlang && window.location.hash.indexOf(mlang[0]) >= 0) {
                 pxt.BrowserUtils.changeHash(window.location.hash.replace(mlang[0], ""));
-            }
-            if (!!mlang?.[1]) {
-                pxt.Util.enableUnapprovedTranslations();
             }
             useLang = mlang ? mlang[3] : (pxt.BrowserUtils.getCookieLang() || theme.defaultLocale || (navigator as any).userLanguage || navigator.language);
             force = !!mlang && !!mlang[2];

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4770,7 +4770,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
                 const locstatic = /staticlang=1/i.test(window.location.href);
                 const stringUpdateDisabled = locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations;
-                updateStrings = !stringUpdateDisabled && requestLive;
+                updateStrings = !stringUpdateDisabled || requestLive;
                 force = requestedForce;
                 fetchUnapproved = requestLive;
             }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4752,7 +4752,6 @@ document.addEventListener("DOMContentLoaded", () => {
             if (/[&?]translate=1/.test(href) && !pxt.BrowserUtils.isIE()) {
                 console.log(`translation mode`);
                 force = true;
-                pxt.Util.enableUnapprovedTranslations();
                 pxt.Util.enableLiveLocalizationUpdates();
                 useLang = ts.pxtc.Util.TRANSLATION_LOCALE;
             } else {
@@ -4766,9 +4765,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 const cookieLang = pxt.BrowserUtils.getCookieLang()
                 // chose the user's language using the following ordering:
                 useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
-                if (requestLive) {
-                    pxt.Util.enableUnapprovedTranslations();
-                }
+
                 const locstatic = /staticlang=1/i.test(window.location.href);
                 const stringUpdateDisabled = locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations;
                 if (!stringUpdateDisabled || requestLive) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4737,10 +4737,11 @@ document.addEventListener("DOMContentLoaded", () => {
     Promise.resolve()
         .then(async () => {
             const href = window.location.href;
-            let live = false;
+            let updateStrings = false;
+            let fetchUnapproved = false;
             let force = false;
             const cloudLang = auth.getState()?.preferences?.language;
-            // kick of a user preferences check; if the language is different we'll reload
+            // kick of a user preferences check; if the language is different we'll request they reload
             auth.initialUserPreferences().then((pref) => {
                 const cookieLang = pxt.BrowserUtils.getCookieLang()
                 if (cookieLang && pref && pref.language != cookieLang) {
@@ -4752,47 +4753,54 @@ document.addEventListener("DOMContentLoaded", () => {
             let useLang: string = undefined;
             if (/[&?]translate=1/.test(href) && !pxt.BrowserUtils.isIE()) {
                 console.log(`translation mode`);
-                live = force = true;
+                force = true;
+                updateStrings = true;
+                fetchUnapproved = true;
                 useLang = ts.pxtc.Util.TRANSLATION_LOCALE;
             } else {
                 const hashLangMatch = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
                 if (hashLangMatch && window.location.hash.indexOf(hashLangMatch[0]) >= 0) {
                     pxt.BrowserUtils.changeHash(window.location.hash.replace(hashLangMatch[0], ""));
                 }
+                const requestLive = !!hashLangMatch?.[1];
+                const requestedForce = !!hashLangMatch?.[2];
                 const hashLang = hashLangMatch?.[3];
                 const cookieLang = pxt.BrowserUtils.getCookieLang()
                 // chose the user's language using the following ordering:
                 useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
                 const locstatic = /staticlang=1/i.test(window.location.href);
-                const liveDisabled = locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations;
-                live = !liveDisabled && !!hashLangMatch?.[1];
-                force = !!hashLangMatch?.[2];
+                const stringUpdateDisabled = locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations;
+                updateStrings = !stringUpdateDisabled && requestLive;
+                force = requestedForce;
+                fetchUnapproved = requestLive;
             }
             const targetId = pxt.appTarget.id;
             const baseUrl = config.commitCdnUrl;
             const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;
             const targetBranch = pxt.appTarget.versions.targetCrowdinBranch;
-            return Util.updateLocalizationAsync(
-                targetId,
-                baseUrl,
-                useLang,
-                pxtBranch,
-                targetBranch,
-                live,
-                force)
-                .then(() => {
+
+            return Util.updateLocalizationAsync({
+                    targetId: targetId,
+                    baseUrl: baseUrl,
+                    code: useLang,
+                    pxtBranch: pxtBranch,
+                    targetBranch: targetBranch,
+                    updateStrings: updateStrings,
+                    force: force,
+                    fetchUnapproved: fetchUnapproved,
+                }).then(() => {
                     if (pxt.Util.isLocaleEnabled(useLang)) {
                         pxt.BrowserUtils.setCookieLang(useLang);
                         lang.setInitialLang(useLang);
                     } else {
                         pxt.tickEvent("unavailablelocale", { lang: useLang, force: (force ? "true" : "false") });
                     }
-                    pxt.tickEvent("locale", { lang: pxt.Util.userLanguage(), live: (live ? "true" : "false") });
+                    pxt.tickEvent("locale", { lang: pxt.Util.userLanguage(), live: (updateStrings ? "true" : "false") });
                     // Download sim translations and save them in the sim
                     // don't wait!
-                    ts.pxtc.Util.downloadTranslationsAsync(
+                    Util.downloadTranslationsAsync(
                         targetId, baseUrl, useLang,
-                        pxtBranch, targetBranch, live, ts.pxtc.Util.TranslationsKind.Sim)
+                        pxtBranch, targetBranch, updateStrings, Util.TranslationsKind.Sim)
                         .then(simStrings => simStrings && simulator.setTranslations(simStrings))
                 });
         })

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4738,7 +4738,6 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(async () => {
             const href = window.location.href;
             let updateStrings = false;
-            let fetchUnapproved = false;
             let force = false;
             const cloudLang = auth.getState()?.preferences?.language;
             // kick of a user preferences check; if the language is different we'll request they reload
@@ -4755,7 +4754,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 console.log(`translation mode`);
                 force = true;
                 updateStrings = true;
-                fetchUnapproved = true;
+                pxt.Util.fetchLiveTranslations = true;
                 useLang = ts.pxtc.Util.TRANSLATION_LOCALE;
             } else {
                 const hashLangMatch = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(window.location.href);
@@ -4768,17 +4767,16 @@ document.addEventListener("DOMContentLoaded", () => {
                 const cookieLang = pxt.BrowserUtils.getCookieLang()
                 // chose the user's language using the following ordering:
                 useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
+                pxt.Util.fetchLiveTranslations = requestLive;
                 const locstatic = /staticlang=1/i.test(window.location.href);
                 const stringUpdateDisabled = locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations;
                 updateStrings = !stringUpdateDisabled || requestLive;
                 force = requestedForce;
-                fetchUnapproved = requestLive;
             }
             const targetId = pxt.appTarget.id;
             const baseUrl = config.commitCdnUrl;
             const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;
             const targetBranch = pxt.appTarget.versions.targetCrowdinBranch;
-
             return Util.updateLocalizationAsync({
                     targetId: targetId,
                     baseUrl: baseUrl,
@@ -4787,7 +4785,6 @@ document.addEventListener("DOMContentLoaded", () => {
                     targetBranch: targetBranch,
                     updateStrings: updateStrings,
                     force: force,
-                    fetchUnapproved: fetchUnapproved,
                 }).then(() => {
                     if (pxt.Util.isLocaleEnabled(useLang)) {
                         pxt.BrowserUtils.setCookieLang(useLang);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4759,13 +4759,14 @@ document.addEventListener("DOMContentLoaded", () => {
                 if (hashLangMatch && window.location.hash.indexOf(hashLangMatch[0]) >= 0) {
                     pxt.BrowserUtils.changeHash(window.location.hash.replace(hashLangMatch[0], ""));
                 }
-                const hashLang = hashLangMatch ? hashLangMatch[3] : undefined
+                const hashLang = hashLangMatch?.[3];
                 const cookieLang = pxt.BrowserUtils.getCookieLang()
                 // chose the user's language using the following ordering:
                 useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
                 const locstatic = /staticlang=1/i.test(window.location.href);
-                live = !(locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations) || (hashLangMatch && !!hashLangMatch[1]);
-                force = !!hashLangMatch && !!hashLangMatch[2];
+                const liveDisabled = locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations;
+                live = !liveDisabled && !!hashLangMatch?.[1];
+                force = !!hashLangMatch?.[2];
             }
             const targetId = pxt.appTarget.id;
             const baseUrl = config.commitCdnUrl;


### PR DESCRIPTION
Right now we're sending out `live=1` VERY aggressively in our translated markdown requests, and we should not be doing that. It looks like over time two distinct uses of live translations got combined -- updating the translations that are packaged with the editor, and fetching translations that are "live" / not yet approved

The change in `downloadLiveTranslationsAsync->downloadFromCloudAsync` isn't strictly necessary / I was mainly just checking if that needed to be fixed as well, but small enough it seemed like it should be included so those can get fetched appropriately as well?