### PR TITLE
Add customts snippet type for loading hidden ts into tutorials

### DIFF
--- a/docs/writing-docs/tutorials/control-options.md
+++ b/docs/writing-docs/tutorials/control-options.md
@@ -65,22 +65,22 @@ This template example gives some initial code as a starting point for making a g
 ````
 ```template
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
-	
+
 })
 scene.setBackgroundColor(9)
 let mySprite = sprites.create(img`
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
 
     `, SpriteKind.Player)
 game.onUpdateInterval(1000, function () {
-	
+
 })
 ```
 ````
@@ -112,6 +112,23 @@ input.onButtonPressed(Button.A, function () {
 
 ```ghost
 basic.showIcon(IconNames.Heart)
+```
+````
+
+### Custom code
+
+If you want to load existing code into a tutorial but have it hidden from the user, you can include a `customts` block. The code in the snippet will **not** appear on the Workspace and will **not** show up in the Toolbox.
+
+This can be used to add starter code that the user does not need to see and should not have to modify. It's a good idea to add this code inside a custom namespace, to avoid inadvertent errors in user code.
+
+````
+```customts
+namespace camera {
+    let camera = sprites.create(image.create(16, 16), SpriteKind.Player)
+    controller.moveSprite(camera)
+    camera.setFlag(SpriteFlag.Invisible, true)
+    scene.cameraFollowSprite(camera)
+}
 ```
 ````
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -951,6 +951,7 @@ declare namespace pxt.tutorial {
         metadata?: TutorialMetadata;
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
+        customTs?: string; // custom typescript code loaded in a separate file for the tutorial
     }
 
     interface TutorialMetadata {
@@ -1004,6 +1005,7 @@ declare namespace pxt.tutorial {
         language?: string; // native language of snippets ("python" for python, otherwise defaults to typescript)
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
+        customTs?: string; // custom typescript code loaded in a separate file for the tutorial
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -510,6 +510,7 @@ namespace pxt {
     export const TUTORIAL_CODE_START = "_onCodeStart.ts";
     export const TUTORIAL_CODE_STOP = "_onCodeStop.ts";
     export const TUTORIAL_INFO_FILE = "tutorial-info-cache.json";
+    export const TUTORIAL_CUSTOM_TS = "tutorial.custom.ts";
 
     export function outputName(trg: pxtc.CompileTarget = null) {
         if (!trg) trg = appTarget.compile

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -279,7 +279,7 @@ ${code}
     /* Remove hidden snippets from text */
     function stripHiddenSnippets(str: string): string {
         if (!str) return str;
-        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson|customts)\s*\n([\s\S]*?)\n```/gmi;
         return str.replace(hiddenSnippetRegex, '').trim();
     }
 

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -10,7 +10,7 @@ namespace pxt.tutorial {
             return undefined; // error parsing steps
 
         // collect code and infer editor
-        const { code, templateCode, editor, language, jres, assetJson } = computeBodyMetadata(body);
+        const { code, templateCode, editor, language, jres, assetJson, customTs } = computeBodyMetadata(body);
 
         // noDiffs legacy
         if (metadata.diffs === true // enabled in tutorial
@@ -42,20 +42,22 @@ namespace pxt.tutorial {
             metadata,
             language,
             jres,
-            assetFiles
+            assetFiles,
+            customTs
         };
     }
 
     function computeBodyMetadata(body: string) {
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson)\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson|customts)\s*\n([\s\S]*?)\n```/gmi;
         let jres: string;
         let code: string[] = [];
         let templateCode: string;
         let language: string;
         let idx = 0;
         let assetJson: string;
+        let customTs: string;
         // Concatenate all blocks in separate code blocks and decompile so we can detect what blocks are used (for the toolbox)
         body
             .replace(/((?!.)\s)+/g, "\n")
@@ -90,7 +92,9 @@ namespace pxt.tutorial {
                     case "assetjson":
                         assetJson = m2;
                         break;
-
+                    case "customts":
+                        customTs = m2;
+                        break;
                 }
                 code.push(m1 == "python" ? `\n${m2}\n` : `{\n${m2}\n}`);
                 idx++
@@ -98,7 +102,7 @@ namespace pxt.tutorial {
             });
         // default to blocks
         editor = editor || pxt.BLOCKS_PROJECT_NAME
-        return { code, templateCode, editor, language, jres, assetJson }
+        return { code, templateCode, editor, language, jres, assetJson, customTs }
 
         function checkTutorialEditor(expected: string) {
             if (editor && editor != expected) {
@@ -361,7 +365,8 @@ ${code}
             metadata: tutorialInfo.metadata,
             language: tutorialInfo.language,
             jres: tutorialInfo.jres,
-            assetFiles: tutorialInfo.assetFiles
+            assetFiles: tutorialInfo.assetFiles,
+            customTs: tutorialInfo.customTs
         };
 
         return { options: tutorialOptions, editor: tutorialInfo.editor };

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -94,6 +94,7 @@ namespace pxt.tutorial {
                         break;
                     case "customts":
                         customTs = m2;
+                        m2 = "";
                         break;
                 }
                 code.push(m1 == "python" ? `\n${m2}\n` : `{\n${m2}\n}`);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1460,6 +1460,7 @@ export class ProjectView
                 return compiler.newProjectAsync();
             }).then(() => compiler.applyUpgradesAsync())
             .then(() => this.loadTutorialJresCodeAsync())
+            .then(() => this.loadTutorialCustomTsAsync())
             .then(() => this.loadTutorialTemplateCodeAsync())
             .then(() => {
                 const main = pkg.getEditorPkg(pkg.mainPkg)
@@ -1689,6 +1690,15 @@ export class ProjectView
         }
 
         return pkg.mainEditorPkg().buildAssetsAsync();
+    }
+
+    private loadTutorialCustomTsAsync(): Promise<void> {
+        const header = pkg.mainEditorPkg().header;
+        if (!header || !header.tutorial || !header.tutorial.customTs)
+            return Promise.resolve();
+
+        const customTs = header.tutorial.customTs;
+        return this.updateFileAsync(pxt.TUTORIAL_CUSTOM_TS, customTs);
     }
 
     removeProject() {


### PR DESCRIPTION
proposing a new tutorial snippet type! the `customts` snippet allows you to write some typescript that's added to a hidden file in the tutorial project--essentially this is like adding an extension, but the code lives with the tutorial and works better with the existing `assetjson` snippet

build + example content, the hidden code creates a "camera" sprite that allows the user to pan the game around with the dpad--we want to hide this to make the game code easier to debug:
https://arcade.makecode.com/app/026265abbadd99d99736bf3e271d1a5b621c64d3-f5083f4725#tutorial:49840-40808-29707-30223