### PR TITLE
Fix local host serve when pointing to production sim

### DIFF
--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -239,12 +239,28 @@ namespace pxsim {
             return res;
         }
 
+        export function isPxtElectron(): boolean {
+            return typeof window != "undefined" && !!(window as any).pxtElectron;
+        }
+
+        export function isIpcRenderer(): boolean {
+            return typeof window != "undefined" && !!(window as any).ipcRenderer;
+        }
+
+        export function isElectron() {
+            return isPxtElectron() || isIpcRenderer();
+        }
+
         export function isLocalHost(): boolean {
             try {
                 return typeof window !== "undefined"
                     && /^http:\/\/(localhost|127\.0\.0\.1):\d+\//.test(window.location.href)
                     && !/nolocalhost=1/.test(window.location.href);
             } catch (e) { return false; }
+        }
+
+        export function isLocalHostDev(): boolean {
+            return isLocalHost() && !isElectron();
         }
 
         export function unique<T>(arr: T[], f: (t: T) => string): T[] {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -393,7 +393,7 @@ namespace pxsim {
         private postMessageCore(frame: HTMLIFrameElement, msg: SimulatorMessage) {
             frame.contentWindow.postMessage(msg, frame.dataset['origin']);
 
-            if (U.isLocalHost() && (pxt as any)?.appTarget?.id) {
+            if (U.isLocalHostDev() && (pxt as any)?.appTarget?.id) {
                 // If using the production simulator on local serve, the domain might have been
                 // redirected by the CLI server. Also send to the production domain just in case
                 try {

--- a/pxtsim/simdriver.ts
+++ b/pxtsim/simdriver.ts
@@ -383,6 +383,10 @@ namespace pxsim {
                 // finally, send the message
                 frame.contentWindow.postMessage(msg, frame.dataset['origin']);
 
+                if (U.isLocalHost() && (pxt as any)?.appTarget?.id) {
+                    frame.contentWindow.postMessage(msg, `https://trg-${(pxt as any)?.appTarget?.id}.userpxt.io/---simulator`);
+                }
+
                 // don't start more than 1 recorder
                 if (msg.type == 'recorder'
                     && (<pxsim.SimulatorRecorderMessage>msg).action == "start")
@@ -677,6 +681,9 @@ namespace pxsim {
                 msg.breakOnStart = false;
             }
             frame.contentWindow.postMessage(msg, frame.dataset['origin']);
+            if (U.isLocalHost() && (pxt as any)?.appTarget?.id) {
+                frame.contentWindow.postMessage(msg, `https://trg-${(pxt as any)?.appTarget?.id}.userpxt.io/---simulator`);
+            }
             if (this.traceInterval) this.setTraceInterval(this.traceInterval);
             this.applyAspectRatioToFrame(frame);
             this.setFrameState(frame);


### PR DESCRIPTION
This fixes local serve in arcade when using the production simulator. It was a regression accidentally caused by #7720

If the simulator is missing, our CLI [redirects requests to the production simulator](https://github.com/microsoft/pxt/blob/master/cli/server.ts#L1136) which ends up changing the domain of the iframe. Because the origin changes with the redirect, the messages we send with `postMessage` never reach the content window.

This fixes that by sending to both domains when on localhost. Should be harmless since one of the messages will just always be ignored. I don't love how I got access to the target id (apptarget isn't usually visible in pxsim), but piping everything from the webapp for local serve seemed messy.

This really only effects arcade