### PR TITLE
Fix sidedocs in electron app

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -127,8 +127,11 @@ namespace pxt.Cloud {
         const downloadAndSetMarkdownAsync = async () => {
             try {
                 const r = await downloadMarkdownAsync(docid, locale, entry?.etag);
-                await db.setAsync(locale, docid, branch, r.etag, undefined, r.md || entry?.md);
-                return r.md;
+                if (entry?.etag !== r.etag) {
+                    await db.setAsync(locale, docid, branch, r.etag, undefined, r.md || entry?.md);
+                    return r.md;
+                }
+                return entry.md;
             } catch {
                 return ""; // no translation
             }

--- a/webapp/public/docs.html
+++ b/webapp/public/docs.html
@@ -117,6 +117,8 @@
             $(backButton).remove(); backButton = undefined;
             $('#sidedocs-back-button-divider').remove();
         }
+
+        if (/pxtElectron=true/.test(window.location)) window.pxtElectron = true;
         var loading = document.getElementById('loading');
         var content = document.getElementById('content');
         ksRunnerReady(function() {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -515,8 +515,10 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
 
     setPath(path: string, blocksEditor: boolean) {
         this.openingSideDoc = true;
-        const docsUrl = this.rootDocsUrl();
+        let docsUrl = this.rootDocsUrl();
         const mode = blocksEditor ? "blocks" : "js";
+        const query = pxt.BrowserUtils.isPxtElectron() ? "?pxtElectron=true" : "";
+        if (query && docsUrl.endsWith("#")) docsUrl = docsUrl.substr(0, docsUrl.length - 1) + query + "#";
         const url = `${docsUrl}doc:${path}:${mode}:${pxt.Util.localeInfo()}`;
         this.setUrl(url);
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4216

There were a couple things going on here:

First, `isPxtElectron()` failed in the sidedocs iframe because it isn't affected by the preload script in pxt-electron. I added a query parameter to the sidedocs URL to set the `window.pxtElectron` global when we first load.

Second, we were always storing the results of the markdown request in the indexedDB, including when the server returned a status code 304 (nothing has changed). The 304 response doesn't include the markdown contents, so we were saving over whatever was in the indexedDB with the empty string when really we shouldn't have done anything.