### PR TITLE
Two small image/tilemap editor fixes

### DIFF
--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -181,6 +181,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
         }
 
         this.editID = value.id;
+        let didUpdate = false;
 
         if (options) {
             this.blocksInfo = options.blocksInfo;
@@ -189,16 +190,22 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                 this.setState({
                     galleryFilter: options.filter
                 });
+                didUpdate = true;
             }
 
             if (options.headerVisible != undefined) {
                 this.setState({ headerVisible: options.headerVisible })
+                didUpdate = true;
             }
 
             if (options.hideMyAssets != undefined) {
                 this.setState({ hideMyAssets: options.hideMyAssets });
+                didUpdate = true;
             }
         }
+
+        // Always update, because we might need to remove the gallery toggle
+        if (!didUpdate) this.forceUpdate();
     }
 
     getValue() {

--- a/webapp/src/components/assetEditor/assetPreview.tsx
+++ b/webapp/src/components/assetEditor/assetPreview.tsx
@@ -14,7 +14,9 @@ export class AssetPreview extends React.Component<AssetPreviewProps> {
 
         const isAnimation = asset.type === pxt.AssetType.Animation && asset.framePreviewURIs?.length > 1;
 
-        return <div className="asset-editor-preview" title={asset.meta.displayName || asset.id}>
+        const title = asset.meta.displayName || (asset.meta.temporaryInfo ? lf("Temporary Asset") : asset.id);
+
+        return <div className="asset-editor-preview" title={title}>
             <img
                 src={asset.previewURI}
                 alt={lf("A preview of your asset (eg image, tile, animation)")}


### PR DESCRIPTION
Fixing two bugs I found while investigating https://github.com/microsoft/pxt-arcade/issues/3365

1. The "gallery" tab showed up in the tilemap editor when opened from Monaco
2. https://github.com/microsoft/pxt/pull/7998 made it so that temporary assets use their Blockly id as the asset id. That was showing up in the hover text in the "my assets" tab, so removing it and replacing it with "Temporary Asset"