### PR TITLE
Translate Python snippets

### DIFF
--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -92,7 +92,7 @@ namespace ts.pxtc.service {
             const dotIdx = param.lastIndexOf(".");
             const left = param.substr(0, dotIdx)
             let right = param.substr(dotIdx + 1)
-            right = snakify(right).toUpperCase();
+            right = U.snakify(right).toUpperCase();
             return `${left}.${right}`
         }
         return undefined;
@@ -285,8 +285,6 @@ namespace ts.pxtc.service {
         }
         return null
     }
-
-
 
     export function getDefaultEnumValue(t: Type, python: boolean): string {
         // Note: AFAIK this is NOT guranteed to get the same default as you get in

--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -76,13 +76,22 @@ namespace ts.pxtc.service {
         return [...retApis, ...completionSymbols(enumVals, COMPLETION_DEFAULT_WEIGHT)]
     }
 
-    export function tsKeywordToPyKeyword(keyword: string): string | undefined {
-        const map: pxt.Map<string> = {
+    export function tsSnippetToPySnippet(param: string): string | undefined {
+        // Keep this unified with webapp/monacoSnippets.ts
+        const keywords: pxt.Map<string> = {
             "true": "True",
             "false": "False",
             "null": "None"
         }
-        return map[keyword]
+        const key = keywords[param];
+        if (key) {
+            return key
+        }
+        if (param.includes(".")) {
+            const match = /(.+)\.(.+)/.exec(param);
+            return `${match[1]}.${match[2].toUpperCase()}`
+        }
+        return undefined;
     }
 
     export function getBasicKindDefault(kind: SyntaxKind, isPython: boolean): string | undefined {

--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -88,6 +88,7 @@ namespace ts.pxtc.service {
             return key
         }
         if (param.includes(".")) {
+            // Python enums are all caps
             const match = /(.+)\.(.+)/.exec(param);
             return `${match[1]}.${match[2].toUpperCase()}`
         }

--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -76,28 +76,6 @@ namespace ts.pxtc.service {
         return [...retApis, ...completionSymbols(enumVals, COMPLETION_DEFAULT_WEIGHT)]
     }
 
-    export function tsSnippetToPySnippet(param: string): string | undefined {
-        // Keep this unified with webapp/monacoSnippets.ts
-        const keywords: pxt.Map<string> = {
-            "true": "True",
-            "false": "False",
-            "null": "None"
-        }
-        const key = keywords[param];
-        if (key) {
-            return key
-        }
-        if (param.includes(".")) {
-            // Python enums are all caps
-            const dotIdx = param.lastIndexOf(".");
-            const left = param.substr(0, dotIdx)
-            let right = param.substr(dotIdx + 1)
-            right = U.snakify(right).toUpperCase();
-            return `${left}.${right}`
-        }
-        return undefined;
-    }
-
     export function getBasicKindDefault(kind: SyntaxKind, isPython: boolean): string | undefined {
         switch (kind) {
             case SK.StringKeyword: return "\"\"";

--- a/pxtcompiler/emitter/languageservice.ts
+++ b/pxtcompiler/emitter/languageservice.ts
@@ -89,8 +89,11 @@ namespace ts.pxtc.service {
         }
         if (param.includes(".")) {
             // Python enums are all caps
-            const match = /(.+)\.(.+)/.exec(param);
-            return `${match[1]}.${match[2].toUpperCase()}`
+            const dotIdx = param.lastIndexOf(".");
+            const left = param.substr(0, dotIdx)
+            let right = param.substr(dotIdx + 1)
+            right = snakify(right).toUpperCase();
+            return `${left}.${right}`
         }
         return undefined;
     }

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -35,55 +35,6 @@ namespace ts.pxtc {
         "_py.range": { n: "range", t: ts.SyntaxKind.Unknown, snippet: 'range(4)' }
     }
 
-    export function snakify(s: string) {
-        const up = s.toUpperCase()
-        const lo = s.toLowerCase()
-
-        // if the name is all lowercase or all upper case don't do anything
-        if (s == up || s == lo)
-            return s
-
-        // if the name already has underscores (not as first character), leave it alone
-        if (s.lastIndexOf("_") > 0)
-            return s
-
-        const isUpper = (i: number) => s[i] != lo[i]
-        const isLower = (i: number) => s[i] != up[i]
-        //const isDigit = (i: number) => /\d/.test(s[i])
-
-        let r = ""
-        let i = 0
-        while (i < s.length) {
-            let upperMode = isUpper(i)
-            let j = i
-            while (j < s.length) {
-                if (upperMode && isLower(j)) {
-                    // ABCd -> AB_Cd
-                    if (j - i > 2) {
-                        j--
-                        break
-                    } else {
-                        // ABdefQ -> ABdef_Q
-                        upperMode = false
-                    }
-                }
-                // abcdE -> abcd_E
-                if (!upperMode && isUpper(j)) {
-                    break
-                }
-                j++
-            }
-            if (r) r += "_"
-            r += s.slice(i, j)
-            i = j
-        }
-
-        // If the name is is all caps (like a constant), preserve it
-        if (r.toUpperCase() === r) {
-            return r;
-        }
-        return r.toLowerCase();
-    }
 
     export function emitPyTypeFromTypeNode(s: ts.TypeNode): string {
         if (!s || !s.kind) return null;
@@ -324,13 +275,13 @@ namespace ts.pxtc {
 
             switch (r.kind) {
                 case SymbolKind.EnumMember:
-                    r.pyName = snakify(r.name).toUpperCase()
+                    r.pyName = U.snakify(r.name).toUpperCase()
                     break
                 case SymbolKind.Variable:
                 case SymbolKind.Method:
                 case SymbolKind.Property:
                 case SymbolKind.Function:
-                    r.pyName = snakify(r.name)
+                    r.pyName = U.snakify(r.name)
                     break
                 case SymbolKind.Enum:
                 case SymbolKind.Class:

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -317,7 +317,7 @@ namespace ts.pxtc.service {
                     return pxt.Util.snakify(paramDefl);
                 }
                 if (python) {
-                    return pxtc.tsSnippetToPySnippet(paramDefl)
+                    return pxtc.tsSnippetToPySnippet(paramDefl, typeSymbol)
                 }
 
                 return paramDefl

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -313,8 +313,8 @@ namespace ts.pxtc.service {
                 }
                 const type = checker?.getTypeAtLocation(param);
                 const typeSymbol = getPxtSymbolFromTsSymbol(type?.symbol, apis, checker);
-                if (typeSymbol?.attributes.fixedInstances) {
-                    return paramDefl;
+                if (typeSymbol?.attributes.fixedInstances && python) {
+                    return pxt.Util.snakify(paramDefl);
                 }
                 if (python) {
                     return pxtc.tsSnippetToPySnippet(paramDefl)

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -312,14 +312,12 @@ namespace ts.pxtc.service {
                     return paramDefl.indexOf(`"`) != 0 ? `"${paramDefl}"` : paramDefl;
                 }
                 let type = checker && checker.getTypeAtLocation(param);
-                const typeSymbol = getPxtSymbolFromTsSymbol(type.symbol, apis, checker);
-                if (typeSymbol && typeSymbol.attributes.fixedInstances) {
+                const typeSymbol = getPxtSymbolFromTsSymbol(type?.symbol, apis, checker);
+                if (typeSymbol?.attributes.fixedInstances) {
                     return paramDefl;
                 }
                 if (python) {
-                    let pyKeyword = tsSnippetToPySnippet(paramDefl)
-                    if (pyKeyword)
-                        return pyKeyword
+                    return pxtc.tsSnippetToPySnippet(paramDefl)
                 }
 
                 return paramDefl

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -139,7 +139,7 @@ namespace ts.pxtc.service {
         }
 
         if (python)
-            fnName = snakify(fnName);
+            fnName = U.snakify(fnName);
 
         const attrs = fn.attributes;
 
@@ -169,7 +169,7 @@ namespace ts.pxtc.service {
             if (element.attributes.defaultInstance) {
                 snippetPrefix = element.attributes.defaultInstance;
                 if (python && snippetPrefix)
-                    snippetPrefix = snakify(snippetPrefix);
+                    snippetPrefix = U.snakify(snippetPrefix);
             }
             else if (element.namespace) { // some blocks don't have a namespace such as parseInt
                 const nsInfo = apis.byQName[element.namespace];
@@ -231,7 +231,7 @@ namespace ts.pxtc.service {
                         }
                         snippetPrefix = params.thisParameter.defaultValue || varName;
                         if (python && snippetPrefix)
-                            snippetPrefix = snakify(snippetPrefix);
+                            snippetPrefix = U.snakify(snippetPrefix);
                     }
                     isInstance = true;
                 }
@@ -257,7 +257,7 @@ namespace ts.pxtc.service {
 
         if (attrs && attrs.blockSetVariable) {
             if (python) {
-                const varName = getUniqueName(snakify(attrs.blockSetVariable));
+                const varName = getUniqueName(U.snakify(attrs.blockSetVariable));
                 const varNode = {
                     default: varName,
                     isDefinition: true
@@ -311,7 +311,11 @@ namespace ts.pxtc.service {
                 if (typeNode.kind === SK.StringKeyword || deflKind === SK.StringKeyword) {
                     return paramDefl.indexOf(`"`) != 0 ? `"${paramDefl}"` : paramDefl;
                 }
-
+                let type = checker && checker.getTypeAtLocation(param);
+                const typeSymbol = getPxtSymbolFromTsSymbol(type.symbol, apis, checker);
+                if (typeSymbol && typeSymbol.attributes.fixedInstances) {
+                    return paramDefl;
+                }
                 if (python) {
                     let pyKeyword = tsSnippetToPySnippet(paramDefl)
                     if (pyKeyword)
@@ -602,7 +606,7 @@ namespace ts.pxtc.service {
 
                 if (enumParams) n += "_" + enumParams;
 
-                n = snakify(n);
+                n = U.snakify(n);
                 n = getUniqueName(n)
                 preStmt = [
                     ...preStmt, preStmt.length ? "\n" : "",
@@ -628,7 +632,7 @@ namespace ts.pxtc.service {
         function emitEmptyFn(n?: string): SnippetNode {
             if (python) {
                 n = n || "fn"
-                n = snakify(n);
+                n = U.snakify(n);
                 n = getUniqueName(n)
                 preStmt = [
                     ...preStmt, preStmt.length ? "\n" : "",

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -311,7 +311,7 @@ namespace ts.pxtc.service {
                 if (typeNode.kind === SK.StringKeyword || deflKind === SK.StringKeyword) {
                     return paramDefl.indexOf(`"`) != 0 ? `"${paramDefl}"` : paramDefl;
                 }
-                let type = checker && checker.getTypeAtLocation(param);
+                const type = checker?.getTypeAtLocation(param);
                 const typeSymbol = getPxtSymbolFromTsSymbol(type?.symbol, apis, checker);
                 if (typeSymbol?.attributes.fixedInstances) {
                     return paramDefl;

--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -313,7 +313,7 @@ namespace ts.pxtc.service {
                 }
 
                 if (python) {
-                    let pyKeyword = tsKeywordToPyKeyword(paramDefl)
+                    let pyKeyword = tsSnippetToPySnippet(paramDefl)
                     if (pyKeyword)
                         return pyKeyword
                 }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -635,7 +635,7 @@ namespace ts.pxtc {
     }
 
 
-    export function tsSnippetToPySnippet(param: string): string {
+    export function tsSnippetToPySnippet(param: string, symbol?: SymbolInfo): string {
         const keywords: pxt.Map<string> = {
             "true": "True",
             "false": "False",
@@ -645,7 +645,7 @@ namespace ts.pxtc {
         if (key) {
             return key
         }
-        if (param.includes(".")) {
+        if ((symbol && symbol.kind == SymbolKind.Enum) || (!symbol && param.includes("."))) {
             // Python enums are all caps
             const dotIdx = param.lastIndexOf(".");
             const left = param.substr(0, dotIdx)

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -634,6 +634,29 @@ namespace ts.pxtc {
         }
     }
 
+
+    export function tsSnippetToPySnippet(param: string): string {
+        const keywords: pxt.Map<string> = {
+            "true": "True",
+            "false": "False",
+            "null": "None"
+        }
+        const key = keywords[param];
+        if (key) {
+            return key
+        }
+        if (param.includes(".")) {
+            // Python enums are all caps
+            const dotIdx = param.lastIndexOf(".");
+            const left = param.substr(0, dotIdx)
+            let right = param.substr(dotIdx + 1)
+            right = U.snakify(right).toUpperCase();
+            return `${left}.${right}`
+        }
+        return param;
+    }
+
+
     export let apiLocalizationStrings: pxt.Map<string> = {};
 
     export async function localizeApisAsync(apis: pxtc.ApisInfo, mainPkg: pxt.MainPackage): Promise<pxtc.ApisInfo> {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -373,6 +373,56 @@ namespace ts.pxtc.Util {
         return str.split(old).join(new_);
     }
 
+    export function snakify(s: string) {
+        const up = s.toUpperCase()
+        const lo = s.toLowerCase()
+
+        // if the name is all lowercase or all upper case don't do anything
+        if (s == up || s == lo)
+            return s
+
+        // if the name already has underscores (not as first character), leave it alone
+        if (s.lastIndexOf("_") > 0)
+            return s
+
+        const isUpper = (i: number) => s[i] != lo[i]
+        const isLower = (i: number) => s[i] != up[i]
+        //const isDigit = (i: number) => /\d/.test(s[i])
+
+        let r = ""
+        let i = 0
+        while (i < s.length) {
+            let upperMode = isUpper(i)
+            let j = i
+            while (j < s.length) {
+                if (upperMode && isLower(j)) {
+                    // ABCd -> AB_Cd
+                    if (j - i > 2) {
+                        j--
+                        break
+                    } else {
+                        // ABdefQ -> ABdef_Q
+                        upperMode = false
+                    }
+                }
+                // abcdE -> abcd_E
+                if (!upperMode && isUpper(j)) {
+                    break
+                }
+                j++
+            }
+            if (r) r += "_"
+            r += s.slice(i, j)
+            i = j
+        }
+
+        // If the name is is all caps (like a constant), preserve it
+        if (r.toUpperCase() === r) {
+            return r;
+        }
+        return r.toLowerCase();
+    }
+
     export function sortObjectFields<T>(o: T): T {
         let keys = Object.keys(o)
         keys.sort(strcmp)

--- a/pxtpy/pydecompiler.ts
+++ b/pxtpy/pydecompiler.ts
@@ -1008,7 +1008,7 @@ namespace pxt.py {
             let calleePart: string = ""
             if (calleeExp)
                 calleePart = getSimpleExpNameParts(calleeExp)
-                    .map(pxtc.snakify)
+                    .map(U.snakify)
                     .join("_")
 
             // get words from the previous parameter(s)/arg(s)
@@ -1020,7 +1020,7 @@ namespace pxt.py {
                     let argType = tc.getTypeAtLocation(arg)
                     if (hasTypeFlag(argType, ts.TypeFlags.EnumLike)) {
                         let argParts = getSimpleExpNameParts(arg)
-                            .map(pxtc.snakify)
+                            .map(U.snakify)
                         enumParamParts = enumParamParts.concat(argParts)
                     }
                 }
@@ -1035,7 +1035,7 @@ namespace pxt.py {
             // the full hint
             let hint = [calleePart, otherParamsPart, paramPart]
                 .filter(s => s)
-                .map(pxtc.snakify)
+                .map(U.snakify)
                 .map(s => s.toLowerCase())
                 .join("_") || "my_callback"
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -5,7 +5,6 @@ import * as toolbox from "./toolbox";
 import * as workspace from "./workspace";
 import * as data from "./data";
 import * as auth from "./auth";
-import * as snippets from "./monacoSnippets";
 
 const DRAG_THRESHOLD = 5;
 const SELECTED_BORDER_WIDTH = 4;
@@ -275,7 +274,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                             || actualParam?.actualName
                             || part.name
                         if (isPython && actualParam?.defaultValue) {
-                            val = snippets.tsSnippetToPySnippet(val) || val;
+                            val = pxtc.tsSnippetToPySnippet(val) || val;
                         }
                         description.push(<span className="argName" key={name + i}>{val}</span>);
                         break;

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -5,6 +5,7 @@ import * as toolbox from "./toolbox";
 import * as workspace from "./workspace";
 import * as data from "./data";
 import * as auth from "./auth";
+import * as snippets from "./monacoSnippets";
 
 const DRAG_THRESHOLD = 5;
 const SELECTED_BORDER_WIDTH = 4;
@@ -251,6 +252,8 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
         let compileInfo = pxt.blocks.compileInfo(block as pxtc.SymbolInfo)
         let parts = block.attributes._def && block.attributes._def.parts;
         let name = block.qName || block.name;
+        const isPython = this.props.fileType == pxt.editor.FileType.Python;
+
         if (parts) {
             if (params &&
                 parts.filter((p: any) => p.kind == "param").length > params.length) {
@@ -271,6 +274,9 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                             || part.varName
                             || actualParam?.actualName
                             || part.name
+                        if (isPython && actualParam?.defaultValue) {
+                            val = snippets.tsSnippetToPySnippet(val) || val;
+                        }
                         description.push(<span className="argName" key={name + i}>{val}</span>);
                         break;
                 }

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -274,7 +274,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
                             || actualParam?.actualName
                             || part.name
                         if (isPython && actualParam?.defaultValue) {
-                            val = pxtc.tsSnippetToPySnippet(val) || val;
+                            val = pxtc.tsSnippetToPySnippet(val);
                         }
                         description.push(<span className="argName" key={name + i}>{val}</span>);
                         break;

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -633,7 +633,7 @@ export function tsSnippetToPySnippet(param: string): string | undefined {
         const dotIdx = param.lastIndexOf(".");
         const left = param.substr(0, dotIdx)
         let right = param.substr(dotIdx + 1)
-        right = pxtc.snakify(right).toUpperCase();
+        right = pxt.Util.snakify(right).toUpperCase();
         return `${left}.${right}`
     }
     return undefined;

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -617,28 +617,6 @@ export function blockIdMap() {
     return _blockIdMap;
 }
 
-export function tsSnippetToPySnippet(param: string): string | undefined {
-    // Keep this unified with pxtcompiler/languageservice.ts
-    const keywords: pxt.Map<string> = {
-        "true": "True",
-        "false": "False",
-        "null": "None"
-    }
-    const key = keywords[param];
-    if (key) {
-        return key
-    }
-    if (param.includes(".")) {
-        // Python enums are all caps
-        const dotIdx = param.lastIndexOf(".");
-        const left = param.substr(0, dotIdx)
-        let right = param.substr(dotIdx + 1)
-        right = pxt.Util.snakify(right).toUpperCase();
-        return `${left}.${right}`
-    }
-    return undefined;
-}
-
 export function getBuiltinCategory(ns: string) {
     return cachedBuiltinCategories()[ns];
 }

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -617,6 +617,24 @@ export function blockIdMap() {
     return _blockIdMap;
 }
 
+export function tsSnippetToPySnippet(param: string): string | undefined {
+    // Keep this unified with pxtcompiler/languageservice.ts
+    const keywords: pxt.Map<string> = {
+        "true": "True",
+        "false": "False",
+        "null": "None"
+    }
+    const key = keywords[param];
+    if (key) {
+        return key
+    }
+    if (param.includes(".")) {
+        const match = /(.+)\.(.+)/.exec(param);
+        return `${match[1]}.${match[2].toUpperCase()}`
+    }
+    return undefined;
+}
+
 export function getBuiltinCategory(ns: string) {
     return cachedBuiltinCategories()[ns];
 }

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -629,6 +629,7 @@ export function tsSnippetToPySnippet(param: string): string | undefined {
         return key
     }
     if (param.includes(".")) {
+        // Python enums are all caps
         const match = /(.+)\.(.+)/.exec(param);
         return `${match[1]}.${match[2].toUpperCase()}`
     }

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -630,8 +630,11 @@ export function tsSnippetToPySnippet(param: string): string | undefined {
     }
     if (param.includes(".")) {
         // Python enums are all caps
-        const match = /(.+)\.(.+)/.exec(param);
-        return `${match[1]}.${match[2].toUpperCase()}`
+        const dotIdx = param.lastIndexOf(".");
+        const left = param.substr(0, dotIdx)
+        let right = param.substr(dotIdx + 1)
+        right = pxtc.snakify(right).toUpperCase();
+        return `${left}.${right}`
     }
     return undefined;
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4007

Similar to https://github.com/microsoft/pxt/pull/8076 except there wasn't a translation path for enums. Added a case to manually update enums, and also added the same function to webapp so the snippets will display correctly in the toolbox (for example, true **should** be capitalized here 
![image](https://user-images.githubusercontent.com/18712271/118858083-9b47b700-b88d-11eb-8210-347c3dd492ca.png) )


I couldn't find a good way to share code between pxtcompiler/webapp so I copied it, but if there's a better way please let me know 😭