### PR TITLE
Add warning when users use code incompatible with connected hardware

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -449,6 +449,7 @@ declare namespace pxt {
         downloadHelpURL?: string;
         firmwareHelpURL?: string;
         troubleshootWebUSBHelpURL?: string;
+        incompatibleHardwareHelpUrl?: string;
 
         dragFileImage?: string;
         connectDeviceImage?: string;
@@ -1037,7 +1038,7 @@ declare namespace pxt.tutorial {
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
         customTs?: string; // custom typescript code loaded in a separate file for the tutorial
-        tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated 
+        tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated
     }
 
     interface TutorialMetadata {
@@ -1102,7 +1103,7 @@ declare namespace pxt.tutorial {
         assetFiles?: pxt.Map<string>;
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
         customTs?: string; // custom typescript code loaded in a separate file for the tutorial
-        tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated 
+        tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -449,7 +449,7 @@ declare namespace pxt {
         downloadHelpURL?: string;
         firmwareHelpURL?: string;
         troubleshootWebUSBHelpURL?: string;
-        incompatibleHardwareHelpUrl?: string;
+        incompatibleHardwareHelpURL?: string;
 
         dragFileImage?: string;
         connectDeviceImage?: string;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -405,6 +405,7 @@ namespace pxt.editor {
         saveProjectAsync?: (project: pxt.cpp.HexFile) => Promise<void>;
         renderBrowserDownloadInstructions?: () => any /* JSX.Element */;
         renderUsbPairDialog?: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */;
+        renderIncompatibleHardwareDialog?: (unsupportedParts: string[]) => any /* JSX.Element */;
         showUploadInstructionsAsync?: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void>;
         toolboxOptions?: IToolboxOptions;
         blocklyPatch?: (pkgTargetVersion: string, dom: Element) => void;

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -17,6 +17,7 @@ namespace pxt.commands {
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
     export let renderBrowserDownloadInstructions: () => any /* JSX.Element */ = undefined;
     export let renderUsbPairDialog: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */ = undefined;
+    export let renderIncompatibleHardwareDialog: (unsupportedParts: string[]) => any /* JSX.Element */ = undefined;
     export let renderDisconnectDialog: () => { header: string, jsx: any, helpUrl: string }
     export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void> = undefined;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;

--- a/pxtlib/packetio.ts
+++ b/pxtlib/packetio.ts
@@ -18,6 +18,9 @@ namespace pxt.packetio {
 
         onCustomEvent: (type: string, payload: Uint8Array) => void;
         sendCustomEventAsync(type: string, payload: Uint8Array): Promise<void>;
+        // returns a list of part ids that are not supported by the connected hardware. currently
+        // only used by pxt-microbit to warn users about v2 blocks on v1 hardware
+        unsupportedParts?(): string[];
     }
 
     export interface PacketIO {
@@ -73,6 +76,10 @@ namespace pxt.packetio {
 
     export function icon() {
         return !!wrapper && (wrapper.icon || pxt.appTarget.appTheme.downloadDialogTheme?.deviceIcon || "usb");
+    }
+
+    export function unsupportedParts() {
+        return wrapper?.unsupportedParts ? wrapper.unsupportedParts() : [];
     }
 
     let disconnectPromise: Promise<void>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2654,7 +2654,7 @@ export class ProjectView
 
     beforeCompile() { }
 
-    compile(saveOnly = false) {
+    async compile(saveOnly = false): Promise<void> {
         pxt.tickEvent("compile", { editor: this.getPreferredEditor() });
         pxt.debug('compiling...');
 
@@ -2691,90 +2691,105 @@ export class ProjectView
             if (simRestart) this.stopSimulator();
             let state = this.editor.snapshotState()
             this.syncPreferredEditor()
-            compiler.compileAsync({ native: true, forceEmit: true })
-                .then<pxtc.CompileResult>(resp => {
-                    this.editor.setDiagnostics(this.editorFile, state)
 
-                    let fn = pxt.outputName()
-                    if (!resp.outfiles[fn]) {
-                        pxt.tickEvent("compile.noemit")
-                        const noHexFileDiagnostic = resp.diagnostics?.find(diag => diag.code === 9043);
-                        if (noHexFileDiagnostic) {
-                            core.warningNotification(noHexFileDiagnostic.messageText as string);
-                        } else {
-                            core.warningNotification(lf("Compilation failed, please check your code for errors."));
-                        }
-                        return Promise.resolve(null)
-                    }
-                    resp.saveOnly = saveOnly
-                    resp.userContextWindow = userContextWindow;
-                    resp.downloadFileBaseName = pkg.genFileName("");
-                    resp.confirmAsync = core.confirmAsync;
-                    let h = this.state.header
-                    if (h)
-                        resp.headerId = h.id
-                    if (pxt.commands.patchCompileResultAsync)
-                        return pxt.commands.patchCompileResultAsync(resp).then(() => resp)
-                    else
-                        return resp
-                }).then(resp => {
-                    if (!resp) return Promise.resolve();
-                    if (saveOnly) {
-                        return pxt.commands.saveOnlyAsync(resp);
-                    }
-                    if (!resp.success) {
-                        if (!this.maybeShowPackageErrors(true)) {
-                            core.confirmAsync({
-                                header: lf("Compilation failed"),
-                                body: lf("Ooops, looks like there are errors in your program."),
-                                hideAgree: true,
-                                disagreeLbl: lf("Close")
-                            });
-                        }
-                    }
+            try {
+                const resp = await compiler.compileAsync({ native: true, forceEmit: true });
+                this.editor.setDiagnostics(this.editorFile, state);
 
-                    // restart sim early before deployment
-                    if (simRestart) {
-                        this.runSimulator();
-                        simRestart = false
-                    }
+                if (!saveOnly) {
+                    const shouldContinue = await cmds.showUnsupportedHardwareMessageAsync(resp);
+                    if (!shouldContinue) return;
+                }
 
-                    // hardware deployment
-                    let deployStartTime = Date.now()
-                    pxt.tickEvent("deploy.start")
-                    return pxt.commands.deployAsync(resp, {
+                let fn = pxt.outputName();
+                if (!resp.outfiles[fn]) {
+                    pxt.tickEvent("compile.noemit")
+                    const noHexFileDiagnostic = resp.diagnostics?.find(diag => diag.code === 9043);
+                    if (noHexFileDiagnostic) {
+                        core.warningNotification(noHexFileDiagnostic.messageText as string);
+                    } else {
+                        core.warningNotification(lf("Compilation failed, please check your code for errors."));
+                    }
+                    return;
+                }
+                resp.saveOnly = saveOnly;
+                resp.userContextWindow = userContextWindow;
+                resp.downloadFileBaseName = pkg.genFileName("");
+                resp.confirmAsync = core.confirmAsync;
+                let h = this.state.header;
+                if (h) {
+                    resp.headerId = h.id;
+                }
+                if (pxt.commands.patchCompileResultAsync) {
+                    await pxt.commands.patchCompileResultAsync(resp);
+                }
+
+                if (saveOnly) {
+                    await pxt.commands.saveOnlyAsync(resp);
+                    return;
+                }
+
+                if (!resp.success) {
+                    if (!this.maybeShowPackageErrors(true)) {
+                        core.confirmAsync({
+                            header: lf("Compilation failed"),
+                            body: lf("Ooops, looks like there are errors in your program."),
+                            hideAgree: true,
+                            disagreeLbl: lf("Close")
+                        });
+                    }
+                }
+
+                // restart sim early before deployment
+                if (simRestart) {
+                    this.runSimulator();
+                    simRestart = false
+                }
+
+                // hardware deployment
+                let deployStartTime = Date.now()
+                pxt.tickEvent("deploy.start")
+
+                try {
+                    await pxt.commands.deployAsync(resp, {
                         reportError: (e) => {
-                            pxt.tickEvent("deploy.reporterror")
-                            return core.errorNotification(e)
+                            pxt.tickEvent("deploy.reporterror");
+                            core.errorNotification(e);
                         },
                         showNotification: (msg) => core.infoNotification(msg)
                     })
-                        .then(() => {
-                            let elapsed = Date.now() - deployStartTime
-                            pxt.tickEvent("deploy.finished", { "elapsedMs": elapsed })
-                        })
-                        .catch(e => {
-                            if (e.notifyUser) {
-                                core.warningNotification(e.message);
-                            } else {
-                                const errorText = pxt.appTarget.appTheme.useUploadMessage ? lf("Upload failed, please try again.") : lf("Download failed, please try again.");
-                                core.warningNotification(errorText);
-                            }
-                            let elapsed = Date.now() - deployStartTime
-                            pxt.tickEvent("deploy.exception", { "notifyUser": e.notifyUser, "elapsedMs": elapsed })
-                            pxt.reportException(e);
-                            if (userContextWindow)
-                                try { userContextWindow.close() } catch (e) { }
-                        })
-                }).catch((e: Error) => {
+
+                    let elapsed = Date.now() - deployStartTime;
+                    pxt.tickEvent("deploy.finished", { "elapsedMs": elapsed });
+                }
+                catch (e) {
+                    if (e.notifyUser) {
+                        core.warningNotification(e.message);
+                    } else {
+                        const errorText = pxt.appTarget.appTheme.useUploadMessage ? lf("Upload failed, please try again.") : lf("Download failed, please try again.");
+                        core.warningNotification(errorText);
+                    }
+                    let elapsed = Date.now() - deployStartTime;
+                    pxt.tickEvent("deploy.exception", { "notifyUser": e.notifyUser, "elapsedMs": elapsed });
                     pxt.reportException(e);
-                    core.errorNotification(lf("Compilation failed, please contact support."));
-                    if (userContextWindow)
-                        try { userContextWindow.close() } catch (e) { }
-                }).finally(() => {
-                    this.setState({ compiling: false, isSaving: false });
-                    if (simRestart) this.runSimulator();
-                });
+                    if (userContextWindow) {
+                        try {
+                            userContextWindow.close()
+                        } catch (e) {
+                        }
+                    }
+                }
+            }
+            catch (e) {
+                pxt.reportException(e);
+                core.errorNotification(lf("Compilation failed, please contact support."));
+                if (userContextWindow)
+                    try { userContextWindow.close() } catch (e) { }
+            }
+            finally {
+                this.setState({ compiling: false, isSaving: false });
+                if (simRestart) this.runSimulator();
+            }
         } catch (e) {
             this.setState({ compiling: false, isSaving: false });
             pxt.reportException(e);

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -643,7 +643,7 @@ export function showUnsupportedHardwareMessageAsync(resp: pxtc.CompileResult) {
         pxt.tickEvent('unsupportedhardwaredialog.shown')
 
         const body = jsx ? undefined : lf("Oops! Looks like your project has code that won't run on the hardware you have connected. Would you like to download anyway?");
-        const helpUrl = pxt.appTarget.appTheme.downloadDialogTheme?.incompatibleHardwareHelpUrl;
+        const helpUrl = pxt.appTarget.appTheme.downloadDialogTheme?.incompatibleHardwareHelpURL;
         let cancelled = true;
         return core.confirmAsync({
             header: lf("Incompatible Code"),

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -317,6 +317,10 @@ function applyExtensionResult() {
         log(`extension renderUsbPairDialog`)
         pxt.commands.renderUsbPairDialog = res.renderUsbPairDialog;
     }
+    if (res.renderIncompatibleHardwareDialog) {
+        log(`extension renderIncompatibleHardwareDialog`)
+        pxt.commands.renderIncompatibleHardwareDialog = res.renderIncompatibleHardwareDialog;
+    }
     if (res.showUploadInstructionsAsync) {
         log(`extension upload instructions async`);
         pxt.commands.showUploadInstructionsAsync = res.showUploadInstructionsAsync;
@@ -617,6 +621,53 @@ function handlePacketIOApi(r: string) {
     }
     return false;
 }
+
+export function showUnsupportedHardwareMessageAsync(resp: pxtc.CompileResult) {
+    const unsupportedParts = pxt.packetio.unsupportedParts();
+    const parts = pxtc.computeUsedParts(resp);
+
+    let unsupported: string[] = [];;
+    for (const part of unsupportedParts) {
+        if (parts.indexOf(part) !== -1) {
+            unsupported.push(part);
+            break;
+        }
+    }
+
+    if (unsupported.length) {
+        let jsx: JSX.Element;
+        if (pxt.commands.renderIncompatibleHardwareDialog) {
+            jsx = pxt.commands.renderIncompatibleHardwareDialog(unsupported);
+        }
+
+        const body = jsx && lf("Oops! Looks like your project has code that won't run on the hardware you have connected. Would you like to download anyway?");
+        const helpUrl = "about:blank";
+        let cancelled = true;
+        return core.confirmAsync({
+            header: lf("Incompatible Code"),
+            body,
+            jsx,
+            hasCloseIcon: true,
+            hideAgree: true,
+            helpUrl,
+            bigHelpButton: true,
+            className: 'downloaddialog',
+            buttons: [
+                {
+                    label: lf("Download Anyway"),
+                    className: "primary",
+                    onclick: () => {
+                        pxt.tickEvent('unsupportedhardwaredialog.downloadagain')
+                        cancelled = false;
+                        core.hideDialog();
+                    }
+                },
+            ]
+        }).then(() => !cancelled);
+    }
+    return Promise.resolve(true);
+}
+
 data.mountVirtualApi("packetio", {
     getSync: handlePacketIOApi
 });

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -640,7 +640,9 @@ export function showUnsupportedHardwareMessageAsync(resp: pxtc.CompileResult) {
             jsx = pxt.commands.renderIncompatibleHardwareDialog(unsupported);
         }
 
-        const body = jsx && lf("Oops! Looks like your project has code that won't run on the hardware you have connected. Would you like to download anyway?");
+        pxt.tickEvent('unsupportedhardwaredialog.shown')
+
+        const body = jsx ? undefined : lf("Oops! Looks like your project has code that won't run on the hardware you have connected. Would you like to download anyway?");
         const helpUrl = pxt.appTarget.appTheme.downloadDialogTheme?.incompatibleHardwareHelpUrl;
         let cancelled = true;
         return core.confirmAsync({
@@ -663,7 +665,13 @@ export function showUnsupportedHardwareMessageAsync(resp: pxtc.CompileResult) {
                     }
                 },
             ]
-        }).then(() => !cancelled);
+        }).then(() => {
+            if (cancelled) {
+                pxt.tickEvent('unsupportedhardwaredialog.cancelled')
+            }
+
+            return !cancelled;
+        });
     }
     return Promise.resolve(true);
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -641,7 +641,7 @@ export function showUnsupportedHardwareMessageAsync(resp: pxtc.CompileResult) {
         }
 
         const body = jsx && lf("Oops! Looks like your project has code that won't run on the hardware you have connected. Would you like to download anyway?");
-        const helpUrl = "about:blank";
+        const helpUrl = pxt.appTarget.appTheme.downloadDialogTheme?.incompatibleHardwareHelpUrl;
         let cancelled = true;
         return core.confirmAsync({
             header: lf("Incompatible Code"),


### PR DESCRIPTION
<img width="857" alt="Screen Shot 2021-06-02 at 4 37 42 PM" src="https://user-images.githubusercontent.com/13754588/120564961-e2bb6080-c3c0-11eb-9db2-93067bd11fbf.png">


This adds a warning when users use code incompatible with connected hardware. I determine what hardware is used via the parts annotations (e.g. `//% parts="builtinspeaker"`). The packetio implementation in the target can optionally define a function called `unsupportedParts` that returns a list of unsupported part annotation ids.

If anything unsupported is used, you get a warning when you download. Clicking "download anyway" will predictable ignore the issues. I'll have a PR in pxt-microbit soon that does the target side of this. Also, I expect the design/text will likely get tweaked down the road.

p.s. this PR looks scarier than it is because I refactored the compile method to use async await (it had three nested promise chains). [ignore whitespace](https://github.com/microsoft/pxt/pull/8213/files?w=1) to make it a little easier to read