### PR TITLE
Fix naming of temporary assets in asset editor view

### DIFF
--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -89,15 +89,13 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
 
         const project = pxt.react.getTilemapProject();
         project.pushUndo();
-        if (!result.meta.displayName && result.meta.temporaryInfo) {
+        if (!this.props.asset.meta?.displayName && result.meta.temporaryInfo) {
             getBlocksEditor().updateTemporaryAsset(result);
-
-            pkg.mainEditorPkg().lookupFile(`this/${pxt.MAIN_BLOCKS}`).setContentAsync(getBlocksEditor().getCurrentSource())
-
+            pkg.mainEditorPkg().lookupFile(`this/${pxt.MAIN_BLOCKS}`).setContentAsync(getBlocksEditor().getCurrentSource());
         }
-        else {
-            project.updateAsset(result);
-        }
+
+        if (result.meta.displayName) project.updateAsset(result);
+
         this.props.dispatchChangeGalleryView(GalleryView.User);
         this.updateAssets().then(() => simulator.setDirty());
     }

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -186,7 +186,7 @@ export class AssetEditor extends Editor {
 
             Promise.resolve(cb(result)).then(() => {
                 // for temporary (unnamed) assets, update the underlying typescript image literal
-                if (!result.meta?.displayName) {
+                if (!asset.meta?.displayName) {
                     this.parent.saveBlocksToTypeScriptAsync().then((src) => {
                         if (src) pkg.mainEditorPkg().setContentAsync(pxt.MAIN_TS, src)
                     })


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3502

two different places where we were using the asset returned from closing the sprite/animation editor to check if it was temporary--we actually generally care about whether the asset was initally temporary (and it might've gotten named during the editing process)