### PR TITLE
prefetch herobanner images on gallery load

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -358,11 +358,12 @@ interface HeroBannerState {
 const HERO_BANNER_DELAY = 6000; // 6 seconds per card
 class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
     protected prevGalleries: pxt.CodeCard[];
+    protected static fetchedImages: pxt.Map<HTMLImageElement> = {};
     protected carouselTimeout: ReturnType<typeof setTimeout> = undefined;
     protected dragStartX: number;
 
     constructor(props: ProjectsCarouselProps) {
-        super(props)
+        super(props);
         this.state = {
             cardIndex: 0,
         };
@@ -509,6 +510,16 @@ class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
                 if (heroBanner) {
                     this.prevGalleries.unshift(heroBanner);
                 }
+
+                this.prevGalleries.forEach(card => {
+                    const bkgd = encodeURI(card.largeImageUrl || card.imageUrl);
+                    if (!HeroBanner.fetchedImages[bkgd]) {
+                        const img = new Image();
+                        img.src = bkgd;
+                        HeroBanner.fetchedImages[bkgd] = img;
+                    }
+                });
+
                 this.scheduleRefresh();
             }
         }


### PR DESCRIPTION
When the hero banner rotates around for the first time, it is currently fetching the images on demand  / when the card is first shown. This isn't so noticeable right now because the current gallery images are very small & there's already a weird transition between them as the sizes are different, but it's particularly noticeable with the new images in https://github.com/microsoft/pxt-microbit/pull/4149 -- the first time you go through the carousel, you'll get a momentary white flash while the image fills in.

This fixes that by prefetching the images to get them into the browser mem cache as soon as the gallery md is available. (there's a 6 second pause between that point & when it will rotate to the next screen for the first time, so unless network is a huge bottleneck there shouldn't be any tearing anymore unless you swipe as soon as the component loads)