### PR TITLE
Correcting the localized name of Traditional Chinese

### DIFF
--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1209,7 +1209,7 @@ namespace ts.pxtc.Util {
         "ur-PK": { englishName: "Urdu (Pakistan)", localizedName: "اردو (پاکستان)" },
         "vi": { englishName: "Vietnamese", localizedName: "Tiếng việt" },
         "zh-CN": { englishName: "Chinese (Simplified)", localizedName: "简体中文" },
-        "zh-TW": { englishName: "Chinese (Traditional)", localizedName: "繁体中文" },
+        "zh-TW": { englishName: "Chinese (Traditional)", localizedName: "繁體中文" },
     };
 
     export function isLocaleEnabled(code: string): boolean {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3446

This is consistent with Microsoft.com as well

![image](https://user-images.githubusercontent.com/6107272/128924339-495d1533-b2cf-49b0-adc0-75223ffc4a35.png)
