### PR TITLE
Update robots.txt to disable crawling for /v2

### DIFF
--- a/common-docs/robots.txt
+++ b/common-docs/robots.txt
@@ -1,1 +1,5 @@
-# robots.txt for PXT sites; nothing here yet
+# robots.txt for PXT sites
+
+# Disable crawling in /v2 path for micro:bit
+User-agent: *
+Disallow: /v2


### PR DESCRIPTION
should address https://github.com/microsoft/pxt-microbit/issues/3829 by bumping the v2 site down in search results. we may want to consider disabling crawling for /v* paths altogether?