### PR TITLE
Fix toggle for OS high contrast, update Github modal link

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -874,13 +874,21 @@
     }
 }
 
+/* OS-specific Fixes (eg Windows High Contrast) */
+
+@media (forced-colors: active) {
+    .ui.toggle.checkbox .box:after,
+    .ui.toggle.checkbox label:after {
+        forced-color-adjust: none;
+    }
+}
+
 @media (forced-colors: active) and (prefers-color-scheme: light) {
     #homemenu .logo.organization img,
     #homemenu .logo.brand img {
         filter: invert(1);
     }
 }
-
 
 /* > Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) {

--- a/webapp/src/githubprovider.tsx
+++ b/webapp/src/githubprovider.tsx
@@ -96,7 +96,7 @@ export class GithubProvider extends cloudsync.ProviderBase {
                 <div><sui.PlainCheckbox label={lf("Remember me")} onChange={handleRememberMe} /></div>
                 {!useToken && <p className="ui small">
                     {lf("Looking to use a Developer token instead?")}
-                    <sui.Link className="link" text={lf("Use Developer token")} onClick={showToken} />
+                    <sui.Link className="link" text={lf("Use Developer token")} onClick={showToken} href="#" />
                 </p>}
                 {useToken && <ol>
                     <li>

--- a/webapp/src/lang.tsx
+++ b/webapp/src/lang.tsx
@@ -170,7 +170,7 @@ class LanguageCard extends sui.StatelessUIElement<LanguageCardProps> {
         return <codecard.CodeCardView className={`card-selected langoption`}
             name={name}
             ariaLabel={ariaLabel}
-            role="link"
+            role="button"
             description={description}
             onClick={this.handleClick}
         />


### PR DESCRIPTION
- overrides OS hc colors for toggle (fixes https://github.com/microsoft/pxt-microbit/issues/3685)
- sets an href on the "Developer token" link (fixes https://github.com/microsoft/pxt-microbit/issues/3584)
- fix role for cards in language modal (addresses https://github.com/microsoft/pxt-microbit/issues/3666)