### PR TITLE
Move virtual api and storage into pxtlib

### DIFF
--- a/pxteditor/shell.ts
+++ b/pxteditor/shell.ts
@@ -40,6 +40,7 @@ namespace pxt.shell {
                 case "ide": layoutType = EditorLayoutType.IDE; break;
             }
         }
+        if (layoutType === EditorLayoutType.Sandbox) pxt.storage.sandbox();
         pxt.debug(`shell: layout type ${EditorLayoutType[layoutType]}, readonly ${isReadOnly()}`);
     }
 

--- a/pxteditor/shell.ts
+++ b/pxteditor/shell.ts
@@ -11,7 +11,7 @@ namespace pxt.shell {
     let editorReadonly: boolean = false;
     let noDefaultProject: boolean = false;
 
-    function init() {
+    export function init() {
         if (layoutType !== undefined) return;
 
         const sandbox = /sandbox=1|#sandbox|#sandboxproject/i.test(window.location.href)

--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -12,6 +12,10 @@ namespace pxt.BrowserUtils {
         return typeof navigator !== "undefined";
     }
 
+    export function hasWindow(): boolean {
+        return typeof window !== "undefined";
+    }
+
     export function isWindows(): boolean {
         return hasNavigator() && /(Win32|Win64|WOW64)/i.test(navigator.platform);
     }

--- a/pxtlib/data.ts
+++ b/pxtlib/data.ts
@@ -32,8 +32,6 @@ namespace pxt.data {
 
     const virtualApis: pxt.Map<VirtualApi> = {};
     let cachedData: pxt.Map<CacheEntry> = {};
-    let cacheName: string;
-
 
     export function subscribe(component: DataSubscriber, path: string) {
         let e = lookup(path)
@@ -70,26 +68,21 @@ namespace pxt.data {
         saveCache();
     }
 
-    export function loadCache(cacheName_: string) {
-        cacheName = cacheName_;
-        if (cacheName) {
-            JSON.parse(pxt.storage.getLocal(cacheName) || "[]").forEach((e: any) => {
-                let ce = lookup(e.path)
-                ce.data = e.data
-            });
-        }
+    export function loadCache() {
+        JSON.parse(pxt.storage.getLocal("apiCache2") || "[]").forEach((e: any) => {
+            let ce = lookup(e.path)
+            ce.data = e.data
+        });
     }
 
     function saveCache() {
-        if (cacheName) {
-            let obj = Util.values(cachedData).filter(e => shouldCache(e)).map(e => {
-                return {
-                    path: e.path,
-                    data: e.data
-                }
-            });
-            pxt.storage.setLocal(cacheName, JSON.stringify(obj));
-        }
+        let obj = Util.values(cachedData).filter(e => shouldCache(e)).map(e => {
+            return {
+                path: e.path,
+                data: e.data
+            }
+        });
+        pxt.storage.setLocal("apiCache2", JSON.stringify(obj));
     }
 
     function matches(ce: CacheEntry, prefix: string) {

--- a/pxtlib/data.ts
+++ b/pxtlib/data.ts
@@ -1,0 +1,255 @@
+namespace pxt.data {
+    export type Action = () => void;
+    export type DataSubscriber = {
+        subscriptions: CacheEntry[];
+        onDataChanged: (path: string) => void;
+    };
+
+    import Cloud = pxt.Cloud;
+    import Util = pxt.Util;
+
+    export interface CacheEntry {
+        path: string;
+        data: any;
+        lastRefresh: number;
+        queued: boolean;
+        callbackOnce: Action[];
+        components: DataSubscriber[];
+        api: VirtualApi;
+    }
+
+    export enum FetchStatus {
+        Pending,
+        Complete,
+        Error,
+        Offline
+    };
+
+    export interface DataFetchResult<T> {
+        data?: T;
+        status: FetchStatus;
+    }
+
+    const virtualApis: pxt.Map<VirtualApi> = {};
+    let cachedData: pxt.Map<CacheEntry> = {};
+    let cacheName: string;
+
+
+    export function subscribe(component: DataSubscriber, path: string) {
+        let e = lookup(path)
+        let lst = e.components
+        if (lst.indexOf(component) < 0) {
+            lst.push(component)
+            component.subscriptions.push(e)
+        }
+    }
+
+    export function unsubscribe(component: DataSubscriber) {
+        let lst = component.subscriptions
+        if (lst.length == 0) return
+        component.subscriptions = []
+        lst.forEach(ce => {
+            let idx = ce.components.indexOf(component)
+            if (idx >= 0) ce.components.splice(idx, 1)
+        })
+    }
+
+    function expired(ce: CacheEntry) {
+        if (!ce.api.expirationTime)
+            return !ce.lastRefresh; // needs to be refreshed at least once
+        return ce.data == null || (Date.now() - ce.lastRefresh) > ce.api.expirationTime(ce.path)
+    }
+
+    function shouldCache(ce: CacheEntry) {
+        if (!ce.data || ce.data instanceof Error) return false;
+        return /^cloud:(me\/settings|ptr-pkg-)/.test(ce.path);
+    }
+
+    export function clearCache() {
+        cachedData = {};
+        saveCache();
+    }
+
+    export function loadCache(cacheName_: string) {
+        cacheName = cacheName_;
+        if (cacheName) {
+            JSON.parse(pxt.storage.getLocal(cacheName) || "[]").forEach((e: any) => {
+                let ce = lookup(e.path)
+                ce.data = e.data
+            });
+        }
+    }
+
+    function saveCache() {
+        if (cacheName) {
+            let obj = Util.values(cachedData).filter(e => shouldCache(e)).map(e => {
+                return {
+                    path: e.path,
+                    data: e.data
+                }
+            });
+            pxt.storage.setLocal(cacheName, JSON.stringify(obj));
+        }
+    }
+
+    function matches(ce: CacheEntry, prefix: string) {
+        return ce.path.slice(0, prefix.length) == prefix;
+    }
+
+    function notify(ce: CacheEntry, path: string) {
+        if (shouldCache(ce)) saveCache();
+
+        let lst = ce.callbackOnce
+        if (lst.length > 0) {
+            ce.callbackOnce = []
+            Util.nextTick(() => lst.forEach(f => f()))
+        }
+
+        if (ce.components.length > 0)
+            ce.components.forEach(c => Util.nextTick(() => c.onDataChanged(path)))
+    }
+
+    function getVirtualApi(path: string) {
+        let m = /^([\w\-]+):/.exec(path)
+        if (!m || !virtualApis[m[1]])
+            Util.oops("bad data protocol: " + path)
+        return virtualApis[m[1]]
+    }
+
+    function queueNotify(ce: CacheEntry, path: string) {
+        if (ce.queued) return
+
+        if (ce.api.isOffline && ce.api.isOffline())
+            return
+
+        ce.queued = true
+
+        let final = (res: any) => {
+            ce.data = res
+            ce.lastRefresh = pxt.Util.now()
+            ce.queued = false
+            notify(ce, path)
+        }
+
+        if (ce.api.isSync)
+            final(ce.api.getSync(ce.path))
+        else {
+            const p = ce.api.getAsync(ce.path);
+            p.then(final)
+        }
+    }
+
+    function lookup(path: string) {
+        if (!cachedData.hasOwnProperty(path))
+            cachedData[path] = {
+                path: path,
+                data: null,
+                lastRefresh: 0,
+                queued: false,
+                callbackOnce: [],
+                components: [],
+                api: getVirtualApi(path)
+            }
+        return cachedData[path]
+    }
+
+    export function getCached(component: DataSubscriber, path: string): DataFetchResult<any> {
+        subscribe(component, path)
+        return getDataWithStatus(path);
+    }
+
+    //
+    // Public interface
+    //
+
+    export interface VirtualApi {
+        getAsync?(path: string): Promise<any>;
+        getSync?(path: string): any;
+        isSync?: boolean;
+        expirationTime?(path: string): number; // in milliseconds
+        isOffline?: () => boolean;
+        onInvalidated?: (path: string) => void;
+    }
+
+    export function mountVirtualApi(protocol: string, handler: VirtualApi) {
+        Util.assert(!virtualApis[protocol])
+        Util.assert(!!handler.getSync || !!handler.getAsync)
+        Util.assert(!!handler.getSync != !!handler.getAsync)
+        handler.isSync = !!handler.getSync
+        virtualApis[protocol] = handler
+    }
+
+    export function stripProtocol(path: string) {
+        let m = /^([\w\-]+):(.*)/.exec(path)
+        if (m) return m[2]
+        else Util.oops("protocol missing in: " + path)
+        return path
+    }
+
+    export function invalidate(path: string) {
+        const prefix = path.replace(/:\*$/, ':'); // remove trailing "*";
+        Util.values(cachedData).forEach(ce => {
+            if (matches(ce, prefix)) {
+                ce.lastRefresh = 0;
+                if (ce.components.length > 0)
+                    queueNotify(lookup(ce.path), path)
+                if (ce.api.onInvalidated) {
+                    ce.api.onInvalidated(path);
+                }
+            }
+        })
+    }
+
+    export function invalidateHeader(prefix: string, hd: pxt.workspace.Header) {
+        if (hd)
+            invalidate(prefix + ':' + hd.id);
+    }
+
+    export function getAsync<T = any>(path: string) {
+        let ce = lookup(path)
+
+        if (ce.api.isSync)
+            return Promise.resolve(ce.api.getSync(ce.path))
+
+        if (!Cloud.isOnline() || !expired(ce))
+            return Promise.resolve(ce.data)
+
+        return new Promise<T>((resolve, reject) => {
+            ce.callbackOnce.push(() => {
+                resolve(ce.data)
+            })
+            queueNotify(ce, path)
+        })
+    }
+
+    export function getData<T>(path: string): T {
+        return getDataWithStatus<T>(path).data;
+    }
+
+    export function getDataWithStatus<T>(path: string): DataFetchResult<T> {
+        let r = lookup(path)
+        if (r.api.isSync)
+            return {
+                data: r.api.getSync(r.path),
+                status: FetchStatus.Complete
+            }
+
+        // cache async values
+        let fetchRes: DataFetchResult<T> = {
+            data: r.data,
+            status: FetchStatus.Complete
+        };
+
+        if (expired(r) || r.data instanceof Error) {
+            fetchRes.status = r.data instanceof Error ? FetchStatus.Error : FetchStatus.Pending;
+            if (r.api.isOffline && r.api.isOffline()) {
+                // The request will not be requeued so we don't want to show it as pending
+                fetchRes.status = FetchStatus.Offline;
+            } else {
+                queueNotify(r, path)
+            }
+        }
+
+        return fetchRes;
+    }
+}

--- a/pxtlib/localStorage.ts
+++ b/pxtlib/localStorage.ts
@@ -72,7 +72,7 @@ namespace pxt.storage {
         const sid = storageId();
         let supported = false;
         // no local storage in sandbox mode
-        if (!sandboxed) {
+        if (!pxt.shell.isSandboxMode()) {
             try {
                 window.localStorage[sid] = '1';
                 let v = window.localStorage[sid];
@@ -87,12 +87,6 @@ namespace pxt.storage {
             impl = new LocalStorage(sid);
             pxt.debug(`storage: local under ${sid}`)
         }
-    }
-
-    let sandboxed = !pxt.BrowserUtils.hasWindow();
-    export function sandbox() {
-        U.assert(!impl);
-        sandboxed = true;
     }
 
     export function setLocal(key: string, value: string) {

--- a/pxtlib/localStorage.ts
+++ b/pxtlib/localStorage.ts
@@ -72,7 +72,7 @@ namespace pxt.storage {
         const sid = storageId();
         let supported = false;
         // no local storage in sandbox mode
-        if (!pxt.shell.isSandboxMode()) {
+        if (!sandboxed) {
             try {
                 window.localStorage[sid] = '1';
                 let v = window.localStorage[sid];
@@ -87,6 +87,12 @@ namespace pxt.storage {
             impl = new LocalStorage(sid);
             pxt.debug(`storage: local under ${sid}`)
         }
+    }
+
+    let sandboxed = !pxt.BrowserUtils.hasWindow();
+    export function sandbox() {
+        U.assert(!impl);
+        sandboxed = true;
     }
 
     export function setLocal(key: string, value: string) {

--- a/pxtlib/shell.ts
+++ b/pxtlib/shell.ts
@@ -11,36 +11,38 @@ namespace pxt.shell {
     let editorReadonly: boolean = false;
     let noDefaultProject: boolean = false;
 
-    export function init() {
+    function init() {
         if (layoutType !== undefined) return;
-
-        const sandbox = /sandbox=1|#sandbox|#sandboxproject/i.test(window.location.href)
-            // in iframe
-            || pxt.BrowserUtils.isIFrame();
-        const nosandbox = /nosandbox=1/i.test(window.location.href);
-        const controller = /controller=1/i.test(window.location.href) && pxt.BrowserUtils.isIFrame();
-        const readonly = /readonly=1/i.test(window.location.href);
-        const layout = /editorlayout=(widget|sandbox|ide)/i.exec(window.location.href);
-        const noproject = /noproject=1/i.test(window.location.href);
-
-        layoutType = EditorLayoutType.IDE;
-        if (nosandbox)
-            layoutType = EditorLayoutType.Widget;
-        else if (controller)
-            layoutType = EditorLayoutType.Controller;
-        else if (sandbox)
+        if (!pxt.BrowserUtils.hasWindow()) {
             layoutType = EditorLayoutType.Sandbox;
+        } else {
+            const sandbox = /sandbox=1|#sandbox|#sandboxproject/i.test(window.location.href)
+                // in iframe
+                || pxt.BrowserUtils.isIFrame();
+            const nosandbox = /nosandbox=1/i.test(window.location.href);
+            const controller = /controller=1/i.test(window.location.href) && pxt.BrowserUtils.isIFrame();
+            const readonly = /readonly=1/i.test(window.location.href);
+            const layout = /editorlayout=(widget|sandbox|ide)/i.exec(window.location.href);
+            const noproject = /noproject=1/i.test(window.location.href);
 
-        if (controller && readonly) editorReadonly = true;
-        if (controller && noproject) noDefaultProject = true;
-        if (layout) {
-            switch (layout[1].toLowerCase()) {
-                case "widget": layoutType = EditorLayoutType.Widget; break;
-                case "sandbox": layoutType = EditorLayoutType.Sandbox; break;
-                case "ide": layoutType = EditorLayoutType.IDE; break;
+            layoutType = EditorLayoutType.IDE;
+            if (nosandbox)
+                layoutType = EditorLayoutType.Widget;
+            else if (controller)
+                layoutType = EditorLayoutType.Controller;
+            else if (sandbox)
+                layoutType = EditorLayoutType.Sandbox;
+
+            if (controller && readonly) editorReadonly = true;
+            if (controller && noproject) noDefaultProject = true;
+            if (layout) {
+                switch (layout[1].toLowerCase()) {
+                    case "widget": layoutType = EditorLayoutType.Widget; break;
+                    case "sandbox": layoutType = EditorLayoutType.Sandbox; break;
+                    case "ide": layoutType = EditorLayoutType.IDE; break;
+                }
             }
         }
-        if (layoutType === EditorLayoutType.Sandbox) pxt.storage.sandbox();
         pxt.debug(`shell: layout type ${EditorLayoutType[layoutType]}, readonly ${isReadOnly()}`);
     }
 
@@ -55,9 +57,9 @@ namespace pxt.shell {
     }
 
     export function isReadOnly() {
-        return (isSandboxMode()
+        return (!pxt.BrowserUtils.hasWindow() || (isSandboxMode()
             && !/[?&]edit=1/i.test(window.location.href)) ||
-            (isControllerMode() && editorReadonly);
+            (isControllerMode() && editorReadonly));
     }
 
     export function isNoProject() {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1590,14 +1590,14 @@ namespace ts.pxtc.Util {
 
     export function parseQueryString(qs: string) {
         let r: pxt.Map<string> = {}
-    
+
         qs.replace(/\+/g, " ").replace(/([^#?&=]+)=([^#?&=]*)/g, (f: string, k: string, v: string) => {
             r[decodeURIComponent(k)] = decodeURIComponent(v)
             return ""
         })
         return r
     }
-    
+
     export function stringifyQueryString(url: string, qs: any) {
         for (let k of Object.keys(qs)) {
             if (url.indexOf("?") >= 0) {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1587,6 +1587,28 @@ namespace ts.pxtc.Util {
                 return res
             })
     }
+
+    export function parseQueryString(qs: string) {
+        let r: pxt.Map<string> = {}
+    
+        qs.replace(/\+/g, " ").replace(/([^#?&=]+)=([^#?&=]*)/g, (f: string, k: string, v: string) => {
+            r[decodeURIComponent(k)] = decodeURIComponent(v)
+            return ""
+        })
+        return r
+    }
+    
+    export function stringifyQueryString(url: string, qs: any) {
+        for (let k of Object.keys(qs)) {
+            if (url.indexOf("?") >= 0) {
+                url += "&"
+            } else {
+                url += "?"
+            }
+            url += encodeURIComponent(k) + "=" + encodeURIComponent(qs[k])
+        }
+        return url
+    }
 }
 
 namespace ts.pxtc.BrowserImpl {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -147,7 +147,7 @@ export class ProjectView
     private preserveUndoStack: boolean;
     private rootClasses: string[];
 
-    private highContrastSubscriber: data.DataSubscriber = {
+    private highContrastSubscriber: pxt.data.DataSubscriber = {
         subscriptions: [],
         onDataChanged: () => {
             this.onHighContrastChanged();
@@ -317,9 +317,9 @@ export class ProjectView
         let active = document.visibilityState == 'visible';
         pxt.debug(`page visibility: ${active}`)
         this.setState({ active: active });
-        data.invalidate('pkg-git-pull-status');
-        data.invalidate('pkg-git-pr');
-        data.invalidate('pkg-git-pages')
+        pxt.data.invalidate('pkg-git-pull-status');
+        pxt.data.invalidate('pkg-git-pr');
+        pxt.data.invalidate('pkg-git-pages')
 
         // disconnect devices to avoid locking between tabs
         if (!active && !navigator?.serviceWorker?.controller)
@@ -332,7 +332,7 @@ export class ProjectView
             }
             this.saveFileAsync();
         } else if (active) {
-            data.invalidate("header:*")
+            pxt.data.invalidate("header:*")
             let hdrId = this.state.header ? this.state.header.id : '';
             const inEditor = !this.state.home && hdrId
             if ((!inEditor && workspace.isHeadersSessionOutdated())
@@ -845,7 +845,7 @@ export class ProjectView
                 }
                 pxt.tickEvent("typecheck.complete", { editor: this.getPreferredEditor() });
                 this.editor.setDiagnostics(this.editorFile, state);
-                data.invalidate("open-pkg-meta:" + pkg.mainEditorPkg().getPkgId());
+                pxt.data.invalidate("open-pkg-meta:" + pkg.mainEditorPkg().getPkgId());
                 if (this.state.autoRun) {
                     const output = pkg.mainEditorPkg().outputPkg.files["output.txt"];
                     if (output && !output.numDiagnosticsOverride
@@ -979,11 +979,11 @@ export class ProjectView
         this.loadBlocklyAsync();
 
         // subscribe to user preference changes (for simulator or non-render subscriptions)
-        data.subscribe(this.highContrastSubscriber, auth.HIGHCONTRAST);
+        pxt.data.subscribe(this.highContrastSubscriber, auth.HIGHCONTRAST);
     }
 
     public componentWillUnmount() {
-        data.unsubscribe(this.highContrastSubscriber);
+        pxt.data.unsubscribe(this.highContrastSubscriber);
     }
 
     // Add an error guard for the entire application
@@ -3128,7 +3128,7 @@ export class ProjectView
                         if (!cancellationToken.isCancelled()) {
                             pxt.debug(`sim: run`)
 
-                            const hc = data.getData<boolean>(auth.HIGHCONTRAST)
+                            const hc = pxt.data.getData<boolean>(auth.HIGHCONTRAST)
                             simulator.run(pkg.mainPkg, opts.debug, resp, {
                                 mute: this.state.mute,
                                 highContrast: hc,
@@ -4239,7 +4239,7 @@ function getEditor() {
 }
 
 function parseLocalToken() {
-    const qs = core.parseQueryString((location.hash || "#").slice(1).replace(/%local_token/, "local_token"))
+    const qs = Util.parseQueryString((location.hash || "#").slice(1).replace(/%local_token/, "local_token"))
     if (qs["local_token"]) {
         pxt.storage.setLocal("local_token", qs["local_token"])
         location.hash = location.hash.replace(/(%23)?[\#\&\?]*local_token.*/, "")
@@ -4251,7 +4251,7 @@ function parseLocalToken() {
 function initPacketIO() {
     pxt.debug(`packetio: hook events`)
     pxt.packetio.configureEvents(
-        () => data.invalidate("packetio:*"),
+        () => pxt.data.invalidate("packetio:*"),
         (buf, isErr) => {
             const data = Util.fromUTF8(Util.uint8ArrayToString(buf))
             //pxt.debug('serial: ' + data)
@@ -4754,7 +4754,7 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
     }
 
-    const query = core.parseQueryString(window.location.href);
+    const query = Util.parseQueryString(window.location.href);
 
     // Handle auth callback redirect.
     if (query["authcallback"]) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4726,6 +4726,12 @@ pxt.winrt.captureInitialActivation();
 document.addEventListener("DOMContentLoaded", () => {
     pxt.perf.recordMilestone(`DOM loaded`)
 
+    // Initialization order is important here.
+    // 1. Initialize shell. Determines whether we're sandboxed.
+    // 2. Load data cache. Will implicitly initialize storage, creating local storage or memory storage, depending on sandbox flag.
+    pxt.shell.init();
+    pxt.data.loadCache();
+
     pxt.setupWebConfig((window as any).pxtConfig);
     const config = pxt.webConfig
     pxt.options.debug = /dbg=1/i.test(window.location.href);

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4726,12 +4726,6 @@ pxt.winrt.captureInitialActivation();
 document.addEventListener("DOMContentLoaded", () => {
     pxt.perf.recordMilestone(`DOM loaded`)
 
-    // Initialization order is important here.
-    // 1. Initialize shell. Determines whether we're sandboxed.
-    // 2. Load data cache. Will implicitly initialize storage, creating local storage or memory storage, depending on sandbox flag.
-    pxt.shell.init();
-    pxt.data.loadCache();
-
     pxt.setupWebConfig((window as any).pxtConfig);
     const config = pxt.webConfig
     pxt.options.debug = /dbg=1/i.test(window.location.href);

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -83,8 +83,8 @@ export function getState(): Readonly<State> {
         loadState();
         if (state$) {
             generateUserProfilePicDataUrl(state$.profile);
-            data.invalidate("auth:*");
-            data.invalidate("user-pref:*");
+            pxt.data.invalidate("auth:*");
+            pxt.data.invalidate("user-pref:*");
         }
     }
     if (!state$) {
@@ -149,7 +149,7 @@ function loadState() {
 function clearState() {
     state$ = {};
     pxt.storage.removeLocal(AUTH_USER_STATE);
-    data.invalidate("auth:*");
+    pxt.data.invalidate("auth:*");
     //data.invalidate("user-prefs:*"); // Should we invalidate this? Or would it be jarring visually?
 }
 
@@ -221,7 +221,7 @@ export async function loginAsync(idp: pxt.IdentityProviderId, persistent: boolea
     pxt.storage.setLocal(AUTH_LOGIN_STATE, stateStr);
 
     // Redirect to the login endpoint.
-    const loginUrl = core.stringifyQueryString('/api/auth/login', {
+    const loginUrl = U.stringifyQueryString('/api/auth/login', {
         response_type: "token",
         provider: idp,
         persistent,
@@ -349,7 +349,7 @@ export async function loginCallback(qs: pxt.Map<string>) {
 
     // Clear url parameters and redirect to the callback location.
     const hash = callbackState.hash.startsWith('#') ? callbackState.hash : `#${callbackState.hash}`;
-    const params = core.stringifyQueryString('', callbackState.params);
+    const params = U.stringifyQueryString('', callbackState.params);
     const pathname = state.callbackPathname.startsWith('/') ? state.callbackPathname : `/${state.callbackPathname}`;
     const redirect = `${pathname}${hash}${params}`;
     window.location.href = redirect;
@@ -462,13 +462,13 @@ function internalPrefUpdateAndInvalidate(newPref: Partial<UserPreferences>) {
     });
     // invalidate fields that change
     if (oldPref?.highContrast !== getState().preferences?.highContrast) {
-        data.invalidate(HIGHCONTRAST)
+        pxt.data.invalidate(HIGHCONTRAST)
     }
     if (oldPref?.language !== getState().preferences?.language) {
-        data.invalidate(LANGUAGE)
+        pxt.data.invalidate(LANGUAGE)
     }
     if (oldPref?.reader !== getState().preferences?.reader) {
-        data.invalidate(READER)
+        pxt.data.invalidate(READER)
     }
 }
 
@@ -561,8 +561,8 @@ function setUserProfile(profile: UserProfile) {
     const wasLoggedIn = loggedInSync();
     transformUserProfile(profile);
     const isLoggedIn = loggedInSync();
-    data.invalidate(PROFILE);
-    data.invalidate(LOGGED_IN);
+    pxt.data.invalidate(PROFILE);
+    pxt.data.invalidate(LOGGED_IN);
     if (isLoggedIn && !wasLoggedIn) {
         core.infoNotification(`Signed in: ${profile.idp.displayName}`);
     }
@@ -620,7 +620,7 @@ export async function apiAsync<T = any>(url: string, data?: any, method?: string
 }
 
 function authApiHandler(p: string) {
-    const field = data.stripProtocol(p);
+    const field = pxt.data.stripProtocol(p);
     const state = getState();
     switch (field) {
         case FIELD_PROFILE: return state.profile;
@@ -631,7 +631,7 @@ function authApiHandler(p: string) {
 
 function internalUserPreferencesHandler(path: string): UserPreferences | boolean | string {
     const state = getState();
-    const field = data.stripProtocol(path);
+    const field = pxt.data.stripProtocol(path);
     switch (field) {
         case FIELD_HIGHCONTRAST: return state.preferences.highContrast;
         case FIELD_LANGUAGE: return state.preferences.language;
@@ -657,13 +657,13 @@ async function userPreferencesHandlerAsync(path: string): Promise<UserPreference
 }
 
 export function init() {
-    data.mountVirtualApi(USER_PREF_MODULE, {
+    pxt.data.mountVirtualApi(USER_PREF_MODULE, {
         getSync: userPreferencesHandlerSync,
         // TODO: virtual apis don't support both sync & async
         // getAsync: userPreferencesHandlerAsync
     });
 
-    data.mountVirtualApi(MODULE, { getSync: authApiHandler });
+    pxt.data.mountVirtualApi(MODULE, { getSync: authApiHandler });
 }
 
 export function enableAuth(enabled = true) {

--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -166,19 +166,19 @@ export class CloudTempMetadata {
 
     public syncInProgress() {
         this._syncStartTime = U.nowSeconds();
-        data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
+        pxt.data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
     }
 
     public syncFinished() {
         this._syncStartTime = 0;
         this._justSynced = true;
-        data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
+        pxt.data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
         // slightly hacky, but we want to keep around a "saved!" message for a small time after
         // a save succeeds so we notify metadata subscribers again after a delay.
         setTimeout(() => {
             if (this._syncStartTime === 0) { // not currently syncing?
                 this._justSynced = false;
-                data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
+                pxt.data.invalidate(`${HEADER_CLOUDSTATE}:${this.headerId}`);
             }
         }, 1500);
     }
@@ -595,7 +595,7 @@ async function syncAsyncInternal(hdrs?: Header[]): Promise<Header[]> {
         pxt.log(`Cloud sync finished after ${elapsed} seconds with ${localHeaderChangesList.length} local changes.`);
         pxt.tickEvent(`identity.sync.finished`, { elapsed })
 
-        data.invalidate("headers:");
+        pxt.data.invalidate("headers:");
 
         return localHeaderChangesList
     }
@@ -636,7 +636,7 @@ const CLOUDSAVE_MAX_MS = 15000;
 let headerWorklist: { [headerId: string]: boolean } = {};
 let onHeaderChangeTimeout: number = 0;
 let onHeaderChangeStarted: number = 0;
-const onHeaderChangeSubscriber: data.DataSubscriber = {
+const onHeaderChangeSubscriber: pxt.data.DataSubscriber = {
     subscriptions: [],
     onDataChanged: (path: string) => {
         const parts = path.split("header:");
@@ -726,7 +726,7 @@ async function onHeadersChanged(): Promise<void> {
 export const HEADER_CLOUDSTATE = "header-cloudstate"
 
 function cloudHeaderMetadataHandler(p: string): any {
-    p = data.stripProtocol(p)
+    p = pxt.data.stripProtocol(p)
     if (p == "*") return workspace.getHeaders().map(h => getCloudTempMetadata(h.id))
     return getCloudTempMetadata(p)
 }
@@ -734,8 +734,8 @@ function cloudHeaderMetadataHandler(p: string): any {
 export function init() {
     console.log("cloud init");
     // mount our virtual APIs
-    data.mountVirtualApi(HEADER_CLOUDSTATE, { getSync: cloudHeaderMetadataHandler });
+    pxt.data.mountVirtualApi(HEADER_CLOUDSTATE, { getSync: cloudHeaderMetadataHandler });
 
     // subscribe to header changes
-    data.subscribe(onHeaderChangeSubscriber, "header:*");
+    pxt.data.subscribe(onHeaderChangeSubscriber, "header:*");
 }

--- a/webapp/src/cloudsync.ts
+++ b/webapp/src/cloudsync.ts
@@ -120,8 +120,8 @@ export class ProviderBase {
             pxt.storage.setLocal(this.name + CLOUD_USER, JSON.stringify(user))
         else
             pxt.storage.removeLocal(this.name + CLOUD_USER);
-        data.invalidate("sync:user")
-        data.invalidate("github:user")
+            pxt.data.invalidate("sync:user")
+            pxt.data.invalidate("github:user")
     }
 
     protected token() {
@@ -418,7 +418,7 @@ export function loginCheck() {
 
     // implicit OAuth flow, via query argument
     {
-        const qs = core.parseQueryString(pxt.storage.getLocal(OAUTH_HASH) || "")
+        const qs = U.parseQueryString(pxt.storage.getLocal(OAUTH_HASH) || "")
         if (qs["access_token"]) {
             const tp = pxt.storage.getLocal(OAUTH_TYPE)
             const impl = provs.filter(p => p.name == tp)[0];
@@ -434,7 +434,7 @@ export function loginCheck() {
 
     // auth OAuth flow, via hash
     {
-        const qs = core.parseQueryString((location.hash || "#")
+        const qs = U.parseQueryString((location.hash || "#")
             .slice(1)
             .replace(/%23access_token/, "access_token"));
         if (qs["access_token"]) {
@@ -470,7 +470,7 @@ export function userInitials(username: string): string {
 
 function syncApiHandler(p: string) {
     const provider = currentProvider;
-    switch (data.stripProtocol(p)) {
+    switch (pxt.data.stripProtocol(p)) {
         case "user":
             return provider && provider.user();
         case "loggedin":
@@ -490,7 +490,7 @@ function syncApiHandler(p: string) {
 
 function githubApiHandler(p: string) {
     const provider = githubProvider();
-    switch (data.stripProtocol(p)) {
+    switch (pxt.data.stripProtocol(p)) {
         case "user":
             return provider && provider.user();
     }
@@ -498,7 +498,7 @@ function githubApiHandler(p: string) {
 }
 
 function pingApiHandlerAsync(p: string): Promise<any> {
-    const url = data.stripProtocol(p);
+    const url = pxt.data.stripProtocol(p);
     // special case favicon.ico
     if (/\.ico$/.test(p)) {
         const imgUrl = pxt.BrowserUtils.isEdge()
@@ -520,19 +520,19 @@ function pingApiHandlerAsync(p: string): Promise<any> {
         .catch(e => false)
 }
 
-data.mountVirtualApi("sync", { getSync: syncApiHandler })
-data.mountVirtualApi("github", { getSync: githubApiHandler })
-data.mountVirtualApi("ping", {
+pxt.data.mountVirtualApi("sync", { getSync: syncApiHandler })
+pxt.data.mountVirtualApi("github", { getSync: githubApiHandler })
+pxt.data.mountVirtualApi("ping", {
     getAsync: pingApiHandlerAsync,
     expirationTime: p => 24 * 3600 * 1000,
     isOffline: () => !pxt.Cloud.isOnline()
 })
 
 function invalidateData() {
-    data.invalidate("sync:status")
-    data.invalidate("sync:user")
-    data.invalidate("sync:loggedin")
-    data.invalidate("sync:provider")
-    data.invalidate("sync:providericon")
-    data.invalidate("github:user");
+    pxt.data.invalidate("sync:status")
+    pxt.data.invalidate("sync:user")
+    pxt.data.invalidate("sync:loggedin")
+    pxt.data.invalidate("sync:provider")
+    pxt.data.invalidate("sync:providericon")
+    pxt.data.invalidate("github:user");
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -631,7 +631,7 @@ async function checkIfServiceWorkerSupportedAsync() {
 }
 
 function handlePacketIOApi(r: string) {
-    const p = data.stripProtocol(r);
+    const p = pxt.data.stripProtocol(r);
     switch (p) {
         case "active":
             return pxt.packetio.isActive();
@@ -695,6 +695,6 @@ export function showUnsupportedHardwareMessageAsync(resp: pxtc.CompileResult) {
     return Promise.resolve(true);
 }
 
-data.mountVirtualApi("packetio", {
+pxt.data.mountVirtualApi("packetio", {
     getSync: handlePacketIOApi
 });

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -299,7 +299,7 @@ export const ENTER_KEY = 13;
 export const SPACE_KEY = 32;
 
 export function getHighContrastOnce(): boolean {
-    return data.getData<boolean>(auth.HIGHCONTRAST) || false
+    return pxt.data.getData<boolean>(auth.HIGHCONTRAST) || false
 }
 export function toggleHighContrast() {
     setHighContrast(!getHighContrastOnce())
@@ -337,28 +337,6 @@ export function findChild(c: React.Component<any, any>, selector: string): Eleme
     let self = ReactDOM.findDOMNode(c);
     if (!selector) return [self]
     return pxt.Util.toArray(self.querySelectorAll(selector));
-}
-
-export function parseQueryString(qs: string) {
-    let r: pxt.Map<string> = {}
-
-    qs.replace(/\+/g, " ").replace(/([^#?&=]+)=([^#?&=]*)/g, (f: string, k: string, v: string) => {
-        r[decodeURIComponent(k)] = decodeURIComponent(v)
-        return ""
-    })
-    return r
-}
-
-export function stringifyQueryString(url: string, qs: any) {
-    for (let k of Object.keys(qs)) {
-        if (url.indexOf("?") >= 0) {
-            url += "&"
-        } else {
-            url += "?"
-        }
-        url += encodeURIComponent(k) + "=" + encodeURIComponent(qs[k])
-    }
-    return url
 }
 
 export function handleNetworkError(e: any, ignoredCodes?: number[]) {

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -159,5 +159,3 @@ export class PureComponent<TProps, TState> extends React.PureComponent<TProps, T
         return this.renderCore();
     }
 }
-
-pxt.data.loadCache();

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -1,47 +1,17 @@
 import * as React from "react";
 import * as core from "./core";
 
-export type Action = () => void;
-export type DataSubscriber = {
-    subscriptions: CacheEntry[];
-    onDataChanged: (path: string) => void;
-};
-
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 
-interface CacheEntry {
-    path: string;
-    data: any;
-    lastRefresh: number;
-    queued: boolean;
-    callbackOnce: Action[];
-    components: DataSubscriber[];
-    api: VirtualApi;
-}
-
-export enum FetchStatus {
-    Pending,
-    Complete,
-    Error,
-    Offline
-};
-
-export interface DataFetchResult<T> {
-    data?: T;
-    status: FetchStatus;
-}
-
-const virtualApis: pxt.Map<VirtualApi> = {}
-
-mountVirtualApi("cloud", {
-    getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(core.handleNetworkError),
+pxt.data.mountVirtualApi("cloud", {
+    getAsync: p => Cloud.privateGetAsync(pxt.data.stripProtocol(p)).catch(core.handleNetworkError),
     expirationTime: p => 60 * 1000,
     isOffline: () => !Cloud.isOnline(),
 })
 
-mountVirtualApi("cloud-search", {
-    getAsync: p => Cloud.privateGetAsync(stripProtocol(p)).catch(e => {
+pxt.data.mountVirtualApi("cloud-search", {
+    getAsync: p => Cloud.privateGetAsync(pxt.data.stripProtocol(p)).catch(e => {
         core.handleNetworkError(e, [404])
         return { statusCode: 404, headers: {}, json: {} }
     }),
@@ -49,32 +19,32 @@ mountVirtualApi("cloud-search", {
     isOffline: () => !Cloud.isOnline(),
 })
 
-mountVirtualApi("gallery", {
-    getAsync: p => pxt.gallery.loadGalleryAsync(stripProtocol(decodeURIComponent(p))).catch((e) => {
+pxt.data.mountVirtualApi("gallery", {
+    getAsync: p => pxt.gallery.loadGalleryAsync(pxt.data.stripProtocol(decodeURIComponent(p))).catch((e) => {
         return Promise.resolve(e);
     }),
     expirationTime: p => 3600 * 1000
 })
 
-mountVirtualApi("gh-search", {
+pxt.data.mountVirtualApi("gh-search", {
     getAsync: query => pxt.targetConfigAsync()
-        .then(config => pxt.github.searchAsync(stripProtocol(query), config ? config.packages : undefined))
+        .then(config => pxt.github.searchAsync(pxt.data.stripProtocol(query), config ? config.packages : undefined))
         .catch(core.handleNetworkError),
     expirationTime: p => 60 * 1000,
     isOffline: () => !Cloud.isOnline(),
 })
 
-mountVirtualApi("gh-pkgcfg", {
+pxt.data.mountVirtualApi("gh-pkgcfg", {
     getAsync: query =>
-        pxt.github.pkgConfigAsync(stripProtocol(query)).catch(core.handleNetworkError),
+        pxt.github.pkgConfigAsync(pxt.data.stripProtocol(query)).catch(core.handleNetworkError),
     expirationTime: p => 60 * 1000,
     isOffline: () => !Cloud.isOnline(),
 })
 
 // gh-commits:repo#sha
-mountVirtualApi("gh-commits", {
+pxt.data.mountVirtualApi("gh-commits", {
     getAsync: query => {
-        const p = stripProtocol(query);
+        const p = pxt.data.stripProtocol(query);
         const [ repo, sha ] = p.split('#', 2)
         return pxt.github.getCommitsAsync(repo, sha).catch(e => {
             core.handleNetworkError(e);
@@ -86,16 +56,16 @@ mountVirtualApi("gh-commits", {
 })
 
 let targetConfigPromise: Promise<pxt.TargetConfig> = undefined;
-mountVirtualApi("target-config", {
+pxt.data.mountVirtualApi("target-config", {
     getAsync: query => {
         if (!targetConfigPromise)
             targetConfigPromise = pxt.targetConfigAsync()
                 .then(js => {
                     if (js) {
                         pxt.storage.setLocal("targetconfig", JSON.stringify(js))
-                        invalidate("target-config");
-                        invalidate("gh-search");
-                        invalidate("gh-pkgcfg");
+                        pxt.data.invalidate("target-config");
+                        pxt.data.invalidate("gh-search");
+                        pxt.data.invalidate("gh-pkgcfg");
                     }
                     return js;
                 })
@@ -109,223 +79,13 @@ mountVirtualApi("target-config", {
     isOffline: () => !Cloud.isOnline()
 })
 
-let cachedData: pxt.Map<CacheEntry> = {};
-
-export function subscribe(component: DataSubscriber, path: string) {
-    let e = lookup(path)
-    let lst = e.components
-    if (lst.indexOf(component) < 0) {
-        lst.push(component)
-        component.subscriptions.push(e)
-    }
-}
-
-export function unsubscribe(component: DataSubscriber) {
-    let lst = component.subscriptions
-    if (lst.length == 0) return
-    component.subscriptions = []
-    lst.forEach(ce => {
-        let idx = ce.components.indexOf(component)
-        if (idx >= 0) ce.components.splice(idx, 1)
-    })
-}
-
-function expired(ce: CacheEntry) {
-    if (!ce.api.expirationTime)
-        return !ce.lastRefresh; // needs to be refreshed at least once
-    return ce.data == null || (Date.now() - ce.lastRefresh) > ce.api.expirationTime(ce.path)
-}
-
-function shouldCache(ce: CacheEntry) {
-    if (!ce.data || ce.data instanceof Error) return false;
-    return /^cloud:(me\/settings|ptr-pkg-)/.test(ce.path);
-}
-
-export function clearCache() {
-    cachedData = {};
-    saveCache();
-}
-
-function loadCache() {
-    JSON.parse(pxt.storage.getLocal("apiCache2") || "[]").forEach((e: any) => {
-        let ce = lookup(e.path)
-        ce.data = e.data
-    })
-}
-
-function saveCache() {
-    let obj = Util.values(cachedData).filter(e => shouldCache(e)).map(e => {
-        return {
-            path: e.path,
-            data: e.data
-        }
-    })
-    pxt.storage.setLocal("apiCache2", JSON.stringify(obj))
-}
-
-function matches(ce: CacheEntry, prefix: string) {
-    return ce.path.slice(0, prefix.length) == prefix;
-}
-
-function notify(ce: CacheEntry, path: string) {
-    if (shouldCache(ce)) saveCache();
-
-    let lst = ce.callbackOnce
-    if (lst.length > 0) {
-        ce.callbackOnce = []
-        Util.nextTick(() => lst.forEach(f => f()))
-    }
-
-    if (ce.components.length > 0)
-        ce.components.forEach(c => Util.nextTick(() => c.onDataChanged(path)))
-}
-
-function getVirtualApi(path: string) {
-    let m = /^([\w\-]+):/.exec(path)
-    if (!m || !virtualApis[m[1]])
-        Util.oops("bad data protocol: " + path)
-    return virtualApis[m[1]]
-}
-
-function queueNotify(ce: CacheEntry, path: string) {
-    if (ce.queued) return
-
-    if (ce.api.isOffline && ce.api.isOffline())
-        return
-
-    ce.queued = true
-
-    let final = (res: any) => {
-        ce.data = res
-        ce.lastRefresh = pxt.Util.now()
-        ce.queued = false
-        notify(ce, path)
-    }
-
-    if (ce.api.isSync)
-        final(ce.api.getSync(ce.path))
-    else {
-        const p = ce.api.getAsync(ce.path);
-        p.then(final)
-    }
-}
-
-function lookup(path: string) {
-    if (!cachedData.hasOwnProperty(path))
-        cachedData[path] = {
-            path: path,
-            data: null,
-            lastRefresh: 0,
-            queued: false,
-            callbackOnce: [],
-            components: [],
-            api: getVirtualApi(path)
-        }
-    return cachedData[path]
-}
-
-function getCached(component: DataSubscriber, path: string): DataFetchResult<any> {
-    subscribe(component, path)
-    return getDataWithStatus(path);
-}
-
-//
-// Public interface
-//
-
-export interface VirtualApi {
-    getAsync?(path: string): Promise<any>;
-    getSync?(path: string): any;
-    isSync?: boolean;
-    expirationTime?(path: string): number; // in milliseconds
-    isOffline?: () => boolean;
-    onInvalidated?: (path: string) => void;
-}
-
-export function mountVirtualApi(protocol: string, handler: VirtualApi) {
-    Util.assert(!virtualApis[protocol])
-    Util.assert(!!handler.getSync || !!handler.getAsync)
-    Util.assert(!!handler.getSync != !!handler.getAsync)
-    handler.isSync = !!handler.getSync
-    virtualApis[protocol] = handler
-}
-
-export function stripProtocol(path: string) {
-    let m = /^([\w\-]+):(.*)/.exec(path)
-    if (m) return m[2]
-    else Util.oops("protocol missing in: " + path)
-    return path
-}
-
-export function invalidate(path: string) {
-    const prefix = path.replace(/:\*$/, ':'); // remove trailing "*";
-    Util.values(cachedData).forEach(ce => {
-        if (matches(ce, prefix)) {
-            ce.lastRefresh = 0;
-            if (ce.components.length > 0)
-                queueNotify(lookup(ce.path), path)
-            if (ce.api.onInvalidated) {
-                ce.api.onInvalidated(path);
-            }
-        }
-    })
-}
-
 export function invalidateHeader(prefix: string, hd: pxt.workspace.Header) {
     if (hd)
-        invalidate(prefix + ':' + hd.id);
+        pxt.data.invalidate(prefix + ':' + hd.id);
 }
 
-export function getAsync<T = any>(path: string) {
-    let ce = lookup(path)
-
-    if (ce.api.isSync)
-        return Promise.resolve(ce.api.getSync(ce.path))
-
-    if (!Cloud.isOnline() || !expired(ce))
-        return Promise.resolve(ce.data)
-
-    return new Promise<T>((resolve, reject) => {
-        ce.callbackOnce.push(() => {
-            resolve(ce.data)
-        })
-        queueNotify(ce, path)
-    })
-}
-
-export function getData<T>(path: string): T {
-    return getDataWithStatus<T>(path).data;
-}
-
-export function getDataWithStatus<T>(path: string): DataFetchResult<T> {
-    let r = lookup(path)
-    if (r.api.isSync)
-        return {
-            data: r.api.getSync(r.path),
-            status: FetchStatus.Complete
-        }
-
-    // cache async values
-    let fetchRes: DataFetchResult<T> = {
-        data: r.data,
-        status: FetchStatus.Complete
-    };
-
-    if (expired(r) || r.data instanceof Error) {
-        fetchRes.status = r.data instanceof Error ? FetchStatus.Error : FetchStatus.Pending;
-        if (r.api.isOffline && r.api.isOffline()) {
-            // The request will not be requeued so we don't want to show it as pending
-            fetchRes.status = FetchStatus.Offline;
-        } else {
-            queueNotify(r, path)
-        }
-    }
-
-    return fetchRes;
-}
-
-export class Component<TProps, TState> extends React.Component<TProps, TState> implements DataSubscriber {
-    subscriptions: CacheEntry[] = [];
+export class Component<TProps, TState> extends React.Component<TProps, TState> implements pxt.data.DataSubscriber {
+    subscriptions: pxt.data.CacheEntry[] = [];
     renderCoreOk = false;
 
     constructor(props: TProps) {
@@ -341,10 +101,10 @@ export class Component<TProps, TState> extends React.Component<TProps, TState> i
     /**
      * Like getData, but the data is wrapped in a result object that indicates the status of the fetch operation
      */
-    getDataWithStatus<T = any>(path: string): DataFetchResult<T> {
+    getDataWithStatus<T = any>(path: string): pxt.data.DataFetchResult<T> {
         if (!this.renderCoreOk)
             Util.oops("Override renderCore() not render()")
-        return getCached(this, path)
+        return pxt.data.getCached(this, path)
     }
 
     onDataChanged(): void {
@@ -352,7 +112,7 @@ export class Component<TProps, TState> extends React.Component<TProps, TState> i
     }
 
     componentWillUnmount(): void {
-        unsubscribe(this)
+        pxt.data.unsubscribe(this)
     }
 
     child(selector: string) {
@@ -364,7 +124,7 @@ export class Component<TProps, TState> extends React.Component<TProps, TState> i
     }
 
     render() {
-        unsubscribe(this)
+        pxt.data.unsubscribe(this)
         this.renderCoreOk = true;
         return this.renderCore();
     }
@@ -400,4 +160,4 @@ export class PureComponent<TProps, TState> extends React.PureComponent<TProps, T
     }
 }
 
-loadCache();
+pxt.data.loadCache("apiCache2");

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -159,3 +159,5 @@ export class PureComponent<TProps, TState> extends React.PureComponent<TProps, T
         return this.renderCore();
     }
 }
+
+pxt.data.loadCache();

--- a/webapp/src/data.ts
+++ b/webapp/src/data.ts
@@ -160,4 +160,4 @@ export class PureComponent<TProps, TState> extends React.PureComponent<TProps, T
     }
 }
 
-pxt.data.loadCache("apiCache2");
+pxt.data.loadCache();

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -1607,7 +1607,7 @@ class CommitView extends sui.UIElement<CommitViewProps, CommitViewState> {
             core.showLoading("github.restore", lf("restoring commit..."))
             workspace.restoreCommitAsync(this.props.parent.props.parent.state.header, commit)
                 .then(() => {
-                    data.invalidate("gh-commits:*");
+                    pxt.data.invalidate("gh-commits:*");
                     return this.props.parent.props.parent.reloadHeaderAsync();
                 })
                 .finally(() => core.hideLoading("github.restore"))

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -214,8 +214,8 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
 export function launchImmersiveReader(content: string, tutorialOptions: pxt.tutorial.TutorialOptions) {
     pxt.tickEvent("immersiveReader.launch", {tutorial: tutorialOptions.tutorial, tutorialStep: tutorialOptions.tutorialStep});
 
-    const userReaderPref = data.getData<string>(auth.READER) || ""
-    const langPref = data.getData<string>(auth.LANGUAGE) || "";
+    const userReaderPref = pxt.data.getData<string>(auth.READER) || ""
+    const langPref = pxt.data.getData<string>(auth.LANGUAGE) || "";
     const tutorialData = {
         chunks: [{
             content: beautifyText(content),

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -365,7 +365,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private exceptionChangesListeners: pxt.Map<(exception: pxsim.DebuggerBreakpointMessage, locations: pxtc.LocationInfo[]) => void> = {}
     private callLocations: pxtc.LocationInfo[];
 
-    private userPreferencesSubscriber: data.DataSubscriber = {
+    private userPreferencesSubscriber: pxt.data.DataSubscriber = {
         subscriptions: [],
         onDataChanged: () => {
             this.onUserPreferencesChanged();
@@ -385,11 +385,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.startDebugger = this.startDebugger.bind(this)
         this.onUserPreferencesChanged = this.onUserPreferencesChanged.bind(this);
 
-        data.subscribe(this.userPreferencesSubscriber, auth.HIGHCONTRAST);
+        pxt.data.subscribe(this.userPreferencesSubscriber, auth.HIGHCONTRAST);
     }
 
     onUserPreferencesChanged() {
-        const hc = data.getData<boolean>(auth.HIGHCONTRAST);
+        const hc = pxt.data.getData<boolean>(auth.HIGHCONTRAST);
 
         if (this.loadMonacoPromise) this.defineEditorTheme(hc, true);
     }

--- a/webapp/src/package.ts
+++ b/webapp/src/package.ts
@@ -93,7 +93,7 @@ export class File implements pxt.editor.IFile {
     }
 
     private updateStatus() {
-        data.invalidate("open-meta:" + this.getName())
+        pxt.data.invalidate("open-meta:" + this.getName())
     }
 
     setBaseGitContent(newContent: string) {
@@ -373,13 +373,13 @@ export class EditorPackage {
         let f = new File(this, n, v)
         if (virtual) f.virtual = true;
         this.files[n] = f
-        data.invalidate("open-meta:")
+        pxt.data.invalidate("open-meta:")
         return f
     }
 
     removeFileAsync(n: string) {
         delete this.files[n];
-        data.invalidate("open-meta:")
+        pxt.data.invalidate("open-meta:")
         return this.updateConfigAsync(cfg => {
             cfg.files = cfg.files.filter(f => f != n)
             if (cfg.testFiles)
@@ -417,7 +417,7 @@ export class EditorPackage {
 
     setFiles(files: pxt.Map<string>) {
         this.files = Util.mapMap(files, (k, v) => new File(this, k, v))
-        data.invalidate("open-meta:")
+        pxt.data.invalidate("open-meta:")
         this.updateGitJsonCache()
     }
 
@@ -825,9 +825,9 @@ export interface FileMeta {
 /*
     open-meta:<pkgName>/<filename> - readonly/saved/unsaved + number of errors
 */
-data.mountVirtualApi("open-meta", {
+pxt.data.mountVirtualApi("open-meta", {
     getSync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const pk = mainEditorPkg()
         const f = pk.lookupFile(p)
         if (!f) return {}
@@ -856,9 +856,9 @@ export interface PackageMeta {
 /*
     open-pkg-meta:<pkgName> - number of errors
 */
-data.mountVirtualApi("open-pkg-meta", {
+pxt.data.mountVirtualApi("open-pkg-meta", {
     getSync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const f = allEditorPkgs().filter(pkg => pkg.getPkgId() == p)[0];
         if (!f || f.getPkgId() == "built")
             return {}
@@ -889,9 +889,9 @@ export interface PackageGitStatus {
 /*
     pkg-git-status:<guid>
 */
-data.mountVirtualApi("pkg-git-status", {
+pxt.data.mountVirtualApi("pkg-git-status", {
     getSync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const f = allEditorPkgs().find(pkg => pkg.header && pkg.header.id == p);
         const r: PackageGitStatus = {};
         if (f) {
@@ -909,9 +909,9 @@ export function invalidatePullStatus(hd: pxt.workspace.Header) {
     data.invalidateHeader("pkg-git-pull-status", hd)
 }
 
-data.mountVirtualApi("pkg-git-pull-status", {
+pxt.data.mountVirtualApi("pkg-git-pull-status", {
     getAsync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const f = allEditorPkgs().find(pkg => pkg.header && pkg.header.id == p);
         const ghid = f.getPkgId() == "this" && f.header && f.header.githubId;
         if (!ghid) return Promise.resolve(workspace.PullStatus.NoSourceControl)
@@ -925,12 +925,12 @@ export function invalidatePullRequestStatus(hd: pxt.workspace.Header) {
     data.invalidateHeader("pkg-git-pr", hd)
 }
 
-data.mountVirtualApi("pkg-git-pr", {
+pxt.data.mountVirtualApi("pkg-git-pr", {
     getAsync: p => {
         const missing = <pxt.github.PullRequest>{
             number: -1
         };
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const f = allEditorPkgs().find(pkg => pkg.header && pkg.header.id == p);
         const header = f.header;
         const ghid = f.getPkgId() == "this" && header && header.githubId;
@@ -947,9 +947,9 @@ export function invalidatePagesStatus(hd: pxt.workspace.Header) {
     data.invalidateHeader("pkg-git-pages", hd)
 }
 
-data.mountVirtualApi("pkg-git-pages", {
+pxt.data.mountVirtualApi("pkg-git-pages", {
     getAsync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const f = allEditorPkgs().find(pkg => pkg.header && pkg.header.id == p);
         const header = f.header;
         const ghid = f.getPkgId() == "this" && header && header.githubId;
@@ -964,9 +964,9 @@ data.mountVirtualApi("pkg-git-pages", {
 
 
 // pkg-status:<guid>
-data.mountVirtualApi("pkg-status", {
+pxt.data.mountVirtualApi("pkg-status", {
     getSync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const ep = allEditorPkgs().find(pkg => pkg.header && pkg.header.id == p)
         if (ep)
             return ep.savingNow ? "saving" : ""

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -137,7 +137,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
             this.setState({ selected: {} })
             return Promise.all(promises)
                 .then(() => {
-                    data.clearCache();
+                    pxt.data.clearCache();
                 });
         }, selectedLength > 1);
     }
@@ -186,7 +186,7 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                     return workspace.saveAsync(clonedHeader);
                 })
                 .then(() => {
-                    data.invalidate(`headers:${this.state.searchFor}`);
+                    pxt.data.invalidate(`headers:${this.state.searchFor}`);
                     this.setState({ selected: {}, markedNew: { '0': 1 }, sortedBy: 'time', sortedAsc: false });
                     setTimeout(() => {
                         this.setState({ markedNew: {} });

--- a/webapp/src/scriptsearch.tsx
+++ b/webapp/src/scriptsearch.tsx
@@ -110,10 +110,10 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         });
     }
 
-    fetchUrlData(): data.DataFetchResult<Cloud.JsonScript[]> {
-        const emptyResult: data.DataFetchResult<Cloud.JsonScript[]> = {
+    fetchUrlData(): pxt.data.DataFetchResult<Cloud.JsonScript[]> {
+        const emptyResult: pxt.data.DataFetchResult<Cloud.JsonScript[]> = {
             data: [],
-            status: data.FetchStatus.Complete
+            status: pxt.data.FetchStatus.Complete
         };
         if (!this.state.searchFor || this.state.mode != ScriptSearchMode.Extensions)
             return emptyResult;
@@ -132,10 +132,10 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         return res;
     }
 
-    fetchGhData(): data.DataFetchResult<pxt.github.GitRepo[]> {
-        const emptyResult: data.DataFetchResult<pxt.github.GitRepo[]> = {
+    fetchGhData(): pxt.data.DataFetchResult<pxt.github.GitRepo[]> {
+        const emptyResult: pxt.data.DataFetchResult<pxt.github.GitRepo[]> = {
             data: [],
-            status: data.FetchStatus.Complete
+            status: pxt.data.FetchStatus.Complete
         };
 
         if (this.state.mode != ScriptSearchMode.Extensions) return emptyResult;
@@ -148,7 +148,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
             const trgConfigFetch = this.getDataWithStatus("target-config:");
             const trgConfig = trgConfigFetch.data as pxt.TargetConfig;
 
-            if (trgConfigFetch.status === data.FetchStatus.Complete && trgConfig && trgConfig.packages && trgConfig.packages.preferredRepos) {
+            if (trgConfigFetch.status === pxt.data.FetchStatus.Complete && trgConfig && trgConfig.packages && trgConfig.packages.preferredRepos) {
                 searchFor = trgConfig.packages.preferredRepos.join("|");
             }
         }
@@ -328,7 +328,7 @@ export class ScriptSearch extends data.Component<ISettingsProps, ScriptSearchSta
         const urldata = this.fetchUrlData();
         const local = this.fetchLocalRepositories();
         const experiments = this.fetchExperiments();
-        const isSearching = searchFor && (ghdata.status === data.FetchStatus.Pending || urldata.status === data.FetchStatus.Pending);
+        const isSearching = searchFor && (ghdata.status === pxt.data.FetchStatus.Pending || urldata.status === pxt.data.FetchStatus.Pending);
         const disableFileAccessinMaciOs = pxt.appTarget.appTheme.disableFileAccessinMaciOs && (pxt.BrowserUtils.isIOS() || pxt.BrowserUtils.isMac());
         const disableFileAccessinAndroid = pxt.appTarget.appTheme.disableFileAccessinAndroid && pxt.BrowserUtils.isAndroid();
         const showImportFile = mode == ScriptSearchMode.Extensions

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -223,8 +223,8 @@ function refreshHeadersSession() {
     if (isHeadersSessionOutdated()) {
         pxt.storage.setLocal('workspacesessionid', sessionID);
         pxt.debug(`workspace: refreshed headers session to ${sessionID}`);
-        data.invalidate("header:*");
-        data.invalidate("text:*");
+        pxt.data.invalidate("header:*");
+        pxt.data.invalidate("text:*");
     }
 }
 // this is an identifier for the current frame
@@ -574,13 +574,13 @@ export async function saveAsync(h: Header, text?: ScriptText, fromCloudSync?: bo
         }
 
         if (text || h.isDeleted) {
-            data.invalidate("text:" + h.id);
-            data.invalidate("pkg-git-status:" + h.id);
+            pxt.data.invalidate("text:" + h.id);
+            pxt.data.invalidate("pkg-git-status:" + h.id);
         }
         data.invalidateHeader("header", h);
         if (newSave) {
             // the count of headers has changed
-            data.invalidate("headers:");
+            pxt.data.invalidate("headers:");
         }
 
         refreshHeadersSession();
@@ -950,7 +950,7 @@ export async function commitAsync(hd: Header, options: CommitOptions = {}) {
     if (newCommit == null) {
         return commitId
     } else {
-        data.invalidate("gh-commits:*"); // invalid any cached commits
+        pxt.data.invalidate("gh-commits:*"); // invalid any cached commits
         // if we created a block preview, add as comment
         if (blocksDiffSha) {
             await pxt.github.postCommitComment(
@@ -1548,7 +1548,7 @@ export function syncAsync(): Promise<pxt.editor.EditorSyncState> {
                         data.invalidateHeader("header", hd);
                         data.invalidateHeader("text", hd);
                         data.invalidateHeader("pkg-git-status", hd);
-                        data.invalidate("gh-commits:*"); // invalidate commits just in case
+                        pxt.data.invalidate("gh-commits:*"); // invalidate commits just in case
                     }
                 } else {
                     ex = {
@@ -1580,7 +1580,7 @@ export function resetAsync() {
         .then(compiler.clearApiInfoDbAsync)
         .then(() => {
             pxt.storage.clearLocal();
-            data.clearCache();
+            pxt.data.clearCache();
             // keep local token (localhost and electron) on reset
             if (Cloud.localToken)
                 pxt.storage.setLocal("local_token", Cloud.localToken);
@@ -1640,9 +1640,9 @@ export function dbgHdrToString(h: Header): string {
     header:*        - all headers
 */
 
-data.mountVirtualApi("header", {
+pxt.data.mountVirtualApi("header", {
     getSync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         if (p == "*") return getHeaders()
         return getHeader(p)
     },
@@ -1652,9 +1652,9 @@ data.mountVirtualApi("header", {
     headers:SEARCH   - search headers
 */
 
-data.mountVirtualApi("headers", {
+pxt.data.mountVirtualApi("headers", {
     getAsync: p => {
-        p = data.stripProtocol(p)
+        p = pxt.data.stripProtocol(p)
         const headers = getHeaders()
         if (!p) return Promise.resolve(headers)
         return compiler.projectSearchAsync({ term: p, headers })
@@ -1674,7 +1674,7 @@ data.mountVirtualApi("headers", {
     text:<guid>            - all files
     text:<guid>/<filename> - one file
 */
-data.mountVirtualApi("text", {
+pxt.data.mountVirtualApi("text", {
     getAsync: p => {
         const m = /^[\w\-]+:([^\/]+)(\/(.*))?/.exec(p)
         return getTextAsync(m[1])


### PR DESCRIPTION
In preparation to move the auth system to pxtlib, I'm moving "virtual api" and "storage" in a separate step. auth has dependencies on these systems. This operation was mostly a lift-and-shift, whereas moving auth will require some mild refactoring.