### PR TITLE
support for ESP32-S2

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -630,15 +630,15 @@ function msdDeployCoreAsync(res: ts.pxtc.CompileResult): Promise<void> {
         return getBoardDrivesAsync()
             .then(drives => filterDrives(drives))
             .then(drives => {
-                if (drives.length == 0) {
-                    pxt.log("cannot find any drives to deploy to");
-                    return Promise.resolve(0);
-                }
+                if (drives.length == 0)
+                    throw new Error("cannot find any drives to deploy to");
                 pxt.log(`copying ${firmwareName} to ` + drives.join(", "));
                 const writeHexFile = (drivename: string) => {
                     return writeFileAsync(path.join(drivename, firmwareName), firmware, encoding)
                         .then(() => pxt.debug("   wrote to " + drivename))
-                        .catch(() => pxt.log(`   failed writing to ${drivename}`));
+                        .catch((e: Error) => {
+                            throw new Error(`failed writing to ${drivename}; ${e.message}`);
+                        })
                 };
                 return U.promiseMapAll(drives, d => writeHexFile(d))
                     .then(() => drives.length);

--- a/pxtcompiler/emitter/backvm.ts
+++ b/pxtcompiler/emitter/backvm.ts
@@ -312,7 +312,7 @@ _start_${name}:
 
             if (embedVTs()) {
                 bin.writeFile(pxtc.BINARY_PXT64, binstring)
-                const patched = hexfile.patchHex(bin, res.buf, false, false)[0]
+                const patched = hexfile.patchHex(bin, res.buf, false, !!target.useUF2)[0]
                 bin.writeFile(pxt.outputName(target), ts.pxtc.encodeBase64(patched))
             } else {
                 bin.writeFile(pxt.outputName(target), binstring)

--- a/pxtcompiler/emitter/emitter.ts
+++ b/pxtcompiler/emitter/emitter.ts
@@ -247,7 +247,7 @@ namespace ts.pxtc {
         console.log(stringKind(n))
     }
 
-    // next free error 9282
+    // next free error 9283
     function userError(code: number, msg: string, secondary = false): Error {
         let e = new Error(msg);
         (<any>e).ksEmitterUserError = true;
@@ -4294,6 +4294,7 @@ ${lbl}: .short 0xffff
             emitBrk(node)
             let label = node.label ? node.label.text : null
             let isBreak = node.kind == SK.BreakStatement
+            let numTry = 0
             function findOuter(parent: Node): Statement {
                 if (!parent) return null;
                 if (label && parent.kind == SK.LabeledStatement &&
@@ -4303,6 +4304,7 @@ ${lbl}: .short 0xffff
                     return parent as Statement
                 if (!label && isIterationStatement(parent, false))
                     return parent as Statement
+                numTry += numBeginTry(parent)
                 return findOuter(parent.parent);
             }
             let stmt = findOuter(node)
@@ -4310,6 +4312,7 @@ ${lbl}: .short 0xffff
                 error(node, 9230, lf("cannot find outer loop"))
             else {
                 let l = getLabels(stmt)
+                emitEndTry(numTry)
                 if (node.kind == SK.ContinueStatement) {
                     if (!isIterationStatement(stmt, false))
                         error(node, 9231, lf("continue on non-loop"));
@@ -4330,6 +4333,13 @@ ${lbl}: .short 0xffff
             } else if (funcHasReturn(proc.action)) {
                 v = emitLit(undefined) // == return undefined
             }
+            let numTry = 0
+            for (let p: Node = node; p; p = p.parent) {
+                if (p == proc.action)
+                    break
+                numTry += numBeginTry(p)
+            }
+            emitEndTry(numTry)
             proc.emitJmp(getLabels(proc.action).ret, v, ir.JmpMode.Always)
         }
 
@@ -4392,6 +4402,44 @@ ${lbl}: .short 0xffff
             proc.emitExpr(rtcallMaskDirect("pxt::throwValue", [emitExpr(node.expression)]))
         }
 
+        function emitEndTry(num = 1) {
+            while (num--) {
+                proc.emitExpr(rtcallMaskDirect("pxt::endTry", []))
+            }
+        }
+
+        function jumpXFinally() {
+            userError(9282, lf("jumps (return, break, continue) through finally blocks not supported yet"))
+        }
+
+        function numBeginTry(node: Node) {
+            let r = 0
+            if (node.kind == SyntaxKind.Block && node.parent) {
+                if (node.parent.kind == SyntaxKind.CatchClause) {
+                    // from inside of catch there's at most the finally block to close
+                    const t = node.parent.parent as TryStatement
+                    if (t.finallyBlock) {
+                        r++
+                        jumpXFinally()
+                    }
+                } else if (node.parent.kind == SyntaxKind.TryStatement) {
+                    // from inside of the body of try{} there possibly the catch and finally blocks to close
+                    const t = node.parent as TryStatement
+                    if (t.tryBlock == node) {
+                        if (t.catchClause) r++
+                        if (t.finallyBlock) {
+                            r++
+                            jumpXFinally()
+                        }
+                    }
+                } else {
+                    // if we're inside of finally there's nothing to close already
+                    // (or more common this block has nothing to do with try{})
+                }
+            }
+            return r
+        }
+
         function emitTryStatement(node: TryStatement) {
             const beginTry = (lbl: ir.Stmt) =>
                 rtcallMaskDirect("pxt::beginTry", [ir.ptrlit(lbl.lblName, lbl as any)])
@@ -4414,7 +4462,7 @@ ${lbl}: .short 0xffff
 
             if (node.catchClause) {
                 const skip = proc.mkLabel("catchend")
-                proc.emitExpr(rtcallMaskDirect("pxt::endTry", []))
+                emitEndTry()
                 proc.emitJmp(skip)
 
                 proc.emitLbl(lcatch)
@@ -4430,7 +4478,7 @@ ${lbl}: .short 0xffff
             }
 
             if (node.finallyBlock) {
-                proc.emitExpr(rtcallMaskDirect("pxt::endTry", []))
+                emitEndTry()
                 proc.emitLbl(lfinally)
                 emitBlock(node.finallyBlock)
                 proc.emitExpr(rtcallMaskDirect("pxt::endFinally", []))

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -272,7 +272,7 @@ namespace pxt.cpp {
             }
 
             for (const fn of pkg.getFiles()) {
-                if (["Makefile", "sdkconfig.defaults", "CMakeLists.txt"].indexOf(fn) >= 0) {
+                if (["Makefile", "sdkconfig.defaults", "CMakeLists.txt"].indexOf(fn) >= 0 || U.endsWith(fn, ".mk")) {
                     res.generatedFiles["/" + fn] = pkg.host().readFile(pkg, fn)
                 }
             }

--- a/pxtlib/hf2.ts
+++ b/pxtlib/hf2.ts
@@ -16,6 +16,7 @@ namespace pxt {
         MMap = 10, // linux, mostly ev3
         BoxedString_SkipList = 11, // used by VM bytecode representation only
         BoxedString_ASCII = 12, // ditto
+        ZPin = 13,
         User0 = 16,
     }
 }

--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -506,9 +506,12 @@ namespace pxt {
     export function outputName(trg: pxtc.CompileTarget = null) {
         if (!trg) trg = appTarget.compile
 
-        if (trg.nativeType == ts.pxtc.NATIVE_TYPE_VM)
-            return trg.useESP ? ts.pxtc.BINARY_ESP : ts.pxtc.BINARY_PXT64
-        else if (trg.useUF2 && !trg.switches.rawELF)
+        if (trg.nativeType == ts.pxtc.NATIVE_TYPE_VM) {
+            if (trg.useESP)
+                return trg.useUF2 ? ts.pxtc.BINARY_UF2 : ts.pxtc.BINARY_ESP
+            else
+                return ts.pxtc.BINARY_PXT64
+        } else if (trg.useUF2 && !trg.switches.rawELF)
             return ts.pxtc.BINARY_UF2
         else if (trg.useELF)
             return ts.pxtc.BINARY_ELF

--- a/tests/compile-test/lang-test0/51exceptions.ts
+++ b/tests/compile-test/lang-test0/51exceptions.ts
@@ -38,7 +38,7 @@ namespace exceptions {
         }
     }
 
-    function lambda(k:number) {
+    function lambda(k: number) {
         function inner() {
             try {
                 throwVal(k)
@@ -85,7 +85,7 @@ namespace exceptions {
         }
     }
 
-    function test3(fn:(k:number)=>void) {
+    function test3(fn: (k: number) => void) {
         glb1 = x = 0
         fn(1)
         assert(glb1 == 10 && x == 10)
@@ -93,6 +93,33 @@ namespace exceptions {
         assert(glb1 == 11 && x == 21)
         fn(3)
         assert(glb1 == 21 && x == 42)
+    }
+
+    function test4(fn: () => void) {
+        try {
+            fn()
+            return 10
+        } catch {
+            return 20
+        }
+    }
+
+    function test5() {
+        let n = 0
+        for (let k of [0, 1, 2]) {
+            try {
+                n++
+                try {
+                    if (k == 1)
+                        break
+                } catch {
+                    n += 1000
+                }
+            } catch {
+                n += 100
+            }
+        }
+        assert(n == 2)
     }
 
     export function run() {
@@ -113,6 +140,12 @@ namespace exceptions {
         glb1 = x = 0
         nested()
         assert(glb1 == 11)
+
+        assert(test4(() => { }) == 10)
+        assert(test4(() => { throw "foo" }) == 20)
+
+        test5()
+
         msg("test exn done")
     }
 }


### PR DESCRIPTION
This adds UF2 generation support for ESP32-S2 (for boards with https://github.com/adafruit/tinyuf2).

Additionally:
* we now throw error when command line deploy is requested but cannot be completed
* break/continue/return inside of try-catch blocks are handled correctly (and ones inside try-finally give explicit errors - not implemented yet)
* .mk (Makefile includes) are now supported in buildengine