### PR TITLE
Fix issue of loading JS editor when exiting extensions

### DIFF
--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -54,9 +54,9 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         this.backOnHide = this.backOnHide.bind(this);
     }
 
-    private hide(back?: boolean) {
+    private hide(evt?: any, back?: boolean) {
         this.setState({ visible: false });
-        if (back) this.props.parent.openPreviousEditor();
+        if (back === true) this.props.parent.openPreviousEditor();
         // something changed?
         if (this.state.mode == ScriptSearchMode.Experiments &&
             this.state.experimentsState !== pxt.editor.experiments.state())
@@ -246,7 +246,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
     }
 
     addUrl(scr: pxt.Cloud.JsonScript) {
-        this.hide(this.backOnHide());
+        this.hide(null, this.backOnHide());
         let p = pkg.mainEditorPkg();
         return p.setDependencyAsync(scr.name, "pub:" + scr.id)
             .then(() => this.props.parent.reloadHeaderAsync())
@@ -255,14 +255,14 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
     addBundle(scr: pxt.PackageConfig) {
         pxt.tickEvent("packages.bundled", { name: scr.name });
-        this.hide(this.backOnHide());
+        this.hide(null, this.backOnHide());
         this.addDepIfNoConflict(scr, "*")
             .finally(() => this.afterHide());
     }
 
     addLocal(hd: pxt.workspace.Header) {
         pxt.tickEvent("packages.local");
-        this.hide(this.backOnHide());
+        this.hide(null, this.backOnHide());
         workspace.getTextAsync(hd.id)
             .then(files => {
                 let cfg = JSON.parse(files[pxt.CONFIG_NAME]) as pxt.PackageConfig
@@ -273,7 +273,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
     async installGh(scr: pxt.github.GitRepo) {
         pxt.tickEvent("packages.github", { name: scr.fullName });
-        this.hide(this.backOnHide());
+        this.hide(null, this.backOnHide());
         let r: { version: string, config: pxt.PackageConfig };
         try {
             core.showLoading("downloadingpackage", lf("downloading extension..."));
@@ -289,7 +289,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
     async addDepIfNoConflict(config: pxt.PackageConfig, version: string) {
         try {
-            this.hide(this.backOnHide());
+            this.hide(null, this.backOnHide());
             core.showLoading("installingextension", lf("installing extension..."))
             const added = await pkg.mainEditorPkg()
                 .addDependencyAsync(config, version, this.state.mode == ScriptSearchMode.Boards)
@@ -310,7 +310,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
 
     importExtensionFile() {
         pxt.tickEvent("extensions.import", undefined, { interactiveConsent: true });
-        this.hide(this.backOnHide());
+        this.hide(null, this.backOnHide());
         this.props.parent.showImportFileDialog({ extension: true });
     }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4135

we pass `hide` as the onClick callback for the modal, so the first argument is actually the click event.