### PR TITLE
Retry request for skillmap markdown in safari

### DIFF
--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -62,7 +62,23 @@ export async function getMarkdownAsync(source: MarkdownSource, url: string): Pro
             break;
     }
 
-    const markdown = await httpGetAsync(toFetch);
+    let markdown: string;
+
+    if (pxt.BrowserUtils.isSafari()) {
+        // FIXME: safari adds the "If-None-Match" header which
+        // causes an exception, so sometimes we need to retry.
+        try {
+            markdown = await httpGetAsync(toFetch);
+        }
+        catch (e) {
+            markdown = await httpGetAsync(toFetch);
+        }
+    }
+    else {
+        markdown = await httpGetAsync(toFetch);
+    }
+
+
 
     return {
         text: markdown,


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3758

The issue here is that Safari is setting the "If-None-Match" header in the request to the etag the backend returns on the markdown request. Our backend doesn't include that header in the "Access-Control-Allow-Headers" list so Safari throws an exception (and clears the cached response). I'm not sure I know enough about CORS to know if we should add that to the list of headers or not (@eanders-MS @aznhassan ?)

Making the request a second time after the cache has been cleared fixes the issue. Obviously not *ideal*, but this does the trick. Not sure how to remove the header from the request directly. 