### PR TITLE
Use whole Immersive Reader API URL

### DIFF
--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -190,10 +190,10 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
     const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
     if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-        return pxt.Cloud.privateGetAsync("immreader").then(
+        return pxt.Util.requestAsync({ url: "https://makecode.com/api/immreader", method: "GET" }).then(
             res => {
-                pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res));
-                return res;
+                pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res.json));
+                return res.json;
             },
             e => {
                 pxt.storage.removeLocal(IMMERSIVE_READER_ID);
@@ -272,7 +272,7 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
     });
 
     function testConnectionAsync(token: ImmersiveReaderToken): Promise<ImmersiveReaderToken> {
-        return pxt.Cloud.privateGetAsync("ping").then(() => {return token});
+        return pxt.Util.requestAsync({url: "https://makecode.com/api/ping"}).then(() => {return token});
     }
 }
 

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -190,10 +190,10 @@ function getTokenAsync(): Promise<ImmersiveReaderToken> {
     const cachedToken: ImmersiveReaderToken = pxt.Util.jsonTryParse(storedTokenString);
 
     if (!cachedToken || (Date.now() / 1000 > cachedToken.expiration)) {
-        return pxt.Util.requestAsync({ url: "https://makecode.com/api/immreader", method: "GET" }).then(
+        return pxt.Cloud.privateGetAsync("immreader", true).then(
             res => {
-                pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res.json));
-                return res.json;
+                pxt.storage.setLocal(IMMERSIVE_READER_ID, JSON.stringify(res));
+                return res;
             },
             e => {
                 pxt.storage.removeLocal(IMMERSIVE_READER_ID);
@@ -272,7 +272,7 @@ export function launchImmersiveReader(content: string, tutorialOptions: pxt.tuto
     });
 
     function testConnectionAsync(token: ImmersiveReaderToken): Promise<ImmersiveReaderToken> {
-        return pxt.Util.requestAsync({url: "https://makecode.com/api/ping"}).then(() => {return token});
+        return pxt.Cloud.privateGetAsync("ping", true).then(() => {return token});
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4281

The issue was in the Electron app it was resolving to makecode.microbit.org/immreader (when it should be makecode.microbit.org**/api/**immreader ) so I'm just hardcoding the whole URL and also reverted to the old API for safety

https://github.com/microsoft/pxt/pull/8259/files?diff=split&w=1

I had changed it in this PR bc I thought it might be better (for offline use) but I don't think it really matters. 