### PR TITLE
include lang query parameter when fetching md

### DIFF
--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -113,11 +113,12 @@ namespace pxt.Cloud {
         })
     }
 
-    // 1h check on markdown content if not on development server
-    const MARKDOWN_EXPIRATION = pxt.BrowserUtils.isLocalHostDev() ? 0 : 1 * 60 * 60 * 1000;
-    // 1w check don't use cached version and wait for new content
-    const FORCE_MARKDOWN_UPDATE = MARKDOWN_EXPIRATION * 24 * 7;
     export async function markdownAsync(docid: string, locale?: string): Promise<string> {
+        // 1h check on markdown content if not on development server
+        const MARKDOWN_EXPIRATION = pxt.BrowserUtils.isLocalHostDev() ? 0 : 1 * 60 * 60 * 1000;
+        // 1w check don't use cached version and wait for new content
+        const FORCE_MARKDOWN_UPDATE = MARKDOWN_EXPIRATION * 24 * 7;
+
         locale = locale || pxt.Util.userLanguage();
         const branch = "";
 

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -182,8 +182,8 @@ namespace pxt.Cloud {
         } else {
             url = `md/${pxt.appTarget.id}/${docid.replace(/^\//, "")}?targetVersion=${encodeURIComponent(targetVersion)}`;
         }
-        if (!packaged && locale != "en") {
-            url += `&lang=${encodeURIComponent(locale)}`
+        if (locale != "en") {
+            url += `${packaged ? "?" : "&"}lang=${encodeURIComponent(locale)}`
         }
         if (pxt.BrowserUtils.isLocalHost() && !pxt.Util.liveLocalizationEnabled()) {
             return localRequestAsync(url).then(resp => {


### PR DESCRIPTION
Include query parameter for language when fetching markdown, even when it is packaged (part of: https://github.com/microsoft/pxt-microbit/issues/4286)

Also minor fix for md expiration which didn't matter before this -- in pxt electron the window.pxtElectron doesn't consistently exist immediately on load, so we need to calculate expiration inside the function instead of at the top level for it to expire local markdown properly (and properly use the cache for the translated ones)