### PR TITLE
Invalidate project headers after cloud sync

### DIFF
--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -522,6 +522,8 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
         pxt.log(`Cloud sync finished after ${elapsed} seconds with ${localHeaderChangesList.length} local changes.`);
         pxt.tickEvent(`identity.sync.finished`, { elapsed })
 
+        data.invalidate("headers:");
+
         return localHeaderChangesList
     }
     catch (e) {


### PR DESCRIPTION
After synchronizing with the cloud, invalidate local project headers in case anything changed. This fixes the issue where a user's cloud projects don't show up after signing in. This solution is kind of blunt-force, but should be ok for now.

Fixes https://github.com/microsoft/pxt-arcade/issues/3476
Fixes https://github.com/microsoft/pxt-arcade/issues/2865