### PR TITLE
Another storage fix. Also add some resilience to cloud ops

### DIFF
--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -16,7 +16,9 @@ namespace pxt.auth {
     const DEV_BACKEND_DEFAULT = "";
     const DEV_BACKEND_PROD = "https://www.makecode.com";
     const DEV_BACKEND_STAGING = "https://staging.pxt.io";
-    const DEV_BACKEND_LOCALHOST = "http://localhost:5500";
+    // Localhost endpoints. Ensure matching port number in pxt-backend/node/.vscode/launch.json
+    const DEV_BACKEND_LOCALHOST_5500 = "http://localhost:5500"; // if running in Docker container
+    const DEV_BACKEND_LOCALHOST_8080 = "http://localhost:8080"; // if not running in Docker
 
     const DEV_BACKEND = DEV_BACKEND_STAGING;
 

--- a/pxtlib/localStorage.ts
+++ b/pxtlib/localStorage.ts
@@ -141,7 +141,7 @@ namespace pxt.storage.shared {
         } else {
             const sval = pxt.storage.getLocal(`${container}:${key}`);
             const val = pxt.Util.jsonTryParse(sval);
-            return val;
+            return val ? val : sval;
         }
     }
 


### PR DESCRIPTION
My storage changes had one more bug: If the JSON parse fails, it should fallback to returning the unparsed value.

While debugging this locally I hit some new cosmos exceptions due to how we were constructing the db queries server side (combined with a new limitation Cosmos put in place on the REST API). This caused some new error conditions in the client we weren't recovering from very well. Quick fix was to add a few try/catches. Longer term fix is to handle these errors better. Will log an issue for that.

**Once this is merged I will bump beta (again)**