### PR TITLE
Fix blockCombine blocks in incontext translation mode

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -478,11 +478,17 @@ namespace ts.pxtc {
                 updateBlockDef(ex.attributes)
                 if (pxt.Util.isTranslationMode()) {
                     ex.attributes.translationId = ex.attributes.block;
-                    pxt.crowdin.inContextLoadAsync(ex.attributes.block)
+                    // This kicks off async work but doesn't wait; give untranslated values to start with
+                    // to avoid a race causing a crash.
+                    ex.attributes.block = isGet ? `%${paramName} %property` :
+                        isSet ? `set %${paramName} %property to %${paramValue}` :
+                            `change %${paramName} %property by %${paramValue}`;
+                    updateBlockDef(ex.attributes);
+                    pxt.crowdin.inContextLoadAsync(ex.attributes.translationId)
                         .then(r => {
                             ex.attributes.block = r;
                             updateBlockDef(ex.attributes);
-                        })
+                        });
                 }
                 blocks.push(ex)
             }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -477,6 +477,7 @@ namespace ts.pxtc {
                             U.lf("change %{0} %property by %{1}", paramName, paramValue)
                 updateBlockDef(ex.attributes)
                 if (pxt.Util.isTranslationMode()) {
+                    ex.attributes.translationId = ex.attributes.block;
                     pxt.crowdin.inContextLoadAsync(ex.attributes.block)
                         .then(r => {
                             ex.attributes.block = r;

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -476,6 +476,13 @@ namespace ts.pxtc {
                         isSet ? U.lf("set %{0} %property to %{1}", paramName, paramValue) :
                             U.lf("change %{0} %property by %{1}", paramName, paramValue)
                 updateBlockDef(ex.attributes)
+                if (pxt.Util.isTranslationMode()) {
+                    pxt.crowdin.inContextLoadAsync(ex.attributes.block)
+                        .then(r => {
+                            ex.attributes.block = r;
+                            updateBlockDef(ex.attributes);
+                        })
+                }
                 blocks.push(ex)
             }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1793
fix https://github.com/microsoft/pxt-arcade/issues/2824
fix https://github.com/microsoft/pxt-arcade/issues/3120

Have to kick off the work async in a sync method here -- in practice it looks like this runs before the page is fully loaded, but I gave it a default english localization while the real one is loading just in case