### PR TITLE
Fast simulator restart on compile

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2700,6 +2700,14 @@ export class ProjectView
                             });
                         }
                     }
+
+                    // restart sim early before deployment
+                    if (simRestart) {
+                        this.runSimulator();
+                        simRestart = false
+                    }
+
+                    // hardware deployment
                     let deployStartTime = Date.now()
                     pxt.tickEvent("deploy.start")
                     return pxt.commands.deployAsync(resp, {


### PR DESCRIPTION
When compiling and deploying, restart the simulator during deployment to speed up experience.

This is particularly important for Jacdac where we rely on a race to determine which device should be in proxy and non-proxy. This is also interresting for Arcade where the simulator becomes responsive again much faster.