### PR TITLE
Add skip the shift of nodes we've already seen if they are adjacent

### DIFF
--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -64,9 +64,12 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
             // 1. Increase child offset by one unit (so it's between the parents) and adjust the total if necessary
             // 2. Increase child depth if necessary (should be deeper than parent)
             next.filter(n => visited[n.activityId]).forEach(n => {
-                n.offset += 1;
-                totalOffset = Math.max(totalOffset, n.offset);
-                n.depth = Math.max(n.depth, current!.depth + 1);
+                // Skip the increment if the nodes are adjacent siblings
+                if (!isAdjacent(n, current!)) {
+                    n.offset += 1;
+                    totalOffset = Math.max(totalOffset, n.offset);
+                    n.depth = Math.max(n.depth, current!.depth + 1);
+                }
             })
             activities = next.concat(activities);
         }
@@ -193,6 +196,17 @@ function setWidths(node: GraphNode): number {
         node.width = node.next.map((el: any) => setWidths(el)).reduce((total: number, w: number) => total + w);
     }
     return node.width;
+}
+
+function isAdjacent(a: GraphNode, b: GraphNode): boolean {
+    if (!a.parents || !b.parents) return false;
+
+    let sharedParent: GraphNode | undefined;
+    a.parents.forEach((p: GraphNode) => {
+        if (b.parents!.indexOf(p) >= 0) sharedParent = p;
+    })
+
+    return !!sharedParent && Math.abs(sharedParent.nextIds.indexOf(a.activityId) - sharedParent.nextIds.indexOf(b.activityId)) == 1;
 }
 
 function bfsArray(root: GraphNode): GraphNode[] {

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -206,7 +206,9 @@ function isAdjacent(a: GraphNode, b: GraphNode): boolean {
         if (b.parents!.indexOf(p) >= 0) sharedParent = p;
     })
 
-    return !!sharedParent && Math.abs(sharedParent.nextIds.indexOf(a.activityId) - sharedParent.nextIds.indexOf(b.activityId)) == 1;
+    return !!sharedParent
+        && Math.abs(sharedParent.nextIds.indexOf(a.activityId) - sharedParent.nextIds.indexOf(b.activityId)) == 1
+        && a.depth == b.depth;
 }
 
 function bfsArray(root: GraphNode): GraphNode[] {


### PR DESCRIPTION
checks if nodes are adjacent siblings (can be directly connected by a vertical line) and does not shift the node in that case. this makes the handling of connections within one depth layer a little better (used in Kiki's collector map)