### PR TITLE
Only show cloud card after using identity

### DIFF
--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -20,6 +20,7 @@ export const USER_PREFERENCES = `${USER_PREF_MODULE}:${FIELD_USER_PREFERENCES}`
 export const HIGHCONTRAST = `${USER_PREF_MODULE}:${FIELD_HIGHCONTRAST}`
 export const LANGUAGE = `${USER_PREF_MODULE}:${FIELD_LANGUAGE}`
 export const READER = `${USER_PREF_MODULE}:${FIELD_READER}`
+export const HAS_USED_CLOUD = "has-used-cloud"; // Key into local storage to see if this computer has logged in before
 
 export class Component<TProps, TState> extends data.Component<TProps, TState> {
     public getUserProfile(): pxt.auth.UserProfile {
@@ -38,6 +39,7 @@ class AuthClient extends pxt.auth.AuthClient {
         const state = this.getState();
         core.infoNotification(lf("Signed in: {0}", state.profile.idp.displayName));
         await cloud.syncAsync();
+        pxt.storage.setLocal(HAS_USED_CLOUD, "true");
     }
     protected onSignedOut(): Promise<void> {
         core.infoNotification(lf("Signed out"));

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -735,7 +735,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
             const headers = this.fetchLocalData()
             const showNewProject = pxt.appTarget.appTheme && !pxt.appTarget.appTheme.hideNewProjectButton;
             const showScriptManagerCard = targetTheme.scriptManager && headers.length > ProjectsCarousel.NUM_PROJECTS_HOMESCREEN;
-            const showCloudProjectsCard = auth.hasIdentity() && !auth.loggedIn();
+            const showCloudProjectsCard = auth.hasIdentity() && !auth.loggedIn() && pxt.storage.getLocal(auth.HAS_USED_CLOUD);
 
             const headersToShow = headers
                 .filter(h => !h.tutorial?.metadata?.hideIteration)


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3719

(clears automatically with the local storage cleanup in reset)