### PR TITLE
Don't show the hide dialog toggle when manually downloading

### DIFF
--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -15,11 +15,11 @@ namespace pxt.commands {
     export let patchCompileResultAsync: (r: pxtc.CompileResult) => Promise<void> = undefined;
     export let browserDownloadAsync: (text: string, name: string, contentType: string) => Promise<void> = undefined;
     export let saveOnlyAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined;
-    export let renderBrowserDownloadInstructions: () => any /* JSX.Element */ = undefined;
+    export let renderBrowserDownloadInstructions: (saveonly?: boolean) => any /* JSX.Element */ = undefined;
     export let renderUsbPairDialog: (firmwareUrl?: string, failedOnce?: boolean) => any /* JSX.Element */ = undefined;
     export let renderIncompatibleHardwareDialog: (unsupportedParts: string[]) => any /* JSX.Element */ = undefined;
     export let renderDisconnectDialog: () => { header: string, jsx: any, helpUrl: string }
-    export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>) => Promise<void> = undefined;
+    export let showUploadInstructionsAsync: (fn: string, url: string, confirmAsync: (options: any) => Promise<number>, saveonly?: boolean) => Promise<void> = undefined;
     export let saveProjectAsync: (project: pxt.cpp.HexFile) => Promise<void> = undefined;
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
     export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number> = undefined;

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -70,18 +70,18 @@ export function browserDownloadDeployCoreAsync(resp: pxtc.CompileResult): Promis
         return Promise.resolve();
     }
 
-    if (!userContext && pxt.BrowserUtils.isBrowserDownloadInSameWindow() || isDontShowDownloadDialogFlagSet()) {
+    if (!userContext && pxt.BrowserUtils.isBrowserDownloadInSameWindow() || (!resp.saveOnly && isDontShowDownloadDialogFlagSet())) {
         return Promise.resolve()
             .then(() => window.URL?.revokeObjectURL(url));
     }
     else {
         // save does the same as download as far iOS is concerned
-        return pxt.commands.showUploadInstructionsAsync(fn, url, core.confirmAsync)
+        return pxt.commands.showUploadInstructionsAsync(fn, url, core.confirmAsync, resp.saveOnly)
             .then(() => window.URL?.revokeObjectURL(url));
     }
 }
 
-function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (options: core.PromptOptions) => Promise<number>): Promise<void> {
+function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (options: core.PromptOptions) => Promise<number>, saveonly?: boolean): Promise<void> {
     const boardName = pxt.appTarget.appTheme.boardName || lf("device");
     const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
 
@@ -94,7 +94,7 @@ function showUploadInstructionsAsync(fn: string, url: string, confirmAsync: (opt
     const saveAs = pxt.BrowserUtils.hasSaveAs();
     const ext = pxt.appTarget.compile.useUF2 ? ".uf2" : ".hex";
     const connect = pxt.usb.isEnabled && pxt.appTarget?.compile?.webUSB;
-    const jsx = !userDownload && !saveAs && pxt.commands.renderBrowserDownloadInstructions && pxt.commands.renderBrowserDownloadInstructions();
+    const jsx = !userDownload && !saveAs && pxt.commands.renderBrowserDownloadInstructions && pxt.commands.renderBrowserDownloadInstructions(saveonly);
     const body = userDownload ? lf("Click 'Download' to open the {0} app.", pxt.appTarget.appTheme.boardName) :
         saveAs ? lf("Click 'Save As' and save the {0} file to the {1} drive to transfer the code into your {2}.",
             ext,

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -734,7 +734,7 @@ export function promptTranslateBlock(blockid: string, blockTranslationIds: strin
     });
 }
 
-export function renderBrowserDownloadInstructions() {
+export function renderBrowserDownloadInstructions(saveonly?: boolean) {
     const boardName = pxt.appTarget.appTheme.boardName || lf("device");
     const boardDriveName = pxt.appTarget.appTheme.driveDisplayName || pxt.appTarget.compile.driveName || "???";
     const fileExtension = pxt.appTarget.compile?.useUF2 ? ".uf2" : ".hex";
@@ -801,10 +801,12 @@ export function renderBrowserDownloadInstructions() {
                 </div>
             </div>
             <div>
-                <sui.Checkbox
-                    inputLabel={lf("Don't show this again")}
-                    onChange={onCheckboxClicked}
-                />
+                {!saveonly &&
+                    <sui.Checkbox
+                        inputLabel={lf("Don't show this again")}
+                        onChange={onCheckboxClicked}
+                    />
+                }
             </div>
         </div>
     </div>;

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -192,7 +192,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         // Matching the tick in the call to compile() above for historical reasons
         pxt.tickEvent("editortools.download", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
         pxt.tickEvent("editortools.downloadasfile", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        clearDontShowDownloadDialogFlag();
         (this.props.parent as ProjectView).compile(true);
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4215

Hides the "Don't show this again" toggle in the download dialog when you manually download as file. Here's the logic for the three download options:

1. If you download using the download button, we respect the toggle
2. If you download using "Download as file" in the "..." menu, we always show the dialog but hide the toggle
3. If you download using the save button, we always show the dialog but hide the toggle

There is now no way to clear the "don't show this again" setting, but it isn't too bad since you can always get to it using 2 or 3
