### PR TITLE
Flip edges in skillmap so they render correctly

### DIFF
--- a/skillmap/src/components/GraphPath.tsx
+++ b/skillmap/src/components/GraphPath.tsx
@@ -12,19 +12,19 @@ export class GraphPath extends React.Component<GraphPathProps> {
     render() {
         const { points, strokeWidth, color } = this.props;
 
-        let pathStart = "M 0 0";
+        let pathStart = `M 0 0`;
         let pathEnd = "";
-        let start, end: SvgCoord;
+        let next, prev: SvgCoord;
         points.forEach(p => {
-            start = p;
-            if (end) {
-                pathStart += ` l ${(end?.x || 0) - start.x} ${(end?.y || 0) - start.y}`;
-                pathEnd = ` l ${start.x - (end?.x || 0)} ${start.y - (end?.y || 0)} ${pathEnd}`;
+            next = p;
+            if (prev) {
+                pathStart += ` l ${(next?.x || 0) - prev.x} ${(next?.y || 0) - prev.y}`;
+                pathEnd = ` l ${prev.x - (next?.x || 0)} ${prev.y - (next?.y || 0)} ${pathEnd}`;
             }
-            end = start;
+            prev = next;
         })
 
-        return  <g transform={`translate(${end!.x || 0} ${end!.y || 0})`}>
+        return  <g transform={`translate(${points[0]!.x || 0} ${points[0]!.y || 0})`}>
             <path stroke={color} strokeWidth={strokeWidth} d={`${pathStart} ${pathEnd}`} />
         </g>
     }

--- a/skillmap/src/lib/skillGraphUtils.ts
+++ b/skillmap/src/lib/skillGraphUtils.ts
@@ -117,7 +117,7 @@ export function manualGraph(root: MapNode): GraphNode[] {
                         const prev = edge[edge.length - 1];
                         // Ensure that there are only horizontal and vertical segments
                         if (el.depth !== prev.depth && el.offset !== prev.offset) {
-                            edge.push({ depth: el.depth, offset: prev.offset });
+                            edge.push({ depth: prev.depth, offset: el.offset });
                         }
                         edge.push(el);
                     })
@@ -125,7 +125,7 @@ export function manualGraph(root: MapNode): GraphNode[] {
                 // Edge ends at "next" node, ensure only horizontal/vertical
                 const prev = edge[edge.length - 1];
                 if (nextDepth !== prev.depth && nextOffset !== prev.offset) {
-                    edge.push({ depth: nextDepth, offset: prev.offset });
+                    edge.push({ depth: prev.depth, offset: nextOffset });
                 }
                 edge.push({ depth: nextDepth, offset: nextOffset });
 
@@ -240,12 +240,12 @@ export function orthogonalGraph(root: MapNode): GraphNode[] {
                     const spaceBelow = n.offset > p.offset && !((offsets[nodeIndex + 1] - offsets[nodeIndex]) < (n.offset - p.offset));
                     const spaceAbove = n.offset < p.offset && !((offsets[nodeIndex] - offsets[nodeIndex - 1]) < (p.offset - n.offset));
                     if (spaceBelow || spaceAbove) {
-                        edge.push({ depth: p.depth, offset: n.offset });
-                    } else {
                         edge.push({ depth: n.depth, offset: p.offset });
+                    } else {
+                        edge.push({ depth: p.depth, offset: n.offset });
                     }
                 } else {
-                    edge.push({ depth: n.depth, offset: p.offset });
+                    edge.push({ depth: p.depth, offset: n.offset });
                 }
                 edge.push({ depth: n.depth, offset: n.offset });
                 n.edges?.push(edge);


### PR DESCRIPTION
the skillmap graph component was drawing edges inverted (rendering each edge node at (y, x) instead of (x, y)), i did not notice this previously because i made the same mistake where the edges were being generated and they cancelled. also renamed some variables to hopefully be less confusing