### PR TITLE
Add 'local' flag and update cli for better skillmap testing

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1980,8 +1980,11 @@ function buildWebStringsAsync() {
 function buildSkillMapAsync(parsed: commandParser.ParsedCommand) {
     // local serve
     const skillmapRoot = "node_modules/pxt-core/skillmap";
+    const docsPath = parsed.flags["docs"];
     return rimrafAsync(`${skillmapRoot}/public/blb`, {})
         .then(() => rimrafAsync(`${skillmapRoot}/build/assets`, {}))
+        .then(() => rimrafAsync(`${skillmapRoot}/public/docs`, {}))
+        .then(() => rimrafAsync(`${skillmapRoot}/public/static`, {}))
         .then(() => {
             // read pxtarget.json, save into 'pxtTargetBundle' global variable
             let cfg = readLocalPxTarget();
@@ -1992,6 +1995,13 @@ function buildSkillMapAsync(parsed: commandParser.ParsedCommand) {
 
             // copy 'assets' over from docs/static
             nodeutil.cpR("docs/static/skillmap/assets", `${skillmapRoot}/public/assets`);
+
+            if (docsPath) {
+                // copy docs over from specified path
+                nodeutil.cpR(`docs/${docsPath}`, `${skillmapRoot}/public/docs/${docsPath}`);
+                nodeutil.cpR(`docs/static/${docsPath}`, `${skillmapRoot}/public/static/${docsPath}`);
+            }
+
             return nodeutil.spawnAsync({
                 cmd: os.platform() === "win32" ? "npm.cmd" : "npm",
                 args: ["run-script", "start"],
@@ -6663,6 +6673,11 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
         flags: {
             serve: {
                 description: "Serve the skill map locally after building (npm start)"
+            },
+            docs: {
+                description: "Path to local docs folder to copy into skillmap",
+                type: "string",
+                argument: "docs"
             }
         }
     }, buildSkillMapAsync);

--- a/skillmap/.gitignore
+++ b/skillmap/.gitignore
@@ -14,6 +14,8 @@
 /public/pxtlib.js
 /public/assets
 /public/blb
+/public/docs
+/public/static
 
 # misc
 .DS_Store

--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -1,7 +1,7 @@
 import { PageSourceStatus } from "../store/reducer";
 
 const apiRoot = "https://www.makecode.com/api";
-export type MarkdownSource = "docs" | "github";
+export type MarkdownSource = "docs" | "github" | "local";
 
 export interface MarkdownFetchResult {
     identifier: string;
@@ -55,6 +55,8 @@ export async function getMarkdownAsync(source: MarkdownSource, url: string): Pro
             break;
         case "github":
             return await fetchSkillMapFromGithub(url);
+        case "local":
+            return await fetchSkillMapFromLocal(url);
         default:
             toFetch = url;
             break;
@@ -118,6 +120,21 @@ async function fetchSkillMapFromGithub(path: string): Promise<MarkdownFetchResul
     }
 
     return undefined
+}
+
+async function fetchSkillMapFromLocal(path: string): Promise<MarkdownFetchResult | undefined> {
+    if (isLocal()) {
+        path = path.replace(/^\//, "").replace(/\.md$/, "");
+        let res = await fetch("docs/" + path + ".md");
+        let text = await res.text();
+        return {
+            text,
+            identifier: path,
+            status: "approved"
+        }
+    }
+
+    return undefined;
 }
 
 export function getDocsIdentifier(path: string) {


### PR DESCRIPTION
- adds a cli flag for copying local docs into the skillmap directory
- adds a hash parameter for loading from local docs

the updated local testing flow will be something like:
1. make changes in the docs file in the target (eg `pxt-arcade/docs/skillmap/intermediate-skillmap`)
2. run `pxt skillmap --docs skillmap` from pxt-arcade
3. load `http://localhost:3000/?nolocalhost=1#local:skillmap/intermediate-skillmap`

there's no file watching/reload but this should at least allow local testing of files! 

@kiki-lee tagging you for a heads-up, i can sync with you in person on monday or whenever to walk you through the steps