### PR TITLE
Added Markdown Flag for Code Validation

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1027,8 +1027,9 @@ declare namespace pxt.tutorial {
         noDiffs?: boolean; // don't automatically generated diffs
         codeStart?: string; // command to run when code starts (MINECRAFT HOC ONLY)
         codeStop?: string; // command to run when code stops (MINECRAFT HOC ONLY)
-        autoexpandOff?: boolean // INTERNAL TESTING ONLY
-        preferredEditor?: string // preferred editor for opening the tutorial
+        autoexpandOff?: boolean; // INTERNAL TESTING ONLY
+        preferredEditor?: string; // preferred editor for opening the tutorial
+        tutorialCodeValidation?: boolean; // enable tutorial validation for this tutorial
     }
 
     interface TutorialStepInfo {

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -29,7 +29,8 @@ namespace pxt.docs {
         "codeStop": "<!-- stop -->",
         "autoOpen": "<!-- autoOpen -->",
         "autoexpandOff": "<!-- autoexpandOff -->",
-        "preferredEditor": "<!-- preferredEditor -->"
+        "preferredEditor": "<!-- preferredEditor -->",
+        "tutorialCodeValidation": "<!-- tutorialCodeValidation -->"
     }
 
     function replaceAll(replIn: string, x: string, y: string) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1287,7 +1287,8 @@ export class ProjectView
     setTutorialCodeStatus(step: number, status: string) {
         const tutorialOptions = this.state.tutorialOptions;
         const stepInfo = tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep];
-        stepInfo.codeValidated = status == pxt.editor.TutorialCodeStatus.Valid;
+        const tutorialCodeValidationIsOn = tutorialOptions.metadata.tutorialCodeValidation;
+        if (tutorialCodeValidationIsOn) stepInfo.codeValidated = status == pxt.editor.TutorialCodeStatus.Valid;
 
         // Update the state with the code status, so the tutorial card can re-render
         this.setState({ tutorialOptions: tutorialOptions });


### PR DESCRIPTION
In a markdown file, this flag can be added:
`### @tutorialCodeValidation true/false`

If this flag is set to true, then the tutorial will go through the process of tutorial code validation. Otherwise features for tutorial code validation will not be included when a user is going through a tutorial.