### PR TITLE
Enable identity in beta

### DIFF
--- a/pxteditor/experiments.ts
+++ b/pxteditor/experiments.ts
@@ -173,13 +173,6 @@ namespace pxt.editor.experiments {
                 name: lf("Blocks Error List"),
                 description: lf("Show an error list panel for Blocks")
             },
-            {
-                id: "identity",
-                name: lf("Cloud Save"),
-                description: lf("Create a profile and save projects to the cloud."),
-                feedbackUrl: "https://github.com/microsoft/pxt/issues/7801",
-                enableOnline: true,
-            }
         ].filter(experiment => ids.indexOf(experiment.id) > -1 && !(pxt.BrowserUtils.isPxtElectron() && experiment.enableOnline));
     }
 

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -363,10 +363,11 @@ export function identityProvider(id: pxt.IdentityProviderId): pxt.AppCloudProvid
 }
 
 export function hasIdentity(): boolean {
-    // Must read storage for this rather than app theme because this method
-    // gets called before experiments are synced to the theme.
+    // If identity experiment was previously enabled, respect this setting. Otherwise early-adopers could lose access to cloud-saved projects.
     const experimentEnabled = pxt.editor.experiments.isEnabled("identity");
-    return !authDisabled && !pxt.BrowserUtils.isPxtElectron() && experimentEnabled && identityProviders().length > 0;
+    // Temporary: Allow identity by default on localhost, staging, or beta.
+    const identityEnabledUri = experimentEnabled || window.location.href.includes("localhost") || window.location.href.includes("staging.pxt.io") || window.location.href.includes("/beta");
+    return identityEnabledUri && !authDisabled && !pxt.BrowserUtils.isPxtElectron() && identityProviders().length > 0;
 }
 
 export async function loggedIn(): Promise<boolean> {
@@ -574,7 +575,7 @@ export type ApiResult<T> = {
 const DEV_BACKEND_DEFAULT = "";
 const DEV_BACKEND_PROD = "https://www.makecode.com";
 const DEV_BACKEND_STAGING = "https://staging.pxt.io";
-const DEV_BACKEND_LOCALHOST = "http://localhost:5500";
+const DEV_BACKEND_LOCALHOST = "http://localhost:8080";
 
 const DEV_BACKEND = DEV_BACKEND_STAGING;
 

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -575,7 +575,7 @@ export type ApiResult<T> = {
 const DEV_BACKEND_DEFAULT = "";
 const DEV_BACKEND_PROD = "https://www.makecode.com";
 const DEV_BACKEND_STAGING = "https://staging.pxt.io";
-const DEV_BACKEND_LOCALHOST = "http://localhost:8080";
+const DEV_BACKEND_LOCALHOST = "http://localhost:5500";
 
 const DEV_BACKEND = DEV_BACKEND_STAGING;
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -288,11 +288,11 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             {showGreenScreen ? <sui.Item role="menuitem" text={greenScreen ? lf("Green Screen Off") : lf("Green Screen On")} onClick={this.toggleGreenScreen} /> : undefined}
             {docItems && renderDocItems(this.props.parent, docItems, "ui mobile only inherit")}
             {githubUser ? <div className="ui divider"></div> : undefined}
-            {githubUser ? <div className="ui item" title={lf("Sign out {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
+            {githubUser ? <div className="ui item" title={lf("Unlink {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
                 <div className="avatar" role="presentation">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
                 </div>
-                {lf("Sign out")}
+                {lf("Unlink GitHub")}
             </div> : undefined}
             {showCenterDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -344,11 +344,11 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
             {targetTheme.selectLanguage && <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} />}
             {targetTheme.highContrast && <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} />}
             {githubUser && <div className="ui divider"></div>}
-            {githubUser && <div className="ui item" title={lf("Sign out {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
+            {githubUser && <div className="ui item" title={lf("Unlink {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
                 <div className="avatar" role="presentation">
                     <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
                 </div>
-                {lf("Sign out")}
+                {lf("Unlink GitHub")}
             </div>}
             {showDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}


### PR DESCRIPTION
In this PR:
* Enable identity by default in localhost, staging, and beta environments.
* Remove Identity experiment.
* On gear menu: re-label GitHub "sign out" to "Unlink GitHub", for consistency with our design choice on the User profile page.
