### PR TITLE
Support public parameters-members in ts2py class constructors

### DIFF
--- a/tests/runtime-trace-tests/cases/ONLY_class_pub_members.ts
+++ b/tests/runtime-trace-tests/cases/ONLY_class_pub_members.ts
@@ -1,0 +1,14 @@
+class Foo {
+    constructor(public n: number = 0) {
+    }
+
+    public change(m: number) {
+        this.n += m
+    }
+}
+
+let rope = new Foo(2)
+
+rope.change(0.1)
+
+console.log(rope.n)

--- a/tests/runtime-trace-tests/cases/callback_names.ts
+++ b/tests/runtime-trace-tests/cases/callback_names.ts
@@ -9,9 +9,8 @@ class Button {
     }
 }
 class Controller {
-    anyButton: Button
+    anyButton = new Button()
     constructor() {
-        this.anyButton = new Button()
     }
 }
 

--- a/tests/runtime-trace-tests/cases/class_pub_members.ts
+++ b/tests/runtime-trace-tests/cases/class_pub_members.ts
@@ -1,5 +1,5 @@
 class Foo {
-    constructor(public n: number = 0) {
+    constructor(public n: number) {
     }
 
     public change(m: number) {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/3188

Widens support for classes in Python by allowing member declarations in the parameter list like `class Foo(public myMem: number)`