### PR TITLE
Escape characters so regex creation doesn't fail

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -766,8 +766,8 @@ namespace pxt {
             }
 
             if (files) {
-                const shortId = getShortIDForAsset(asset);
-                const displayName = asset.meta?.displayName || "";
+                const shortId = Util.escapeForRegex(getShortIDForAsset(asset));
+                const displayName = Util.escapeForRegex(asset.meta?.displayName) || "";
 
                 let assetTsRefs: string;
                 switch (asset.type) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3642

When we attempted to create a RegExp, if the sprite had been generated with an ID that contained reserved regex symbols, this would fail. This fix aims at escaping all these special characters.

It was tested using https://github.com/eanders-MS/palette-sprite project.