### PR TITLE
Increase the C++ build timeout from 2min to 3min

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1375,7 +1375,7 @@ namespace pxt.hexloader {
                             .then(ret => new Promise<string>((resolve, reject) => {
                                 let retry = 0;
                                 const delay = 8000; // ms
-                                const maxWait = 120000; // ms
+                                const maxWait = 180000; // ms
                                 const startTry = U.now();
                                 const tryGet = () => {
                                     retry++;


### PR DESCRIPTION
 (needed by esp32 builds)