### PR TITLE
Fix pitch in safari and clipping in simulator

### DIFF
--- a/pxtlib/audioUtil.ts
+++ b/pxtlib/audioUtil.ts
@@ -63,14 +63,15 @@ namespace pxt.AudioContextManager {
                 _vco.type = 'triangle';
 
                 _gain = ctx.createGain();
+                _gain.gain.value = 0;
                 _gain.connect(ctx.destination);
 
                 _vco.connect(_gain);
                 _vco.start(0);
 
             }
-            _vco.frequency.value = frequency;
-            _gain.gain.setTargetAtTime(1, _context.currentTime, 0.015);
+            _vco.frequency.linearRampToValueAtTime(frequency, _context.currentTime)
+            _gain.gain.setTargetAtTime(.2, _context.currentTime, 0.015);
 
         } catch (e) {
             _vco = undefined;

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -268,23 +268,22 @@ namespace pxsim {
             stopTone();
             clearVca();
         }
-
-        function clearVco() {
-            if (_vco) {
-                try {
-                    _vco.stop();
-                    _vco.disconnect();
-                } catch { }
-                _vco = undefined;
-            }
-        }
         function clearVca() {
             if (_vca) {
                 try {
-                    _vca.disconnect();
+                    disconnectVca(_vca, _vco);
                 } catch { }
                 _vca = undefined;
+                _vco = undefined;
             }
+        }
+
+        function disconnectVca(gain: GainNode, osc?: AudioNode) {
+            gain.gain.setTargetAtTime(0, context().currentTime, 0.015);
+            setTimeout(() => {
+                gain.disconnect();
+                if (osc) osc.disconnect();
+            }, 450)
         }
 
         export function frequency(): number {
@@ -457,12 +456,12 @@ namespace pxsim {
             generator: OscillatorNode | AudioBufferSourceNode;
             gain: GainNode
             mute() {
-                if (this.generator) {
+                if (this.gain)
+                    disconnectVca(this.gain, this.generator)
+                else if (this.generator) {
                     this.generator.stop()
                     this.generator.disconnect()
                 }
-                if (this.gain)
-                    this.gain.disconnect()
                 this.gain = null
                 this.generator = null
             }
@@ -551,7 +550,8 @@ namespace pxsim {
                     currWave = soundWaveIdx
                     currFreq = freq
                     ch.gain = ctx.createGain()
-                    ch.gain.gain.value = scaledStart;
+                    ch.gain.gain.value = 0;
+                    ch.gain.gain.setTargetAtTime(scaledStart, _context.currentTime, 0.015);
 
                     if (endFreq != freq) {
                         if ((ch.generator as any).frequency != undefined) {
@@ -591,17 +591,19 @@ namespace pxsim {
             let ctx = context();
             if (!ctx) return;
 
-            clearVco();
 
             gain = Math.max(0, Math.min(1, gain));
             try {
-                _vco = ctx.createOscillator();
-                _vca = ctx.createGain();
-                _vco.type = 'triangle';
-                _vco.connect(_vca);
-                _vca.connect(ctx.destination);
+                if (!_vco) {
+                    _vco = ctx.createOscillator();
+                    _vca = ctx.createGain();
+                    _vca.gain.value = 0;
+                    _vco.type = 'triangle';
+                    _vco.connect(_vca);
+                    _vca.connect(ctx.destination);
+                    _vco.start(0);
+                }
                 setCurrentToneGain(gain);
-                _vco.start(0);
             } catch (e) {
                 _vco = undefined;
                 _vca = undefined;
@@ -614,7 +616,7 @@ namespace pxsim {
 
         export function setCurrentToneGain(gain: number) {
             if (_vca?.gain) {
-                _vca.gain.value = _mute ? 0 : gain;
+                _vca.gain.setTargetAtTime(_mute ? 0 : gain, _context.currentTime, 0.015)
             }
         }
 
@@ -702,6 +704,7 @@ namespace pxsim {
 
                 const channel = new Channel();
                 channel.gain = context().createGain();
+                channel.gain.gain.value = 0;
                 channel.gain.gain.setValueAtTime(volume, context().currentTime);
                 channel.gain.connect(context().destination);
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3703

The newest version of Safari doesn't respect changing the pitch directly, so I switched to using `linearRampToValue`. I also took this opportunity to make the field editors much, much quieter. They now are closer to the volume in the simulator.

I also fixed the clipping that happens in the simulator when playing notes/melodies. Clipping happens whenever there is a sudden shift in gain values with an oscillator attached. I fixed it by making it so that we never set the gain value directly once an oscillator is playing. Instead I use `setTargetAtTime` which interpolates to the value based on the time constant you pass in. Other interesting notes:

1. GainNodes start fully open, which means connecting an oscillator is the same as going from a gain of 0 to 1 instantaneously. Now I set them to be closed and then ramp up with `setTargetAtTime`
2. Disconnecting the GainNode or OscillatorNode at the end of each tone also causes a clip, so instead I ramp the gain down to 0 and then disconnect it