### PR TITLE
Don't use block id for asset id

### DIFF
--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -108,7 +108,14 @@ namespace pxtblockly {
                     if (pxt.assetEquals(this.asset, result)) return;
 
                     const oldId = isTemporaryAsset(this.asset) ? null : this.asset.id;
-                    const newId = isTemporaryAsset(result) ? null : result.id;
+                    let newId = isTemporaryAsset(result) ? null : result.id;
+
+                    if (!oldId && newId === this.sourceBlock_.id) {
+                        // The temporary assets we create just use the block id as the id; give it something
+                        // a little nicer
+                        result.id = project.generateNewID(result.type);
+                        newId = result.id;
+                    }
 
                     this.pendingEdit = true;
 

--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -356,7 +356,7 @@ namespace pxt {
         }
 
         public createNewImage(width = 16, height = 16) {
-            const id = this.generateNewID(AssetType.Image, pxt.sprite.IMAGE_PREFIX, pxt.sprite.IMAGES_NAMESPACE);
+            const id = this.generateNewID(AssetType.Image);
             const bitmap = new pxt.sprite.Bitmap(width, height).data()
 
             const newImage: ProjectImage = {
@@ -371,7 +371,7 @@ namespace pxt {
         }
 
         public createNewAnimation(width = 16, height = 16) {
-            const id = this.generateNewID(AssetType.Animation, pxt.sprite.ANIMATION_PREFIX, pxt.sprite.ANIMATION_NAMESPACE);
+            const id = this.generateNewID(AssetType.Animation);
             const bitmap = new pxt.sprite.Bitmap(width, height).data()
 
             const newAnimation: Animation = {
@@ -386,7 +386,7 @@ namespace pxt {
         }
 
         public createNewAnimationFromData(frames: pxt.sprite.BitmapData[], interval = 500, displayName?: string) {
-            const id = this.generateNewID(AssetType.Animation, pxt.sprite.ANIMATION_PREFIX, pxt.sprite.ANIMATION_NAMESPACE);
+            const id = this.generateNewID(AssetType.Animation);
 
             const newAnimation: Animation = {
                 internalID: this.getNewInternalId(),
@@ -434,7 +434,7 @@ namespace pxt {
             this.onChange();
 
             if (!id || this.isNameTaken(AssetType.Tile, id)) {
-                id = this.generateNewID(AssetType.Tile, pxt.sprite.TILE_PREFIX, pxt.sprite.TILE_NAMESPACE);
+                id = this.generateNewID(AssetType.Tile);
             }
 
             const newTile: Tile = {
@@ -457,7 +457,7 @@ namespace pxt {
 
             const newImage: ProjectImage = {
                 internalID: this.getNewInternalId(),
-                id: this.generateNewID(AssetType.Image, pxt.sprite.IMAGE_PREFIX, pxt.sprite.IMAGES_NAMESPACE),
+                id: this.generateNewID(AssetType.Image),
                 type: AssetType.Image,
                 jresData: pxt.sprite.base64EncodeBitmap(data),
                 meta: {
@@ -601,7 +601,7 @@ namespace pxt {
         public createNewTilemapFromData(data: pxt.sprite.TilemapData, name?: string): [string, pxt.sprite.TilemapData] {
             this.onChange()
 
-            const id = this.generateNewID(AssetType.Tilemap, name || lf("level"));
+            const id = this.generateNewIDInternal(AssetType.Tilemap, name || lf("level"));
             this.state.tilemaps.add({
                 internalID: this.getNewInternalId(),
                 id,
@@ -1204,7 +1204,20 @@ namespace pxt {
             return animation;
         }
 
-        protected generateNewID(type: AssetType, varPrefix: string, namespaceString?: string) {
+        generateNewID(type: AssetType) {
+            switch (type) {
+                case AssetType.Animation:
+                    return this.generateNewIDInternal(AssetType.Animation, pxt.sprite.ANIMATION_PREFIX, pxt.sprite.ANIMATION_NAMESPACE);
+                case AssetType.Image:
+                    return this.generateNewIDInternal(AssetType.Image, pxt.sprite.IMAGE_PREFIX, pxt.sprite.IMAGES_NAMESPACE);
+                case AssetType.Tile:
+                    return this.generateNewIDInternal(AssetType.Tile, pxt.sprite.TILE_PREFIX, pxt.sprite.TILE_NAMESPACE);
+                case AssetType.Tilemap:
+                    return this.generateNewIDInternal(AssetType.Tilemap, lf("level"));
+            }
+        }
+
+        protected generateNewIDInternal(type: AssetType, varPrefix: string, namespaceString?: string) {
             varPrefix = varPrefix.replace(/\d+$/, "");
             const prefix = namespaceString ? namespaceString + "." + varPrefix : varPrefix;
             let index = 1;


### PR DESCRIPTION
Noticed this while I was working on skillmap code carryover stuff. We're using blockly's id for the id of temporary assets in blocks which is probably a bad idea, especially if we ever start having blocks with multiple asset field editors. The asset ids are also supposed to be identifiers (though I'm not sure they're used as such anywhere currently) so better to enforce allowable characters.

This makes it so that we switch to a proper id when upgrading the asset from temporary to real.