### PR TITLE
various hero gallery updates

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -86,12 +86,13 @@
         }
 
         .dots button {
+            transition: background-color 0.2s;
             border: 2px solid @heroBannerDotOutlineColor;
             margin-right: 1.25rem;
 
             &.active {
                 border-color: @heroBannerDotOutlineAtiveColor;
-                background: none;
+                background-color: transparent;
             }
         }
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -408,7 +408,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
     }
 
     protected onTouchEnd = (e: React.TouchEvent) => {
-        this.handleRelease(e.changedTouches?.[0]?.clientX, e)
+        this.handleRelease(e.changedTouches?.[0]?.clientX, e);
     }
 
     protected handleRelease(xPos: number, e: React.TouchEvent | React.PointerEvent) {
@@ -428,7 +428,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
         const key = core.keyCodeFromEvent(e);
         switch (key) {
             case 37: /** left **/
-                this.handleRefreshCard(true /** backwards **/)
+                this.handleRefreshCard(true /** backwards **/);
                 e.stopPropagation();
                 break;
             case 39: /** right */
@@ -440,7 +440,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
 
     protected handleCardClick = () => {
         const card = this.state.cardIndex !== undefined
-            && this.prevGalleries[this.state.cardIndex]
+            && this.prevGalleries[this.state.cardIndex];
         if (card) {
             pxt.tickEvent("hero.card.click", {
                 gallery: pxt.appTarget.appTheme.homeScreenHeroGallery,
@@ -462,7 +462,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
 
     protected clearRefresh() {
         if (this.carouselTimeout) {
-            clearTimeout(this.carouselTimeout)
+            clearTimeout(this.carouselTimeout);
             this.carouselTimeout = undefined;
         }
     }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -363,7 +363,7 @@ interface HeroBannerState {
     paused?: boolean;
 }
 
-const HERO_BANNER_DELAY = 7500; // 7.5 seconds per card
+const HERO_BANNER_DELAY = 6000; // 6 seconds per card
 class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
     private prevGalleries: pxt.CodeCard[];
     private carouselInterval: any = undefined;

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -490,6 +490,8 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
         const encodedBkgd = `url(${encodeURI(card.largeImageUrl || card.imageUrl)})`;
         const label = codeCardButtonLabel(card.cardType, card.youTubeId, card.youTubePlaylistId);
         const hasAction = !!url || !!card.youTubeId || !!card.youTubePlaylistId;
+        /** Do not remove; common default that may be specified in pxtarget **/
+        // lf("New? Start here!");
 
         return <div className="ui segment getting-started-segment hero"
             style={{ backgroundImage: encodedBkgd }}>

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -463,7 +463,6 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
                 // ignore;
             } else {
                 this.prevGalleries = pxt.Util.concat(res.map(g => g.cards))
-                    .filter(card => card.url)
                     .slice(0, 5); // max 5 cards
                 if (heroBanner) {
                     this.prevGalleries.unshift(heroBanner);

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -443,6 +443,7 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
             imageUrl: heroBannerImg || heroCard?.imageUrl,
             description: heroCard?.description && pxt.U.rlf(heroCard.description),
             name: heroCard?.name && pxt.U.rlf(heroCard.name),
+            buttonLabel: heroCard?.buttonLabel && pxt.U.rlf(heroCard.buttonLabel),
         };
 
         if (!this.prevGalleries) {
@@ -488,8 +489,10 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
 
         const description = card.description || card.name;
         const encodedBkgd = `url(${encodeURI(card.largeImageUrl || card.imageUrl)})`;
-        const label = codeCardButtonLabel(card.cardType, card.youTubeId, card.youTubePlaylistId);
+
+        const label = card.buttonLabel || codeCardButtonLabel(card.cardType, card.youTubeId, card.youTubePlaylistId);
         const hasAction = !!url || !!card.youTubeId || !!card.youTubePlaylistId;
+
         /** Do not remove; common default that may be specified in pxtarget **/
         // lf("New? Start here!");
 


### PR DESCRIPTION
* don't filter out cards without urls (make youtube videos / playlists in gallery work too)
* add 'start here' msg to translations
* allow overriding button label in gallery
* few minor prettifying updates
* speed up a bit (6seconds instead of 7.5 seconds
* keyboard nav (left / right keys while focus is on dots / start button)
* swipe support (mainly for mobile but works everywhere)

build: https://makecode.microbit.org/app/aacb838af702b5ff97c4dc393ede6781b547ea86-abf686df1b

will want these in for testing monday~