### PR TITLE
Handle snippets with default values translating to py

### DIFF
--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -77,7 +77,7 @@ namespace ts.pxtc.service {
     }
 
     export function tsKeywordToPyKeyword(keyword: string): string | undefined {
-        const map: { [tsType: string]: string } = {
+        const map: pxt.Map<string> = {
             "true": "True",
             "false": "False",
             "null": "None"

--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -76,6 +76,14 @@ namespace ts.pxtc.service {
         return [...retApis, ...completionSymbols(enumVals, COMPLETION_DEFAULT_WEIGHT)]
     }
 
+    export function tsKeywordToPyKeyword(keyword: string): string | undefined {
+        const map: { [tsType: string]: string } = {
+            "true": "True",
+            "false": "False",
+            "null": "None"
+        }
+        return map[keyword]
+    }
 
     export function getBasicKindDefault(kind: SyntaxKind, isPython: boolean): string | undefined {
         switch (kind) {

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -289,10 +289,11 @@ namespace ts.pxtc.service {
             const name = param.name.kind === SK.Identifier ? (param.name as ts.Identifier).text : undefined;
 
             // check for explicit default in the attributes
-            if (attrs?.paramDefl?.[name]) {
+            const paramDefl = attrs?.paramDefl?.[name]
+            if (paramDefl) {
                 let deflKind: SyntaxKind;
                 if (typeNode.kind == SK.AnyKeyword) {
-                    const defaultName = attrs.paramDefl[name].toUpperCase();
+                    const defaultName = paramDefl.toUpperCase();
                     if (!Number.isNaN(+defaultName)) {
                         // try to parse as a number
                         deflKind = SK.NumberKeyword;
@@ -308,10 +309,16 @@ namespace ts.pxtc.service {
                     }
                 }
                 if (typeNode.kind === SK.StringKeyword || deflKind === SK.StringKeyword) {
-                    const defaultName = attrs.paramDefl[name];
-                    return defaultName.indexOf(`"`) != 0 ? `"${defaultName}"` : defaultName;
+                    return paramDefl.indexOf(`"`) != 0 ? `"${paramDefl}"` : paramDefl;
                 }
-                return attrs.paramDefl[name];
+
+                if (python) {
+                    let pyKeyword = tsKeywordToPyKeyword(paramDefl)
+                    if (pyKeyword)
+                        return pyKeyword
+                }
+
+                return paramDefl
             }
 
             let shadowDefFromFieldEditor = getDefaultValueFromFieldEditor(name)

--- a/tests/language-service/languageservicerunner.ts
+++ b/tests/language-service/languageservicerunner.ts
@@ -295,7 +295,7 @@ function runSnippetTestCaseAsync(testCase: SnippetTestCase): Promise<void> {
                 return;
             }
 
-            chai.assert(typeof result === "string", `Lang service returned non-string result: ${result}`)
+            chai.assert(typeof result === "string", `Lang service returned non-string result: ${JSON.stringify(result)}`)
 
             const match = util.compareBaselines(result, expectedSnippet, {
                 whitespaceSensitive: false

--- a/tests/language-service/snippet_cases/functions.py
+++ b/tests/language-service/snippet_cases/functions.py
@@ -1,0 +1,5 @@
+# testNamespace.someFunction
+testNamespace.some_function("", 0, False)
+
+# testNamespace.someFunctionWithDefl
+testNamespace.some_function_with_defl(5, True)

--- a/tests/language-service/snippet_cases/functions.ts
+++ b/tests/language-service/snippet_cases/functions.ts
@@ -1,2 +1,5 @@
 // testNamespace.someFunction
 testNamespace.someFunction("", 0, false)
+
+// testNamespace.someFunctionWithDefl
+testNamespace.someFunctionWithDefl(5, true)

--- a/tests/language-service/test-package/basic.ts
+++ b/tests/language-service/test-package/basic.ts
@@ -2,6 +2,12 @@ namespace testNamespace {
     export function someFunction(someParam: string, someNum: number, someBool: boolean) {
         return someParam
     }
+    
+    //% someNum.defl=5
+    //% someBool.defl=true
+    export function someFunctionWithDefl(someNum: number, someBool: boolean) {
+        return someNum + 1
+    }
 
     export let someString: string;
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/3281

We weren't doing any sort of TS->PY translation for specified defaults on blocks.