### PR TITLE
fix share page docfile on edge <= 18

### DIFF
--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -160,7 +160,7 @@
                                 'simulator.user.tick',
                                 data,
                             );
-                        } catch { /** failed to parse tick from game **/ }
+                        } catch (e) { /** failed to parse tick from game **/ }
                     }
                 });
             </script>


### PR DESCRIPTION
Same as https://github.com/microsoft/pxt-arcade/pull/3351 but for default share page (as we override this file in pxt-arcade)