### PR TITLE
Tutorial accessibility fixes + no opening hint on content click

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -65,6 +65,13 @@
     justify-content: center;
 }
 
+#mainmenu .ui.item.tutorialname {
+    cursor: unset;
+    &:hover, &:focus {
+        background: none;
+    }
+}
+
 .tutorial #tutorialcard {
     position: relative;
     z-index: @tutorialCardZIndex;

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -154,7 +154,6 @@ body#docs.tutorial {
     height: 100%;
     margin-bottom: 0.4rem;
     overflow-x: auto;
-    cursor:pointer;
 }
 
 .tutorial.tutorialExpanded #tutorialcard .tutorialmessage .content {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -585,7 +585,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 }
                 {!inTutorial && homeEnabled ? <sui.Item className="icon openproject" role="menuitem" textClass="landscape only" icon="home large" ariaLabel={lf("Home screen")} text={lf("Home")} onClick={this.goHome} /> : null}
                 {showShare ? <sui.Item className="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project")} text={lf("Share")} icon="share alternate large" onClick={this.showShareDialog} /> : null}
-                {inTutorial && <sui.Item className="tutorialname" tabIndex={-1} textClass="landscape only" text={tutorialOptions.tutorialName} />}
+                {inTutorial && <sui.Item className="tutorialname" tabIndex={-1} ariaHidden={true} textClass="landscape only" text={tutorialOptions.tutorialName} />}
             </div> : <div className="left menu">
                 <span id="logo" className="ui item logo">
                     <img className="ui mini image" src={rightLogo} tabIndex={0} onClick={this.launchFullEditor} onKeyDown={sui.fireClickOnEnter} alt={`${targetTheme.boardName} Logo`} />

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -585,7 +585,7 @@ export class MainMenu extends data.Component<ISettingsProps, {}> {
                 }
                 {!inTutorial && homeEnabled ? <sui.Item className="icon openproject" role="menuitem" textClass="landscape only" icon="home large" ariaLabel={lf("Home screen")} text={lf("Home")} onClick={this.goHome} /> : null}
                 {showShare ? <sui.Item className="icon shareproject" role="menuitem" textClass="widedesktop only" ariaLabel={lf("Share Project")} text={lf("Share")} icon="share alternate large" onClick={this.showShareDialog} /> : null}
-                {inTutorial && <sui.Item className="tutorialname" tabIndex={-1} ariaHidden={true} textClass="landscape only" text={tutorialOptions.tutorialName} />}
+                {inTutorial && <sui.Item className="tutorialname" tabIndex={-1} textClass="landscape only" text={tutorialOptions.tutorialName}/>}
             </div> : <div className="left menu">
                 <span id="logo" className="ui item logo">
                     <img className="ui mini image" src={rightLogo} tabIndex={0} onClick={this.launchFullEditor} onKeyDown={sui.fireClickOnEnter} alt={`${targetTheme.boardName} Logo`} />

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -10,6 +10,7 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 interface MarkedContentProps extends ISettingsProps {
     markdown: string;
     className?: string;
+    tabIndex?: number;
     // do not emit segment around snippets
     unboxSnippets?: boolean;
     blocksDiffOptions?: pxt.blocks.DiffOptions;
@@ -365,7 +366,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
     }
 
     renderCore() {
-        const { className } = this.props;
-        return <div ref="marked-content" className={className || ""} />;
+        const { className, tabIndex } = this.props;
+        return <div ref="marked-content" className={className || ""} tabIndex={tabIndex} />;
     }
 }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -19,6 +19,7 @@ export interface UiProps {
     role?: string;
     title?: string;
     ariaLabel?: string;
+    ariaHidden?: boolean;
     tabIndex?: number;
     rightIcon?: boolean;
     inverted?: boolean;
@@ -487,7 +488,8 @@ export class Item extends data.Component<ItemProps, {}> {
         const {
             text,
             title,
-            ariaLabel
+            ariaLabel,
+            ariaHidden
         } = this.props;
 
         return (
@@ -495,6 +497,7 @@ export class Item extends data.Component<ItemProps, {}> {
                 role={this.props.role}
                 aria-label={ariaLabel || title || text}
                 aria-selected={this.props.active}
+                aria-hidden={ariaHidden}
                 title={title || text}
                 tabIndex={this.props.tabIndex || 0}
                 key={this.props.value}

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -650,7 +650,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                     </div>
                     <div className="avatar-container">
                         {(!showDialog && hasHint) && <sui.Button
-                            className={`ui circular label blue hintbutton hidelightbox ${hasHint && this.props.pokeUser ? 'shake flash' : ''}`}
+                            className={`ui circular label blue hintbutton hidelightbox ${this.props.pokeUser ? 'shake flash' : ''}`}
                             icon="lightbulb outline"
                             aria-label={tutorialAriaLabel} title={tutorialHintTooltip}
                             onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter}

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -645,7 +645,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                 <div className="ui segment attached tutorialsegment">
                     <div ref="tutorialmessage" className={`tutorialmessage`} role="alert">
                         <div className="content">
-                            {!showDialog && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
+                            {!showDialog && <md.MarkedContent className="no-select" tabIndex={0} markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
                         </div>
                     </div>
                     <div className="avatar-container">

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -628,12 +628,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const tutorialCardContent = stepInfo.headerContentMd;
         const showDialog = stepInfo.showDialog;
 
-        let tutorialAriaLabel = '',
-            tutorialHintTooltip = '';
-        if (hasHint) {
-            tutorialAriaLabel += lf("Press Space or Enter to show a hint.");
-            tutorialHintTooltip += lf("Click to show a hint!");
-        }
+        const tutorialAriaLabel = lf("Press Space or Enter to show a hint.");
+        const tutorialHintTooltip = lf("Click to show a hint!");
 
         let hintOnClick = this.hintOnClick;
         // double-click issue on edge when closing hint from tutorial card click
@@ -647,14 +643,18 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             <div className='ui buttons'>
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">
-                    <div ref="tutorialmessage" className={`tutorialmessage`} role="alert" aria-label={tutorialAriaLabel} tabIndex={hasHint ? 0 : -1}
-                        onClick={hasHint ? hintOnClick : undefined} onKeyDown={hasHint ? sui.fireClickOnEnter : undefined}>
+                    <div ref="tutorialmessage" className={`tutorialmessage`} role="alert" tabIndex={hasHint ? 0 : -1}>
                         <div className="content">
                             {!showDialog && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
                         </div>
                     </div>
                     <div className="avatar-container">
-                        {(!showDialog && hasHint) && <sui.Button className={`ui circular label blue hintbutton hidelightbox ${hasHint && this.props.pokeUser ? 'shake flash' : ''}`} icon="lightbulb outline" tabIndex={-1} onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter} />}
+                        {(!showDialog && hasHint) && <sui.Button
+                            className={`ui circular label blue hintbutton hidelightbox ${hasHint && this.props.pokeUser ? 'shake flash' : ''}`}
+                            icon="lightbulb outline"
+                            aria-label={tutorialAriaLabel} title={tutorialHintTooltip}
+                            onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter}
+                        />}
                         {(!showDialog && hasHint) && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={hintOnClick} />}
                         <TutorialHint ref="tutorialhint" parent={this.props.parent} />
                     </div>

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -643,7 +643,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             <div className='ui buttons'>
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">
-                    <div ref="tutorialmessage" className={`tutorialmessage`} role="alert" tabIndex={hasHint ? 0 : -1}>
+                    <div ref="tutorialmessage" className={`tutorialmessage`} role="alert">
                         <div className="content">
                             {!showDialog && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
                         </div>


### PR DESCRIPTION
Variety of small nitpicky things as well

* fix https://github.com/microsoft/pxt-microbit/issues/3982 -- move tab stop from text content to hint btn 
* tutorial name -- make it not styled like a button -- remove pointer cursor, no background darken on click
* unfiled acc bug - move tabstop for the tutorial step content from the outer div to the one directly containing the p tags, so keyboard navigation can scroll when necessary / a scrollbar exists.
* remove pointer cursor from the step content

Got a build since I was testing mobile anyways https://makecode.microbit.org/app/384c3bdf51b88f2471fe118cab7e127600e7b85f-98538ccfad (pxt / microbit might be a few commits back though)