### PR TITLE
Manual layout option for skillmaps

### DIFF
--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -102,13 +102,33 @@ export function manualGraph(root: MapNode): GraphNode[] {
             visited.push(n.activityId);
             n.depth = n.position?.depth || 0;
             n.offset = n.position?.offset || 0;
+
+            // Generate straight-line edges between nodes
             const edges: GraphCoord[][] = []
             n.next.forEach((next, i) => {
                 const nextDepth = next.position?.depth || 0;
                 const nextOffset = next.position?.offset || 0;
-                const edge = n.edges?.[i] || [{ depth: nextDepth, offset: n.offset }];
-                edge.unshift({depth: n.depth, offset: n.offset });
+
+                // Edge starts from current node
+                const edge = [{depth: n.depth, offset: n.offset }];
+                // If manual edge is specified for this node, push edge points
+                if (n.edges?.[i]) {
+                    n.edges[i].forEach(el => {
+                        const prev = edge[edge.length - 1];
+                        // Ensure that there are only horizontal and vertical segments
+                        if (el.depth !== prev.depth && el.offset !== prev.offset) {
+                            edge.push({ depth: el.depth, offset: prev.offset });
+                        }
+                        edge.push(el);
+                    })
+                }
+                // Edge ends at "next" node, ensure only horizontal/vertical
+                const prev = edge[edge.length - 1];
+                if (nextDepth !== prev.depth && nextOffset !== prev.offset) {
+                    edge.push({ depth: nextDepth, offset: prev.offset });
+                }
                 edge.push({ depth: nextDepth, offset: nextOffset });
+
                 edges.push(edge);
             });
             n.edges = edges;

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -32,14 +32,14 @@ export const MIN_HEIGHT = 40 * UNIT;
 export const MIN_WIDTH = 60 * UNIT;
 
 export function getGraph(map: SkillMap): SvgGraph {
-    let nodes = [];
+    let nodes: GraphNode[] = [];
     switch (map.layout) {
         case "manual":
-            nodes = manualGraph(map.root);
+            nodes = nodes.concat(manualGraph(map.root));
             break;
         case "ortho":
         default:
-            nodes = orthogonalGraph(map.root);
+            nodes = nodes.concat(orthogonalGraph(map.root));
     }
 
     let maxDepth = 0, maxOffset = 0;

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -13,14 +13,13 @@ interface SkillMap {
     displayName: string;
     description?: string;
     prerequisites: MapPrerequisite[];
-    completionUrl?: string; // DEPRECATED, urls should be specified on completion nodes
-
-    // Indicates whether or not code can be copied from previous activity
-    // for all cards in this skillmap
-    allowCodeCarryover?: boolean;
+    allowCodeCarryover?: boolean; // Indicates if code can be copied from previous activity for all cards in this skillmap
+    layout?: "ortho" | "manual"; // The graph layout system to use. Defaults to "ortho"
 
     activities: {[index: string]: MapNode};
     root: MapNode;
+
+    completionUrl?: string; // DEPRECATED, urls should be specified on completion nodes
 }
 
 type MapPrerequisite = TagPrerequisite | MapFinishedPrerequisite;
@@ -48,6 +47,9 @@ interface BaseNode {
 
     next: MapNode[];
     nextIds: string[];
+
+    position?: GraphCoord; // INTERNAL: The (depth, offset) position of the node, for manually laid out graphs
+    edges?: GraphCoord[][]; // INTERNAL: A list of edges, where each edge is a list of (depth, offset) points
 }
 
 type MapActivityType = "tutorial";
@@ -107,6 +109,17 @@ interface ActivityState {
     currentStep?: number;
     maxSteps?: number;
     completedTime?: number;
+}
+
+interface GraphCoord {
+    depth: number; // The depth of this node (distance from root)
+    offset: number; // The offset of the node within the layer
+}
+
+interface GraphNode extends BaseNode, GraphCoord {
+    width?: number; // The maximum subtree width from this node
+    edges?: GraphCoord[][]; // Each edge is an array of (depth, offset) pairs
+    parents?: GraphNode[];
 }
 
 interface SkillGraphTheme {

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -118,7 +118,6 @@ interface GraphCoord {
 
 interface GraphNode extends BaseNode, GraphCoord {
     width?: number; // The maximum subtree width from this node
-    edges?: GraphCoord[][]; // Each edge is an array of (depth, offset) pairs
     parents?: GraphNode[];
 }
 

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -172,6 +172,8 @@ function inflateSkillMap(section: MarkdownSection): Partial<SkillMap> {
         allowCodeCarryover: section.attributes["allowcodecarryover"] ? !isFalse(section.attributes["allowcodecarryover"]) : true
     };
 
+    if (section.attributes["layout"] === "manual") result["layout"] = "manual";
+
     if (section.attributes["required"]) {
         const parts = section.attributes["required"].split(",");
         for (const part of parts) {
@@ -203,6 +205,23 @@ function inflateMapNode(section: MarkdownSection): MapNode {
         next: [],
         displayName: section.attributes["name"] || section.header,
         nextIds: parseList(section.attributes["next"])
+    }
+
+    if (section.attributes["position"]) {
+        const coord = section.attributes["position"].split(" ");
+        base.position = { depth: parseInt(coord[0]) || 0, offset: parseInt(coord[1]) || 0 };
+    }
+
+    if (section.attributes["edges"]) {
+        base.edges = [];
+        const edges = parseList(section.attributes["edges"], false, ";");
+        edges.forEach(e => {
+            const points = parseList(e) || [];
+            base.edges?.push(points.map(p => {
+                const coord = p.split(" ");
+                return { depth: parseInt(coord[0]) || 0, offset: parseInt(coord[1]) || 0 };
+            }))
+        })
     }
 
     if (section.attributes.kind === "reward" || section.attributes.kind === "completion") {
@@ -374,9 +393,9 @@ function cleanInfoUrl(url?: string) {
     error("Educator info URL must be to Github or MakeCode documentation")
 }
 
-function parseList(list: string, includeDuplicates = false) {
+function parseList(list: string, includeDuplicates = false, separator = ",") {
     if (!list) return [];
-    const parts = list.split(",").map(p => p.trim().toLowerCase()).filter(p => !!p);
+    const parts = list.split(separator).map(p => p.trim().toLowerCase()).filter(p => !!p);
 
     if (!includeDuplicates) {
         let map: {[index: string]: string} = {};

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -215,8 +215,8 @@ function inflateMapNode(section: MarkdownSection): MapNode {
     if (section.attributes["edges"]) {
         base.edges = [];
         const edges = parseList(section.attributes["edges"], false, ";");
-        edges.forEach(e => {
-            const points = parseList(e) || [];
+        base.nextIds?.forEach((next, i) => {
+            const points = parseList(edges[i]) || [];
             base.edges?.push(points.map(p => {
                 const coord = p.split(" ");
                 return { depth: parseInt(coord[0]) || 0, offset: parseInt(coord[1]) || 0 };


### PR DESCRIPTION
allow fully manual skillmap layouts for @kiki-lee ! syntax:

specify the layout type at the *map* level (not the top of the page)
```
## shark
* name: Shark Splash
* layout: manual
```

each node has a position:
```
* position: 0 3 // defaults to 0 0 if unspecified 
```

and edges. edges are a comma-separated list of coordinates, and each edge corresponds to the node in the `next` list at the same index. if an edge is not specified the graph will connect the two with an L-shaped line, not accounting for collisions. the edge will always start from the current node and end at the "next" node, those coordinates do not need to be included.
```
* next: enemies-move, enemies-damage
* edges: 0 1, 0 2; 1 1
``` 

example markdown: https://raw.githubusercontent.com/shakao-test/demo/master/manual.md