### PR TITLE
extract hero banner strings for localization

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1791,6 +1791,12 @@ function saveThemeJson(cfg: pxt.TargetBundle, localDir?: boolean, packaged?: boo
     if (theme.title) targetStrings[theme.title] = theme.title;
     if (theme.name) targetStrings[theme.name] = theme.name;
     if (theme.description) targetStrings[theme.description] = theme.description;
+    if (theme.homeScreenHero && typeof theme.homeScreenHero != "string" ) {
+        const heroBannerCard = theme.homeScreenHero;
+        if (heroBannerCard.title) targetStrings[heroBannerCard.title] = heroBannerCard.title;
+        if (heroBannerCard.description) targetStrings[heroBannerCard.description] = heroBannerCard.description;
+        if (heroBannerCard.buttonLabel) targetStrings[heroBannerCard.buttonLabel] = heroBannerCard.buttonLabel;
+    }
 
     // add the labels for the target contributed types that appear in the block function create dialog
     if (cfg.runtime?.functionsOptions?.extraFunctionEditorTypes?.length) {

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -534,9 +534,6 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
         const label = card.buttonLabel || codeCardButtonLabel(card.cardType, card.youTubeId, card.youTubePlaylistId);
         const hasAction = !!url || !!card.youTubeId || !!card.youTubePlaylistId;
 
-        /** Do not remove; common default that may be specified in pxtarget **/
-        // lf("New? Start here!");
-
         return <div className="ui segment getting-started-segment hero"
                 style={{ backgroundImage: encodedBkgd }}
                 onKeyDown={this.onKeyDown}


### PR DESCRIPTION
Since the 'main' hero banner has to live in pxtarget to make sure it is readily available, it doesn't get the same auto localization we do from the gallery versions. Extract those strings in the same way we pull out name / title / etc