### PR TITLE
Two more accessibility fixes

### DIFF
--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -73,6 +73,28 @@
     background: rgba(255, 255, 255, 0.30);
 }
 
+#homemenu.ui.link.inverted.menu,
+#homemenu.ui.inverted.menu {
+    .item,
+    .dropdown.item,
+    .link.item,
+    a.item {
+        border: @homeHeaderBorderSize solid transparent;
+    }
+
+    .item:focus,
+    .dropdown.item:focus,
+    .link.item:focus,
+    a.item:focus {
+        background: @invertedHoverBackground;
+        color: @invertedHoverColor;
+        border: @homeHeaderBorderSize solid @homeHeaderSelectedBorderColor;
+        outline: 1px ridge black;
+    }
+}
+
+
+
 .ui.vertical.menu .item > .label {
     background-color: #8F8F8F;
 

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -318,7 +318,8 @@
 @homeDetailCardActionBackground: @homeScreenBackground;
 @homeDetailCardActionText: white;
 @homeInvertedDetailCardActionBackground: lighten(@homeScreenBackground, 10%);
-
+@homeHeaderBorderSize: 3px;
+@homeHeaderSelectedBorderColor: white;
 /*-------------------
    Tutorial
 --------------------*/

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -324,7 +324,8 @@ class BaseMenuItemProps extends data.Component<IBaseMenuItemProps, {}> {
 
     renderCore() {
         const active = this.props.isActive();
-        return <sui.Item className={`base-menuitem ${this.props.className} ${active ? "selected" : ""}`} role="menuitem" textClass="landscape only" text={this.props.text} icon={this.props.icon} active={active} onClick={this.props.onClick} title={this.props.title} />
+        return <sui.Item className={`base-menuitem ${this.props.className} ${active ? "selected" : ""}`} role="option" textClass="landscape only"
+            text={this.props.text} icon={this.props.icon} active={active} onClick={this.props.onClick} title={this.props.title} />
     }
 }
 
@@ -452,7 +453,7 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         const showAssets = pxt.appTarget.appTheme.assetEditor && !sandbox;
 
         return (
-            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`}>
+            <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="listbox" aria-orientation="horizontal">
                 {showSandbox && <SandboxMenuItem parent={parent} />}
                 {showBlocks && <BlocksMenuItem parent={parent} />}
                 {showPython ? <PythonMenuItem parent={parent} /> : <JavascriptMenuItem parent={parent} />}

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -494,6 +494,7 @@ export class Item extends data.Component<ItemProps, {}> {
             <div className={genericClassName("ui item link", this.props, true) + ` ${this.props.active ? 'active' : ''}`}
                 role={this.props.role}
                 aria-label={ariaLabel || title || text}
+                aria-selected={this.props.active}
                 title={title || text}
                 tabIndex={this.props.tabIndex || 0}
                 key={this.props.value}


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3510
by adding a white border and fading (which is different from any other header that isn't the home page -- I can add this to others too if we'd like.) I added a border bc there was a default border getting added to everybody except settings :( but if you guys think just the fade would be better I can do that toooo
![image](https://user-images.githubusercontent.com/18712271/114591017-49809100-9c3e-11eb-9805-b807e0f74968.png)

this was the default border: 
![image](https://user-images.githubusercontent.com/18712271/114591248-8ea4c300-9c3e-11eb-964c-dd231085e399.png)


fixes https://github.com/microsoft/pxt-microbit/issues/3651