### PR TITLE
UI updates for identity

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -129,7 +129,6 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         this.pairBluetooth = this.pairBluetooth.bind(this);
         this.showAboutDialog = this.showAboutDialog.bind(this);
         this.print = this.print.bind(this);
-        this.signOutGithub = this.signOutGithub.bind(this);
     }
 
     showShareDialog() {
@@ -223,16 +222,6 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
         this.props.parent.printCode();
     }
 
-    signOutGithub() {
-        pxt.tickEvent("menu.github.signout");
-        const githubProvider = cloudsync.githubProvider();
-        if (githubProvider) {
-            githubProvider.logout();
-            this.props.parent.forceUpdate();
-            core.infoNotification(lf("Signed out from GitHub..."))
-        }
-    }
-
     UNSAFE_componentWillReceiveProps(nextProps: SettingsMenuProps) {
         const newState: SettingsMenuState = {};
         if (nextProps.greenScreen !== undefined) {
@@ -287,13 +276,6 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             {targetTheme.accessibleBlocks ? <sui.Item role="menuitem" text={accessibleBlocks ? lf("Accessible Blocks Off") : lf("Accessible Blocks On")} onClick={this.toggleAccessibleBlocks} /> : undefined}
             {showGreenScreen ? <sui.Item role="menuitem" text={greenScreen ? lf("Green Screen Off") : lf("Green Screen On")} onClick={this.toggleGreenScreen} /> : undefined}
             {docItems && renderDocItems(this.props.parent, docItems, "ui mobile only inherit")}
-            {githubUser ? <div className="ui divider"></div> : undefined}
-            {githubUser ? <div className="ui item" title={lf("Unlink {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
-                <div className="avatar" role="presentation">
-                    <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
-                </div>
-                {lf("Unlink GitHub")}
-            </div> : undefined}
             {showCenterDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             {!isController ? <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} /> : undefined}

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -53,9 +53,6 @@ export class LoginDialog extends auth.Component<LoginDialogProps, LoginDialogSta
                 <div className="description">
                     <p>{lf("Connect an existing account in order to sign in or signup for the first time.")} <sui.Link className="ui" text={lf("Learn more")} icon="external alternate" ariaLabel={lf("Learn more")} href="https://aka.ms/cloudsave" target="_blank" onKeyDown={sui.fireClickOnEnter} /></p>
                 </div>
-                <div className="warning">
-                    <p>{lf("WARNING: Experimental feature ahead! Before you sign in, please backup any projects you don't want to lose.")}</p>
-                </div>
                 <div className="container">
                     <div className="prompt">
                         <p>Choose an account to connect:</p>
@@ -126,6 +123,16 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
         this.props.parent.showProfileDialog();
     }
 
+    handleUnlinkGitHubClicked = () => {
+        pxt.tickEvent("menu.github.signout");
+        const githubProvider = cloudsync.githubProvider();
+        if (githubProvider) {
+            githubProvider.logout();
+            this.props.parent.forceUpdate();
+            core.infoNotification(lf("Signed out from GitHub..."))
+        }
+    }
+
     renderCore() {
         const loggedIn = this.isLoggedIn();
         const user = this.getUser();
@@ -156,15 +163,27 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
             );
         }
 
+        const githubUser = this.getData("github:user") as pxt.editor.UserInfo;
+        const showGhUnlink = !loggedIn && githubUser;
+
         return (
             <sui.DropdownMenu role="menuitem"
                 title={title}
                 className="item icon user-dropdown-menuitem"
                 titleContent={loggedIn ? signedInElem : signedOutElem}
             >
-                {!loggedIn ? <sui.Item role="menuitem" text={lf("Sign in")} onClick={this.handleLoginClicked} /> : undefined}
                 {loggedIn ? <sui.Item role="menuitem" text={lf("My Profile")} onClick={this.handleProfileClicked} /> : undefined}
                 {loggedIn ? <div className="ui divider"></div> : undefined}
+                {showGhUnlink ?
+                    <sui.Item role="menuitem" title={lf("Unlink {0} from GitHub", githubUser.name)} onClick={this.handleUnlinkGitHubClicked}>
+                        <div className="icon avatar" role="presentation">
+                            <img className="circular image" src={githubUser.photo} alt={lf("User picture")} />
+                        </div>
+                        <span>{lf("Unlink GitHub")}</span>
+                    </sui.Item>
+                : undefined}
+                {showGhUnlink ? <div className="ui divider"></div> : undefined}
+                {!loggedIn ? <sui.Item role="menuitem" text={lf("Sign in")} onClick={this.handleLoginClicked} /> : undefined}
                 {loggedIn ? <sui.Item role="menuitem" text={lf("Sign out")} onClick={this.handleLogoutClicked} /> : undefined}
             </sui.DropdownMenu>
         );

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -336,20 +336,12 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
     renderCore() {
         const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
         const targetTheme = pxt.appTarget.appTheme;
-        const githubUser = this.getData("github:user") as pxt.editor.UserInfo;
         const reportAbuse = pxt.appTarget.cloud && pxt.appTarget.cloud.sharing && pxt.appTarget.cloud.importing;
-        const showDivider = targetTheme.selectLanguage || targetTheme.highContrast || githubUser;
+        const showDivider = targetTheme.selectLanguage || targetTheme.highContrast;
 
         return <sui.DropdownMenu role="menuitem" icon={'setting large'} title={lf("More...")} className="item icon more-dropdown-menuitem">
             {targetTheme.selectLanguage && <sui.Item icon='xicon globe' role="menuitem" text={lf("Language")} onClick={this.showLanguagePicker} />}
             {targetTheme.highContrast && <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} />}
-            {githubUser && <div className="ui divider"></div>}
-            {githubUser && <div className="ui item" title={lf("Unlink {0} from GitHub", githubUser.name)} role="menuitem" onClick={this.signOutGithub}>
-                <div className="avatar" role="presentation">
-                    <img className="ui circular image" src={githubUser.photo} alt={lf("User picture")} />
-                </div>
-                {lf("Unlink GitHub")}
-            </div>}
             {showDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} />

--- a/webapp/src/user.tsx
+++ b/webapp/src/user.tsx
@@ -48,6 +48,9 @@ export class ProfileDialog extends auth.Component<ProfileDialogProps, ProfileDia
 
         const user = this.getUser();
 
+        const github = cloudsync.githubProvider();
+        const ghUser = github.user();
+
         return (
             <sui.Modal isOpen={this.state.visible} className="ui profiledialog" size="fullscreen"
                 onClose={this.hide} dimmer={true}
@@ -57,7 +60,7 @@ export class ProfileDialog extends auth.Component<ProfileDialogProps, ProfileDia
                 closeOnEscape={false}
             >
                 <AccountPanel parent={this} />
-                <GitHubPanel parent={this} />
+                { ghUser ? <GitHubPanel parent={this} /> : undefined }
                 <FeedbackPanel parent={this} />
             </sui.Modal>
         );
@@ -225,10 +228,10 @@ class FeedbackPanel extends sui.UIElement<FeedbackPanelProps, {}> {
                     <label>{lf("Feedback")}</label>
                 </div>
                 <div className="row-span-two">
-                    {lf("What do you think about this feature? Is there something you'd like to change? Did you encounter issues? Please let us know on GitHub.")}
+                    {lf("What do you think about the Sign In & Cloud Save feature? Is there something you'd like to change? Did you encounter issues? Please let us know!")}
                 </div>
                 <div className="row-span-two">
-                    <sui.Link className="ui" text={lf("Feedback")} icon="external alternate" ariaLabel={lf("Provide feedback at GitHub")} href="https://github.com/microsoft/pxt-arcade/issues/new/choose" target="_blank" onKeyDown={sui.fireClickOnEnter} />
+                    <sui.Link className="ui" text={lf("Take the Survey")} icon="external alternate" ariaLabel={lf("Provide feedback at GitHub")} href="https://aka.ms/AAcnpaj" target="_blank" onKeyDown={sui.fireClickOnEnter} />
                 </div>
             </div>
         );


### PR DESCRIPTION
* Moved "Unlink GitHub" to the profile menu, and only show it if not signed into identity. When signed in, users can unlink GitHub from the "My Profile" screen.
* Clarified feedback text and updated link to point to a form survey (via aka.ms).
* Removed experimental feature warning from sign in dialog.