### PR TITLE
Use default color for orphan melody blocks

### DIFF
--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -310,11 +310,19 @@ namespace pxtblockly {
         }
 
         protected getDropdownBackgroundColour() {
-            return this.sourceBlock_.parentBlock_.getColour();
+            if (this.sourceBlock_.parentBlock_) {
+                return this.sourceBlock_.parentBlock_.getColour();
+            } else {
+                return "#3D3D3D";
+            }
         }
 
         protected getDropdownBorderColour() {
-            return (this.sourceBlock_.parentBlock_ as Blockly.BlockSvg).getColourTertiary();
+            if (this.sourceBlock_.parentBlock_) {
+                return (this.sourceBlock_.parentBlock_ as Blockly.BlockSvg).getColourTertiary();
+            } else {
+                return "#2A2A2A";
+            }
         }
 
         private updateFieldLabel(): void {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4089

This uses the default color that the note picker uses when it has no parent

![image](https://user-images.githubusercontent.com/18712271/119700641-53cea700-be08-11eb-8af3-b5b3ae6a664b.png)
