### PR TITLE
Support sort() and sort() w/ lambda in py

### DIFF
--- a/libs/pxt-python/pxt-python.d.ts
+++ b/libs/pxt-python/pxt-python.d.ts
@@ -14,8 +14,8 @@ declare namespace _py {
         //% py2tsOverride="removeElement($0)"
         remove(value: any): void;
 
-        //% py2tsOverride="sort()"
-        sort(): void;
+        //% py2tsOverride="sort($0?)"
+        sort(sorter?: (a: any, b: any) => number): void;
 
         //% py2tsOverride="reverse()"
         reverse(): void;

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -497,7 +497,7 @@ namespace pxt.py {
         }
     }
 
-    // next free error 9572; 9550-9599 reserved for parser
+    // next free error 9575
     function error(astNode: py.AST | null | undefined, code: number, msg: string) {
         diagnostics.push(mkDiag(astNode, pxtc.DiagnosticCategory.Error, code, msg))
         //const pos = position(astNode ? astNode.startPos || 0 : 0, mod.source)
@@ -1985,7 +1985,10 @@ namespace pxt.py {
             U.assert(!!op)
             return B.mkInfix(null!, op, expr(n.operand))
         },
-        Lambda: (n: py.Lambda) => exprTODO(n),
+        Lambda: (n: py.Lambda) => {
+            error(n, 9574, U.lf("lambda expressions are not supported yet"))
+            return exprTODO(n)
+        },
         IfExp: (n: py.IfExp) =>
             B.mkInfix(B.mkInfix(expr(n.test), "?", expr(n.body)), ":", expr(n.orelse)),
         Dict: (n: py.Dict) => {

--- a/pxtpy/parser.ts
+++ b/pxtpy/parser.ts
@@ -112,7 +112,7 @@ namespace pxt.py {
         // console.log(`TOK: ${tokenToString(peekToken())}`)
     }
 
-    // next error 9574 (limit 9599)
+    // next error: see "next free error" in "converter.ts"
     function error(code?: number, msg?: string) {
         if (!msg) msg = U.lf("invalid syntax")
         if (!code) code = 9550

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -41,6 +41,11 @@ namespace pxt.py {
     }
 
     ///
+    /// FLAGS
+    ///
+    const SUPPORT_LAMBDAS = false;
+
+    ///
     /// UTILS
     ///
     export const INDENT = "    "
@@ -1145,7 +1150,7 @@ namespace pxt.py {
         }
         function emitFnExp(s: ts.FunctionExpression | ts.ArrowFunction, nameHint?: string, altParams?: ts.NodeArray<ts.ParameterDeclaration>, skipType?: boolean): ExpRes {
             // if the anonymous function is simple enough, use a lambda
-            if (!ts.isBlock(s.body)) {
+            if (SUPPORT_LAMBDAS && !ts.isBlock(s.body)) {
                 // TODO we're speculatively emitting this expression. This speculation is only safe if emitExp is pure, which it's not quite today (e.g. getNewGlobalName)
                 let [fnBody, fnSup] = emitExp(s.body as ts.Expression)
                 if (fnSup.length === 0) {

--- a/tests/pyconverter-test/baselines/sort.ts
+++ b/tests/pyconverter-test/baselines/sort.ts
@@ -1,0 +1,12 @@
+let n: number;
+let numbers = [2, 10, 1]
+numbers.sort()
+for (n of numbers) {
+    console.log(n)
+}
+numbers.sort(function sorter(a: number, b: number): number {
+    return b - a
+})
+for (n of numbers) {
+    console.log(n)
+}

--- a/tests/pyconverter-test/cases/sort.py
+++ b/tests/pyconverter-test/cases/sort.py
@@ -1,0 +1,11 @@
+numbers = [2, 10, 1]
+
+numbers.sort()
+for n in numbers:
+    print(n)
+
+def sorter(a, b): 
+    return b - a
+numbers.sort(sorter)
+for n in numbers:
+    print(n)


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/3374

We supported lambdas in ts2py but not py2ts so I created a clearer error message and disabled them in ts2py for now.

Also, I allow the optional sort function in ts<->py even though py doesn't technically support that.