### PR TITLE
Add extra help link and don't say downloaded when cancelled

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -90,6 +90,7 @@ namespace pxt.editor {
 
         home?: boolean;
         hasError?: boolean;
+        cancelledDownload?: boolean;
 
         simSerialActive?: boolean;
         deviceSerialActive?: boolean;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2687,7 +2687,7 @@ export class ProjectView
             simRestart = false;
 
         try {
-            this.setState({ compiling: true });
+            this.setState({ compiling: true, cancelledDownload: false });
             this.clearSerial();
             this.editor.beforeCompile();
             if (simRestart) this.stopSimulator();
@@ -2700,7 +2700,10 @@ export class ProjectView
 
                 if (!saveOnly) {
                     const shouldContinue = await cmds.showUnsupportedHardwareMessageAsync(resp);
-                    if (!shouldContinue) return;
+                    if (!shouldContinue) {
+                        this.setState({ cancelledDownload: true });
+                        return;
+                    }
                 }
 
                 let fn = pxt.outputName();

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -636,19 +636,13 @@ export function showUnsupportedHardwareMessageAsync(resp: pxtc.CompileResult) {
     }
 
     if (unsupported.length) {
-        let jsx: JSX.Element;
-        if (pxt.commands.renderIncompatibleHardwareDialog) {
-            jsx = pxt.commands.renderIncompatibleHardwareDialog(unsupported);
-        }
-
+        const jsx = pxt.commands.renderIncompatibleHardwareDialog(unsupported);
         pxt.tickEvent('unsupportedhardwaredialog.shown')
 
-        const body = jsx ? undefined : lf("Oops! Looks like your project has code that won't run on the hardware you have connected. Would you like to download anyway?");
         const helpUrl = pxt.appTarget.appTheme.downloadDialogTheme?.incompatibleHardwareHelpURL;
         let cancelled = true;
         return core.confirmAsync({
             header: lf("Incompatible Code"),
-            body,
             jsx,
             hasCloseIcon: true,
             hideAgree: true,

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -16,6 +16,7 @@ function log(msg: string) {
 let extensionResult: pxt.editor.ExtensionResult;
 // This can be overidden by the extension result
 pxt.commands.renderBrowserDownloadInstructions = dialogs.renderBrowserDownloadInstructions;
+pxt.commands.renderIncompatibleHardwareDialog = dialogs.renderIncompatibleHardwareDialog;
 
 
 function browserDownloadAsync(text: string, name: string, contentType: string): Promise<void> {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -788,6 +788,18 @@ export function renderBrowserDownloadInstructions() {
     </div>;
 }
 
+export function renderIncompatibleHardwareDialog() {
+    const bodyText = lf("Oops! Looks like your project has code that won't run on the hardware you have connected. Would you like to download anyway?");
+    const helpText = lf("Learn more about what's supported by your hardware…")
+    const helpURL = pxt.appTarget.appTheme.downloadDialogTheme?.incompatibleHardwareHelpURL;
+
+    return <div className="ui content">
+        {bodyText}
+        <br />
+        {helpURL && <a target="_blank" rel="noopener noreferrer" href={helpURL}>{helpText}</a>}
+    </div>;
+}
+
 export function clearDontShowDownloadDialogFlag() {
     dontShowDownloadFlag = false;
 }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -106,11 +106,16 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
             }
         }
         else if (this.state?.compileState === "compiling") {
-            this.setState({ compileState: "success" });
-            if (this.compileTimeout) clearTimeout(this.compileTimeout);
-            this.compileTimeout = setTimeout(() => {
-                if (this.state?.compileState === "success") this.setState({ compileState: null });
-            }, 2000)
+            if (this.props.parent.state.cancelledDownload) {
+                this.setState({ compileState: null });
+            }
+            else {
+                this.setState({ compileState: "success" });
+                if (this.compileTimeout) clearTimeout(this.compileTimeout);
+                this.compileTimeout = setTimeout(() => {
+                    if (this.state?.compileState === "success") this.setState({ compileState: null });
+                }, 2000)
+            }
         }
     }
 

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -250,7 +250,7 @@ function showConnectionFailureAsync(confirmAsync: ConfirmAsync) {
                             <div className="description">
                                 {firmwareText}
                                 <br/>
-                                <a target="_blank" href={theme().firmwareHelpURL}>{lf("Learn more about firmware.", boardName)}</a>
+                                <a target="_blank" href={theme().firmwareHelpURL} rel="noopener noreferrer">{lf("Learn more about firmware.", boardName)}</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Few changes:

1. Adds a link to the incompatible hardware dialog
2. Fixes the issue where the download button still said "Downloaded!" even if you cancelled it
3. Added `rel="noopener noreferrer"` to the webusub dialog