### PR TITLE
Windows App deprecation UI fixes

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -441,6 +441,7 @@ declare namespace pxt {
         tutorialCodeValidation?: boolean; // Enable code validation for tutorials
         downloadDialogTheme?: DownloadDialogTheme;
         winAppDeprImage?: string; // Image to show on Windows App for deprecation
+        showWinAppDeprBanner?: boolean; // show banner announcing Windows App deprecation
     }
 
     interface DownloadDialogTheme {

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -534,6 +534,15 @@
         }
     }
 
+    #winAppError {
+        img {
+            background-color: white;
+        }
+        #winAppErrorMsg {
+            color: @HCtextColor;
+        }
+    }
+
     /* Cards */
     .card {
         background: @HCbackground !important;

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -525,6 +525,15 @@
         border: 2px solid @HCtextColor !important;
     }
 
+    #notificationBanner {
+        background: @HCbackground !important;
+        border: 2px solid @HCtextColor !important;
+
+        .header {
+            color: @HCtextColor !important;
+        }
+    }
+
     /* Cards */
     .card {
         background: @HCbackground !important;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4126,7 +4126,7 @@ export class ProjectView
             pxt.BrowserUtils.isTouchEnabled() ? 'has-touch' : '',
             hideMenuBar ? 'hideMenuBar' : '',
             !showEditorToolbar || transparentEditorToolbar ? 'hideEditorToolbar' : '',
-            this.state.bannerVisible ? "notificationBannerVisible" : "",
+            this.state.bannerVisible && !inHome ? "notificationBannerVisible" : "",
             this.state.debugging ? "debugging" : "",
             sandbox && this.isEmbedSimActive() ? 'simView' : '',
             isApp ? "app" : "",

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -699,10 +699,8 @@ export function showWinAppDeprecateAsync() {
         jsx: <div>
             <img className="ui medium centered image" src={pxt.appTarget.appTheme.winAppDeprImage} alt={lf("An image of a shrugging board")}/>
             <div>
-                {lf(`This app is being deprecated. Text editing is only available on the `)}
-                <a href={`https://${pxt.appTarget.name}`} target="_blank" rel="noopener noreferrer" onClick={()=>{pxt.tickEvent("winApp.openSite", undefined)}}>
-                    {lf("MakeCode website.")}
-                </a>
+                {lf(`This app is being deprecated. Text editing is only available on the MakeCode website `)}
+                {`(https://${pxt.appTarget.name}).`}
             </div>
         </div>
     })

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -666,16 +666,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     getWinAppErrorMsg(): (JSX.Element | string)[] {
-        const errMsg = lf("Oops! Text editing is only available on the website at {0}. Go {1} for more information.", "{0}", "{1}");
+        const errMsg = lf("Oops! Text editing is only available on the website at {0}. Go {1} for more information.", `https://${pxt.appTarget.name}`, "{1}");
         const parts = errMsg.split(/\{\d\}/);
         const textElements: (JSX.Element | string)[] = [
             parts[0],
-            `https://${pxt.appTarget.name}`,
-            parts[1],
             <a href={"/windows-app"} target="_blank" rel="noopener noreferrer">
                 {lf("here")}
             </a>,
-            parts[2]]
+            parts[1]]
         return textElements;
     }
 

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -666,13 +666,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     getWinAppErrorMsg(): (JSX.Element | string)[] {
-        const errMsg = lf("Oops! Text editing is only available on the {0} Go {1} for more information.", "{0}", "{1}");
+        const errMsg = lf("Oops! Text editing is only available on the website at {0}. Go {1} for more information.", "{0}", "{1}");
         const parts = errMsg.split(/\{\d\}/);
         const textElements: (JSX.Element | string)[] = [
             parts[0],
-            <a href={`https://${pxt.appTarget.name}`} target="_blank" rel="noopener noreferrer">
-                {lf("MakeCode website.")}
-            </a>,
+            `https://${pxt.appTarget.name}`,
             parts[1],
             <a href={"/windows-app"} target="_blank" rel="noopener noreferrer">
                 {lf("here")}

--- a/webapp/src/notification.tsx
+++ b/webapp/src/notification.tsx
@@ -121,19 +121,13 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
         const showExperiments = pxt.editor.experiments.someEnabled() && !/experiments=1/.test(window.location.href);
         const showWinAppBanner = pxt.appTarget.appTheme.showWinAppDeprBanner && pxt.BrowserUtils.isWinRT();
 
-        const errMsg = lf("This app is being deprecated. Please use {0} instead.", "{0}");
-        const parts = errMsg.split(/\{\d\}/);
-        const textElems = [
-            parts[0],
-            lf("the website"),
-            parts[1]
-        ];
+        const errMsg = lf("This app is being deprecated. Please use the website instead.");
 
         if (showWinAppBanner) {
             return <GenericBanner id="winAppBanner" parent={this.props.parent} bannerType={"negative"}>
                 <sui.Icon icon="warning circle" />
                 <div className="header">
-                    {textElems}
+                    {errMsg}
                 </div>
                 <sui.Link className="link" ariaLabel={lf("More info")} onClick={this.handleBannerClick}>{lf("More info")}</sui.Link>
 

--- a/webapp/src/notification.tsx
+++ b/webapp/src/notification.tsx
@@ -119,19 +119,17 @@ export class NotificationBanner extends data.Component<ISettingsProps, {}> {
             && (targetTheme.appPathNames || []).indexOf(location.pathname) === -1;
         const showExperimentalBanner = !isLocalServe && isApp && isExperimentalUrlPath;
         const showExperiments = pxt.editor.experiments.someEnabled() && !/experiments=1/.test(window.location.href);
-        const isWinApp = pxt.BrowserUtils.isWinRT();
+        const showWinAppBanner = pxt.appTarget.appTheme.showWinAppDeprBanner && pxt.BrowserUtils.isWinRT();
 
         const errMsg = lf("This app is being deprecated. Please use {0} instead.", "{0}");
         const parts = errMsg.split(/\{\d\}/);
         const textElems = [
             parts[0],
-            <a href={`https://${pxt.appTarget.name}`} target="_blank" rel="noopener noreferrer" onClick={()=>{pxt.tickEvent("winApp.openSite", undefined)}}>
-                {lf("the website")}
-            </a>,
+            lf("the website"),
             parts[1]
         ];
 
-        if (isWinApp) {
+        if (showWinAppBanner) {
             return <GenericBanner id="winAppBanner" parent={this.props.parent} bannerType={"negative"}>
                 <sui.Icon icon="warning circle" />
                 <div className="header">


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4165
fixes https://github.com/microsoft/pxt-microbit/issues/4176

I don't think there's a good way to open up the website in a browser instead of another app window, so just don't link to it. The text is copy-able, and we can include a link to the website in docs.

Looks like:

![image](https://user-images.githubusercontent.com/18712271/122143742-e7dbcf00-ce06-11eb-9321-94a32863d5c6.png)
![image](https://user-images.githubusercontent.com/18712271/122145647-7e5dbf80-ce0a-11eb-8ce3-49be3b3c0a6c.png)
![image](https://user-images.githubusercontent.com/18712271/122145142-8832f300-ce09-11eb-80ff-c0fc7a0e3586.png)
