### PR TITLE
homescreen detail view button icon contrast

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -278,9 +278,14 @@
 
                 .button.attached i {
                     display: block;
-                    margin: auto!important;
-                    opacity: 0.05;
+                    margin: auto !important;
+                    opacity: 0.65;
                     color: @homeCardHeaderColor;
+
+                    // These three have text in front of the icons, so leave them faint.
+                    &.blocks, &.js, &.py {
+                        opacity: 0.05;
+                    }
                 }
                 .button.attached .icon:not(.xicon) {
                     margin: 0 auto!important;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3268:

![image](https://user-images.githubusercontent.com/5615930/117895590-85296d80-b273-11eb-9e34-8628bc6931ce.png)

![image](https://user-images.githubusercontent.com/5615930/117895575-7b076f00-b273-11eb-8534-607da8add7c8.png)

js / blocks / python projects all have text overlaid on top of the icon, so leave those with the current opacity so that the text is still easily readable. 

https://github.com/microsoft/pxt/blob/9a2fc6ec1171e240e3d58450592a8232ffa3b08f/webapp/src/projects.tsx#L968-L979

![image](https://user-images.githubusercontent.com/5615930/117895464-3da2e180-b273-11eb-97a6-ecfc21a00343.png)
