### PR TITLE
Tutorial Validation Extracts Rules from Markdown

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1016,6 +1016,7 @@ declare namespace pxt.tutorial {
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
         customTs?: string; // custom typescript code loaded in a separate file for the tutorial
+        tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated 
     }
 
     interface TutorialMetadata {
@@ -1044,7 +1045,7 @@ declare namespace pxt.tutorial {
         hintContentMd?: string;
         activity?: number;
         resetDiff?: boolean; // reset diffify algo
-        codeValidated?: boolean; // Whether the user code has been marked valid for this step
+        codeValidated?: pxt.tutorial.TutorialRuleStatus[]; // Whether the user code has been marked valid for these set of rules
     }
 
     interface TutorialActivityInfo {
@@ -1072,6 +1073,7 @@ declare namespace pxt.tutorial {
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
         customTs?: string; // custom typescript code loaded in a separate file for the tutorial
+        tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated 
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1034,6 +1034,14 @@ declare namespace pxt.tutorial {
         tutorialCodeValidation?: boolean; // enable tutorial validation for this tutorial
     }
 
+    interface TutorialRuleStatus {
+        RuleName: string;
+        RuleTurnOn: boolean;
+        RuleStatus: boolean;
+        RuleMessage: string;
+        test?: boolean;
+    }
+    
     interface TutorialStepInfo {
         // fullscreen?: boolean; // DEPRECATED, replaced by "showHint"
         // unplugged?: boolean: // DEPRECATED, replaced by "showDialog"

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -42,12 +42,6 @@ namespace pxt.editor {
         Expanded = "errorListExpanded"
     }
 
-    export enum TutorialCodeStatus {
-        Unknown = "Unknown",
-        Invalid = "Invalid",
-        Valid = "Valid"
-    }
-
     export interface IAppProps { }
     export interface IAppState {
         active?: boolean; // is this tab visible at all
@@ -251,7 +245,7 @@ namespace pxt.editor {
         completeTutorialAsync(): Promise<void>;
         showTutorialHint(): void;
         isTutorial(): boolean;
-        setTutorialCodeStatus(step: number, status: TutorialCodeStatus): void;
+        setTutorialCodeStatus(step: number, status: pxt.tutorial.TutorialRuleStatus[]): void;
         pokeUserActivity(): void;
         stopPokeUserActivity(): void;
         clearUserPoke(): void;

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -290,20 +290,17 @@ ${code}
         return { header, hint };
     }
 
+    /* Parse Tutorial Validation Rules */
     function parseTutorialValidationRules(body: string, tutorialCodeValidation?: boolean): pxt.Map<boolean> {
-
         let listOfRules: pxt.Map<boolean> = {};
-
         if (tutorialCodeValidation) {
             body = body.replace("{", '').replace("}", '').trim();
             const rules: string[] = body.split(",");
             for (let i = 0; i < rules.length; i++) {
-                let currRule = rules[i];
-                currRule = currRule.replace("\"/g", '').trim();
+                let currRule = rules[i].trim();
                 const ruleValuePair: string[] = currRule.split(":");
                 const ruleKey = ruleValuePair[0].replace("\"", '').replace("\"", '').trim();
                 const ruleValue = (ruleValuePair[1] === 'true');
-                console.log(ruleKey);
                 listOfRules[ruleKey] = ruleValue;
             }
         }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -301,7 +301,7 @@ ${code}
                 let currRule = rules[i];
                 currRule = currRule.replace("\"/g", '').trim();
                 const ruleValuePair: string[] = currRule.split(":");
-                const ruleKey = ruleValuePair[0].replace("\"", '').trim();
+                const ruleKey = ruleValuePair[0].replace("\"", '').replace("\"", '').trim();
                 const ruleValue = (ruleValuePair[1] === 'true');
                 console.log(ruleKey);
                 listOfRules[ruleKey] = ruleValue;

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -45,6 +45,11 @@ namespace pxt.tutorial {
         return TutorialRuleStatuses;
     }
 
+    /**
+    * Gives each rule from the mmarkdown file a TutorialRuleStatus
+    * @param listOfRules a map of rules from makrdown file 
+    * @return An array of TutorialRuleStatus
+    */
     function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
         let listOfRuleStatuses: TutorialRuleStatus[] = [];
         const ruleNames: string[] = Object.keys(listOfRules);

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -1,11 +1,5 @@
 namespace pxt.tutorial {
 
-    export enum TutorialCodeStatus {
-        Unknown = "Unknown",
-        Valid = "Valid",
-        Invalid = "Invalid"
-    }
-
     export interface TutorialRuleStatus {
         RuleName: string;
         RuleTurnOn: boolean;

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -6,16 +6,27 @@ namespace pxt.tutorial {
         Invalid = "Invalid"
     }
 
+    export interface TutorialRuleStatus {
+        RuleName: string;
+        RuleTurnOn: boolean;
+        RuleStatus: boolean;
+        RuleMessage: string;
+    }
+
     /**
     * Check the user's code to the tutorial and returns a Tutorial status of the user's code
     * @param tutorial the tutorial 
     * @param workspaceBlocks Blockly blocks used of workspace
     * @param blockinfo Typescripts of the workspace
-    * @return A TutorialCodeStatus
+    * @return A TutorialRuleStatus
     */
-    export async function validate(tutorial: TutorialOptions, workspaceBlocks: Blockly.Block[], blockinfo: pxtc.BlocksInfo): Promise<TutorialCodeStatus> {
-        // Check to make sure blocks are in the workspace
-        if (workspaceBlocks.length > 0) {
+    export async function validate(tutorial: TutorialOptions, workspaceBlocks: Blockly.Block[], blockinfo: pxtc.BlocksInfo): Promise<TutorialRuleStatus[]> {
+
+        const listOfRules = tutorial.tutorialValidationRules;
+        let TutorialRuleStatuses: TutorialRuleStatus[] = classifyRules(listOfRules);
+
+        // Check to if there are rules to valdiate and to see if there are blocks are in the workspace to compare to
+        if (TutorialRuleStatuses.length > 0 && workspaceBlocks.length > 0) {
             // User blocks
             const userBlockTypes = workspaceBlocks.map(b => b.type);
             const usersBlockUsed = blockCount(userBlockTypes);
@@ -24,13 +35,32 @@ namespace pxt.tutorial {
             const step = tutorialStepInfo[tutorialStep];
             const indexdb = await tutorialBlockList(tutorial, step);
             const tutorialBlockUsed = extractBlockSnippet(tutorial, indexdb);
-            // Checks user's blocks against tutorial blocks
-            if (!validateNumberOfBlocks(usersBlockUsed, tutorialBlockUsed)) {
-                return TutorialCodeStatus.Invalid;
+            for (let i = 0; i < TutorialRuleStatuses.length; i++) {
+                let currRuleToValidate = TutorialRuleStatuses[i];
+                const ruleName = TutorialRuleStatuses[i].RuleName;
+                switch (ruleName) {
+                    case "validateNumberOfBlocks":
+                        const ruleStatus = validateNumberOfBlocks(usersBlockUsed, tutorialBlockUsed);
+                        currRuleToValidate.RuleStatus = ruleStatus;
+                        break;
+                    case "placeholder":
+                        break;
+                }
             }
-            return TutorialCodeStatus.Valid;
         }
-        return TutorialCodeStatus.Unknown;
+        return TutorialRuleStatuses;
+    }
+
+    function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
+        let listOfRuleStatuses: TutorialRuleStatus[] = [];
+        const ruleNames: string[] = Object.keys(listOfRules);
+        for (let i = 0; i < ruleNames.length; i++) {
+            const currRule: string = ruleNames[i];
+            const ruleVal: boolean = listOfRules[currRule];
+            const currRuleStatus: TutorialRuleStatus = { RuleName: currRule, RuleTurnOn: ruleVal, RuleStatus: false, RuleMessage: ""};
+            listOfRuleStatuses.push(currRuleStatus);
+        }
+        return listOfRuleStatuses;
     }
 
     /**

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -8,7 +8,7 @@ namespace pxt.tutorial {
     }
 
     /**
-    * Check the user's code to the tutorial and returns a Tutorial status of the user's code
+    * Check the user's code to the map of tutorial validation rules from TutorialOptions and returns an array of TutorialRuleStatus
     * @param tutorial the tutorial 
     * @param workspaceBlocks Blockly blocks used of workspace
     * @param blockinfo Typescripts of the workspace
@@ -46,7 +46,7 @@ namespace pxt.tutorial {
     }
 
     /**
-    * Gives each rule from the mmarkdown file a TutorialRuleStatus
+    * Gives each rule from the markdown file a TutorialRuleStatus
     * @param listOfRules a map of rules from makrdown file 
     * @return An array of TutorialRuleStatus
     */

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1284,11 +1284,11 @@ export class ProjectView
         }
     }
 
-    setTutorialCodeStatus(step: number, status: string) {
+    setTutorialCodeStatus(step: number, status: pxt.tutorial.TutorialRuleStatus[]) {
         const tutorialOptions = this.state.tutorialOptions;
         const stepInfo = tutorialOptions.tutorialStepInfo[tutorialOptions.tutorialStep];
         const tutorialCodeValidationIsOn = tutorialOptions.metadata.tutorialCodeValidation;
-        if (tutorialCodeValidationIsOn) stepInfo.codeValidated = status == pxt.editor.TutorialCodeStatus.Valid;
+        if (tutorialCodeValidationIsOn) stepInfo.codeValidated = status;
 
         // Update the state with the code status, so the tutorial card can re-render
         this.setState({ tutorialOptions: tutorialOptions });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -214,7 +214,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     getTemporaryAssets(): pxt.Asset[] {
-        if (!this.editor) return[];
+        if (!this.editor) return [];
 
         return pxtblockly.getTemporaryAssets(this.editor, pxt.AssetType.Image)
             .concat(pxtblockly.getTemporaryAssets(this.editor, pxt.AssetType.Animation))
@@ -710,8 +710,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         // Current tutorial step
         const { tutorialStep } = tutorial;
         const blocks = this.editor.getAllBlocks();
-        const tutorialCodeStatus = await pxt.tutorial.validate(tutorial, blocks, this.blockInfo);
-        this.parent.setTutorialCodeStatus(tutorialStep, tutorialCodeStatus);
+        const tutorialRulesValidated: pxt.tutorial.TutorialRuleStatus[] = await pxt.tutorial.validate(tutorial, blocks, this.blockInfo);
+        this.parent.setTutorialCodeStatus(tutorialStep, tutorialRulesValidated);
     }
 
     getBlocksAreaDiv() {
@@ -1026,7 +1026,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         if (this.debuggerToolbox) {
             const visibleVars = Blockly.Variables.allUsedVarModels(this.editor)
-                    .map((variable: Blockly.VariableModel) => pxtc.escapeIdentifier(variable.name));
+                .map((variable: Blockly.VariableModel) => pxtc.escapeIdentifier(variable.name));
 
             this.debuggerToolbox.setBreakpoint(brk, visibleVars);
         }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -626,6 +626,17 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.setState({ showUnusedBlockMessage: false });
     }
 
+    isCodeValidated(rules: pxt.tutorial.TutorialRuleStatus[]) {
+        if (rules != undefined) {
+            for (let i = 0; i < rules.length; i++) {
+                if (rules[i].RuleTurnOn && !rules[i].RuleStatus) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     renderCore() {
         const options = this.props.parent.state.tutorialOptions;
         const { tutorialReady, tutorialStepInfo, tutorialStep, tutorialStepExpanded, metadata } = options;
@@ -642,7 +653,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const hasHint = this.hasHint();
         const tutorialCardContent = stepInfo.headerContentMd;
         const showDialog = stepInfo.showDialog;
-        const tutorialCodeValidated = stepInfo.codeValidated;
+        const tutorialCodeValidated = this.isCodeValidated(stepInfo.codeValidated);
         const validationEnabled = tutorialCodeValidated != undefined;
         const showMissingBlockPopupMessage = this.state.showUnusedBlockMessage && validationEnabled;
         const nextOnClick = (tutorialCodeValidated || !validationEnabled ||


### PR DESCRIPTION
Tutorial Code validation now extracts rules from a markdown file in the format:

```tutorialValidationRules
{"rule1":true, "rule2":false}
```
"rule1" corresponds to the name of the rule, and the boolean after the colon indicates if the rule is turned on/off. Associated with each rule is a boolean status flag that indicates if the user passes this rule and a rule message. 