### PR TITLE
Use newproject instead of workspaceevent for skillmap project creation

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -144,13 +144,8 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         }
 
         switch (data.action) {
-            case "event":
-                this.handleEditorTickEvent(data as pxt.editor.EditorMessageEventRequest);
-                break;
-            case "workspaceevent":
-                if ((data as pxt.editor.EditorWorkspaceEvent).event.type === "createproject") {
-                    this.handleWorkspaceReadyEventAsync();
-                }
+            case "newproject":
+                this.handleWorkspaceReadyEventAsync();
                 break;
             case "tutorialevent":
                 this.handleTutorialEvent(data as pxt.editor.EditorMessageTutorialEventRequest);
@@ -204,14 +199,6 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
                 carryoverPreviousCode: this.props.carryoverCode,
                 previousProjectHeaderId: this.props.previousHeaderId
             } as pxt.editor.EditorMessageStartActivity);
-        }
-    }
-
-    protected handleEditorTickEvent(event: pxt.editor.EditorMessageEventRequest) {
-        switch (event.tick) {
-            case "editor.loaded":
-                this.handleWorkspaceReadyEventAsync();
-                break;
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5056,7 +5056,10 @@ document.addEventListener("DOMContentLoaded", async () => {
                 return pxt.winrt.loadActivationProject();
             }
             if (pxt.shell.isNoProject()) {
-                workspace.fireEvent({ type: "createproject", editor: "blocks" });
+                pxt.editor.postHostMessageAsync({
+                    action: "newproject",
+                    options: { preferredEditor: "blocks" }
+                } as pxt.editor.EditorMessageNewProjectRequest)
                 return Promise.resolve();
             }
             if (showHome) return Promise.resolve();


### PR DESCRIPTION
fixes a bug where the makecode editor was not loading in the skill map iframe

we switched from the iframe workspace to the browser workspace, which has no implementation of `fireEvent`. starting the tutorial from the `editor.loaded` tick worked until we added some awaits that meant the event was firing before the message handlers were bound

this swaps the `createproject` tick out for an existing editor message and removes the `editor.loaded` handler--we want to wait until that initial load is done before attempting to load a tutorial