### PR TITLE
Always keep the skillmap iframe in the DOM

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -253,6 +253,7 @@ namespace pxt.editor {
         updateFileAsync(name: string, content: string, open?: boolean): Promise<void>;
 
         openHome(): void;
+        unloadProjectAsync(home?: boolean): Promise<void>;
         setTutorialStep(step: number): void;
         setTutorialInstructionsExpanded(value: boolean): void;
         exitTutorial(): void;

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -268,6 +268,7 @@ namespace pxt.editor {
         setHintSeen(step: number): void;
 
         anonymousPublishAsync(screenshotUri?: string): Promise<string>;
+        anonymousPublishHeaderByIdAsync(headerId: string): Promise<Cloud.JsonScript>;
 
         startStopSimulator(opts?: SimulatorStartOptions): void;
         stopSimulator(unload?: boolean, opts?: SimulatorStartOptions): void;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -53,7 +53,8 @@ namespace pxt.editor {
         | "setscale"
         | "startactivity"
         | "saveproject"
-        | "home"
+        | "unloadproject"
+        | "shareproject"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
         | "togglehighcontrast"
@@ -319,6 +320,16 @@ namespace pxt.editor {
         type: "pxtsim";
     }
 
+    export interface EditorShareRequest extends EditorMessageRequest {
+        action: "shareproject";
+        headerId: string;
+    }
+
+    export interface EditorShareResponse extends EditorMessageRequest {
+        action: "shareproject";
+        script: Cloud.JsonScript;
+    }
+
     const pendingRequests: pxt.Map<{
         resolve: (res?: EditorMessageResponse | PromiseLike<EditorMessageResponse>) => void;
         reject: (err: any) => void;
@@ -386,7 +397,7 @@ namespace pxt.editor {
                                 case "hidesimulator": return Promise.resolve().then(() => projectView.collapseSimulator());
                                 case "showsimulator": return Promise.resolve().then(() => projectView.expandSimulator());
                                 case "closeflyout": return Promise.resolve().then(() => projectView.closeFlyout());
-                                case "home": return Promise.resolve().then(() => projectView.unloadProjectAsync());
+                                case "unloadproject": return Promise.resolve().then(() => projectView.unloadProjectAsync());
                                 case "saveproject": return projectView.saveProjectAsync();
                                 case "redo": return Promise.resolve()
                                     .then(() => {
@@ -515,6 +526,13 @@ namespace pxt.editor {
                                                 locale: ts.pxtc.Util.userLanguage(),
                                                 availableLocales: pxt.appTarget.appTheme.availableLocales
                                             }
+                                        });
+                                }
+                                case "shareproject": {
+                                    const msg = data as EditorShareRequest;
+                                    return projectView.anonymousPublishHeaderByIdAsync(msg.headerId)
+                                        .then(scriptInfo => {
+                                            resp = scriptInfo;
                                         });
                                 }
                             }

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -53,6 +53,7 @@ namespace pxt.editor {
         | "setscale"
         | "startactivity"
         | "saveproject"
+        | "home"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
         | "togglehighcontrast"
@@ -385,6 +386,7 @@ namespace pxt.editor {
                                 case "hidesimulator": return Promise.resolve().then(() => projectView.collapseSimulator());
                                 case "showsimulator": return Promise.resolve().then(() => projectView.expandSimulator());
                                 case "closeflyout": return Promise.resolve().then(() => projectView.closeFlyout());
+                                case "home": return Promise.resolve().then(() => projectView.unloadProjectAsync());
                                 case "saveproject": return projectView.saveProjectAsync();
                                 case "redo": return Promise.resolve()
                                     .then(() => {

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -229,15 +229,16 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const maps = Object.keys(skillMaps).map((id: string) => skillMaps[id]);
         return (<div className={`app-container ${pxt.appTarget.id}`}>
                 <HeaderBar />
-                { activityOpen ? <MakeCodeFrame /> :
-                    <div className="skill-map-container" style={{ backgroundColor: theme.backgroundColor }}>
-                        { error
-                            ? <div className="skill-map-error">{error}</div>
-                            : <SkillGraphContainer maps={maps} backgroundImageUrl={backgroundImageUrl} />
-                        }
-                        { !error && <InfoPanel />}
-                    </div>
-                }
+                    { !activityOpen &&
+                        <div className="skill-map-container" style={{ backgroundColor: theme.backgroundColor }}>
+                            { error
+                                ? <div className="skill-map-error">{error}</div>
+                                : <SkillGraphContainer maps={maps} backgroundImageUrl={backgroundImageUrl} />
+                            }
+                            { !error && <InfoPanel />}
+                        </div>
+                    }
+                    <MakeCodeFrame />
                 <AppModal />
             </div>);
     }

--- a/skillmap/src/actions/dispatch.ts
+++ b/skillmap/src/actions/dispatch.ts
@@ -38,3 +38,5 @@ export const dispatchHideModal = () => ({ type: actions.HIDE_MODAL });
 export const dispatchSetUserProfile = (profile?: pxt.auth.UserProfile) => ({ type: actions.SET_USER_PROFILE, profile });
 export const dispatchSetUserPreferences = (preferences?: pxt.auth.UserPreferences) => ({ type: actions.SET_USER_PREFERENCES, preferences });
 export const dispatchLogout = () => ({type: actions.USER_LOG_OUT});
+
+export const dispatchSetShareStatus = (headerId?: string, url?: string) =>  ({ type: actions.SET_SHARE_STATUS, headerId, url })

--- a/skillmap/src/actions/types.ts
+++ b/skillmap/src/actions/types.ts
@@ -35,3 +35,5 @@ export const HIDE_MODAL = "HIDE_MODAL";
 export const SET_USER_PROFILE = "SET_USER_PROFILE";
 export const SET_USER_PREFERENCES = "SET_USER_PREFERENCES";
 export const USER_LOG_OUT = "USER_LOG_OUT";
+
+export const SET_SHARE_STATUS = "SET_SHARE_STATUS";

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -16,7 +16,6 @@ interface MakeCodeFrameProps {
     mapId: string;
     activityId: string;
     title: string;
-    url: string;
     tutorialPath: string;
     activityHeaderId?: string;
     activityType: MapActivityType;
@@ -29,10 +28,12 @@ interface MakeCodeFrameProps {
     dispatchUpdateUserCompletedTags: () => void;
 }
 
+type FrameState = "loading" | "home" | "opening-project" | "project-open" | "closing-project";
+
 interface MakeCodeFrameState {
-    loaded: boolean;
-    unloading: "unloading" | "unloaded" | null; // See handleFrameRef
+    frameState: FrameState;
     loadPercent?: number; // Progress bar load % from 0 - 100 (loaded)
+    workspaceReady: boolean;
 }
 
 interface PendingMessage {
@@ -53,21 +54,22 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     constructor(props: MakeCodeFrameProps) {
         super(props);
         this.state = {
-            loaded: false,
-            unloading: null,
+            frameState: "loading",
+            workspaceReady: false,
             loadPercent: 0
         };
     }
 
     async componentDidUpdate() {
-        if (this.props.save && !this.state.unloading) {
-            await this.sendMessageAsync({
-                type: "pxteditor",
-                action: "saveproject"
-            } as pxt.editor.EditorMessageRequest);
-
-            this.setState({
-                unloading: "unloading"
+        const { frameState } = this.state;
+        if (frameState === "project-open" && this.props.save) {
+            this.setState({ frameState: "closing-project" }, async () => {
+                await this.closeActivityAsync();
+            })
+        }
+        else if (frameState === "home" && this.props.activityId) {
+            this.setState({ frameState: "opening-project", loadPercent: 0 }, async () => {
+                await this.startActivityAsync();
             });
         }
     }
@@ -84,22 +86,31 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     }
 
     render() {
-        const { url, title } = this.props;
-        const { loaded, unloading, loadPercent } = this.state;
+        const {title, activityId } = this.props;
+        const { frameState, loadPercent } = this.state;
 
         const loadingText =  lf("Loading...")
         const imageAlt = "MakeCode Logo";
 
+        const openingProject = frameState === "opening-project";
+        const showLoader = openingProject || frameState === "closing-project";
+
+        let url = editorUrl
+        if (editorUrl.charAt(editorUrl.length - 1) === "/" && !isLocal()) {
+            url = editorUrl.substr(0, editorUrl.length - 1);
+        }
+        url += `?controller=1&skillsMap=1&noproject=1&nocookiebanner=1&ws=browser`;
+
         /* eslint-disable @microsoft/sdl/react-iframe-missing-sandbox */
-        return <div className="makecode-frame-outer">
-            <div className={`makecode-frame-loader ${loaded ? "hidden" : ""}`}>
+        return <div className="makecode-frame-outer" style={{ display: activityId ? "block" : "none" }}>
+            <div className={`makecode-frame-loader ${showLoader ? "" : "hidden"}`}>
                 <img src={resolvePath("assets/logo.svg")} alt={imageAlt} />
-                {!loaded && <div className="makecode-frame-loader-bar">
+                {openingProject && <div className="makecode-frame-loader-bar">
                     <div className="makecode-frame-loader-fill" style={{ width: loadPercent + "%" }} />
                 </div>}
                 <div className="makecode-frame-loader-text">{loadingText}</div>
             </div>
-            <iframe className="makecode-frame" src={unloading ? "about:blank" : url} title={title} ref={this.handleFrameRef}></iframe>
+            <iframe className="makecode-frame" src={url} title={title} ref={this.handleFrameRef}></iframe>
         </div>
         /* eslint-enable @microsoft/sdl/react-iframe-missing-sandbox */
     }
@@ -110,18 +121,17 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             window.addEventListener("message", this.onMessageReceived);
             this.ref = ref;
 
-            this.ref.addEventListener("load", () => {
-                // This is a workaround for a bug in Chrome where for some reason the page hangs when
-                // trying to unload the makecode iframe. Instead, we set the src to about:blank, wait for
-                // that to load, and then unload the iframe
-                if (this.state.unloading === "unloading") {
-                    this.props.dispatchCloseActivity(this.finishedActivityState === "finished");
-                    this.props.dispatchUpdateUserCompletedTags();
+            // this.ref.addEventListener("load", () => {
+            //     // This is a workaround for a bug in Chrome where for some reason the page hangs when
+            //     // trying to unload the makecode iframe. Instead, we set the src to about:blank, wait for
+            //     // that to load, and then unload the iframe
+            //     if (this.state.unloading === "unloading") {
 
-                    this.finishedActivityState = undefined;
-                    this.setState({ unloading: "unloaded" });
-                }
-            });
+
+            //         this.finishedActivityState = undefined;
+            //         this.setState({ unloading: "unloaded" });
+            //     }
+            // });
 
             // Hide Usabilla widget + footer when inside iframe view
             setElementVisible(".usabilla_live_button_container", false);
@@ -134,7 +144,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
     protected onMessageReceived = (event: MessageEvent) => {
         const data = event.data as pxt.editor.EditorMessageRequest;
-        if (!this.state.loaded) this.setState({ loadPercent: Math.min((this.state.loadPercent || 0) + 4, 95) });
+        if (this.state.frameState === "opening-project") this.setState({ loadPercent: Math.min((this.state.loadPercent || 0) + 4, 95) });
 
         if (data.type === "pxteditor" && data.id && this.pendingMessages[data.id]) {
             const pending = this.pendingMessages[data.id];
@@ -145,7 +155,9 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
         switch (data.action) {
             case "newproject":
-                this.handleWorkspaceReadyEventAsync();
+                if (this.state.frameState === "loading") {
+                    this.setState({ frameState: "home" });
+                }
                 break;
             case "tutorialevent":
                 this.handleTutorialEvent(data as pxt.editor.EditorMessageTutorialEventRequest);
@@ -181,7 +193,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         });
     }
 
-    protected async handleWorkspaceReadyEventAsync() {
+    protected async startActivityAsync() {
         if (this.props.activityHeaderId) {
             await this.sendMessageAsync({
                 type: "pxteditor",
@@ -202,19 +214,38 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         }
     }
 
+    protected async closeActivityAsync() {
+        await this.sendMessageAsync({
+            type: "pxteditor",
+            action: "saveproject"
+        } as pxt.editor.EditorMessageRequest);
+
+        this.props.dispatchCloseActivity(this.finishedActivityState === "finished");
+        this.props.dispatchUpdateUserCompletedTags();
+
+        await this.sendMessageAsync({
+            type: "pxteditor",
+            action: "home"
+        } as pxt.editor.EditorMessageRequest);
+
+        this.setState({ frameState: "home" });
+    }
+
     protected handleTutorialEvent(event: pxt.editor.EditorMessageTutorialEventRequest) {
         const { dispatchSetHeaderIdForActivity, mapId, activityId, progress } = this.props;
 
         switch (event.tutorialEvent) {
             case "progress":
-                dispatchSetHeaderIdForActivity(
-                    mapId,
-                    activityId,
-                    event.projectHeaderId,
-                    event.currentStep + 1,
-                    event.totalSteps,
-                    event.isCompleted || !!progress?.isCompleted
-                );
+                if (activityId) {
+                    dispatchSetHeaderIdForActivity(
+                        mapId,
+                        activityId,
+                        event.projectHeaderId,
+                        event.currentStep + 1,
+                        event.totalSteps,
+                        event.isCompleted || !!progress?.isCompleted
+                    );
+                }
                 break;
             case "loaded":
                 this.onEditorLoaded();
@@ -229,7 +260,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         const { mapId, activityId } = this.props;
         tickEvent("skillmap.activity.loaded", { path: mapId, activity: activityId });
         this.setState({
-            loaded: true
+            frameState: "project-open"
         });
 
         if (this.isNewActivity) {
@@ -250,22 +281,15 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
 
     const { currentActivityId, currentMapId, currentHeaderId, state: saveState, allowCodeCarryover, previousHeaderId } = state.editorView;
 
-    let url = editorUrl
     let title: string | undefined;
     const map = state.maps[currentMapId];
     const activity = map?.activities[currentActivityId] as MapActivity;
 
-    if (editorUrl.charAt(editorUrl.length - 1) === "/" && !isLocal()) {
-        url = editorUrl.substr(0, editorUrl.length - 1);
-    }
-
-    url += `?controller=1&skillsMap=1&noproject=1&nocookiebanner=1&ws=browser`;
     title = activity?.displayName;
 
     const progress = lookupActivityProgress(state.user, state.pageSourceUrl, currentMapId, currentActivityId);
 
     return {
-        url,
         tutorialPath: activity.url,
         title,
         mapId: currentMapId,

--- a/skillmap/src/store/reducer.ts
+++ b/skillmap/src/store/reducer.ts
@@ -20,6 +20,8 @@ export interface SkillMapState {
     maps: { [key: string]: SkillMap };
     selectedItem?: { mapId: string, activityId: string };
 
+    shareState?: ShareState;
+
     editorView?: EditorViewState;
     modal?: ModalState;
     theme: SkillGraphTheme;
@@ -39,6 +41,11 @@ interface ModalState {
     type: ModalType;
     currentMapId?: string;
     currentActivityId?: string;
+}
+
+export interface ShareState {
+    headerId: string;
+    url?: string;
 }
 
 interface AuthState {
@@ -259,6 +266,14 @@ const topReducer = (state: SkillMapState = initialState, action: any): SkillMapS
                         [state.pageSourceUrl]: getCompletedTags(state.user, state.pageSourceUrl, Object.keys(state.maps).map(key => state.maps[key]))
                     }
                 }
+            }
+        case actions.SET_SHARE_STATUS:
+            return {
+                ...state,
+                shareState: action.headerId || action.url ? {
+                    headerId: action.headerId,
+                    url: action.url
+                } : undefined
             }
         case actions.SET_PAGE_TITLE:
             return {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3478,6 +3478,29 @@ export class ProjectView
             })
     }
 
+    async anonymousPublishHeaderByIdAsync(headerId: string): Promise<Cloud.JsonScript> {
+        const header = workspace.getHeader(headerId);
+        const text = await workspace.getTextAsync(headerId);
+        const stext = JSON.stringify(text, null, 2) + "\n"
+        const scrReq = {
+            name: header.name,
+            target: header.target,
+            targetVersion: header.targetVersion,
+            description: lf("Made with ❤️ in {0}.", pxt.appTarget.title || pxt.appTarget.name),
+            editor: header.editor,
+            text: text,
+
+            // FIXME: skillmap shares should set the metadata properly
+            meta: {
+                versions: pxt.appTarget.versions,
+                blocksHeight: 0,
+                blocksWidth: 0
+            }
+        }
+        pxt.debug(`publishing script; ${stext.length} bytes`)
+        return Cloud.privatePostAsync("scripts", scrReq, /* forceLiveEndpoint */ true)
+    }
+
     private debouncedSaveProjectName: () => void;
 
     updateHeaderName(name: string) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2321,16 +2321,31 @@ export class ProjectView
             && !pxt.appTarget.appTheme.lockedEditor;
         if (!hasHome) return;
 
+        this.unloadProjectAsync(true)
+    }
+
+    private homeLoaded() {
+        pxt.tickEvent('app.home');
+    }
+
+    private editorLoaded() {
+        pxt.tickEvent('app.editor');
+    }
+
+    unloadProjectAsync(home?: boolean) {
         this.stopSimulator(true); // don't keep simulator around
         this.showKeymap(false); // close keymap if open
         cmds.disconnectAsync(); // turn off any kind of logging
         if (this.editor) this.editor.unloadFileAsync();
         this.extensions.unload();
-        // clear the hash
-        pxt.BrowserUtils.changeHash("", true);
         this.editorFile = undefined;
-        this.setStateAsync({
-            home: true,
+
+        if (home) {
+            // clear the hash
+            pxt.BrowserUtils.changeHash("", true);
+        }
+        return this.setStateAsync({
+            home: home !== undefined ? home : this.state.home,
             tracing: undefined,
             fullscreen: undefined,
             tutorialOptions: undefined,
@@ -2341,18 +2356,14 @@ export class ProjectView
             fileState: undefined
         }).then(() => {
             this.allEditors.forEach(e => e.setVisible(false));
-            this.homeLoaded();
-            this.showPackageErrorsOnNextTypecheck();
+
+            if (home) {
+                this.homeLoaded();
+                this.showPackageErrorsOnNextTypecheck();
+            }
             return workspace.syncAsync();
-        });
-    }
-
-    private homeLoaded() {
-        pxt.tickEvent('app.home');
-    }
-
-    private editorLoaded() {
-        pxt.tickEvent('app.editor');
+        })
+        .then(() => {})
     }
 
     reloadEditor() {
@@ -3964,20 +3975,25 @@ export class ProjectView
             })
     }
 
-    exitTutorialAsync(removeProject?: boolean): Promise<void> {
+    async exitTutorialAsync(removeProject?: boolean): Promise<void> {
         let curr = pkg.mainEditorPkg().header;
         curr.isDeleted = removeProject;
         let files = pkg.mainEditorPkg().getAllFiles();
-        return workspace.saveAsync(curr, files)
-            .then(() => Util.delay(500))
-            .finally(() => {
-                this.setState({
-                    tutorialOptions: undefined,
-                    tracing: undefined,
-                    editorState: undefined
-                }, () => workspace.saveAsync(this.state.header));
-                core.resetFocus();
+
+        try {
+            await workspace.saveAsync(curr, files)
+            await Util.delay(500)
+        }
+        catch (e) {}
+        finally {
+            core.resetFocus();
+            await this.setStateAsync({
+                tutorialOptions: undefined,
+                tracing: undefined,
+                editorState: undefined
             });
+            await workspace.saveAsync(this.state.header);
+        }
     }
 
     showTutorialHint(showFullText?: boolean) {

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -107,7 +107,7 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             <AssetTopbar />
             <div className={`asset-editor-card-list ${view !== GalleryView.User ? "hidden" : ""}`}>
                 <AssetCardList assets={filterAssets(userAssets, isBlocksProject)}>
-                    <div className={`create-new ${disableCreateButton ? "disabled" : ""}`} role="button" onClick={!disableCreateButton && this.showCreateModal}>
+                    <div className={`create-new ${disableCreateButton ? "disabled" : ""}`} role="button" onClick={!disableCreateButton ? this.showCreateModal : undefined}>
                         <i className="icon huge add circle" />
                         <span>{lf("New Asset")}</span>
                     </div>


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3747

This changes the skillmap to always keep the iframe around in the background. When no tutorial is open, the editor unloads the current project and has its visibility hidden until the next activity is opened.

In the meantime, you can send whatever messages you want to the editor. For sharing, i'm doing it through the redux state (see makecodeframe's componentDidUpdate) but @eanders-MS I expect you might want to use the frame directly. Easiest way to do that is to probably pass a message channel of some kind from the makecodeframe in App.tsx


Not sure if this will improve perf at all, but it might! I think @shakao tried out something similar in the past but the gains weren't huge.