### PR TITLE
Delete old fields from project header on save

### DIFF
--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -523,7 +523,7 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
         // from the header in the case where the project is being exported to local from cloud.
         Object.keys(e.header)
             .filter(key => h[key as keyof Header] === undefined)
-            .forEach(key  => delete e.header[key as keyof Header]);
+            .forEach(key => delete e.header[key as keyof Header]);
         h = e.header;
     }
     if (text)

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -518,7 +518,12 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
         // persist header changes to our local cache, but keep the old
         // reference around because (unfortunately) other layers (e.g. package.ts)
         // assume the reference is stable per id.
-        Object.assign(e.header, h)
+        Object.assign(e.header, h);
+        // Delete keys from `e.header` that don't exist in `h`. This will clear cloud state
+        // from the header in the case where the project is being exported to local from cloud.
+        Object.keys(e.header)
+            .filter(key => h[key as keyof Header] === undefined)
+            .forEach(key  => delete e.header[key as keyof Header]);
         h = e.header;
     }
     if (text)


### PR DESCRIPTION
MakeCode keeps an in-memory cache of all project headers, and some parts of the app assume these to be long-lived, i.e. they won't be replaced by a newer version but instead updated in place.

This is problematic for cloud save on a number of levels, and something that I think I'll need to address in a later PR.

In the short term, this change modifies the cached header update process to delete header fields in the cached version of the object that don't exist on the incoming version.

#### How this fixes cloud profile delete
When a user deletes their cloud profile, we export their cloud-saved projects to local. Functionally, this happens by deleting the cloud information from the project header and re-saving it. During the above-mentioned cached header update, deleted fields on the incoming version were not being removed from the cached copy, so the cloud info was essentially getting restored.

Fixes https://github.com/microsoft/pxt-arcade/issues/3505