### PR TITLE
fix crash when tutorial does not contain any code snippets

### DIFF
--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -110,11 +110,11 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                     pxt.log("Unable to cache used blocks in DB");
                 }
                 pxt.tickEvent(`tutorial.usedblocks.computed`, { tutorial: id });
-
-                return { snippetBlocks, usedBlocks };
-            } else {
+            } else if (code?.length > 0) {
                 throw new Error("Failed to decompile");
             }
+
+            return { snippetBlocks, usedBlocks };
         }).catch((e) => {
             pxt.reportException(e);
             throw new Error(`Failed to decompile tutorial`);


### PR DESCRIPTION
We'll need to port this to microbit, though it's unlikely to be super urgent as the tutorials that error out here can't do anything.

Fix crash on https://makecode.microbit.org/#tutorial:https://makecode.microbit.org/_aCefY5KxgFJu . It's crashing because it doesn't get any block xml when decompiling, but it only doesn't get any block xml because there are no snippets in the first place. (I'm guessing this was only caught because it is the default tutorial over at https://makecode.com/tutorial-tool)

A bit of context here: https://forum.makecode.com/t/tutorial-help-please-check-your-internet-connection-and-check-the-tutorial-is-valid/9178/7?u=jwunderl