### PR TITLE
Fix on-demand sync from cloud

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1385,7 +1385,7 @@ export class ProjectView
         return undefined;
     }
 
-    loadHeaderAsync(h: pxt.workspace.Header, editorState?: pxt.editor.EditorState): Promise<void> {
+    async loadHeaderAsync(h: pxt.workspace.Header, editorState?: pxt.editor.EditorState): Promise<void> {
         if (!h)
             return Promise.resolve()
 
@@ -1393,48 +1393,45 @@ export class ProjectView
         if (checkAsync)
             return checkAsync.then(() => this.openHome());
 
-        let p = Promise.resolve();
         // check our multi-tab session
         if (workspace.isHeadersSessionOutdated()) {
             // reload header before loading
             pxt.log(`multi-tab sync before load`)
-            p = p.then(() => workspace.syncAsync().then(() => { }))
+            await workspace.syncAsync();
         }
 
         // Try a quick cloud fetch. If it doesn't complete within X second(s),
         // continue on.
+        const TIMEOUT_MS = 15000;
         const timeoutStart = Util.nowSeconds();
         let timedOut = false;
-        p = p.then(() => {
-            Promise.race([
-                pxt.U.delay(1500)
-                    .then(() => { timedOut = true }),
-                cloud.syncAsync([h])
-                    .then(changes => {
-                        if (changes.length) {
-                            const elapsed = Util.nowSeconds() - timeoutStart;
-                            if (timedOut) {
-                                // We are too late; the editor has already been loaded.
-                                // Call the onChanges handler to update the editor.
-                                pxt.tickEvent(`identity.syncOnProjectOpen.timedout`, { 'elapsedSec': elapsed })
-                                if (changes.some(header => header.id === h.id))
-                                    cloud.forceReloadForCloudSync()
-                            } else {
-                                // We're not too late, update the local var so that the
-                                // first load has the new info.
-                                pxt.tickEvent(`identity.syncOnProjectOpen.syncSuccess`, { 'elapsedSec': elapsed })
-                                h = workspace.getHeader(h.id)
-                            }
+        await Promise.race([
+            pxt.U.delay(TIMEOUT_MS)
+                .then(() => { timedOut = true }),
+            cloud.syncAsync([h])
+                .then(changes => {
+                    if (changes.length) {
+                        const elapsed = Util.nowSeconds() - timeoutStart;
+                        if (timedOut) {
+                            // We are too late; the editor has already been loaded.
+                            // Call the onChanges handler to update the editor.
+                            pxt.tickEvent(`identity.syncOnProjectOpen.timedout`, { 'elapsedSec': elapsed })
+                            if (changes.some(header => header.id === h.id))
+                                cloud.forceReloadForCloudSync()
+                        } else {
+                            // We're not too late, update the local var so that the
+                            // first load has the new info.
+                            pxt.tickEvent(`identity.syncOnProjectOpen.syncSuccess`, { 'elapsedSec': elapsed })
+                            h = workspace.getHeader(h.id)
                         }
-                    })
-            ]);
-        });
+                    }
+                })
+        ]);
 
-        return p.then(() => {
+        if (h) {
             workspace.acquireHeaderSession(h);
-            if (!h) return Promise.resolve();
-            else return this.internalLoadHeaderAsync(h, editorState);
-        })
+            await this.internalLoadHeaderAsync(h, editorState);
+        }
     }
 
     private internalLoadHeaderAsync(h: pxt.workspace.Header, editorState?: pxt.editor.EditorState): Promise<void> {


### PR DESCRIPTION
When the user clicks a project to open it, we try to pull the latest version from the cloud before loading it into the editor. This process involves a variable number of asynchronous steps. The prior implementation chained these steps together as a set of `then` clauses appended to a resolved promise. It isn't entirely clear why, but this wasn't working correctly; the chained `then` clauses weren't executing in the expected order. This resulted in the project being loaded into the editor before the cloud sync completed. Note: This is a common pattern in the codebase, which is worrisome. I wonder if we were previously relying on a Bluebird-specific behavior.

I also increased the cloud sync timeout from 1.5 to 15 secs. I'd rather be generous here, and looking at the telemetry from different geographical regions, 1.5 secs is too short.

Fixes https://github.com/microsoft/pxt-arcade/issues/3549
