### PR TITLE
don't outline blocks/js toggle due to active style

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -383,6 +383,10 @@ div.simframe > iframe {
     justify-content: center;
 }
 
+#editortoggle > .item {
+    outline: none;
+}
+
 #editortoggle {
     /* toggle positioning, no dropdown */
     .base-menuitem:nth-of-type(1).active ~ .toggle { margin-left: 0!important; }


### PR DESCRIPTION
This just happened recently (in microbit/beta) so it looks like it was one of the rules we added for tab visibility on other buttons. Remove the outline from the active toggle in non-high contrast:

![image](https://user-images.githubusercontent.com/5615930/114767103-190f2480-9d1c-11eb-9b13-4df3c8634780.png)

