### PR TITLE
Handle iframe reload in skillmap

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -130,8 +130,8 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
     protected handleFrameRef = (ref: HTMLIFrameElement) => {
         if (ref && ref.contentWindow) {
             window.addEventListener("message", this.onMessageReceived);
+            ref.addEventListener("load", this.handleFrameReload)
             this.ref = ref;
-
             // Hide Usabilla widget + footer when inside iframe view
             setElementVisible(".usabilla_live_button_container", false);
             setElementVisible("footer", false);
@@ -139,6 +139,10 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             const root = document.getElementById("root");
             if (root) pxt.BrowserUtils.addClass(root, "editor");
         }
+    }
+
+    protected handleFrameReload = () => {
+        this.setState({frameState: "loading"})
     }
 
     protected onMessageReceived = (event: MessageEvent) => {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3782

When the iframe is loading again, kick us back into the loading state for the makecodeFrame. I tested this with an automatic reload (suggested by richard!!) and not the scenario in the bug, but I *think* it should work. 

I will see if an uploadtrg might trigger the bug, and if it does, I'll try testing it there