### PR TITLE
Updates and edits to the 'CSP' page

### DIFF
--- a/docs/csp.md
+++ b/docs/csp.md
@@ -117,7 +117,11 @@ All of the materials for the **AP Computer Science Principles with Microsoft Mak
 
 If you decide to use the AP Computer Science Principles with Microsoft MakeCode curriculum or materials, please keep in touch. Join the [Microsoft MakeCode AP CSP Forum](https://forum.makecode.com/c/ap-cs-principles/23) to connect with other Educators teaching the course, ask questions, or give feedback on course materials. Please also follow [@MSMakeCode](https://twitter.com/MSMakeCode) on Twitter for the latest news and announcements.
 
-## FAQ 
+## FAQ
+
+* Are there professional development opportunities or other training available for this curriculum?
+
+>The professional development workshops for the 2021-2022 academic year have concluded. However, we will publish the schedule for Summer 2022 workshops in the Spring. Join the [Microsoft MakeCode AP CSP Forum](https://forum.makecode.com/c/ap-cs-principles/23) to be notified of the upcoming workshops.
 
 * How is the course graded/assessed?
 
@@ -135,7 +139,7 @@ If you decide to use the AP Computer Science Principles with Microsoft MakeCode 
 
 >The curriculum is all online and browser-based, so works on any platform (Windows, MacOS, iPads, and Chromebooks)
 
-* How does this course promote diversity & inclusion in computer science?
+* How does this course promote diversity and inclusion in computer science?
 
 >The Microsoft MakeCode curriculum was written to be culturally relevant to a wide variety of students with diverse backgrounds and experience levels with technology.  All computing terms are explained using language and analogies that students understand, most projects encourage student choice in the topic to ensure that the learning aligns to their interests, and no prior knowledge or computing experience is assumed in the course design and pacing.
 

--- a/docs/csp.md
+++ b/docs/csp.md
@@ -4,18 +4,6 @@
 
 The College Board’s [Advanced Placement (AP) Computer Science Principles](https://apcentral.collegeboard.org/courses/ap-computer-science-principles) course is an introductory class for High School students (typically 14-18 years old). While academically rigorous, the AP Computer Science Principles course is designed to attract students of all backgrounds, experience levels, and interests. Therefore, the course covers a wide range of computing topics with a special focus on the impact of technology and computing on students’ lives. The course covers a full academic year, does not require any prerequisites, and an end-of-course exam may be taken to receive college credit.
 
-### ~ reminder
-
-#### Professional Development Opportunities
-
-There are three free professional development opportunities available this summer to help prepare Educators to teach the AP CS Principles with Microsoft MakeCode course for the 2021-2022 academic year. These professional development workshops will focus on the course's Big Ideas, Learning Objectives and Essential Knowledge skills. Additionally, you will learn how Microsoft MakeCode's curriculum meets the course's learning objectives and prepares students for the AP Exam and Create Performance Task. By attending the training and using Microsoft MakeCode's curriculum, you will be prepared with a syllabus, pacing plan, and lesson plans, PowerPoints, student handouts, and resources for every day of the course.  Register below, limited capacity:
-
-* **[Workshop 1](https://microsoftedu.eventbuilder.com/MicrosoftMakeCodeWorkshops)** : June 14th - 17th (4 full days)
-* **[Workshop 2](https://microsoftedu.eventbuilder.com/MicrosoftMakeCodeWorkshops)** : June 22nd, June 29th, July 6th, and July 13th (1 day a week for 4 weeks)
-* **[Workshop 3](https://www.infosys.org/infosys-foundation-usa/pathfinders/summer/course-catalogue.html#microsoft-makeCode)** : July 18th - 23th (part of InfoSys Pathfinders Summer Institute)
-
-### ~
-
 The **[AP CS Principles with Microsoft MakeCode](https://microsoft.github.io/makecode-csp)** curriculum is free and uses web-based technology and tools that can be accessed across platforms and devices. The curriculum is also endorsed and approved by the College Board as aligning with the [CS Principles curriculum framework](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/course?course=ap-computer-science-principles) and [AP CS Principles exam](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam).
 
 Some additional features of the Microsoft MakeCode curriculum include: 

--- a/docs/csp.md
+++ b/docs/csp.md
@@ -2,7 +2,7 @@
 
 # AP Computer Science Principles with Microsoft MakeCode
 
-The College Board’s [Advanced Placement (AP) Computer Science Principles](https://apcentral.collegeboard.org/courses/ap-computer-science-principles) course is an introductory class for High School students (typically 14-18 years old). While academically rigorous, the AP Computer Science Principles course is designed to attract students of all backgrounds, experience levels, and interests. Therefore, the course covers a wide range of computing topics with a special focus on the impact of technology and computing on students’ lives. The course covers a full academic year, does not require any prerequisites, and an end-of-course exam may be taken to receive college credit.
+The College Board’s [Advanced Placement (AP®) Computer Science Principles](https://apcentral.collegeboard.org/courses/ap-computer-science-principles) course is an introductory computer science course for High School students (typically 14-18 years old). While academically rigorous, the AP Computer Science Principles course is designed to attract students of all backgrounds, experience levels, and interests, and covers a wide range of computing topics with a special focus on the impact of technology and computing on students’ lives. The course covers a full academic year, does not require any prerequisites( Algebra I is recommended), and an end-of-course exam may be taken to receive college credit.
 
 The **[AP CS Principles with Microsoft MakeCode](https://microsoft.github.io/makecode-csp)** curriculum is free and uses web-based technology and tools that can be accessed across platforms and devices. The curriculum is also endorsed and approved by the College Board as aligning with the [CS Principles curriculum framework](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/course?course=ap-computer-science-principles) and [AP CS Principles exam](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam).
 
@@ -96,7 +96,7 @@ In the Service Learning unit, students will explore the [United Nations Sustaina
 
 ## Educator Materials
 
-The course materials include:
+The curriculum materials include:
 
 * Daily Lesson plans in the form of a OneNote notebook.
 * PowerPoint decks for classroom lectures with talking points in the Notes section.
@@ -107,15 +107,15 @@ The course materials include:
 
 #### Download Educator Materials
 
-All of the materials for the **AP Computer Science Principles with Microsoft MakeCode** course are available to download here:
+All of the materials for the **AP Computer Science Principles with Microsoft MakeCode** curriculum are available to download here:
 
-* **[Course Materials Downloads](https://aka.ms/MSMakeCodeAPCSP)**
+* **[Curriculum Materials Downloads](https://aka.ms/MSMakeCodeAPCSP)**
 
 ### ~
 
 ## Stay Connected 
 
-If you decide to use the AP Computer Science Principles with Microsoft MakeCode curriculum or materials, please keep in touch. Join the [Microsoft MakeCode AP CSP Forum](https://forum.makecode.com/c/ap-cs-principles/23) to connect with other Educators teaching the course, ask questions, or give feedback on course materials. Please also follow [@MSMakeCode](https://twitter.com/MSMakeCode) on Twitter for the latest news and announcements.
+If you decide to use the AP Computer Science Principles with Microsoft MakeCode curriculum or materials, please keep in touch. Join the [Microsoft MakeCode AP CSP Forum](https://forum.makecode.com/c/ap-cs-principles/23) to connect with other Educators teaching the curriculum, ask questions, or give feedback on curriculum materials. Please also follow [@MSMakeCode](https://twitter.com/MSMakeCode) on Twitter for the latest news and announcements.
 
 ## FAQ
 
@@ -123,15 +123,15 @@ If you decide to use the AP Computer Science Principles with Microsoft MakeCode 
 
 >The professional development workshops for the 2021-2022 academic year have concluded. However, we will publish the schedule for Summer 2022 workshops in the Spring. Join the [Microsoft MakeCode AP CSP Forum](https://forum.makecode.com/c/ap-cs-principles/23) to be notified of the upcoming workshops.
 
-* How is the course graded/assessed?
+* How is the curriculum graded/assessed?
 
->Aside from the College Board’s AP Computer Science Principles exam that is administered at the conclusion of the course, educators can use a variety of formative assessment methods throughout the course to track student progress.  Some student activities and assignments are open-ended projects or journaling responses, in which case a rubric is provided as a grading criterion.  Some assignments are coding activities or responses to questions/prompts, in which case an example solution is provided to the educator for grading.  In general, this course tends to be more open and flexible in its approach to encourage risk-taking and to inspire student creativity and self-confidence.
+>Aside from the College Board’s AP Computer Science Principles exam that is administered at the conclusion of the course, educators can use a variety of formative assessment methods throughout to track student progress. Some student activities and assignments are open-ended projects or journaling responses, in which case a rubric is provided as a grading criterion. Some assignments are coding activities or responses to questions/prompts, in which case an example solution is provided to the educator for grading. In general, this curriculum tends to be more open and flexible in its approach to encourage risk-taking and to inspire student creativity and self-confidence.
 
-* How is this course accessible for students with various forms of learning differences?
+* How is this curriculum accessible for students with various forms of learning differences?
 
 >[Microsoft’s Learning Tools](https://www.microsoft.com/en-us/education/products/learning-tools) and [Immersive Reader](https://education.microsoft.com/en-us/resource/9b010288) help improve reading comprehension for English language learners, offers text decoding solutions for dyslexic students and provides read aloud and dictation options. In addition, the curriculum supports screen reader technology for vision impaired students, and Microsoft MakeCode has a [high-contrast](https://makecode.com/accessibility#high-contrast) mode for low-vision students.
 
-* What language is this course offered in?
+* What language is this curriculum offered in?
 
 >English only at this time.
 
@@ -139,11 +139,11 @@ If you decide to use the AP Computer Science Principles with Microsoft MakeCode 
 
 >The curriculum is all online and browser-based, so works on any platform (Windows, MacOS, iPads, and Chromebooks)
 
-* How does this course promote diversity and inclusion in computer science?
+* How does this curriculum promote diversity and inclusion in computer science?
 
 >The Microsoft MakeCode curriculum was written to be culturally relevant to a wide variety of students with diverse backgrounds and experience levels with technology.  All computing terms are explained using language and analogies that students understand, most projects encourage student choice in the topic to ensure that the learning aligns to their interests, and no prior knowledge or computing experience is assumed in the course design and pacing.
 
-* Who wrote this course?
+* Who wrote this curriculum?
 
 >The MakeCode curriculum was written by [Kelli Etheredge](https://www.linkedin.com/in/ketheredge), a Director of Teaching & Learning and an AP Computer Science Principles teacher herself.  Follow her on Twitter [@ketheredge](https://twitter.com/ketheredge).
 


### PR DESCRIPTION
Some updates to the 'Computer Science Principles' launch page.

- [x] Remove 'Professional Development Opportunities' section
- [x] Add workshop Q&A item to FAQ
- [x] Include page edits from College Board

Closes #8342