### PR TITLE
Check if previous activity is completed before trying to show skillmap code carryover

### DIFF
--- a/skillmap/src/components/ActivityActions.tsx
+++ b/skillmap/src/components/ActivityActions.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { dispatchOpenActivity, dispatchShowRestartActivityWarning, dispatchShowShareModal, dispatchShowCarryoverModal } from '../actions/dispatch';
 
-import { ActivityStatus, lookupActivityProgress, isCodeCarryoverEnabled } from '../lib/skillMapUtils';
+import { ActivityStatus, isCodeCarryoverEnabled } from '../lib/skillMapUtils';
 import { tickEvent } from '../lib/browserUtils';
 import { editorUrl } from "./makecodeFrame";
 import { SkillMapState } from "../store/reducer";

--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -367,22 +367,12 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
         (currentMapId && state.maps[currentMapId]);
     const activity = (currentMapId && currentActivityId) ? state.maps[currentMapId]?.activities[currentActivityId] : undefined
 
-    let showCodeCarryoverModal = false;
-
-    if (currentMap && activity) {
-        const previous = lookupPreviousActivityStates(state.user, state.pageSourceUrl, currentMap, activity.activityId);
-        const previousActivityCompleted = previous.some(state => state?.isCompleted &&
-            state.maxSteps === state.currentStep);
-
-        showCodeCarryoverModal = !!((activity as MapActivity).allowCodeCarryover && previousActivityCompleted);
-    }
-
     return {
         type,
         pageSourceUrl,
         skillMap: currentMap,
         userState: state.user,
-        showCodeCarryoverModal,
+        showCodeCarryoverModal: currentMap && activity && isCodeCarryoverEnabled(state.user, state.pageSourceUrl, currentMap, activity),
         mapId: currentMapId,
         activity: currentMapId && currentActivityId ? state.maps[currentMapId].activities[currentActivityId] : undefined
     }

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -7,7 +7,7 @@ import { dispatchChangeSelectedItem, dispatchShowCompletionModal,
 import { GraphNode } from './GraphNode';
 import { GraphPath } from "./GraphPath";
 
-import { getActivityStatus, isCodeCarryoverEnabled } from '../lib/skillMapUtils';
+import { getActivityStatus, isCodeCarryoverEnabled, lookupActivityProgress } from '../lib/skillMapUtils';
 import { SvgGraphItem, SvgGraphPath } from '../lib/skillGraphUtils';
 import { tickEvent } from "../lib/browserUtils";
 
@@ -66,7 +66,8 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
         const activity = map.activities[activityId];
         tickEvent("skillmap.activity.open.doubleclick", { path: map.mapId, activity: activityId, status: status || "" });
 
-        if (isCodeCarryoverEnabled(user, pageSourceUrl, map, activity)) {
+        const progress = lookupActivityProgress(user, pageSourceUrl, map.mapId, activity.activityId);
+        if (isCodeCarryoverEnabled(user, pageSourceUrl, map, activity) && !progress?.headerId) {
             dispatchShowCarryoverModal(map.mapId, activityId);
         } else if (kind == "activity" && status !== "locked") {
             dispatchOpenActivity(map.mapId, activityId);

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -137,12 +137,13 @@ export function lookupPreviousCompletedActivityState(user: UserState, pageSource
 
 // Code carryover is enabled for unlocked activities (non-rewards) that haven't been started
 export function isCodeCarryoverEnabled(user: UserState, pageSource: string, map: SkillMap, activity: MapNode) {
-    if (activity.kind !== "activity") return false;
+    if (!user || !map || !activity || activity.kind !== "activity") return false;
 
-    const prevActivities = lookupPreviousActivities(map, activity.activityId);
-    const progress = lookupActivityProgress(user, pageSource, map.mapId, activity.activityId);
-    return activity.allowCodeCarryover && prevActivities.length > 0
-        && isActivityUnlocked(user, pageSource, map, activity.activityId) && !progress?.headerId;
+    const previous = lookupPreviousActivityStates(user, pageSource, map, activity.activityId);
+    const previousActivityCompleted = previous?.some(state => state?.isCompleted &&
+        state.maxSteps === state.currentStep);
+    return activity.allowCodeCarryover && previous.length > 0 && previousActivityCompleted
+        && isActivityUnlocked(user, pageSource, map, activity.activityId);
 }
 
 export function flattenRewardNodeChildren(node: MapNode): MapNode[] {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3744

bug was that the button was attempting to show the code carryover modal, but the previous activity wasn't completed so the code couldn't be carried over. 

i'm not going to do it for this release, but we have a lot of different ways to open an activity (start, restart, double-click on tile) and we should unify the "show carryover modal vs open activity" logic somewhere. 