### PR TITLE
Add back asset type icon, keep temporary asset warning hidden

### DIFF
--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -426,7 +426,7 @@
         margin: 0.2rem 0 0 0.2rem;
     }
 
-    .asset-editor-card-icon {
+    .asset-editor-card-icon.warning {
         display: none;
     }
 }

--- a/webapp/src/components/assetEditor/assetCard.tsx
+++ b/webapp/src/components/assetEditor/assetCard.tsx
@@ -61,7 +61,7 @@ export class AssetCardView extends React.Component<AssetCardCoreProps> {
                 {icon && <div className="asset-editor-card-icon">
                     <i className={`icon ${icon}`} />
                 </div>}
-                {!asset.meta?.displayName && !inGallery && <div className="asset-editor-card-icon">
+                {!asset.meta?.displayName && !inGallery && <div className="asset-editor-card-icon warning">
                     <i className="icon exclamation triangle" />
                 </div>}
             </div>}


### PR DESCRIPTION
accidentally hid all the icons while attempting to hide the warning icon! this adds them back