### PR TITLE
allow new github token format

### DIFF
--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -189,36 +189,30 @@ export class GithubProvider extends cloudsync.ProviderBase {
         core.showLoading(LOAD_ID, lf("validating GitHub token..."));
         return Promise.resolve()
             .then(() => {
-                if (hextoken.length != 40 || !/^gh[pousr]_[a-z0-9_]+$/i.test(hextoken)) {
-                    pxt.tickEvent("github.token.invalid");
-                    core.errorNotification(lf("Invalid token format"))
-                    return Promise.resolve();
-                } else {
-                    pxt.github.token = hextoken
-                    // try to create a bogus repo - it will fail with
-                    // 401 - invalid token, 404 - when token doesn't have repo permission,
-                    // 422 - because the request is bogus, but token OK
-                    // Don't put any string in repo name - github seems to normalize these
-                    return pxt.github.createRepoAsync(undefined, "")
-                        .then(r => {
-                            // what?!
-                            pxt.reportError("github", "Succeeded creating undefined repo!")
-                            core.infoNotification(lf("Something went wrong with validation; token stored"))
+                pxt.github.token = hextoken
+                // try to create a bogus repo - it will fail with
+                // 401 - invalid token, 404 - when token doesn't have repo permission,
+                // 422 - because the request is bogus, but token OK
+                // Don't put any string in repo name - github seems to normalize these
+                return pxt.github.createRepoAsync(undefined, "")
+                    .then(r => {
+                        // what?!
+                        pxt.reportError("github", "Succeeded creating undefined repo!")
+                        core.infoNotification(lf("Something went wrong with validation; token stored"))
+                        this.setNewToken(hextoken, rememberMe);
+                        pxt.tickEvent("github.token.wrong");
+                    }, err => {
+                        pxt.github.token = ""
+                        if (!dialogs.showGithubTokenError(err)) {
+                            if (err.statusCode == 422)
+                                core.infoNotification(lf("Token validated and stored"))
+                            else
+                                core.infoNotification(lf("Token stored but not validated"))
                             this.setNewToken(hextoken, rememberMe);
-                            pxt.tickEvent("github.token.wrong");
-                        }, err => {
-                            pxt.github.token = ""
-                            if (!dialogs.showGithubTokenError(err)) {
-                                if (err.statusCode == 422)
-                                    core.infoNotification(lf("Token validated and stored"))
-                                else
-                                    core.infoNotification(lf("Token stored but not validated"))
-                                this.setNewToken(hextoken, rememberMe);
-                                pxt.tickEvent("github.token.ok");
-                            }
-                        })
-                        .then(() => cloudsync.syncAsync())
-                }
+                            pxt.tickEvent("github.token.ok");
+                        }
+                    })
+                    .then(() => cloudsync.syncAsync())
             }).finally(() => core.hideLoading(LOAD_ID))
     }
 

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -117,7 +117,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
                 </ol>}
                 {useToken && <div className="ui field">
                     <label id="selectUrlToOpenLabel">{lf("Paste GitHub token here:")}</label>
-                    <input id="githubTokenInput" type="url" tabIndex={0} autoFocus aria-labelledby="selectUrlToOpenLabel" placeholder="0123abcd..." className="ui blue fluid"></input>
+                    <input id="githubTokenInput" type="url" tabIndex={0} autoFocus aria-labelledby="selectUrlToOpenLabel" placeholder="ghp_ABC..." className="ui blue fluid"></input>
                 </div>}
             </div>,
         }).then(res => {

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -189,7 +189,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
         core.showLoading(LOAD_ID, lf("validating GitHub token..."));
         return Promise.resolve()
             .then(() => {
-                if (hextoken.length != 40 || !/^[a-fA-F0-9]+$/.test(hextoken)) {
+                if (hextoken.length != 40 || !/^gh[pousr]_[a-z0-9_]+$/i.test(hextoken)) {
                     pxt.tickEvent("github.token.invalid");
                     core.errorNotification(lf("Invalid token format"))
                     return Promise.resolve();


### PR DESCRIPTION
github changed their format today so our 'looks kinda like a token' check is failing. New format info: https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/

could trim down the regex a bit more based off the valid token types but I don't see much of a reason to do so, if the user puts in something invalid it will fail a bit further down. (Conversely, could be a bit more general with just `/^[a-z0-9_]+$/i` to allow old tokens, but this is only run through the 'login to github dialog' so they'd have to be using a token created before today / really they *should* create a new token anyway in that case.)

here's a build: https://arcade.makecode.com/app/0f247e4a7a42ba773e2a1810f4acec7bc9c59e1f-20861107f6