### PR TITLE
set a static height of 3 lines for hero banner description

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -75,10 +75,18 @@
         }
 
         .description {
+            display: flex;
+            align-items: flex-end;
             width: 20rem;
+            height: 6.5rem;
+            overflow-y: auto;
             font-size: 1.5rem;
             font-weight: 600;
             color: @white;
+            p {
+                flex-grow: 0;
+                max-height: 100%;
+            }
         }
 
         .action {
@@ -617,6 +625,7 @@
                 margin-left: @carouselArrowSizeMobile;
                 .description {
                     width: 12rem;
+                    height: 4rem;
                     font-size: 1rem;
                 }
                 .dots {
@@ -816,6 +825,7 @@
             &.hero .hero-banner-contents {
                 .description {
                     width: 12rem;
+                    height: 4rem;
                     font-size: 1rem;
                 }
                 .dots {


### PR DESCRIPTION
Set aside 3 lines worth of height for the hero banner description, so the buttons don't bounce up / down depending on how long each description is. (just in case if it's longer than 3 lines it scrolls, but we should aim for short/sweet descriptions for the banner anyways).

https://makecode.microbit.org/app/a62737398fa226bd5fa625a7e8e31da3a9739a21-0af9ff82f8