### PR TITLE
Renamed Tutorial Validation Variables, Toggle Validation Message, and Render Blocks in Validation Message

### DIFF
--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -167,18 +167,15 @@ namespace pxt.tutorial {
             tutorialBlockKeys = Object.keys(tutorialBlockUsed);
         }
         let isValid = userBlockKeys.length >= tutorialBlockKeys.length; // user has enough blocks
-        let sArr: string[] = [];
-        sArr[0] = lf("These are the blocks you seem to be missing:");
+        const message = lf("These are the blocks you seem to be missing:");
         for (let i: number = 0; i < tutorialBlockKeys.length; i++) {
             let tutorialBlockKey = tutorialBlockKeys[i];
             if (!usersBlockUsed[tutorialBlockKey]                                            // user did not use a specific block or
                 || usersBlockUsed[tutorialBlockKey] < tutorialBlockUsed[tutorialBlockKey]) { // user did not use enough of a certain block
-                sArr.push("- " + tutorialBlockKey);
                 blockIds.push(tutorialBlockKey);
                 isValid = false;
             }
         }
-        const message: string = sArr.join('\n');
         currRule.ruleMessage = message;
         currRule.ruleStatus = isValid;
         currRule.blockIds = blockIds;
@@ -218,22 +215,22 @@ namespace pxt.tutorial {
         currRule.isStrict = true;
         const userBlockKeys = Object.keys(usersBlockUsed);
         let requiredBlockKeys: string[] = []
+        let blockIds = [];
         if (requiredBlocks != undefined) {
             requiredBlockKeys = Object.keys(requiredBlocks);
         }
         let isValid: boolean = true;
-        let sArr: string[] = [];
-        sArr[0] = lf("You are required to have the following block:");
+        const message = lf("You are required to have the following block:");
         for (let i: number = 0; i < requiredBlockKeys.length; i++) {
             let requiredBlockKey = requiredBlockKeys[i];
             if (!usersBlockUsed[requiredBlockKey]) {
-                sArr.push("- " + requiredBlockKey);
+                blockIds.push(requiredBlockKey);
                 isValid = false;
             }
         }
-        const message: string = sArr.join('\n');
         currRule.ruleMessage = message;
         currRule.ruleStatus = isValid;
+        currRule.blockIds = blockIds;
         return currRule;
     }
 }

--- a/pxtlib/tutorialValidator.ts
+++ b/pxtlib/tutorialValidator.ts
@@ -37,13 +37,13 @@ namespace pxt.tutorial {
                 const isRuleEnabled = TutorialRuleStatuses[i].ruleTurnOn;
                 if (isRuleEnabled) {
                     switch (ruleName) {
-                        case "validateExactNumberOfBlocks":
+                        case "exact":
                             currRuleToValidate = validateExactNumberOfBlocks(usersBlockUsed, tutorialBlockUsed, currRuleToValidate);
                             break;
-                        case "validateAtleastOneBlocks":
+                        case "atleastone":
                             currRuleToValidate = validateAtleastOneBlocks(usersBlockUsed, tutorialBlockUsed, currRuleToValidate);
                             break;
-                        case "validateMeetRequiredBlocks":
+                        case "required":
                             const requiredBlocksList = extractRequiredBlockSnippet(tutorial, indexdb);
                             currRuleToValidate = validateMeetRequiredBlocks(usersBlockUsed, requiredBlocksList, currRuleToValidate);
                             break;

--- a/theme/tutorialCodeValidation.less
+++ b/theme/tutorialCodeValidation.less
@@ -69,4 +69,3 @@
     font-size: small;
     white-space: pre-line;
 }
-

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -715,7 +715,6 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const isRtl = pxt.Util.isUserLanguageRtl();
         return <div id="tutorialcard" className={`ui ${tutorialStepExpanded ? 'tutorialExpanded' : ''} ${tutorialReady ? 'tutorialReady' : ''} ${this.state.showSeeMore ? 'seemore' : ''}  ${!this.state.showHint ? 'showTooltip' : ''} ${hasHint ? 'hasHint' : ''}`} style={tutorialStepExpanded ? this.getExpandedCardStyle('height') : null} >
             {hasHint && this.state.showHint && !showDialog && <div className="mask" role="region" onClick={this.closeHint}></div>}
-            {validationEnabled && showTutorialValidationMessage && <div className="mask" role="region" onClick={this.closeTutorialValidationMessage}></div>}
             <div className='ui buttons'>
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -359,7 +359,7 @@ export class TutorialHint extends data.Component<ISettingsProps, TutorialHintSta
 interface TutorialCardState {
     showHint?: boolean;
     showSeeMore?: boolean;
-    showUnusedBlockMessage?: boolean;
+    showTutorialValidationMessage?: boolean;
 }
 
 interface TutorialCardProps extends ISettingsProps {
@@ -381,7 +381,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.state = {
             showSeeMore: false,
             showHint: options.tutorialStepInfo[this.prevStep].showHint,
-            showUnusedBlockMessage: false
+            showTutorialValidationMessage: false
         }
 
         this.toggleHint = this.toggleHint.bind(this);
@@ -396,8 +396,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.toggleExpanded = this.toggleExpanded.bind(this);
         this.onMarkdownDidRender = this.onMarkdownDidRender.bind(this);
         this.handleResize = this.handleResize.bind(this);
-        this.showUnusedBlocksMessageOnClick = this.showUnusedBlocksMessageOnClick.bind(this);
-        this.showUnusedBlocksMessage = this.showUnusedBlocksMessage.bind(this);
+        this.showTutorialValidationMessageOnClick = this.showTutorialValidationMessageOnClick.bind(this);
+        this.closeTutorialValidationMessage = this.closeTutorialValidationMessage.bind(this);
         this.doubleClickedNextStep = this.doubleClickedNextStep.bind(this);
         this.validationTelemetry = this.validationTelemetry.bind(this);
     }
@@ -412,7 +412,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
 
         pxt.tickEvent(`tutorial.previous`, { tutorial: options.tutorial, step: previousStep }, { interactiveConsent: true });
         this.props.parent.setTutorialStep(previousStep);
-        this.setState({ showUnusedBlockMessage: false });
+        this.setState({ showTutorialValidationMessage: false });
     }
 
     nextTutorialStep() {
@@ -427,8 +427,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         this.props.parent.setTutorialStep(nextStep);
 
         const tutorialCodeValidationIsOn = options.metadata.tutorialCodeValidation;
-        if (tutorialCodeValidationIsOn && this.state.showUnusedBlockMessage) { // disables tutorial validation pop-up if next buttion is clicked
-            this.setState({ showUnusedBlockMessage: false });
+        if (tutorialCodeValidationIsOn && this.state.showTutorialValidationMessage) { // disables tutorial validation pop-up if next buttion is clicked
+            this.setState({ showTutorialValidationMessage: false });
         }
     }
 
@@ -571,8 +571,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         }
     }
 
-    private showUnusedBlocksMessageOnClick(evt?: any) {
-        this.setState({ showUnusedBlockMessage: true });
+    private showTutorialValidationMessageOnClick(evt?: any) {
+        this.setState({ showTutorialValidationMessage: true });
     }
 
     private expandedHintOnClick(evt?: any) {
@@ -635,12 +635,12 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         }
         th.showHint(visible, showFullText);
         if (visible) {
-            this.setState({ showUnusedBlockMessage: false });
+            this.setState({ showTutorialValidationMessage: false });
         }
     }
 
-    showUnusedBlocksMessage() {
-        this.setState({ showUnusedBlockMessage: false });
+    closeTutorialValidationMessage() {
+        this.setState({ showTutorialValidationMessage: false });
     }
 
     isCodeValidated(rules: pxt.tutorial.TutorialRuleStatus[]) {
@@ -697,10 +697,10 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const showDialog = stepInfo.showDialog;
         const validationEnabled = (stepInfo.listOfValidationRules != undefined);
         const tutorialCodeValidated = this.isCodeValidated(stepInfo.listOfValidationRules);
-        const showMissingBlockPopupMessage = this.state.showUnusedBlockMessage && validationEnabled;
+        const showTutorialValidationMessage = this.state.showTutorialValidationMessage && validationEnabled;
         const strictRulePresent = this.areStrictRulesPresent(stepInfo.listOfValidationRules);
         const nextOnClick = (!validationEnabled || !strictRulePresent || (tutorialCodeValidated && strictRulePresent)) ? this.nextTutorialStep :
-            (this.state.showUnusedBlockMessage) ? this.doubleClickedNextStep : this.showUnusedBlocksMessageOnClick;
+            (this.state.showTutorialValidationMessage) ? this.doubleClickedNextStep : this.showTutorialValidationMessageOnClick;
 
         const tutorialAriaLabel = lf("Press Space or Enter to show a hint.");
         const tutorialHintTooltip = lf("Click to show a hint!");
@@ -715,7 +715,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         const isRtl = pxt.Util.isUserLanguageRtl();
         return <div id="tutorialcard" className={`ui ${tutorialStepExpanded ? 'tutorialExpanded' : ''} ${tutorialReady ? 'tutorialReady' : ''} ${this.state.showSeeMore ? 'seemore' : ''}  ${!this.state.showHint ? 'showTooltip' : ''} ${hasHint ? 'hasHint' : ''}`} style={tutorialStepExpanded ? this.getExpandedCardStyle('height') : null} >
             {hasHint && this.state.showHint && !showDialog && <div className="mask" role="region" onClick={this.closeHint}></div>}
-
+            {validationEnabled && showTutorialValidationMessage && <div className="mask" role="region" onClick={this.closeTutorialValidationMessage}></div>}
             <div className='ui buttons'>
                 {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">
@@ -740,8 +740,8 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                 </div>
                 {hasNext ? <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron large`} className={`nextbutton right attached ${!hasNext ? 'disabled' : ''}  ${tutorialCodeValidated ? 'isValidated' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")}
                     onClick={nextOnClick} onKeyDown={sui.fireClickOnEnter} /> : undefined}
-                {showMissingBlockPopupMessage &&
-                    <TutorialCodeValidation.ShowValidationMessage onYesButtonClick={this.nextTutorialStep} onNoButtonClick={this.showUnusedBlocksMessage} initialVisible={this.state.showUnusedBlockMessage} isTutorialCodeInvalid={!tutorialCodeValidated} ruleComponents={stepInfo.listOfValidationRules} areStrictRulesPresent={strictRulePresent} validationTelemetry={this.validationTelemetry} parent={this.props.parent} />}
+                {showTutorialValidationMessage &&
+                    <TutorialCodeValidation.ShowValidationMessage onYesButtonClick={this.nextTutorialStep} onNoButtonClick={this.closeTutorialValidationMessage} initialVisible={this.state.showTutorialValidationMessage} isTutorialCodeInvalid={!tutorialCodeValidated} ruleComponents={stepInfo.listOfValidationRules} areStrictRulesPresent={strictRulePresent} validationTelemetry={this.validationTelemetry} parent={this.props.parent} />}
                 {hasFinish ? <sui.Button icon="left checkmark" className={`orange right attached ${!tutorialReady ? 'disabled' : ''}`} text={lf("Finish")} ariaLabel={lf("Finish the tutorial.")} onClick={this.finishTutorial} onKeyDown={sui.fireClickOnEnter} /> : undefined}
             </div>
         </div>;

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -4,7 +4,6 @@ import * as React from "react";
 import * as data from "./data";
 import * as sui from "./sui";
 import * as compiler from "./compiler";
-import { TutorialCard } from "./tutorial";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -32,14 +31,14 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         this.state = { visible: this.props.initialVisible, ruleSnippets: {} };
     }
 
-    showUnusedBlocksMessage(vis: boolean) {
+    showTutorialValidationMessage(vis: boolean) {
         this.setState({ visible: vis });
     }
 
     moveOnToNextTutorialStep() {
         this.props.validationTelemetry("continue");
         this.props.onYesButtonClick();
-        this.showUnusedBlocksMessage(false);
+        this.showTutorialValidationMessage(false);
     }
 
     stayOnThisTutorialStep() {
@@ -108,6 +107,7 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         const rulesDefined = (rules != undefined);
         const strictRulePresent = this.props.areStrictRulesPresent;
         return <div>
+            {this.state.visible && <div className="mask" role="region" onClick={this.props.onNoButtonClick}></div>}
             <div className={`tutorialCodeValidation no-select ${(!codeInvalid || (codeInvalid && !strictRulePresent)) ? 'hidden' : ''}`}>
                 <div className="codeValidationPopUpText">
                     {rulesDefined && rules.map((rule, index) => this.renderRule(rule, index))}

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import * as data from "./data";
 import * as sui from "./sui";
-import * as md from "./marked";
 import * as compiler from "./compiler";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
@@ -71,11 +70,10 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         if (!blockUris) {
             return <p key={index + rule.ruleName}>{(rule.ruleTurnOn && !rule.ruleStatus) ? rule.ruleMessage : ''}</p>
         } else {
-            // TODO (jxwoon): render snippets
             return <div>
                 {rule.ruleTurnOn && !rule.ruleStatus ? rule.ruleMessage : ''}
                 <div className="validationRendering">
-                    {blockUris.map((blockUri, index) => <div> <img key={index + blockUri} src={blockUri} alt="block rendered image" /></div>)}
+                    {blockUris.map((blockUri, index) => <div> <img key={index + blockUri} src={blockUri} alt="block rendered" /></div>)}
                 </div>
             </div>
 

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import * as data from "./data";
 import * as sui from "./sui";
+import * as md from "./marked";
 import * as compiler from "./compiler";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
@@ -70,8 +71,14 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         if (!blockUris) {
             return <p key={index + rule.ruleName}>{(rule.ruleTurnOn && !rule.ruleStatus) ? rule.ruleMessage : ''}</p>
         } else {
-            // TODO (jxwoon): render block dataUris
-            return <p key={index + rule.ruleName}>{(rule.ruleTurnOn && !rule.ruleStatus) ? rule.ruleMessage : ''}</p>
+            // TODO (jxwoon): render snippets
+            return <div>
+                {rule.ruleTurnOn && !rule.ruleStatus ? rule.ruleMessage : ''}
+                <div className="validationRendering">
+                    {blockUris.map((blockUri, index) => <div> <img key={index + blockUri} src={blockUri} alt="block rendered image" /></div>)}
+                </div>
+            </div>
+
         }
     }
 
@@ -96,16 +103,18 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
                         return pxt.blocks.layout.blocklyToSvgAsync(svg, viewBox[0], viewBox[1], viewBox[2], viewBox[3])
                             .then(sg => {
                                 if (!sg) return Promise.resolve<string>(undefined);
-                                return pxt.BrowserUtils.encodeToPngAsync(sg.xml, { width: sg.width, height: sg.height, pixelDensity: 1  });
+                                return pxt.BrowserUtils.encodeToPngAsync(sg.xml, { width: sg.width, height: sg.height, pixelDensity: 1 });
                             })
                     }
 
                     return Promise.resolve(undefined)
                 })).then(blockUris => {
-                    this.setState({ ruleBlocks: {
-                        ...this.state.ruleBlocks,
-                        [rule.ruleName]: blockUris.filter(b => !!b)
-                    } });
+                    this.setState({
+                        ruleBlocks: {
+                            ...this.state.ruleBlocks,
+                            [rule.ruleName]: blockUris.filter(b => !!b)
+                        }
+                    });
                 })
             })
         }

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -92,10 +92,12 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
                         return snippet;
                     })
                 })).then(snippets => {
-                    this.setState({ ruleSnippets: {
-                        ...this.state.ruleSnippets,
-                        [rule.ruleName]: snippets.filter(s => !!s)
-                    } });
+                    this.setState({
+                        ruleSnippets: {
+                            ...this.state.ruleSnippets,
+                            [rule.ruleName]: snippets.filter(s => !!s)
+                        }
+                    });
                 })
             })
         }

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -124,7 +124,7 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
         const rulesDefined = (rules != undefined);
         const strictRulePresent = this.props.areStrictRulesPresent;
         return <div>
-            {this.state.visible && <div className="mask" role="region" onClick={this.props.onNoButtonClick}></div>}
+            {this.state.visible && <div className="mask" role="region" onClick={this.props.onNoButtonClick} />}
             <div className={`tutorialCodeValidation no-select ${(!codeInvalid || (codeInvalid && !strictRulePresent)) ? 'hidden' : ''}`}>
                 <div className="codeValidationPopUpText">
                     {rulesDefined && rules.map((rule, index) => this.renderRule(rule, index))}


### PR DESCRIPTION
Few things in this PR

- Renamed variables

- Validation Blocks are rendered into the message
![Screenshot (53)](https://user-images.githubusercontent.com/13580493/121573428-1e19e880-c9da-11eb-8713-51a531ac1df1.png)

- Validation Messages disappears when anywhere in the workspace is clicked 
![click workspace validation message dissapears ](https://user-images.githubusercontent.com/13580493/121573577-46094c00-c9da-11eb-9fbe-514b3dce927d.gif)
