### PR TITLE
Just use logoURL for skillmap logo

### DIFF
--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -52,9 +52,10 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
     protected getOrganizationLogo(targetTheme: pxt.AppTheme) {
         const logoUrl = targetTheme.organizationWideLogo;
 
+        // TODO FIX LOCALSERVE FETCH OF LOGO
         return <div className="header-logo">
             {logoUrl
-                ? <img src={resolvePath(logoUrl)} alt={lf("{0} Logo", targetTheme.organization)}/>
+                ? <img src={isLocal() ? logoUrl : logoUrl} alt={lf("{0} Logo", targetTheme.organization)}/>
                 : <span className="name">{targetTheme.organization}</span>}
         </div>
     }


### PR DESCRIPTION
This should fix the broken logo in the skillmap page, but I'm not sure how to test it :\ I can't uploadtrg bc my build is super mad about it, but the issue was it was trying to fetch the logo at:

/static/skillmap/https://pxt.azureedge.net/blob/d6139e3d0af51f02aa5f8765ecb0985acbd98551/static/Micorsoft_logo_rgb_W-white_D.png

bc I was using resolvePath and it was prepending /static/skillmap.

This doesn't fix the localhost serve logo. I could only ever get it to work if I dropped something in pxt/skillmap/public, which *feels* like a place I shouldn't be touching???? Any advice is appreciated