### PR TITLE
Add color for completed skill map nodes, open activity on double-click

### DIFF
--- a/skillmap/src/components/GraphNode.tsx
+++ b/skillmap/src/components/GraphNode.tsx
@@ -16,6 +16,7 @@ interface GraphNodeProps {
     theme: SkillGraphTheme;
     selected?: boolean;
     onItemSelect?: (id: string, kind: MapNodeKind) => void;
+    onItemDoubleClick?: (id: string, kind: MapNodeKind) => void;
 }
 
 interface GraphNodeState {
@@ -27,8 +28,13 @@ export class GraphNode extends React.Component<GraphNodeProps, GraphNodeState> {
         super(props);
         this.state = { hover: false }
     }
+
     protected handleClick = () => {
         if (this.props.onItemSelect) this.props.onItemSelect(this.props.activityId, this.props.kind);
+    }
+
+    protected handleDoubleClick = () => {
+        if (this.props.onItemDoubleClick) this.props.onItemDoubleClick(this.props.activityId, this.props.kind);
     }
 
     protected getIcon(status: ActivityStatus, kind: MapNodeKind): string {
@@ -103,7 +109,8 @@ export class GraphNode extends React.Component<GraphNodeProps, GraphNodeState> {
 
         const selectedUnit = width / 8;
 
-        return  <g className={`graph-activity ${selected ? "selected" : ""} ${hover ? "hover" : ""}`} transform={`translate(${position.x} ${position.y})`} onClick={this.handleClick} ref={this.handleRef}>
+        return  <g className={`graph-activity ${selected ? "selected" : ""} ${hover ? "hover" : ""}`} transform={`translate(${position.x} ${position.y})`}
+            onClick={this.handleClick} onDoubleClick={this.handleDoubleClick} ref={this.handleRef}>
             { selected &&
                 (kind !== "activity" ?
                     <circle className="highlight" cx={0} cy={0} r={width / 2 + selectedUnit} stroke={theme.selectedStrokeColor} /> :

--- a/skillmap/src/components/GraphNode.tsx
+++ b/skillmap/src/components/GraphNode.tsx
@@ -93,10 +93,12 @@ export class GraphNode extends React.Component<GraphNodeProps, GraphNodeState> {
         if (status === "locked") {
             background = hover ? theme.lockedNodeForeground : theme.lockedNodeColor;
             foreground = hover ? theme.lockedNodeColor : theme.lockedNodeForeground;
-        }
-        else if (kind !== "activity") {
+        } else if (kind !== "activity") {
             background = hover ? theme.rewardNodeForeground : theme.rewardNodeColor;
             foreground = hover ? theme.rewardNodeColor : theme.rewardNodeForeground;
+        } else if (status ==="completed") {
+            background = hover ? theme.completedNodeForeground : theme.completedNodeColor;
+            foreground = hover ? theme.completedNodeColor : theme.completedNodeForeground;
         }
 
         const selectedUnit = width / 8;

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import { connect } from 'react-redux';
 
 import { SkillMapState } from '../store/reducer';
-import { dispatchChangeSelectedItem, dispatchShowCompletionModal, dispatchSetSkillMapCompleted } from '../actions/dispatch';
+import { dispatchChangeSelectedItem, dispatchShowCompletionModal,
+    dispatchSetSkillMapCompleted, dispatchOpenActivity } from '../actions/dispatch';
 import { GraphNode } from './GraphNode';
 import { GraphPath } from "./GraphPath";
 
@@ -29,6 +30,7 @@ interface SkillGraphProps {
     dispatchChangeSelectedItem: (mapId?: string, activityId?: string) => void;
     dispatchShowCompletionModal: (mapId: string, activityId?: string) => void;
     dispatchSetSkillMapCompleted: (mapId: string) => void;
+    dispatchOpenActivity: (mapId: string, activityId: string) => void;
 }
 
 const UNIT = 10;
@@ -96,6 +98,13 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
         }
     }
 
+    protected onItemDoubleClick = (activityId: string, kind: MapNodeKind) => {
+        const { user, pageSourceUrl, map, dispatchOpenActivity } = this.props;
+        if (kind === "activity" && isActivityUnlocked(user, pageSourceUrl, map, activityId)) {
+            dispatchOpenActivity(map.mapId, activityId);
+        }
+    }
+
     // This function converts graph position (no units) to x/y (SVG units)
     protected getPosition(depth: number, offset: number): SvgCoord {
         return { x: this.getX(depth), y: this.getY(offset) }
@@ -141,6 +150,7 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
                     width={5 * UNIT}
                     selected={el.activity.activityId === selectedActivityId}
                     onItemSelect={this.onItemSelect}
+                    onItemDoubleClick={this.onItemDoubleClick}
                     status={getActivityStatus(user, pageSourceUrl, map, el.activity.activityId).status} />
             })}
         </svg>
@@ -163,7 +173,8 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
 const mapDispatchToProps = {
     dispatchChangeSelectedItem,
     dispatchShowCompletionModal,
-    dispatchSetSkillMapCompleted
+    dispatchSetSkillMapCompleted,
+    dispatchOpenActivity
 };
 
 export const SkillGraph = connect(mapStateToProps, mapDispatchToProps)(SkillGraphImpl);

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -118,6 +118,8 @@ interface SkillGraphTheme {
     unlockedNodeForeground: string;
     lockedNodeColor: string;
     lockedNodeForeground: string;
+    completedNodeColor: string;
+    completedNodeForeground: string;
     rewardNodeColor: string;
     rewardNodeForeground: string;
     pathOpacity: number;

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -317,6 +317,10 @@ function inflateMetadata(section: MarkdownSection): PageMetadata {
     const tertiary = section.attributes["tertiarycolor"];
     const highlight = section.attributes["highlightcolor"];
 
+    const unlockedNodeColor = section.attributes["unlockednodecolor"];
+    const lockedNodeColor = section.attributes["lockednodecolor"];
+    const completedNodeColor = section.attributes["completednodecolor"];
+
     return {
         title: section.attributes["name"] || section.header,
         description: section.attributes["description"],
@@ -330,10 +334,12 @@ function inflateMetadata(section: MarkdownSection): PageMetadata {
             strokeColor: "#000000",
             rewardNodeColor: highlight || "var(--primary-color)",
             rewardNodeForeground: highlight ? getContrastingColor(highlight) : "#000000",
-            unlockedNodeColor: secondary || "var(--secondary-color)",
-            unlockedNodeForeground: secondary ? getContrastingColor(secondary) : "#000000",
-            lockedNodeColor: primary || "#BFBFBF",
-            lockedNodeForeground: primary ? getContrastingColor(primary) : "#000000",
+            unlockedNodeColor: unlockedNodeColor || secondary || "var(--secondary-color)",
+            unlockedNodeForeground: (unlockedNodeColor || secondary) ? getContrastingColor(unlockedNodeColor || secondary) : "#000000",
+            lockedNodeColor: lockedNodeColor || primary || "#BFBFBF",
+            lockedNodeForeground: (lockedNodeColor || primary) ? getContrastingColor(lockedNodeColor || primary) : "#000000",
+            completedNodeColor: completedNodeColor || secondary || "var(--secondary-color)",
+            completedNodeForeground: (completedNodeColor || secondary) ? getContrastingColor(completedNodeColor || secondary) : "#000000",
             selectedStrokeColor: highlight || "var(--primary-color)",
             pathOpacity: 0.5,
         }

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -61,6 +61,8 @@ const initialState: SkillMapState = {
         unlockedNodeForeground: "#000000",
         lockedNodeColor: "#BFBFBF",
         lockedNodeForeground: "#000000",
+        completedNodeColor: "var(--secondary-color)",
+        completedNodeForeground: "#000000",
         selectedStrokeColor: "var(--hover-color)",
         pathOpacity: 0.5,
     },


### PR DESCRIPTION
will probably conflict with https://github.com/microsoft/pxt/pull/8160, i'll merge them in/handle issues

- add a color for completed nodes (by default, same as unlocked node), expose some theme override fields (internal use only) https://github.com/microsoft/pxt/commit/72bce1a4205b5faff423ad7763d2ed04c9bc78bf
- open an activity on double-click https://github.com/microsoft/pxt/commit/c7e86521705b7ac7b919d0ee32ae4c94c67b7e5f