### PR TITLE
Fix pwa scope and starturl

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1695,8 +1695,8 @@ function buildWebManifest(cfg: pxt.TargetBundle) {
         "short_name": cfg.nickname || cfg.name,
         "background_color": "#FAFAFA",
         "icons": [],
-        "scope": "./",
-        "start_url": "./",
+        "scope": "/",
+        "start_url": "/",
         "display": "standalone",
         "orientation": "landscape"
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4273

With this change we can't test the beta or /app/ urls, but that isn't a big deal. Testing the normal site should suffice in those scenarios