### PR TITLE
Add placeholder 'chart' to serial view when no charts are present

### DIFF
--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -584,7 +584,8 @@
         color: @HCtextColor;
     }
 
-    #serialCharts .ui.segment {
+    #serialCharts .ui.segment,
+    #serialPlaceholder.ui.segment {
         background-color: @HCtextColor;
     }
 

--- a/theme/serial.less
+++ b/theme/serial.less
@@ -97,7 +97,8 @@
     height: calc(100% - 2.5rem);
 }
 
-#serialCharts .seriallabel {
+#serialCharts .seriallabel,
+#serialPlaceholder .seriallabel {
     padding: 5px 10px 5px 10px;
     border: 1px solid black;
     color: #000;
@@ -107,7 +108,8 @@
     font-family: monospace;
 }
 
-#serialCharts .ui.segment {
+#serialCharts .ui.segment,
+#serialPlaceholder {
     padding: 0.4rem;
     height: 12rem;
     background-color: @serialGraphBackground;
@@ -186,4 +188,3 @@ div.smoothie-chart-tooltip {
     font-size: 0.8rem;
     pointer-events: none;
 }
-     

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3035,6 +3035,7 @@ export class ProjectView
     }
 
     onHighContrastChanged() {
+        this.clearSerial();
         this.restartSimulator();
     }
 

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -29,7 +29,7 @@ export class Editor extends srceditor.Editor {
     lineColors: string[];
     hcLineColors: string[];
     currentLineColors: string[];
-    highContrast?: boolean = false
+    highContrast?: boolean = false;
 
     //refs
     startPauseButton: StartPauseButton
@@ -48,7 +48,7 @@ export class Editor extends srceditor.Editor {
 
     setVisible(b: boolean) {
         // TODO: It'd be great to re-render this component dynamically when the contrast changes,
-        // but for now the user has to toggle the serial editor to see a change. 
+        // but for now the user has to toggle the serial editor to see a change.
         const highContrast = core.getHighContrastOnce();
         if (highContrast !== this.highContrast) {
             this.setHighContrast(highContrast)
@@ -241,6 +241,9 @@ export class Editor extends srceditor.Editor {
             if (this.consoleRoot) {
                 pxt.BrowserUtils.removeClass(this.consoleRoot, "nochart");
             }
+
+            // Force rerender to hide placeholder chart
+            if (this.charts.length == 1) this.parent.forceUpdate();
         }
         homeChart.addPoint(variable, nvalue, receivedTime)
     }
@@ -471,6 +474,9 @@ export class Editor extends srceditor.Editor {
                         <span className="ui small header">{this.isSim ? lf("Simulator") : lf("Device")}</span>
                     </div>
                 </div>
+                {this.charts?.length == 0 && <div id="serialPlaceholder" className="ui segment">
+                    <div className="ui orange bottom left attached no-select label seriallabel">0</div>
+                </div>}
                 <div id="serialCharts" ref={this.handleChartRootRef}></div>
                 <div id="serialConsole" ref={this.handleConsoleRootRef}></div>
             </div>


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3587

technically the chart disappearing is the correct behavior--we are restarting the simulator, which changes the sim id, which means the serial output will render a new chart anyway. there's currently a behavior (on latest master) where if you turn high contrast on and off while the simulator/serial recording is running, it will just continuously append charts.

this fixes that bug, and also adds a placeholder div that looks like a chart, so that the space doesn't look so empty.

build link with test project: https://makecode.microbit.org/app/79daa6bbe818bc8fa3c2f8c3a43551026f6d811e-fb5e027396#pub:68673-35636-09676-33850