### PR TITLE
Save project when exiting tutorial via target logo

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3490,10 +3490,12 @@ export class ProjectView
 
     showExitAndSaveDialog() {
         this.setState({ debugging: false })
-        if (this.state.projectName !== lf("Untitled")) {
+        if (this.isTutorial()) {
+            pxt.tickEvent("tutorial.exit.home", { tutorial: this.state.header?.tutorial?.tutorial });
+            this.exitTutorialAsync().finally(() => this.openHome());
+        } else if (this.state.projectName !== lf("Untitled")) {
             this.openHome();
-        }
-        else {
+        } else {
             this.exitAndSaveDialog.show();
         }
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/3998

adds a tick event for exiting the tutorial via this button also (`tutorial.exit` is exiting via the "Exit Tutorial" button)