### PR TITLE
Green screen safari fix

### DIFF
--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -40,6 +40,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
 
     handleDeviceClick(deviceId: any) {
         this.setState({ hasPrompt: false });
+        pxt.debug(`greenscreen: device ${deviceId}`)
         this.deviceId = deviceId;
         // deviceId is "" if green screen selected
         if (this.deviceId) {
@@ -47,6 +48,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
                 video: { deviceId: { exact: deviceId } },
                 audio: false
             }).then(stream => {
+                pxt.debug(`greenscreen: stream acquired`)
                 try {
                     this.stream = stream;
                     this.video.srcObject = this.stream;
@@ -61,10 +63,13 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
                     }
                 }
                 catch (e) {
-                    pxt.debug(`greenscreen: play failed, ${e}`)
+                    pxt.debug(`greenscreen: play failed`)
+                    console.error(e)
                     this.stop();
                 }
             }, err => {
+                pxt.debug(`greenscreen: get camera failed`)
+                console.error(err)
                 this.stop();
             })
         }
@@ -112,6 +117,8 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
     render() {
         // playsInline required for iOS
         const { hasPrompt, devices, userFacing } = this.state;
+        const handleClick = (deviceId: string) => () => this.handleDeviceClick(deviceId)
+
         return <div className="videoContainer">
             <video className={userFacing ? "flipx" : ""} autoPlay playsInline ref={this.handleVideoRef} />
             {hasPrompt ?
@@ -121,14 +128,14 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
                         <WebCamCard
                             key={`devicegreenscreen`}
                             icon='green tint'
-                            onClick={this.handleDeviceClick}
+                            onClick={handleClick("")}
                             deviceId={""} header={lf("Green background")} />
                         {devices && devices
                             .map((device, di) =>
                                 <WebCamCard
                                     key={`device${di}`}
                                     icon='video camera'
-                                    onClick={this.handleDeviceClick}
+                                    onClick={handleClick(device.deviceId)}
                                     deviceId={device.deviceId} header={device.label || lf("camera {0}", di)} />
                             )}
                     </div>

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -85,14 +85,12 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
         if (isMediaDevicesSupported()) {
             // first ask for permission from ther user so that
             // labels are populated in enumerateDevices
-            navigator.mediaDevices.getUserMedia({
-                audio: false, video: true
-            }).then(() => navigator.mediaDevices.enumerateDevices()
-                    .then(devices => {
-                        this.setState({ devices: devices.filter(device => device.kind == "videoinput") });
-                    })
-            , e => {
-                pxt.debug(`greenscreen: get user media failed`)
+            navigator.mediaDevices.getUserMedia({ audio: false, video: true })
+            .then(() => navigator.mediaDevices.enumerateDevices())
+            .then(devices => {
+                this.setState({ devices: devices.filter(device => device.kind == "videoinput") });
+            }, e => {
+                pxt.debug(`greenscreen: enumerate devices failed`)
                 console.error(e);
             });
         }

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -24,7 +24,7 @@ function isMediaDevicesSupported(): boolean {
 }
 
 export class WebCam extends data.Component<WebCamProps, WebCamState> {
-    private deviceInfo: MediaDeviceInfo;
+    private deviceId: string;
     private stream: MediaStream;
     private video: HTMLVideoElement;
 
@@ -38,14 +38,14 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
         this.handleClose = this.handleClose.bind(this);
     }
 
-    handleDeviceClick(deviceInfo: MediaDeviceInfo) {
+    handleDeviceClick(deviceId: string) {
         this.setState({ hasPrompt: false });
         pxt.debug(`greenscreen: start`)
-        this.deviceInfo = deviceInfo;
+        this.deviceId = deviceId;
         // deviceId is "" if green screen selected
-        if (this.deviceInfo?.deviceId) {
+        if (this.deviceId) {
             navigator.mediaDevices.getUserMedia({
-                video: { deviceId: { exact: deviceInfo.deviceId } },
+                video: { deviceId: { exact: deviceId } },
                 audio: false
             }).then(stream => {
                 pxt.debug(`greenscreen: stream acquired`)
@@ -76,7 +76,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
     }
 
     handleClose() {
-        if (!this.deviceInfo) {
+        if (!this.deviceId) {
             this.props.close();
         }
     }
@@ -103,7 +103,7 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
     }
 
     private stop() {
-        this.deviceInfo = undefined;
+        this.deviceId = undefined;
         if (this.stream) {
             try {
                 const tracks = this.stream.getTracks();
@@ -137,14 +137,14 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
                             key={`devicegreenscreen`}
                             icon='green tint'
                             onClick={this.handleDeviceClick}
-                            device={undefined} header={lf("Green background")} />
+                            deviceId={""} header={lf("Green background")} />
                         {devices && devices
                             .map((device, di) =>
                                 <WebCamCard
                                     key={`device${di}`}
                                     icon='video camera'
                                     onClick={this.handleDeviceClick}
-                                    device={device} header={device.label || lf("camera {0}", di)} />
+                                    deviceId={device.deviceId} header={device.label || lf("camera {0}", di)} />
                             )}
                     </div>
                 </sui.Modal>
@@ -157,8 +157,8 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
 interface WebCamCardProps {
     header: string;
     icon: string;
-    device: MediaDeviceInfo;
-    onClick: (device: MediaDeviceInfo) => void;
+    deviceId: string;
+    onClick: (deviceId: string) => void;
 }
 
 class WebCamCard extends data.Component<WebCamCardProps, {}> {
@@ -172,8 +172,8 @@ class WebCamCard extends data.Component<WebCamCardProps, {}> {
     }
 
     handleClick() {
-        const { device, onClick } = this.props;
-        onClick(device);
+        const { deviceId, onClick } = this.props;
+        onClick(deviceId);
     }
 
     renderCore() {

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -86,13 +86,13 @@ export class WebCam extends data.Component<WebCamProps, WebCamState> {
             // first ask for permission from ther user so that
             // labels are populated in enumerateDevices
             navigator.mediaDevices.getUserMedia({ audio: false, video: true })
-            .then(() => navigator.mediaDevices.enumerateDevices())
-            .then(devices => {
-                this.setState({ devices: devices.filter(device => device.kind == "videoinput") });
-            }, e => {
-                pxt.debug(`greenscreen: enumerate devices failed`)
-                console.error(e);
-            });
+                .then(() => navigator.mediaDevices.enumerateDevices())
+                .then(devices => {
+                    this.setState({ devices: devices.filter(device => device.kind == "videoinput") });
+                }, e => {
+                    pxt.debug(`greenscreen: enumerate devices failed`)
+                    console.error(e);
+                });
         }
     }
 


### PR DESCRIPTION
Safari changed it's policy and will not provide label, deviceId on enumerated user media devices until getUserMedia is called, and user consent is given.
Fix for https://github.com/microsoft/pxt-microbit/issues/3633

Tested on Safari MaxOSX, Edge.

![image](https://user-images.githubusercontent.com/4175913/113388932-6809a100-938f-11eb-9bd0-c7885db429be.png)
