### PR TITLE
Get typescript snippet from block id for rendering missing blocks in tutorial validation

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1063,6 +1063,7 @@ declare namespace pxt.tutorial {
         ruleStatus?: boolean;
         ruleMessage?: string;
         isStrict?: boolean;
+        blockIds?: string[];
     }
 
     interface TutorialStepInfo {

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -6,11 +6,12 @@ namespace pxt.tutorial {
         ruleStatus?: boolean;
         ruleMessage?: string;
         isStrict?: boolean;
+        blockIds?: string[];
     }
 
     /**
     * Check the user's code to the map of tutorial validation rules from TutorialOptions and returns an array of TutorialRuleStatus
-    * @param tutorial the tutorial 
+    * @param tutorial the tutorial
     * @param workspaceBlocks Blockly blocks used of workspace
     * @param blockinfo Typescripts of the workspace
     * @return A TutorialRuleStatus
@@ -55,7 +56,7 @@ namespace pxt.tutorial {
 
     /**
     * Gives each rule from the markdown file a TutorialRuleStatus
-    * @param listOfRules a map of rules from makrdown file 
+    * @param listOfRules a map of rules from makrdown file
     * @return An array of TutorialRuleStatus
     */
     function classifyRules(listOfRules: pxt.Map<boolean>): TutorialRuleStatus[] {
@@ -161,6 +162,7 @@ namespace pxt.tutorial {
         currRule.isStrict = true;
         const userBlockKeys = Object.keys(usersBlockUsed);
         let tutorialBlockKeys: string[] = []
+        let blockIds = [];
         if (tutorialBlockUsed != undefined) {
             tutorialBlockKeys = Object.keys(tutorialBlockUsed);
         }
@@ -172,12 +174,14 @@ namespace pxt.tutorial {
             if (!usersBlockUsed[tutorialBlockKey]                                            // user did not use a specific block or
                 || usersBlockUsed[tutorialBlockKey] < tutorialBlockUsed[tutorialBlockKey]) { // user did not use enough of a certain block
                 sArr.push("- " + tutorialBlockKey);
+                blockIds.push(tutorialBlockKey);
                 isValid = false;
             }
         }
         const message: string = sArr.join('\n');
         currRule.ruleMessage = message;
         currRule.ruleStatus = isValid;
+        currRule.blockIds = blockIds;
         return currRule;
     }
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -50,7 +50,7 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
     componentDidMount() {
         this.props.ruleComponents.forEach(rule => {
             if (rule.blockIds && !this.state.ruleSnippets?.[rule.ruleName]?.length) {
-                this.getRuleSnippets(rule);
+                this.getRuleSnippetsAsync(rule);
             }
         })
     }
@@ -61,7 +61,7 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
             // Update if the list of blockids is different
             if ((rule.blockIds && rule.blockIds.sort().toString() != prev?.blockIds?.sort()?.toString())
                 || rule.blockIds.length != nextState.ruleSnippets?.[rule.ruleName]?.length) {
-                this.getRuleSnippets(rule);
+                this.getRuleSnippetsAsync(rule);
             }
         })
     }
@@ -76,7 +76,7 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         }
     }
 
-    getRuleSnippets(rule: pxt.tutorial.TutorialRuleStatus) {
+    getRuleSnippetsAsync(rule: pxt.tutorial.TutorialRuleStatus) {
         if (rule.blockIds) {
             // Get all APIs from compiler
             compiler.getBlocksAsync().then(blocksInfo => {

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import * as data from "./data";
 import * as sui from "./sui";
+import * as compiler from "./compiler";
 import { TutorialCard } from "./tutorial";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
@@ -17,15 +18,18 @@ interface TutorialCodeValidationProps extends ISettingsProps {
     areStrictRulesPresent: boolean;
 }
 
-interface tutorialCodeValidationState {
+interface TutorialCodeValidationState {
     visible: boolean;
+    ruleSnippets?: pxt.Map<string[]>;
 }
 
-export class ShowValidationMessage extends data.Component<TutorialCodeValidationProps, tutorialCodeValidationState> {
+export class ShowValidationMessage extends data.Component<TutorialCodeValidationProps, TutorialCodeValidationState> {
+    protected snippetCache: pxt.Map<string> = {};
+
     constructor(props: TutorialCodeValidationProps) {
         super(props);
 
-        this.state = { visible: this.props.initialVisible };
+        this.state = { visible: this.props.initialVisible, ruleSnippets: {} };
     }
 
     showUnusedBlocksMessage(vis: boolean) {
@@ -43,6 +47,61 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         this.props.onNoButtonClick();
     }
 
+    componentDidMount() {
+        this.props.ruleComponents.forEach(rule => {
+            if (rule.blockIds && !this.state.ruleSnippets?.[rule.ruleName]?.length) {
+                this.getRuleSnippets(rule);
+            }
+        })
+    }
+
+    UNSAFE_componentWillReceiveProps(nextProps: TutorialCodeValidationProps, nextState: TutorialCodeValidationState) {
+        nextProps.ruleComponents.forEach(rule => {
+            const prev = this.props.ruleComponents.find(r => r.ruleName == rule.ruleName);
+            // Update if the list of blockids is different
+            if ((rule.blockIds && rule.blockIds.sort().toString() != prev?.blockIds?.sort()?.toString())
+                || rule.blockIds.length != nextState.ruleSnippets?.[rule.ruleName]?.length) {
+                this.getRuleSnippets(rule);
+            }
+        })
+    }
+
+    renderRule(rule: pxt.tutorial.TutorialRuleStatus, index?: number) {
+        const snippets = this.state.ruleSnippets?.[rule.ruleName];
+        if (!snippets) {
+            return <p key={index + rule.ruleName}>{(rule.ruleTurnOn && !rule.ruleStatus) ? rule.ruleMessage : ''}</p>
+        } else {
+            // TODO (jxwoon): render snippets
+            return <p key={index + rule.ruleName}>{(rule.ruleTurnOn && !rule.ruleStatus) ? rule.ruleMessage : ''}</p>
+        }
+    }
+
+    getRuleSnippets(rule: pxt.tutorial.TutorialRuleStatus) {
+        if (rule.blockIds) {
+            // Get all APIs from compiler
+            compiler.getBlocksAsync().then(blocksInfo => {
+                return Promise.all(rule.blockIds.map(id => {
+                    if (this.snippetCache[id]) return this.snippetCache[id];
+
+                    const symbol = blocksInfo.blocksById[id];
+                    if (!symbol) {
+                        return Promise.resolve(undefined);
+                    }
+                    // Get snippet based on the qualified name
+                    return compiler.snippetAsync(symbol.qName, false).then(snippet => {
+                        this.snippetCache[id] = snippet;
+                        return snippet;
+                    })
+                })).then(snippets => {
+                    this.setState({ ruleSnippets: {
+                        ...this.state.ruleSnippets,
+                        [rule.ruleName]: snippets.filter(s => !!s)
+                    } });
+                })
+            })
+        }
+    }
+
     renderCore() {
         const codeInvalid = this.props.isTutorialCodeInvalid;
         const rules = this.props.ruleComponents;
@@ -51,7 +110,7 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         return <div>
             <div className={`tutorialCodeValidation no-select ${(!codeInvalid || (codeInvalid && !strictRulePresent)) ? 'hidden' : ''}`}>
                 <div className="codeValidationPopUpText">
-                    {rulesDefined ? rules.map((rule, index) => <p key={index + rule.ruleName}>{(rule.ruleTurnOn && !rule.ruleStatus) ? rule.ruleMessage : ''}</p>) : ''}
+                    {rulesDefined && rules.map((rule, index) => this.renderRule(rule, index))}
                 </div>
                 <div className="codeValidationPopUpText">
                     {lf("Do you still want to continue?")}


### PR DESCRIPTION
i think the better way to do this would be with react hooks, but sticking with the old lifecycle for now, for simplicity's sake