### PR TITLE
Increase header icon padding on tablet, hide sign in text on small desktop

### DIFF
--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -37,17 +37,20 @@
     transform: scale(1.2);
 }
 
-@media only screen and (max-width: @largestTabletScreen) {
-    .menubar .ui.menu {
-        height: @mobileMenuHeight !important;
-        min-height: @mobileMenuHeight !important;
-    }
+@media only screen and (max-width: @largestMobileScreen) {
     .menubar .left.menu > .item.icon:not(.logo),  .menubar .right.menu > .item.icon:not(.logo) {
         width: 48px;
 
         & > i.icon {
             margin-left: -8px;
         }
+    }
+}
+
+@media only screen and (max-width: @largestTabletScreen) {
+    .menubar .ui.menu {
+        height: @mobileMenuHeight !important;
+        min-height: @mobileMenuHeight !important;
     }
     .sandbox .menubar .ui.menu {
         height: @sandboxMobileMenuHeight !important;

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -298,7 +298,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
             {targetTheme.highContrast ? <sui.Item role="menuitem" text={highContrast ? lf("High Contrast Off") : lf("High Contrast On")} onClick={this.toggleHighContrast} /> : undefined}
             {targetTheme.accessibleBlocks ? <sui.Item role="menuitem" text={accessibleBlocks ? lf("Accessible Blocks Off") : lf("Accessible Blocks On")} onClick={this.toggleAccessibleBlocks} /> : undefined}
             {showGreenScreen ? <sui.Item role="menuitem" text={greenScreen ? lf("Green Screen Off") : lf("Green Screen On")} onClick={this.toggleGreenScreen} /> : undefined}
-            {docItems && renderDocItems(this.props.parent, docItems, "ui mobile only inherit")}
+            {docItems && renderDocItems(this.props.parent, docItems, "setting-docs-item mobile only inherit")}
             {showCenterDivider && <div className="ui divider"></div>}
             {reportAbuse ? <sui.Item role="menuitem" icon="warning circle" text={lf("Report Abuse...")} onClick={this.showReportAbuse} /> : undefined}
             {!isController ? <sui.Item role="menuitem" icon='sign out' text={lf("Reset")} onClick={this.showResetDialog} /> : undefined}

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -141,7 +141,7 @@ export class UserMenu extends auth.Component<UserMenuProps, UserMenuState> {
 
         const signedOutElem = (
             <div className="signin-button">
-                <div className="ui text desktop only">{lf("Sign In")}</div>
+                <div className="ui text widedesktop only">{lf("Sign In")}</div>
                 {sui.genericContent({
                     icon
                 })}


### PR DESCRIPTION
associated with https://github.com/microsoft/pxt-arcade/pull/3725, increases padding for the icons on tablet since we're hiding the help icon and have a bit more space. small fix to hide sign in text on landscape ipad.