### PR TITLE
CSS fix for dropdown flickering

### DIFF
--- a/theme/themes/pxt/globals/zindex.variables
+++ b/theme/themes/pxt/globals/zindex.variables
@@ -14,6 +14,9 @@
 /* Menu bar */
 @menuBarZIndex: 101; /* From semantic */
 
+/* Dropdown menu */
+@dropdownMenuZIndex: 11; /* From semantic */
+
 /* Editor */
 @aboveEditorZIndex: 90;
 

--- a/theme/themes/pxt/modules/dropdown.overrides
+++ b/theme/themes/pxt/modules/dropdown.overrides
@@ -48,6 +48,11 @@
     display: none;
 }
 
+.ui.dropdown.button:hover,
+.ui.dropdown.button:focus {
+    z-index: @dropdownMenuZIndex;
+}
+
 /* inverted */
 .ui.form.inverted .ui.dropdown {
     background: #333940 !important;

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -299,7 +299,6 @@ export class DropdownMenu extends UIElement<DropdownProps, DropdownState> {
     }
 
     protected captureMouseEvent = (e: React.MouseEvent) => {
-        e.preventDefault();
         e.stopPropagation();
     }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4200

some items in our dropdown menus are links, and `preventDefault` breaks the link behavior. the dropdown flickering in the project view page appears to be coming from the CSS filter (https://github.com/microsoft/pxt/blob/master/theme/common.less#L600) and explicitly setting the z-index should fix it

build: https://makecode.microbit.org/app/add6f95af87d3c2d45477f356764cfa5fef457e6-d68371ac11