### PR TITLE
give bitmaps default 16x16 if 0 height / 0 width

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -50,6 +50,8 @@ namespace pxt.sprite {
         }
 
         constructor(public width: number, public height: number, public x0 = 0, public y0 = 0, buf?: Uint8ClampedArray) {
+            if (!this.width) this.width = 16;
+            if (!this.height) this.height = 16;
             this.buf = buf || new Uint8ClampedArray(this.dataLength());
         }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/3364

I don't see a reason to support 0x0 bitmaps, but if there's a better location for this fix happy to do it; root of the problem is that https://github.com/microsoft/pxt/blob/5c832a89a7b51e8d8ce4c78f9da36de82142bf4f/pxtlib/spriteutils.ts#L591  is ending up with the empty string and parsing as 0 width / 0 height, could see making that return undefined on empty & handling in monaco-fields/field_sprite (but I do kind of like the behavior it currently has if you have an invalid sprite of crashing / not opening -- could maybe give a toast but at least if you accidentally type a z into the sprite it will crash rather than destroy it)