### PR TITLE
Initial Telemetry for Tutorial Validation

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -16,6 +16,7 @@ namespace pxt.tutorial {
         let tutorialValidationRules: pxt.Map<boolean>;
         if (metadata.tutorialCodeValidation) {
             tutorialValidationRules = pxt.Util.jsonTryParse(tutorialValidationRulesStr);
+            categorizingValidationRules(tutorialValidationRules);
         }
 
         // noDiffs legacy
@@ -303,6 +304,27 @@ ${code}
             }
         }
         return { header, hint, requiredBlocks };
+    }
+
+    function categorizingValidationRules(listOfRules: pxt.Map<boolean>) {
+        const ruleNames: string[] = Object.keys(listOfRules);
+        let enabledRulesMessageArr: string[] = [];
+        let turnedOffRulesMessageArr: string[] = [];
+        for (let i = 0; i < ruleNames.length; i++) {
+            const currRule: string = ruleNames[i];
+            const ruleVal: boolean = listOfRules[currRule];
+            if (ruleVal) {
+                enabledRulesMessageArr.push(currRule);
+            } else {
+                turnedOffRulesMessageArr.push(currRule);
+            }
+        }
+        const enabledRulesMessage = enabledRulesMessageArr.join(', ');
+        const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
+        let enabledRulesMap: pxt.Map<string> = {};
+        enabledRulesMap['enableRules'] = enabledRulesMessage;
+        enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
+        pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
     }
 
     /* Remove hidden snippets from text */

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -323,7 +323,7 @@ ${code}
         const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
         let enabledRulesMap: pxt.Map<string> = {};
         enabledRulesMap['enableRules'] = enabledRulesMessage;
-        enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
+        enabledRulesMap['notEnableRules'] = turnedOffRulesMessage;
         pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
     }
 

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -61,13 +61,26 @@ namespace pxt.tutorial {
     function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
         let listOfRuleStatuses: TutorialRuleStatus[] = [];
         if (listOfRules != undefined) {
+            let enabledRulesMessageArr: string[] = [];
+            let turnedOffRulesMessageArr: string[] = [];
             const ruleNames: string[] = Object.keys(listOfRules);
             for (let i = 0; i < ruleNames.length; i++) {
                 const currRule: string = ruleNames[i];
                 const ruleVal: boolean = listOfRules[currRule];
                 const currRuleStatus: TutorialRuleStatus = { ruleName: currRule, ruleTurnOn: ruleVal };
                 listOfRuleStatuses.push(currRuleStatus);
+                if (ruleVal) {
+                    enabledRulesMessageArr.push(currRule);
+                } else {
+                    turnedOffRulesMessageArr.push(currRule);
+                }
             }
+            const enabledRulesMessage = enabledRulesMessageArr.join(', ');
+            const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
+            let enabledRulesMap: pxt.Map<string> = {};
+            enabledRulesMap['enableRules'] = enabledRulesMessage;
+            enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
+            pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
         }
         return listOfRuleStatuses;
     }

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -61,26 +61,13 @@ namespace pxt.tutorial {
     function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
         let listOfRuleStatuses: TutorialRuleStatus[] = [];
         if (listOfRules != undefined) {
-            let enabledRulesMessageArr: string[] = [];
-            let turnedOffRulesMessageArr: string[] = [];
             const ruleNames: string[] = Object.keys(listOfRules);
             for (let i = 0; i < ruleNames.length; i++) {
                 const currRule: string = ruleNames[i];
                 const ruleVal: boolean = listOfRules[currRule];
                 const currRuleStatus: TutorialRuleStatus = { ruleName: currRule, ruleTurnOn: ruleVal };
                 listOfRuleStatuses.push(currRuleStatus);
-                if (ruleVal) {
-                    enabledRulesMessageArr.push(currRule);
-                } else {
-                    turnedOffRulesMessageArr.push(currRule);
-                }
             }
-            const enabledRulesMessage = enabledRulesMessageArr.join(', ');
-            const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
-            let enabledRulesMap: pxt.Map<string> = {};
-            enabledRulesMap['enableRules'] = enabledRulesMessage;
-            enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
-            pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
         }
         return listOfRuleStatuses;
     }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -412,11 +412,10 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.props.parent.setTutorialStep(previousStep);
 
         const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
-        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) {
+        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) { // disables tutorial validation pop-up if previous buttion is clicked
             const stepInfo = options.tutorialStepInfo[currentStep];
             const sortedValidAndInvalidRules = this.classifyingValidAndInvalidRules(stepInfo.listOfValidationRules);
-            pxt.tickEvent('tutorial.validation.clickedPrevious ', sortedValidAndInvalidRules);
-            console.log('tutorial.validation.clickedPrevious ', sortedValidAndInvalidRules);
+            pxt.tickEvent('tutorial.validation.clickedPreviousBttn ', sortedValidAndInvalidRules);
             this.setState({ showUnusedBlockMessage: false });
         }
     }
@@ -433,11 +432,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.props.parent.setTutorialStep(nextStep);
 
         const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
-        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) {
-            const stepInfo = options.tutorialStepInfo[currentStep];
-            const sortedValidAndInvalidRules = this.classifyingValidAndInvalidRules(stepInfo.listOfValidationRules);
-            pxt.tickEvent('tutorial.validation.clickedNext ', sortedValidAndInvalidRules);
-            console.log('tutorial.validation.clickedNext ', sortedValidAndInvalidRules);
+        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) { // disables tutorial validation pop-up if next buttion is clicked
             this.setState({ showUnusedBlockMessage: false });
         }
     }
@@ -639,14 +634,13 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             this.props.parent.setHintSeen(currentStep);
         }
         th.showHint(visible, showFullText);
-        if (visible) {
+        if (visible) { // disables tutorial validation pop-up if hint is clicked
             const options = this.props.parent.state.tutorialOptions;
             const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
             if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) {
                 const stepInfo = options.tutorialStepInfo[currentStep];
                 const sortedValidAndInvalidRules = this.classifyingValidAndInvalidRules(stepInfo.listOfValidationRules);
                 pxt.tickEvent('tutorial.validation.clickedHint ', sortedValidAndInvalidRules);
-                console.log('tutorial.validation.clickedHint ', sortedValidAndInvalidRules);
                 this.setState({ showUnusedBlockMessage: false });
             }
         }
@@ -685,8 +679,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                 }
             }
         }
-        const codeValidListStr = this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeValidList.join(', ');
-        const codeInValidListStr = this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeInValidList.join(', ');
+        const codeValidListStr = "step " + this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeValidList.join(', ');
+        const codeInValidListStr = "step " + this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeInValidList.join(', ');
         turnedOnRulesList["codeValid"] = codeValidListStr;
         turnedOnRulesList["codeInvalid"] = codeInValidListStr;
         return turnedOnRulesList;

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -31,12 +31,28 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
         this.setState({ visible: vis });
     }
 
+    collectingTurnedOnRulesList(rules: pxt.tutorial.TutorialRuleStatus[]) {
+        let turnedOnRulesList: pxt.Map<string> = {};
+        if (rules != undefined) {
+            for (let i = 0; i < rules.length; i++) {
+                if (rules[i].ruleTurnOn) {
+                    turnedOnRulesList[rules[i].ruleName] = rules[i].ruleStatus + '';
+                }
+            }
+        }
+        return turnedOnRulesList;
+    }
+
     moveOnToNextTutorialStep() {
+        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
+        pxt.tickEvent('tutorial.validation.next ', listOfTurnedOnRules);
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
+        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
+        pxt.tickEvent('tutorial.validation.stay ', listOfTurnedOnRules);
         this.props.onNoButtonClick();
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -36,16 +36,14 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
 
     moveOnToNextTutorialStep() {
         const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
-        pxt.tickEvent('tutorial.validation.next ', sortedValidAndInvalidRules);
-        console.log('tutorial.validation.next ', sortedValidAndInvalidRules)
+        pxt.tickEvent('tutorial.validation.continueAnyway ', sortedValidAndInvalidRules);
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
         const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
-        pxt.tickEvent('tutorial.validation.stay ', sortedValidAndInvalidRules);
-        console.log('tutorial.validation.stay ', sortedValidAndInvalidRules);
+        pxt.tickEvent('tutorial.validation.keepEditing ', sortedValidAndInvalidRules);
         this.props.onNoButtonClick();
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -14,6 +14,7 @@ interface TutorialCodeValidationProps extends ISettingsProps {
     isTutorialCodeInvalid: boolean;
     ruleComponents: pxt.tutorial.TutorialRuleStatus[];
     areStrictRulesPresent: boolean;
+    codeValidAndInvalidRuleMap: pxt.Map<string>;
 }
 
 interface tutorialCodeValidationState {
@@ -31,28 +32,20 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
         this.setState({ visible: vis });
     }
 
-    collectingTurnedOnRulesList(rules: pxt.tutorial.TutorialRuleStatus[]) {
-        let turnedOnRulesList: pxt.Map<string> = {};
-        if (rules != undefined) {
-            for (let i = 0; i < rules.length; i++) {
-                if (rules[i].ruleTurnOn) {
-                    turnedOnRulesList[rules[i].ruleName] = rules[i].ruleStatus + '';
-                }
-            }
-        }
-        return turnedOnRulesList;
-    }
+
 
     moveOnToNextTutorialStep() {
-        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
-        pxt.tickEvent('tutorial.validation.next ', listOfTurnedOnRules);
+        const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
+        pxt.tickEvent('tutorial.validation.next ', sortedValidAndInvalidRules);
+        console.log('tutorial.validation.next ', sortedValidAndInvalidRules)
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
-        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
-        pxt.tickEvent('tutorial.validation.stay ', listOfTurnedOnRules);
+        const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
+        pxt.tickEvent('tutorial.validation.stay ', sortedValidAndInvalidRules);
+        console.log('tutorial.validation.stay ', sortedValidAndInvalidRules);
         this.props.onNoButtonClick();
     }
 


### PR DESCRIPTION
Added telemetry to indicate

- a map of rules that are enabled/ not enabled 
- a map of valid and invalid code for ...
    - when the user clicks pop-message button "continue anyway"
    - when the user clicks pop-message button "keep editing"
    - when the user clicks hint button with pop up still in view
    - when the user clicks the previous button with pop-up still in view


Below is a sample console.log of the telemetry: 
![Screenshot (43)](https://user-images.githubusercontent.com/13580493/120867873-ac5c1d80-c547-11eb-85be-71024916fb20.png)
