### PR TITLE
Add progress bar to skillmap iframe loader

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -35,9 +35,8 @@ interface MakeCodeFrameProps {
 
 interface MakeCodeFrameState {
     loaded: boolean;
-
-    // See handleFrameRef
-    unloading: boolean;
+    unloading: boolean; // See handleFrameRef
+    loadPercent?: number; // Progress bar load % from 0 - 100 (loaded)
 }
 
 /* tslint:disable:no-http-string */
@@ -57,7 +56,8 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         super(props);
         this.state = {
             loaded: false,
-            unloading: false
+            unloading: false,
+            loadPercent: 0
         };
     }
 
@@ -94,7 +94,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
     render() {
         const { url, title, save, carryoverModalVisible } = this.props;
-        const { loaded, unloading } = this.state;
+        const { loaded, unloading, loadPercent } = this.state;
 
         const loadingText = save ? lf("Saving...") : lf("Loading...")
         const imageAlt = "MakeCode Logo";
@@ -103,6 +103,9 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         return <div className="makecode-frame-outer">
             <div className={`makecode-frame-loader ${(loaded && !save && !carryoverModalVisible) ? "hidden" : ""}`}>
                 <img src={resolvePath("assets/logo.svg")} alt={imageAlt} />
+                {!loaded && <div className="makecode-frame-loader-bar">
+                    <div className="makecode-frame-loader-fill" style={{ width: loadPercent + "%" }} />
+                </div>}
                 <div className="makecode-frame-loader-text">{loadingText}</div>
             </div>
             <iframe className="makecode-frame" src={unloading ? "about:blank" : url} title={title} ref={this.handleFrameRef}></iframe>
@@ -139,6 +142,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
     protected onMessageReceived = (event: MessageEvent) => {
         const data = event.data as pxt.editor.EditorMessageRequest;
+        if (!this.state.loaded) this.setState({ loadPercent: Math.min((this.state.loadPercent || 0) + 4, 95) });
 
         if (data.type === "pxteditor" && data.id && this.pendingMessages[data.id]) {
             this.onResponseReceived(this.pendingMessages[data.id], event.data as pxt.editor.EditorMessageResponse);

--- a/skillmap/src/styles/makecode-editor.css
+++ b/skillmap/src/styles/makecode-editor.css
@@ -35,6 +35,20 @@
    animation: loader-pxt  2s infinite linear;
  }
 
+.makecode-frame-loader-bar {
+    border: 1px solid var(--black);
+    width: 10rem;
+    height: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.makecode-frame-loader-fill {
+    background-color: var(--primary-color);
+    height: 100%;
+    width: 1rem;
+    transition: width 0.5s ease-out;
+}
+
  @-webkit-keyframes loader-pxt {
    0% {
      -webkit-transform: perspective(160px) rotateX(0deg) rotateY(0deg);


### PR DESCRIPTION
progress bar was a lot more straightforward than i thought it'd be! this is based on the number of events it takes to load a new project (~30); continuing a project requires fewer events but i think it still feels fine to jump from a 2/3 filled bar to the loaded editor

![skillmap-progress-bar](https://user-images.githubusercontent.com/34112083/113222797-a0e53100-923c-11eb-9825-4d39fff7bbed.gif)
