### PR TITLE
Upgrade Typescript from v3.7 to v4.2

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,2 @@
 **/ext-typescript/
 .eslintrc.js
-
-# For some reason these files cause eslint to crash inside the TS compiler :(
-#   Error: Debug Failure. Unhandled declaration kind! ModuleDeclaration for {...}
-# Might be fixed if we update our TS version.
-# TODO: update to TS 4.2 and try again
-blocks.tsx
-snippetBuilder.tsx

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@types/web-bluetooth": "0.0.4",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
+    "@vusion/webfonts-generator": "^0.7.1",
     "crypto-js": "^3.1.9-1",
     "envify": "4.1.0",
     "eslint": "^7.23.0",
@@ -133,9 +134,8 @@
     "react-tooltip": "3.9.0",
     "redux": "3.7.2",
     "smoothie": "1.35.0",
-    "typescript": "3.7.5",
-    "uglifyify": "5.0.2",
-    "@vusion/webfonts-generator": "^0.7.1"
+    "typescript": "4.2.3",
+    "uglifyify": "5.0.2"
   },
   "scripts": {
     "build": "gulp",

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -405,7 +405,7 @@ namespace ts.pxtc.service {
                     if (sigs && sigs.length) {
                         return createDefaultFunction(sigs[0], false);
                     }
-                    return emitEmptyFn(name);
+                    return emitEmptyFn();
                 }
             }
             if (type.flags & ts.TypeFlags.NumberLike) {
@@ -618,7 +618,7 @@ namespace ts.pxtc.service {
             }
         }
 
-        function emitEmptyFn(n: string): SnippetNode {
+        function emitEmptyFn(n?: string): SnippetNode {
             if (python) {
                 n = n || "fn"
                 n = snakify(n);

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -156,7 +156,7 @@ namespace pxsim {
 
         export async function promiseTimeout<T>(ms: number, promise: T | Promise<T>, msg?: string): Promise<T> {
             let timeoutId: any;
-            let res: () => void;
+            let res: (_?: any) => void;
 
             const timeoutPromise: Promise<T> = new Promise((resolve, reject) => {
                 res = resolve;

--- a/tests/decompile-test/decompilerunner.ts
+++ b/tests/decompile-test/decompilerunner.ts
@@ -67,7 +67,7 @@ function compareBlocksBaselines(a: string, b: string): boolean {
 }
 
 function decompileTestAsync(filename: string) {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         const basename = path.basename(filename);
         const baselineFile = path.join(baselineDir, util.replaceFileExtension(basename, ".blocks"))
 

--- a/tests/pyconverter-test/pyconvertrunner.ts
+++ b/tests/pyconverter-test/pyconvertrunner.ts
@@ -96,7 +96,7 @@ function fail(msg: string) {
 }
 
 function pyconverterTestAsync(pyFilename: string) {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         const basename = path.basename(pyFilename);
         let baselineFile = path.join(baselineDir, util.replaceFileExtension(basename, ".ts"))
         baselineFile = baselineFile.replace("ONLY_", "")

--- a/tests/pydecompile-test/pydecompilerunner.ts
+++ b/tests/pydecompile-test/pydecompilerunner.ts
@@ -70,7 +70,7 @@ function pydecompileTestAsync(caseFile: string) {
 }
 
 function pydecompileTestCoreAsync(tsFilename: string, baselineFile: string) {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
         const basename = path.basename(baselineFile);
 
         let baselineExists: boolean;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1744,6 +1744,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     let type = shadow.getAttribute('type');
                     const builtin = snippets.allBuiltinBlocks()[type];
                     let b = this.getBlockXml(builtin ? builtin : { name: type, attributes: { blockId: type } }, ignoregap, true);
+                    // Note: we're setting one innerHTML to another
+                    // eslint-disable-next-line @microsoft/sdl/no-inner-html
                     if (b && b.length > 0 && b[0]) shadow.innerHTML = b[0].innerHTML;
                 })
         }

--- a/webapp/src/electron.ts
+++ b/webapp/src/electron.ts
@@ -34,7 +34,7 @@ export function initElectron(projectView: ProjectView): void {
         }
     });
 
-    const criticalUpdateFailedPromise = new Promise((resolve) => {
+    const criticalUpdateFailedPromise = new Promise<void>((resolve) => {
         pxtElectron.onCriticalUpdateFailed(() => {
             pxt.tickEvent("electron.criticalupdate.failed");
             resolve();

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -609,7 +609,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                     this.props.parent.newProject({ name, languageRestriction });
                 })
         } else {
-            this.props.parent.newProject({ name });
+            this.props.parent.newProject({});
         }
     }
 


### PR DESCRIPTION
Now that we've moved to ESLint (https://github.com/microsoft/pxt/pull/8039), we can now upgrade our Typescript version! Hurray!

Also, this lets us remove the lint exceptions I had to introduce for blocks.tsx and snippetBuilder.tsx because those were crashing eslint due to a typescript bug.

The upgrade went surprisingly smooth... just a few new complaints about void types and removing the "name: void" global by default.