### PR TITLE
Add temporary assets to JRes when doing skillmap carryover

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -649,6 +649,26 @@ namespace pxt.sprite {
         return result;
     }
 
+    export function encodeAnimationString(frames: BitmapData[], interval: number) {
+        const encodedFrames = frames.map(frame => frame.data);
+
+        const data = new Uint8ClampedArray(8 + encodedFrames[0].length * encodedFrames.length);
+
+        // interval, frame width, frame height, frame count
+        set16Bit(data, 0, interval);
+        set16Bit(data, 2, frames[0].width);
+        set16Bit(data, 4, frames[0].height);
+        set16Bit(data, 6, frames.length);
+
+        let offset = 8;
+        encodedFrames.forEach(buf => {
+            data.set(buf, offset);
+            offset += buf.length;
+        })
+
+        return btoa(pxt.sprite.uint8ArrayToHex(data))
+    }
+
     export function addMissingTilemapTilesAndReferences(project: TilemapProject, asset: ProjectTilemap) {
         const allTiles = project.getProjectTiles(asset.data.tileset.tileWidth, true);
         asset.data.projectReferences = [];
@@ -797,6 +817,11 @@ namespace pxt.sprite {
             res += hex[data[i] & 0xf];
         }
         return res;
+    }
+
+    function set16Bit(buf: Uint8ClampedArray, offset: number, value: number) {
+        buf[offset] = value & 0xff;
+        buf[offset + 1] = (value >> 8) & 0xff;
     }
 
     function colorStringToRGB(color: string) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1631,27 +1631,11 @@ namespace pxt {
     }
 
     function serializeAnimation(asset: Animation): JRes {
-        const encodedFrames = asset.frames.map(frame => frame.data);
-
-        const data = new Uint8ClampedArray(8 + encodedFrames[0].length * encodedFrames.length);
-
-        // interval, frame width, frame height, frame count
-        set16Bit(data, 0, asset.interval);
-        set16Bit(data, 2, asset.frames[0].width);
-        set16Bit(data, 4, asset.frames[0].height);
-        set16Bit(data, 6, asset.frames.length);
-
-        let offset = 8;
-        encodedFrames.forEach(buf => {
-            data.set(buf, offset);
-            offset += buf.length;
-        })
-
         return {
             namespace: asset.id.substr(0, asset.id.lastIndexOf(".")),
             id: asset.id.substr(asset.id.lastIndexOf(".") + 1),
             mimeType: ANIMATION_MIME_TYPE,
-            data: btoa(pxt.sprite.uint8ArrayToHex(data)),
+            data: pxt.sprite.encodeAnimationString(asset.frames, asset.interval),
             displayName: asset.meta.displayName
         }
     }

--- a/skillmap/src/lib/codeCarryover.ts
+++ b/skillmap/src/lib/codeCarryover.ts
@@ -1,3 +1,4 @@
+import { guidGen } from "./browserUtils";
 import { lookupPreviousCompletedActivityState } from "./skillMapUtils";
 import { getProjectAsync, saveProjectAsync } from "./workspaceProvider";
 
@@ -21,17 +22,28 @@ export async function carryoverProjectCode(user: UserState, pageSource: string, 
 
 
 function mergeProjectCode(previousProject: pxt.Map<string>, newProject: pxt.Map<string>, carryoverCode: boolean) {
+    const configString = carryoverCode ? previousProject[pxt.CONFIG_NAME] : newProject[pxt.CONFIG_NAME];
+    const config = pxt.U.jsonTryParse(configString) as pxt.PackageConfig;
+
+    const previousImageJres = appendTemporaryAssets(previousProject["main.blocks"], previousProject[pxt.IMAGES_JRES]);
+    const tilemapJres = carryoverCode ?
+        mergeJRES(newProject[pxt.TILEMAP_JRES], previousProject[pxt.TILEMAP_JRES]) :
+        mergeJRES(previousProject[pxt.TILEMAP_JRES], newProject[pxt.TILEMAP_JRES]);
+    const imageJres = carryoverCode ?
+        mergeJRES(newProject[pxt.IMAGES_JRES], previousProject[pxt.IMAGES_JRES]) :
+        mergeJRES(previousImageJres, newProject[pxt.IMAGES_JRES]);
+
+    if (tilemapJres && config.files.indexOf(pxt.TILEMAP_JRES) < 0) config.files.push(pxt.TILEMAP_JRES)
+    if (imageJres && config.files.indexOf(pxt.IMAGES_JRES) < 0) config.files.push(pxt.IMAGES_JRES)
+
     return {
         ...newProject,
         ["main.ts"]: carryoverCode ? previousProject["main.ts"] : newProject["main.ts"],
         ["main.py"]: carryoverCode ? previousProject["main.py"] : newProject["main.py"],
         ["main.blocks"]: carryoverCode ? previousProject["main.blocks"] : newProject["main.blocks"],
-        [pxt.TILEMAP_JRES]: carryoverCode ?
-            mergeJRES(newProject[pxt.TILEMAP_JRES], previousProject[pxt.TILEMAP_JRES]) :
-            mergeJRES(previousProject[pxt.TILEMAP_JRES], newProject[pxt.TILEMAP_JRES]),
-        [pxt.IMAGES_JRES]: carryoverCode ?
-            mergeJRES(newProject[pxt.IMAGES_JRES], previousProject[pxt.IMAGES_JRES]) :
-            mergeJRES(previousProject[pxt.IMAGES_JRES], newProject[pxt.IMAGES_JRES])
+        [pxt.TILEMAP_JRES]: tilemapJres,
+        [pxt.IMAGES_JRES]: imageJres,
+        [pxt.CONFIG_NAME]: JSON.stringify(config)
     };
 }
 
@@ -181,4 +193,94 @@ function mergeJRES(previous: string, next: string) {
     }
 
     return JSON.stringify(nextParsed);
+}
+
+function appendTemporaryAssets(blocks: string, assets: string) {
+    if (!blocks) return assets;
+
+    let jres = pxt.U.jsonTryParse(assets) as pxt.Map<Partial<pxt.JRes> | string> || {};
+    if (!jres["*"]) {
+        (jres as any)["*"] = {
+            "mimeType": "image/x-mkcd-f4",
+            "dataEncoding": "base64",
+            "namespace": pxt.sprite.IMAGES_NAMESPACE
+        };
+    }
+
+    // Regex image literals from blocks, append to existing JRes
+    let index = 0;
+    getImages(blocks)
+        .forEach(data => {
+            const id = guidGen();
+            while (jres[`${pxt.sprite.IMAGES_NAMESPACE}.${pxt.sprite.IMAGE_PREFIX}${index}`]) {
+                index++;
+            }
+            jres[id] = {
+                data: pxt.sprite.base64EncodeBitmap(data),
+                mimeType: pxt.IMAGE_MIME_TYPE,
+                displayName: `${pxt.sprite.IMAGES_NAMESPACE}.${pxt.sprite.IMAGE_PREFIX}${index}`
+            }
+            index++;
+        });
+
+    // Regex animations (array of image literals) from blocks, append to existing JRes
+    index = 0;
+    getAnimations(blocks)
+        .forEach(anim => {
+            const id = guidGen();
+            while (jres[`${pxt.sprite.ANIMATION_NAMESPACE}.${pxt.sprite.ANIMATION_NAMESPACE}${index}`]) {
+                index++;
+            }
+            jres[id] = {
+                data: pxt.sprite.encodeAnimationString(anim.frames, anim.interval),
+                mimeType: pxt.ANIMATION_MIME_TYPE,
+                displayName: `${pxt.sprite.ANIMATION_NAMESPACE}.${pxt.sprite.ANIMATION_PREFIX}${index}`
+            }
+            index++;
+        });
+
+    return JSON.stringify(jres)
+}
+
+/**
+ *  <field name="img">img`
+ *      . .
+ *      . .
+ *  `</field>
+ */
+function getImages(text: string): pxt.sprite.BitmapData[] {
+    const imgRegex = /<field name=\"img\">\s*(img`[\s\da-f.#tngrpoyw]+`)\s*<\/field>/gim;
+    const images: pxt.sprite.BitmapData[] = [];
+
+    text.replace(imgRegex, (m, literal) => {
+        images.push(pxt.sprite.imageLiteralToBitmap(literal).data());
+        return m;
+    })
+
+    return images;
+}
+
+/**
+ *  <field name="frames">[img`
+ *      . .
+ *      . .
+ *  `,img`
+ *      . .
+ *      . .
+ *  `]</field>
+ */
+function getAnimations(text: string): { frames: pxt.sprite.BitmapData[], interval: number}[] {
+    const animRegex = /<field name=\"frames\">\s*\[((?:img`[\s\da-f.#tngrpoyw]+`,?)+)\]\s*<\/field>.*<shadow type=\"timePicker\"><field name=\"ms\">(\d+)<\/field><\/shadow>/gim;
+    const literals: { frames: pxt.sprite.BitmapData[], interval: number}[] = [];
+
+    text.replace(animRegex, (m, f, i) => {
+        const frames: string[] = f.split(",");
+        literals.push({
+            frames: frames.map(el => pxt.sprite.imageLiteralToBitmap(el).data()),
+            interval: i
+        });
+        return m;
+    })
+
+    return literals;
 }


### PR DESCRIPTION
now that temporary blocks assets are stored in the workspace, we need to separately pull them out in order to carry them over in the skillmap. the updated flow:

if we are not carrying over the code (if we are carrying over the code the temporary assets are included, we keep the present behavior):
- regex to strip temporary image and animation literals from the blocks xml
- convert to jres and append to the project's jres
- continue with merge

plus an additional fix to add the tilemap/image jres file to the pxt.json if it is not present