### PR TITLE
[stable6.0] don't fetch unapproved md translations

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -168,7 +168,6 @@ namespace pxt.Cloud {
         }
         if (!packaged && locale != "en") {
             url += `&lang=${encodeURIComponent(locale)}`
-            if (live) url += "&live=1"
         }
         if (pxt.BrowserUtils.isLocalHost() && !live)
             return localRequestAsync(url).then(resp => {


### PR DESCRIPTION
micro:bit port of unapproved translations fix, same as https://github.com/microsoft/pxt/commit/db148da35097f5fd0df1cf234287052f16e89ed1