### PR TITLE
Fix skill graph position relative to background image

### DIFF
--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -4,78 +4,39 @@ import { connect } from 'react-redux';
 import { SkillMapState } from '../store/reducer';
 import { dispatchChangeSelectedItem, dispatchShowCompletionModal,
     dispatchSetSkillMapCompleted, dispatchOpenActivity } from '../actions/dispatch';
+import { SvgGraphItem, SvgGraphPath } from './SkillGraphContainer';
 import { GraphNode } from './GraphNode';
 import { GraphPath } from "./GraphPath";
 
 import { getActivityStatus, isActivityUnlocked } from '../lib/skillMapUtils';
-import { SvgCoord, orthogonalGraph } from '../lib/skillGraphUtils';
 import { tickEvent } from "../lib/browserUtils";
 
-interface SvgGraphItem {
-    activity: MapActivity;
-    position: SvgCoord;
-}
+export interface SkillGraphProps {
+    // Rendering
+    unit: number;
+    items: SvgGraphItem[];
+    paths: SvgGraphPath[];
+    width: number;
+    height: number;
 
-interface SvgGraphPath {
-    points: SvgCoord[];
-}
-
-interface SkillGraphProps {
+    // Skill map
     map: SkillMap;
     user: UserState;
     selectedActivityId?: string;
     pageSourceUrl: string;
     theme: SkillGraphTheme;
     completionState: "incomplete" | "transitioning" | "completed";
+
+    // Events
     dispatchChangeSelectedItem: (mapId?: string, activityId?: string) => void;
     dispatchShowCompletionModal: (mapId: string, activityId?: string) => void;
     dispatchSetSkillMapCompleted: (mapId: string) => void;
     dispatchOpenActivity: (mapId: string, activityId: string) => void;
 }
 
-const UNIT = 10;
-const PADDING = 4;
-
 class SkillGraphImpl extends React.Component<SkillGraphProps> {
-    protected items: SvgGraphItem[];
-    protected paths: SvgGraphPath[];
-    protected size: { width: number, height: number };
-
     constructor(props: SkillGraphProps) {
         super(props);
-        this.size = { width: 0, height: 0 };
-
-        const { items, paths } = this.getItems(props.map.root);
-        this.items = items;
-        this.paths = paths;
-    }
-
-    protected getItems(root: MapNode): { items: SvgGraphItem[], paths: SvgGraphPath[] } {
-        const nodes = orthogonalGraph(root);
-
-        // Convert into renderable items
-        const items: SvgGraphItem[] = [];
-        const paths: SvgGraphPath[] = [];
-        for (let current of nodes) {
-            const { depth, offset } = current;
-            items.push({
-                activity: current,
-                position: this.getPosition(depth, offset)
-            } as any);
-
-            if (current.edges) {
-                current.edges.forEach(edge => {
-                    const points: SvgCoord[] = [];
-                    edge.forEach(n => points.push(this.getPosition(n.depth, n.offset)));
-                    paths.push({ points });
-                });
-            }
-
-            this.size.height = Math.max(this.size.height, current.offset);
-            this.size.width = Math.max(this.size.width, current.depth);
-        }
-
-        return { items, paths };
     }
 
     protected onItemSelect = (activityId: string, kind: MapNodeKind) => {
@@ -105,19 +66,6 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
         }
     }
 
-    // This function converts graph position (no units) to x/y (SVG units)
-    protected getPosition(depth: number, offset: number): SvgCoord {
-        return { x: this.getX(depth), y: this.getY(offset) }
-    }
-
-    protected getX(position: number) {
-        return ((position * 12) + PADDING) * UNIT;
-    }
-
-    protected getY(position: number) {
-        return ((position * 9) + PADDING) * UNIT;
-    }
-
     componentDidUpdate(props: SkillGraphProps) {
         if (props.completionState === "transitioning") {
             setTimeout(() => {
@@ -129,31 +77,30 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
     }
 
     render() {
-        const { map, user, selectedActivityId, pageSourceUrl, theme } = this.props;
-        const width = this.getX(this.size.width) + UNIT * PADDING;
-        const height = this.getY(this.size.height) + UNIT * PADDING;
-        return <svg className="skill-graph" xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        const { unit, items, paths, map, user, selectedActivityId, pageSourceUrl, theme } = this.props;
+
+        return <g className="skill-graph">
             <g opacity={theme.pathOpacity}>
-                {this.paths.map((el, i) => {
-                    return <GraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT} color={theme.strokeColor} points={el.points} />
+                {paths.map((el, i) => {
+                    return <GraphPath key={`graph-activity-${i}`} strokeWidth={3 * unit} color={theme.strokeColor} points={el.points} />
                 })}
-                {this.paths.map((el, i) => {
-                    return <GraphPath key={`graph-activity-${i}`} strokeWidth={3 * UNIT - 4} color={theme.pathColor}  points={el.points} />
+                {paths.map((el, i) => {
+                    return <GraphPath key={`graph-activity-${i}`} strokeWidth={3 * unit - 4} color={theme.pathColor}  points={el.points} />
                 })}
             </g>
-            {this.items.map((el, i) => {
+            {items.map((el, i) => {
                 return <GraphNode key={`graph-activity-${i}`}
                     theme={theme}
                     kind={el.activity.kind}
                     activityId={el.activity.activityId}
                     position={el.position}
-                    width={5 * UNIT}
+                    width={5 * unit}
                     selected={el.activity.activityId === selectedActivityId}
                     onItemSelect={this.onItemSelect}
                     onItemDoubleClick={this.onItemDoubleClick}
                     status={getActivityStatus(user, pageSourceUrl, map, el.activity.activityId).status} />
             })}
-        </svg>
+        </g>
     }
 }
 

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -4,11 +4,11 @@ import { connect } from 'react-redux';
 import { SkillMapState } from '../store/reducer';
 import { dispatchChangeSelectedItem, dispatchShowCompletionModal,
     dispatchSetSkillMapCompleted, dispatchOpenActivity } from '../actions/dispatch';
-import { SvgGraphItem, SvgGraphPath } from './SkillGraphContainer';
 import { GraphNode } from './GraphNode';
 import { GraphPath } from "./GraphPath";
 
 import { getActivityStatus, isActivityUnlocked } from '../lib/skillMapUtils';
+import { SvgGraphItem, SvgGraphPath } from '../lib/skillGraphUtils';
 import { tickEvent } from "../lib/browserUtils";
 
 export interface SkillGraphProps {

--- a/skillmap/src/components/SkillGraphContainer.tsx
+++ b/skillmap/src/components/SkillGraphContainer.tsx
@@ -1,30 +1,161 @@
 import * as React from "react";
 
 import { SkillGraph } from "./SkillGraph";
+import { SvgCoord, orthogonalGraph } from '../lib/skillGraphUtils';
 
 /* eslint-disable import/no-unassigned-import, import/no-internal-modules */
 import '../styles/skillgraph.css'
 /* eslint-enable import/no-unassigned-import, import/no-internal-modules */
+
+interface SvgGraph {
+    map: SkillMap;
+    items: SvgGraphItem[];
+    paths: SvgGraphPath[];
+    width: number;
+    height: number
+}
+
+export interface SvgGraphItem {
+    activity: MapActivity;
+    position: SvgCoord;
+}
+
+export interface SvgGraphPath {
+    points: SvgCoord[];
+}
 
 interface SkillGraphContainerProps {
     maps: SkillMap[];
     backgroundImageUrl: string;
 }
 
-export class SkillGraphContainer extends React.Component<SkillGraphContainerProps> {
+interface SkillGraphContainerState {
+    backgroundSize: {
+        width: number,
+        height: number
+    };
+}
+
+const UNIT = 10;
+const PADDING = 4;
+const MIN_HEIGHT = 40 * UNIT;
+const MIN_WIDTH = 60 * UNIT;
+const THRESHOLD = 0.05;
+
+export class SkillGraphContainer extends React.Component<SkillGraphContainerProps, SkillGraphContainerState> {
+    protected graphs: SvgGraph[] = [];
+    protected graphSize = { width: 0, height: 0 };
+
+    constructor(props: SkillGraphContainerProps) {
+        super(props);
+
+        this.state = { backgroundSize: { width: 0, height: 0 } };
+        this.graphs = props.maps.map(el => this.getGraph(el));
+    }
+
+    UNSAFE_componentWillReceiveProps(props: SkillGraphContainerProps) {
+        this.graphSize = { width: 0, height: 0 };
+        this.graphs = props.maps.map(el => this.getGraph(el));
+    }
+
+    protected getGraph(map: SkillMap): SvgGraph {
+        const nodes = orthogonalGraph(map.root);
+        let maxDepth = 0, maxOffset = 0;
+
+        // Convert into renderable items
+        const items: SvgGraphItem[] = [];
+        const paths: SvgGraphPath[] = [];
+        for (let current of nodes) {
+            const { depth, offset } = current;
+            items.push({
+                activity: current,
+                position: this.getPosition(depth, offset)
+            } as any);
+
+            if (current.edges) {
+                current.edges.forEach(edge => {
+                    const points: SvgCoord[] = [];
+                    edge.forEach(n => points.push(this.getPosition(n.depth, n.offset)));
+                    paths.push({ points });
+                });
+            }
+
+            maxDepth = Math.max(maxDepth, current.depth);
+            maxOffset = Math.max(maxOffset, current.offset);
+        }
+
+        const width = this.getX(maxDepth) + UNIT * PADDING;
+        const height = this.getY(maxOffset) + UNIT * PADDING;
+
+        // Update width of entire skill map, if this graph changes it
+        this.graphSize.width = Math.max(this.graphSize.width, width);
+        this.graphSize.height += height;
+
+        return { map, items, paths, width, height };
+    }
+
+    // This function converts graph position (no units) to x/y (SVG units)
+    protected getPosition(depth: number, offset: number): SvgCoord {
+        return { x: this.getX(depth), y: this.getY(offset) }
+    }
+
+    protected getX(position: number) {
+        return ((position * 12) + PADDING) * UNIT;
+    }
+
+    protected getY(position: number) {
+        return ((position * 9) + PADDING) * UNIT;
+    }
+
+    protected onImageLoad = (evt: any) => {
+        console.log(evt.target)
+        this.setState({
+            backgroundSize: {
+                    width: evt.target.offsetWidth,
+                    height: evt.target.offsetHeight
+                }
+            })
+    }
+
     render() {
-        const { maps, backgroundImageUrl } = this.props;
+        const { backgroundImageUrl } = this.props;
+        const { backgroundSize } = this.state;
+        let translateY = 0;
+
+        const padding = PADDING * UNIT;
+        const graphAspectRatio = this.graphSize.width / this.graphSize.height;
+        const backgroundAspectRatio = backgroundSize.width / backgroundSize.height;
+
+        let height = Math.max(MIN_HEIGHT, this.graphSize.height);
+        let width = Math.max(MIN_WIDTH, this.graphSize.width);
+
+        if (backgroundImageUrl) {
+            // Scale the SVG to exactly fit the background image
+            if (graphAspectRatio - backgroundAspectRatio > THRESHOLD) {
+                height = width * (1 / backgroundAspectRatio);
+            } else if (graphAspectRatio - backgroundAspectRatio < -THRESHOLD)  {
+                width = height * backgroundAspectRatio;
+            }
+        }
+
+        const heightDiff = Math.max(height - this.graphSize.height, 0) / 2;
+        const widthDiff = Math.max(width - this.graphSize.width, 0) / 2;
 
         return <div className="skill-graph-wrapper">
-            <div className={`skill-graph-content`}>
-                {maps.map((el, i) => {
-                        return <SkillGraph map={el} key={i} />
-                    })}
-            </div>
-            <div className="skill-graph-background">
-                {backgroundImageUrl &&
-                    <img src={backgroundImageUrl} alt={lf("Background Image")}/>
-                }
+            <div className={`skill-graph-content ${backgroundImageUrl ? "has-background" : ""}`}>
+                <div className="skill-graph-activities">
+                    <svg viewBox={`-${widthDiff + padding} -${heightDiff + padding} ${width + padding * 2} ${height + padding * 2}`} preserveAspectRatio="xMidYMid meet">
+                        {this.graphs.map((el, i) => {
+                            translateY += el.height;
+                            return <g key={i} transform={`translate(0, ${translateY - el.height})`}>
+                                <SkillGraph unit={UNIT} {...el} />
+                            </g>
+                        })}
+                    </svg>
+                </div>
+                {backgroundImageUrl && <div className="skill-graph-background">
+                    <img src={backgroundImageUrl} alt={lf("Background Image")} onLoad={this.onImageLoad} />
+                </div>}
             </div>
         </div>
     }

--- a/skillmap/src/components/SkillGraphContainer.tsx
+++ b/skillmap/src/components/SkillGraphContainer.tsx
@@ -1,114 +1,41 @@
 import * as React from "react";
+import { connect } from 'react-redux';
 
+import { SkillMapState } from '../store/reducer';
 import { SkillGraph } from "./SkillGraph";
-import { SvgCoord, orthogonalGraph } from '../lib/skillGraphUtils';
+import { SvgGraph, getGraph, PADDING, UNIT, MIN_HEIGHT, MIN_WIDTH } from '../lib/skillGraphUtils';
 
 /* eslint-disable import/no-unassigned-import, import/no-internal-modules */
 import '../styles/skillgraph.css'
 /* eslint-enable import/no-unassigned-import, import/no-internal-modules */
 
-interface SvgGraph {
-    map: SkillMap;
-    items: SvgGraphItem[];
-    paths: SvgGraphPath[];
-    width: number;
-    height: number
-}
-
-export interface SvgGraphItem {
-    activity: MapActivity;
-    position: SvgCoord;
-}
-
-export interface SvgGraphPath {
-    points: SvgCoord[];
-}
-
 interface SkillGraphContainerProps {
     maps: SkillMap[];
+    graphs: SvgGraph[];
     backgroundImageUrl: string;
+    graphSize: {
+        width: number;
+        height: number;
+    };
 }
 
 interface SkillGraphContainerState {
     backgroundSize: {
-        width: number,
-        height: number
+        width: number;
+        height: number;
     };
 }
 
-const UNIT = 10;
-const PADDING = 4;
-const MIN_HEIGHT = 40 * UNIT;
-const MIN_WIDTH = 60 * UNIT;
 const THRESHOLD = 0.05;
 
-export class SkillGraphContainer extends React.Component<SkillGraphContainerProps, SkillGraphContainerState> {
-    protected graphs: SvgGraph[] = [];
-    protected graphSize = { width: 0, height: 0 };
-
+export class SkillGraphContainerImpl extends React.Component<SkillGraphContainerProps, SkillGraphContainerState> {
     constructor(props: SkillGraphContainerProps) {
         super(props);
 
         this.state = { backgroundSize: { width: 0, height: 0 } };
-        this.graphs = props.maps.map(el => this.getGraph(el));
-    }
-
-    UNSAFE_componentWillReceiveProps(props: SkillGraphContainerProps) {
-        this.graphSize = { width: 0, height: 0 };
-        this.graphs = props.maps.map(el => this.getGraph(el));
-    }
-
-    protected getGraph(map: SkillMap): SvgGraph {
-        const nodes = orthogonalGraph(map.root);
-        let maxDepth = 0, maxOffset = 0;
-
-        // Convert into renderable items
-        const items: SvgGraphItem[] = [];
-        const paths: SvgGraphPath[] = [];
-        for (let current of nodes) {
-            const { depth, offset } = current;
-            items.push({
-                activity: current,
-                position: this.getPosition(depth, offset)
-            } as any);
-
-            if (current.edges) {
-                current.edges.forEach(edge => {
-                    const points: SvgCoord[] = [];
-                    edge.forEach(n => points.push(this.getPosition(n.depth, n.offset)));
-                    paths.push({ points });
-                });
-            }
-
-            maxDepth = Math.max(maxDepth, current.depth);
-            maxOffset = Math.max(maxOffset, current.offset);
-        }
-
-        const width = this.getX(maxDepth) + UNIT * PADDING;
-        const height = this.getY(maxOffset) + UNIT * PADDING;
-
-        // Update width of entire skill map, if this graph changes it
-        this.graphSize.width = Math.max(this.graphSize.width, width);
-        this.graphSize.height += height;
-
-        return { map, items, paths, width, height };
-    }
-
-    // This function converts graph position (no units) to x/y (SVG units)
-    protected getPosition(depth: number, offset: number): SvgCoord {
-        return { x: this.getX(depth), y: this.getY(offset) }
-    }
-
-    protected getX(position: number) {
-        return ((position * 12) + PADDING) * UNIT;
-    }
-
-    protected getY(position: number) {
-        return ((position * 9) + PADDING) * UNIT;
     }
 
     protected onImageLoad = (evt: any) => {
-        console.log(evt.target)
         this.setState({
             backgroundSize: {
                     width: evt.target.offsetWidth,
@@ -118,16 +45,16 @@ export class SkillGraphContainer extends React.Component<SkillGraphContainerProp
     }
 
     render() {
-        const { backgroundImageUrl } = this.props;
+        const { graphs, graphSize, backgroundImageUrl } = this.props;
         const { backgroundSize } = this.state;
         let translateY = 0;
 
         const padding = PADDING * UNIT;
-        const graphAspectRatio = this.graphSize.width / this.graphSize.height;
+        const graphAspectRatio = graphSize.width / graphSize.height;
         const backgroundAspectRatio = backgroundSize.width / backgroundSize.height;
 
-        let height = Math.max(MIN_HEIGHT, this.graphSize.height);
-        let width = Math.max(MIN_WIDTH, this.graphSize.width);
+        let height = Math.max(MIN_HEIGHT, graphSize.height);
+        let width = Math.max(MIN_WIDTH, graphSize.width);
 
         if (backgroundImageUrl) {
             // Scale the SVG to exactly fit the background image
@@ -138,14 +65,14 @@ export class SkillGraphContainer extends React.Component<SkillGraphContainerProp
             }
         }
 
-        const heightDiff = Math.max(height - this.graphSize.height, 0) / 2;
-        const widthDiff = Math.max(width - this.graphSize.width, 0) / 2;
+        const heightDiff = Math.max(height - graphSize.height, 0) / 2;
+        const widthDiff = Math.max(width - graphSize.width, 0) / 2;
 
         return <div className="skill-graph-wrapper">
             <div className={`skill-graph-content ${backgroundImageUrl ? "has-background" : ""}`}>
                 <div className="skill-graph-activities">
                     <svg viewBox={`-${widthDiff + padding} -${heightDiff + padding} ${width + padding * 2} ${height + padding * 2}`} preserveAspectRatio="xMidYMid meet">
-                        {this.graphs.map((el, i) => {
+                        {graphs.map((el, i) => {
                             translateY += el.height;
                             return <g key={i} transform={`translate(0, ${translateY - el.height})`}>
                                 <SkillGraph unit={UNIT} {...el} />
@@ -160,3 +87,20 @@ export class SkillGraphContainer extends React.Component<SkillGraphContainerProp
         </div>
     }
 }
+
+
+function mapStateToProps(state: SkillMapState, ownProps: SkillGraphContainerProps) {
+    if (!state) return {};
+
+    // Compute graph layout, update size of skill map
+    const graphs = ownProps.maps.map(el => getGraph(el));
+    const width = graphs?.length ? graphs.map(el => el.width).reduce((prev, curr) => Math.max(prev, curr)) : 0;
+    const height = graphs?.length ? graphs.map(el => el.height).reduce((prev, curr) => prev + curr) : 0;
+
+    return {
+        graphs,
+        graphSize: { width, height }
+    }
+}
+
+export const SkillGraphContainer = connect(mapStateToProps)(SkillGraphContainerImpl);

--- a/skillmap/src/styles/skillgraph.css
+++ b/skillmap/src/styles/skillgraph.css
@@ -1,13 +1,3 @@
-.skill-graph {
-    display: block;
-    max-width: 100%;
-}
-
-.skill-graph-content {
-    display: flex;
-    flex-direction: column;
-    z-index: var(--above-graph-zindex);
-}
 
 .skill-graph-wrapper {
     display: flex;
@@ -15,23 +5,30 @@
     align-items: center;
     justify-content: center;
     flex: 1;
-    position: relative;
 }
 
-.skill-graph-background {
+.skill-graph-content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 90%;
+    z-index: var(--above-graph-zindex);
+}
+
+.skill-graph-activities {
+    z-index: var(--graph-backround-zindex);
+    user-select: none;
+}
+
+.has-background .skill-graph-activities {
     position: absolute;
     width: 100%;
     height: 100%;
-    z-index: var(--graph-backround-zindex);
-    user-select: none;
-    text-align: center;
 }
 
+.skill-graph-activities svg,
 .skill-graph-background img {
-    max-width: 80%;
-    max-height: 80%;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    object-fit: contain;
+    width: 100%;
+    max-height: 100%;
 }


### PR DESCRIPTION
some changes to support a fixed graph position relative to the background image. this does make the overall page less responsive, but was requested specifically for the beginner skillmap launch

- moves all graph layout computation code into `SkillGraphContainer.tsx`; previously each "path" was it's own SVG, now they are all positioned on the same parent SVG
- when the background image (if there is one) loads, we get the dimenions and scale the graph SVG to exactly match, that way it's always centered
- some CSS changes/cleanup to support this

![skillmap-resize](https://user-images.githubusercontent.com/34112083/118558596-b5618800-b71b-11eb-9867-15a87919f125.gif)
