### PR TITLE
Fix temporary asset duplication

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -924,28 +924,28 @@ namespace pxt {
             }
         }
 
-        public duplicateAsset(asset: ProjectImage): ProjectImage;
-        public duplicateAsset(asset: Tile): Tile;
-        public duplicateAsset(asset: ProjectTilemap): ProjectTilemap;
-        public duplicateAsset(asset: Animation): Animation;
-        public duplicateAsset(asset: Asset): Asset;
-        public duplicateAsset(asset: Asset) {
+        public duplicateAsset(asset: ProjectImage, displayName?: string): ProjectImage;
+        public duplicateAsset(asset: Tile, displayName?: string): Tile;
+        public duplicateAsset(asset: ProjectTilemap, displayName?: string): ProjectTilemap;
+        public duplicateAsset(asset: Animation, displayName?: string): Animation;
+        public duplicateAsset(asset: Asset, displayName?: string): Asset;
+        public duplicateAsset(asset: Asset, displayName?: string) {
             this.onChange();
             const clone = cloneAsset(asset);
-            const displayName = clone.meta?.displayName;
+            const name = displayName || clone.meta?.displayName;
 
             let newAsset: pxt.Asset;
             switch (asset.type) {
                 case AssetType.Image:
-                    newAsset = this.createNewProjectImage((clone as pxt.ProjectImage).bitmap, displayName); break;
+                    newAsset = this.createNewProjectImage((clone as pxt.ProjectImage).bitmap, name); break;
                 case AssetType.Tile:
-                    newAsset = this.createNewTile((clone as pxt.Tile).bitmap, null, displayName); break;
+                    newAsset = this.createNewTile((clone as pxt.Tile).bitmap, null, name); break;
                 case AssetType.Tilemap:
-                    const [id, tilemap] = this.createNewTilemapFromData((clone as pxt.ProjectTilemap).data, displayName);
+                    const [id, tilemap] = this.createNewTilemapFromData((clone as pxt.ProjectTilemap).data, name);
                     newAsset = this.getTilemap(id);
                     break;
                 case AssetType.Animation:
-                    newAsset = this.createNewAnimationFromData((clone as pxt.Animation).frames, (clone as pxt.Animation).interval, displayName)
+                    newAsset = this.createNewAnimationFromData((clone as pxt.Animation).frames, (clone as pxt.Animation).interval, name)
             }
             return newAsset;
         }
@@ -1577,6 +1577,21 @@ namespace pxt {
         }
 
         return undefined
+    }
+
+    export function getDefaultAssetDisplayName(type: pxt.AssetType): string {
+        switch (type) {
+            case pxt.AssetType.Image:
+                return lf("myImage");
+            case pxt.AssetType.Tile:
+                return lf("myTile");
+            case pxt.AssetType.Tilemap:
+                return lf("level");
+            case pxt.AssetType.Animation:
+                return lf("myAnim");
+            default:
+                return lf("asset")
+        }
     }
 
     export function getShortIDForAsset(asset: pxt.Asset) {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -778,11 +778,11 @@ namespace ts.pxtc.Util {
     }
 
     export function escapeForRegex(str: string) {
-        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+        return str?.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
     }
 
     export function stripUrlProtocol(str: string) {
-        return str.replace(/.*?:\/\//g, "");
+        return str?.replace(/.*?:\/\//g, "");
     }
 
     export function normalizePath(path: string) {

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -80,7 +80,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
 
     protected getEmptyAsset(type: pxt.AssetType): pxt.Asset {
         const project = pxt.react.getTilemapProject();
-        const asset = { type, id: "", internalID: 0, meta: { displayName: this.getEmptyAssetDisplayName(type) } } as pxt.Asset;
+        const asset = { type, id: "", internalID: 0, meta: { displayName: pxt.getDefaultAssetDisplayName(type) } } as pxt.Asset;
         switch (type) {
             case pxt.AssetType.Image:
             case pxt.AssetType.Tile:
@@ -96,21 +96,6 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
 
         }
         return asset;
-    }
-
-    protected getEmptyAssetDisplayName(type: pxt.AssetType): string {
-        switch (type) {
-            case pxt.AssetType.Image:
-                return lf("myImage");
-            case pxt.AssetType.Tile:
-                return lf("myTile");
-            case pxt.AssetType.Tilemap:
-                return lf("level");
-            case pxt.AssetType.Animation:
-                return lf("myAnim");
-            default:
-                return lf("asset")
-        }
     }
 
     render() {

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -107,7 +107,7 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
         pxt.tickEvent("assets.duplicate", { type: this.props.asset.type.toString(), gallery: isGalleryAsset.toString() });
 
         const asset = this.props.asset;
-        const displayName = asset.meta.displayName
+        const displayName = asset.meta?.displayName
             || getDisplayNameForAsset(asset, isGalleryAsset)
             || pxt.getDefaultAssetDisplayName(asset.type);
 

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -103,16 +103,19 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
     }
 
     protected duplicateAssetHandler = () => {
-        pxt.tickEvent("assets.duplicate", { type: this.props.asset.type.toString(), gallery: this.props.isGalleryAsset.toString() });
+        const { isGalleryAsset } = this.props;
+        pxt.tickEvent("assets.duplicate", { type: this.props.asset.type.toString(), gallery: isGalleryAsset.toString() });
 
         const asset = this.props.asset;
-        if (!asset.meta?.displayName) asset.meta = { ...asset.meta, displayName: getDisplayNameForAsset(asset, this.props.isGalleryAsset) }
+        const displayName = asset.meta.displayName
+            || getDisplayNameForAsset(asset, isGalleryAsset)
+            || pxt.getDefaultAssetDisplayName(asset.type);
 
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        const { type, id } = project.duplicateAsset(asset);
+        const { type, id } = project.duplicateAsset(asset, displayName);
         this.updateAssets().then(() => {
-            this.props.dispatchChangeGalleryView(GalleryView.User, type, id);
+            if (isGalleryAsset) this.props.dispatchChangeGalleryView(GalleryView.User, type, id);
         });
     }
 
@@ -218,9 +221,10 @@ function getDisplayNameForAsset(asset: pxt.Asset, isGalleryAsset?: boolean) {
         return lf("No asset selected");
     } else if (asset?.meta?.displayName) {
         return asset.meta.displayName;
-    } else {
-        return isGalleryAsset ? asset.id.split('.').pop() : lf("Temporary asset");
+    } else if (isGalleryAsset) {
+        return asset.id.split('.').pop();
     }
+    return null;
 }
 
 function mapStateToProps(state: AssetEditorState, ownProps: any) {


### PR DESCRIPTION
- don't set the display name on temporary assets at all
- some null checks
- move the default display name code to tilemap so it can be shared
- skips dispatching the change gallery view event if you're already on the correct (user assets) view, as it makes this very slow

fixes https://github.com/microsoft/pxt-arcade/issues/3068