### PR TITLE
Don't fail when indexed DB isn't available to cache

### DIFF
--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -666,7 +666,15 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
     }
 
     if (externalPackages.length) {
-        const db = await ApiInfoIndexedDb.createAsync();
+        let db: ApiInfoIndexedDb;
+        try {
+            db = await ApiInfoIndexedDb.createAsync();
+        }
+        catch (e) {
+            // Don't fail if the indexeddb fails, but log it
+            console.log("Unable to open API info cache DB");
+            return null;
+        }
 
         for (const dep of externalPackages) {
             const entry = await db.getAsync(dep);
@@ -731,7 +739,16 @@ async function cacheApiInfoAsync(project: pkg.EditorPackage, info: pxtc.ApisInfo
 
     if (externalPackages.length) {
         const apiList = Object.keys(info.byQName);
-        const db = await ApiInfoIndexedDb.createAsync();
+        let db: ApiInfoIndexedDb;
+
+        try {
+            db = await ApiInfoIndexedDb.createAsync();
+        }
+        catch (e) {
+            // Don't fail if the indexeddb fails, but log it
+            pxt.log("Unable to create DB to cache API info");
+            return;
+        }
 
         for (const dep of externalPackages) {
             const pkgId = dep.getPkgId();

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -102,7 +102,13 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                 if (pxt.options.debug)
                     pxt.debug(JSON.stringify(snippetBlocks, null, 2));
 
-                if (db && !skipCache) db.setAsync(id, snippetBlocks, code);
+                try {
+                    if (db && !skipCache) db.setAsync(id, snippetBlocks, code);
+                }
+                catch (e) {
+                    // Don't fail if the indexeddb fails, but log it
+                    pxt.log("Unable to cache used blocks in DB");
+                }
                 pxt.tickEvent(`tutorial.usedblocks.computed`, { tutorial: id });
 
                 return { snippetBlocks, usedBlocks };

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -721,7 +721,13 @@ export async function getPublishedScriptAsync(id: string) {
                 files = await (Cloud.downloadScriptFilesAsync(id)
                     .catch(core.handleNetworkError))
             }
-            await scripts.setAsync({ id: eid, files: files })
+            try {
+                await scripts.setAsync({ id: eid, files: files })
+            }
+            catch (e) {
+                // Don't fail if the indexeddb fails, but log it
+                pxt.log("Unable to cache script in DB");
+            }
         }
         return fixupFileNames(files)
     })


### PR DESCRIPTION
In ios 13.3, indexedDB will not work in an iframe that is embedded in a separate domain. Most of the time we handle indexedDB errors gracefully, but we have a few places where we cache things that assume the DB exists and don't handle errors.

Adding a few try/catch statements so that we ignore failed cache operations. Makes everything slow, but at least it works at all!