### PR TITLE
Add storage api to pxt server

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -7137,7 +7137,7 @@ function errorHandler(reason: any) {
         process.exit(1)
     }
 
-    let msg = reason.stack || reason.message || (reason + "")
+    let msg = reason.stack || reason.message || reason.statusMessage || (reason + "")
     console.error("INTERNAL ERROR:", msg)
     process.exit(20)
 }

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -7,6 +7,7 @@ import * as nodeutil from './nodeutil';
 import * as hid from './hid';
 import * as net from 'net';
 import * as crowdin from './crowdin';
+import * as storage from './storage';
 
 import { promisify } from "util";
 
@@ -283,6 +284,49 @@ function getCachedHexAsync(sha: string): Promise<any> {
                     };
                 });
         });
+}
+
+async function handleApiStoreRequestAsync(req: http.IncomingMessage, res: http.ServerResponse, elts: string[]): Promise<void> {
+    const meth = req.method.toUpperCase();
+    const container = decodeURIComponent(elts[0]);
+    const key = decodeURIComponent(elts[1]);
+    if (!container || !key) { throw throwError(400, "malformed api/store request: " + req.url); }
+    const origin = req.headers['origin'] || '*';
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    if (meth === "GET") {
+        const val = await storage.getAsync(container, key);
+        if (val) {
+            if (typeof val === "object") {
+                res.writeHead(200, { 'Content-Type': 'application/json; charset=utf8' });
+                res.end(JSON.stringify(val));
+            } else {
+                res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf8' });
+                res.end(val.toString());
+            }
+        } else {
+            res.writeHead(404);
+            res.end();
+        }
+    } else if (meth === "POST") {
+        const srec = (await nodeutil.readResAsync(req)).toString("utf8");
+        const rec = JSON.parse(srec) as storage.Record;
+        await storage.setAsync(container, key, rec);
+        res.writeHead(200);
+        res.end();
+    } else if (meth === "DELETE") {
+        await storage.delAsync(container, key);
+        res.writeHead(200);
+        res.end();
+    } else if (meth === "OPTIONS") {
+        const allowedHeaders = req.headers['access-control-request-headers'] || 'Content-Type';
+        const allowedMethods = req.headers['access-control-request-method'] || 'GET, POST, DELETE';
+        res.setHeader('Access-Control-Allow-Headers', allowedHeaders);
+        res.setHeader('Access-Control-Allow-Methods', allowedMethods);
+        res.writeHead(200);
+        res.end();
+    } else {
+        throw res.writeHead(400, "Unsupported HTTP method: " + meth);
+    }
 }
 
 function handleApiAsync(req: http.IncomingMessage, res: http.ServerResponse, elts: string[]): Promise<any> {
@@ -903,7 +947,7 @@ export function serveAsync(options: ServeOptions) {
     if (serveOptions.serial)
         initSerialMonitor();
 
-    const server = http.createServer((req, res) => {
+    const server = http.createServer(async (req, res) => {
         const error = (code: number, msg: string = null) => {
             res.writeHead(code, { "Content-Type": "text/plain" })
             res.end(msg || "Error " + code)
@@ -978,6 +1022,10 @@ export function serveAsync(options: ServeOptions) {
                 res.setHeader("Location", trg)
                 error(302, "Redir: " + trg)
                 return
+            }
+
+            if (elts[1] == "store") {
+                return await handleApiStoreRequestAsync(req, res, elts.slice(2));
             }
 
             if (/^\d\d\d[\d\-]*$/.test(elts[1]) && elts[2] == "js") {

--- a/cli/storage.ts
+++ b/cli/storage.ts
@@ -69,7 +69,8 @@ export async function delAsync(container: string, key: string): Promise<void> {
 
 const whitespaceRe = /[\r\n\s\t]+/g;
 const illegalRe = /[\/\?<>\\:\*\|"]/g;
-const controlRe = /[\x00-\x1f\x80-\x9f]/g;
+// eslint-disable-next-line no-control-regex
+const controlRe = /[\x00-\x1f\x80-\x9f]/g; // https://en.wikipedia.org/wiki/C0_and_C1_control_codes
 const reservedRe = /^\.+$/;
 const windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
 const windowsTrailingRe = /[\. ]+$/;

--- a/cli/storage.ts
+++ b/cli/storage.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from "util";
+
+import U = pxt.Util;
+
+const rootPath = path.resolve('.pxt', 'storage');
+const mkdirAsync = promisify(fs.mkdir);
+const unlinkAsync = promisify(fs.unlink);
+const readFileAsync = promisify(fs.readFile);
+const writeFileAsync = promisify(fs.writeFile);
+
+export type Record = {
+    type: "json" | "text",
+    val: string;
+};
+
+async function initAsync() {
+    try {
+        await mkdirAsync(rootPath, { recursive: true });
+    } catch (err) {
+        pxt.debug(err);
+    }
+}
+
+export async function getAsync<T>(container: string, key: string): Promise<T | undefined> {
+    await initAsync();
+    try {
+        const fname = path.resolve(rootPath, sanitize(container), sanitize(key));
+        pxt.debug(`GET ${fname}`);
+        const srec = (await readFileAsync(fname)).toString("utf8");
+        const rec = JSON.parse(srec) as Record;
+        let val: any;
+        if (rec.type === "json")
+            val = JSON.parse(rec.val);
+        else
+            val = rec.val;
+        return Promise.resolve<T>(val);
+    } catch (err) {
+        pxt.debug(err);
+    }
+    return undefined;
+}
+
+export async function setAsync(container: string, key: string, rec: Record): Promise<void> {
+    await initAsync();
+    try {
+        const dir = path.resolve(rootPath, sanitize(container));
+        const fname = path.resolve(dir, sanitize(key));
+        pxt.debug(`SET ${fname}`);
+        const srec = JSON.stringify(rec);
+        try { await mkdirAsync(path.resolve(rootPath, dir)); } catch { }
+        await writeFileAsync(fname, srec);
+    } catch (err) {
+        pxt.debug(err);
+    }
+}
+
+export async function delAsync(container: string, key: string): Promise<void> {
+    await initAsync();
+    try {
+        const p = path.resolve(rootPath, sanitize(container), sanitize(key));
+        pxt.debug(`DEL ${p}`);
+        await unlinkAsync(p);
+    } catch (err) {
+        pxt.debug(err);
+    }
+}
+
+const whitespaceRe = /[\r\n\s\t]+/g;
+const illegalRe = /[\/\?<>\\:\*\|"]/g;
+const controlRe = /[\x00-\x1f\x80-\x9f]/g;
+const reservedRe = /^\.+$/;
+const windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+const windowsTrailingRe = /[\. ]+$/;
+
+function sanitize(path: string): string {
+    path = path
+        .replace(whitespaceRe, '-')
+        .replace(illegalRe, '-')
+        .replace(controlRe, '-')
+        .replace(reservedRe, '-')
+        .replace(windowsReservedRe, '-')
+        .replace(windowsTrailingRe, '-');
+    U.assert(path.length > 0);
+    return path;
+}

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@types/jquery": "3.3.29",
     "@types/marked": "0.3.0",
     "@types/mocha": "2.2.44",
-    "@types/node": "8.10.66",
+    "@types/node": "10.14.2",
     "@types/react": "16.8.25",
     "@types/react-dom": "16.0.3",
     "@types/react-modal": "3.1.2",


### PR DESCRIPTION
This PR adds a new storage API to pxtlib: `pxt.storage.localhost`. When calls to this API are made while running on localhost, it will route them to the pxt server running in the background on port 3232. In production, it routes calls to local browser storage. This API enables multiple localhost document frames to share local storage, the way they would if they were running in production (assuming the frames were served from the same domain). 

#### Why do we need this?
Browsers consider port number when determining same-origin, and skillmap and editor are served on different ports when running locally. This means their same-origin status is different when developing locally vs. running in production. In production, the two will share browser local storage, whereas they won't when running locally in development. This matters now because the two need to share some auth state via browser storage. Integrating auth and cloud sync into skillmap would be very difficult without this workaround.

#### Are there side effects?
There are a few:
1. This change has a non-obvious side effect which we might want to curb at some point: *All* localhost frames using this API will map to the same local storage regardless of browser or in-private status.
2. Stored data is persisted in files in a subfolder off the current working directory, at `.pxt/store/...`. I will open a PR in pxt-arcade to .gitignore this path.

#### Anything else?
I needed to update @types/node to get a new mkdir signature. **You will need to npm install after syncing these changes.**