### PR TITLE
actually restart simulator when hc setting changes

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3048,7 +3048,10 @@ export class ProjectView
 
     onHighContrastChanged() {
         this.clearSerial();
-        this.restartSimulator();
+        // Not this.restartSimulator; need full restart to consistently update visuals,
+        // and don't want to steal focus.
+        this.stopSimulator();
+        this.startSimulator();
     }
 
     runSimulator(opts: compiler.CompileOptions = {}): Promise<void> {


### PR DESCRIPTION
Fix https://github.com/microsoft/pxt-microbit/issues/3126. We were trying to restart here already but it was getting ignored in multiple places -- the restart always hits the 'fast restart' path which doesn't update the iframe options, and even with that fixed the start would ignore it as the simulator was already running.

We also don't want to use restart here because it steals focus to the simulator, which messes with tab accessibility a bit.
