### PR TITLE
communicate dependencies to simulator

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -24,6 +24,7 @@ namespace pxsim {
         breakOnStart?: boolean;
         storedState?: Map<any>;
         ipc?: boolean;
+        dependencies?: Map<string>;
         single?: boolean;
     }
 

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -66,6 +66,7 @@ namespace pxsim {
         storedState?: Map<any>;
         autoRun?: boolean;
         ipc?: boolean;
+        dependencies?: Map<string>;
         // single iframe, no message simulators
         single?: boolean;
     }
@@ -617,7 +618,8 @@ namespace pxsim {
                 breakOnStart: opts.breakOnStart,
                 storedState: opts.storedState,
                 ipc: opts.ipc,
-                single: opts.single
+                single: opts.single,
+                dependencies: opts.dependencies
             }
             this.start();
         }

--- a/webapp/src/simulator.ts
+++ b/webapp/src/simulator.ts
@@ -291,6 +291,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
     lastCompileResult = res;
     const { mute, highContrast, light, clickTrigger, storedState, autoRun } = options;
     const isIpcRenderer = pxt.BrowserUtils.isIpcRenderer() || undefined;
+    const dependencies = pkg.dependencies()
 
     const opts: pxsim.SimulatorRunOptions = {
         boardDefinition: boardDefinition,
@@ -313,6 +314,7 @@ export function run(pkg: pxt.MainPackage, debug: boolean,
         storedState: storedState,
         autoRun,
         ipc: isIpcRenderer,
+        dependencies
     }
     //if (pxt.options.debug)
     //    pxt.debug(JSON.stringify(opts, null, 2))


### PR DESCRIPTION
Pass down the list of dependencies to the simulators to allow them to compute which extension is missing in the project.