### PR TITLE
Don't show timestamp on tutorial cards

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1429,6 +1429,10 @@ p.ui.font.small {
         bottom: 2.2rem;
         margin: 0;
     }
+
+    .ui.card .meta .date.small-screen.hide {
+        display: none;
+    }
 }
 
 @media only screen and (min-width: @tabletBreakpoint) {

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -133,7 +133,7 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                 {card.tutorialLength ? <span className={`ui tutorial-progress ${tutorialDone ? "green" : "orange"} left floated label`}><i className={`${tutorialDone ? "trophy" : "circle"} icon`}></i>&nbsp;{lf("{0}/{1}", (card.tutorialStep || 0) + 1, card.tutorialLength)}</span> : undefined}
                 {!cloudStatus && card.time && <span key="date" className="date">{pxt.Util.timeSince(card.time)}</span>}
                 {cloudStatus && cloudShowTimestamp &&
-                    <span key="date" className="date">{pxt.Util.timeSince(lastCloudSave)}{cloudStatus.indicator}</span>
+                    <span key="date" className={`date ${card.tutorialLength ? "small-screen hide" : ""}`}>{pxt.Util.timeSince(lastCloudSave)}{cloudStatus.indicator}</span>
                 }
                 {cloudStatus && !cloudShowTimestamp &&
                     <span key="date" className="date">{cloudStatus.indicator}</span>


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3216

(don't show it when on a smaller screen)