### PR TITLE
updated "add extensions" dialog wording

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -262,7 +262,7 @@ export class ProjectView
                 header: lf("Add extensions?"),
                 jsx: <>
                     <p>
-                        {lf("Add these user-provided extensions to your project?")}
+                        {lf("Add or update these user-provided extensions to your project?")}
                     </p>
                     <ul>
                         {ghidToBeApproved.map(scr => <li key={scr.fullName}>


### PR DESCRIPTION
Updated wording to mention "add or update" in the dialog "add extensions" dialog. (note that this only applies to non-approved extensions)

Fix for https://github.com/microsoft/jacdac/issues/280