### PR TITLE
fix centering on homescreen banner

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -532,6 +532,7 @@
     /* Carousel */
     .projectsdialog {
         .getting-started-segment {
+            background-position: left center;
             height: 250px;
             .getting-started {
                 padding: @carouselArrowSizeTablet;


### PR DESCRIPTION
fix issue pointed out here: https://github.com/microsoft/pxt-microbit/issues/4142#issuecomment-861873429 -- we had a little centering logic that was messing with it in the microbit target that I removed here: https://github.com/microsoft/pxt-microbit/pull/4182/commits/3124b5991d83c87a13185253972b6e5ba6ccbe8c, this just retains the nice vertical centering so the primary content of the image is visible.