### PR TITLE
fix block.loc.ab-CD where lang is fully enumerated (e.g. .zh-CN)

### DIFF
--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -805,7 +805,7 @@ namespace ts.pxtc {
         let didSomething = true
         while (didSomething) {
             didSomething = false
-            cmt = cmt.replace(/\/\/%[ \t]*([\w\.]+)(=(("[^"\n]*")|'([^'\n]*)'|([^\s]*)))?/,
+            cmt = cmt.replace(/\/\/%[ \t]*([\w\.-]+)(=(("[^"\n]*")|'([^'\n]*)'|([^\s]*)))?/,
                 (f: string, n: string, d0: string, d1: string,
                     v0: string, v1: string, v2: string) => {
                     let v = v0 ? JSON.parse(v0) : (d0 ? (v0 || v1 || v2) : "true");


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/3985

Here's a build with a test block in it - it should say 'this failed' in any language except simplifed chinese, where it should say 'this succeeded': https://makecode.microbit.org/app/3b23aba2d03c06d2865dddd8098d647af20731b3-d8a2867831#pub:_icDCV21Wrhtk

in custom.ts:
```typescript
namespace test {
    //% block="this failed"
    //% block.loc.zh-CN="this succeeded"
    export function testMyStuff() { }
}
```