### PR TITLE
Fix immersive reader in electron (v2)

### DIFF
--- a/cli/server.ts
+++ b/cli/server.ts
@@ -973,6 +973,13 @@ export function serveAsync(options: ServeOptions) {
                 return
             }
 
+            if (elts[1] == "immreader") {
+                let trg = Cloud.apiRoot + elts[1];
+                res.setHeader("Location", trg)
+                error(302, "Redir: " + trg)
+                return
+            }
+
             if (/^\d\d\d[\d\-]*$/.test(elts[1]) && elts[2] == "js") {
                 return compileScriptAsync(elts[1])
                     .then(data => {

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as data from "./data";
-import * as auth from "./auth";
 import * as core from "./core";
 import * as sui from "./sui";
 import * as ImmersiveReader from '@microsoft/immersive-reader-sdk';

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -175,14 +175,14 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-            return auth.apiAsync("/api/immreader").then(res => {
+            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(res => {
                 if (res.statusCode == 200 ) {
-                    pxt.storage.setLocal('immReader', JSON.stringify(res.resp));
-                    return res.resp;
+                    pxt.storage.setLocal('immReader', JSON.stringify(res.json));
+                    return res.json;
                 } else {
                     pxt.storage.removeLocal("/api/immreader");
-                    console.log("immersive reader fetch token error: " + JSON.stringify(res.err));
-                    pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(res.err)})
+                    console.log("immersive reader fetch token error: " + JSON.stringify(res.json));
+                    pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(res.json)})
                     return Promise.reject(new Error("token"));
                 }
             });

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -176,7 +176,7 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(
+            return pxt.Util.requestAsync({ url: "/api/immreader", method: "GET" }).then(
                 res => {
                     pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res.json));
                     return res.json;

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -175,17 +175,18 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(res => {
-                if (res.statusCode == 200 ) {
+            return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(
+                res => {
                     pxt.storage.setLocal('immReader', JSON.stringify(res.json));
                     return res.json;
-                } else {
+                },
+                e => {
                     pxt.storage.removeLocal("/api/immreader");
-                    console.log("immersive reader fetch token error: " + JSON.stringify(res.json));
-                    pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(res.json)})
+                    console.log("immersive reader fetch token error: " + JSON.stringify(e));
+                    pxt.tickEvent("immersiveReader.error", { error: JSON.stringify(e) });
                     return Promise.reject(new Error("token"));
                 }
-            });
+            );
         } else {
             pxt.tickEvent("immersiveReader.cachedToken");
             return Promise.resolve(cachedToken);

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -171,17 +171,18 @@ function beautifyText(content: string): string {
 
 function getTokenAsync(): Promise<ImmersiveReaderToken> {
     if (Cloud.isOnline()) {
-        const storedTokenString = pxt.storage.getLocal('immReader');
+        const IMMERSIVE_READER_ID = "immReader";
+        const storedTokenString = pxt.storage.getLocal(IMMERSIVE_READER_ID);
         const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
         if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
             return Cloud.apiRequestWithCdnAsync({ url: "immreader", forceLiveEndpoint: true }).then(
                 res => {
-                    pxt.storage.setLocal('immReader', JSON.stringify(res.json));
+                    pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res.json));
                     return res.json;
                 },
                 e => {
-                    pxt.storage.removeLocal("/api/immreader");
+                    pxt.storage.removeLocal(IMMERSIVE_READER_ID);
                     console.log("immersive reader fetch token error: " + JSON.stringify(e));
                     pxt.tickEvent("immersiveReader.error", { error: JSON.stringify(e) });
                     return Promise.reject(new Error("token"));


### PR DESCRIPTION
Similar to previous one but not using cdn, just going through requestAsync rather than cdnapiurl. Added a redirect in the local serve rather than an explicit check like in auth.ts so `pxt serve` can still fetch tokens.