### PR TITLE
Add ?compiler=size switch

### DIFF
--- a/docs/js/profiling.md
+++ b/docs/js/profiling.md
@@ -110,3 +110,10 @@ contiguous block was 25092 bytes (this is the largest allocation that
 would still succeed right after that last collection).
 Since reset, the minimum free memory was 32328
 (which means that if the device had 32k less memory it would crash).
+
+## Profiling executable size
+
+This can be enabled with `?compiler=size`.
+When compiling for native, this will generate `size.csv` file alongside
+`binary.asm` and `binary.uf2`.
+You can load it into Excel and draw a treemap from the first three columns. 

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -596,6 +596,7 @@ declare namespace ts.pxtc {
         noIncr?: boolean;
         rawELF?: boolean;
         multiVariant?: boolean;
+        size?: boolean;
     }
 
     interface CompileTarget {

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -320,6 +320,9 @@ ${baseLabel}_nochk:
                         this.write(s.lblName + ":")
                         this.validateJmpStack(s)
                         break;
+                    case ir.SK.Comment:
+                        this.write(`; ${s.expr.data}`)
+                        break
                     case ir.SK.Breakpoint:
                         if (this.bin.options.breakpoints) {
                             let lbl = `__brkp_${s.breakpointInfo.id}`

--- a/pxtcompiler/emitter/backbase.ts
+++ b/pxtcompiler/emitter/backbase.ts
@@ -219,12 +219,16 @@ ${hexLiteralAsm(data)}
 ;
 `)
 
-            this.emitLambdaWrapper(this.proc.isRoot)
-
             let baseLabel = this.proc.label()
+            let preLabel = baseLabel + "_pre"
             let bkptLabel = baseLabel + "_bkpt"
             let locLabel = baseLabel + "_locals"
             let endLabel = baseLabel + "_end"
+
+            this.write(`${preLabel}:`)
+
+            this.emitLambdaWrapper(this.proc.isRoot)
+
             this.write(`.section code`)
             this.write(`${baseLabel}:`)
 
@@ -255,7 +259,8 @@ ${baseLabel}_nochk:
                     bkptLoc: U.lookup(labels, bkptLabel),
                     localsMark: U.lookup(th.stackAtLabel, locLabel),
                     idx: this.proc.seqNo,
-                    calls: this.calls
+                    calls: this.calls,
+                    size: U.lookup(labels, endLabel) + 2 - U.lookup(labels, preLabel)
                 }
 
                 for (let ci of this.calls) {

--- a/pxtcompiler/emitter/backjs.ts
+++ b/pxtcompiler/emitter/backjs.ts
@@ -276,6 +276,9 @@ switch (step) {
                     if (s.lblNumUses > 0)
                         writeRaw(`  case ${s.lblId}:`)
                     break;
+                case ir.SK.Comment:
+                    writeRaw(`// ${s.expr.data}`)
+                    break
                 case ir.SK.Breakpoint:
                     emitBreakpoint(s)
                     break;

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -335,6 +335,9 @@ _start_${name}:
                     case ir.SK.Label:
                         writeRaw(`${s.lblName}:`)
                         break;
+                    case ir.SK.Comment:
+                        writeRaw(`; ${s.expr.data}`)
+                        break
                     case ir.SK.Breakpoint:
                         break;
                     default: oops();

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -3891,14 +3891,21 @@ ${lbl}: .short 0xffff
             let pos = node.pos
             while (/^\s$/.exec(src.text[pos]))
                 pos++;
+
+            // a leading comment gets attached to statement
+            while (src.text[pos] == '/' && src.text[pos + 1] == '/') {
+                while (src.text[pos] && src.text[pos] != '\n') pos++
+                pos++
+            }
+
             const p = ts.getLineAndCharacterOfPosition(src, pos)
 
             if (assembler.debug) {
                 let endpos = node.end
                 if (endpos - pos > 80)
                     endpos = pos + 80
-                const srctext = src.text.slice(pos,endpos).trim().replace(/\n[^]*/, "...")
-                proc.emit(ir.comment(`${src.fileName.replace(/pxt_modules\//, "")}(${p.line},${p.character}): ${srctext}`))
+                const srctext = src.text.slice(pos, endpos).trim().replace(/\n[^]*/, "...")
+                proc.emit(ir.comment(`${src.fileName.replace(/pxt_modules\//, "")}(${p.line + 1},${p.character + 1}): ${srctext}`))
             }
 
             if (!needsBreak)

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -880,7 +880,7 @@ namespace ts.pxtc {
             if (node.kind == SK.Constructor) {
                 text = "constructor"
             } else {
-                for (let parent = node; parent; parent = parent.parent as Declaration) {
+                for (let parent = node.parent as Declaration; parent; parent = parent.parent as Declaration) {
                     if (isNamedDeclaration(parent))
                         return getDeclName(parent) + ".inline"
                 }

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1231,6 +1231,25 @@ __flash_checksums:
             }
 
             cres.procDebugInfo = bin.procs.map(p => p.debugInfo)
+
+            if (bin.target.switches.size) {
+                const csv: string[] = []
+                // "filename,line,name,type,size\n"
+                for (const proc of bin.procs) {
+                    const info = ts.pxtc.nodeLocationInfo(proc.action)
+                    const line = [
+                        info.fileName.replace("pxt_modules/", ""),
+                        getDeclName(proc.action),
+                        proc.debugInfo.size,
+                        "function",
+                        info.line + 1
+                    ]
+                    csv.push(toCSV(line))
+                }
+                csv.sort()
+                csv.unshift("filename,name,size,type,line")
+                bin.writeFile(prefix + "size.csv", csv.join("\n"))
+            }
         }
 
         function writeOutput() {
@@ -1243,6 +1262,10 @@ __flash_checksums:
                 bin.writeFile(prefix + pxt.outputName(target), myhex);
             }
         }
+    }
+
+    function toCSV(elts: (string | number)[]) {
+        return elts.map(s => `"${s}"`).join(",")
     }
 
     export function processorEmit(bin: Binary, opts: CompileOptions, cres: CompileResult) {

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -174,6 +174,7 @@ namespace ts.pxtc.ir {
         Jmp,
         StackEmpty,
         Breakpoint,
+        Comment,
     }
 
     export enum JmpMode {
@@ -283,6 +284,8 @@ namespace ts.pxtc.ir {
                         return "    ;\n"
                     case ir.SK.Breakpoint:
                         return "    // brk " + (stmt.breakpointInfo.id) + "\n"
+                    case ir.SK.Comment:
+                        return "    // " + stmt.expr.data + "\n"
                     case ir.SK.Label:
                         return stmt.lblName + ":\n"
                     default: throw oops();
@@ -803,6 +806,7 @@ namespace ts.pxtc.ir {
                     case ir.SK.StackEmpty:
                     case ir.SK.Label:
                     case ir.SK.Breakpoint:
+                    case ir.SK.Comment:
                         break;
                     default: oops();
                 }
@@ -885,6 +889,10 @@ namespace ts.pxtc.ir {
 
     export function stmt(kind: SK, expr: Expr): Stmt {
         return new Stmt(kind, expr)
+    }
+
+    export function comment(msg: string): Stmt {
+        return stmt(SK.Comment, ptrlit(msg, msg))
     }
 
     export function op(kind: EK, args: Expr[], data?: any): Expr {

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -583,7 +583,7 @@ namespace ts.pxtc.ir {
         }
 
         getFullName() {
-            let name = this.getName()
+            let name = getDeclName(this.action)
             if (this.action) {
                 let info = ts.pxtc.nodeLocationInfo(this.action)
                 name += " " + info.fileName.replace("pxt_modules/", "") + ":" + (info.line + 1)
@@ -592,7 +592,8 @@ namespace ts.pxtc.ir {
         }
 
         getName() {
-            return getDeclName(this.action)
+            let text = this.action && this.action.name ? (<Identifier>this.action.name).text : null
+            return text || "inline"
         }
 
         mkLocal(def: Declaration, info: VariableAddInfo) {

--- a/pxtcompiler/emitter/ir.ts
+++ b/pxtcompiler/emitter/ir.ts
@@ -592,8 +592,7 @@ namespace ts.pxtc.ir {
         }
 
         getName() {
-            let text = this.action && this.action.name ? (<Identifier>this.action.name).text : null
-            return text || "inline"
+            return getDeclName(this.action)
         }
 
         mkLocal(def: Declaration, info: VariableAddInfo) {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -287,6 +287,7 @@ namespace ts.pxtc {
         args: CellInfo[];
         localsMark: number;
         calls: ProcCallInfo[];
+        size: number;
     }
 
     export const enum BitSize {


### PR DESCRIPTION
This generates `built/sizes.csv` that can be visualized like so (with Excel):

![image](https://user-images.githubusercontent.com/10673976/118567209-a7405580-b775-11eb-816c-52b09b333e2e.png)
