### PR TITLE
Fix dx / dy blocks

### DIFF
--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -244,7 +244,7 @@ namespace pxt.blocks {
             const showPlus = visibleOptions !== totalOptions;
             const showMinus = visibleOptions !== 0;
             const hasMinus = !!b.getInput(buttonRemName);
-            let hasPlus = !!b.getInput(buttonAddName);
+            const hasPlus = !!b.getInput(buttonAddName);
 
             if (!showPlus) {
                 b.removeInput(buttonAddName, true);
@@ -255,15 +255,17 @@ namespace pxt.blocks {
             }
 
             if (showMinus && !hasMinus) {
-                if (hasPlus) {
-                    b.removeInput(buttonAddName, true);
-                    hasPlus = false;
-                }
                 addMinusButton();
             }
 
-            if (showPlus && !hasPlus) {
-                addPlusButton();
+            if (showPlus) {
+                // make sure plus button is last in line.
+                if (hasPlus && b.inputList.findIndex(el => el.name === buttonAddName) !== b.inputList.length - 1) {
+                    b.removeInput(buttonAddName, true);
+                    addPlusButton();
+                } else if (!hasPlus) {
+                    addPlusButton();
+                }
             }
         }
 

--- a/pxtblocks/composablemutations.ts
+++ b/pxtblocks/composablemutations.ts
@@ -174,7 +174,6 @@ namespace pxt.blocks {
         setTimeout(() => {
             if ((b as Blockly.BlockSvg).rendered && !(b.workspace as Blockly.WorkspaceSvg).isDragging()) {
                 updateShape(0, undefined, true);
-                updateButtons();
             }
         }, 1);
 
@@ -243,16 +242,27 @@ namespace pxt.blocks {
         function updateButtons() {
             const visibleOptions = state.getNumber(numVisibleAttr);
             const showPlus = visibleOptions !== totalOptions;
-            const showRemove = visibleOptions !== 0;
+            const showMinus = visibleOptions !== 0;
+            const hasMinus = !!b.getInput(buttonRemName);
+            let hasPlus = !!b.getInput(buttonAddName);
 
-            b.removeInput(buttonRemName, true);
-            b.removeInput(buttonAddName, true);
+            if (!showPlus) {
+                b.removeInput(buttonAddName, true);
+            }
 
-            if (showRemove) {
+            if (!showMinus) {
+                b.removeInput(buttonRemName, true);
+            }
+
+            if (showMinus && !hasMinus) {
+                if (hasPlus) {
+                    b.removeInput(buttonAddName, true);
+                    hasPlus = false;
+                }
                 addMinusButton();
             }
 
-            if (showPlus) {
+            if (showPlus && !hasPlus) {
                 addPlusButton();
             }
         }


### PR DESCRIPTION
This fixes the issue, but it seems like there's something really weird going on deep down in the gesture logic here or something of the sort. I looked around for a bit and didn't see anything obvious, and then Shannon gave it a quick look too, so for now leaving it at 'well it works now' and having it in the back of our head that something is broken... somewhere, and it's not necessarily worth the time to find right now.

Fix https://github.com/microsoft/pxt-arcade/issues/3421 (also affects the `player {1|2|3|4} dx` block)

This started happening with https://github.com/microsoft/pxt/pull/7845, but there's no obvious reason for why that broke it -- something to do with removing and re-adding the plus icon to these specific blocks makes it deeply upset / breaks the gestures on the block. I kept the "move plus to the end if it's not there" logic because game.splash started crashing again without it, I don't think the patch to catch that error got applied in blockly.

There was also a redundant call to updateButtons that I dropped -- it didn't end up being the cause of the issue, but updateShape will always call updateButtons in that case since force == true and .rendered == true, as these are the only cases that cause updateShape to bail out before updating buttons:

https://github.com/microsoft/pxt/blob/188e0c8835918b36350dd7095b14e134ffe4a073/pxtblocks/composablemutations.ts#L186-L196