### PR TITLE
Fix dropdown menu flicker, going off screen

### DIFF
--- a/theme/themes/pxt/modules/dropdown.overrides
+++ b/theme/themes/pxt/modules/dropdown.overrides
@@ -2,7 +2,7 @@
         User Overrides
 *******************************/
 
-.ui.dropdown > .avatar > img, 
+.ui.dropdown > .avatar > img,
 .ui.dropdown > .avatar > .initials {
     height: 2.5rem;
     width: 2.5rem;
@@ -31,6 +31,11 @@
 .ui.dropdown.menuAbove > .menu {
     top: 0%;
     transform: translateY(-100%);
+}
+
+.ui.dropdown.menuLeft > .menu {
+    left: unset;
+    right: 0;
 }
 
 .ui.buttons > .ui.dropdown.menuRight:last-child .menu {

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -376,7 +376,11 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                     <div role="button" className="ui container fluid" style={{ height: "100%" }} onClick={this.handleAreaClick} onKeyDown={this.handleKeyDown}>
                         <div className="sort-by">
                             <div role="menu" className="ui compact buttons">
-                                <sui.DropdownMenu role="menuitem" text={sortedBy == 'time' ? lf("Last Modified") : lf("Name")} title={lf("Sort by dropdown")} className={`inline button ${darkTheme ? 'inverted' : ''}`}>
+                                <sui.DropdownMenu
+                                    role="menuitem" text={sortedBy == 'time' ? lf("Last Modified") : lf("Name")}
+                                    title={lf("Sort by dropdown")} className={`inline button ${darkTheme ? 'inverted' : ''}`}
+                                    displayLeft
+                                >
                                     <sui.Item role="menuitem" icon={sortedBy == 'name' ? 'check' : undefined} className={`${sortedBy != 'name' ? 'no-icon' : ''} ${darkTheme ? 'inverted' : ''}`} text={lf("Name")} tabIndex={-1} onClick={this.handleSortName} />
                                     <sui.Item role="menuitem" icon={sortedBy == 'time' ? 'check' : undefined} className={`${sortedBy != 'time' ? 'no-icon' : ''} ${darkTheme ? 'inverted' : ''}`} text={lf("Last Modified")} tabIndex={-1} onClick={this.handleSortTime} />
                                 </sui.DropdownMenu>

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -78,6 +78,7 @@ export interface DropdownProps extends UiProps {
     titleContent?: React.ReactNode;
     displayAbove?: boolean;
     displayRight?: boolean;
+    displayLeft?: boolean;
     dataTooltip?: string;
 }
 
@@ -319,7 +320,8 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
     }
 
     renderCore() {
-        const { disabled, title, role, icon, className, titleContent, children, displayAbove, displayRight, dataTooltip } = this.props;
+        const { disabled, title, role, icon, className, titleContent, children,
+            displayAbove, displayLeft, displayRight, dataTooltip } = this.props;
         const { open } = this.state;
 
         const aria = {
@@ -340,7 +342,8 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
             icon ? 'icon' : '',
             className || '',
             displayAbove ? 'menuAbove' : '',
-            displayRight ? 'menuRight' : ''
+            displayRight ? 'menuRight' : '',
+            displayLeft ? "menuLeft" : '',
         ]);
         const menuClasses = cx([
             'menu',

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -141,11 +141,8 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
     }
 
     isChildFocused() {
-        const children = this.getChildren();
-        for (let i = 0; i < children.length; i++) {
-            if (document.activeElement === children[i]) return true;
-        }
-        return false;
+        const menu = this.refs["menu"] as HTMLElement;
+        return menu.contains(document.activeElement);
     }
 
     private navigateToNextElement = (e: KeyboardEvent, prev: HTMLElement, next: HTMLElement) => {

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -300,6 +300,11 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
         }, 1);
     }
 
+    protected captureMouseEvent = (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+    }
+
     private focusFirst: boolean;
     private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
         const charCode = core.keyCodeFromEvent(e);
@@ -356,7 +361,10 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
             >
                 {titleContent ? titleContent : genericContent(this.props)}
                 <div ref="menu" {...menuAria} className={menuClasses}
-                    role="menu">
+                    role="menu"
+                    onMouseDown={this.captureMouseEvent}
+                    onClick={this.captureMouseEvent}
+                >
                     {children}
                 </div>
             </div>);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-microbit/issues/4084

Also fix it going offscreen / repositioning when name is selected by aligning to right, as that was annoying me a lot while I was trying to debug this:

![image](https://user-images.githubusercontent.com/5615930/119712043-099ff280-be15-11eb-98c2-9d87f0f6d4e2.png)

vs after this 

![image](https://user-images.githubusercontent.com/5615930/119712110-1e7c8600-be15-11eb-99e5-634970d6a761.png)

(also worth a note this component is very tedious to debug, as it's got fairly complex state management / actually changes in response to any clicks the user makes, even outside the window -- e.g. even in the debug tools. Something for the backlog I guess)