### PR TITLE
Initial Telemetry for Tutorial Validation

### DIFF
--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -31,12 +31,28 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
         this.setState({ visible: vis });
     }
 
+    collectingTurnedOnRulesList(rules: pxt.tutorial.TutorialRuleStatus[]) {
+        let turnedOnRulesList: pxt.Map<string> = {};
+        if (rules != undefined) {
+            for (let i = 0; i < rules.length; i++) {
+                if (rules[i].ruleTurnOn) {
+                    turnedOnRulesList[rules[i].ruleName] = rules[i].ruleStatus + '';
+                }
+            }
+        }
+        return turnedOnRulesList;
+    }
+
     moveOnToNextTutorialStep() {
+        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
+        pxt.tickEvent('tutorial.validation.next ', listOfTurnedOnRules);
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
+        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
+        pxt.tickEvent('tutorial.validation.stay ', listOfTurnedOnRules);
         this.props.onNoButtonClick();
     }
 


### PR DESCRIPTION
Added telemetry when the user clicks 'Continue Anyway' and 'Keep Editing' button. The telemetry will monitor which rules were turned on for this tutorial and state which rules were incorrect. Below is a sample telemetry output with console.log.

![Screenshot (36)](https://user-images.githubusercontent.com/13580493/120353883-db0f9500-c2b6-11eb-977c-6b1fad4aad67.png)