### PR TITLE
Don't select things when using touch

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -14,6 +14,12 @@ html {
     width: 100%;
     overflow: hidden;
     font-size:16px;
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none;   /* Chrome/Safari/Opera */
+    -khtml-user-select: none;    /* Konqueror */
+    -moz-user-select: none;      /* Firefox */
+    -ms-user-select: none;       /* Internet Explorer/Edge */
+    user-select: none;
 }
 
 body {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/2742

Just disable selection for the whole page. You can still select text within text fields and text inside modals for tutorials.

I'm not sure if there are any other places where we want to explicitly allow selection for copy & paste? Maybe the help panel for the joke tutorial? Lemme know and I can fix it

I tested on my Surface touch screen (chrome + firefox) and iPad, feel free to try out on your devices too! https://makecode.microbit.org/app/ff9afedf38eb905974ecabcf30631f35d46fd510-e126cce456