### PR TITLE
Add resilience to cloud sync tasks

### DIFF
--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -343,7 +343,7 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
                 }
                 return remoteFiles[h.id]
             } catch {
-                // Failed to remote project. This can happen when:
+                // Failed to fetch remote project. This can happen when:
                 // - Client is opening a project that hasn't been saved to the cloud yet.
                 // - Client is importing a project from GitHub or elsewhere.
                 // - We're offline.


### PR DESCRIPTION
Syncing projects to/from the cloud is a complex process involving many async tasks running at once. Any one of these tasks could fail for reasons that aren't necessarily fatal to the overall sync process, so don't let an individual task failure cancel the entire sync. Instead, log the error and let the other tasks continue.

This is part of an effort to uncover why cloud sync mysteriously stops working. This particular code (cloud.syncAsyncInternal) needs more work and refactoring. It is terribly nuanced at the moment.