### PR TITLE
Fix lf checks in gulpfile to grab missing translations

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3025,7 +3025,7 @@ function installPackageNameAsync(packageName: string): Promise<void> {
         return addDepAsync(sharedId, packageName, false);
 
     // don't know
-    U.userError(lf(`unknown package ${packageName}`))
+    U.userError(lf("unknown package {0}", packageName))
     return Promise.resolve();
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1730,8 +1730,12 @@ function processLf(filename: string, translationStrings: pxt.Map<string>): void 
     fs.readFileSync(filename, { encoding: "utf8" })
         .split('\n').forEach((line, idx) => {
             function err(msg: string) {
-                console.error(`${filename}(${idx}): ${msg}`);
+                console.error(`${filename}(${idx + 1}): ${msg}`);
             }
+
+            if (/@ignorelf@/.test(line))
+                return;
+
             while (true) {
                 const newLine = line.replace(/\blf(_va)?\s*\(\s*(.*)/, (all, a, args) => {
                     const m = /^("([^"]|(\\"))+")\s*[\),]/.exec(args)
@@ -1744,7 +1748,7 @@ function processLf(filename: string, translationStrings: pxt.Map<string>): void 
                         }
                     } else {
                         if (!/util\.ts$/.test(filename))
-                            err("invalid format of lf() argument: " + args)
+                            err("invalid format of lf() argument: " + args) // @ignorelf@
                     }
                     return "BLAH " + args
                 })
@@ -6108,9 +6112,12 @@ function extractLocStringsAsync(output: string, dirs: string[]): Promise<void> {
         pxt.debug(`extracting strings from${filename}`);
         fs.readFileSync(filename, "utf8").split('\n').forEach((line: string, idx: number) => {
             function err(msg: string) {
-                console.log("%s(%d): %s", filename, idx, msg);
+                console.log("%s(%d): %s", filename, idx + 1, msg);
                 errCnt++;
             }
+
+            if (/@ignorelf@/.test(line))
+                return;
 
             while (true) {
                 let newLine = line.replace(/\blf(_va)?\s*\(\s*(.*)/, (all, a, args) => {
@@ -6124,7 +6131,7 @@ function extractLocStringsAsync(output: string, dirs: string[]): Promise<void> {
                         }
                     } else {
                         if (!/util\.ts$/.test(filename))
-                            err("invalid format of lf() argument: " + args)
+                            err("invalid format of lf() argument: " + args) // @ignorelf@
                     }
                     return "BLAH " + args
                 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -214,7 +214,20 @@ function pxtcommon() {
 
 // TODO: Copied from Jakefile; should be async
 function updatestrings() {
-    return buildStrings("built/strings.json", ["pxtlib", "pxtblocks", "pxtblocks/fields", "webapp/src"]);
+    return buildStrings("built/strings.json", [
+        "cli",
+        "pxtblocks",
+        "pxtblocks/fields",
+        "pxtcompiler",
+        "pxteditor",
+        "pxteditor/monaco-fields",
+        "pxtlib",
+        "pxtlib/emitter",
+        "pxtlib/melody-editor",
+        "pxtpy",
+        "pxtsim",
+        "webapp/src",
+    ]);
 }
 
 function updateSkillMapStrings() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,17 +217,13 @@ function updatestrings() {
     return buildStrings("built/strings.json", [
         "cli",
         "pxtblocks",
-        "pxtblocks/fields",
         "pxtcompiler",
         "pxteditor",
-        "pxteditor/monaco-fields",
         "pxtlib",
-        "pxtlib/emitter",
-        "pxtlib/melody-editor",
         "pxtpy",
         "pxtsim",
         "webapp/src",
-    ]);
+    ], true);
 }
 
 function updateSkillMapStrings() {
@@ -244,12 +240,15 @@ function buildStrings(out, rootPaths, recursive) {
         if (!/\.(ts|tsx|html)$/.test(filename)) return
         if (/\.d\.ts$/.test(filename)) return
 
-        //console.log('extracting strings from %s', filename);
+        // console.log(`extracting strings from ${filename}`);
         fs.readFileSync(filename, "utf8").split('\n').forEach((line, idx) => {
             function err(msg) {
-                console.log("%s(%d): %s", filename, idx, msg);
+                console.log("%s(%d): %s", filename, idx + 1, msg);
                 errCnt++;
             }
+
+            if (/@ignorelf@/.test(line))
+                return;
 
             while (true) {
                 let newLine = line.replace(/\blf(_va)?\s*\(\s*(.*)/, (all, a, args) => {
@@ -262,8 +261,7 @@ function buildStrings(out, rootPaths, recursive) {
                             err("cannot JSON-parse " + m[1])
                         }
                     } else {
-                        if (!/util\.ts$/.test(filename))
-                            err("invalid format of lf() argument: " + args)
+                        err("invalid format of lf() argument: " + args)
                     }
                     return "BLAH " + args
                 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -261,7 +261,7 @@ function buildStrings(out, rootPaths, recursive) {
                             err("cannot JSON-parse " + m[1])
                         }
                     } else {
-                        err("invalid format of lf() argument: " + args)
+                        err("invalid format of lf() argument: " + args)  // @ignorelf@
                     }
                     return "BLAH " + args
                 })

--- a/pxtlib/commonutil.ts
+++ b/pxtlib/commonutil.ts
@@ -190,7 +190,7 @@ namespace ts.pxtc.Util {
     }
 
     let sForPlural = true;
-    export function lf_va(format: string, args: any[]): string {
+    export function lf_va(format: string, args: any[]): string { // @ignorelf@
         if (!format) return format;
 
         locStats[format] = (locStats[format] || 0) + 1;
@@ -205,14 +205,14 @@ namespace ts.pxtc.Util {
         return fmt_va(lfmt, args);
     }
 
-    export function lf(format: string, ...args: any[]): string {
-        return lf_va(format, args);
+    export function lf(format: string, ...args: any[]): string { // @ignorelf@
+        return lf_va(format, args); // @ignorelf@
     }
     /**
      * Similar to lf but the string do not get extracted into the loc file.
      */
     export function rlf(format: string, ...args: any[]): string {
-        return lf_va(format, args);
+        return lf_va(format, args); // @ignorelf@
     }
 
     export function lookup<T>(m: pxt.Map<T>, key: string): T {

--- a/pxtlib/emitter/assembler.ts
+++ b/pxtlib/emitter/assembler.ts
@@ -25,7 +25,7 @@ namespace ts.pxtc.assembler {
         labelName?: string;
     }
 
-    export function lf(fmt: string, ...args: any[]) {
+    export function lf(fmt: string, ...args: any[]) { // @ignorelf@
         return fmt.replace(/{(\d+)}/g, (match, index) => args[+index]);
     }
 
@@ -100,7 +100,7 @@ namespace ts.pxtc.assembler {
                                 stack = (v / this.ei.wordSize());
                         }
                     } else if (enc.isRegList) {
-                        // register lists are ARM-specific - this code not used in AVR 
+                        // register lists are ARM-specific - this code not used in AVR
                         if (actual != "{") return emitErr("expecting {", actual);
                         v = 0;
                         while (tokens[j] != "}") {
@@ -133,7 +133,7 @@ namespace ts.pxtc.assembler {
                                 if (ln.bin.finalEmit)
                                     return emitErr("unknown label", actual)
                                 else
-                                    // just need some value when we are 
+                                    // just need some value when we are
                                     // doing some pass other than finalEmit
                                     v = 8; // needs to be divisible by 4 etc
                             }
@@ -187,7 +187,7 @@ namespace ts.pxtc.assembler {
     export class Line {
         public type: string;
         public lineNo: number;
-        public words: string[]; // the tokens in this line 
+        public words: string[]; // the tokens in this line
         public scope: string;
         public location: number;
         public instruction: Instruction;
@@ -285,7 +285,7 @@ namespace ts.pxtc.assembler {
             return this.location() + this.baseOffset;
         }
 
-        // parsing of an "integer", well actually much more than 
+        // parsing of an "integer", well actually much more than
         // just that
         public parseOneInt(s: string): number {
             if (!s)
@@ -1113,7 +1113,7 @@ namespace ts.pxtc.assembler {
     export interface Encoder {
         name: string;
         pretty: string;
-        // given a value, check it is the right number of bits and 
+        // given a value, check it is the right number of bits and
         // translate the value to the proper set of bits
         encode: (v: number) => number;
         isRegister: boolean;
@@ -1288,7 +1288,7 @@ namespace ts.pxtc.assembler {
     function parseString(s: string) {
         s = s.replace(/\\\\/g, "\\B")           // don't get confused by double backslash
             .replace(/\\(['\?])/g, (f, q) => q) // these are not valid in JSON yet valid in C
-            .replace(/\\[z0]/g, "\u0000")      // \0 is valid in C 
+            .replace(/\\[z0]/g, "\u0000")      // \0 is valid in C
             .replace(/\\x([0-9a-f][0-9a-f])/gi, (f, h) => "\\u00" + h)
             .replace(/\\B/g, "\\\\") // undo anti-confusion above
         try {

--- a/pxtpy/converter.ts
+++ b/pxtpy/converter.ts
@@ -2139,7 +2139,7 @@ namespace pxt.py {
             }
 
             if (!fun) {
-                error(n, 9508, U.lf(`can't find called function "${nm}"`))
+                error(n, 9508, U.lf("can't find called function '{0}'", nm))
             }
 
             let formals = fun ? fun.parameters : null

--- a/pxtsim/localization.ts
+++ b/pxtsim/localization.ts
@@ -7,7 +7,7 @@ namespace pxsim.localization {
     }
 
     let sForPlural = true;
-    export function lf(s: string, ...args: any[]): string {
+    export function lf(s: string, ...args: any[]): string { // @ignorelf@
         let lfmt = _localizeStrings[s] || s;
 
         if (!sForPlural && lfmt != s && /\d:s\}/.test(lfmt)) {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -699,7 +699,7 @@ export function showWinAppDeprecateAsync() {
         jsx: <div>
             <img className="ui medium centered image" src={pxt.appTarget.appTheme.winAppDeprImage} alt={lf("An image of a shrugging board")}/>
             <div>
-                {lf(`This app is being deprecated. Text editing is only available on the MakeCode website `)}
+                {lf("This app is being deprecated. Text editing is only available on the MakeCode website ")}
                 {`(https://${pxt.appTarget.name}).`}
             </div>
         </div>


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/3627

one of the strings was formatted incorrectly (\` instead of \"), and when I was finding it I noticed a few others were broken as well (but not getting reported). This is because we were not properly extracting from a number of files (subfolders that weren't being checked, as well as a number of folders that had lfs but weren't included in the list: cli, pxtcompiler, pxteditor, pxtpy, pxtsim)

with this change updatestrings builds `334 files; 1811 strings`, where before it had `196 files; 1349 strings`

Also add an escape for skipping lfs on a given line to avoid a hack we had before for not erroring out on the lf function definitions.