### PR TITLE
Don't let the header overlap with each other

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -696,7 +696,7 @@ code.lang-filterblocks {
 
 /* > Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) {
-    .shrink {
+    .thin {
         .landscape.only {
             display: none;
         }

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -696,6 +696,11 @@ code.lang-filterblocks {
 
 /* > Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) {
+    .shrink {
+        .landscape.only {
+            display: none;
+        }
+    }
 }
 
 /* Large Monitor */

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -700,6 +700,15 @@ code.lang-filterblocks {
         .landscape.only {
             display: none;
         }
+
+        .portrait.hide {
+            display: none;
+        }
+
+        .portrait.only {
+            display: block!important;
+            height: auto!important;
+        }
     }
 }
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -528,6 +528,44 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         this.props.parent.toggleDebugging();
     }
 
+    componentDidUpdate() {
+        const tutorialOptions = this.props.parent.state.tutorialOptions;
+        const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
+        const header = document.getElementById("mainmenu")
+        if (inTutorial && header && !header.classList.contains("shrink")) {
+            const shrinkHeader = this.shouldShrinkItems();
+            if (shrinkHeader) {
+                header.classList.add("shrink");
+            }
+        }
+
+    }
+
+    shouldShrinkItems(): boolean {
+        const header = document.getElementById("mainmenu")
+        if (header) {
+            let headerWidth = 0;
+            for (let i = 0; i < header.children.length; i++) {
+                headerWidth += addUiSize(header.children[i]);
+            }
+            return headerWidth > window.innerWidth;
+        }
+        return false;
+
+        function addUiSize(elem: Element): number {
+            if (elem.classList.contains("ui")) {
+                return elem.clientWidth;
+            }
+            else {
+                let totalWidth = 0
+                for (let i = 0; i < elem.children.length; i++) {
+                    totalWidth += addUiSize(elem.children[i]);
+                }
+                return totalWidth;
+            }
+        }
+    }
+
     renderCore() {
         const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
         const { debugging, home, header, greenScreen, accessibleBlocks, simState, tutorialOptions } = this.props.parent.state;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -539,7 +539,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const homeEnabled = !lockedEditor && !isController;
         const sandbox = pxt.shell.isSandboxMode();
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
-        const manyTutorialSteps = inTutorial && (tutorialOptions.tutorialStepInfo.length > 10);
+
+        // Approximate each tutorial step to be 22 px
+        const manyTutorialSteps = inTutorial && (tutorialOptions.tutorialStepInfo.length * 22 > window.innerWidth / 3);
 
         const activityName = tutorialOptions && tutorialOptions.tutorialActivityInfo ?
             tutorialOptions.tutorialActivityInfo[tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity].name :

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -578,7 +578,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         }
 
         /* tslint:disable:react-a11y-anchors */
-        return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu ${manyTutorialSteps ? "thin": ""}`} role="menubar" aria-label={lf("Main menu")}>
+        return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu ${manyTutorialSteps ? "thin" : ""}`} role="menubar" aria-label={lf("Main menu")}>
             {!sandbox ? <div className="left menu">
                 {!targetTheme.hideMenubarLogo &&
                     <a href={(!lockedEditor && isController) ? targetTheme.logoUrl : undefined} aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" tabIndex={0} onClick={lockedEditor ? undefined : this.brandIconClick} onKeyDown={sui.fireClickOnEnter}>

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -572,11 +572,6 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
             && (sandbox || !(tsOnly || pyOnly)); // show if sandbox or not single language
         const editor = this.props.parent.isPythonActive() ? "Python" : (this.props.parent.isJavaScriptActive() ? "JavaScript" : "Blocks");
 
-        const mainMenuDiv = document.getElementById("mainmenu")
-        if (mainMenuDiv) {
-            mainMenuDiv.classList.remove("shrink");
-        }
-
         /* tslint:disable:react-a11y-anchors */
         return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu ${manyTutorialSteps ? "thin" : ""}`} role="menubar" aria-label={lf("Main menu")}>
             {!sandbox ? <div className="left menu">

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -528,40 +528,6 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         this.props.parent.toggleDebugging();
     }
 
-    componentDidUpdate() {
-        const tutorialOptions = this.props.parent.state.tutorialOptions;
-        const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
-        const header = document.getElementById("mainmenu")
-        if (inTutorial && header && !header.classList.contains("shrink") && this.shouldShrinkItems()) {
-            header.classList.add("shrink");
-        }
-    }
-
-    shouldShrinkItems(): boolean {
-        const header = document.getElementById("mainmenu")
-        if (header) {
-            let headerWidth = 0;
-            for (let i = 0; i < header.children.length; i++) {
-                headerWidth += addUiSize(header.children[i]);
-            }
-            return headerWidth > window.innerWidth;
-        }
-        return false;
-
-        function addUiSize(elem: Element): number {
-            if (elem.classList.contains("ui")) {
-                return elem.clientWidth;
-            }
-            else {
-                let totalWidth = 0
-                for (let i = 0; i < elem.children.length; i++) {
-                    totalWidth += addUiSize(elem.children[i]);
-                }
-                return totalWidth;
-            }
-        }
-    }
-
     renderCore() {
         const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
         const { debugging, home, header, greenScreen, accessibleBlocks, simState, tutorialOptions } = this.props.parent.state;
@@ -573,6 +539,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const homeEnabled = !lockedEditor && !isController;
         const sandbox = pxt.shell.isSandboxMode();
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
+        const manyTutorialSteps = inTutorial && (tutorialOptions.tutorialStepInfo.length > 10);
 
         const activityName = tutorialOptions && tutorialOptions.tutorialActivityInfo ?
             tutorialOptions.tutorialActivityInfo[tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity].name :
@@ -609,7 +576,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         }
 
         /* tslint:disable:react-a11y-anchors */
-        return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar" aria-label={lf("Main menu")}>
+        return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu ${manyTutorialSteps ? "thin": ""}`} role="menubar" aria-label={lf("Main menu")}>
             {!sandbox ? <div className="left menu">
                 {!targetTheme.hideMenubarLogo &&
                     <a href={(!lockedEditor && isController) ? targetTheme.logoUrl : undefined} aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" tabIndex={0} onClick={lockedEditor ? undefined : this.brandIconClick} onKeyDown={sui.fireClickOnEnter}>

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -605,7 +605,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 {sandbox || inTutorial || debugging ? undefined : <container.SettingsMenu parent={this.props.parent} greenScreen={greenScreen} accessibleBlocks={accessibleBlocks} />}
                 {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} /> : undefined}
                 {inTutorial && tutorialReportId ? <sui.ButtonMenuItem className="report-tutorial-btn" role="menuitem" icon="warning circle" text={lf("Report Abuse")} textClass="landscape only" onClick={this.showReportAbuse} /> : undefined}
-                {(inTutorial && !lockedEditor && !hideIteration) && <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={this.exitTutorial} />}
+                {(inTutorial && !lockedEditor && !hideIteration) && <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="sign out" text={lf("Exit tutorial")} textClass="landscape only" onClick={this.exitTutorial} />}
 
                 {auth.hasIdentity() ? <identity.UserMenu parent={this.props.parent} continuationHash={"#editor"} /> : undefined}
                 {!sandbox ? <a href={lockedEditor ? undefined : targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo organization" onClick={lockedEditor ? undefined : this.orgIconClick}>

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -532,13 +532,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const tutorialOptions = this.props.parent.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const header = document.getElementById("mainmenu")
-        if (inTutorial && header && !header.classList.contains("shrink")) {
-            const shrinkHeader = this.shouldShrinkItems();
-            if (shrinkHeader) {
-                header.classList.add("shrink");
-            }
+        if (inTutorial && header && !header.classList.contains("shrink") && this.shouldShrinkItems()) {
+            header.classList.add("shrink");
         }
-
     }
 
     shouldShrinkItems(): boolean {
@@ -606,6 +602,11 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const showToggle = !inAltEditor && !targetTheme.blocksOnly
             && (sandbox || !(tsOnly || pyOnly)); // show if sandbox or not single language
         const editor = this.props.parent.isPythonActive() ? "Python" : (this.props.parent.isJavaScriptActive() ? "JavaScript" : "Blocks");
+
+        const mainMenuDiv = document.getElementById("mainmenu")
+        if (mainMenuDiv) {
+            mainMenuDiv.classList.remove("shrink");
+        }
 
         /* tslint:disable:react-a11y-anchors */
         return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar" aria-label={lf("Main menu")}>


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3322

This is the best way I could think of to fix this :\ -> After we render the menu bar, check all the UI elements under the parent and add up the widths. If it's bigger than the screen width, add a class to the menu bar, "shrink", which will hide all elements with the landscape class (like tutorial name, text on the exit button)

One weird thing that's happening that I don't know if it's a result of me not understanding React or this change, is when the MainMenu element rerenders, it keeps the "shrink" class, which makes going from not shrunk -> shrunk a one way street until you refresh the page.

This is a window at (1200x649), which is the dimension of the Pixelbook I have:
![image](https://user-images.githubusercontent.com/18712271/112916824-2db1b280-90b6-11eb-94fd-0dbd0d58c7cc.png)

And with these changes:
![image](https://user-images.githubusercontent.com/18712271/112916847-3bffce80-90b6-11eb-8e8a-cbed22c55ffe.png)

And this shows the one-way street ness of it :\

![width changes](https://user-images.githubusercontent.com/18712271/112916971-8719e180-90b6-11eb-933a-cbb0bd40a23a.gif)
