### PR TITLE
Don't apply image editor scrollbar to all of pxt

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -306,21 +306,22 @@
     line-height: 2.25rem;
 }
 
-// this impacts all scrollbars in pxt
-::-webkit-scrollbar {
-    width: @customScrollbarWidth;
-}
+.image-editor-wrapper {
+    ::-webkit-scrollbar {
+        width: @customScrollbarWidth;
+    }
 
-::-webkit-scrollbar-track {
-    background: #3c3c3c;
-}
+    ::-webkit-scrollbar-track {
+        background: #3c3c3c;
+    }
 
-::-webkit-scrollbar-thumb {
-    background: #adadad;
-}
+    ::-webkit-scrollbar-thumb {
+        background: #adadad;
+    }
 
-::-webkit-scrollbar-thumb:hover {
-    background: #979797;
+    ::-webkit-scrollbar-thumb:hover {
+        background: #979797;
+    }
 }
 
 .gallery-filter-button {


### PR DESCRIPTION
Just noticed this today -- the scrollbar in arcade was the scrollbar I added for the image editor :\ 