### PR TITLE
bump blockly for datalogger array fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "monaco-editor": "0.24.0",
     "pouchdb": "7.2.1",
     "pouchdb-adapter-memory": "7.2.1",
-    "pxt-blockly": "3.0.34",
+    "pxt-blockly": "3.0.35",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -268,6 +268,7 @@ namespace pxt.blocks {
         const itemCount = fieldValues ? fieldValues.length : 2;
         const mut = document.createElement('mutation');
         mut.setAttribute("items", "" + itemCount);
+        mut.setAttribute("horizontalafter", "" + itemCount);
         shadow.appendChild(mut);
 
         for (let i = 0; i < itemCount; i++) {


### PR DESCRIPTION
Pick up https://github.com/microsoft/pxt-blockly/pull/351

* fixes https://github.com/microsoft/pxt-microbit/issues/4177 (one line addition added as second commit to make it swap to vertical after 2)
* fix https://github.com/microsoft/pxt-microbit/issues/4161
* fix https://github.com/microsoft/pxt-arcade/issues/1779