### PR TITLE
adding dedicated buildshims command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -211,6 +211,27 @@
 			}
 		},
 		{
+			"name": "BuildShims",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/built/pxt.js",
+			"stopOnEntry": false,
+			"args": [
+				"buildshims"
+			],
+			"cwd": "${workspaceRoot}/../pxt-microbit/libs/flashlog",
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
+			"env": {
+				"NODE_ENV": "development"
+			},
+			"console": "integratedTerminal",
+			"sourceMaps": false,
+			"outFiles": []
+		},		
+		{
 			"name": "Attach",
 			"type": "node",
 			"request": "attach",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -6354,6 +6354,17 @@ function blockTestsAsync(parsed?: commandParser.ParsedCommand) {
     }
 }
 
+async function buildShimsAsync() {
+    pxt.log(`building shims.d.ts, enum.d.ts files`)
+
+    await mainPkg.loadAsync()
+    setBuildEngine();
+    const target = mainPkg.getTargetOptions()
+    target.isNative = true
+    target.keepCppFiles = true
+    await mainPkg.getCompileOptionsAsync(target)
+}
+
 function initCommands() {
     // Top level commands
     simpleCmd("help", "display this message or info about a command", pc => {
@@ -6998,6 +7009,8 @@ ${pxt.crowdin.KEY_VARIABLE} - crowdin key
         name: "checkpkgcfg",
         help: "Validate and attempt to fix common pxt.json issues",
     }, validateAndFixPkgConfig);
+
+    advancedCommand("buildshims", "Regenerate shims.d.ts, enums.d.ts", buildShimsAsync)
 
     function simpleCmd(name: string, help: string, callback: (c?: commandParser.ParsedCommand) => Promise<void>, argString?: string, onlineHelp?: boolean): void {
         p.defineCommand({ name, help, onlineHelp, argString }, callback);

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1064,7 +1064,7 @@ namespace pxt {
 
                 try {
                     let einfo = cpp.getExtensionInfo(this)
-                    if (!shimsGenerated) {
+                    if (!shimsGenerated && (einfo.shimsDTS || einfo.enumsDTS)) {
                         shimsGenerated = true
                         if (einfo.shimsDTS) generateFile("shims.d.ts", einfo.shimsDTS)
                         if (einfo.enumsDTS) generateFile("enums.d.ts", einfo.enumsDTS)


### PR DESCRIPTION
With multivariant, it is quite tricky to figure out when and why shims are generated. Only the 1st variant generates shims which does not current work when building a library with variant exclusions.

- [x] add a pxt cli command ``pxt buildshims``
- [x] don't consider shims generated if nothing was generated