### PR TITLE
Surface more Immersive Reader errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   },
   "devDependencies": {
     "@microsoft/eslint-plugin-sdl": "^0.1.5",
-    "@microsoft/immersive-reader-sdk": "1.1.0",
     "@types/chai": "4.0.6",
     "@types/fuse": "2.5.2",
     "@types/highlight.js": "9.12.2",

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -216,8 +216,12 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
                 core.warningNotification(lf("Immersive Reader cannot be used offline"));
                 break;
             }
+            case "token": {
+                break;
+            }
             default: {
                 core.warningNotification(lf("Immersive Reader could not be launched"));
+                pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(e)});
             }
         }
         console.log("Immersive Reader Error: " + e);

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -182,7 +182,8 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
                 },
                 e => {
                     pxt.storage.removeLocal(IMMERSIVE_READER_ID);
-                    pxt.tickEvent("immersiveReader.error", e);
+                    pxt.reportException(e)
+                    pxt.tickEvent("immersiveReader.error", {error: e.statusCode, message: e.message});
                     return Promise.reject(new Error("token"));
                 }
             );
@@ -209,7 +210,13 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
         onExit: () => {pxt.tickEvent("immersiveReader.close", {tutorial: tutorialOptions.tutorial, tutorialStep: tutorialOptions.tutorialStep})}
     }
 
-    getTokenAsync().then(res => ImmersiveReader.launchAsync(res.token, res.subdomain, data, options)).catch(e => {
+    getTokenAsync().then(res => {
+        if (Cloud.isOnline()) {
+            return ImmersiveReader.launchAsync(res.token, res.subdomain, data, options)
+        } else {
+            return Promise.reject(new Error("offline"));
+        }
+    }).catch(e => {
         switch (e.message) {
             case "offline": {
                 core.warningNotification(lf("Immersive Reader cannot be used offline"));
@@ -220,7 +227,12 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
             }
             default: {
                 core.warningNotification(lf("Immersive Reader could not be launched"));
-                pxt.tickEvent("immersiveReader.error", e);
+                if (typeof e == "string") {
+                    pxt.tickEvent("immersiveReader.error", {message: e});
+                } else {
+                    pxt.tickEvent("immersiveReader.error", {message: e.message, statusCode: e.statusCode})
+                }
+
             }
         }
         pxt.reportException(e);

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -182,8 +182,7 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
                 },
                 e => {
                     pxt.storage.removeLocal(IMMERSIVE_READER_ID);
-                    console.log("immersive reader fetch token error: " + JSON.stringify(e));
-                    pxt.tickEvent("immersiveReader.error", { error: JSON.stringify(e) });
+                    pxt.tickEvent("immersiveReader.error", e);
                     return Promise.reject(new Error("token"));
                 }
             );
@@ -221,10 +220,10 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
             }
             default: {
                 core.warningNotification(lf("Immersive Reader could not be launched"));
-                pxt.tickEvent("immersiveReader.error", {error: JSON.stringify(e)});
+                pxt.tickEvent("immersiveReader.error", e);
             }
         }
-        console.log("Immersive Reader Error: " + e);
+        pxt.reportException(e);
         ImmersiveReader.close();
     });
 }


### PR DESCRIPTION
Add an immersiveReader.error tick for when the immersive reader returns an error -- right now we can't see when the users are getting the "Immersive Reader is already launching" issue.

Also @jwunderl I think you pointed this out in the initial PR and I forgot, but I removed the double package dependency -- it was required for prod and dev before, and this removes it for dev.