### PR TITLE
Replace dynamic name (page title) in pageview data with 'Share Page'

### DIFF
--- a/docfiles/apptracking.html
+++ b/docfiles/apptracking.html
@@ -17,11 +17,18 @@
         appInsights.queue.push(function () {
             appInsights.context.addTelemetryInitializer(telemetryInitializer);
         });
-        appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
+        var location = window.location.toString();
+        // Use generic title for script share page, otherwise use current page title
+        var pageTitle = isScriptPage(location) ? "Share Page" : null;
+        appInsights.trackPageView(pageTitle, scrubUrl(location), {urlReferrer: scrubUrl(document.referrer.toString())});
 
-        //Scrub the key (if any) from the URL.
+        var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
+        // Check if the current page contains a share URL
+        function isScriptPage(url) {
+            return !!url.match(scriptIdRegex);
+        }
+        // Scrub the key (if any) from the URL.
         function scrubUrl(url) {
-            var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
             return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
         }
 

--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -46,13 +46,21 @@
                 }
             });
         });
-        appInsights.trackPageView(null, scrubUrl(window.location.toString()), {urlReferrer: scrubUrl(document.referrer.toString())});
+        var location = window.location.toString();
+        // Use generic title for script share page, otherwise use current page title
+        var pageTitle = isScriptPage(location) ? "Share Page" : null;
+        appInsights.trackPageView(pageTitle, scrubUrl(location), {urlReferrer: scrubUrl(document.referrer.toString())});
 
-        //Scrub the key (if any) from the URL.
+        var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
+        // Check if the current page contains a share URL
+        function isScriptPage(url) {
+            return !!url.match(scriptIdRegex);
+        }
+        // Scrub the key (if any) from the URL.
         function scrubUrl(url) {
-            var scriptIdRegex = /(?:\d{5}-\d{5}-\d{5}-\d{5})|(?:_[0-9a-zA-Z]{12})/g;
             return url.replace(scriptIdRegex, "xxxxx-xxxxx-xxxxx-xxxxx");
         }
+
         return isProduction;
     }
     pxt.initAnalyticsAsync();


### PR DESCRIPTION
trying to change this file as little as possible, since it's used everywhere... appinsights by default sets the page title as the EntityName for a page view event. however, in share pages this title is dynamic; this replaces the user's project name with a more generic "Share Page" string