### PR TITLE
Show offline message for Immersive Reader

### DIFF
--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -237,9 +237,9 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
 
     getTokenAsync().then(res => {
         if (Cloud.isOnline()) {
-            const syncStart = pxt.Util.now();
+            const launchStart = pxt.Util.now();
             return ImmersiveReader.launchAsync(res.token, res.subdomain, tutorialData, options).then(res => {
-                const elapsed = pxt.Util.now() - syncStart;
+                const elapsed = pxt.Util.now() - launchStart;
                 pxt.tickEvent("immersiveReader.launch.finished", {elapsed: elapsed})
             })
         } else {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4213

-> in the scenario where you don't already have the token and you're offline:
- this change properly handles the error and shows the offline message

-> in the scenario where you do have the token and you're offline
- I added a ping to check the connection before starting the launch to the immersive reader. the "Launch Immersive Reader" call doesn't fail quickly enough if there's no internet, so this shows the offline error instead of white-screening it for 15 seconds first