### PR TITLE
Add titles and aria-labels across homepage carousels, help icon

### DIFF
--- a/webapp/src/carousel.tsx
+++ b/webapp/src/carousel.tsx
@@ -87,7 +87,7 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
         const isRTL = pxt.Util.isUserLanguageRtl();
 
         return <div className="ui carouselouter">
-            {!leftDisabled && <span role="button" className={"carouselarrow left aligned"} tabIndex={0}
+            {!leftDisabled && <span role="button" className={"carouselarrow left aligned"} tabIndex={0} title={lf("See previous")}
                 aria-label={lf("See previous")} onClick={this.onLeftArrowClick} onKeyDown={sui.fireClickOnEnter} ref={this.handleArrowRefs}>
                 <sui.Icon icon={"circle angle " + (!isRTL ? "left" : "right")} />
             </span>}
@@ -101,7 +101,7 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
                     }
                 </div>
             </div>
-            {!rightDisabled && <span role="button" className={"carouselarrow right aligned"} tabIndex={0}
+            {!rightDisabled && <span role="button" className={"carouselarrow right aligned"} tabIndex={0} title={lf("See more")}
                 aria-label={lf("See more")} onClick={this.onRightArrowClick} onKeyDown={sui.fireClickOnEnter} ref={this.handleArrowRefs}>
                 <sui.Icon icon={"circle angle " + (!pxt.Util.isUserLanguageRtl() ? "right" : "left")} />
             </span>}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -520,7 +520,8 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
                 </sui.Link>
             </div>}
             {cardIndex !== undefined && cards?.length > 1 && <div key="cards" className="dots">
-                {cards.map((_, i) => <button key={"dot" + i} className={`ui button empty circular label  clear ${i === cardIndex && "active"}`} onClick={handleSetCard(i)}>
+                {cards.map((card, i) => <button key={"dot" + i} className={`ui button empty circular label  clear ${i === cardIndex && "active"}`}
+                    onClick={handleSetCard(i)} aria-label={lf("View {0} hero image", card.title || card.name)} title={lf("View {0} hero image", card.title || card.name)}>
                 </button>)}
             </div>}
         </div>
@@ -824,7 +825,7 @@ export class ProjectsCodeCard extends sui.StatelessUIElement<ProjectsCodeCardPro
             else
                 className = 'file ' + className;
         }
-        return <codecard.CodeCardView className={className} imageUrl={imageUrl} cardType={cardType} {...rest} onClick={this.handleClick}
+        return <codecard.CodeCardView role="button" className={className} imageUrl={imageUrl} cardType={cardType} {...rest} onClick={this.handleClick}
             onLabelClicked={onLabelClick ? this.handleLabelClick : undefined} />
     }
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1300,7 +1300,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
                 </div> : undefined}
                 {helpUrl ?
                     <div className="header-help">
-                        <a className={`ui icon help-button`} href={helpUrl} target="_docs" role="button" aria-label={lf("Help on {0} dialog", header)}>
+                        <a className={`ui icon help-button`} href={helpUrl} target="_docs" role="button" aria-label={lf("Help on {0} dialog", header)} title={lf("Help on {0} dialog", header)}>
                             <Icon icon="help" />
                         </a>
                     </div>


### PR DESCRIPTION
- add titles to carousel "See more", "See previous", dialog "Help"
- add title and aria-label to dots on hero banner carousel
- add "button" role to all code cards

fixes https://github.com/microsoft/pxt-microbit/issues/3521
fixes https://github.com/microsoft/pxt-microbit/issues/3548
fixes https://github.com/microsoft/pxt-microbit/issues/3546