### PR TITLE
Cherrypick skillmap & asset editor fixes

### DIFF
--- a/docs/writing-docs/tutorials/control-options.md
+++ b/docs/writing-docs/tutorials/control-options.md
@@ -49,22 +49,22 @@ This template example gives some initial code as a starting point for making a g
 ````
 ```template
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
-	
+
 })
 scene.setBackgroundColor(9)
 let mySprite = sprites.create(img`
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
-    . . . . . . . . 
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
+    . . . . . . . .
 
     `, SpriteKind.Player)
 game.onUpdateInterval(1000, function () {
-	
+
 })
 ```
 ````
@@ -96,6 +96,23 @@ input.onButtonPressed(Button.A, function () {
 
 ```ghost
 basic.showIcon(IconNames.Heart)
+```
+````
+
+### Custom code
+
+If you want to load existing code into a tutorial but have it hidden from the user, you can include a `customts` block. The code in the snippet will **not** appear on the Workspace and will **not** show up in the Toolbox.
+
+This can be used to add starter code that the user does not need to see and should not have to modify. It's a good idea to add this code inside a custom namespace, to avoid inadvertent errors in user code.
+
+````
+```customts
+namespace camera {
+    let camera = sprites.create(image.create(16, 16), SpriteKind.Player)
+    controller.moveSprite(camera)
+    camera.setFlag(SpriteFlag.Invisible, true)
+    scene.cameraFollowSprite(camera)
+}
 ```
 ````
 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -951,6 +951,7 @@ declare namespace pxt.tutorial {
         metadata?: TutorialMetadata;
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
+        customTs?: string; // custom typescript code loaded in a separate file for the tutorial
     }
 
     interface TutorialMetadata {
@@ -1004,6 +1005,7 @@ declare namespace pxt.tutorial {
         language?: string; // native language of snippets ("python" for python, otherwise defaults to typescript)
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
+        customTs?: string; // custom typescript code loaded in a separate file for the tutorial
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/pxtblocks/fields/field_kind.ts
+++ b/pxtblocks/fields/field_kind.ts
@@ -86,6 +86,12 @@ namespace pxtblockly {
                     return;
                 }
 
+                if (pxt.blocks.isReservedWord(response)) {
+                    Blockly.alert(lf("'{0}' is a reserved word and cannot be used.", response),
+                        () => promptAndCreateKind(ws, opts, message, cb));
+                    return;
+                }
+
                 const existing = getExistingKindMembers(ws, opts.name);
                 for (let i = 0; i < existing.length; i++) {
                     const name = existing[i];

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -510,6 +510,7 @@ namespace pxt {
     export const TUTORIAL_CODE_START = "_onCodeStart.ts";
     export const TUTORIAL_CODE_STOP = "_onCodeStop.ts";
     export const TUTORIAL_INFO_FILE = "tutorial-info-cache.json";
+    export const TUTORIAL_CUSTOM_TS = "tutorial.custom.ts";
 
     export function outputName(trg: pxtc.CompileTarget = null) {
         if (!trg) trg = appTarget.compile

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -10,7 +10,7 @@ namespace pxt.tutorial {
             return undefined; // error parsing steps
 
         // collect code and infer editor
-        const { code, templateCode, editor, language, jres, assetJson } = computeBodyMetadata(body);
+        const { code, templateCode, editor, language, jres, assetJson, customTs } = computeBodyMetadata(body);
 
         // noDiffs legacy
         if (metadata.diffs === true // enabled in tutorial
@@ -42,12 +42,13 @@ namespace pxt.tutorial {
             metadata,
             language,
             jres,
-            assetFiles
+            assetFiles,
+            customTs
         };
     }
 
     export function getMetadataRegex(): RegExp {
-        return /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson)\s*\n([\s\S]*?)\n```/gmi;
+        return /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson|customts)\s*\n([\s\S]*?)\n```/gmi;
     }
 
     function computeBodyMetadata(body: string) {
@@ -60,6 +61,7 @@ namespace pxt.tutorial {
         let language: string;
         let idx = 0;
         let assetJson: string;
+        let customTs: string;
         // Concatenate all blocks in separate code blocks and decompile so we can detect what blocks are used (for the toolbox)
         body
             .replace(/((?!.)\s)+/g, "\n")
@@ -94,7 +96,10 @@ namespace pxt.tutorial {
                     case "assetjson":
                         assetJson = m2;
                         break;
-
+                    case "customts":
+                        customTs = m2;
+                        m2 = "";
+                        break;
                 }
                 code.push(m1 == "python" ? `\n${m2}\n` : `{\n${m2}\n}`);
                 idx++
@@ -102,7 +107,7 @@ namespace pxt.tutorial {
             });
         // default to blocks
         editor = editor || pxt.BLOCKS_PROJECT_NAME
-        return { code, templateCode, editor, language, jres, assetJson }
+        return { code, templateCode, editor, language, jres, assetJson, customTs }
 
         function checkTutorialEditor(expected: string) {
             if (editor && editor != expected) {
@@ -279,7 +284,7 @@ ${code}
     /* Remove hidden snippets from text */
     function stripHiddenSnippets(str: string): string {
         if (!str) return str;
-        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson)\s*\n([\s\S]*?)\n```/gmi;
+        const hiddenSnippetRegex = /```(filterblocks|package|ghost|config|template|jres|assetjson|customts)\s*\n([\s\S]*?)\n```/gmi;
         return str.replace(hiddenSnippetRegex, '').trim();
     }
 
@@ -365,7 +370,8 @@ ${code}
             metadata: tutorialInfo.metadata,
             language: tutorialInfo.language,
             jres: tutorialInfo.jres,
-            assetFiles: tutorialInfo.assetFiles
+            assetFiles: tutorialInfo.assetFiles,
+            customTs: tutorialInfo.customTs
         };
 
         return { options: tutorialOptions, editor: tutorialInfo.editor };

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -47,7 +47,7 @@ namespace pxt.tutorial {
     }
 
     export function getMetadataRegex(): RegExp {
-        return /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson)?\s*\n([\s\S]*?)\n```/gmi;
+        return /``` *(sim|block|blocks|filterblocks|spy|ghost|typescript|ts|js|javascript|template|python|jres|assetjson)\s*\n([\s\S]*?)\n```/gmi;
     }
 
     function computeBodyMetadata(body: string) {

--- a/skillmap/src/components/InfoPanel.tsx
+++ b/skillmap/src/components/InfoPanel.tsx
@@ -109,17 +109,19 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
             const mapIds = Object.keys(maps);
             let completed = 0;
             let total = 0;
-            let rewards = 0;
+            let completedRewards = 0;
+            let totalRewards = 0;
             mapIds.forEach(mapId => {
                 const activities = maps[mapId].activities;
                 const activityIds = Object.keys(activities).filter(el => activities[el].kind == "activity");
                 activityIds.forEach(activityId => ++total && isActivityCompleted(user, pageSourceUrl, mapId, activityId) && ++completed);
 
-                rewards += Object.keys(activities).filter(el => isRewardNode(activities[el])).length;
+                const rewardIds = Object.keys(activities).filter(el => isRewardNode(activities[el]));
+                rewardIds.forEach(rewardId => ++totalRewards && isActivityCompleted(user, pageSourceUrl, mapId, rewardId) && ++completedRewards);
             })
 
             details.push(`${completed}/${total} ${lf("Complete")}`);
-            details.push(rewards ? `${rewards} ${lf("Reward(s)")}` : "")
+            details.push(totalRewards ? `${completedRewards}/${totalRewards} ${lf("Reward(s)")}` : "")
         }
     }
 

--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -9,6 +9,7 @@
     width: @blocklyRowWidthWide;
     height: 100%;
     border-right: 1px solid @assetSidebarBorder;
+    overflow-y: auto;
 }
 
 .asset-editor-sidebar-info {

--- a/theme/image-editor/sideBar.less
+++ b/theme/image-editor/sideBar.less
@@ -79,3 +79,31 @@
         }
     }
 }
+
+/* Asset editor tutorial is the max height of the tutorial header */
+@media only screen and (max-height: 900px) {
+    .asset-editor-tutorial {
+        .image-editor-sidebar {
+            width: 10rem;
+        }
+
+        .image-editor-tilemap-minimap {
+            display: none;
+        }
+
+        .image-editor-colors {
+            height: 2rem;
+            width: 100%;
+        }
+
+        .image-editor-color-buttons {
+            padding-left: .5rem;
+            padding-top: 0;
+
+            .image-editor-button {
+                width: 2rem;
+                height: 2rem;
+            }
+        }
+    }
+}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1460,6 +1460,7 @@ export class ProjectView
                 return compiler.newProjectAsync();
             }).then(() => compiler.applyUpgradesAsync())
             .then(() => this.loadTutorialJresCodeAsync())
+            .then(() => this.loadTutorialCustomTsAsync())
             .then(() => this.loadTutorialTemplateCodeAsync())
             .then(() => {
                 const main = pkg.getEditorPkg(pkg.mainPkg)
@@ -1689,6 +1690,15 @@ export class ProjectView
         }
 
         return pkg.mainEditorPkg().buildAssetsAsync();
+    }
+
+    private loadTutorialCustomTsAsync(): Promise<void> {
+        const header = pkg.mainEditorPkg().header;
+        if (!header || !header.tutorial || !header.tutorial.customTs)
+            return Promise.resolve();
+
+        const customTs = header.tutorial.customTs;
+        return this.updateFileAsync(pxt.TUTORIAL_CUSTOM_TS, customTs);
     }
 
     removeProject() {

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -40,6 +40,7 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
     protected overlayDiv: HTMLDivElement;
     protected persistentData: any;
     protected hideCallback: () => void;
+    protected containerClass: string;
 
     constructor(protected contentDiv: HTMLDivElement) {
     }
@@ -120,6 +121,14 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
         else this.persistentData = value;
     }
 
+    setContainerClass(className: string) {
+        if (this.contentDiv && this.contentDiv.classList.contains(this.containerClass)) {
+            this.contentDiv.classList.remove(this.containerClass);
+        }
+        this.containerClass = className;
+        this.updateContainerClass();
+    }
+
     protected clearContents() {
         ReactDOM.unmountComponentAtNode(this.contentDiv);
         while (this.contentDiv.firstChild) this.contentDiv.removeChild(this.contentDiv.firstChild);
@@ -177,6 +186,14 @@ export class FieldEditorView<U> implements pxt.react.FieldEditorView<U> {
             this.hide();
         }
     }
+
+    protected updateContainerClass() {
+        if (this.contentDiv && this.containerClass) {
+            if (!this.contentDiv.classList.contains(this.containerClass)) {
+                this.contentDiv.classList.add(this.containerClass);
+            }
+        }
+    }
 }
 
 export function setEditorBounds(editorBounds: EditorBounds) {
@@ -184,6 +201,12 @@ export function setEditorBounds(editorBounds: EditorBounds) {
         current.resize(editorBounds)
     }
     cachedBounds = editorBounds;
+}
+
+export function setContainerClass(className: string) {
+    if (current) {
+        current.setContainerClass(className);
+    }
 }
 
 export function init() {

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -63,11 +63,12 @@ export class AssetEditor extends Editor {
         // In tutorial view, the image editor is smaller and has no padding
         if (container && this.parent.isTutorial()) {
             const containerRect = container.getBoundingClientRect();
+            const editorTools = document.getElementById("editortools");
             blocklyFieldView.setEditorBounds({
                 top: containerRect.top,
                 left: containerRect.left,
                 width: containerRect.width,
-                height: containerRect.height,
+                height: containerRect.height + (editorTools ? editorTools.getBoundingClientRect().height : 0),
                 horizontalPadding: 0,
                 verticalPadding: 0
             });
@@ -169,6 +170,10 @@ export class AssetEditor extends Editor {
                 break;
         }
 
+        if (this.parent.isTutorial()) {
+            blocklyFieldView.setContainerClass("asset-editor-tutorial");
+        }
+
         fieldView.onHide(() => {
             if (this.parent.isTutorial()) this.unbindTutorialEvents();
 
@@ -185,6 +190,8 @@ export class AssetEditor extends Editor {
                     })
                 }
             });
+
+            blocklyFieldView.setContainerClass(null);
         });
 
         // Do not close image editor when clicking on previous/next in the tutorial, or menu dots


### PR DESCRIPTION
Display unlocked rewards out of total reward count in skill map (#7992)
Adjust the asset editor sidebar in asset editor-tutorials (#7999) 
Don't allow reserved words in kinds (#8004)
Only match recognized snippets when parsing tutorial metadata (#7995)
Add customts snippet type for loading hidden ts into tutorials (#7994)