### PR TITLE
Improve debugging of radio programs

### DIFF
--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -26,6 +26,7 @@ namespace pxsim {
         ipc?: boolean;
         dependencies?: Map<string>;
         single?: boolean;
+        traceDisabled?: boolean;
     }
 
     export interface SimulatorInstructionsMessage extends SimulatorMessage {

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -956,7 +956,6 @@ namespace pxsim {
         static messagePosted: (data: SimulatorMessage) => void;
         static postMessage(data: SimulatorMessage) {
             if (!data) return;
-            if (runtime) (data as any).traceDisabled = !!runtime.traceDisabled;
             // TODO: origins
             if (typeof window !== 'undefined' && window.parent && window.parent.postMessage) {
                 window.parent.postMessage(data, "*");

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -835,10 +835,18 @@ namespace pxsim {
                 case "breakpoint": {
                     const brk = msg as pxsim.DebuggerBreakpointMessage
                     if (this.state == SimulatorState.Running) {
-                        if (brk.exceptionMessage)
+                        if (brk.exceptionMessage) {
                             this.suspend();
-                        else
+                        }
+                        else {
                             this.setState(SimulatorState.Paused);
+                            const frames = this.simFrames(true);
+                            if (frames.length > 1) {
+                                // Make sure all frames pause
+                                this.resume(SimulatorDebuggerCommand.Pause);
+                            }
+                        }
+
                         if (this.options.onDebuggerBreakpoint)
                             this.options.onDebuggerBreakpoint(brk);
                         let stackTrace = brk.exceptionMessage + "\n"

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -94,6 +94,7 @@ namespace pxsim {
         public hwdbg: HwDebugger;
         private _dependentEditors: Window[];
         private _allowedOrigins: string[] = [];
+        private debuggingFrame: string;
 
         // we might "loan" a simulator when the user is recording
         // screenshots for sharing
@@ -295,7 +296,7 @@ namespace pxsim {
             }
         }
 
-        public postMessage(msg: pxsim.SimulatorMessage, source?: Window) {
+        public postMessage(msg: pxsim.SimulatorMessage, source?: Window, frameID?: string) {
             if (this.hwdbg) {
                 this.hwdbg.postMessage(msg)
                 return
@@ -303,6 +304,8 @@ namespace pxsim {
 
             const depEditors = this.dependentEditors();
             let frames = this.simFrames();
+
+            if (frameID) frames = frames.filter(f => f.id === frameID);
 
             const broadcastmsg = msg as pxsim.SimulatorBroadcastMessage;
             if (source && broadcastmsg?.broadcast) {
@@ -652,6 +655,8 @@ namespace pxsim {
             } else // reuse simulator
                 this.startFrame(frame);
 
+            this.debuggingFrame = frame.id;
+
             this.setState(SimulatorState.Running);
             this.setTraceInterval(this.traceInterval);
         }
@@ -754,20 +759,24 @@ namespace pxsim {
 
         public resume(c: SimulatorDebuggerCommand) {
             let msg: string;
+            let frameID: string;
             switch (c) {
                 case SimulatorDebuggerCommand.Resume:
                     msg = 'resume';
                     this.setState(SimulatorState.Running);
                     break;
                 case SimulatorDebuggerCommand.StepInto:
+                    frameID = this.debuggingFrame;
                     msg = 'stepinto';
                     this.setState(SimulatorState.Running);
                     break;
                 case SimulatorDebuggerCommand.StepOut:
+                    frameID = this.debuggingFrame;
                     msg = 'stepout';
                     this.setState(SimulatorState.Running);
                     break;
                 case SimulatorDebuggerCommand.StepOver:
+                    frameID = this.debuggingFrame;
                     msg = 'stepover';
                     this.setState(SimulatorState.Running);
                     break;
@@ -779,21 +788,21 @@ namespace pxsim {
                     return;
             }
 
-            this.postMessage({ type: 'debugger', subtype: msg, source: MESSAGE_SOURCE } as pxsim.DebuggerMessage)
+            this.postMessage({ type: 'debugger', subtype: msg, source: MESSAGE_SOURCE } as pxsim.DebuggerMessage, undefined, frameID);
         }
 
         public setBreakpoints(breakPoints: number[]) {
             this.breakpointsSet = true;
-            this.postDebuggerMessage("config", { setBreakpoints: breakPoints })
+            this.postDebuggerMessage("config", { setBreakpoints: breakPoints }, undefined, this.debuggingFrame);
         }
 
         public setTraceInterval(intervalMs: number) {
             this.traceInterval = intervalMs;
-            this.postDebuggerMessage("traceConfig", { interval: intervalMs });
+            this.postDebuggerMessage("traceConfig", { interval: intervalMs }, undefined, this.debuggingFrame);
         }
 
         public variablesAsync(id: number, fields?: string[]): Promise<VariablesMessage> {
-            return this.postDebuggerMessageAsync("variables", { variablesReference: id, fields: fields } as DebugProtocol.VariablesArguments)
+            return this.postDebuggerMessageAsync("variables", { variablesReference: id, fields: fields } as DebugProtocol.VariablesArguments, this.debuggingFrame)
                 .then(msg => msg as VariablesMessage, e => undefined)
         }
 
@@ -880,22 +889,22 @@ namespace pxsim {
             }
         }
 
-        private postDebuggerMessageAsync(subtype: string, data: any = {}): Promise<DebuggerMessage> {
+        private postDebuggerMessageAsync(subtype: string, data: any = {}, frameID: string): Promise<DebuggerMessage> {
             return new Promise((resolve, reject) => {
                 const seq = this.debuggerSeq++;
                 this.debuggerResolvers[seq.toString()] = { resolve, reject };
-                this.postDebuggerMessage(subtype, data, seq);
+                this.postDebuggerMessage(subtype, data, seq, frameID);
             })
         }
 
-        private postDebuggerMessage(subtype: string, data: any = {}, seq?: number) {
+        private postDebuggerMessage(subtype: string, data: any = {}, seq?: number, frameID?: string) {
             const msg: pxsim.DebuggerMessage = JSON.parse(JSON.stringify(data))
             msg.type = "debugger"
             msg.subtype = subtype;
             msg.source = MESSAGE_SOURCE;
             if (seq)
                 msg.seq = seq;
-            this.postMessage(msg);
+            this.postMessage(msg, undefined, frameID);
         }
 
         private nextId(): string {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3194

Debugging is pretty terrible right now for radio programs because both simulators send/receive all messages from the debugger.

This pr does a few things to improve it:

1. Disables breakpoints in the second simulator
2. Disables trace messages coming from the second simulator
3. When the primary simulator pauses, the second simulator will also pause