### PR TITLE
Improve cloud sync status indicator

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1162,10 +1162,18 @@ p.ui.font.small {
     font-size: 0.95rem;
 }
 
-#projectNameArea .cloudState {
-    color: rgba(0, 0, 0, 0.5);
+#projectNameArea .cloudstatusarea {
+    color: @teal;
+    align-self: center;
 }
 
+#projectNameArea .cloudicon {
+    margin-left: 0.5rem;
+}
+
+#projectNameArea .cloudtext {
+    margin-left: 0.5rem;
+}
 
 /*******************************
         Download dialogs

--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -47,24 +47,6 @@ export function excludeCloudMetadataFields(h: Header): Header {
     return excludeMetadataFields(h, cloudMetadataFields);
 }
 
-export type CloudStateSummary = ""/*none*/ | "saved" | "justSaved" | "offline" | "syncing" | "conflict" | "localEdits";
-export function getCloudSummary(h: pxt.workspace.Header, md: CloudTempMetadata): CloudStateSummary {
-    if (!h.cloudUserId || !md)
-        return "" // none
-    if (!auth.loggedInSync())
-        return "offline"
-    if (md.cloudInProgressSyncStartTime > 0)
-        return "syncing"
-    if (!h.cloudCurrent)
-        return "localEdits"
-    if (md.justSaved)
-        return "justSaved"
-    if (h.cloudLastSyncTime > 0)
-        return "saved"
-    pxt.reportError("cloudsave", `Invalid project cloud state for project ${h.name}(${h.id.substr(0, 4)}..): user: ${h.cloudUserId}, inProg: ${md.cloudInProgressSyncStartTime}, cloudCurr: ${h.cloudCurrent}, lastCloud: ${h.cloudLastSyncTime}`);
-    return ""
-}
-
 async function listAsync(): Promise<Header[]> {
     return new Promise(async (resolve, reject) => {
         const result = await auth.apiAsync<CloudProject[]>("/api/user/project");
@@ -91,81 +73,126 @@ async function listAsync(): Promise<Header[]> {
 
 function getAsync(h: Header): Promise<File> {
     return new Promise(async (resolve, reject) => {
-        const result = await auth.apiAsync<CloudProject>(`/api/user/project/${h.id}`);
-        if (result.success) {
-            const userId = auth.user()?.id;
-            const project = result.resp;
-            const rawHeader = JSON.parse(project.header);
-            const header = excludeLocalOnlyMetadataFields(rawHeader)
-            const text = JSON.parse(project.text);
-            const version = project.version;
-            const file: File = {
-                header,
-                text,
-                version
-            };
-            file.header.cloudCurrent = true;
-            file.header.cloudVersion = file.version;
-            file.header.cloudUserId = userId;
-            file.header.cloudLastSyncTime = U.nowSeconds();
-            pxt.tickEvent(`identity.cloudApi.getProject.success`);
-            resolve(file);
-        } else {
-            pxt.tickEvent(`identity.cloudApi.getProject.failed`);
-            reject(result.err);
+        const cloudMeta = getCloudTempMetadata(h.id);
+        try {
+            cloudMeta.syncInProgress();
+            const result = await auth.apiAsync<CloudProject>(`/api/user/project/${h.id}`);
+            if (result.success) {
+                const userId = auth.user()?.id;
+                const project = result.resp;
+                const rawHeader = JSON.parse(project.header);
+                const header = excludeLocalOnlyMetadataFields(rawHeader)
+                const text = JSON.parse(project.text);
+                const version = project.version;
+                const file: File = {
+                    header,
+                    text,
+                    version
+                };
+                file.header.cloudCurrent = true;
+                file.header.cloudVersion = file.version;
+                file.header.cloudUserId = userId;
+                file.header.cloudLastSyncTime = U.nowSeconds();
+                pxt.tickEvent(`identity.cloudApi.getProject.success`);
+                resolve(file);
+            } else {
+                pxt.tickEvent(`identity.cloudApi.getProject.failed`);
+                reject(result.err);
+            }
+        } finally {
+            cloudMeta.syncFinished();
         }
     });
 }
 
+export type CloudStateSummary = ""/*none*/ | "synced" | "justSynced" | "offline" | "syncing" | "conflict" | "localEdits";
+
 // temporary per-project cloud metadata is only kept in memory and shouldn't be persisted to storage.
-export interface CloudTempMetadata {
-    cloudInProgressSyncStartTime?: number,
-    justSaved?: boolean,
+export class CloudTempMetadata {
+    constructor(public headerId: string) { }
+    private _justSynced: boolean;
+    private _syncStartTime: number;
+
+    public get justSynced() { return this._justSynced; }
+
+    public syncInProgress() {
+        this._syncStartTime = U.nowSeconds();
+        data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
+    }
+
+    public syncFinished() {
+        this._syncStartTime = 0;
+        this._justSynced = true;
+        data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
+        // slightly hacky, but we want to keep around a "saved!" message for a small time after
+        // a save succeeds so we notify metadata subscribers again after a delay.
+        setTimeout(() => {
+            if (this._syncStartTime === 0) { // not currently syncing?
+                this._justSynced = false;
+                data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
+            }
+        }, 1500);
+    }
+
+    public cloudStateSummary(): CloudStateSummary {
+        const h = workspace.getHeader(this.headerId);
+        if (!h.cloudUserId)
+            return "" // none
+        if (!auth.loggedInSync())
+            return "offline"
+        if (this._syncStartTime > 0)
+            return "syncing"
+        if (!h.cloudCurrent)
+            return "localEdits"
+        if (this.justSynced)
+            return "justSynced"
+        if (h.cloudLastSyncTime > 0)
+            return "synced"
+        pxt.reportError("cloudsave", `Invalid project cloud state for project ${h.name}(${h.id.substr(0, 4)}..): user: ${h.cloudUserId}, inProg: ${this._syncStartTime}, cloudCurr: ${h.cloudCurrent}, lastCloud: ${h.cloudLastSyncTime}`);
+        return ""
+    }
 }
 const temporaryHeaderMetadata: { [key: string]: CloudTempMetadata } = {};
 export function getCloudTempMetadata(headerId: string): CloudTempMetadata {
-    return temporaryHeaderMetadata[headerId] || {};
-}
-function updateCloudTempMetadata(headerId: string, props: Partial<CloudTempMetadata>) {
-    const oldMd = temporaryHeaderMetadata[headerId] || {};
-    const newMd = { ...oldMd, ...props }
-    temporaryHeaderMetadata[headerId] = newMd
-    data.invalidate(`${HEADER_CLOUDSTATE}:${headerId}`);
+    if (!temporaryHeaderMetadata[headerId]) {
+        temporaryHeaderMetadata[headerId] = new CloudTempMetadata(headerId);
+    }
+    return temporaryHeaderMetadata[headerId];
 }
 
 function setAsync(h: Header, prevVersion: string, text?: ScriptText): Promise<string> {
     return new Promise(async (resolve, reject) => {
-        const userId = auth.user()?.id;
-        h.cloudUserId = userId;
-        h.cloudCurrent = false;
-        h.cloudVersion = prevVersion;
-        updateCloudTempMetadata(h.id, { cloudInProgressSyncStartTime: U.nowSeconds() })
-        const project: CloudProject = {
-            id: h.id,
-            header: JSON.stringify(excludeLocalOnlyMetadataFields(h)),
-            text: text ? JSON.stringify(text) : undefined,
-            version: prevVersion
+        const cloudMeta = getCloudTempMetadata(h.id);
+        try {
+            const userId = auth.user()?.id;
+            h.cloudUserId = userId;
+            h.cloudCurrent = false;
+            h.cloudVersion = prevVersion;
+            cloudMeta.syncInProgress();
+            const project: CloudProject = {
+                id: h.id,
+                header: JSON.stringify(excludeLocalOnlyMetadataFields(h)),
+                text: text ? JSON.stringify(text) : undefined,
+                version: prevVersion
+            }
+            const result = await auth.apiAsync<string>('/api/user/project', project);
+            if (result.success) {
+                h.cloudCurrent = true;
+                h.cloudVersion = result.resp;
+                h.cloudLastSyncTime = U.nowSeconds()
+                pxt.tickEvent(`identity.cloudApi.setProject.success`);
+                resolve(result.resp);
+            } else if (result.statusCode === 409) {
+                // conflict
+                pxt.tickEvent(`identity.cloudApi.setProject.conflict`);
+                resolve(undefined)
+            } else {
+                pxt.tickEvent(`identity.cloudApi.setProject.failed`);
+                reject(result.err);
+            }
         }
-        const result = await auth.apiAsync<string>('/api/user/project', project);
-        updateCloudTempMetadata(h.id, { cloudInProgressSyncStartTime: 0, justSaved: true })
-        setTimeout(() => {
-            // slightly hacky, but we want to keep around a "saved!" message for a small time after
-            // a save succeeds so we notify metadata subscribers again afte a delay.
-            updateCloudTempMetadata(h.id, { justSaved: false })
-        }, 1000);
-        if (result.success) {
-            h.cloudCurrent = true;
-            h.cloudVersion = result.resp;
-            h.cloudLastSyncTime = U.nowSeconds()
-            pxt.tickEvent(`identity.cloudApi.setProject.success`);
-            resolve(result.resp);
-        } else if (result.statusCode === 409) {
-            // conflict
-            pxt.tickEvent(`identity.cloudApi.setProject.conflict`);
-            resolve(undefined)
-        } else {
-            pxt.tickEvent(`identity.cloudApi.setProject.failed`);
-            reject(result.err);
+        finally {
+            cloudMeta.syncFinished();
         }
     });
 }
@@ -391,9 +418,6 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
 
         async function syncOneUp(local: Header): Promise<void> {
             try {
-                // track the fact that we're checking for updates on each project
-                updateCloudTempMetadata(local.id, { cloudInProgressSyncStartTime: U.nowSeconds() });
-
                 const remote = remoteHeadersToProcess[local.id];
                 delete remoteHeadersToProcess[local.id];
                 if (remote) {
@@ -516,13 +540,6 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
         // log failed sync tasks.
         errors.forEach(err => pxt.log(err));
         errors = [];
-
-        // reset cloud state sync metadata if there is any
-        getLocalCloudHeaders(hdrs).forEach(hdr => {
-            if (getCloudTempMetadata(hdr.id).cloudInProgressSyncStartTime > 0) {
-                updateCloudTempMetadata(hdr.id, { cloudInProgressSyncStartTime: 0 });
-            }
-        })
 
         const elapsed = U.nowSeconds() - syncStart;
         const localHeaderChangesList = U.values(localHeaderChanges)

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -83,8 +83,8 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
         // they won't update dynamically when headers change.
         const header = card.projectId ? this.getData<pxt.workspace.Header>(`header:${card.projectId}`) : null;
         const name = header ? header.name : card.name;
-        const cloudMd = card.projectId ? this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${card.projectId}`) : {};
-        const cloudState = header ? cloud.getCloudSummary(header, cloudMd) : "";
+        const cloudMd = card.projectId ? this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${card.projectId}`) : null;
+        const cloudState = header ? cloudMd?.cloudStateSummary() : "";
         const lastCloudSave = cloudState ? Math.min(header.cloudLastSyncTime, header.modificationTime) : card.time;
 
         const ariaLabel = card.ariaLabel || card.title || card.shortName || name;
@@ -131,7 +131,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
             {card.time ? <div className="meta">
                 {card.tutorialLength ? <span className={`ui tutorial-progress ${tutorialDone ? "green" : "orange"} left floated label`}><i className={`${tutorialDone ? "trophy" : "circle"} icon`}></i>&nbsp;{lf("{0}/{1}", (card.tutorialStep || 0) + 1, card.tutorialLength)}</span> : undefined}
                 {!cloudState && card.time && <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span>}
-                {(cloudState === "saved" || cloudState === "justSaved") &&
+                {(cloudState === "synced" || cloudState === "justSynced") &&
                     <span key="date" className="date">{pxt.Util.timeSince(lastCloudSave)}</span>
                 }
                 {cloudState === "localEdits" &&

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -84,8 +84,9 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
         const header = card.projectId ? this.getData<pxt.workspace.Header>(`header:${card.projectId}`) : null;
         const name = header ? header.name : card.name;
         const cloudMd = card.projectId ? this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${card.projectId}`) : null;
-        const cloudState = header ? cloudMd?.cloudStateSummary() : "";
-        const lastCloudSave = cloudState ? Math.min(header.cloudLastSyncTime, header.modificationTime) : card.time;
+        const cloudStatus = cloudMd?.cloudStatus();
+        const lastCloudSave = cloudStatus ? Math.min(header.cloudLastSyncTime, header.modificationTime) : card.time;
+        const cloudShowTimestamp = cloudStatus && (cloudStatus.value === "synced" || cloudStatus.value === "justSynced" || cloudStatus.value === "localEdits");
 
         const ariaLabel = card.ariaLabel || card.title || card.shortName || name;
 
@@ -130,23 +131,14 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                 </div> : undefined}
             {card.time ? <div className="meta">
                 {card.tutorialLength ? <span className={`ui tutorial-progress ${tutorialDone ? "green" : "orange"} left floated label`}><i className={`${tutorialDone ? "trophy" : "circle"} icon`}></i>&nbsp;{lf("{0}/{1}", (card.tutorialStep || 0) + 1, card.tutorialLength)}</span> : undefined}
-                {!cloudState && card.time && <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span>}
-                {(cloudState === "synced" || cloudState === "justSynced") &&
-                    <span key="date" className="date">{pxt.Util.timeSince(lastCloudSave)}</span>
+                {!cloudStatus && card.time && <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span>}
+                {cloudStatus && cloudShowTimestamp &&
+                    <span key="date" className="date">{pxt.Util.timeSince(lastCloudSave)}{cloudStatus.indicator}</span>
                 }
-                {cloudState === "localEdits" &&
-                    <span key="date" className="date">{pxt.Util.timeSince(lastCloudSave)}*</span>
+                {cloudStatus && !cloudShowTimestamp &&
+                    <span key="date" className="date">{cloudStatus.indicator}</span>
                 }
-                {cloudState === "conflict" &&
-                    lf("needs attention!")
-                }
-                {cloudState === "offline" &&
-                    lf("offline")
-                }
-                {cloudState === "syncing" &&
-                    lf("syncing...")
-                }
-                {cloudState &&
+                {cloudStatus &&
                     // TODO: alternate icons depending on state
                     <i className="ui large right floated icon cloud"></i>
                 }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -298,32 +298,17 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     getCloudStatus(header: pxt.workspace.Header): JSX.Element {
         const cloudMd = this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${header.id}`);
-        const cloudState = cloudMd.cloudStateSummary();
-        const showCloudButton = !!cloudState && auth.hasIdentity();
+        const cloudStatus = cloudMd.cloudStatus();
+        const showCloudButton = !!cloudStatus && cloudStatus.value !== "none" && auth.hasIdentity();
         if (!showCloudButton) { return undefined; }
-        const getCloudIcon = () => {
-            if (cloudState === "syncing" || cloudState === "localEdits")
-                return "cloud-saving-b"
-            if (cloudState === "conflict" || cloudState === "offline")
-                return "cloud-error-b"
-            return "cloud-saved-b"
-        }
-        const getCloudTooltip = () => {
-            if (cloudState === "syncing" || cloudState === "localEdits")
-                return lf("Saving project to the cloud...")
-            if (cloudState === "conflict")
-                return lf("Project was edited in two places and the changes conflict")
-            if (cloudState === "offline")
-                return lf("Unable to connect to cloud")
-            return lf("Project saved to cloud")
-        }
+
         return (<div className="cloudstatusarea">
-            {showCloudButton && <i className={"ui large right floated cloudicon xicon " + getCloudIcon()} title={getCloudTooltip()}></i>}
-            {showCloudButton && cloudState === "localEdits" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
-            {showCloudButton && cloudState === "syncing" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
-            {showCloudButton && cloudState === "justSynced" && <span className="ui mobile hide cloudtext">{lf("saved!")}</span>}
-            {showCloudButton && cloudState === "offline" && <span className="ui mobile hide cloudtext">{lf("offline")}</span>}
-            {showCloudButton && cloudState === "conflict" && <span className="ui mobile hide cloudtext">{lf("conflict!")}</span>}
+            {showCloudButton && <i className={"ui large right floated cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip}></i>}
+            {showCloudButton && cloudStatus.value === "localEdits" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
+            {showCloudButton && cloudStatus.value === "syncing" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
+            {showCloudButton && cloudStatus.value === "justSynced" && <span className="ui mobile hide cloudtext">{lf("saved!")}</span>}
+            {showCloudButton && cloudStatus.value === "offline" && <span className="ui mobile hide cloudtext">{lf("offline")}</span>}
+            {showCloudButton && cloudStatus.value === "conflict" && <span className="ui mobile hide cloudtext">{lf("conflict!")}</span>}
         </div>);
     }
 


### PR DESCRIPTION
Addresses https://github.com/microsoft/pxt-arcade/issues/3608, but without the spinner as I didn't find an existing spinner widget. But it looks pretty nice as-is, imo. Will bring it to the next design office hours for review.

![cloud](https://user-images.githubusercontent.com/12176807/124338372-761cb880-db5c-11eb-88a1-35c2d44e2b42.gif)


Also did some tidying up of how we track cloud sync status per project.