### PR TITLE
Properly exclude python keywords & reserved words from ALL declarations

### DIFF
--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -273,13 +273,18 @@ namespace ts.pxtc.decompiler {
         }
     }
 
+    export type RenameMapOpts = {
+        declarations: "variables" | "all"
+        takenNames: NamesSet,
+    }
     export type NamesSet = pxt.Map<boolean | {}>
     /**
      * Uses the language service to ensure that there are no duplicate variable
      * names in the given file. All variables in Blockly are global, so this is
      * necessary to prevent local variables from colliding.
      */
-    export function buildRenameMap(p: Program, s: SourceFile, takenNames: NamesSet = {}): [RenameMap, NamesSet] {
+    export function buildRenameMap(p: Program, s: SourceFile,
+        { declarations, takenNames }: RenameMapOpts = { declarations: "variables", takenNames: {} }): [RenameMap, NamesSet] {
         let service = ts.createLanguageService(new LSHost(p))
         const allRenames: RenameLocation[] = [];
 
@@ -293,7 +298,8 @@ namespace ts.pxtc.decompiler {
 
             function checkChildren(n: Node): void {
                 ts.forEachChild(n, (child) => {
-                    if (ts.isDeclarationName(child)) {
+                    if (isDeclarationName(child)
+                        && (declarations === "all" || ts.isVariableDeclaration(child.parent))) {
                         const name = child.getText();
 
                         if (takenNames[name]) {

--- a/pxtcompiler/emitter/decompiler.ts
+++ b/pxtcompiler/emitter/decompiler.ts
@@ -293,12 +293,12 @@ namespace ts.pxtc.decompiler {
 
             function checkChildren(n: Node): void {
                 ts.forEachChild(n, (child) => {
-                    if (child.kind === SK.VariableDeclaration && (child as ts.VariableDeclaration).name.kind === SK.Identifier) {
-                        const name = (child as ts.VariableDeclaration).name.getText();
+                    if (ts.isDeclarationName(child)) {
+                        const name = child.getText();
 
                         if (takenNames[name]) {
                             const newName = getNewName(name, takenNames);
-                            const renames = service.findRenameLocations(s.fileName, (child as ts.VariableDeclaration).name.pos + 1, false, false);
+                            const renames = service.findRenameLocations(s.fileName, child.pos + 1, false, false);
                             if (renames) {
                                 renames.forEach(r => {
                                     allRenames.push({

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -301,7 +301,7 @@ namespace ts.pxtc {
             allowedArgumentTypes: opts.allowedArgumentTypes || ["number", "boolean", "string"],
             errorOnGreyBlocks: !!opts.errorOnGreyBlocks,
         };
-        const [renameMap, _] = pxtc.decompiler.buildRenameMap(program, file)
+        const [renameMap, _] = pxtc.decompiler.buildRenameMap(program, file, { declarations: "variables", takenNames: {} })
         const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, decompileOpts, renameMap);
         return bresp;
     }

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -103,7 +103,9 @@ namespace pxt.py {
                 'max', 'memoryview', 'min', 'next', 'object', 'oct', 'open', 'ord', 'pow',
                 'print', 'property', 'quit', 'range', 'repr', 'reversed', 'round', 'set',
                 'setattr', 'slice', 'sorted', 'staticmethod', 'str', 'sum', 'super', 'tuple',
-                'type', 'vars', 'zip']
+                'type', 'vars', 'zip',
+                ...Object.keys(pxt.py.keywords)
+            ]
             return reservedNames;
         }
         function tryGetSymbol(exp: ts.Node) {
@@ -156,7 +158,7 @@ namespace pxt.py {
             }
             let outName = name.text;
             let hasSrc = name.getSourceFile()
-            if (renameMap && hasSrc) {
+            if (hasSrc) {
                 const rename = renameMap.getRenameForPosition(name.getStart());
                 if (rename) {
                     outName = rename.name;

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -59,7 +59,7 @@ namespace pxt.py {
         const file = prog.getSourceFile(filename)
         const commentMap = pxtc.decompiler.buildCommentMap(file);
         const reservedWords = pxt.U.toSet(getReservedNmes(), s => s)
-        const [renameMap, globalNames] = ts.pxtc.decompiler.buildRenameMap(prog, file, reservedWords)
+        const [renameMap, globalNames] = ts.pxtc.decompiler.buildRenameMap(prog, file, { takenNames: reservedWords, declarations: "all" })
         const allSymbols = pxtc.getApiInfo(prog)
         const symbols = pxt.U.mapMap(allSymbols.byQName,
             // filter out symbols from the .ts corresponding to this file

--- a/tests/runtime-trace-tests/cases/reserved_words_decl.ts
+++ b/tests/runtime-trace-tests/cases/reserved_words_decl.ts
@@ -1,0 +1,4 @@
+function def() {
+    console.log("foo")
+}
+def();


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/3145

- buildRenameMap considers ALL declarations (functions, classes, etc) instead of just variable declarations
- Add PY keywords to the reserved words list (should always have been there.)