### PR TITLE
Show code carryover modal on skillmap node double click

### DIFF
--- a/skillmap/src/components/ActivityActions.tsx
+++ b/skillmap/src/components/ActivityActions.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { dispatchOpenActivity, dispatchShowRestartActivityWarning, dispatchShowShareModal, dispatchShowCarryoverModal } from '../actions/dispatch';
 
-import { ActivityStatus, lookupActivityProgress, lookupPreviousActivityStates } from '../lib/skillMapUtils';
+import { ActivityStatus, lookupActivityProgress, isCodeCarryoverEnabled } from '../lib/skillMapUtils';
 import { tickEvent } from '../lib/browserUtils';
 import { editorUrl } from "./makecodeFrame";
 import { SkillMapState } from "../store/reducer";
@@ -113,17 +113,10 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     if (!state) return {};
 
     const props = ownProps as OwnProps;
-    const map = state.maps[ownProps.mapId];
-    const activity = map.activities[ownProps.activityId] as MapActivity;
-
-    const previous = lookupPreviousActivityStates(state.user, state.pageSourceUrl, map, activity.activityId);
-    const previousActivityCompleted = previous.some(state => state?.isCompleted &&
-        state.maxSteps === state.currentStep);
-
-    const progress = lookupActivityProgress(state.user, state.pageSourceUrl, ownProps.mapId, ownProps.activityId);
-
+    const map = state.maps[props.mapId];
+    const activity = map.activities[props.activityId] as MapActivity;
     return {
-        showCodeCarryoverModal: activity.allowCodeCarryover && previousActivityCompleted && !progress?.headerId
+        showCodeCarryoverModal: isCodeCarryoverEnabled(state.user, state.pageSourceUrl, map, activity)
     };
 }
 

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -15,6 +15,7 @@ export function test() {
 
 export function parseSkillMap(text: string): { maps: SkillMap[], metadata?: PageMetadata } {
     const sections = getSectionsFromText(text);
+    if (!sections?.length) error(`Cannot parse content: ${text}`)
 
     const parsed: SkillMap[] = [];
     let metadata: PageMetadata | undefined;

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -135,6 +135,14 @@ export function lookupPreviousCompletedActivityState(user: UserState, pageSource
     return previous?.[0]
 }
 
+// Code carryover is enabled for unlocked activities (non-rewards) that haven't been started
+export function isCodeCarryoverEnabled(user: UserState, pageSource: string, map: SkillMap, activity: MapNode) {
+    if (activity.kind !== "activity") return false;
+
+    const progress = lookupActivityProgress(user, pageSource, map.mapId, activity.activityId);
+    return activity.allowCodeCarryover && isActivityUnlocked(user, pageSource, map, activity.activityId) && !progress?.headerId;
+}
+
 export function flattenRewardNodeChildren(node: MapNode): MapNode[] {
     if (!isRewardNode(node)) {
         return node.next;


### PR DESCRIPTION
the double-click handler was opening the activity directly instead of hooking into the carryover flow. changes:

- double-click opens the code carryover modal if the activity has not been started and carryover is enabled
- tick event for double-click
- better error when loading an incorrect docs markdown path