### PR TITLE
Add cancellation function to playPCMBufferAsync

### DIFF
--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -649,7 +649,7 @@ namespace pxsim {
 
         const MAX_SCHEDULED_BUFFER_NODES = 3;
 
-        export function playPCMBufferStreamAsync(pull: () => Float32Array, sampleRate: number, volume = 0.3) {
+        export function playPCMBufferStreamAsync(pull: () => Float32Array, sampleRate: number, volume = 0.3, isCancelled?: () => boolean) {
             return new Promise<void>(resolve => {
                 let nodes: AudioBufferSourceNode[] = [];
                 let nextTime = context().currentTime;
@@ -660,8 +660,8 @@ namespace pxsim {
                 // do it when the previous node completes (which sounds SUPER choppy in
                 // FireFox).
                 function playNext() {
-                    const isCancelled = !channel.gain;
-                    while (!allScheduled && nodes.length < MAX_SCHEDULED_BUFFER_NODES && !isCancelled) {
+                    const cancelled = isCancelled && isCancelled();
+                    while (!allScheduled && nodes.length < MAX_SCHEDULED_BUFFER_NODES && !cancelled) {
                         const data = pull();
                         if (!data || !data.length) {
                             allScheduled = true;
@@ -670,7 +670,7 @@ namespace pxsim {
                         play(data);
                     }
 
-                    if ((allScheduled && nodes.length === 0) || isCancelled) {
+                    if ((allScheduled && nodes.length === 0)) {
                         channel.remove();
                         if (resolve) resolve();
                         resolve = undefined;


### PR DESCRIPTION
Part of a fix for this issue: https://github.com/microsoft/pxt-microbit/issues/4212

Sometimes Safari delays sounds before the user interacts with the page instead of just cancelling them. That means when the user does finally do something to unmute, whatever sound they tried to play five minutes ago will play. Adding a cancellation token like function to be used in pxt-microbit to prevent that from happening.