### PR TITLE
Initial Telemetry for Tutorial Validation

### DIFF
--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -16,6 +16,7 @@ namespace pxt.tutorial {
         let tutorialValidationRules: pxt.Map<boolean>;
         if (metadata.tutorialCodeValidation) {
             tutorialValidationRules = pxt.Util.jsonTryParse(tutorialValidationRulesStr);
+            categorizingValidationRules(tutorialValidationRules);
         }
 
         // noDiffs legacy
@@ -303,6 +304,27 @@ ${code}
             }
         }
         return { header, hint, requiredBlocks };
+    }
+
+    function categorizingValidationRules(listOfRules: pxt.Map<boolean>) {
+        const ruleNames: string[] = Object.keys(listOfRules);
+        let enabledRulesMessageArr: string[] = [];
+        let turnedOffRulesMessageArr: string[] = [];
+        for (let i = 0; i < ruleNames.length; i++) {
+            const currRule: string = ruleNames[i];
+            const ruleVal: boolean = listOfRules[currRule];
+            if (ruleVal) {
+                enabledRulesMessageArr.push(currRule);
+            } else {
+                turnedOffRulesMessageArr.push(currRule);
+            }
+        }
+        const enabledRulesMessage = enabledRulesMessageArr.join(', ');
+        const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
+        let enabledRulesMap: pxt.Map<string> = {};
+        enabledRulesMap['enableRules'] = enabledRulesMessage;
+        enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
+        pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
     }
 
     /* Remove hidden snippets from text */

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -311,10 +311,9 @@ ${code}
         for (let i = 0; i < ruleNames.length; i++) {
             const setValidationRule: pxt.Map<string | number> = {};
             setValidationRule["ruleName"] = ruleNames[i];
-            setValidationRule["enabledFlag"] = listOfRules[ruleNames[i]] ? 1 : 0;
+            setValidationRule["enabled"] = listOfRules[ruleNames[i]] ? 'true' : 'false';
             setValidationRule["tutorial"] = title;
             pxt.tickEvent('tutorial.validation.setValidationRules', setValidationRule);
-            console.log('tutorial.validation.setValidationRules', setValidationRule);
         }
     }
 

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -322,8 +322,8 @@ ${code}
         const enabledRulesMessage = enabledRulesMessageArr.join(', ');
         const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
         let enabledRulesMap: pxt.Map<string> = {};
-        enabledRulesMap['enableRules'] = enabledRulesMessage;
-        enabledRulesMap['notEnableRules'] = turnedOffRulesMessage;
+        enabledRulesMap['enabledRules'] = enabledRulesMessage;
+        enabledRulesMap['notEnabledRules'] = turnedOffRulesMessage;
         pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
     }
 

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -309,10 +309,11 @@ ${code}
     function categorizingValidationRules(listOfRules: pxt.Map<boolean>, title: string) {
         const ruleNames = Object.keys(listOfRules);
         for (let i = 0; i < ruleNames.length; i++) {
-            const setValidationRule: pxt.Map<string | number> = {};
-            setValidationRule["ruleName"] = ruleNames[i];
-            setValidationRule["enabled"] = listOfRules[ruleNames[i]] ? 'true' : 'false';
-            setValidationRule["tutorial"] = title;
+            const setValidationRule: pxt.Map<string> = {
+                ruleName: ruleNames[i],
+                enabled: listOfRules[ruleNames[i]] ? 'true' : 'false',
+                tutorial: title,
+            };
             pxt.tickEvent('tutorial.validation.setValidationRules', setValidationRule);
         }
     }

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -16,7 +16,7 @@ namespace pxt.tutorial {
         let tutorialValidationRules: pxt.Map<boolean>;
         if (metadata.tutorialCodeValidation) {
             tutorialValidationRules = pxt.Util.jsonTryParse(tutorialValidationRulesStr);
-            categorizingValidationRules(tutorialValidationRules);
+            categorizingValidationRules(tutorialValidationRules, title);
         }
 
         // noDiffs legacy
@@ -306,25 +306,16 @@ ${code}
         return { header, hint, requiredBlocks };
     }
 
-    function categorizingValidationRules(listOfRules: pxt.Map<boolean>) {
-        const ruleNames: string[] = Object.keys(listOfRules);
-        let enabledRulesMessageArr: string[] = [];
-        let turnedOffRulesMessageArr: string[] = [];
+    function categorizingValidationRules(listOfRules: pxt.Map<boolean>, title: string) {
+        const ruleNames = Object.keys(listOfRules);
         for (let i = 0; i < ruleNames.length; i++) {
-            const currRule: string = ruleNames[i];
-            const ruleVal: boolean = listOfRules[currRule];
-            if (ruleVal) {
-                enabledRulesMessageArr.push(currRule);
-            } else {
-                turnedOffRulesMessageArr.push(currRule);
-            }
+            const setValidationRule: pxt.Map<string | number> = {};
+            setValidationRule["ruleName"] = ruleNames[i];
+            setValidationRule["enabledFlag"] = listOfRules[ruleNames[i]] ? 1 : 0;
+            setValidationRule["tutorial"] = title;
+            pxt.tickEvent('tutorial.validation.setValidationRules', setValidationRule);
+            console.log('tutorial.validation.setValidationRules', setValidationRule);
         }
-        const enabledRulesMessage = enabledRulesMessageArr.join(', ');
-        const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
-        let enabledRulesMap: pxt.Map<string> = {};
-        enabledRulesMap['enabledRules'] = enabledRulesMessage;
-        enabledRulesMap['notEnabledRules'] = turnedOffRulesMessage;
-        pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
     }
 
     /* Remove hidden snippets from text */

--- a/pxtlib/tutorial.ts
+++ b/pxtlib/tutorial.ts
@@ -323,7 +323,7 @@ ${code}
         const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
         let enabledRulesMap: pxt.Map<string> = {};
         enabledRulesMap['enableRules'] = enabledRulesMessage;
-        enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
+        enabledRulesMap['notEnableRules'] = turnedOffRulesMessage;
         pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
     }
 

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -61,13 +61,26 @@ namespace pxt.tutorial {
     function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
         let listOfRuleStatuses: TutorialRuleStatus[] = [];
         if (listOfRules != undefined) {
+            let enabledRulesMessageArr: string[] = [];
+            let turnedOffRulesMessageArr: string[] = [];
             const ruleNames: string[] = Object.keys(listOfRules);
             for (let i = 0; i < ruleNames.length; i++) {
                 const currRule: string = ruleNames[i];
                 const ruleVal: boolean = listOfRules[currRule];
                 const currRuleStatus: TutorialRuleStatus = { ruleName: currRule, ruleTurnOn: ruleVal };
                 listOfRuleStatuses.push(currRuleStatus);
+                if (ruleVal) {
+                    enabledRulesMessageArr.push(currRule);
+                } else {
+                    turnedOffRulesMessageArr.push(currRule);
+                }
             }
+            const enabledRulesMessage = enabledRulesMessageArr.join(', ');
+            const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
+            let enabledRulesMap: pxt.Map<string> = {};
+            enabledRulesMap['enableRules'] = enabledRulesMessage;
+            enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
+            pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
         }
         return listOfRuleStatuses;
     }

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -61,26 +61,13 @@ namespace pxt.tutorial {
     function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
         let listOfRuleStatuses: TutorialRuleStatus[] = [];
         if (listOfRules != undefined) {
-            let enabledRulesMessageArr: string[] = [];
-            let turnedOffRulesMessageArr: string[] = [];
             const ruleNames: string[] = Object.keys(listOfRules);
             for (let i = 0; i < ruleNames.length; i++) {
                 const currRule: string = ruleNames[i];
                 const ruleVal: boolean = listOfRules[currRule];
                 const currRuleStatus: TutorialRuleStatus = { ruleName: currRule, ruleTurnOn: ruleVal };
                 listOfRuleStatuses.push(currRuleStatus);
-                if (ruleVal) {
-                    enabledRulesMessageArr.push(currRule);
-                } else {
-                    turnedOffRulesMessageArr.push(currRule);
-                }
             }
-            const enabledRulesMessage = enabledRulesMessageArr.join(', ');
-            const turnedOffRulesMessage = turnedOffRulesMessageArr.join(', ');
-            let enabledRulesMap: pxt.Map<string> = {};
-            enabledRulesMap['enableRules'] = enabledRulesMessage;
-            enabledRulesMap['turnedOffRules'] = turnedOffRulesMessage;
-            pxt.tickEvent('tutorial.validation.listOfRules ', enabledRulesMap);
         }
         return listOfRuleStatuses;
     }

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -411,11 +411,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
 
         pxt.tickEvent(`tutorial.previous`, { tutorial: options.tutorial, step: previousStep }, { interactiveConsent: true });
         this.props.parent.setTutorialStep(previousStep);
-
-        const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
-        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) { // disables tutorial validation pop-up if previous buttion is clicked
-            this.setState({ showUnusedBlockMessage: false });
-        }
+        this.setState({ showUnusedBlockMessage: false });
     }
 
     nextTutorialStep() {
@@ -653,11 +649,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         }
         th.showHint(visible, showFullText);
         if (visible) { // disables tutorial validation pop-up if hint is clicked
-            const options = this.props.parent.state.tutorialOptions;
-            const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
-            if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) {
-                this.setState({ showUnusedBlockMessage: false });
-            }
+            this.setState({ showUnusedBlockMessage: false });
         }
     }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -723,8 +723,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const showMissingBlockPopupMessage = this.state.showUnusedBlockMessage && validationEnabled;
         const strictRulePresent = this.areStrictRulesPresent(stepInfo.listOfValidationRules);
         const validationRuleStepStatus = this.getValidationRuleStepStatus();
-        const nextOnClick = (!validationEnabled || (tutorialCodeValidated && !strictRulePresent)) ?  this.nextTutorialStep : 
-        (this.state.showUnusedBlockMessage) ? this.doubleClickedNextStep : this.showUnusedBlocksMessageOnClick;
+        const nextOnClick = (!validationEnabled || (tutorialCodeValidated && !strictRulePresent)) ? this.nextTutorialStep :
+            (this.state.showUnusedBlockMessage) ? this.doubleClickedNextStep : this.showUnusedBlocksMessageOnClick;
 
         const tutorialAriaLabel = lf("Press Space or Enter to show a hint.");
         const tutorialHintTooltip = lf("Click to show a hint!");

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -648,7 +648,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             this.props.parent.setHintSeen(currentStep);
         }
         th.showHint(visible, showFullText);
-        if (visible) { // disables tutorial validation pop-up if hint is clicked
+        if (visible) {
             this.setState({ showUnusedBlockMessage: false });
         }
     }
@@ -676,7 +676,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
 
     renderCore() {
         const options = this.props.parent.state.tutorialOptions;
-        const { tutorialName, tutorialReady, tutorialStepInfo, tutorialStep, tutorialStepExpanded, metadata } = options;
+        const { tutorialReady, tutorialStepInfo, tutorialStep, tutorialStepExpanded, metadata } = options;
         if (!tutorialReady) return <div />
         const stepInfo = tutorialStepInfo[tutorialStep];
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -765,7 +765,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                 {hasNext ? <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron large`} className={`nextbutton right attached ${!hasNext ? 'disabled' : ''}  ${tutorialCodeValidated ? 'isValidated' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")}
                     onClick={nextOnClick} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 {showMissingBlockPopupMessage &&
-                    <TutorialCodeValidation.MoveOn onYesButtonClick={this.nextTutorialStep} onNoButtonClick={this.showUnusedBlocksMessage} initialVisible={this.state.showUnusedBlockMessage} isTutorialCodeInvalid={!tutorialCodeValidated} ruleComponents={stepInfo.listOfValidationRules} areStrictRulesPresent={strictRulePresent} validationRuleStepStatus={validationRuleStepStatus} parent={this.props.parent} />}
+                    <TutorialCodeValidation.ShowValidationMessage onYesButtonClick={this.nextTutorialStep} onNoButtonClick={this.showUnusedBlocksMessage} initialVisible={this.state.showUnusedBlockMessage} isTutorialCodeInvalid={!tutorialCodeValidated} ruleComponents={stepInfo.listOfValidationRules} areStrictRulesPresent={strictRulePresent} validationRuleStepStatus={validationRuleStepStatus} parent={this.props.parent} />}
                 {hasFinish ? <sui.Button icon="left checkmark" className={`orange right attached ${!tutorialReady ? 'disabled' : ''}`} text={lf("Finish")} ariaLabel={lf("Finish the tutorial.")} onClick={this.finishTutorial} onKeyDown={sui.fireClickOnEnter} /> : undefined}
             </div>
         </div>;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -412,11 +412,10 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.props.parent.setTutorialStep(previousStep);
 
         const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
-        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) {
+        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) { // disables tutorial validation pop-up if previous buttion is clicked
             const stepInfo = options.tutorialStepInfo[currentStep];
             const sortedValidAndInvalidRules = this.classifyingValidAndInvalidRules(stepInfo.listOfValidationRules);
-            pxt.tickEvent('tutorial.validation.clickedPrevious ', sortedValidAndInvalidRules);
-            console.log('tutorial.validation.clickedPrevious ', sortedValidAndInvalidRules);
+            pxt.tickEvent('tutorial.validation.clickedPreviousBttn ', sortedValidAndInvalidRules);
             this.setState({ showUnusedBlockMessage: false });
         }
     }
@@ -433,11 +432,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.props.parent.setTutorialStep(nextStep);
 
         const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
-        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) {
-            const stepInfo = options.tutorialStepInfo[currentStep];
-            const sortedValidAndInvalidRules = this.classifyingValidAndInvalidRules(stepInfo.listOfValidationRules);
-            pxt.tickEvent('tutorial.validation.clickedNext ', sortedValidAndInvalidRules);
-            console.log('tutorial.validation.clickedNext ', sortedValidAndInvalidRules);
+        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) { // disables tutorial validation pop-up if next buttion is clicked
             this.setState({ showUnusedBlockMessage: false });
         }
     }
@@ -639,14 +634,13 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             this.props.parent.setHintSeen(currentStep);
         }
         th.showHint(visible, showFullText);
-        if (visible) {
+        if (visible) { // disables tutorial validation pop-up if hint is clicked
             const options = this.props.parent.state.tutorialOptions;
             const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
             if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) {
                 const stepInfo = options.tutorialStepInfo[currentStep];
                 const sortedValidAndInvalidRules = this.classifyingValidAndInvalidRules(stepInfo.listOfValidationRules);
                 pxt.tickEvent('tutorial.validation.clickedHint ', sortedValidAndInvalidRules);
-                console.log('tutorial.validation.clickedHint ', sortedValidAndInvalidRules);
                 this.setState({ showUnusedBlockMessage: false });
             }
         }
@@ -685,8 +679,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                 }
             }
         }
-        const codeValidListStr = this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeValidList.join(', ');
-        const codeInValidListStr = this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeInValidList.join(', ');
+        const codeValidListStr = "step " + this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeValidList.join(', ');
+        const codeInValidListStr = "step " + this.props.parent.state.tutorialOptions.tutorialStep + ": " + codeInValidList.join(', ');
         turnedOnRulesList["codeValid"] = codeValidListStr;
         turnedOnRulesList["codeInvalid"] = codeInValidListStr;
         return turnedOnRulesList;

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -433,7 +433,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
     }
 
     doubleClickedNextStep() {
-        this.validationTelemetry('.next');
+        this.validationTelemetry('next');
         this.nextTutorialStep();
     }
 
@@ -671,7 +671,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             for (let i = 0; i < rules.length; i++) {
                 if (rules[i].ruleTurnOn) {
                     validationRuleStepStatus["ruleName"] = rules[i].ruleName;
-                    let str = 'tutorial.validation' + (command) + (rules[i].ruleStatus ? '.pass' : '.fail');
+                    let str = 'tutorial.validation.' + (command) + (rules[i].ruleStatus ? '.pass' : '.fail');
                     pxt.tickEvent(str, validationRuleStepStatus);
                 }
             }

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -31,12 +31,28 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
         this.setState({ visible: vis });
     }
 
+    collectingTurnedOnRulesList(rules: pxt.tutorial.TutorialRuleStatus[]) {
+        let turnedOnRulesList: pxt.Map<string> = {};
+        if (rules != undefined) {
+            for (let i = 0; i < rules.length; i++) {
+                if (rules[i].ruleTurnOn) {
+                    turnedOnRulesList[rules[i].ruleName] = rules[i].ruleStatus + '';
+                }
+            }
+        }
+        return turnedOnRulesList;
+    }
+
     moveOnToNextTutorialStep() {
+        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
+        pxt.tickEvent('tutorial.validation.next ', listOfTurnedOnRules);
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
+        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
+        pxt.tickEvent('tutorial.validation.stay ', listOfTurnedOnRules);
         this.props.onNoButtonClick();
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -32,8 +32,6 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         this.setState({ visible: vis });
     }
 
-
-
     moveOnToNextTutorialStep() {
         this.validationRuleStatus(false);
         this.props.onYesButtonClick();

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -33,13 +33,13 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
     }
 
     moveOnToNextTutorialStep() {
-        this.props.validationTelemetry(".continue");
+        this.props.validationTelemetry("continue");
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
-        this.props.validationTelemetry(".edit");
+        this.props.validationTelemetry("edit");
         this.props.onNoButtonClick();
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -14,7 +14,7 @@ interface TutorialCodeValidationProps extends ISettingsProps {
     isTutorialCodeInvalid: boolean;
     ruleComponents: pxt.tutorial.TutorialRuleStatus[];
     areStrictRulesPresent: boolean;
-    validationRuleStepStatus: pxt.Map<string | number>;
+    options: pxt.tutorial.TutorialOptions;
 }
 
 interface tutorialCodeValidationState {
@@ -35,20 +35,35 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
 
 
     moveOnToNextTutorialStep() {
-        const sortedValidAndInvalidRules = this.props.validationRuleStepStatus;
-        pxt.tickEvent('tutorial.validation.continueAnyway', sortedValidAndInvalidRules);
-        console.log('tutorial.validation.continueAnyway', sortedValidAndInvalidRules);
+        this.validationRuleStatus(false);
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
-        const sortedValidAndInvalidRules = this.props.validationRuleStepStatus;
-        pxt.tickEvent('tutorial.validation.keepEditing', sortedValidAndInvalidRules);
-        console.log('tutorial.validation.keepEditing', sortedValidAndInvalidRules);
+        this.validationRuleStatus(true);
         this.props.onNoButtonClick();
     }
 
+
+    validationRuleStatus(isEditing: boolean) {
+        const { tutorialName, tutorialStepInfo, tutorialStep } = this.props.options;
+        const stepInfo = tutorialStepInfo[tutorialStep];
+        const rules = stepInfo.listOfValidationRules;
+
+        if (rules != undefined) {
+            const validationRuleStepStatus: pxt.Map<string | number> = {};
+            validationRuleStepStatus["tutorial"] = tutorialName;
+            validationRuleStepStatus["step"] = tutorialStep;
+            for (let i = 0; i < rules.length; i++) {
+                if (rules[i].ruleTurnOn) {
+                    validationRuleStepStatus["ruleName"] = rules[i].ruleName;
+                    let str = 'tutorial.validation' + (isEditing ? '.edit' : '.continue') + (rules[i].ruleStatus ? '.pass' : '.fail');
+                    pxt.tickEvent(str, validationRuleStepStatus);
+                }
+            }
+        }
+    }
 
     renderCore() {
         const codeInvalid = this.props.isTutorialCodeInvalid;

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -36,16 +36,14 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
 
     moveOnToNextTutorialStep() {
         const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
-        pxt.tickEvent('tutorial.validation.next ', sortedValidAndInvalidRules);
-        console.log('tutorial.validation.next ', sortedValidAndInvalidRules)
+        pxt.tickEvent('tutorial.validation.continueAnyway ', sortedValidAndInvalidRules);
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
         const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
-        pxt.tickEvent('tutorial.validation.stay ', sortedValidAndInvalidRules);
-        console.log('tutorial.validation.stay ', sortedValidAndInvalidRules);
+        pxt.tickEvent('tutorial.validation.keepEditing ', sortedValidAndInvalidRules);
         this.props.onNoButtonClick();
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -21,7 +21,7 @@ interface tutorialCodeValidationState {
     visible: boolean;
 }
 
-export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorialCodeValidationState> {
+export class ShowValidationMessage extends data.Component<TutorialCodeValidationProps, tutorialCodeValidationState> {
     constructor(props: TutorialCodeValidationProps) {
         super(props);
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -14,6 +14,7 @@ interface TutorialCodeValidationProps extends ISettingsProps {
     isTutorialCodeInvalid: boolean;
     ruleComponents: pxt.tutorial.TutorialRuleStatus[];
     areStrictRulesPresent: boolean;
+    codeValidAndInvalidRuleMap: pxt.Map<string>;
 }
 
 interface tutorialCodeValidationState {
@@ -31,28 +32,20 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
         this.setState({ visible: vis });
     }
 
-    collectingTurnedOnRulesList(rules: pxt.tutorial.TutorialRuleStatus[]) {
-        let turnedOnRulesList: pxt.Map<string> = {};
-        if (rules != undefined) {
-            for (let i = 0; i < rules.length; i++) {
-                if (rules[i].ruleTurnOn) {
-                    turnedOnRulesList[rules[i].ruleName] = rules[i].ruleStatus + '';
-                }
-            }
-        }
-        return turnedOnRulesList;
-    }
+
 
     moveOnToNextTutorialStep() {
-        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
-        pxt.tickEvent('tutorial.validation.next ', listOfTurnedOnRules);
+        const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
+        pxt.tickEvent('tutorial.validation.next ', sortedValidAndInvalidRules);
+        console.log('tutorial.validation.next ', sortedValidAndInvalidRules)
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
-        const listOfTurnedOnRules = this.collectingTurnedOnRulesList(this.props.ruleComponents);
-        pxt.tickEvent('tutorial.validation.stay ', listOfTurnedOnRules);
+        const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
+        pxt.tickEvent('tutorial.validation.stay ', sortedValidAndInvalidRules);
+        console.log('tutorial.validation.stay ', sortedValidAndInvalidRules);
         this.props.onNoButtonClick();
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -14,7 +14,7 @@ interface TutorialCodeValidationProps extends ISettingsProps {
     isTutorialCodeInvalid: boolean;
     ruleComponents: pxt.tutorial.TutorialRuleStatus[];
     areStrictRulesPresent: boolean;
-    codeValidAndInvalidRuleMap: pxt.Map<string>;
+    validationRuleStepStatus: pxt.Map<string | number>;
 }
 
 interface tutorialCodeValidationState {
@@ -35,15 +35,17 @@ export class MoveOn extends data.Component<TutorialCodeValidationProps, tutorial
 
 
     moveOnToNextTutorialStep() {
-        const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
-        pxt.tickEvent('tutorial.validation.continueAnyway ', sortedValidAndInvalidRules);
+        const sortedValidAndInvalidRules = this.props.validationRuleStepStatus;
+        pxt.tickEvent('tutorial.validation.continueAnyway', sortedValidAndInvalidRules);
+        console.log('tutorial.validation.continueAnyway', sortedValidAndInvalidRules);
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
-        const sortedValidAndInvalidRules = this.props.codeValidAndInvalidRuleMap;
-        pxt.tickEvent('tutorial.validation.keepEditing ', sortedValidAndInvalidRules);
+        const sortedValidAndInvalidRules = this.props.validationRuleStepStatus;
+        pxt.tickEvent('tutorial.validation.keepEditing', sortedValidAndInvalidRules);
+        console.log('tutorial.validation.keepEditing', sortedValidAndInvalidRules);
         this.props.onNoButtonClick();
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -10,11 +10,11 @@ type ISettingsProps = pxt.editor.ISettingsProps;
 interface TutorialCodeValidationProps extends ISettingsProps {
     onYesButtonClick: () => void;
     onNoButtonClick: () => void;
+    validationTelemetry: (command: string) => void;
     initialVisible: boolean;
     isTutorialCodeInvalid: boolean;
     ruleComponents: pxt.tutorial.TutorialRuleStatus[];
     areStrictRulesPresent: boolean;
-    options: pxt.tutorial.TutorialOptions;
 }
 
 interface tutorialCodeValidationState {
@@ -33,34 +33,14 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
     }
 
     moveOnToNextTutorialStep() {
-        this.validationRuleStatus(false);
+        this.props.validationTelemetry(".continue");
         this.props.onYesButtonClick();
         this.showUnusedBlocksMessage(false);
     }
 
     stayOnThisTutorialStep() {
-        this.validationRuleStatus(true);
+        this.props.validationTelemetry(".edit");
         this.props.onNoButtonClick();
-    }
-
-
-    validationRuleStatus(isEditing: boolean) {
-        const { tutorialName, tutorialStepInfo, tutorialStep } = this.props.options;
-        const stepInfo = tutorialStepInfo[tutorialStep];
-        const rules = stepInfo.listOfValidationRules;
-
-        if (rules != undefined) {
-            const validationRuleStepStatus: pxt.Map<string | number> = {};
-            validationRuleStepStatus["tutorial"] = tutorialName;
-            validationRuleStepStatus["step"] = tutorialStep;
-            for (let i = 0; i < rules.length; i++) {
-                if (rules[i].ruleTurnOn) {
-                    validationRuleStepStatus["ruleName"] = rules[i].ruleName;
-                    let str = 'tutorial.validation' + (isEditing ? '.edit' : '.continue') + (rules[i].ruleStatus ? '.pass' : '.fail');
-                    pxt.tickEvent(str, validationRuleStepStatus);
-                }
-            }
-        }
     }
 
     renderCore() {


### PR DESCRIPTION
Telemetry cases:

Once the tutorial loads, all validation rules are add to the telemetry. 

All user cases require the validation pop-up to be visible
- User clicks the next button
- User clicks 'Continue Anyways' 
- User clicks 'Keep Editing' 

Below is a sample console.log of telemetry with two rules enabled
![Screenshot (48)](https://user-images.githubusercontent.com/13580493/121091840-7d3fe900-c79f-11eb-825c-3ceeea0f3633.png)
