### PR TITLE
Fix the editor toolbar project name to use local state

### DIFF
--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -543,29 +543,60 @@ interface EditorToolbarSaveInputProps extends React.DetailedHTMLProps<React.Inpu
     onChangeValue: (value: string, view: string) => void;
 }
 
-class EditorToolbarSaveInput extends sui.StatelessUIElement<EditorToolbarSaveInputProps> {
+interface EditorToolbarSaveInputState {
+    editValue: string | undefined;
+}
 
+class EditorToolbarSaveInput extends React.Component<EditorToolbarSaveInputProps, EditorToolbarSaveInputState> {
     constructor(props: EditorToolbarSaveInputProps) {
         super(props);
-
-        this.handleChange = this.handleChange.bind(this);
+        this.state = {
+            editValue: undefined
+        };
     }
 
-    handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-        const { onChangeValue, view } = this.props;
-        onChangeValue((e.target as any).value, view);
-    }
-
-    renderCore() {
+    render() {
         const { onChange, onChangeValue, view, ...rest } = this.props;
+        const { editValue } = this.state;
+
+
         return <input
-            onChange={this.handleChange}
+            onChange={this.onChange}
+            onBlur={this.onBlur}
+            onKeyDown={this.onKeyDown}
             className="mobile hide ui"
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
             spellCheck={false}
             {...rest}
+            value={editValue !== undefined ? editValue : this.props.value}
         />
+    }
+
+    protected onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({
+            editValue: e.target.value
+        });
+
+        const { onChangeValue, view } = this.props;
+        onChangeValue(e.target.value, view);
+    }
+
+    protected onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+        if (!this.state.editValue) return;
+
+        const { onChangeValue, view } = this.props;
+        onChangeValue(e.target.value, view);
+        this.setState({
+            editValue: undefined
+        });
+    }
+
+    protected onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter" && !e.metaKey && !e.shiftKey) {
+            (e.target as HTMLInputElement).blur();
+            e.stopPropagation();
+        }
     }
 }


### PR DESCRIPTION
The project name input in the editor toolbar uses the project name that comes from the parent editor state, which means that every time you do a keystroke the effect of that keystroke needs to propagate from the top down. That makes editing laggy and sometimes causes characters to be missed or the cursor to jump around. Fixing it by using local state.

This bug is easier to see if you open a big project and trigger a compile (i.e. drag a block) right before you start typing in the input.

I don't think this is filed anywhere but it has been annoying me a ton lately. Not a regression but should probably get cherry picked for either this release or next.