### PR TITLE
Stop storing temporary assets in the tilemap project

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -79,14 +79,36 @@ namespace pxtblockly {
                 const frames = parseImageArrayString(text);
 
                 if (frames && frames.length) {
-                    return project.createNewAnimationFromData(frames, this.getParentInterval());
+                    const id = this.sourceBlock_.id;
+
+                    const newAnimation: pxt.Animation = {
+                        internalID: -1,
+                        id,
+                        type: pxt.AssetType.Animation,
+                        frames,
+                        interval: this.getParentInterval(),
+                        meta: { },
+                    };
+                    return newAnimation;
                 }
 
                 const asset = project.lookupAssetByName(pxt.AssetType.Animation, text.trim());
                     if (asset) return asset;
             }
 
-            return project.createNewAnimation(this.params.initWidth, this.params.initHeight);
+            const id = this.sourceBlock_.id;
+            const bitmap = new pxt.sprite.Bitmap(this.params.initWidth, this.params.initHeight).data()
+
+            const newAnimation: pxt.Animation = {
+                internalID: -1,
+                id,
+                type: pxt.AssetType.Animation,
+                frames: [bitmap],
+                interval: 500,
+                meta: {},
+            };
+
+            return newAnimation;
         }
 
         protected onEditorClose(newValue: pxt.Animation) {

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -264,12 +264,7 @@ namespace pxtblockly {
                             this.asset.meta.blockIDs = this.asset.meta.blockIDs.filter(id => id !== this.sourceBlock_.id);
 
                             if (!this.isTemporaryAsset()) {
-                                if (this.asset.meta.blockIDs.length === 0 && !this.asset.meta.displayName) {
-                                    project.removeAsset(this.asset);
-                                }
-                                else {
-                                    project.updateAsset(this.asset);
-                                }
+                                project.updateAsset(this.asset);
                             }
                         }
                     }

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -66,7 +66,9 @@ namespace pxtblockly {
         showEditor_() {
             if (this.isGreyBlock) return;
 
-            (this.params as any).blocksInfo = this.blocksInfo;
+            const params: any = {...this.params};
+
+            params.blocksInfo = this.blocksInfo;
 
             let editorKind: string;
 
@@ -74,9 +76,12 @@ namespace pxtblockly {
                 case pxt.AssetType.Tile:
                 case pxt.AssetType.Image:
                     editorKind = "image-editor";
+                    params.temporaryAssets = getTemporaryAssets(this.sourceBlock_.workspace, pxt.AssetType.Image);
                     break;
                 case pxt.AssetType.Animation:
                     editorKind = "animation-editor";
+                    params.temporaryAssets = getTemporaryAssets(this.sourceBlock_.workspace, pxt.AssetType.Image)
+                        .concat(getTemporaryAssets(this.sourceBlock_.workspace, pxt.AssetType.Animation));
                     break;
                 case pxt.AssetType.Tilemap:
                     editorKind = "tilemap-editor";
@@ -86,7 +91,7 @@ namespace pxtblockly {
             }
 
 
-            const fv = pxt.react.getFieldEditorView(editorKind, this.asset, this.params);
+            const fv = pxt.react.getFieldEditorView(editorKind, this.asset, params);
 
             if (this.undoRedoState) {
                 fv.restorePersistentData(this.undoRedoState);
@@ -183,6 +188,14 @@ namespace pxtblockly {
             }
         }
 
+        isTemporaryAsset() {
+            return this.asset && !this.asset.meta.displayName;
+        }
+
+        getAsset() {
+            return this.asset;
+        }
+
         protected onEditorClose(newValue: pxt.Asset) {
             // Subclass
         }
@@ -245,11 +258,13 @@ namespace pxtblockly {
                         if (this.sourceBlock_ && this.asset.meta.blockIDs) {
                             this.asset.meta.blockIDs = this.asset.meta.blockIDs.filter(id => id !== this.sourceBlock_.id);
 
-                            if (this.asset.meta.blockIDs.length === 0 && !this.asset.meta.displayName) {
-                                project.removeAsset(this.asset);
-                            }
-                            else {
-                                project.updateAsset(this.asset);
+                            if (!this.isTemporaryAsset()) {
+                                if (this.asset.meta.blockIDs.length === 0 && !this.asset.meta.displayName) {
+                                    project.removeAsset(this.asset);
+                                }
+                                else {
+                                    project.updateAsset(this.asset);
+                                }
                             }
                         }
                     }
@@ -308,7 +323,7 @@ namespace pxtblockly {
                     const blockIDs = this.asset.meta.blockIDs;
                     if (blockIDs.length && this.isTemporaryAsset() && blockIDs.some(id => this.sourceBlock_.workspace.getBlockById(id))) {
                         // This temporary asset is already used, so we should clone a copy for ourselves
-                        this.asset = pxt.react.getTilemapProject().duplicateAsset(this.asset);
+                        this.asset = pxt.cloneAsset(this.asset)
                         this.asset.meta.blockIDs = [];
                     }
                     this.asset.meta.blockIDs.push(this.sourceBlock_.id);
@@ -316,12 +331,14 @@ namespace pxtblockly {
                 this.setBlockData(this.asset.id);
             }
 
-            pxt.react.getTilemapProject().updateAsset(this.asset);
+            if (!this.isTemporaryAsset()) {
+                pxt.react.getTilemapProject().updateAsset(this.asset);
+            }
         }
 
         protected updateAssetListener() {
             pxt.react.getTilemapProject().removeChangeListener(this.getAssetType(), this.assetChangeListener);
-            if (this.asset) {
+            if (this.asset && !this.isTemporaryAsset()) {
                 pxt.react.getTilemapProject().addChangeListener(this.asset, this.assetChangeListener);
             }
         }
@@ -333,10 +350,6 @@ namespace pxtblockly {
                 this.asset = pxt.react.getTilemapProject().lookupAsset(this.getAssetType(), id);
             }
             this.redrawPreview();
-        }
-
-        protected isTemporaryAsset() {
-            return this.asset && !this.asset.meta.displayName;
         }
     }
 

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -196,6 +196,11 @@ namespace pxtblockly {
             return this.asset;
         }
 
+        updateAsset(asset: pxt.Asset) {
+            this.asset = asset;
+            this.setValue(this.getValue());
+        }
+
         protected onEditorClose(newValue: pxt.Asset) {
             // Subclass
         }
@@ -333,6 +338,12 @@ namespace pxtblockly {
 
             if (!this.isTemporaryAsset()) {
                 pxt.react.getTilemapProject().updateAsset(this.asset);
+            }
+            else {
+                this.asset.meta.temporaryInfo = {
+                    blockId: this.sourceBlock_.id,
+                    fieldName: this.name
+                };
             }
         }
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -51,7 +51,18 @@ namespace pxtblockly {
                 return undefined;
             }
 
-            const newAsset = project.createNewProjectImage(bmp.data());
+            const data = bmp.data();
+
+            const newAsset: pxt.ProjectImage = {
+                internalID: -1,
+                id: this.sourceBlock_.id,
+                type: pxt.AssetType.Image,
+                jresData: pxt.sprite.base64EncodeBitmap(data),
+                meta: {
+                },
+                bitmap: data
+            };
+
             return newAsset;
         }
 

--- a/pxtblocks/fields/field_utils.ts
+++ b/pxtblocks/fields/field_utils.ts
@@ -276,4 +276,17 @@ namespace pxtblockly {
 
         return Object.keys(all).map(key => all[key]).filter(t => !!t);
     }
+
+    export function getTemporaryAssets(workspace: Blockly.Workspace, type: pxt.AssetType) {
+        switch (type) {
+            case pxt.AssetType.Image:
+                return getAllFieldsCore(workspace, field => field instanceof FieldSpriteEditor && field.isTemporaryAsset())
+                    .map(f => (f.ref as unknown as FieldSpriteEditor).getAsset());
+            case pxt.AssetType.Animation:
+                return getAllFieldsCore(workspace, field => field instanceof FieldAnimationEditor && field.isTemporaryAsset())
+                    .map(f => (f.ref as unknown as FieldAnimationEditor).getAsset());
+
+            default: return [];
+        }
+    }
 }

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1404,7 +1404,7 @@ namespace pxt {
         return new pxt.sprite.TilemapData(tilemap, tileset, layers);
     }
 
-    function cloneAsset<U extends Asset>(asset: U): U {
+    export function cloneAsset<U extends Asset>(asset: U): U {
         asset.meta = Object.assign({}, asset.meta);
         switch (asset.type) {
             case AssetType.Tile:

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -14,6 +14,12 @@ namespace pxt {
         displayName?: string;
         tags?: string[];
         blockIDs?: string[];
+        temporaryInfo?: TemporaryAssetInfo;
+    }
+
+    export interface TemporaryAssetInfo {
+        blockId: string;
+        fieldName: string;
     }
 
     export type Asset = ProjectImage | Tile | Animation | ProjectTilemap;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -89,6 +89,11 @@ export function getEditorAsync() {
     });
 }
 
+export function getBlocksEditor() {
+    if (!theEditor) return null;
+    return theEditor.blocksEditor;
+}
+
 function setEditor(editor: ProjectView) {
     theEditor = editor;
     if (pendingEditorRequests) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -212,6 +212,18 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         Blockly.WidgetDiv.hide();
     }
 
+    getTemporaryAssets(): pxt.Asset[] {
+        if (!this.editor) return[];
+
+        return pxtblockly.getTemporaryAssets(this.editor, pxt.AssetType.Image)
+            .concat(pxtblockly.getTemporaryAssets(this.editor, pxt.AssetType.Animation))
+    }
+
+    updateTemporaryAsset(asset: pxt.Asset) {
+        const block = this.editor.getBlockById(asset.meta.temporaryInfo.blockId);
+        (block.getField(asset.meta.temporaryInfo.fieldName) as pxtblockly.FieldAssetEditor<any, any>).updateAsset(asset);
+    }
+
     private saveBlockly(): string {
         // make sure we don't return an empty document before we get started
         // otherwise it may get saved and we're in trouble

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -448,7 +448,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     protected showMyAssets = () => {
         this.setImageEditorShortcutsEnabled(false);
         tickImageEditorEvent("gallery-my-assets");
-        this.userAssets = getAssets();
+        this.userAssets = getAssets(undefined, undefined, this.options.temporaryAssets);
         this.setState({
             currentView: "my-assets",
             tileGalleryVisible: false
@@ -483,7 +483,16 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                     pxt.sprite.updateTilemapReferencesFromResult(project, this.asset);
                 }
 
-                project.updateAsset(this.asset);
+                if (this.asset.meta.displayName) {
+                    project.updateAsset(this.asset);
+                }
+                else if (!asset.meta.displayName) {
+                    // If both are temporary, copy by value
+                    asset = {
+                        ...asset,
+                        id: this.asset.id
+                    }
+                }
 
                 if (asset.type === pxt.AssetType.Tilemap) {
                     pxt.sprite.addMissingTilemapTilesAndReferences(project, asset);

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -489,8 +489,9 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                 else if (!asset.meta.displayName) {
                     // If both are temporary, copy by value
                     asset = {
-                        ...asset,
-                        id: this.asset.id
+                        ...pxt.cloneAsset(asset),
+                        id: this.asset.id,
+                        meta: this.asset.meta
                     }
                 }
 

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -8,6 +8,7 @@ import { AssetEditorState, GalleryView, isGalleryAsset } from './store/assetEdit
 import { dispatchChangeGalleryView, dispatchChangeSelectedAsset, dispatchUpdateUserAssets } from './actions/dispatch';
 
 import { AssetPreview } from "./assetPreview";
+import { getBlocksEditor } from "../../app";
 
 interface AssetDetail {
     name: string;
@@ -83,12 +84,17 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         this.props.showAssetFieldView(this.props.asset, this.editAssetDoneHandler);
     }
 
-    protected editAssetDoneHandler = (result: any) => {
+    protected editAssetDoneHandler = (result: pxt.Asset) => {
         pxt.tickEvent("assets.edit", { type: result.type.toString() });
 
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        project.updateAsset(result);
+        if (!result.meta.displayName && result.meta.temporaryInfo) {
+            getBlocksEditor().updateTemporaryAsset(result);
+        }
+        else {
+            project.updateAsset(result);
+        }
         this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets().then(() => simulator.setDirty());
     }

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -91,6 +91,9 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         project.pushUndo();
         if (!result.meta.displayName && result.meta.temporaryInfo) {
             getBlocksEditor().updateTemporaryAsset(result);
+
+            pkg.mainEditorPkg().lookupFile("this/main.blocks").setContentAsync(getBlocksEditor().getCurrentSource())
+
         }
         else {
             project.updateAsset(result);

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -60,7 +60,7 @@ function getSelectedAsset(state: AssetEditorState, type: pxt.AssetType, id: stri
         || state.galleryAssets.find(el => el.type == type && el.id == id);
 }
 
-export function getAssets(gallery = false, firstType = pxt.AssetType.Image): pxt.Asset[] {
+export function getAssets(gallery = false, firstType = pxt.AssetType.Image, tempAssets: pxt.Asset[] = []): pxt.Asset[] {
     const project = pxt.react.getTilemapProject();
     const imgConv = new pxt.ImageConverter();
 
@@ -73,6 +73,23 @@ export function getAssets(gallery = false, firstType = pxt.AssetType.Image): pxt
         .filter((t: pxt.Tile) => !t.id.match(/^myTiles.transparency(8|16|32)$/gi)).sort(compareInternalId);
     const tilemaps = getAssetType(pxt.AssetType.Tilemap).map(toGalleryItem).sort(compareInternalId);
     const animations = getAssetType(pxt.AssetType.Animation).map(toGalleryItem).sort(compareInternalId);
+
+    for (const asset of tempAssets) {
+        switch (asset.type) {
+            case pxt.AssetType.Image:
+                images.push(toGalleryItem(asset));
+                break;
+            case pxt.AssetType.Tile:
+                tiles.push(toGalleryItem(asset));
+                break;
+            case pxt.AssetType.Animation:
+                animations.push(toGalleryItem(asset));
+                break;
+            case pxt.AssetType.Tilemap:
+                tilemaps.push(toGalleryItem(asset));
+                break;
+        }
+    }
 
     let assets: pxt.Asset[] = [];
     switch (firstType) {

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -1,4 +1,6 @@
 import * as actions from '../actions/types'
+import * as pkg from '../../../package';
+import { getBlocksEditor } from '../../../app';
 
 export const enum GalleryView {
     User,
@@ -33,7 +35,13 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
                 selectedAsset
             };
         case actions.UPDATE_USER_ASSETS:
-            const assets = getAssets();
+            let assets = getAssets();
+            let imgConv = new pxt.ImageConverter();
+
+            if (isBlocksProject()) {
+                assets = assets.concat(getBlocksEditor().getTemporaryAssets().map(a => assetToGalleryItem(a, imgConv)));
+            }
+
             return {
                 ...state,
                 selectedAsset: state.selectedAsset ? assets.find(el => el.id == state.selectedAsset.id) : undefined,
@@ -128,6 +136,10 @@ export function assetToGalleryItem(asset: pxt.Asset, imgConv = new pxt.ImageConv
             asset.previewURI = asset.framePreviewURIs[0];
             return asset;
     }
+}
+
+function isBlocksProject() {
+    return pkg.mainPkg?.config?.preferredEditor === pxt.BLOCKS_PROJECT_NAME;
 }
 
 export function isGalleryAsset(asset?: pxt.Asset) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3296

This PR changes how we store temporary assets a bit. We used to store them in the tilemap project, which was very error prone because it was difficult to keep the tilemap project and blocks file in sync. Now it just stores them in the blocks themselves, and fetches them from the workspace when opening the asset editor and "my assets" tab.

This fixes a lot of undo/redo bugs and probably quite a few other "disappearing asset" cases that we haven't reported. It also should fix the bug we saw on stream the other day where we lost all of our assets when skipping javascript decompile.

From my testing, this seems much more stable than it was before. Still we should make sure we test this before release.