### PR TITLE
Adjust the asset editor sidebar in asset editor-tutorials

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -9,6 +9,7 @@
     width: @blocklyRowWidthWide;
     height: 100%;
     border-right: 1px solid @assetSidebarBorder;
+    overflow-y: auto;
 }
 
 .asset-editor-sidebar-info {

--- a/theme/image-editor/sideBar.less
+++ b/theme/image-editor/sideBar.less
@@ -79,3 +79,31 @@
         }
     }
 }
+
+/* Asset editor tutorial is the max height of the tutorial header */
+@media only screen and (max-height: 900px) {
+    .asset-editor-tutorial {
+        .image-editor-sidebar {
+            width: 10rem;
+        }
+
+        .image-editor-tilemap-minimap {
+            display: none;
+        }
+
+        .image-editor-colors {
+            height: 2rem;
+            width: 100%;
+        }
+
+        .image-editor-color-buttons {
+            padding-left: .5rem;
+            padding-top: 0;
+
+            .image-editor-button {
+                width: 2rem;
+                height: 2rem;
+            }
+        }
+    }
+}

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -17,7 +17,6 @@
 @avatarSize: 4.5rem;
 @avatarMargin: @avatarSize + 0.5rem;
 @mobileAvatarMargin: 2rem;
-@tutorialCardMaxHeight: 20rem;
 
 @workspaceHeaderHeight: 4rem;
 @sidebarPadding: 1.6rem;
@@ -82,7 +81,7 @@
 }
 
 .tutorial.tutorialExpanded #tutorialcard {
-    max-height: @tutorialCardMaxHeight;
+    max-height: 20rem;
 }
 
 #root.dimmable.dimmed #tutorialcard.tutorialReady {

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -17,6 +17,7 @@
 @avatarSize: 4.5rem;
 @avatarMargin: @avatarSize + 0.5rem;
 @mobileAvatarMargin: 2rem;
+@tutorialCardMaxHeight: 20rem;
 
 @workspaceHeaderHeight: 4rem;
 @sidebarPadding: 1.6rem;
@@ -81,7 +82,7 @@
 }
 
 .tutorial.tutorialExpanded #tutorialcard {
-    max-height: 20rem;
+    max-height: @tutorialCardMaxHeight;
 }
 
 #root.dimmable.dimmed #tutorialcard.tutorialReady {

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -188,7 +188,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
     }
 
     protected updateContainerClass() {
-        if (this.contentDiv) {
+        if (this.contentDiv && this.containerClass) {
             if (!this.contentDiv.classList.contains(this.containerClass)) {
                 this.contentDiv.classList.add(this.containerClass);
             }

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -40,6 +40,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
     protected overlayDiv: HTMLDivElement;
     protected persistentData: any;
     protected hideCallback: () => void;
+    protected containerClass: string;
 
     constructor(protected contentDiv: HTMLDivElement) {
     }
@@ -120,6 +121,14 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
         else this.persistentData = value;
     }
 
+    setContainerClass(className: string) {
+        if (this.contentDiv && this.contentDiv.classList.contains(this.containerClass)) {
+            this.contentDiv.classList.remove(this.containerClass);
+        }
+        this.containerClass = className;
+        this.updateContainerClass();
+    }
+
     protected clearContents() {
         ReactDOM.unmountComponentAtNode(this.contentDiv);
         while (this.contentDiv.firstChild) this.contentDiv.removeChild(this.contentDiv.firstChild);
@@ -177,6 +186,14 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
             this.hide();
         }
     }
+
+    protected updateContainerClass() {
+        if (this.contentDiv) {
+            if (!this.contentDiv.classList.contains(this.containerClass)) {
+                this.contentDiv.classList.add(this.containerClass);
+            }
+        }
+    }
 }
 
 export function setEditorBounds(editorBounds: EditorBounds) {
@@ -184,6 +201,12 @@ export function setEditorBounds(editorBounds: EditorBounds) {
         current.resize(editorBounds)
     }
     cachedBounds = editorBounds;
+}
+
+export function setContainerClass(className: string) {
+    if (current) {
+        current.setContainerClass(className);
+    }
 }
 
 export function init() {

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -72,7 +72,6 @@ export class AssetEditor extends Editor {
                 horizontalPadding: 0,
                 verticalPadding: 0
             });
-            blocklyFieldView.setContainerClass("asset-editor-tutorial");
         } else {
             blocklyFieldView.setEditorBounds({
                 top: 0,
@@ -171,6 +170,10 @@ export class AssetEditor extends Editor {
                 break;
         }
 
+        if (this.parent.isTutorial()) {
+            blocklyFieldView.setContainerClass("asset-editor-tutorial");
+        }
+
         fieldView.onHide(() => {
             if (this.parent.isTutorial()) this.unbindTutorialEvents();
 
@@ -187,6 +190,8 @@ export class AssetEditor extends Editor {
                     })
                 }
             });
+
+            blocklyFieldView.setContainerClass(null);
         });
 
         // Do not close image editor when clicking on previous/next in the tutorial, or menu dots

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -63,14 +63,16 @@ export class AssetEditor extends Editor {
         // In tutorial view, the image editor is smaller and has no padding
         if (container && this.parent.isTutorial()) {
             const containerRect = container.getBoundingClientRect();
+            const editorTools = document.getElementById("editortools");
             blocklyFieldView.setEditorBounds({
                 top: containerRect.top,
                 left: containerRect.left,
                 width: containerRect.width,
-                height: containerRect.height,
+                height: containerRect.height + (editorTools ? editorTools.getBoundingClientRect().height : 0),
                 horizontalPadding: 0,
                 verticalPadding: 0
             });
+            blocklyFieldView.setContainerClass("asset-editor-tutorial");
         } else {
             blocklyFieldView.setEditorBounds({
                 top: 0,


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3356

Also make the image editor extend over the editor toolbar (clicking it just dismissed the image editor previously, so no real reason to show it) and makes it so that the asset editor sidebar scrolls when needed.

<img width="1660" alt="Screen Shot 2021-03-24 at 5 52 15 PM" src="https://user-images.githubusercontent.com/13754588/112402389-b0f39280-8cc9-11eb-9f95-f23e30387742.png">
