### PR TITLE
Always use new project pxt.json for skillmap carryover

### DIFF
--- a/skillmap/src/lib/codeCarryover.ts
+++ b/skillmap/src/lib/codeCarryover.ts
@@ -22,7 +22,7 @@ export async function carryoverProjectCode(user: UserState, pageSource: string, 
 
 
 function mergeProjectCode(previousProject: pxt.Map<string>, newProject: pxt.Map<string>, carryoverCode: boolean) {
-    const configString = carryoverCode ? previousProject[pxt.CONFIG_NAME] : newProject[pxt.CONFIG_NAME];
+    const configString = newProject[pxt.CONFIG_NAME];
     const config = pxt.U.jsonTryParse(configString) as pxt.PackageConfig;
 
     const tilemapJres = carryoverCode ?


### PR DESCRIPTION
bug: picking "Keep Code" from space explorer activity3 -> activity4 was loading without the Status Bars extension, because we were overwriting the config of the new project and erasing the dependencies.

we never want to take the pxt.json of the old project when doing code carryover, we only want to push the tilemap/image.g.jres files into the new config if the filenames are not there (eg activity A1 has images, activity A2 does not, so when carrying over assets from A1 -> A2 we need to add `images.g.jres` to the list of files in pxt.json)