### PR TITLE
Add custom actions in skillmap completion modal

### DIFF
--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -6,8 +6,9 @@ import { connect } from 'react-redux';
 import { ModalType, SkillMapState } from '../store/reducer';
 import { dispatchHideModal, dispatchRestartActivity, dispatchOpenActivity, dispatchResetUser, dispatchShowCarryoverModal } from '../actions/dispatch';
 import { tickEvent, postAbuseReportAsync, postShareAsync } from "../lib/browserUtils";
-import { lookupActivityProgress, lookupPreviousActivityStates, lookupPreviousCompletedActivityState } from "../lib/skillMapUtils";
+import { lookupActivityProgress, lookupPreviousActivityStates, lookupPreviousCompletedActivityState, isCodeCarryoverEnabled } from "../lib/skillMapUtils";
 import { getProjectAsync } from "../lib/workspaceProvider";
+import { editorUrl } from "./makecodeFrame";
 
 import { Modal, ModalAction } from './Modal';
 
@@ -70,17 +71,75 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
         this.props.dispatchHideModal();
     }
 
-    protected getRewardText(type: MapRewardType) {
-        switch (type) {
-            case "certificate":
-                return lf("Certificate");
+    protected handleRewardClick = () => {
+        const  { mapId, skillMap, type, activity } = this.props;
+        const reward = activity as MapReward;
+        tickEvent("skillmap.reward", { path: mapId, activity: reward.activityId });
+        window.open(reward.url || skillMap!.completionUrl);
+    }
+
+    protected getCompletionActionText(action: MapCompletionAction) {
+        switch (action.kind) {
+            case "activity":
+                return lf("Start Activity")
+            case "map":
+                return lf("Start Skill Map")
+            case "editor":
+                return lf("Keep Building")
+            case "docs":
             default:
-                return lf("Reward");
+                return lf("Learn More")
         }
     }
 
+    protected getCompletionActions(actions: MapCompletionAction[]) {
+        const { userState, pageSourceUrl, mapId, skillMap, activity,
+            dispatchOpenActivity, dispatchShowCarryoverModal } = this.props;
+        const reward = activity as MapReward;
+        const modalActions: ModalAction[] = [];
+        actions?.forEach(el => {
+            const action: Partial<ModalAction> = {
+                label: el.label || this.getCompletionActionText(el),
+                url: el.url
+            }
+            switch (el.kind) {
+                case "activity":
+                    const nextActivity = skillMap?.activities[el.activityId || ""];
+                    if (nextActivity) {
+                        action.onClick = () => {
+                            tickEvent("skillmap.reward.action.activity", { path: mapId, activity: reward.activityId, nextActivityId: nextActivity.activityId });
+                            this.handleOnClose();
+                            if (isCodeCarryoverEnabled(userState!, pageSourceUrl!, skillMap!, nextActivity)) {
+                                dispatchShowCarryoverModal(skillMap!.mapId, nextActivity.activityId);
+                            } else {
+                                dispatchOpenActivity(mapId, nextActivity.activityId);
+                            }
+                        };
+                        modalActions.push(action as ModalAction);
+                    }
+                    break;
+                case "editor":
+                    const previousActivity = lookupPreviousCompletedActivityState(userState!, pageSourceUrl!, skillMap!, activity!.activityId);
+                    if (previousActivity?.headerId) {
+                        action.onClick = () => {
+                            tickEvent("skillmap.reward.action.editor", { path: mapId, activity: reward.activityId });
+                            window.open(`${editorUrl}#skillmapimport:${previousActivity.headerId}`);
+                        };
+                        modalActions.push(action as ModalAction);
+                    }
+                    break;
+                case "map":
+                case "docs":
+                default:
+                    action.onClick = () => tickEvent(`skillmap.reward.action.${el.kind}`, { path: mapId, activity: reward.activityId, url: action.url || "" });
+                    modalActions.push(action as ModalAction);
+            }
+        })
+        return modalActions;
+    }
+
     renderCompletionModal() {
-        const  { mapId, skillMap, type, activity } = this.props;
+        const  { skillMap, type, activity } = this.props;
         if (!type || !skillMap) return <div />
 
         const reward = activity as MapReward;
@@ -91,16 +150,13 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
 
         const density = 100;
 
-        const actions = [
-            { label: this.getRewardText(reward.type),  onClick: () => {
-                tickEvent("skillmap.reward", { path: mapId, activity: reward.activityId });
-                window.open(reward.url || skillMap.completionUrl);
-            } }
-        ]
-
         return <div className="confetti-container">
-            <Modal title={completionModalTitle} actions={actions} className="completion" onClose={this.handleOnClose}>
+            <Modal title={completionModalTitle} actions={this.getCompletionActions(reward.actions)} className="completion" onClose={this.handleOnClose}>
                 {completionModalTextSegments[0]}{<strong>{skillMap.displayName}</strong>}{completionModalTextSegments[1]}
+                <div className="completion-reward" onClick={this.handleRewardClick}>
+                    <i className="icon gift" />
+                    <span>{lf("Claim your reward!")}</span>
+                </div>
             </Modal>
             {Array(density).fill(0).map((el, i) => {
                 const style = {

--- a/skillmap/src/components/Modal.tsx
+++ b/skillmap/src/components/Modal.tsx
@@ -8,6 +8,7 @@ export interface ModalAction {
     label: string;
     className?: string;
     onClick: () => void;
+    url?: string;
 }
 
 interface ModalProps {
@@ -20,7 +21,6 @@ interface ModalProps {
 export class Modal extends React.Component<ModalProps> {
     protected handleModalClick = (e: any) => {
         e.stopPropagation();
-        e.preventDefault();
     }
 
     protected handleCloseClick = () => {
@@ -42,7 +42,9 @@ export class Modal extends React.Component<ModalProps> {
                 </div>
                 {actions && actions.length > 0 && <div className="modal-actions">
                     {actions.map((el, i) => {
-                        return <div key={i} className={`modal-button ${el.className || ""}`} onClick={el.onClick} role="button">{el.label}</div>
+                        return el.url
+                            ? <a key={i} className={`modal-button ${el.className || ""}`} href={el.url} onClick={el.onClick} target="_blank" rel="noopener noreferrer" role="button">{el.label}</a>
+                            : <div key={i} className={`modal-button ${el.className || ""}`} onClick={el.onClick} role="button">{el.label}</div>
                     })}
                 </div>}
             </div>

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -74,10 +74,18 @@ interface MapReward extends BaseNode {
     kind: "reward";
     type: MapRewardType;
     url: string;
+    actions: MapCompletionAction[];
 }
 
 interface MapCompletionNode extends MapReward {
     kind: "completion";
+}
+
+interface MapCompletionAction {
+    kind: "activity" | "map" | "docs" | "editor";
+    label?: string;
+    activityId?: string;
+    url?: string;
 }
 
 interface MapLayoutNode extends BaseNode {

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -6,7 +6,8 @@ const testMap = ``
 interface MarkdownSection {
     headerKind: "single" | "double" | "triple";
     header: string;
-    attributes: {[index: string]: string};
+    attributes: { [index: string]: string };
+    listAttributes?: { [index: string]: string[] };
 }
 
 export function test() {
@@ -77,6 +78,7 @@ function getSectionsFromText(text: string) {
 
         if (currentSection) {
             const keyMatch = /^[*-]\s+(?:([^:]+):)?(.*)$/.exec(line);
+            const subkeyMatch = /^    ([*-])\s+(.*)$/.exec(line);
 
             if (keyMatch) {
                 if (keyMatch[1]) {
@@ -88,6 +90,12 @@ function getSectionsFromText(text: string) {
                 }
                 else if (currentKey) {
                     currentValue += keyMatch[2];
+                }
+            } else if (subkeyMatch && currentKey) {
+                if (!currentSection.listAttributes) currentSection.listAttributes = {};
+                if (!currentSection.listAttributes[currentKey]) currentSection.listAttributes[currentKey] = [];
+                if (subkeyMatch[2]) {
+                    currentSection.listAttributes[currentKey].push(subkeyMatch[2].trim());
                 }
             }
         }
@@ -259,6 +267,40 @@ function inflateMapReward(section: MarkdownSection, base: Partial<MapReward>): M
         }
     }
 
+    if (section.listAttributes?.["actions"]) {
+        const parsedActions: MapCompletionAction[] = [];
+        const actions = section.listAttributes["actions"];
+        for (const action of actions) {
+            let [kind, ...rest] = action.split(":");
+            const valueMatch = /\s*\[\s*(.*)\s*\]\(([^\s]+)\)/gi.exec(rest.join(":"));
+            const label = valueMatch?.[1];
+            const link = valueMatch?.[2];
+            switch (kind) {
+                case "activity":
+                    parsedActions.push({kind: "activity", label, activityId: link });
+                    break;
+                case "map":
+                    if (link) {
+                        let prefix = validGithubUrl(link) ? "github" : (validDocsUrl(link) ? "docs" : undefined);
+                        if (!prefix) error(`URL: ${link} must be to Github or MakeCode documentation`);
+                        parsedActions.push({ kind: "map", label, url: `#${prefix}:${link}` });
+                    }
+                    break;
+                case "docs":
+                    if (link) {
+                        let docsUrl = (link.startsWith("/") ? "" : "/") + link;
+                        if (!validDocsUrl(docsUrl)) error(`URL: ${docsUrl} must be to MakeCode documentation`);
+                        parsedActions.push({ kind: "docs", label, url: docsUrl });
+                    }
+                    break;
+                case "editor":
+                    parsedActions.push({ kind: "editor", label });
+                    break;
+            }
+        }
+        if (parsedActions.length) result.actions = parsedActions;
+    }
+
     return result as MapReward;
 }
 
@@ -380,17 +422,25 @@ function getContrastingColor(color: string) {
     }
 }
 
+function validGithubUrl(url: string) {
+    return url.match(/^(https?:\/\/)?(www\.)?github\.com\//gi);
+}
+
+function validDocsUrl(url: string) {
+    return url.indexOf(".") < 0;
+}
+
 function cleanInfoUrl(url?: string) {
     // No info URL provided
     if (!url) return undefined;
 
     // Valid URL to Github (eg a README)
-    if (url.match(/^(https?:\/\/)?(www\.)?github\.com\//gi)) return url.replace(/\?[\s\S]+$/gi, "");
+    if (validGithubUrl(url)) return url.replace(/\?[\s\S]+$/gi, "");
 
     // Valid URL to MakeCode docs
-    if (url.indexOf(".") < 0) return `${url.startsWith("/") ? "" : "/"}${url}`;
+    if (validDocsUrl(url)) return `${url.startsWith("/") ? "" : "/"}${url}`;
 
-    error("Educator info URL must be to Github or MakeCode documentation")
+    error(`URL: ${url} must be to Github or MakeCode documentation`);
 }
 
 function parseList(list: string, includeDuplicates = false, separator = ",") {

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -78,7 +78,7 @@ function getSectionsFromText(text: string) {
 
         if (currentSection) {
             const keyMatch = /^[*-]\s+(?:([^:]+):)?(.*)$/.exec(line);
-            const subkeyMatch = /^    ([*-])\s+(.*)$/.exec(line);
+            const subkeyMatch = /^ {4}([*-])\s+(.*)$/.exec(line);
 
             if (keyMatch) {
                 if (keyMatch[1]) {

--- a/skillmap/src/styles/modal.css
+++ b/skillmap/src/styles/modal.css
@@ -38,15 +38,15 @@
 }
 
 .modal-actions {
-    display: flex;
-    justify-content: space-around;
-    margin-top: 1rem;
+    display: grid;
+    margin-top: 1.5rem;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
 }
 
 .modal-button {
     border: 1px solid var(--active-color);
-
-    width: 8rem;
+    color: var(--active-color);
     padding: 0.5rem;
     text-align: center;
     cursor: pointer;
@@ -56,6 +56,8 @@
 
 .modal-button:hover {
     background-color: var(--hover-color);
+    color: var(--active-color);
+    text-decoration: none;
 }
 
 /* SHARE MODAL */
@@ -105,6 +107,27 @@
     background-color: var(--primary-color);
     color: var(--white);
     cursor: pointer;
+}
+
+/* COMPLETION MODAL */
+.completion-reward {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    margin: 1rem 0;
+    color: var(--white);
+    background-color: var(--primary-color);
+    border-radius: 2rem;
+    font-size: 1.2rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.completion-reward i {
+    margin-right: 0.5rem;
+    font-size: 2rem;
+    line-height: 2rem;
 }
 
 /* COMPLETION CONFETTI */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/127413689-735f3e44-5eb9-4a2a-a6fe-9079e0a716e6.png)

syntax! in the reward node, specify an attribute called `actions`. this will have a nested list of actions which is indented with 4 spaces exactly. each action has the action type as the key, and a label/url using markdown URL syntax as the value:

```
### reward-node
* actions:
    * map: [Go to skillmap](docs:/path/to/skillmap)
    * docs: [Learn more](/path/to/docs)
    * activity: [Try this activity](activity-id)
    * editor: [Optional label]
```

the four kinds of action (represented above) are:
- map: link to another skillmap in a new tab
- docs: link to a makecode docs page
- activity: open another activity in this skillmap
- editor: export the last completed project to the full editor 