### PR TITLE
Persist Immersive Reader preferences

### DIFF
--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -56,6 +56,7 @@ export type UserPreferences = {
 const DEFAULT_USER_PREFERENCES: () => UserPreferences = () => ({
     highContrast: false,
     language: pxt.appTarget.appTheme.defaultLocale,
+    reader: ""
 })
 
 /**

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -16,8 +16,10 @@ export const LOGGED_IN = `${MODULE}:${FIELD_LOGGED_IN}`;
 const USER_PREF_MODULE = "user-pref";
 const FIELD_HIGHCONTRAST = "high-contrast";
 const FIELD_LANGUAGE = "language";
+const FIELD_READER = "reader";
 export const HIGHCONTRAST = `${USER_PREF_MODULE}:${FIELD_HIGHCONTRAST}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
+export const READER = `${USER_PREF_MODULE}:${FIELD_READER}`
 
 const CSRF_TOKEN = "csrf-token";
 const AUTH_LOGIN_STATE = "auth:login-state";
@@ -48,6 +50,7 @@ export type UserProfile = {
 export type UserPreferences = {
     language?: string;
     highContrast?: boolean;
+    reader?: string;
 }
 
 const DEFAULT_USER_PREFERENCES: () => UserPreferences = () => ({
@@ -466,6 +469,9 @@ function internalPrefUpdateAndInvalidate(newPref: Partial<UserPreferences>) {
     if (oldPref?.language !== getState().preferences?.language) {
         data.invalidate(LANGUAGE)
     }
+    if (oldPref?.reader !== getState().preferences?.reader) {
+        data.invalidate(READER)
+    }
 }
 
 let initialUserPreferences_: Promise<UserPreferences | undefined> = undefined;
@@ -631,6 +637,7 @@ function internalUserPreferencesHandler(path: string): UserPreferences | boolean
     switch (field) {
         case FIELD_HIGHCONTRAST: return state.preferences.highContrast;
         case FIELD_LANGUAGE: return state.preferences.language;
+        case FIELD_READER: return state.preferences.reader;
     }
     return state.preferences
 }

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as data from "./data";
 import * as core from "./core";
 import * as sui from "./sui";
+import * as auth from "./auth";
 import * as ImmersiveReader from '@microsoft/immersive-reader-sdk';
 
 import Cloud = pxt.Cloud;
@@ -199,7 +200,9 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
 export function launchImmersiveReader(content: string, tutorialOptions: pxt.tutorial.TutorialOptions) {
     pxt.tickEvent("immersiveReader.launch", {tutorial: tutorialOptions.tutorial, tutorialStep: tutorialOptions.tutorialStep});
 
-    const data = {
+    const userReaderPref = data.getData<string>(auth.READER) || ""
+    const langPref = data.getData<string>(auth.LANGUAGE) || "";
+    const tutorialData = {
         chunks: [{
             content: beautifyText(content),
             mimeType: "text/html"
@@ -207,12 +210,19 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
     }
 
     const options = {
-        onExit: () => {pxt.tickEvent("immersiveReader.close", {tutorial: tutorialOptions.tutorial, tutorialStep: tutorialOptions.tutorialStep})}
+        uiLang: langPref,
+        onExit: () => {
+            pxt.tickEvent("immersiveReader.close", {tutorial: tutorialOptions.tutorial, tutorialStep: tutorialOptions.tutorialStep})
+        },
+        onPreferencesChanged: (pref: string) => {
+            auth.updateUserPreferencesAsync({reader: pref})
+        },
+        preferences: userReaderPref
     }
 
     getTokenAsync().then(res => {
         if (Cloud.isOnline()) {
-            return ImmersiveReader.launchAsync(res.token, res.subdomain, data, options)
+            return ImmersiveReader.launchAsync(res.token, res.subdomain, tutorialData, options)
         } else {
             return Promise.reject(new Error("offline"));
         }

--- a/webapp/src/screenshot.ts
+++ b/webapp/src/screenshot.ts
@@ -266,9 +266,7 @@ export class GifEncoder {
                     if (this.options.maxLength && imageUri.length > this.options.maxLength) {
                         const nframes = Math.floor(this.gif.frames.length * this.options.maxLength / imageUri.length) - 1;
                         pxt.log(`gif: size too large (${(imageUri.length / 1000) | 0}kb) reducing frames to ${nframes}`);
-                        console.log("VVN: gif size too big");
                         if (nframes <= 0) {
-                            console.log("WAAAAAY too big...");
                             pxt.log(`gif: simulator image too large, cannot have a single frame`);
                             return undefined;
                         }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4005

Use the nice auth APIs to store the reader preferences, which will use local storage (not idb) if not logged in, and will sync w/ cloud if you are :D it works!

Also snuck in the user language preferences, so the UI in Immersive Reader is the one you selected in Arcade! wow

![image](https://user-images.githubusercontent.com/18712271/117379721-f096c800-ae8c-11eb-9044-080f5b965a42.png)

oh also i found some logs i left before so i took those out sorry