### PR TITLE
Reset finishedActivityState when opening new activity

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -222,6 +222,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
         this.props.dispatchCloseActivity(this.finishedActivityState === "finished");
         this.props.dispatchUpdateUserCompletedTags();
+        this.finishedActivityState = undefined;
 
         await this.sendMessageAsync({
             type: "pxteditor",


### PR DESCRIPTION
think this just got dropped as stuff was being shifted around in the iframe component. we might be able to clean up some of this state later (after release) also!

fixes https://github.com/microsoft/pxt-arcade/issues/3778