### PR TITLE
Cloud status with spinner

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1162,17 +1162,26 @@ p.ui.font.small {
     font-size: 0.95rem;
 }
 
-#projectNameArea .cloudstatusarea {
+.cloudstatusarea {
     color: @teal;
     align-self: center;
-}
+    display: flex;
 
-#projectNameArea .cloudicon {
-    margin-left: 0.5rem;
-}
+    .cloudicon {
+        margin-left: 0.5rem;
+    }
 
-#projectNameArea .cloudtext {
-    margin-left: 0.5rem;
+    .cloudprogress {
+        margin-left: 0.5rem !important;
+    }
+
+    .cloudtext {
+        margin-left: 0.5rem;
+    }
+
+    .ui.loader:after {
+        border-top-color: @teal;
+    }
 }
 
 /*******************************

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -7,6 +7,7 @@ import * as githubbutton from "./githubbutton";
 import * as cmds from "./cmds"
 import * as cloud from "./cloud";
 import * as auth from "./auth";
+import * as identity from "./identity";
 import { ProjectView } from "./app";
 import { clearDontShowDownloadDialogFlag } from "./dialogs";
 
@@ -296,22 +297,6 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         return el;
     }
 
-    getCloudStatus(header: pxt.workspace.Header): JSX.Element {
-        const cloudMd = this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${header.id}`);
-        const cloudStatus = cloudMd.cloudStatus();
-        const showCloudButton = !!cloudStatus && cloudStatus.value !== "none" && auth.hasIdentity();
-        if (!showCloudButton) { return undefined; }
-
-        return (<div className="cloudstatusarea">
-            {showCloudButton && <i className={"ui large right floated cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip}></i>}
-            {showCloudButton && cloudStatus.value === "localEdits" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
-            {showCloudButton && cloudStatus.value === "syncing" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
-            {showCloudButton && cloudStatus.value === "justSynced" && <span className="ui mobile hide cloudtext">{lf("saved!")}</span>}
-            {showCloudButton && cloudStatus.value === "offline" && <span className="ui mobile hide cloudtext">{lf("offline")}</span>}
-            {showCloudButton && cloudStatus.value === "conflict" && <span className="ui mobile hide cloudtext">{lf("conflict!")}</span>}
-        </div>);
-    }
-
     renderCore() {
         const { tutorialOptions, projectName, compiling, isSaving, simState, debugging, editorState } = this.props.parent.state;
         const header = this.getData(`header:${this.props.parent.state.header.id}`) ?? this.props.parent.state.header;
@@ -397,7 +382,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                     <div className={`ui right ${showSave ? "labeled" : ""} input projectname-input projectname-computer`}>
                         {showProjectRename && this.getSaveInput(showSave, "fileNameInput2", projectName, showProjectRenameReadonly)}
                         {showGithub && <githubbutton.GithubButton parent={this.props.parent} key={`githubbtn${computer}`} />}
-                        {this.getCloudStatus(header)}
+                        <identity.CloudSaveStatus headerId={header.id} />
                     </div>
                 </div>}
             <div id="editorToolbarArea" role="menu" className="ui column items">

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -205,13 +205,13 @@ export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
         const syncing = preparing || cloudStatus.value === "syncing";
 
         return (<div className="cloudstatusarea">
-            {!syncing && <i className={"ui tiny cloudicon xicon " + cloudStatus.icon}></i>}
-            {syncing && <div className={"ui tiny inline loader active cloudprogress " + (preparing ? "indeterminate" : "")}></div>}
-            {cloudStatus.value === "localEdits" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
-            {cloudStatus.value === "syncing" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
-            {cloudStatus.value === "justSynced" && <span className="ui mobile hide cloudtext">{lf("saved!")}</span>}
-            {cloudStatus.value === "offline" && <span className="ui mobile hide cloudtext">{lf("offline")}</span>}
-            {cloudStatus.value === "conflict" && <span className="ui mobile hide cloudtext">{lf("conflict!")}</span>}
+            {!syncing && <sui.Item className={"ui tiny cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip}></sui.Item>}
+            {syncing && <sui.Item className={"ui tiny inline loader active cloudprogress" + (preparing ? " indeterminate" : "")} title={cloudStatus.tooltip}></sui.Item>}
+            {cloudStatus.value === "localEdits" && <span className="ui mobile hide cloudtext" role="note">{lf("saving...")}</span>}
+            {cloudStatus.value === "syncing" && <span className="ui mobile hide cloudtext" role="note">{lf("saving...")}</span>}
+            {cloudStatus.value === "justSynced" && <span className="ui mobile hide cloudtext" role="note">{lf("saved!")}</span>}
+            {cloudStatus.value === "offline" && <span className="ui mobile hide cloudtext" role="note">{lf("offline")}</span>}
+            {cloudStatus.value === "conflict" && <span className="ui mobile hide cloudtext" role="note">{lf("conflict!")}</span>}
         </div>);
     }
 }

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -3,8 +3,8 @@ import * as sui from "./sui";
 import * as core from "./core";
 import * as auth from "./auth";
 import * as data from "./data";
-import * as codecard from "./codecard";
 import * as cloudsync from "./cloudsync";
+import * as cloud from "./cloud";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -181,11 +181,37 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
                         </div>
                         <span>{lf("Unlink GitHub")}</span>
                     </sui.Item>
-                : undefined}
+                    : undefined}
                 {showGhUnlink ? <div className="ui divider"></div> : undefined}
                 {!loggedIn ? <sui.Item role="menuitem" text={lf("Sign in")} onClick={this.handleLoginClicked} /> : undefined}
                 {loggedIn ? <sui.Item role="menuitem" text={lf("Sign out")} onClick={this.handleLogoutClicked} /> : undefined}
             </sui.DropdownMenu>
         );
+    }
+}
+
+export type CloudSaveStatusProps = {
+    headerId: string;
+};
+
+export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
+    renderCore() {
+        if (!this.props.headerId) { return null; }
+        const cloudMd = this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${this.props.headerId}`);
+        const cloudStatus = cloudMd.cloudStatus();
+        const showCloudButton = !!cloudStatus && cloudStatus.value !== "none" && auth.hasIdentity();
+        if (!showCloudButton) { return null; }
+        const preparing = cloudStatus.value === "localEdits";
+        const syncing = preparing || cloudStatus.value === "syncing";
+
+        return (<div className="cloudstatusarea">
+            {!syncing && <i className={"ui tiny cloudicon xicon " + cloudStatus.icon}></i>}
+            {syncing && <div className={"ui tiny inline loader active cloudprogress " + (preparing ? "indeterminate" : "")}></div>}
+            {cloudStatus.value === "localEdits" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
+            {cloudStatus.value === "syncing" && <span className="ui mobile hide cloudtext">{lf("saving...")}</span>}
+            {cloudStatus.value === "justSynced" && <span className="ui mobile hide cloudtext">{lf("saved!")}</span>}
+            {cloudStatus.value === "offline" && <span className="ui mobile hide cloudtext">{lf("offline")}</span>}
+            {cloudStatus.value === "conflict" && <span className="ui mobile hide cloudtext">{lf("conflict!")}</span>}
+        </div>);
     }
 }

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -205,8 +205,8 @@ export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
         const syncing = preparing || cloudStatus.value === "syncing";
 
         return (<div className="cloudstatusarea">
-            {!syncing && <sui.Item className={"ui tiny cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip}></sui.Item>}
-            {syncing && <sui.Item className={"ui tiny inline loader active cloudprogress" + (preparing ? " indeterminate" : "")} title={cloudStatus.tooltip}></sui.Item>}
+            {!syncing && <sui.Item className={"ui tiny cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
+            {syncing && <sui.Item className={"ui tiny inline loader active cloudprogress" + (preparing ? " indeterminate" : "")} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
             {cloudStatus.value === "localEdits" && <span className="ui mobile hide cloudtext" role="note">{lf("saving...")}</span>}
             {cloudStatus.value === "syncing" && <span className="ui mobile hide cloudtext" role="note">{lf("saving...")}</span>}
             {cloudStatus.value === "justSynced" && <span className="ui mobile hide cloudtext" role="note">{lf("saved!")}</span>}

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -207,11 +207,11 @@ export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
         return (<div className="cloudstatusarea">
             {!syncing && <sui.Item className={"ui tiny cloudicon xicon " + cloudStatus.icon} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
             {syncing && <sui.Item className={"ui tiny inline loader active cloudprogress" + (preparing ? " indeterminate" : "")} title={cloudStatus.tooltip} tabIndex={-1}></sui.Item>}
-            {cloudStatus.value === "localEdits" && <span className="ui mobile hide cloudtext" role="note">{lf("saving...")}</span>}
-            {cloudStatus.value === "syncing" && <span className="ui mobile hide cloudtext" role="note">{lf("saving...")}</span>}
-            {cloudStatus.value === "justSynced" && <span className="ui mobile hide cloudtext" role="note">{lf("saved!")}</span>}
-            {cloudStatus.value === "offline" && <span className="ui mobile hide cloudtext" role="note">{lf("offline")}</span>}
-            {cloudStatus.value === "conflict" && <span className="ui mobile hide cloudtext" role="note">{lf("conflict!")}</span>}
+            {cloudStatus.value === "localEdits" && <span className="ui mobile hide no-select cloudtext" role="note">{lf("saving...")}</span>}
+            {cloudStatus.value === "syncing" && <span className="ui mobile hide no-select cloudtext" role="note">{lf("saving...")}</span>}
+            {cloudStatus.value === "justSynced" && <span className="ui mobile hide no-select cloudtext" role="note">{lf("saved!")}</span>}
+            {cloudStatus.value === "offline" && <span className="ui mobile hide no-select cloudtext" role="note">{lf("offline")}</span>}
+            {cloudStatus.value === "conflict" && <span className="ui mobile hide no-select cloudtext" role="note">{lf("conflict!")}</span>}
         </div>);
     }
 }


### PR DESCRIPTION
This version more closely resembles the design, and uses a spinner to indicate save in progress.

![cloud2](https://user-images.githubusercontent.com/12176807/124682068-c5c1f380-de7e-11eb-8538-cfbdef3a7f92.gif)

As you can see, it is vastly superior.

Notice the spinner has two states:
* Spinner rotating counterclockwise: Debouncer is active, waiting for a span of 1.5 seconds with no new edits.
* Spinner rotating clockwise (and more quickly): Cloud save is in progress.

If this feels too busy we can just use the clockwise spinner for both. To me that makes cloud sync feel slower than it actually is.
