### PR TITLE
Small skillmap fixes for opening activity, switching maps

### DIFF
--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -321,7 +321,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     const currentMap = state.editorView ?
         state.maps[state.editorView.currentMapId] :
         (currentMapId && state.maps[currentMapId]);
-    const activity = currentMapId && currentActivityId ? state.maps[currentMapId].activities[currentActivityId] : undefined
+    const activity = (currentMapId && currentActivityId) ? state.maps[currentMapId]?.activities[currentActivityId] : undefined
 
     let showCodeCarryoverModal = false;
 

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -143,7 +143,7 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     let currentActivityDisplayName: string | undefined;
 
     if (state.editorView?.currentActivityId) {
-        const activity = state.maps[state.editorView.currentMapId].activities[state.editorView.currentActivityId];
+        const activity = state.maps[state.editorView.currentMapId]?.activities[state.editorView.currentActivityId];
         if (activity) {
             currentActivityDisplayName = activity.displayName;
         }

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -68,7 +68,7 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
 
         if (isCodeCarryoverEnabled(user, pageSourceUrl, map, activity)) {
             dispatchShowCarryoverModal(map.mapId, activityId);
-        } else if (kind == "activity") {
+        } else if (kind == "activity" && status !== "locked") {
             dispatchOpenActivity(map.mapId, activityId);
         }
     }

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -139,8 +139,10 @@ export function lookupPreviousCompletedActivityState(user: UserState, pageSource
 export function isCodeCarryoverEnabled(user: UserState, pageSource: string, map: SkillMap, activity: MapNode) {
     if (activity.kind !== "activity") return false;
 
+    const prevActivities = lookupPreviousActivities(map, activity.activityId);
     const progress = lookupActivityProgress(user, pageSource, map.mapId, activity.activityId);
-    return activity.allowCodeCarryover && isActivityUnlocked(user, pageSource, map, activity.activityId) && !progress?.headerId;
+    return activity.allowCodeCarryover && prevActivities.length > 0
+        && isActivityUnlocked(user, pageSource, map, activity.activityId) && !progress?.headerId;
 }
 
 export function flattenRewardNodeChildren(node: MapNode): MapNode[] {


### PR DESCRIPTION
- some null checks
- only open on doubleclick for unlocked activities
- check if previous activities present for displaying code carryover (fixes issue with first activity of carryover maps not opening)