### PR TITLE
[stable6.12] Cherry-pick debug button and asset carryover changes

### DIFF
--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -649,6 +649,26 @@ namespace pxt.sprite {
         return result;
     }
 
+    export function encodeAnimationString(frames: BitmapData[], interval: number) {
+        const encodedFrames = frames.map(frame => frame.data);
+
+        const data = new Uint8ClampedArray(8 + encodedFrames[0].length * encodedFrames.length);
+
+        // interval, frame width, frame height, frame count
+        set16Bit(data, 0, interval);
+        set16Bit(data, 2, frames[0].width);
+        set16Bit(data, 4, frames[0].height);
+        set16Bit(data, 6, frames.length);
+
+        let offset = 8;
+        encodedFrames.forEach(buf => {
+            data.set(buf, offset);
+            offset += buf.length;
+        })
+
+        return btoa(pxt.sprite.uint8ArrayToHex(data))
+    }
+
     export function addMissingTilemapTilesAndReferences(project: TilemapProject, asset: ProjectTilemap) {
         const allTiles = project.getProjectTiles(asset.data.tileset.tileWidth, true);
         asset.data.projectReferences = [];
@@ -797,6 +817,11 @@ namespace pxt.sprite {
             res += hex[data[i] & 0xf];
         }
         return res;
+    }
+
+    function set16Bit(buf: Uint8ClampedArray, offset: number, value: number) {
+        buf[offset] = value & 0xff;
+        buf[offset + 1] = (value >> 8) & 0xff;
     }
 
     function colorStringToRGB(color: string) {

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1631,27 +1631,11 @@ namespace pxt {
     }
 
     function serializeAnimation(asset: Animation): JRes {
-        const encodedFrames = asset.frames.map(frame => frame.data);
-
-        const data = new Uint8ClampedArray(8 + encodedFrames[0].length * encodedFrames.length);
-
-        // interval, frame width, frame height, frame count
-        set16Bit(data, 0, asset.interval);
-        set16Bit(data, 2, asset.frames[0].width);
-        set16Bit(data, 4, asset.frames[0].height);
-        set16Bit(data, 6, asset.frames.length);
-
-        let offset = 8;
-        encodedFrames.forEach(buf => {
-            data.set(buf, offset);
-            offset += buf.length;
-        })
-
         return {
             namespace: asset.id.substr(0, asset.id.lastIndexOf(".")),
             id: asset.id.substr(asset.id.lastIndexOf(".") + 1),
             mimeType: ANIMATION_MIME_TYPE,
-            data: btoa(pxt.sprite.uint8ArrayToHex(data)),
+            data: pxt.sprite.encodeAnimationString(asset.frames, asset.interval),
             displayName: asset.meta.displayName
         }
     }

--- a/skillmap/src/App.css
+++ b/skillmap/src/App.css
@@ -92,10 +92,6 @@ code {
     height: 100%;
 }
 
-.header-right > div {
-    margin-left: 1rem;
-}
-
 .header-logo {
     width: 3rem;
     height: 3rem;
@@ -103,6 +99,7 @@ code {
 
 .header-org-logo {
     height: 2rem;
+    margin-left: 1rem;
 }
 
 .header-org-logo img {
@@ -136,6 +133,11 @@ code {
     flex: 1;
     user-select: none;
     white-space: nowrap;
+}
+
+.header-button.icon-only {
+    font-size: unset;
+    padding: 1rem 0.5rem;
 }
 
 .header-button .header-button-label {

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -73,6 +73,7 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
             }
             <div className="spacer" />
             <div className="header-right">
+                <HeaderBarButton icon="icon bug" title={lf("Report a bug or issue")} onClick={this.onBugClicked}/>
                 { items?.length > 0 && <Dropdown icon="setting" className="header-settings" items={items} /> }
                 <div className="header-org-logo">
                     <img className="header-org-logo-large" src={resolvePath("assets/microsoft.png")} alt={organizationLogoAlt} />
@@ -92,11 +93,16 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
         tickEvent("skillmap.home");
         window.open(pxt.appTarget.appTheme.homeUrl);
     }
+
+    onBugClicked = () => {
+        tickEvent("skillmap.bugreport");
+        (window as any).usabilla_live?.("click");
+    }
 }
 
 interface HeaderBarButtonProps {
     icon: string;
-    label: string;
+    label?: string;
     title: string;
     onClick: () => void;
 }
@@ -104,9 +110,9 @@ interface HeaderBarButtonProps {
 const HeaderBarButton = (props: HeaderBarButtonProps) => {
     const { icon, label, title, onClick } = props;
 
-    return <div className="header-button" title={title} role="button" onClick={onClick}>
+    return <div className={`header-button ${!label ? "icon-only" : ""}`} title={title} role="button" onClick={onClick}>
         <i className={icon} />
-        <span className="header-button-label">{label}</span>
+        {label && <span className="header-button-label">{label}</span>}
     </div>
 }
 

--- a/skillmap/src/lib/codeCarryover.ts
+++ b/skillmap/src/lib/codeCarryover.ts
@@ -1,3 +1,4 @@
+import { guidGen } from "./browserUtils";
 import { lookupPreviousCompletedActivityState } from "./skillMapUtils";
 import { getProjectAsync, saveProjectAsync } from "./workspaceProvider";
 
@@ -21,17 +22,27 @@ export async function carryoverProjectCode(user: UserState, pageSource: string, 
 
 
 function mergeProjectCode(previousProject: pxt.Map<string>, newProject: pxt.Map<string>, carryoverCode: boolean) {
+    const configString = carryoverCode ? previousProject[pxt.CONFIG_NAME] : newProject[pxt.CONFIG_NAME];
+    const config = pxt.U.jsonTryParse(configString) as pxt.PackageConfig;
+
+    const tilemapJres = carryoverCode ?
+        mergeJRES(newProject[pxt.TILEMAP_JRES], previousProject[pxt.TILEMAP_JRES]) :
+        mergeJRES(previousProject[pxt.TILEMAP_JRES], newProject[pxt.TILEMAP_JRES]);
+    const imageJres = carryoverCode ?
+        mergeJRES(newProject[pxt.IMAGES_JRES], previousProject[pxt.IMAGES_JRES]) :
+        mergeJRES(appendTemporaryAssets(previousProject["main.blocks"], previousProject[pxt.IMAGES_JRES]), newProject[pxt.IMAGES_JRES]);
+
+    if (tilemapJres && config?.files?.indexOf(pxt.TILEMAP_JRES) < 0) config.files.push(pxt.TILEMAP_JRES)
+    if (imageJres && config?.files?.indexOf(pxt.IMAGES_JRES) < 0) config.files.push(pxt.IMAGES_JRES)
+
     return {
         ...newProject,
         ["main.ts"]: carryoverCode ? previousProject["main.ts"] : newProject["main.ts"],
         ["main.py"]: carryoverCode ? previousProject["main.py"] : newProject["main.py"],
         ["main.blocks"]: carryoverCode ? previousProject["main.blocks"] : newProject["main.blocks"],
-        [pxt.TILEMAP_JRES]: carryoverCode ?
-            mergeJRES(newProject[pxt.TILEMAP_JRES], previousProject[pxt.TILEMAP_JRES]) :
-            mergeJRES(previousProject[pxt.TILEMAP_JRES], newProject[pxt.TILEMAP_JRES]),
-        [pxt.IMAGES_JRES]: carryoverCode ?
-            mergeJRES(newProject[pxt.IMAGES_JRES], previousProject[pxt.IMAGES_JRES]) :
-            mergeJRES(previousProject[pxt.IMAGES_JRES], newProject[pxt.IMAGES_JRES])
+        [pxt.TILEMAP_JRES]: tilemapJres,
+        [pxt.IMAGES_JRES]: imageJres,
+        [pxt.CONFIG_NAME]: JSON.stringify(config)
     };
 }
 
@@ -181,4 +192,96 @@ function mergeJRES(previous: string, next: string) {
     }
 
     return JSON.stringify(nextParsed);
+}
+
+function appendTemporaryAssets(blocks: string, assets: string) {
+    if (!blocks) return assets;
+
+    let jres = pxt.U.jsonTryParse(assets) as pxt.Map<Partial<pxt.JRes> | string> || {};
+    if (!jres["*"]) {
+        (jres as any)["*"] = {
+            "mimeType": "image/x-mkcd-f4",
+            "dataEncoding": "base64",
+            "namespace": pxt.sprite.IMAGES_NAMESPACE
+        };
+    }
+
+    // Regex image literals from blocks, append to existing JRes
+    let index = 0;
+    getImages(blocks)
+        .forEach(data => {
+            const id = guidGen();
+            while (jres[`${pxt.sprite.IMAGES_NAMESPACE}.${pxt.sprite.IMAGE_PREFIX}${index}`]) {
+                index++;
+            }
+            jres[id] = {
+                data: pxt.sprite.base64EncodeBitmap(data),
+                mimeType: pxt.IMAGE_MIME_TYPE,
+                displayName: `${pxt.sprite.IMAGES_NAMESPACE}.${pxt.sprite.IMAGE_PREFIX}${index}`
+            }
+            index++;
+        });
+
+    // Regex animations (array of image literals) from blocks, append to existing JRes
+    index = 0;
+    getAnimations(blocks)
+        .forEach(anim => {
+            const id = guidGen();
+            while (jres[`${pxt.sprite.ANIMATION_NAMESPACE}.${pxt.sprite.ANIMATION_NAMESPACE}${index}`]) {
+                index++;
+            }
+            jres[id] = {
+                data: pxt.sprite.encodeAnimationString(anim.frames, anim.interval),
+                mimeType: pxt.ANIMATION_MIME_TYPE,
+                displayName: `${pxt.sprite.ANIMATION_NAMESPACE}.${pxt.sprite.ANIMATION_PREFIX}${index}`
+            }
+            index++;
+        });
+
+    return JSON.stringify(jres)
+}
+
+/**
+ *  <field name="FIELDNAME">img`
+ *      . .
+ *      . .
+ *  `</field>
+ */
+function getImages(text: string): pxt.sprite.BitmapData[] {
+    const imgRegex = /<field name=\"[\da-zA-Z]+\">\s*(img`[\s\da-f.#tngrpoyw]+`)\s*<\/field>/gim;
+    const images: pxt.sprite.BitmapData[] = [];
+
+    text.replace(imgRegex, (m, literal) => {
+        const data = pxt.sprite.imageLiteralToBitmap(literal)?.data();
+        if (data) images.push(data);
+        return m;
+    })
+
+    return images;
+}
+
+/**
+ *  <field name="FIELDNAME">[img`
+ *      . .
+ *      . .
+ *  `,img`
+ *      . .
+ *      . .
+ *  `]</field>
+ */
+function getAnimations(text: string): { frames: pxt.sprite.BitmapData[], interval: number}[] {
+    const animRegex = /<field name=\"[\da-zA-Z]+\">\s*\[((?:img`[\s\da-f.#tngrpoyw]+`,?)+)\]\s*<\/field>(?:.*<shadow type=\"timePicker\"><field name=\"ms\">(\d+)<\/field><\/shadow>)?/gim;
+    const literals: { frames: pxt.sprite.BitmapData[], interval: number}[] = [];
+
+    text.replace(animRegex, (m, f, i) => {
+        const frames: pxt.sprite.BitmapData[] = f.split(",")
+            .map((el: string) => pxt.sprite.imageLiteralToBitmap(el)?.data());
+        literals.push({
+            frames: frames.filter(frame => !!frame),
+            interval: i || 500
+        });
+        return m;
+    })
+
+    return literals;
 }


### PR DESCRIPTION
- https://github.com/microsoft/pxt/pull/8029 - request from Kiki, she said that in user testing people don't think of the "Feedback" button as a way to report bugs or issues, so she wanted a separate "Bug" button that will toggle the Usabilla form
- https://github.com/microsoft/pxt/pull/8032 - slightly bigger change, but is related to https://github.com/microsoft/pxt/pull/7998; this fixes the asset carryover when you click "Start Fresh" on a skillmap activity. we can leave this out and not have the asset carryover for now but should probably sync with kiki to make sure that's okay