### PR TITLE
Fix py string.replace

### DIFF
--- a/libs/pxt-python/pxt-python-helpers.ts
+++ b/libs/pxt-python/pxt-python-helpers.ts
@@ -119,11 +119,6 @@ namespace _py {
         return str;
     }
 
-    export function py_string_replace(str: string, oldString: string, newString: string, count?: number): string {
-        nullCheck(str);
-        return str;
-    }
-
     export function py_string_rfind(str: string, sub: string, start?: number, end?: number): number {
         nullCheck(str);
         return 0;

--- a/libs/pxt-python/pxt-python.d.ts
+++ b/libs/pxt-python/pxt-python.d.ts
@@ -106,8 +106,8 @@ declare namespace _py {
         //% pyHelper="py_string_lstrip"
         lstrip(chars?: string): string;
 
-        //% pyHelper="py_string_replace"
-        replace(oldString: string, newString: string, count?: number): string;
+        //% py2tsOverride="replace($0, $1)"
+        replace(oldString: string, newString: string): string;
 
         //% pyHelper="py_string_rfind"
         rfind(sub: string, start?: number, end?: number): number;

--- a/tests/pyconverter-test/baselines/string_replace.ts
+++ b/tests/pyconverter-test/baselines/string_replace.ts
@@ -1,0 +1,4 @@
+let sa = "1.2"
+console.log(sa)
+let ssa = sa.replace(".", ",")
+console.log(ssa)

--- a/tests/pyconverter-test/cases/string_replace.py
+++ b/tests/pyconverter-test/cases/string_replace.py
@@ -1,0 +1,4 @@
+sa = "1.2"
+print(sa)
+ssa = sa.replace(".", ",")
+print(ssa)


### PR DESCRIPTION
The JS and PY String.replace behaviors are similar enough we can do a straight translation. Python technically has an option for a third param, but this is rare and if it comes up we can use a py override.

Fixes: https://github.com/microsoft/pxt-microbit/issues/3831