### PR TITLE
Only load project if skillmap editorview open

### DIFF
--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -274,13 +274,15 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
     protected onEditorLoaded() {
         const { mapId, activityId } = this.props;
-        tickEvent("skillmap.activity.loaded", { path: mapId, activity: activityId });
-        this.setState({
-            frameState: "project-open"
-        });
+        if (mapId && activityId) {
+            tickEvent("skillmap.activity.loaded", { path: mapId, activity: activityId });
+            this.setState({
+                frameState: "project-open"
+            });
 
-        if (this.isNewActivity) {
-            this.isNewActivity = false;
+            if (this.isNewActivity) {
+                this.isNewActivity = false;
+            }
         }
     }
 


### PR DESCRIPTION
this seems to fix https://github.com/microsoft/pxt-arcade/issues/3789 on localhost--i couldn't get a repro on /beta so i'm not entirely sure.

this is a quick fix--the issue is there's some concurrency in the webapp that's causing the blocks editor to reload after we send an unload event, and send an extra editor.loaded tick, which causes the skillmap load a project even when the iframe is hidden. (only happens when clicking the tutorial "Finish" button as far as i can tell.) will try to untangle it from the webapp end later