### PR TITLE
Apply high contrast styles when OS high contrast is enabled

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -874,6 +874,14 @@
     }
 }
 
+@media (forced-colors: active) and (prefers-color-scheme: light) {
+    #homemenu .logo.organization img,
+    #homemenu .logo.brand img {
+        filter: invert(1);
+    }
+}
+
+
 /* > Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) {
     /* Hide the editor toolbor in tutorial mode */

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -162,7 +162,7 @@ export class ProjectView
         this.reload = false; //set to true in case of reset of the project where we are going to reload the page.
         this.settings = JSON.parse(pxt.storage.getLocal("editorSettings") || "{}")
         const shouldShowHomeScreen = this.shouldShowHomeScreen();
-        const isHighContrast = /hc=(\w+)/.test(window.location.href);
+        const isHighContrast = /hc=(\w+)/.test(window.location.href) || (window.matchMedia?.('(forced-colors: active)')?.matches);
         if (isHighContrast) core.setHighContrast(true);
 
         const simcfg = pxt.appTarget.simulator;


### PR DESCRIPTION
this fix adds our "hc" class when it detects that the operating system's high contrast is on. this seems like the right behavior because it ensures all future fixes to our high contrast will also propagate to windows/os high contrast users

one gotcha is if a user is swapping repeatedly between high-contrast on/off (i'm not sure if this is a real scenario?)--if you turn windows high contrast on, you'll need to refresh makecode to apply our high contrast styles. we also save high contrast preferences, so if you turn off the OS high contrast, makecode will still be high contrast for that session.

\+ one additional fix to invert the logo color if the user is in "light-mode" high contrast

fixes https://github.com/microsoft/pxt-microbit/issues/3551
fixes https://github.com/microsoft/pxt-microbit/issues/3549
fixes https://github.com/microsoft/pxt-microbit/issues/3562
fixes https://github.com/microsoft/pxt-microbit/issues/3565