### PR TITLE
Always hit the live endpoint for compile requests

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1371,7 +1371,7 @@ namespace pxt.hexloader {
                         return U.httpGetTextAsync(hexurl + ".hex")
                     })
                     .then(r => r, e =>
-                        Cloud.privatePostAsync("compile/extension", { data: extInfo.compileData })
+                        Cloud.privatePostAsync("compile/extension", { data: extInfo.compileData }, true)
                             .then(ret => new Promise<string>((resolve, reject) => {
                                 let retry = 0;
                                 const delay = 8000; // ms


### PR DESCRIPTION
Fixes the main problem with https://github.com/microsoft/pxt-microbit/issues/4207

I will file an issue for fixing the hexcache so this also works better online