### PR TITLE
Add filter options to monaco image editor

### DIFF
--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -57,7 +57,7 @@ namespace pxt.editor {
                 initWidth: 16,
                 initHeight: 16,
                 blocksInfo: this.host.blocksInfo(),
-                filter: ""
+                filter: " "
             };
         }
     }

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -57,7 +57,7 @@ namespace pxt.editor {
                 initWidth: 16,
                 initHeight: 16,
                 blocksInfo: this.host.blocksInfo(),
-                filter: "!tile !dialog !background"
+                filter: ""
             };
         }
     }

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -56,8 +56,7 @@ namespace pxt.editor {
             return {
                 initWidth: 16,
                 initHeight: 16,
-                blocksInfo: this.host.blocksInfo(),
-                filter: " "
+                blocksInfo: this.host.blocksInfo()
             };
         }
     }

--- a/pxteditor/monaco-fields/field_sprite.ts
+++ b/pxteditor/monaco-fields/field_sprite.ts
@@ -56,7 +56,8 @@ namespace pxt.editor {
             return {
                 initWidth: 16,
                 initHeight: 16,
-                blocksInfo: this.host.blocksInfo()
+                blocksInfo: this.host.blocksInfo(),
+                filter: "!tile !dialog !background"
             };
         }
     }

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -21,7 +21,7 @@ export interface ImageFieldEditorState {
     tileGalleryVisible?: boolean;
     headerVisible?: boolean;
     hideMyAssets?: boolean;
-    galleryFilter?: string;
+    galleryFilter: string;
     editingTile?: boolean;
 }
 
@@ -52,7 +52,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             headerVisible: true,
             filterOpen: false,
             gallerySelectedTags: [],
-            galleryFilter: " "
+            galleryFilter: ""
         };
         setTelemetryFunction(tickImageEditorEvent);
     }
@@ -121,12 +121,12 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                     <ImageEditorToggle options={toggleOptions} view={currentView} />
                 </div>
                 <div className="image-editor-header-right">
-                    {this.state.galleryFilter && <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={sui.fireClickOnEnter}>
+                    <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={sui.fireClickOnEnter}>
                         <div className="gallery-filter-button-icon">
                             <i className="icon filter" />
                         </div>
                         <div className="gallery-filter-button-label">{lf("Filter")}</div>
-                    </div>}
+                    </div>
                     {!editingTile && <div className="image-editor-close-button" role="button" onClick={this.onDoneClick}>
                         <i className="ui icon close"/>
                     </div>}

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -120,12 +120,12 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                     <ImageEditorToggle options={toggleOptions} view={currentView} />
                 </div>
                 <div className="image-editor-header-right">
-                    <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={sui.fireClickOnEnter}>
+                    {this.state.galleryFilter && <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={sui.fireClickOnEnter}>
                         <div className="gallery-filter-button-icon">
                             <i className="icon filter" />
                         </div>
                         <div className="gallery-filter-button-label">{lf("Filter")}</div>
-                    </div>
+                    </div>}
                     {!editingTile && <div className="image-editor-close-button" role="button" onClick={this.onDoneClick}>
                         <i className="ui icon close"/>
                     </div>}

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -51,7 +51,8 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             currentView: "editor",
             headerVisible: true,
             filterOpen: false,
-            gallerySelectedTags: []
+            gallerySelectedTags: [],
+            galleryFilter: " "
         };
         setTelemetryFunction(tickImageEditorEvent);
     }
@@ -342,7 +343,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             }
         }
 
-        if (this.state.galleryFilter && useTags) {
+        if (useTags) {
             assets.forEach(a => {
                 if (!a.meta.tags && this.options) {
                     a.meta.tags = this.blocksInfo.apis.byQName[a.id]?.attributes.tags?.split(" ") || [];


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3384

- don't show the filter button if the filter option isn't there
- add filter to the field editor option for monaco 

The issue is tags weren't being populated in monaco, adding the option fixes it