### PR TITLE
Webusb tweaks

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -1302,7 +1302,9 @@ namespace pxt.BrowserUtils {
     }
 
     export function getCookieLang() {
-        return getCookie(pxt.Util.pxtLangCookieId);
+        const cookiePropRegex = new RegExp(`${pxt.Util.escapeForRegex(pxt.Util.pxtLangCookieId)}=(.*?)(?:;|$)`)
+        const cookieValue = cookiePropRegex.exec(document.cookie);
+        return cookieValue && cookieValue[1] || null;
     }
 
     export function setCookieLang(langId: string, docs = false) {
@@ -1313,20 +1315,9 @@ namespace pxt.BrowserUtils {
         if (langId !== getCookieLang()) {
             pxt.tickEvent(`menu.lang.setcookielang`, { lang: langId, docs: `${docs}` });
             const expiration = new Date();
-            setCookie(pxt.Util.pxtLangCookieId, langId, expiration.getTime() + (pxt.Util.langCookieExpirationDays * 24 * 60 * 60 * 1000));
+            expiration.setTime(expiration.getTime() + (pxt.Util.langCookieExpirationDays * 24 * 60 * 60 * 1000));
+            document.cookie = `${pxt.Util.pxtLangCookieId}=${langId}; expires=${expiration.toUTCString()}; path=/`;
         }
-    }
-
-    export function getCookie(id: string) {
-        const cookiePropRegex = new RegExp(`${pxt.Util.escapeForRegex(id)}=(.*?)(?:;|$)`)
-        const cookieValue = cookiePropRegex.exec(document.cookie);
-        return cookieValue && cookieValue[1] || null;
-    }
-
-    export function setCookie(id: string, value: string, expirationDate: number) {
-        const expireDate = new Date();
-        expireDate.setTime(expirationDate);
-        document.cookie = `${id}=${value}; expires=${expireDate.toUTCString()}; path=/`;
     }
 
     export function cacheBustingUrl(url: string): string {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3484,6 +3484,7 @@ export class ProjectView
                     return pxt.winrt.releaseAllDevicesAsync();
                 })
                 .then(() => {
+                    dialogs.clearDontShowDownloadDialogFlag();
                     return this.resetWorkspace();
                 });
         });

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -7,7 +7,7 @@ import * as webusb from "./webusb";
 import * as data from "./data";
 import * as dialogs from "./dialogs";
 import Cloud = pxt.Cloud;
-import { isDontShowDownloadDialogCookieSet } from "./dialogs";
+import { isDontShowDownloadDialogFlagSet } from "./dialogs";
 
 function log(msg: string) {
     pxt.debug(`cmds: ${msg}`);
@@ -73,7 +73,7 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
         return Promise.resolve()
             .then(() => window.URL?.revokeObjectURL(url));
     }
-    else if (isDontShowDownloadDialogCookieSet()) {
+    else if (isDontShowDownloadDialogFlagSet()) {
         window.URL?.revokeObjectURL(url)
         return Promise.resolve();
     }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -69,13 +69,9 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
         return Promise.resolve();
     }
 
-    if (!userContext && (resp.saveOnly || pxt.BrowserUtils.isBrowserDownloadInSameWindow())) {
+    if (!userContext && pxt.BrowserUtils.isBrowserDownloadInSameWindow() || isDontShowDownloadDialogFlagSet()) {
         return Promise.resolve()
             .then(() => window.URL?.revokeObjectURL(url));
-    }
-    else if (isDontShowDownloadDialogFlagSet()) {
-        window.URL?.revokeObjectURL(url)
-        return Promise.resolve();
     }
     else {
         // save does the same as download as far iOS is concerned

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -722,6 +722,7 @@ export function renderBrowserDownloadInstructions() {
     const boardName = pxt.appTarget.appTheme.boardName || lf("device");
     const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
     const fileExtension = pxt.appTarget.compile?.useUF2 ? ".uf2" : ".hex";
+    const webUSBSupported = pxt.usb.isEnabled && pxt.appTarget?.compile?.webUSB;
 
     const onPairClicked = () => {
         core.hideDialog();
@@ -747,21 +748,23 @@ export function renderBrowserDownloadInstructions() {
                                         <div className="description">
                                             {lf("Your code is being downloaded as a {1} file. You can drag this file to your {0} using your computer's file explorer.", boardName, fileExtension)}
                                         </div>
-                                        <div className="download-callout">
-                                            <label className="ui purple ribbon large label">{lf("New!")}</label>
-                                            <div className="ui two column grid">
-                                                <div className="icon-align three wide column">
-                                                    <div />
-                                                    <i className="icon big usb"/>
-                                                    <div />
-                                                </div>
-                                                <div className="thirteen wide column">
-                                                    {lf("Download your code faster by pairing with web usb!")}
-                                                    <br/>
-                                                    <strong><a onClick={onPairClicked}>{lf("Pair now")}</a></strong>
+                                        {webUSBSupported &&
+                                            <div className="download-callout">
+                                                <label className="ui purple ribbon large label">{lf("New!")}</label>
+                                                <div className="ui two column grid">
+                                                    <div className="icon-align three wide column">
+                                                        <div />
+                                                        <i className="icon big usb"/>
+                                                        <div />
+                                                    </div>
+                                                    <div className="thirteen wide column">
+                                                        {lf("Download your code faster by pairing with web usb!")}
+                                                        <br/>
+                                                        <strong><a onClick={onPairClicked}>{lf("Pair now")}</a></strong>
+                                                    </div>
                                                 </div>
                                             </div>
-                                        </div>
+                                        }
                                     </div>
                                 </div>
                             </div>

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -10,8 +10,7 @@ import * as cloudsync from "./cloudsync";
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 
-const DONT_SHOW_KEY = "downloaddialog_dontshowagain";
-const DONT_SHOW_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
+let dontShowDownloadFlag = false;
 
 export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
     const compileService = pxt.appTarget.compileService;
@@ -733,7 +732,7 @@ export function renderBrowserDownloadInstructions() {
         const valueString = "" + value;
         pxt.tickEvent("downloaddialog.dontshowagain", { checked: valueString });
 
-        window.localStorage[DONT_SHOW_KEY] = valueString + ";" + Date.now() + DONT_SHOW_EXPIRATION;
+        dontShowDownloadFlag = value;
     }
 
     return <div className="ui grid stackable upload">
@@ -790,22 +789,9 @@ export function renderBrowserDownloadInstructions() {
 }
 
 export function clearDontShowDownloadDialogFlag() {
-    window.localStorage[DONT_SHOW_KEY] = "";
+    dontShowDownloadFlag = false;
 }
 
 export function isDontShowDownloadDialogFlagSet() {
-    const value = window.localStorage[DONT_SHOW_KEY];
-
-    if (value) {
-        const [boolString, expiration] = value.split(";");
-
-        if (parseInt(expiration) < Date.now()) {
-            clearDontShowDownloadDialogFlag();
-            return false;
-        }
-
-        return boolString === "true";
-    }
-
-    return false;
+    return dontShowDownloadFlag;
 }

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -10,7 +10,7 @@ import * as cloudsync from "./cloudsync";
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 
-const DONT_SHOW_COOKIE_ID = "downloaddialog_dontshowagain";
+const DONT_SHOW_KEY = "downloaddialog_dontshowagain";
 const DONT_SHOW_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
 
 export function showAboutDialogAsync(projectView: pxt.editor.IProjectView) {
@@ -731,7 +731,8 @@ export function renderBrowserDownloadInstructions() {
     const onCheckboxClicked = (value: boolean) => {
         const valueString = "" + value;
         pxt.tickEvent("downloaddialog.dontshowagain", { checked: valueString });
-        pxt.BrowserUtils.setCookie(DONT_SHOW_COOKIE_ID, valueString, Date.now() + DONT_SHOW_EXPIRATION);
+
+        window.localStorage[DONT_SHOW_KEY] = valueString + ";" + Date.now() + DONT_SHOW_EXPIRATION;
     }
 
     return <div className="ui grid stackable upload">
@@ -785,6 +786,19 @@ export function renderBrowserDownloadInstructions() {
     </div>;
 }
 
-export function isDontShowDownloadDialogCookieSet() {
-    return pxt.BrowserUtils.getCookie(DONT_SHOW_COOKIE_ID) === "true";
+export function isDontShowDownloadDialogFlagSet() {
+    const value = window.localStorage[DONT_SHOW_KEY];
+
+    if (value) {
+        const [boolString, expiration] = value.split(";");
+
+        if (parseInt(expiration) < Date.now()) {
+            window.localStorage[DONT_SHOW_KEY] = "";
+            return false;
+        }
+
+        return boolString === "true";
+    }
+
+    return false;
 }

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -789,6 +789,10 @@ export function renderBrowserDownloadInstructions() {
     </div>;
 }
 
+export function clearDontShowDownloadDialogFlag() {
+    window.localStorage[DONT_SHOW_KEY] = "";
+}
+
 export function isDontShowDownloadDialogFlagSet() {
     const value = window.localStorage[DONT_SHOW_KEY];
 
@@ -796,7 +800,7 @@ export function isDontShowDownloadDialogFlagSet() {
         const [boolString, expiration] = value.split(";");
 
         if (parseInt(expiration) < Date.now()) {
-            window.localStorage[DONT_SHOW_KEY] = "";
+            clearDontShowDownloadDialogFlag();
             return false;
         }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -8,6 +8,7 @@ import * as cmds from "./cmds"
 import * as cloud from "./cloud";
 import * as auth from "./auth";
 import { ProjectView } from "./app";
+import { clearDontShowDownloadDialogFlag } from "./dialogs";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -177,7 +178,16 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     }
 
+    protected onDownloadButtonClick = () => {
+        pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
+        this.compile();
+    }
+
     protected onHwDownloadClick = () => {
+        // Matching the tick in the call to compile() above for historical reasons
+        pxt.tickEvent("editortools.download", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
+        pxt.tickEvent("editortools.downloadasfile", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
+        clearDontShowDownloadDialogFlag();
         (this.props.parent as ProjectView).compile(true);
     }
 
@@ -256,7 +266,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         }
 
         let el = [];
-        el.push(<EditorToolbarButton key="downloadbutton" icon={downloadIcon} className={`primary download-button ${downloadButtonClasses}`} text={view != View.Mobile ? downloadText : undefined} title={compileTooltip} onButtonClick={this.compile} view='computer' />)
+        el.push(<EditorToolbarButton key="downloadbutton" icon={downloadIcon} className={`primary download-button ${downloadButtonClasses}`} text={view != View.Mobile ? downloadText : undefined} title={compileTooltip} onButtonClick={this.onDownloadButtonClick} view='computer' />)
 
         const deviceName = pxt.hwName || pxt.appTarget.appTheme.boardNickname || lf("device");
         const tooltip = pxt.hwName

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -234,9 +234,8 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
             || (!!packetioConnected && packetioIcon)
             || targetTheme.downloadIcon
             || "xicon file-download";
-        const hasMenu = boards || webUSBSupported;
 
-        let downloadButtonClasses = hasMenu ? "left attached " : "";
+        let downloadButtonClasses = "left attached ";
         const downloadButtonIcon = "ellipsis";
         let hwIconClasses = "";
         let displayRight = false;
@@ -272,24 +271,24 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         const tooltip = pxt.hwName
             || (packetioConnected && lf("Connected to {0}", deviceName))
             || (packetioConnecting && lf("Connecting..."))
-            || (boards ? lf("Click to select hardware") : lf("Click for one-click downloads."));
+            || (boards ? lf("Click to select hardware") : (webUSBSupported ? lf("Click for one-click downloads.") : undefined));
 
         const hardwareMenuText = view == View.Mobile ? lf("Hardware") : lf("Choose hardware");
         const downloadMenuText = view == View.Mobile ? (pxt.hwName || lf("Download")) : lf("Download as file");
         const downloadHelp = pxt.appTarget.appTheme.downloadDialogTheme?.downloadMenuHelpURL;
 
-        if (hasMenu) {
-            const usbIcon = pxt.appTarget.appTheme.downloadDialogTheme?.deviceIcon || "usb";
-            el.push(
-                <sui.DropdownMenu key="downloadmenu" role="menuitem" icon={`${downloadButtonIcon} horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight}>
-                    {webUSBSupported && !packetioConnected && <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect device")} tabIndex={-1} onClick={this.onPairClick} />}
-                    {webUSBSupported && (packetioConnecting || packetioConnected) && <sui.Item role="menuitem" icon={usbIcon} text={lf("Disconnect")} tabIndex={-1} onClick={this.onDisconnectClick} />}
-                    {boards && <sui.Item role="menuitem" icon="microchip" text={hardwareMenuText} tabIndex={-1} onClick={this.onHwItemClick} />}
-                    <sui.Item role="menuitem" icon="xicon file-download" text={downloadMenuText} tabIndex={-1} onClick={this.onHwDownloadClick} />
-                    {downloadHelp && <sui.Item role="menuitem" icon="help circle" text={lf("Help")} tabIndex={-1} onClick={this.onHelpClick} />}
-                </sui.DropdownMenu>
-            )
-        }
+        // Add the ... menu
+        const usbIcon = pxt.appTarget.appTheme.downloadDialogTheme?.deviceIcon || "usb";
+        el.push(
+            <sui.DropdownMenu key="downloadmenu" role="menuitem" icon={`${downloadButtonIcon} horizontal ${hwIconClasses}`} title={lf("Download options")} className={`${hwIconClasses} right attached editortools-btn hw-button button`} dataTooltip={tooltip} displayAbove={true} displayRight={displayRight}>
+                {webUSBSupported && !packetioConnected && <sui.Item role="menuitem" icon={usbIcon} text={lf("Connect device")} tabIndex={-1} onClick={this.onPairClick} />}
+                {webUSBSupported && (packetioConnecting || packetioConnected) && <sui.Item role="menuitem" icon={usbIcon} text={lf("Disconnect")} tabIndex={-1} onClick={this.onDisconnectClick} />}
+                {boards && <sui.Item role="menuitem" icon="microchip" text={hardwareMenuText} tabIndex={-1} onClick={this.onHwItemClick} />}
+                <sui.Item role="menuitem" icon="xicon file-download" text={downloadMenuText} tabIndex={-1} onClick={this.onHwDownloadClick} />
+                {downloadHelp && <sui.Item role="menuitem" icon="help circle" text={lf("Help")} tabIndex={-1} onClick={this.onHelpClick} />}
+            </sui.DropdownMenu>
+        )
+
         return el;
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -275,8 +275,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
             || (boards ? lf("Click to select hardware") : lf("Click for one-click downloads."));
 
         const hardwareMenuText = view == View.Mobile ? lf("Hardware") : lf("Choose hardware");
-        const ext = pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex";
-        const downloadMenuText = view == View.Mobile ? (pxt.hwName || lf("Download")) : lf("Download {0} file", ext);
+        const downloadMenuText = view == View.Mobile ? (pxt.hwName || lf("Download")) : lf("Download as file");
         const downloadHelp = pxt.appTarget.appTheme.downloadDialogTheme?.downloadMenuHelpURL;
 
         if (hasMenu) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4085
Fixes https://github.com/microsoft/pxt-microbit/issues/4087
Fixes https://github.com/microsoft/pxt-microbit/issues/4097

Complete list of changes:

1. "Download .hex file" -> "Download as file"
2. No longer shows the callout for pairing in browsers where it isn't supported (Firefox, Safari)
3. "Don't show this again" flag is now stored in memory
4. Fixes some ticks for the ... menu
5. ... menu now also shows on ios
6. Reset clears the "Don't show this again" flag
7. Selecting "save as file" now always shows the download dialog (even if selected "Don't show this again"). I can change this behavior if desired.