### PR TITLE
Handle generics from array methods in pyconverter

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2048,7 +2048,7 @@ namespace pxt.py {
 
             let fun = namedSymbol
 
-            let recvTp: Type
+            let recvTp: Type | undefined = undefined;
             let recv: py.Expr | undefined = undefined
             let methName: string = ""
 
@@ -2222,7 +2222,13 @@ namespace pxt.py {
             if (fun) {
                 if (!fun.pyRetType)
                     error(n, 9549, lf("function missing pyRetType"));
-                unifyTypeOf(n, fun.pyRetType!)
+
+                if (isGenericType(fun.pyRetType!) && recv && isArrayType(recv) && recvTp) {
+                    unifyTypeOf(n, recvTp.typeArgs![0])
+                }
+                else {
+                    unifyTypeOf(n, fun.pyRetType!)
+                }
                 n.symbolInfo = fun
 
                 if (fun.attributes.py2tsOverride) {

--- a/tests/pyconverter-test/baselines/array_generics2.ts
+++ b/tests/pyconverter-test/baselines/array_generics2.ts
@@ -1,0 +1,2 @@
+let obstacles : number[][] = []
+obstacles.removeAt(0).removeAt(0)

--- a/tests/pyconverter-test/baselines/array_generics3.ts
+++ b/tests/pyconverter-test/baselines/array_generics3.ts
@@ -1,0 +1,3 @@
+let x = [[0]]
+let y = x.removeAt(0)
+y.length

--- a/tests/pyconverter-test/baselines/array_generics4.ts
+++ b/tests/pyconverter-test/baselines/array_generics4.ts
@@ -1,0 +1,8 @@
+let x = ["hello"]
+let y = null
+function whatever(arg: string) {
+    
+    y = arg
+}
+
+whatever(x.removeAt(0))

--- a/tests/pyconverter-test/baselines/array_generics5.ts
+++ b/tests/pyconverter-test/baselines/array_generics5.ts
@@ -1,0 +1,25 @@
+function f1() {
+    let a: string[];
+    let b: number[];
+    let c: string[];
+    let d: number[];
+    let e: string;
+    let f: number;
+    let g: string;
+    let h: number;
+    let x = ["a", "b", "c"]
+    let z = [0, 1, 2]
+    while (true) {
+        a = x.slice()
+        b = z.concat(z)
+        c = x.fill("u", 1, 1)
+        d = z.filter(function filt(a: any): boolean {
+            return true
+        })
+        e = x.removeAt(1)
+        f = z.shift()
+        g = x.get(0)
+        h = z._pickRandom()
+    }
+}
+

--- a/tests/pyconverter-test/baselines/array_generics_map.ts
+++ b/tests/pyconverter-test/baselines/array_generics_map.ts
@@ -1,0 +1,10 @@
+function f1() {
+    let b: any[];
+    let x = ["a", "b", "c"]
+    while (true) {
+        b = x.map(function mapf(a: any): boolean {
+            return true
+        })
+    }
+}
+

--- a/tests/pyconverter-test/baselines/array_generics_reduce.ts
+++ b/tests/pyconverter-test/baselines/array_generics_reduce.ts
@@ -1,0 +1,14 @@
+function f1() {
+    let y: string;
+    let z: number;
+    let x = [1, 3, 4]
+    while (true) {
+        y = x.reduce(on_reduce, "hello")
+        z = x.reduce(on_reduce, 1)
+    }
+}
+
+function on_reduce(previousValue: any, currentValue: any, currentIndex: number) {
+    return previousValue + currentIndex
+}
+

--- a/tests/pyconverter-test/cases/array_generics2.py
+++ b/tests/pyconverter-test/cases/array_generics2.py
@@ -1,0 +1,2 @@
+obstacles: List[List[number]] = []
+obstacles.removeAt(0).removeAt(0)

--- a/tests/pyconverter-test/cases/array_generics3.py
+++ b/tests/pyconverter-test/cases/array_generics3.py
@@ -1,0 +1,3 @@
+x = [[0]]
+y = x.remove_at(0)
+y.length

--- a/tests/pyconverter-test/cases/array_generics4.py
+++ b/tests/pyconverter-test/cases/array_generics4.py
@@ -1,0 +1,8 @@
+x = ["hello"]
+y = None
+
+def whatever(arg):
+    global y
+    y = arg
+
+whatever(x.remove_at(0))

--- a/tests/pyconverter-test/cases/array_generics5.py
+++ b/tests/pyconverter-test/cases/array_generics5.py
@@ -1,0 +1,15 @@
+def f1():
+    x = ["a", "b", "c"]
+    z = [0, 1, 2]
+    while True:
+        a = x.slice()
+        b = z.concat(z)
+        c = x.fill("u", 1, 1)
+        d = z.filter(filt)
+        e = x.remove_at(1)
+        f = z.shift()
+        g = x.get(0)
+        h = z._pick_random()
+
+def filt(a):
+    return True

--- a/tests/pyconverter-test/cases/array_generics_map.py
+++ b/tests/pyconverter-test/cases/array_generics_map.py
@@ -1,0 +1,7 @@
+def f1():
+    x = ["a", "b", "c"]
+    while True:
+        b = x.map(mapf)
+
+def mapf(a):
+    return True

--- a/tests/pyconverter-test/cases/array_generics_reduce.py
+++ b/tests/pyconverter-test/cases/array_generics_reduce.py
@@ -1,0 +1,8 @@
+def f1():
+    x = [1, 3, 4]
+    while True:
+        y = x.reduce(on_reduce, "hello")
+        z = x.reduce(on_reduce, 1)
+
+def on_reduce(previousValue, currentValue, currentIndex):
+    return previousValue + currentIndex


### PR DESCRIPTION
We still don't support generics except for arrays

Fixes https://github.com/microsoft/pxt-microbit/issues/3579