### PR TITLE
Don't unload/reload skillmap graph, reduces jittering

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -229,15 +229,13 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const maps = Object.keys(skillMaps).map((id: string) => skillMaps[id]);
         return (<div className={`app-container ${pxt.appTarget.id}`}>
                 <HeaderBar />
-                    { !activityOpen &&
-                        <div className="skill-map-container" style={{ backgroundColor: theme.backgroundColor }}>
-                            { error
-                                ? <div className="skill-map-error">{error}</div>
-                                : <SkillGraphContainer maps={maps} backgroundImageUrl={backgroundImageUrl} />
-                            }
-                            { !error && <InfoPanel />}
-                        </div>
-                    }
+                    <div className={`skill-map-container ${activityOpen ? "hidden" : ""}`} style={{ backgroundColor: theme.backgroundColor }}>
+                        { error
+                            ? <div className="skill-map-error">{error}</div>
+                            : <SkillGraphContainer maps={maps} backgroundImageUrl={backgroundImageUrl} />
+                        }
+                        { !error && <InfoPanel />}
+                    </div>
                     <MakeCodeFrame />
                 <AppModal />
             </div>);

--- a/skillmap/src/styles/skillgraph.css
+++ b/skillmap/src/styles/skillgraph.css
@@ -26,6 +26,10 @@
     height: 100%;
 }
 
+.skill-graph-content:not(.has-background) .skill-graph-background {
+    position: absolute;
+}
+
 .skill-graph-activities svg,
 .skill-graph-background img {
     object-fit: contain;


### PR DESCRIPTION
there is still a slight jump when the page first loads as the graph goes from default size -> sized to fit the background image, but this should remove the jitter when going in between activities. 