### PR TITLE
Added Strict Rule: Required Blocks

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1072,6 +1072,7 @@ declare namespace pxt.tutorial {
         contentMd?: string;
         headerContentMd?: string;
         hintContentMd?: string;
+        requiredBlockMd?: string;
         activity?: number;
         resetDiff?: boolean; // reset diffify algo
         listOfValidationRules?: pxt.tutorial.TutorialRuleStatus[]; // Whether the user code has been marked valid for these set of rules

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -60,12 +60,14 @@ namespace pxt.tutorial {
     */
     function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
         let listOfRuleStatuses: TutorialRuleStatus[] = [];
-        const ruleNames: string[] = Object.keys(listOfRules);
-        for (let i = 0; i < ruleNames.length; i++) {
-            const currRule: string = ruleNames[i];
-            const ruleVal: boolean = listOfRules[currRule];
-            const currRuleStatus: TutorialRuleStatus = { ruleName: currRule, ruleTurnOn: ruleVal };
-            listOfRuleStatuses.push(currRuleStatus);
+        if (listOfRules != undefined) {
+            const ruleNames: string[] = Object.keys(listOfRules);
+            for (let i = 0; i < ruleNames.length; i++) {
+                const currRule: string = ruleNames[i];
+                const ruleVal: boolean = listOfRules[currRule];
+                const currRuleStatus: TutorialRuleStatus = { ruleName: currRule, ruleTurnOn: ruleVal };
+                listOfRuleStatuses.push(currRuleStatus);
+            }
         }
         return listOfRuleStatuses;
     }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -84,8 +84,8 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                         throw new Error("blocksXml failed to load");
                     }
                     const allblocks = headless.getAllBlocks();
+                    snippetBlocks[snippetHash] = {}
                     for (let bi = 0; bi < allblocks.length; ++bi) {
-                        if (!snippetBlocks[snippetHash]) snippetBlocks[snippetHash] = {}
                         const blk = allblocks[bi];
                         if (!blk.isShadow()) {
                             if (!snippetBlocks[snippetHash][blk.type]) {


### PR DESCRIPTION
### Markdown
Under each tutorial step, the tutorial maker will have the ability to inform the user that a block or blocks are required for a tutorial step. To enable required blocks in markdown, the tutorial maker must use...

```
```requiredTutorialBlock
[Insert block here]
```'
```

### Behavior

 A custom pop-up message will appear informing the user what blocks they are required to use. In the screenshot below, this rule is combined with other rules.
![Screenshot (40)](https://user-images.githubusercontent.com/13580493/120845720-0a780900-c526-11eb-8479-96af89795fc7.png)

This rule can be used as a standalone too, but if a step does not have required block specified, the 'next' button will turn green. 
![required blocks behavior stand alone ](https://user-images.githubusercontent.com/13580493/120846694-5aa39b00-c527-11eb-90ff-018def1aded5.gif)



