### PR TITLE
loosing builtinparts info in driver

### DIFF
--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -602,6 +602,7 @@ namespace pxsim {
                 source: MESSAGE_SOURCE,
                 boardDefinition: opts.boardDefinition,
                 parts: opts.parts,
+                builtinParts: opts.builtinParts,
                 fnArgs: opts.fnArgs,
                 code: js,
                 partDefinitions: opts.partDefinitions,


### PR DESCRIPTION
We compute the set of builtin parts used by the program but loose the information between the compiled code and the simulator driver.

This explains why we never hit the static parts detection in microbit.