### PR TITLE
Screen picker should not display value as NaN if block is in it

### DIFF
--- a/pxtblocks/fields/field_position.ts
+++ b/pxtblocks/fields/field_position.ts
@@ -106,7 +106,7 @@ namespace pxtblockly {
 
                 x = Math.round(Math.max(0, Math.min(this.params.screenWidth, x / width * this.params.screenWidth)));
                 y = Math.round(Math.max(0, Math.min(this.params.screenHeight, y / height * this.params.screenHeight)));
-                
+
                 // Check to see if label exists instead of showing NaN
                 if(isNaN(x)) {
                     label.textContent = `${this.params.yInputName}=${y}`;
@@ -117,7 +117,7 @@ namespace pxtblockly {
                 else {
                     label.textContent = `${this.params.xInputName}=${x} ${this.params.yInputName}=${y}`;
                 }
-                
+
                 // Position the label so that it doesn't go outside the screen bounds
                 const bb = label.getBoundingClientRect();
                 if (x > this.params.screenWidth / 2) {

--- a/pxtblocks/fields/field_position.ts
+++ b/pxtblocks/fields/field_position.ts
@@ -118,7 +118,6 @@ namespace pxtblockly {
                     label.textContent = `${this.params.xInputName}=${x} ${this.params.yInputName}=${y}`;
                 }
                 
-
                 // Position the label so that it doesn't go outside the screen bounds
                 const bb = label.getBoundingClientRect();
                 if (x > this.params.screenWidth / 2) {

--- a/pxtblocks/fields/field_position.ts
+++ b/pxtblocks/fields/field_position.ts
@@ -106,8 +106,18 @@ namespace pxtblockly {
 
                 x = Math.round(Math.max(0, Math.min(this.params.screenWidth, x / width * this.params.screenWidth)));
                 y = Math.round(Math.max(0, Math.min(this.params.screenHeight, y / height * this.params.screenHeight)));
-
-                label.textContent = `${this.params.xInputName}=${x} ${this.params.yInputName}=${y}`;
+                
+                // Check to see if label exists instead of showing NaN
+                if(isNaN(x)) {
+                    label.textContent = `${this.params.yInputName}=${y}`;
+                }
+                else if(isNaN(y)) {
+                    label.textContent = `${this.params.xInputName}=${x}`;
+                }
+                else {
+                    label.textContent = `${this.params.xInputName}=${x} ${this.params.yInputName}=${y}`;
+                }
+                
 
                 // Position the label so that it doesn't go outside the screen bounds
                 const bb = label.getBoundingClientRect();


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3672

We will now check values to see if they exist before displaying them as NaN

![image](https://user-images.githubusercontent.com/3288375/127387774-d62d10c5-06d2-4515-90c4-5acbd3d87adc.png)
