### PR TITLE
don't double encode pxtparts.json images

### DIFF
--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1264,7 +1264,9 @@ namespace pxt {
                                 if (typeof part.visual.image === "string" && /\.svg$/i.test(part.visual.image)) {
                                     let f = d.readFile(part.visual.image);
                                     if (!f) pxt.reportError("parts", "invalid part definition", { "error": `missing visual ${part.visual.image}` })
-                                    part.visual.image = `data:image/svg+xml,` + encodeURIComponent(f);
+                                    if (!/^data:image\/svg\+xml/.test(f)) // encode svg if not encoded yet
+                                        f = `data:image/svg+xml,` + encodeURIComponent(f);
+                                    part.visual.image = f;
                                 }
                             }
                         });


### PR DESCRIPTION
Just making sure to not double encode the stored SVG when loading an image from pxtpart.json. Fix for https://github.com/microsoft/pxt-microbit/issues/3968