### PR TITLE
Use relprefix for the home button in skillmap

### DIFF
--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -147,7 +147,19 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
 
     onHomeClicked = () => {
         tickEvent("skillmap.home");
-        window.open(pxt.appTarget.appTheme.homeUrl);
+
+        // relprefix looks like "/beta---", need to chop off the hyphens and slash
+        let rel = pxt.webConfig?.relprefix.substr(0, pxt.webConfig.relprefix.length - 3);
+        if (pxt.appTarget.appTheme.homeUrl && rel) {
+            if (pxt.appTarget.appTheme.homeUrl?.lastIndexOf("/") === pxt.appTarget.appTheme.homeUrl?.length - 1) {
+                rel = rel.substr(1);
+            }
+            window.open(pxt.appTarget.appTheme.homeUrl + rel);
+        }
+        else {
+            window.open(pxt.appTarget.appTheme.homeUrl);
+        }
+
     }
 
     onBugClicked = () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3328