### PR TITLE
limit concurrency when syncing cloud projects

### DIFF
--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -334,7 +334,7 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
         if (fullSync) {
             hdrs = getLocalCloudHeaders();
         }
-    
+
         pxt.log(`Synchronizing ${hdrs.length} local project(s) with the cloud...`);
 
         const localCloudHeaders = getLocalCloudHeaders(hdrs);
@@ -388,7 +388,7 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
             return undefined;
         }
         let errors: Error[] = [];
-        
+
         async function syncOneUp(local: Header): Promise<void> {
             try {
                 // track the fact that we're checking for updates on each project
@@ -510,7 +510,7 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
         await U.promisePoolAsync(
             MAX_CONCURRENCY,
             U.values(remoteHeadersToProcess)
-            .filter(h => !h.isDeleted),  // don't bother downloading deleted projects
+                .filter(h => !h.isDeleted),  // don't bother downloading deleted projects
             syncOneDown);
 
         // log failed sync tasks.

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -1565,7 +1565,7 @@ export function syncAsync(): Promise<pxt.editor.EditorSyncState> {
                 }
                 return ex;
             })
-            cloudsync.syncAsync(); // sync in background
+            Promise.all([cloudsync.syncAsync(), cloud.syncAsync()]); // sync in background
         })
         .then(() => {
             refreshHeadersSession();


### PR DESCRIPTION
Well, this isn't the change I was hoping to make, but it is less radical, and a nice intermediate step toward a better solution.

Main change: limit the number of projects syncing with the cloud at one time. Max concurrency is set to 10. While working on this, I noticed a race condition between the sync up and sync down processes. I fixed this by running the phases in serial.

I also discovered a case where signing into github could trigger a full cloud sync, so I untangled that.

Lastly, I deleted a bunch of unused code from cloudsync.ts.