### PR TITLE
serve local file in pxt serve again

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -218,7 +218,8 @@ namespace pxt.runner {
             const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(href);
             lang = mlang ? mlang[3] : (cookieValue && cookieValue[1] || pxt.appTarget.appTheme.defaultLocale || (navigator as any).userLanguage || navigator.language);
 
-            if (!pxt.appTarget.appTheme.disableLiveTranslations || !!mlang?.[1]) {
+            const liveTranslationsDisabled = pxt.BrowserUtils.isPxtElectron() || pxt.BrowserUtils.isLocalHostDev() || pxt.appTarget.appTheme.disableLiveTranslations;
+            if (!liveTranslationsDisabled || !!mlang?.[1]) {
                 pxt.Util.enableLiveLocalizationUpdates();
             }
             force = !!mlang && !!mlang[2];

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -124,7 +124,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const targetId = pxt.appTarget.id;
         const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;
         const targetBranch = pxt.appTarget.versions.targetCrowdinBranch;
-        if (!pxt.BrowserUtils.isLocalHostDev()) {
+        if (!pxt.BrowserUtils.isLocalHostDev() && !pxt.BrowserUtils.isPxtElectron()) {
             pxt.Util.enableLiveLocalizationUpdates();
         }
 

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -124,7 +124,9 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const targetId = pxt.appTarget.id;
         const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;
         const targetBranch = pxt.appTarget.versions.targetCrowdinBranch;
-        pxt.Util.enableLiveLocalizationUpdates();
+        if (!pxt.BrowserUtils.isLocalHostDev()) {
+            pxt.Util.enableLiveLocalizationUpdates();
+        }
 
         await updateLocalizationAsync({
             targetId: targetId,

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4794,7 +4794,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
 
                 const locstatic = /staticlang=1/i.test(window.location.href);
-                const stringUpdateDisabled = locstatic || pxt.BrowserUtils.isPxtElectron() || theme.disableLiveTranslations;
+                const serveLocal = pxt.BrowserUtils.isPxtElectron() || pxt.BrowserUtils.isLocalHostDev();
+                const stringUpdateDisabled = locstatic || serveLocal || theme.disableLiveTranslations;
+
                 if (!stringUpdateDisabled || requestLive) {
                     pxt.Util.enableLiveLocalizationUpdates();
                 }


### PR DESCRIPTION
When I gave https://github.com/microsoft/pxt/pull/8097 a quick check locally, my local markdown updates weren't going through and I noticed it was fetching everything from the server.

Turns out this weird behavior https://github.com/microsoft/pxt/pull/7989/files#r598994321 of updating as a side effect was the thing preventing it from serving docs from the server instead of the local versions when doing a `pxt serve`, as setting that to true makes us skip the local request path here:

https://github.com/microsoft/pxt/blob/108e3785e2ae20fdeb5b59e4f0956fd83092b4e1/pxtlib/emitter/cloud.ts#L184-L195

Fix that so we don't go to makecode.com/api/* for markdown on pxt serve. (the changes are just guarding with `pxt.BrowserUtils.isLocalHostDev()` in a few places where we don't want to default to fetching from server -- e.g. we still want to get updates when if we're doing incontext translations or if we pass `livelang=de`)