### PR TITLE
Fix project name input padding on thin screens

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1764,10 +1764,6 @@ p.ui.font.small {
             font-size: 0.8em !important;
         }
 
-        #projectNameArea {
-            padding-left: 0;
-        }
-
         .ui.button {
             font-size: .92857143rem !important;
         }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2953

![image](https://user-images.githubusercontent.com/34112083/127366905-7909b61f-da01-4cc5-93ef-9a8a3f86f59d.png)
