### PR TITLE
Disable touch and pointer events for unclickable logos

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -482,10 +482,17 @@ div.simframe > iframe {
     background: none;
 }
 
+.ui.item.logo.organization,
+.inHome .ui.item.logo.brand {
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+}
+
 .ui.item.logo.brand:hover {
     cursor: pointer;
 }
-
 .inHome .ui.item.logo.brand:hover {
     cursor: auto;
 }


### PR DESCRIPTION
for removing the long press event in ios; should be fine to apply generally