### PR TITLE
Bring workspace comments back to print dialog

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -68,13 +68,14 @@ namespace pxt.blocks.layout {
             otherClass: string,
             blocki: number,
             size: { height: number, width: number },
-            translate: { x: number, y: number }
+            translate: { x: number, y: number },
+            itemClass?: string
         ) {
             const svgclone = svg.cloneNode(true) as SVGSVGElement;
             // collect all blocks
             const parentSvg = svgclone.querySelector(`g.blocklyWorkspace > g.${parentClass}`) as SVGGElement;
             const otherSvg = svgclone.querySelector(`g.blocklyWorkspace > g.${otherClass}`) as SVGGElement;
-            const blocksSvg = Util.toArray(parentSvg.querySelectorAll(`g.blocklyWorkspace > g.${parentClass} > g[data-id]`));
+            const blocksSvg = Util.toArray(parentSvg.querySelectorAll(`g.blocklyWorkspace > g.${parentClass} > ${itemClass ? ("." + itemClass) : "g[transform]"}`));
             const blockSvg = blocksSvg.splice(blocki, 1)[0];
             if (!blockSvg) {
                 // seems like no blocks were generated
@@ -102,7 +103,7 @@ namespace pxt.blocks.layout {
         }
 
         comments.forEach((comment, commenti) => extract('blocklyBubbleCanvas', 'blocklyBlockCanvas',
-            commenti, comment.getHeightWidth(), { x: 0, y: 0 }));
+            commenti, comment.getHeightWidth(), { x: 0, y: 0 }, "blocklyComment"));
         blocks.forEach((block, blocki) => {
             const size = block.getHeightWidth();
             const translate = { x: 0, y: 0 };

--- a/theme/print.less
+++ b/theme/print.less
@@ -24,12 +24,12 @@
     /* bigger fonts */
     body {
         color: #000 !important; /* explicit colors */
-        background: #fff !important;        
+        background: #fff !important;
         font-size: 12pt;
         line-height: 1.3;
         position: inherit !important;
-    }        
-    
+    }
+
     #docs {
         position: inherit !important; /* otherwise prints a single page */
 
@@ -53,7 +53,7 @@
             color: #000;
             font-weight: bolder;
             text-decoration: none;
-        }    
+        }
         a:after {
             content:" (" attr(href) ") ";
             font-size:0.8em;
@@ -82,7 +82,7 @@
         /* inline blocks*/
         span.docs.inlineblock {
             background: none !important;
-            border: black 2px solid !important;        
+            border: black 2px solid !important;
         }
         /* avatar */
         .avatar .avatar-image, .avatar .ui.compact.message::after {
@@ -128,9 +128,14 @@
             fill: transparent !important;
         }
         /* comments */
-        .blocklyCommentRect {
+        .blocklyCommentRect,
+        .blocklyUneditableComment {
             fill: white !important;
             stroke: black !important;
+            stroke-width: 1px;
+        }
+        .blocklyUneditableMinimalBody {
+            fill: white !important;
         }
         .blocklyCommentTextarea {
             overflow: hidden !important;


### PR DESCRIPTION
workspace comments don't have a `data-id` attribute, so we weren't picking them up. this adds them back in and has some light CSS for styling as well. 

![image](https://user-images.githubusercontent.com/34112083/115313051-6aa61d80-a127-11eb-9d7f-1344ba354fcc.png)

this is a partial fix for https://github.com/microsoft/pxt-microbit/issues/3258, it doesn't include block comments yet because our "Format Code" doesn't factor in block comments, so they would overlap the other blocks in the print dialog. i THINK it shouldn't be terrible to add them in but i'm gonna switch gears and look at some other bugs first