### PR TITLE
Don't write the contents of nonexistent files when merging projects

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1738,7 +1738,9 @@ export class ProjectView
         }
 
         for (const file of Object.keys(newText)) {
-            pkg.mainEditorPkg().setFile(file, newText[file]);
+            if (newText[file] !== undefined) {
+                pkg.mainEditorPkg().setFile(file, newText[file]);
+            }
         }
 
         await workspace.saveAsync(header);


### PR DESCRIPTION
This fixes the koala bug, aka https://github.com/microsoft/pxt-arcade/issues/3786