### PR TITLE
Only match recognized snippets when parsing tutorial metadata

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -49,7 +49,7 @@ namespace pxt.tutorial {
     function computeBodyMetadata(body: string) {
         // collect code and infer editor
         let editor: string = undefined;
-        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson)?\s*\n([\s\S]*?)\n```/gmi;
+        const regex = /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson)\s*\n([\s\S]*?)\n```/gmi;
         let jres: string;
         let code: string[] = [];
         let templateCode: string;


### PR DESCRIPTION
there was a bug where having an unrecognized snippet (eg `package`) would break all subsequent snippets since the regex matches the trailing \`\`\` . this restricts it to match only on snippets that we know; i don't think we were relying on replacing the untagged snippets anywhere?