### PR TITLE
Color contrast fixes for toggles, file explorer, card focus

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -348,7 +348,7 @@ div.simframe > iframe {
     background: none;
 }
 .menubar .ui.menu.fixed .ui.item.editor-menuitem .item:not(.active) {
-    opacity: 0.6;
+    opacity: 0.8;
 }
 .menubar .ui.menu.inverted.fixed .ui.item.editor-menuitem .active.item {
     background: none;

--- a/theme/home.less
+++ b/theme/home.less
@@ -58,7 +58,7 @@
             position: absolute;
             left: 1rem;
             bottom: 1rem;
-            margin: 0.5rem;       
+            margin: 0.5rem;
         }
         .dots {
             position: absolute;
@@ -393,8 +393,8 @@
         }
     }
     .ui.card:focus {
-        outline: none;
-        border: @homeCardBorderSize solid @homeCardFocusBorderColor !important;
+        border: 2px solid transparent;
+        outline: @homeCardBorderSize solid @homeCardFocusBorderColor !important;
     }
 }
 

--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -70,7 +70,8 @@
 }
 
 .ui.inverted.menu .active.item {
-    background: rgba(255, 255, 255, 0.30);
+    background: rgba(255, 255, 255, 0.15);
+    outline: 1px solid rgba(255, 255, 255, 0.5);
 }
 
 .ui.vertical.menu .item > .label {

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -298,7 +298,7 @@
 @homeCardBorderSize: 5px;
 @homeCardBorderColor: #e9eef2;
 @homeCardHoverBorderColor: white;
-@homeCardFocusBorderColor: yellow;
+@homeCardFocusBorderColor: @primaryColor;
 @homeCardColor: @textColor;
 @homeCardMetaColor: @homeCardColor;
 @homeCardHeaderColor: @homeCardColor;

--- a/theme/themes/pxt/modules/checkbox.overrides
+++ b/theme/themes/pxt/modules/checkbox.overrides
@@ -12,3 +12,8 @@
     border-radius: .21428571rem;
     background: #fff;
 }
+
+.ui.toggle.checkbox .box:before,
+.ui.toggle.checkbox label:before {
+    border: 1px solid #949494;
+}

--- a/theme/themes/pxt/modules/checkbox.variables
+++ b/theme/themes/pxt/modules/checkbox.variables
@@ -1,3 +1,5 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+@handleBoxShadow: 0 1px 2px 0 rgba(34, 36, 38, 0.5), 0px 0px 0px 1px rgba(34, 36, 38, 0.5) inset;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3653 (increase opacity in blocks/js toggle)
fixes https://github.com/microsoft/pxt-microbit/issues/3650 (darken bg for selected file, add light border)
fixes https://github.com/microsoft/pxt-microbit/issues/3684 (add border to toggle and toggle handle)

fixes https://github.com/microsoft/pxt-microbit/issues/3547
![fix-card-focus](https://user-images.githubusercontent.com/34112083/114109592-69a10080-988a-11eb-9d59-06fd39116087.gif)
