### PR TITLE
Send 'backtap' event for touchend events < longpress threshold

### DIFF
--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -18,6 +18,7 @@ const LONGPRESS_DURATION = 750;
 
 export class HeaderBar extends data.Component<ISettingsProps, {}> {
     protected longpressTimer: any;
+    protected touchStartTime: number;
 
     constructor(props: ISettingsProps) {
         super(props);
@@ -60,11 +61,17 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         this.goHome();
     }
 
-    backButtonTouchStart = () => {
+    backButtonTouchStart = (evt: any) => {
         this.longpressTimer = setTimeout(() => cmds.nativeHostLongpressAsync(), LONGPRESS_DURATION);
+        this.touchStartTime = new Date().getTime();
     }
 
-    backButtonTouchEnd = () => {
+    backButtonTouchEnd = (evt: any) => {
+        evt.preventDefault();
+        if (this.touchStartTime && (new Date().getTime() - this.touchStartTime) < LONGPRESS_DURATION) {
+            cmds.nativeHostBackAsync();
+        }
+        this.touchStartTime = null;
         clearTimeout(this.longpressTimer);
     }
 

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -487,9 +487,9 @@ export interface ItemProps extends UiProps {
     active?: boolean;
     value?: string;
     onClick?: () => void;
-    onMouseDown?: () => void;
-    onMouseUp?: () => void;
-    onMouseLeave?: () => void;
+    onMouseDown?: (e: any) => void;
+    onMouseUp?: (e: any) => void;
+    onMouseLeave?: (e: any) => void;
     onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
 }
 


### PR DESCRIPTION
for the microbit iOS app! we send a "backtap" message for click/short tap events, and a "backpress" message for presses > 750ms. this modifies it to also send a "backtap" message for any press < 750ms. 