### PR TITLE
Don't emit nonsense internal types when converting from Python

### DIFF
--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2529,7 +2529,8 @@ namespace pxt.py {
 
     function declareVariable(s: SymbolInfo) {
         const name = quote(s.name);
-        let type = t2s(getOrSetSymbolType(s));
+        const type = t2s(getOrSetSymbolType(s));
+
         return B.mkStmt(B.mkGroup([B.mkText("let "), name, B.mkText(": " + type + ";")]));
     }
 

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -466,7 +466,7 @@ namespace pxt.py {
         else if (t.moduleType && t.moduleType.pyQName)
             return applyTypeMap(t.moduleType.pyQName) + suff("/M")
         else
-            return "?" + t.tid
+            return "any"
     }
 
     function mkDiag(astNode: py.AST | undefined | null, category: pxtc.DiagnosticCategory, code: number, messageText: string): pxtc.KsDiagnostic {
@@ -1119,7 +1119,7 @@ namespace pxt.py {
 
     function typeAnnot(t: Type, defaultToAny = false) {
         let s = t2s(t)
-        if (s[0] == "?") {
+        if (s === "any") {
             // TODO:
             // example from minecraft doc snippet:
             // player.onChat("while",function(num1){while(num1<10){}})
@@ -2529,8 +2529,7 @@ namespace pxt.py {
 
     function declareVariable(s: SymbolInfo) {
         const name = quote(s.name);
-        const type = t2s(getOrSetSymbolType(s));
-
+        let type = t2s(getOrSetSymbolType(s));
         return B.mkStmt(B.mkGroup([B.mkText("let "), name, B.mkText(": " + type + ";")]));
     }
 

--- a/tests/pyconverter-test/baselines/empty_array_declaration.ts
+++ b/tests/pyconverter-test/baselines/empty_array_declaration.ts
@@ -1,0 +1,7 @@
+function f1() {
+    let x: any[];
+    while (true) {
+        x = []
+    }
+}
+

--- a/tests/pyconverter-test/cases/empty_array_declaration.py
+++ b/tests/pyconverter-test/cases/empty_array_declaration.py
@@ -1,0 +1,3 @@
+def f1():
+    while True:
+        x = []


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/3849

Currently, we emit our internal type id with a question mark when we encounter a type we couldn't infer in the Python compiler. It ends up giving us something that looks like `let x: ?359;`. There's no real reason I can see to ever emit those internal type IDs when `any` should work most of the time.

We did use it in one place in the code to detect when we had an invalid type, but I think that information should probably be propagated in a more intentional manner if it's important.