### PR TITLE
Fix immersive reader in electron

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -34,18 +34,18 @@ namespace pxt.Cloud {
             && !BrowserUtils.isLocalHost() && !!pxt.webConfig.cdnUrl
     }
 
-    export function cdnApiUrl(url: string) {
+    export function cdnApiUrl(url: string, hourly?: boolean) {
         url = url.replace(/^\//, '');
         if (!useCdnApi())
             return apiRoot + url;
 
         const d = new Date()
-        const timestamp = d.getUTCFullYear() + ("0" + (d.getUTCMonth() + 1)).slice(-2) + ("0" + d.getUTCDate()).slice(-2)
+        const timestamp = d.getUTCFullYear() + ("0" + (d.getUTCMonth() + 1)).slice(-2) + ("0" + d.getUTCDate()).slice(-2);
         if (url.indexOf("?") < 0)
             url += "?"
         else
             url += "&"
-        url += "cdn=" + timestamp
+        url += `cdn=${timestamp}${hourly ? d.getUTCHours() : ""}`;
         // url = url.replace("?", "$")
         return pxt.webConfig.cdnUrl + "/api/" + url
     }
@@ -53,7 +53,7 @@ namespace pxt.Cloud {
     export function apiRequestWithCdnAsync(options: Util.HttpRequestOptions) {
         if (!useCdnApi())
             return privateRequestAsync(options)
-        options.url = cdnApiUrl(options.url)
+        options.url = cdnApiUrl(options.url, options.hourlyCache)
         return Util.requestAsync(options)
             .catch(e => handleNetworkError(options, e))
     }

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -776,6 +776,7 @@ namespace ts.pxtc.Util {
         forceLiveEndpoint?: boolean;
         successCodes?: number[];
         withCredentials?: boolean;
+        hourlyCache?: boolean;
     }
 
     export interface HttpResponse {

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -175,14 +175,14 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-            return auth.apiAsync("/api/immreader").then(res => {
+            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(res => {
                 if (res.statusCode == 200 ) {
-                    pxt.storage.setLocal('immReader', JSON.stringify(res.resp));
-                    return res.resp;
+                    pxt.storage.setLocal('immReader', JSON.stringify(res.json));
+                    return res.json;
                 } else {
                     pxt.storage.removeLocal("/api/immreader");
-                    console.log("immersive reader fetch token error: " + JSON.stringify(res.err));
-                    pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(res.err)})
+                    console.log("immersive reader fetch token error: " + JSON.stringify(res.json));
+                    pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(res.json)})
                     return Promise.reject(new Error("token"));
                 }
             });

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -175,17 +175,18 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(res => {
-                if (res.statusCode == 200 ) {
+            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(
+                res => {
                     pxt.storage.setLocal('immReader', JSON.stringify(res.json));
                     return res.json;
-                } else {
+                },
+                e => {
                     pxt.storage.removeLocal("/api/immreader");
-                    console.log("immersive reader fetch token error: " + JSON.stringify(res.json));
-                    pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(res.json)})
+                    console.log("immersive reader fetch token error: " + JSON.stringify(e));
+                    pxt.tickEvent("immersiveReader.error", { error: JSON.stringify(e) });
                     return Promise.reject(new Error("token"));
                 }
-            });
+            );
         } else {
             pxt.tickEvent("immersiveReader.cachedToken");
             return Promise.resolve(cachedToken);

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -171,17 +171,18 @@ function beautifyText(content: string): string {
 
 function getTokenAsync(): Promise<ImmersiveReaderToken> {
     if (Cloud.isOnline()) {
-        const storedTokenString = pxt.storage.getLocal('immReader');
+        const IMMERSIVE_READER_ID = "immReader";
+        const storedTokenString = pxt.storage.getLocal(IMMERSIVE_READER_ID);
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
             return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(
                 res => {
-                    pxt.storage.setLocal('immReader', JSON.stringify(res.json));
+                    pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res.json));
                     return res.json;
                 },
                 e => {
-                    pxt.storage.removeLocal("/api/immreader");
+                    pxt.storage.removeLocal(IMMERSIVE_READER_ID);
                     console.log("immersive reader fetch token error: " + JSON.stringify(e));
                     pxt.tickEvent("immersiveReader.error", { error: JSON.stringify(e) });
                     return Promise.reject(new Error("token"));

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -176,7 +176,7 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(
+            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true, hourlyCache: true }).then(
                 res => {
                     pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res.json));
                     return res.json;


### PR DESCRIPTION
Api requests in electron expect the local token for authentication, where auth.apiAsync attaches the user's token for authentication - so typically we wanna use Cloud.apiRequestWithCdnAsync. In this case we always want to hit the live endpoint too (makecode.com/api/immreader instead of localhost/api/immreader), so this fixes in electron. My understanding is that we want these to hit through the cdn anyways? e.g. https://pxt.azureedge.net/api/immreader?cdn=20210402 (I believethe cdn= changes every 12 hours so that should be good with the refreshes, though I'll double check -- if it's 24 hours will have to fix that or do a different fix.)

test https://arcade.makecode.com/app/d32c7f199fbdc6a758b45eb7255cda3b1caacada-7050ed1730

![image](https://user-images.githubusercontent.com/5615930/113459536-b25c4380-93ca-11eb-950c-31da9db998a0.png)

Also I think small side fix in https://github.com/microsoft/pxt/commit/61eba0bed2cda340551e41292c19664b337f35b4 @livcheerful, let me know if it was intentional but the removeLocal wasn't removing the token as the key didn't match
