### PR TITLE
Disable 'Create Asset' button in tutorials

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -201,6 +201,12 @@
     background-color: darken(@green, 10%);
 }
 
+.create-new.disabled,
+.create-new.disabled:hover {
+    cursor: not-allowed;
+    background-color: @assetUnselected;
+}
+
 .delete-asset {
     margin: 0.5rem;
     text-align: center;

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -13,6 +13,7 @@ interface AssetGalleryProps {
     view: GalleryView;
     galleryAssets: pxt.Asset[];
     userAssets: pxt.Asset[];
+    disableCreateButton?: boolean;
     showAssetFieldView?: (asset: pxt.Asset, cb: (result: any) => void) => void;
     dispatchUpdateUserAssets?: () => void;
 }
@@ -113,7 +114,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
     }
 
     render() {
-        const { view, galleryAssets, userAssets } = this.props;
+        const { view, galleryAssets, userAssets, disableCreateButton } = this.props;
         const { showCreateModal } = this.state;
         const isBlocksProject = pkg.mainPkg?.config && pkg.mainPkg.getPreferredEditor() === pxt.BLOCKS_PROJECT_NAME;
 
@@ -121,7 +122,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             <AssetTopbar />
             <div className={`asset-editor-card-list ${view !== GalleryView.User ? "hidden" : ""}`}>
                 <AssetCardList assets={filterAssets(userAssets, isBlocksProject)}>
-                    <div className="create-new" role="button" onClick={this.showCreateModal}>
+                    <div className={`create-new ${disableCreateButton ? "disabled" : ""}`} role="button" onClick={!disableCreateButton && this.showCreateModal}>
                         <i className="icon huge add circle" />
                         <span>{lf("New Asset")}</span>
                     </div>

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -83,10 +83,12 @@ export class AssetEditor extends Editor {
     }
 
     display(): JSX.Element {
+        // TODO: re-enable the create asset button in tutorials when we add
+        // the ability to switch editors inside a tutorial
         return <Provider store={store}>
             <div className="asset-editor-outer">
                 <AssetSidebar showAssetFieldView={this.showAssetFieldView} />
-                <AssetGallery showAssetFieldView={this.showAssetFieldView} />
+                <AssetGallery showAssetFieldView={this.showAssetFieldView} disableCreateButton={this.parent.isTutorial()} />
             </div>
         </Provider>
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/128098699-a59bddde-9df3-43ef-a450-0831b9f384c0.png)

grays out the button and changes the cursor to a "not allowed" (circle with line through it). small fix for https://github.com/microsoft/pxt-arcade/issues/3357 in this upcoming release, long-term we still want to add the ability to switch editors in a tutorial