### PR TITLE
Fix asset editor size in safari

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -117,7 +117,6 @@
     flex-grow: 1;
     overflow: hidden;
     position: relative;
-    height: 100%;
     flex: 9;
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3224

Just some weird safari bug

Tested in Safari, Firefox, and Chrome.