### PR TITLE
Send long press event on header bar back button press (for iOS app)

### DIFF
--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -185,6 +185,17 @@ export function nativeHostBackAsync(): Promise<void> {
     return Promise.resolve();
 }
 
+export function nativeHostLongpressAsync(): Promise<void> {
+    log(`native longpress`)
+    const nativePostMessage = nativeHostPostMessageFunction();
+    if (nativePostMessage) {
+        nativePostMessage(<pxt.editor.NativeHostMessage>{
+            longpress: true
+        })
+    }
+    return Promise.resolve();
+}
+
 export function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.commands.DeployOptions): Promise<void> {
     pxt.tickEvent(`hid.deploy`);
     log(`hid deploy`)

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -14,8 +14,11 @@ import * as tutorial from "./tutorial";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 type HeaderBarView = "home" | "editor" | "tutorial" | "debugging" | "sandbox";
+const LONGPRESS_DURATION = 750;
 
 export class HeaderBar extends data.Component<ISettingsProps, {}> {
+    protected longpressTimer: any;
+
     constructor(props: ISettingsProps) {
         super(props);
     }
@@ -55,6 +58,14 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
     brandIconClick = () => {
         pxt.tickEvent("projects.brand", undefined, { interactiveConsent: true });
         this.goHome();
+    }
+
+    backButtonTouchStart = () => {
+        this.longpressTimer = setTimeout(() => cmds.nativeHostLongpressAsync(), LONGPRESS_DURATION);
+    }
+
+    backButtonTouchEnd = () => {
+        clearTimeout(this.longpressTimer);
     }
 
     protected getView = (): HeaderBarView => {
@@ -191,7 +202,8 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
 
         return <div id="mainmenu" className={`ui borderless fixed menu ${targetTheme.invertedMenu ? `inverted` : ''} ${manyTutorialSteps ? "thin" : ""}`} role="menubar">
             <div className="left menu">
-                {isNativeHost && <sui.Item className="icon" role="menuitem" icon="chevron left large" ariaLabel={lf("Back to application")} onClick={cmds.nativeHostBackAsync} />}
+                {isNativeHost && <sui.Item className="icon" role="menuitem" icon="chevron left large" ariaLabel={lf("Back to application")}
+                    onClick={cmds.nativeHostBackAsync} onMouseDown={this.backButtonTouchStart} onMouseUp={this.backButtonTouchEnd} onMouseLeave={this.backButtonTouchEnd} />}
                 {this.getOrganizationLogo(targetTheme, highContrast, view)}
                 {view === "tutorial"
                     // TODO: temporary place for tutorial name, we will eventually redesign the header for tutorial view

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -487,6 +487,9 @@ export interface ItemProps extends UiProps {
     active?: boolean;
     value?: string;
     onClick?: () => void;
+    onMouseDown?: () => void;
+    onMouseUp?: () => void;
+    onMouseLeave?: () => void;
     onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
 }
 
@@ -510,6 +513,11 @@ export class Item extends data.Component<ItemProps, {}> {
                 key={this.props.value}
                 data-value={this.props.value}
                 onClick={this.props.onClick}
+                onMouseDown={this.props.onMouseDown}
+                onTouchStart={this.props.onMouseDown}
+                onMouseUp={this.props.onMouseUp}
+                onTouchEnd={this.props.onMouseUp}
+                onMouseLeave={this.props.onMouseLeave}
                 onKeyDown={this.props.onKeyDown || fireClickOnEnter}>
                 {genericContent(this.props)}
                 {this.props.children}


### PR DESCRIPTION
tested this on my surface with touchscreen/mouse click, but have not tested on an iOS device. apparently iOS default long press duration is 500ms but that felt really fast to me