### PR TITLE
[stable6.12] Arcade stable ports

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -181,7 +181,6 @@ namespace pxt.Cloud {
         }
         if (!packaged && locale != "en") {
             url += `&lang=${encodeURIComponent(locale)}`
-            if (live) url += "&live=1"
         }
         if (pxt.BrowserUtils.isLocalHost() && !live)
             return localRequestAsync(url).then(resp => {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -476,6 +476,20 @@ namespace ts.pxtc {
                         isSet ? U.lf("set %{0} %property to %{1}", paramName, paramValue) :
                             U.lf("change %{0} %property by %{1}", paramName, paramValue)
                 updateBlockDef(ex.attributes)
+                if (pxt.Util.isTranslationMode()) {
+                    ex.attributes.translationId = ex.attributes.block;
+                    // This kicks off async work but doesn't wait; give untranslated values to start with
+                    // to avoid a race causing a crash.
+                    ex.attributes.block = isGet ? `%${paramName} %property` :
+                        isSet ? `set %${paramName} %property to %${paramValue}` :
+                            `change %${paramName} %property by %${paramValue}`;
+                    updateBlockDef(ex.attributes);
+                    pxt.crowdin.inContextLoadAsync(ex.attributes.translationId)
+                        .then(r => {
+                            ex.attributes.block = r;
+                            updateBlockDef(ex.attributes);
+                        });
+                }
                 blocks.push(ex)
             }
 

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -648,27 +648,41 @@ namespace ts.pxtc {
             .then(loc => Promise.all(Util.values(apis.byQName).map(fn => {
                 if (apiLocalizationStrings)
                     Util.jsonMergeFrom(loc, apiLocalizationStrings);
-                const attrLocs = fn.attributes.locs || {};
-                const locJsDoc = loc[fn.qName] || attrLocs[attrJsLocsKey];
+
+                const altLocSrc = fn.attributes.useLoc || fn.attributes.blockAliasFor;
+                const altLocSrcFn = altLocSrc && apis.byQName[altLocSrc];
+
+                const lookupLoc = (locSuff: string, attrKey: string) => {
+                    return loc[fn.qName + locSuff] || fn.attributes.locs?.[attrKey]
+                        || (altLocSrcFn && (loc[altLocSrcFn.qName + locSuff] || altLocSrcFn.attributes.locs?.[attrKey]));
+                }
+
+                const locJsDoc = lookupLoc("", attrJsLocsKey);
                 if (locJsDoc) {
                     fn.attributes._untranslatedJsDoc = fn.attributes.jsDoc;
                     fn.attributes.jsDoc = locJsDoc;
-                    if (fn.parameters)
-                        fn.parameters.forEach(pi => pi.description = loc[`${fn.qName}|param|${pi.name}`] || attrLocs[`${langLower}|param|${pi.name}`] || pi.description);
                 }
-                const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
-                let locBlock = loc[`${fn.qName}|block`] || attrLocs[attrBlockLocsKey];
 
-                if (!locBlock && fn.attributes.useLoc) {
-                    const otherFn = apis.byQName[fn.attributes.useLoc];
+                if (fn.parameters) {
+                    fn.parameters.forEach(pi => {
+                        const paramSuff = `|param|${pi.name}`;
+                        const paramLocs = lookupLoc(paramSuff, langLower + paramSuff);
 
-                    if (otherFn) {
-                        const otherTranslation = loc[`${otherFn.qName}|block`];
-                        const isSameBlockDef = fn.attributes.block === (otherFn.attributes._untranslatedBlock || otherFn.attributes.block);
-
-                        if (isSameBlockDef && !!otherTranslation) {
-                            locBlock = otherTranslation;
+                        if (paramLocs) {
+                            pi.description = paramLocs;
                         }
+                    });
+                }
+
+                const nsDoc = loc['{id:category}' + Util.capitalize(fn.qName)];
+                let locBlock = loc[`${fn.qName}|block`] || fn.attributes.locs?.[attrBlockLocsKey];
+
+                if (!locBlock && altLocSrcFn) {
+                    const otherTranslation = loc[`${altLocSrcFn.qName}|block`] || altLocSrcFn.attributes.locs?.[attrBlockLocsKey];
+                    const isSameBlockDef = fn.attributes.block === (altLocSrcFn.attributes._untranslatedBlock || altLocSrcFn.attributes.block);
+
+                    if (isSameBlockDef && !!otherTranslation) {
+                        locBlock = otherTranslation;
                     }
                 }
 

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -50,6 +50,8 @@ namespace pxt.sprite {
         }
 
         constructor(public width: number, public height: number, public x0 = 0, public y0 = 0, buf?: Uint8ClampedArray) {
+            if (!this.width) this.width = 16;
+            if (!this.height) this.height = 16;
             this.buf = buf || new Uint8ClampedArray(this.dataLength());
         }
 


### PR DESCRIPTION
* in context translation fix for some block flyouts breaking https://github.com/microsoft/pxt/pull/8000
* fix translation for the sprite create reporter block https://github.com/microsoft/pxt/pull/7996
* don't fetch unapproved localizations for md -- https://github.com/microsoft/pxt/commit/db148da35097f5fd0df1cf234287052f16e89ed1, pulled out of https://github.com/microsoft/pxt/pull/7989 as a more minimal change for stable branch.
* fix `` img` ` `` in monaco https://github.com/microsoft/pxt/pull/8009

Left out https://github.com/microsoft/pxt/pull/7986 for now to avoid any merge weirdness since vivian has some other changes in the same space that are going to come in later / easier to port those two together~