### PR TITLE
Fix crash on project delete

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -236,7 +236,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, {}> {
 
     renderCore() {
         const { tutorialOptions, projectName, compiling, isSaving, simState, debugging, editorState } = this.props.parent.state;
-        const header = this.getData(`header:${this.props.parent.state.header.id}`);
+        const header = this.getData(`header:${this.props.parent.state.header.id}`) ?? this.props.parent.state.header;
 
         const targetTheme = pxt.appTarget.appTheme;
         const isController = pxt.shell.isControllerMode();


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-microbit/issues/3959
Fixes: https://github.com/microsoft/pxt-arcade/issues/3413

This was a regression introduced by the cloud work. It's not cloud related, just that I changed the toolboxeditor from fetching the header from the props to instead fetch from the virtual APIs but there's a case (during delete) where the header from the virtual API is null.