### PR TITLE
Break on first breakpoint in debugger

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -79,6 +79,7 @@ namespace pxt.editor {
         }; // ensure that this line is visible when loading the editor
         tracing?: boolean;
         debugging?: boolean;
+        debugFirstRun?: boolean;
         bannerVisible?: boolean;
         pokeUserComponent?: string;
         flashHint?: boolean;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -928,7 +928,7 @@ export class ProjectView
             highlightStatement: (stmt, brk) => {
                 if (this.state.debugging && !simulator.driver.areBreakpointsSet() && brk && !brk.exceptionMessage) {
                     // The simulator has paused on the first statement, so we need to send the breakpoints
-                    // and continue
+                    // and then step to get to the actual first breakpoint
                     let breakpoints: number[];
                     if (this.isAnyEditeableJavaScriptOrPackageActive() || this.isPythonActive()) {
                         breakpoints = this.textEditor.getBreakpoints();
@@ -941,7 +941,7 @@ export class ProjectView
                     simulator.driver.setBreakpoints(breakpoints);
 
                     if (breakpoints.indexOf(brk.breakpointId) === -1) {
-                        this.dbgPauseResume();
+                        this.dbgStepInto();
                         return true;
                     }
                 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -941,7 +941,12 @@ export class ProjectView
                     simulator.driver.setBreakpoints(breakpoints);
 
                     if (breakpoints.indexOf(brk.breakpointId) === -1) {
-                        this.dbgStepInto();
+                        if (this.state.tracing) {
+                            this.dbgPauseResume();
+                        }
+                        else {
+                            this.dbgStepInto();
+                        }
                         return true;
                     }
                 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -941,11 +941,14 @@ export class ProjectView
                     simulator.driver.setBreakpoints(breakpoints);
 
                     if (breakpoints.indexOf(brk.breakpointId) === -1) {
-                        if (this.state.tracing) {
+                        if (!this.state.debugFirstRun) {
                             this.dbgPauseResume();
                         }
                         else {
                             this.dbgStepInto();
+                            this.setState({
+                                debugFirstRun: false
+                            });
                         }
                         return true;
                     }
@@ -3183,7 +3186,10 @@ export class ProjectView
 
     toggleDebugging() {
         const state = !this.state.debugging;
-        this.setState({ debugging: state }, () => {
+        this.setState({
+            debugging: state,
+            debugFirstRun: state
+         }, () => {
             this.onDebuggingStart();
         });
     }


### PR DESCRIPTION
Potential fix for https://github.com/microsoft/pxt-microbit/issues/3280

This makes it so that we automatically pause on the first breakpoint when running a program in the debugger. It does *not* pause if you have slow-mo turned on, but I can change that if desired. Also, should it pause if you hit restart?