### PR TITLE
Patch top level shadow blocks

### DIFF
--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -246,6 +246,18 @@ namespace pxt.blocks {
                     }));
             }
 
+            // Blockly doesn't allow top-level shadow blocks. We've had bugs in the past where shadow blocks
+            // have ended up as top-level blocks, so promote them to regular blocks just in case
+            const shadows = getDirectChildren(doc.children.item(0), "shadow");
+            for (const shadow of shadows) {
+                const block = doc.createElement("block");
+                shadow.getAttributeNames().forEach(attr => block.setAttribute(attr, shadow.getAttribute(attr)));
+                for (let j = 0; j < shadow.childNodes.length; j++) {
+                    block.appendChild(shadow.childNodes.item(j));
+                }
+                shadow.replaceWith(block);
+            }
+
             // build upgrade map
             const enums: Map<string> = {};
             Object.keys(info.apis.byQName).forEach(k => {


### PR DESCRIPTION
If a shadow block somehow becomes a top-level block (e.g. via https://github.com/microsoft/pxt-arcade/issues/3623), blockly refuses to load the workspace and throws an error instead. We don't really care about that restriction, so just convert any top-level shadow blocks in the XML to regular blocks before loading the workspace.

This will make it so that if any projects were affected by https://github.com/microsoft/pxt-arcade/issues/3623, they can now be opened. The actual fix for that issue is here:

https://github.com/microsoft/pxt-blockly/pull/354

