### PR TITLE
Decompile tutorial snippets separately, hash usedBlocks to individual code snippet

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5855,7 +5855,7 @@ function internalCacheUsedBlocksAsync(): Promise<Map<pxt.BuiltTutorialInfo>> {
         tutorial.pkgs = pkgs;
         tutorial.path = path;
 
-        const hash = pxt.BrowserUtils.getTutorialInfoHash(tutorial.code);
+        const hash = pxt.BrowserUtils.getTutorialCodeHash(tutorial.code);
         tutorialInfo[hash] = tutorial;
     }
 
@@ -5870,7 +5870,7 @@ function internalCacheUsedBlocksAsync(): Promise<Map<pxt.BuiltTutorialInfo>> {
             info.code.forEach((snippet, i) => extra["snippet_" + i + ".py"] = snippet);
             inFiles = { "main.ts": "", "main.py": "", "main.blocks": "", ...extra }
         } else {
-            inFiles = { "main.ts": info.code.join("\n"), "main.py": "", "main.blocks": "" }
+            inFiles = { "main.ts": "", "main.py": "", "main.blocks": "" }
         }
 
         const host = new SnippetHost("usedblocks", inFiles, info.pkgs);
@@ -5880,6 +5880,7 @@ function internalCacheUsedBlocksAsync(): Promise<Map<pxt.BuiltTutorialInfo>> {
             .then(() => pkg.getCompileOptionsAsync().then(opts => {
                 opts.ast = true;
                 // convert python to ts
+                let sourceTexts = []
                 if (isPy) {
                     opts.target.preferredEditor = pxt.JAVASCRIPT_PROJECT_NAME
                     const stsCompRes = pxtc.compile(opts);
@@ -5891,28 +5892,34 @@ function internalCacheUsedBlocksAsync(): Promise<Map<pxt.BuiltTutorialInfo>> {
                     opts.target.preferredEditor = pxt.PYTHON_PROJECT_NAME
                     const { outfiles } = pxt.py.py2ts(opts)
 
-                    let ts = "";
                     for (let f of Object.keys(outfiles)) {
                         if (f.match(/^snippet/)) {
                             let match = outfiles[f].match(namespaceRegex);
-                            if (match && match[1]) ts += `{\n${match[1]}\n}\n`
+                            if (match && match[1]) sourceTexts.push(match[1]);
                         }
                     }
-                    opts.fileSystem["main.ts"] = ts;
+                } else {
+                    sourceTexts = info.code;
                 }
 
                 // convert ts to blocks
                 try {
-                    const decompiled = pxtc.decompile(pxtc.getTSProgram(opts), opts, "main.ts");
-                    if (decompiled.success) {
-                        const blocksXml = decompiled.outfiles["main.blocks"];
+                    opts.sourceTexts = sourceTexts;
+                    const decompiled = pxtc.decompileSnippets(pxtc.getTSProgram(opts), opts, false);
+                    if (decompiled?.length > 0) {
                         // scrape block IDs matching <block type="block_id">
+                        let builtInfo: pxt.BuiltTutorialInfo = builtTututorialInfo[hash] || { usedBlocks: {}, snippetBlocks: {} };
                         const blockIdRegex = /<\s*block(?:[^>]*)? type="([^ ]*)"/ig;
-                        let builtInfo: pxt.BuiltTutorialInfo = builtTututorialInfo[hash] || { usedBlocks: {} };
-                        blocksXml.replace(blockIdRegex, (m0, m1) => {
-                            builtInfo.usedBlocks[m1] = 1;
-                            return m0;
-                        })
+                        for (let i = 0; i < decompiled.length; i++) {
+                            const blocksXml = decompiled[i];
+                            const snippetHash = pxt.BrowserUtils.getTutorialCodeHash([opts.sourceTexts[i]])
+                            blocksXml.replace(blockIdRegex, (m0, m1) => {
+                                if (!builtInfo.snippetBlocks[snippetHash]) builtInfo.snippetBlocks[snippetHash] = {};
+                                builtInfo.snippetBlocks[snippetHash][m1] = 1;
+                                builtInfo.usedBlocks[m1] = 1;
+                                return m0;
+                            })
+                        }
                         builtTututorialInfo[hash] = builtInfo;
                     }
                 } catch {

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -474,6 +474,7 @@ declare namespace pxt {
     interface BuiltTutorialInfo {
         hash?: string;
         usedBlocks: Map<number>;
+        snippetBlocks: Map<Map<number>>;
     }
 
     interface PackageApiInfo {
@@ -905,7 +906,8 @@ declare namespace ts.pxtc {
         fileSystem: pxt.Map<string>;
         target: CompileTarget;
         testMode?: boolean;
-        sourceFiles?: string[];
+        sourceFiles?: string[]; // list of file names
+        sourceTexts?: string[]; // list of file text content (TS string)
         generatedFiles?: string[];
         jres?: pxt.Map<pxt.JRes>;
         extinfo?: ExtensionInfo;

--- a/pxtcompiler/emitter/driver.ts
+++ b/pxtcompiler/emitter/driver.ts
@@ -321,16 +321,20 @@ namespace ts.pxtc {
             errorOnGreyBlocks: !!opts.errorOnGreyBlocks
         };
 
+        let programCache: Program; // Initialize to undefined, using the input program will incorrectly mark it as stale
         const xml: string[] = [];
-        opts.sourceTexts?.forEach((text: string) => {
-            opts.fileSystem[pxt.MAIN_TS] = text;
-            opts.fileSystem[pxt.MAIN_BLOCKS] = "";
+        if (opts.sourceTexts) {
+            for (let i = 0; i < opts.sourceTexts.length; i++) {
+                opts.fileSystem[pxt.MAIN_TS] = opts.sourceTexts[i];
+                opts.fileSystem[pxt.MAIN_BLOCKS] = "";
 
-            program = getTSProgram(opts);
-            const file = program.getSourceFile(pxt.MAIN_TS);
-            const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, decompileOpts, renameMap);
-            xml.push(bresp.outfiles[pxt.MAIN_BLOCKS]);
-        })
+                let newProgram = getTSProgram(opts, programCache);
+                const file = newProgram.getSourceFile(pxt.MAIN_TS);
+                const bresp = pxtc.decompiler.decompileToBlocks(blocksInfo, file, decompileOpts, renameMap);
+                xml.push(bresp.outfiles[pxt.MAIN_BLOCKS]);
+                programCache = newProgram;
+            }
+        }
 
         return xml;
     }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -820,6 +820,7 @@ namespace ts.pxtc.service {
         compile: (v: OpArg) => CompileResult;
         decompile: (v: OpArg) => CompileResult;
         pydecompile: (v: OpArg) => transpile.TranspileResult;
+        decompileSnippets: (v: OpArg) => string[];
         assemble: (v: OpArg) => {
             words: number[];
         };
@@ -999,6 +1000,10 @@ namespace ts.pxtc.service {
             host.setOpts(v.options)
             return transpile.tsToPy(service.getProgram(), v.fileName);
 
+        },
+        decompileSnippets: v => {
+            host.setOpts(v.options)
+            return decompileSnippets(service.getProgram(), v.options, false);
         },
         assemble: v => {
             return {

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -387,11 +387,11 @@ ${code}
             .then(db =>  {
                 if (id && cachedInfo[id]) {
                     const info = cachedInfo[id];
-                    if (info.usedBlocks && info.hash) db.setWithHashAsync(id, info.usedBlocks, info.hash);
+                    if (info.usedBlocks && info.hash) db.setWithHashAsync(id, info.snippetBlocks, info.hash);
                 } else {
                     for (let key of Object.keys(cachedInfo)) {
                         const info = cachedInfo[key];
-                        if (info.usedBlocks && info.hash) db.setWithHashAsync(key, info.usedBlocks, info.hash);
+                        if (info.usedBlocks && info.hash) db.setWithHashAsync(key, info.snippetBlocks, info.hash);
                     }
                 }
             }).catch((err) => {})

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1589,13 +1589,14 @@ export class ProjectView
         const t = header.tutorial;
         return this.loadBlocklyAsync()
             .then(() => tutorial.getUsedBlocksAsync(t.tutorialCode, t.tutorial, t.language))
-            .then((usedBlocks) => {
+            .then((tutorialBlocks) => {
                 let editorState: pxt.editor.EditorState = {
                     searchBar: false
                 }
-                if (usedBlocks && Object.keys(usedBlocks).length > 0) {
+
+                if (tutorialBlocks && tutorialBlocks.usedBlocks && Object.keys(tutorialBlocks.usedBlocks).length > 0) {
                     editorState.filters = {
-                        blocks: usedBlocks,
+                        blocks: tutorialBlocks.usedBlocks,
                         defaultState: pxt.editor.FilterState.Hidden
                     }
                     editorState.hasCategories = !(header.tutorial.metadata && header.tutorial.metadata.flyoutOnly);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1594,7 +1594,7 @@ export class ProjectView
                     searchBar: false
                 }
 
-                if (tutorialBlocks && tutorialBlocks.usedBlocks && Object.keys(tutorialBlocks.usedBlocks).length > 0) {
+                if (tutorialBlocks?.usedBlocks && Object.keys(tutorialBlocks.usedBlocks).length > 0) {
                     editorState.filters = {
                         blocks: tutorialBlocks.usedBlocks,
                         defaultState: pxt.editor.FilterState.Hidden

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -338,56 +338,6 @@ export function pySnippetToBlocksAsync(code: string, blockInfo?: ts.pxtc.BlocksI
         });
 }
 
-// Py[] -> blocks
-export function pySnippetArrayToBlocksAsync(code: string[], blockInfo?: ts.pxtc.BlocksInfo): Promise<pxtc.CompileResult> {
-    const namespaceRegex = /^\s*namespace\s+[^\s]+\s*{([\S\s]*)}\s*$/im;
-    const exportLetRegex = /^\s*export\s(let\s*[\S\s]*)\s*$/im;
-    const exportFunctionRegex = /^\s*export\s(function\s*[\S\s]*)\s*$/im;
-    const snippetBlocks = "main.blocks";
-    let trg = pkg.mainPkg.getTargetOptions()
-    let files: string[] = [];
-    return waitForFirstTypecheckAsync()
-        .then(() => pkg.mainPkg.getCompileOptionsAsync(trg))
-        .then(opts => {
-            // split each code snippet into a separate file to preserve scoping
-            for (let i = 0; i < code.length; i++) {
-                const snippetName = `snippet_${i}`;
-                opts.fileSystem[snippetName + ".py"] = code[i];
-                opts.sourceFiles.push(snippetName + ".py");
-                files.push(snippetName)
-            }
-            opts.fileSystem[snippetBlocks] = "";
-            if (opts.sourceFiles.indexOf(snippetBlocks) === -1) {
-                opts.sourceFiles.push(snippetBlocks);
-            }
-            return workerOpAsync("py2ts", { options: opts });
-        })
-        .then(res => {
-            // strip the namespace declaration out of the converted snippets and concat to convert to blocks
-            let ts = "";
-            for (let file of files) {
-                let match = res.outfiles[file + ".ts"].match(namespaceRegex);
-                if (match && match[1]) {
-                    const noNamespace = match[1];
-                    // strip out 'export let' and 'export function'. This won't hit custom kinds since those are always const
-                    let lines = noNamespace.split("\n");
-                    let cleanLines = lines.map((element: string) => {
-                        const matchExportLet = element.match(exportLetRegex);
-                        const strippedExportLet = matchExportLet ? matchExportLet[1] : element;
-                        const strippedExportFunc = strippedExportLet.match(exportFunctionRegex);
-                        if (strippedExportFunc) {
-                            return strippedExportFunc[1];
-                        } else {
-                            return strippedExportLet;
-                        }
-                    })
-                    ts += `{\n${cleanLines.join("\n")}\n}\n`;
-                }
-            }
-            return decompileBlocksSnippetAsync(ts, blockInfo)
-        });
-}
-
 function decompileCoreAsync(opts: pxtc.CompileOptions, fileName: string): Promise<pxtc.CompileResult> {
     return workerOpAsync("decompile", { options: opts, fileName: fileName })
 }
@@ -435,6 +385,79 @@ export function decompilePythonSnippetAsync(code: string): Promise<string> {
 
 function pyDecompileCoreAsync(opts: pxtc.CompileOptions, fileName: string): Promise<pxtc.transpile.TranspileResult> {
     return workerOpAsync("pydecompile", { options: opts, fileName: fileName })
+}
+
+// TS[] -> XML[] (blocks)
+export function decompileSnippetstoXmlAsync(code: string[]): Promise<string[]> {
+    const trg = pkg.mainPkg.getTargetOptions()
+    return pkg.mainPkg.getCompileOptionsAsync(trg)
+        .then(opts => {
+            opts.sourceTexts = code;
+            opts.snippetMode = false;
+
+            if (opts.sourceFiles.indexOf(pxt.MAIN_TS) === -1) {
+                opts.sourceFiles.push(pxt.MAIN_TS);
+            }
+            if (opts.sourceFiles.indexOf(pxt.MAIN_BLOCKS) === -1) {
+                opts.sourceFiles.push(pxt.MAIN_BLOCKS);
+            }
+            opts.ast = true;
+            return decompileSnippetsCoreAsync(opts);
+        });
+}
+
+// Py[] -> XML[] (blocks)
+export function decompilePySnippetstoXmlAsync(code: string[]): Promise<string[]> {
+    const namespaceRegex = /^\s*namespace\s+[^\s]+\s*{([\S\s]*)}\s*$/im;
+    const exportLetRegex = /^\s*export\s(let\s*[\S\s]*)\s*$/im;
+    const exportFunctionRegex = /^\s*export\s(function\s*[\S\s]*)\s*$/im;
+    const trg = pkg.mainPkg.getTargetOptions()
+    let files: string[] = [];
+    return waitForFirstTypecheckAsync()
+        .then(() => pkg.mainPkg.getCompileOptionsAsync(trg))
+        .then(opts => {
+            // split each code snippet into a separate file to preserve scoping
+            for (let i = 0; i < code.length; i++) {
+                const snippetName = `snippet_${i}`;
+                opts.fileSystem[snippetName + ".py"] = code[i];
+                opts.sourceFiles.push(snippetName + ".py");
+                files.push(snippetName)
+            }
+            opts.fileSystem[pxt.MAIN_BLOCKS] = "";
+            if (opts.sourceFiles.indexOf(pxt.MAIN_BLOCKS) === -1) {
+                opts.sourceFiles.push(pxt.MAIN_BLOCKS);
+            }
+            return workerOpAsync("py2ts", { options: opts });
+        })
+        .then(res => {
+            // strip the namespace declaration out of the converted snippets and concat to convert to blocks
+            const tsCode = [];
+            for (let file of files) {
+                let match = res.outfiles[file + ".ts"].match(namespaceRegex);
+                if (match && match[1]) {
+                    const noNamespace = match[1];
+                    // strip out 'export let' and 'export function'. This won't hit custom kinds since those are always const
+                    let lines = noNamespace.split("\n");
+                    let cleanLines = lines.map((element: string) => {
+                        const matchExportLet = element.match(exportLetRegex);
+                        const strippedExportLet = matchExportLet ? matchExportLet[1] : element;
+                        const strippedExportFunc = strippedExportLet.match(exportFunctionRegex);
+                        if (strippedExportFunc) {
+                            return strippedExportFunc[1];
+                        } else {
+                            return strippedExportLet;
+                        }
+                    })
+                    tsCode.push(cleanLines.join("\n"));
+                }
+            }
+            return decompileSnippetstoXmlAsync(tsCode);
+        });
+}
+
+
+function decompileSnippetsCoreAsync(opts: pxtc.CompileOptions): Promise<string[]> {
+    return workerOpAsync("decompileSnippets", { options: opts })
 }
 
 export function workerOpAsync<T extends keyof pxtc.service.ServiceOps>(op: T, arg: pxtc.service.OpArg): Promise<any> {

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -484,10 +484,17 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
         const tutorialInfo: pxt.Map<pxt.BuiltTutorialInfo> = {};
         for (let path of mdPaths) {
             const parsed = pxt.tutorial.parseTutorial(files[path]);
-            const hash = pxt.BrowserUtils.getTutorialInfoHash(parsed.code);
-            const usedBlocks = await tutorial.getUsedBlocksAsync(parsed.code, path, parsed.language, true);
-            const formatPath = path.replace(mdRegex, "");
-            tutorialInfo[`https://github.com/${githubId.fullName}${formatPath == "README" ? "" : "/" + formatPath}`] = { usedBlocks, hash };
+            const hash = pxt.BrowserUtils.getTutorialCodeHash(parsed.code);
+            const tutorialBlocks = await tutorial.getUsedBlocksAsync(parsed.code, path, parsed.language, true);
+            if (tutorialBlocks) {
+                const formatPath = path.replace(mdRegex, "");
+                tutorialInfo[`https://github.com/${githubId.fullName}${formatPath == "README" ? "" : "/" + formatPath}`] = {
+                    snippetBlocks: tutorialBlocks.snippetBlocks,
+                    usedBlocks: tutorialBlocks.usedBlocks,
+                    hash
+                };
+
+            }
         }
         files[pxt.TUTORIAL_INFO_FILE] = JSON.stringify(tutorialInfo);
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -17,19 +17,24 @@ import * as ImmersiveReader from "./immersivereader";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
+interface ITutorialBlocks {
+    snippetBlocks: pxt.Map<pxt.Map<number>>;
+    usedBlocks: pxt.Map<number>;
+}
+
 /**
  * We'll run this step when we first start the tutorial to figure out what blocks are used so we can
  * filter the toolbox.
  */
-export function getUsedBlocksAsync(code: string[], id: string, language?: string, skipCache = false): Promise<pxt.Map<number>> {
-    if (!code) return Promise.resolve({});
+export function getUsedBlocksAsync(code: string[], id: string, language?: string, skipCache = false): Promise<ITutorialBlocks | void> {
+    if (!code) return Promise.resolve();
 
     // check to see if usedblocks has been prebuilt. this is hashed on the tutorial code + pxt version + target version
     if (pxt.appTarget?.tutorialInfo && !skipCache) {
-        const hash = pxt.BrowserUtils.getTutorialInfoHash(code);
+        const hash = pxt.BrowserUtils.getTutorialCodeHash(code);
         if (pxt.appTarget.tutorialInfo[hash]) {
             pxt.tickEvent(`tutorial.usedblocks.cached`, { tutorial: id });
-            return Promise.resolve(pxt.appTarget.tutorialInfo[hash].usedBlocks);
+            return Promise.resolve(pxt.appTarget.tutorialInfo[hash]);
         }
     }
 
@@ -38,7 +43,9 @@ export function getUsedBlocksAsync(code: string[], id: string, language?: string
             .then(entry => {
                 if (entry?.blocks && Object.keys(entry.blocks).length > 0 && !skipCache) {
                     pxt.tickEvent(`tutorial.usedblocks.indexeddb`, { tutorial: id });
-                    return Promise.resolve(entry.blocks);
+                    // populate snippets if usedBlocks are present, but snippets are not
+                    if (!entry?.snippets) getUsedBlocksInternalAsync(code, id, language, db, skipCache);
+                    return Promise.resolve({ snippetBlocks: entry.snippets, usedBlocks: entry.blocks });
                 } else {
                     return getUsedBlocksInternalAsync(code, id, language, db, skipCache);
                 }})
@@ -52,35 +59,48 @@ export function getUsedBlocksAsync(code: string[], id: string, language?: string
         })
 }
 
-function getUsedBlocksInternalAsync(code: string[], id: string, language?: string, db?: pxt.BrowserUtils.ITutorialInfoDb, skipCache = false): Promise<pxt.Map<number>> {
+function getUsedBlocksInternalAsync(code: string[], id: string, language?: string, db?: pxt.BrowserUtils.ITutorialInfoDb, skipCache = false): Promise<ITutorialBlocks> {
+    const snippetBlocks: pxt.Map<pxt.Map<number>> = {};
     const usedBlocks: pxt.Map<number> = {};
     return compiler.getBlocksAsync()
         .then(blocksInfo => {
             pxt.blocks.initializeAndInject(blocksInfo);
-            if (language == "python")
-                return compiler.pySnippetArrayToBlocksAsync(code, blocksInfo);
-            return compiler.decompileBlocksSnippetAsync(code.join("\n"), blocksInfo);
-        }).then(resp => {
-            const blocksXml = resp.outfiles["main.blocks"];
-            if (blocksXml) {
-                const headless = pxt.blocks.loadWorkspaceXml(blocksXml);
-                if (!headless) {
-                    pxt.debug(`used blocks xml failed to load\n${blocksXml}`);
-                    throw new Error("blocksXml failed to load");
+            if (language == "python") {
+                return compiler.decompilePySnippetstoXmlAsync(code);
+            }
+            return compiler.decompileSnippetstoXmlAsync(code);
+        }).then(xml => {
+            if (xml?.length > 0) {
+                let headless: Blockly.Workspace;
+                for (let i = 0; i < xml.length; i++) {
+                    const blocksXml = xml[i];
+                    const snippetHash = pxt.BrowserUtils.getTutorialCodeHash([code[i]]);
+
+                    headless = pxt.blocks.loadWorkspaceXml(blocksXml);
+                    if (!headless) {
+                        pxt.debug(`used blocks xml failed to load\n${blocksXml}`);
+                        throw new Error("blocksXml failed to load");
+                    }
+                    const allblocks = headless.getAllBlocks();
+                    for (let bi = 0; bi < allblocks.length; ++bi) {
+                        if (!snippetBlocks[snippetHash]) snippetBlocks[snippetHash] = {}
+                        const blk = allblocks[bi];
+                        if (!blk.isShadow()) {
+                            snippetBlocks[snippetHash][blk.type] = 1;
+                            usedBlocks[blk.type] = 1;
+                        }
+                    }
                 }
-                const allblocks = headless.getAllBlocks();
-                for (let bi = 0; bi < allblocks.length; ++bi) {
-                    const blk = allblocks[bi];
-                    if (!blk.isShadow()) usedBlocks[blk.type] = 1;
-                }
-                headless.dispose();
+
+                headless?.dispose();
 
                 if (pxt.options.debug)
-                    pxt.debug(JSON.stringify(usedBlocks, null, 2));
+                    pxt.debug(JSON.stringify(snippetBlocks, null, 2));
 
-                if (db && !skipCache) db.setAsync(id, usedBlocks, code);
+                if (db && !skipCache) db.setAsync(id, snippetBlocks, code);
                 pxt.tickEvent(`tutorial.usedblocks.computed`, { tutorial: id });
-                return usedBlocks;
+
+                return { snippetBlocks, usedBlocks };
             } else {
                 throw new Error("Failed to decompile");
             }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -26,8 +26,8 @@ interface ITutorialBlocks {
  * We'll run this step when we first start the tutorial to figure out what blocks are used so we can
  * filter the toolbox.
  */
-export function getUsedBlocksAsync(code: string[], id: string, language?: string, skipCache = false): Promise<ITutorialBlocks | void> {
-    if (!code) return Promise.resolve();
+export function getUsedBlocksAsync(code: string[], id: string, language?: string, skipCache = false): Promise<ITutorialBlocks> {
+    if (!code) return Promise.resolve(undefined);
 
     // check to see if usedblocks has been prebuilt. this is hashed on the tutorial code + pxt version + target version
     if (pxt.appTarget?.tutorialInfo && !skipCache) {


### PR DESCRIPTION
- adds a new op to the service to decompile an array of ts snippets (strings) & return an array of xml snippets
- where previously we were caching "usedBlocks" (map of blockId to the number 1) we now also cache "snippetBlocks" (map of code snippet hash, to <map of blockIds to the number 1>). usedBlocks is kept as-is to prevent weirdness with existing caches (in git repos, indexeddb, etc)
- also checked with python

perf-wise, it did make things slightly slower (increased a ~2s load time by about ~0.1s on average, on my machine), but that should only be for the initial load, before the blocks are cached

build: https://arcade.makecode.com/app/779fd95829c1d84fb875251dbb9e2f8dc047d2ca-ea561d6c56