### PR TITLE
Compare text content instead of etags when fetching markdown

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -127,8 +127,9 @@ namespace pxt.Cloud {
         const downloadAndSetMarkdownAsync = async () => {
             try {
                 const r = await downloadMarkdownAsync(docid, locale, entry?.etag);
-                if (entry?.etag !== r.etag) {
-                    await db.setAsync(locale, docid, branch, r.etag, undefined, r.md || entry?.md);
+                // TODO directly compare the entry/response etags after backend change
+                if (!entry || (r.md && entry.md !== r.md)) {
+                    await db.setAsync(locale, docid, branch, r.etag, undefined, r.md);
                     return r.md;
                 }
                 return entry.md;


### PR DESCRIPTION
we're requesting markdown content from `makecode.microbit.org` and our markdown is hosted on `makecode.com` so i believe we're hitting CORS issues where the etag is not accessible from javascript: https://stackoverflow.com/questions/5822985/cross-domain-resource-sharing-get-refused-to-get-unsafe-header-etag-from-re

i think we can fix this by adding an `Access-Controls-Expose-Headers` header to the backend response but in the meantime, comparing the markdown should also work 