### PR TITLE
[stable 6.12] Cherry pick gallery filter fix, tutorial header overload fix

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -696,6 +696,20 @@ code.lang-filterblocks {
 
 /* > Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) {
+    .thin {
+        .landscape.only {
+            display: none;
+        }
+
+        .portrait.hide {
+            display: none;
+        }
+
+        .portrait.only {
+            display: block!important;
+            height: auto!important;
+        }
+    }
 }
 
 /* Large Monitor */

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -21,7 +21,7 @@ export interface ImageFieldEditorState {
     tileGalleryVisible?: boolean;
     headerVisible?: boolean;
     hideMyAssets?: boolean;
-    galleryFilter?: string;
+    galleryFilter: string;
     editingTile?: boolean;
 }
 
@@ -51,7 +51,8 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             currentView: "editor",
             headerVisible: true,
             filterOpen: false,
-            gallerySelectedTags: []
+            gallerySelectedTags: [],
+            galleryFilter: ""
         };
         setTelemetryFunction(tickImageEditorEvent);
     }
@@ -342,7 +343,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             }
         }
 
-        if (this.state.galleryFilter && useTags) {
+        if (useTags) {
             assets.forEach(a => {
                 if (!a.meta.tags && this.options) {
                     a.meta.tags = this.blocksInfo.apis.byQName[a.id]?.attributes.tags?.split(" ") || [];

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -540,6 +540,9 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const sandbox = pxt.shell.isSandboxMode();
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
 
+        // Approximate each tutorial step to be 22 px
+        const manyTutorialSteps = inTutorial && (tutorialOptions.tutorialStepInfo.length * 22 > window.innerWidth / 3);
+
         const activityName = tutorialOptions && tutorialOptions.tutorialActivityInfo ?
             tutorialOptions.tutorialActivityInfo[tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep].activity].name :
             null;
@@ -570,7 +573,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
         const editor = this.props.parent.isPythonActive() ? "Python" : (this.props.parent.isJavaScriptActive() ? "JavaScript" : "Blocks");
 
         /* tslint:disable:react-a11y-anchors */
-        return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menubar" aria-label={lf("Main menu")}>
+        return <div id="mainmenu" className={`ui borderless fixed ${targetTheme.invertedMenu ? `inverted` : ''} menu ${manyTutorialSteps ? "thin" : ""}`} role="menubar" aria-label={lf("Main menu")}>
             {!sandbox ? <div className="left menu">
                 {!targetTheme.hideMenubarLogo &&
                     <a href={(!lockedEditor && isController) ? targetTheme.logoUrl : undefined} aria-label={lf("{0} Logo", targetTheme.boardName)} role="menuitem" target="blank" rel="noopener" className="ui item logo brand" tabIndex={0} onClick={lockedEditor ? undefined : this.brandIconClick} onKeyDown={sui.fireClickOnEnter}>
@@ -602,7 +605,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 {sandbox || inTutorial || debugging ? undefined : <container.SettingsMenu parent={this.props.parent} greenScreen={greenScreen} accessibleBlocks={accessibleBlocks} />}
                 {sandbox && !targetTheme.hideEmbedEdit ? <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} /> : undefined}
                 {inTutorial && tutorialReportId ? <sui.ButtonMenuItem className="report-tutorial-btn" role="menuitem" icon="warning circle" text={lf("Report Abuse")} textClass="landscape only" onClick={this.showReportAbuse} /> : undefined}
-                {(inTutorial && !lockedEditor && !hideIteration) && <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="external" text={lf("Exit tutorial")} textClass="landscape only" onClick={this.exitTutorial} />}
+                {(inTutorial && !lockedEditor && !hideIteration) && <sui.ButtonMenuItem className="exit-tutorial-btn" role="menuitem" icon="sign out" text={lf("Exit tutorial")} textClass="landscape only" onClick={this.exitTutorial} />}
 
                 {auth.hasIdentity() ? <identity.UserMenu parent={this.props.parent} continuationHash={"#editor"} /> : undefined}
                 {!sandbox ? <a href={lockedEditor ? undefined : targetTheme.organizationUrl} aria-label={lf("{0} Logo", targetTheme.organization)} role="menuitem" target="blank" rel="noopener" className="ui item logo organization" onClick={lockedEditor ? undefined : this.orgIconClick}>


### PR DESCRIPTION
Picks of:

Add filter options to monaco image editor #8042
Don't let the header overlap with each other #8026

which fixes:
microsoft/pxt-arcade#3384
microsoft/pxt-arcade#3322