### PR TITLE
Cloud save tutorial state

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1270,7 +1270,7 @@ export class ProjectView
             let tutorialOptions = this.state.tutorialOptions;
             tutorialOptions.tutorialStep = step;
             tutorialOptions.tutorialStepExpanded = false;
-            this.setState({ tutorialOptions: tutorialOptions });
+            this.setState({ tutorialOptions: tutorialOptions }, () => workspace.saveAsync(this.state.header));
             const showHint = tutorialOptions.tutorialStepInfo[step].showHint;
             if (showHint) this.showTutorialHint();
 
@@ -1321,7 +1321,7 @@ export class ProjectView
                         let tutorialOptions = this.state.tutorialOptions;
                         tutorialOptions.tutorialReady = true;
                         tutorialOptions.tutorialStepInfo = tt.stepInfo;
-                        this.setState({ tutorialOptions: tutorialOptions });
+                        this.setState({ tutorialOptions: tutorialOptions }, () => workspace.saveAsync(this.state.header));
                         const showHint = tutorialOptions.tutorialStepInfo[0].showHint;
                         if (showHint) this.showTutorialHint();
                         //else {
@@ -3845,7 +3845,7 @@ export class ProjectView
                     tutorialOptions: undefined,
                     tracing: undefined,
                     editorState: undefined
-                });
+                }, () => workspace.saveAsync(this.state.header));
                 core.resetFocus();
             });
     }

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -377,7 +377,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                     {compileBtn && this.getCompileButton(mobile)}
                 </div>}
             </div>
-            {(showProjectRename || showGithub || identity.CloudSaveStatus.WouldRender(header.id)) &&
+            {(showProjectRename || showGithub || identity.CloudSaveStatus.wouldRender(header.id)) &&
                 <div id="projectNameArea" role="menu" className="ui column items">
                     <div className={`ui right ${showSave ? "labeled" : ""} input projectname-input projectname-computer`}>
                         {showProjectRename && this.getSaveInput(showSave, "fileNameInput2", projectName, showProjectRenameReadonly)}

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -377,7 +377,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                     {compileBtn && this.getCompileButton(mobile)}
                 </div>}
             </div>
-            {(showProjectRename || showGithub) &&
+            {(showProjectRename || showGithub || identity.CloudSaveStatus.WouldRender(header.id)) &&
                 <div id="projectNameArea" role="menu" className="ui column items">
                     <div className={`ui right ${showSave ? "labeled" : ""} input projectname-input projectname-computer`}>
                         {showProjectRename && this.getSaveInput(showSave, "fileNameInput2", projectName, showProjectRenameReadonly)}

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -200,7 +200,7 @@ export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
         const cloudStatus = cloudMd.cloudStatus();
         return !!cloudStatus && cloudStatus.value !== "none" && auth.hasIdentity();
     }
-    
+
     renderCore() {
         if (!this.props.headerId) { return null; }
         const cloudMd = this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${this.props.headerId}`);

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -195,7 +195,7 @@ export type CloudSaveStatusProps = {
 };
 
 export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
-    public static WouldRender(headerId: string): boolean {
+    public static wouldRender(headerId: string): boolean {
         const cloudMd = cloud.getCloudTempMetadata(headerId);
         const cloudStatus = cloudMd.cloudStatus();
         return !!cloudStatus && cloudStatus.value !== "none" && auth.hasIdentity();

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -195,6 +195,12 @@ export type CloudSaveStatusProps = {
 };
 
 export class CloudSaveStatus extends data.Component<CloudSaveStatusProps, {}> {
+    public static WouldRender(headerId: string): boolean {
+        const cloudMd = cloud.getCloudTempMetadata(headerId);
+        const cloudStatus = cloudMd.cloudStatus();
+        return !!cloudStatus && cloudStatus.value !== "none" && auth.hasIdentity();
+    }
+    
     renderCore() {
         if (!this.props.headerId) { return null; }
         const cloudMd = this.getData<cloud.CloudTempMetadata>(`${cloud.HEADER_CLOUDSTATE}:${this.props.headerId}`);

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -474,7 +474,7 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
         allScripts.push(e)
     }
 
-    const hasUserFileChanges = async () => {
+    const hasUserFileChanges = () => {
         // we see lots of frequent "saves" that don't come from real changes made by the user. This
         // causes problems for cloud sync since this can cause us to think the user is making when
         // just reading a project. The "correct" solution would be to have a full history and .gitignore
@@ -501,9 +501,10 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
 
         return hasUserChanges;
     }
+    const isHeaderOnlyChange = !fromCloudSync && !text;
     const isUserChange = !fromCloudSync
-        && (h.isDeleted || text && await hasUserFileChanges())
-    if (isUserChange) {
+        && (h.isDeleted || text && hasUserFileChanges())
+    if (isHeaderOnlyChange || isUserChange) {
         h.pubCurrent = false
         h.cloudCurrent = false
         h.modificationTime = U.nowSeconds();


### PR DESCRIPTION
In app.tsx, tutorial state is written directly to the project header. When the project is later saved, some "smart diffing" happens to discover if any meaningful changes were made. If there were, then the change will be synced to the cloud. In the case of tutorial state, because it was written directly to the source project header, the diff process detected no meaningful changes - because it was diffing the header with itself!

The fix I made is a patch to the smart diff that makes an exception for header-only changes, to just always let them through.

##### Other changes in this PR
* Show cloud sync indicator in tutorial view
* Save tutorial progress each time the step changes, not just when the user exits tutorial

##### Thoughts and reflections
* It would be nice if project changes were made via transformations on an immutable store. But that's not the case, and making this change would be a large undertaking.
* Tutorial state should probably be saved in a separate project file, not in the header. This might be a better fix, actually.

Fixes https://github.com/microsoft/pxt-arcade/issues/3243