### PR TITLE
Fix two undo/redo bugs for assets in the blocks editor

### DIFF
--- a/pxtblocks/fields/field_base.ts
+++ b/pxtblocks/fields/field_base.ts
@@ -55,6 +55,7 @@ namespace pxtblockly {
         }
 
         onLoadedIntoWorkspace() {
+            if (this.loaded) return;
             this.loaded = true;
             this.valueText = this.onValueChanged(this.valueText);
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3393
Fixes https://github.com/microsoft/pxt-arcade/issues/3406

We were hitting these on stream, so here's a quick fix to two different undo/redo bugs. I believe that the two issues I reference were the same, the other bug that I found could be reproed like this:

1. Create a few images in the asset editor
2. Switch to blocks, drag out a sprite block
3. Open the sprite editor and select one of your assets
4. Close the sprite editor
5. Repeat 3+4 a few times, then try doing undo/redo