### PR TITLE
Don't sync cloud when resolving conflict

### DIFF
--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -262,7 +262,7 @@ async function resolveConflict(local: Header, remoteFile: File) {
         if (app.hasEditor()) {
             const editor = await app.getEditorAsync();
             if (!editor.state.home && editor.state.header?.id === local.id) {
-                await editor.loadHeaderAsync(newCopyHdr, editor.state.editorState);
+                await editor.loadHeaderAsync(newCopyHdr, editor.state.editorState, false);
             }
         }
     } catch (e) {


### PR DESCRIPTION
This is a targeted fix on top of a previous tactical change. Some background: As part of integrating cloud sync into the existing workspace code, we made the tactical decision to add a quick cloud sync whenever a project is being loaded into the editor. This is to ensure that the latest version is being loaded. This cloud check has a timeout that I recently increased from 1.5s to 15s. Cut over to the cloud sync code: The process of saving a project to the cloud includes an etag check on the backend, and if that check fails that indicates a conflict. We handle the conflict by duplicating the project and loading the new one into the editor. After I increased the aforementioned timeout to 15 secs, it became obvious that conflict resolution codepath was somehow entangled with the cloud check timeout, as it would wait 15 secs after a conflict to load the duplicated project. The root cause lies in some convoluted sync code that ended up with two promises waiting on each other to resolve, and would have been a deadlock were it not for the timeout eject. 

The targeted fix: it was unnecessary to do the cloud check on the duplicated level in the first place, so I made it conditional.

The cloud check is done in `loadHeaderAsync`, and we call this method from a _lot_ of places. I'm not certain it should be doing a cloud check every time. Something to know as it could be a source of difficult to explain behavior.

Fixes https://github.com/microsoft/pxt-arcade/issues/3562