### PR TITLE
Move editor sidebar into a tabbed panel component 

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -50,18 +50,18 @@ pre {
     position: relative;
 }
 
-#filelist,
+#editorSidebar,
 #maineditor,
 #sidedocs {
   position: absolute;
   bottom: 0rem;
 }
 
-#filelist, #maineditor, #sidedocs {
+#editorSidebar, #maineditor, #sidedocs {
     top: @mainMenuHeight;
 }
 
-.hideMenuBar:not(.headless) #filelist,
+.hideMenuBar:not(.headless) #editorSidebar,
     .hideMenuBar #maineditor,
     .hideMenuBar #sidedocs {
     top: 0 !important;
@@ -153,7 +153,7 @@ pre {
     z-index: (@blocklyFlyoutZIndex)-1;
 }
 
-#blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #filelist {
+#blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #editorSidebar {
     bottom: @editorToolsCollapsedHeight;
 }
 
@@ -163,11 +163,11 @@ pre {
 .hideEditorToolbar #serialEditor,
 .hideEditorToolbar #githubEditor,
 .hideEditorToolbar #assetEditor,
-.hideEditorToolbar #filelist {
+.hideEditorToolbar #editorSidebar {
     bottom: 0rem !important;
 }
 
-#filelistOverlay {
+#miniSimOverlay {
     position: absolute;
     left: 0;
     top: 0;
@@ -181,13 +181,13 @@ pre {
 #simulator {
     height: 100%;
 }
-#filelist, #downloadArea {
+#editorSidebar, #downloadArea {
     min-width: @simulatorWidth;
     max-width: @simulatorWidth;
     left: 0;
 }
 
-#filelist {
+#editorSidebar {
     padding-top: 1em;
     padding-right: ~"calc(2em - @{customScrollbarWidth})";
     padding-bottom: 1em;
@@ -215,7 +215,7 @@ pre {
 }
 
 
-#filelist .simtoolbar {
+#editorSidebar .simtoolbar {
     -webkit-transition: opacity 0.2s; /* Safari */
     -moz-transition: opacity 0.2s; /* Mozilla */
     -webkit-transition-timing-function: linear; /* Mozilla */
@@ -246,30 +246,27 @@ pre {
     background-color: transparent !important;
 }
 
-.filemenu {
-    direction:ltr;
-}
-
-#filelist .menu {
+#editorSidebar .filemenu {
+    direction: ltr;
     width: 100%;
     margin: 0;
     margin-top: 1rem;
 }
 
-#filelist .nested.item {
+.filemenu .nested.item {
     padding: .92857143em 1.14285714em;
     padding-left: 1rem;
 }
 
-#filelist .header.item {
+.filemenu .header.item {
     background: @filelistHeaderBackground;
 }
 
-#filelist .folder.item {
+.filemenu .folder.item {
     font-weight: bold;
 }
 
-#filelist .folderitem.item {
+.filemenu .folderitem.item {
     padding-left: 2rem;
 }
 
@@ -278,7 +275,7 @@ pre {
 }
 
 .simulator .ui.embed .icon.xicon::before {
-    transform: translateX(-77%) translateY(-120%);
+    transform: translateX(-50%) translateY(-50%);
     transition: opacity .25s ease,color .25s ease;
 }
 
@@ -679,7 +676,7 @@ div.simframe > iframe {
     z-index: 1000;
 }
 
-.notificationBannerVisible #filelist,
+.notificationBannerVisible #editorSidebar,
 .notificationBannerVisible #maineditor,
 .notificationBannerVisible #sidedocs {
     top: calc(@mainMenuHeight + @bannerHeight);
@@ -971,7 +968,7 @@ p.ui.font.small {
         display:none !important; // hide desktop simulator toggle
     }
 
-    .hideEditorToolbar #filelist {
+    .hideEditorToolbar #editorSidebar {
         display:none !important;
     }
 
@@ -1035,7 +1032,7 @@ p.ui.font.small {
 *******************************/
 .fullscreensim {
     /* Full screen */
-    #filelist {
+    .simPanel {
         position: fixed;
         z-index: @fullscreenZIndex;
         top:0 !important;
@@ -1048,7 +1045,7 @@ p.ui.font.small {
         min-width: 100%;
         height:100% !important;
     }
-    #filelistOverlay {
+    #miniSimOverlay {
         display: none;
     }
     #boardview {
@@ -1082,7 +1079,7 @@ p.ui.font.small {
     #mainmenu {
         background: transparent !important;
     }
-    #filelist .simtoolbar {
+    .simPanel .simtoolbar {
         position: fixed;
         bottom: 1rem;
         left: auto;
@@ -1125,12 +1122,12 @@ p.ui.font.small {
 ************************************/
 
 #root.headless {
-    #filelist {
+    .simPanel {
         display: block;
         bottom: 0 !important;
     }
 
-    #filelist .simtoolbar.item {
+    .simPanel .simtoolbar.item {
         margin: 1rem 0;
     }
 
@@ -1140,7 +1137,7 @@ p.ui.font.small {
 }
 
 #root.headless.collapsedEditorTools {
-    #filelist {
+    #editorSidebar {
         position: absolute;
         width: auto;
         top: auto;
@@ -1156,7 +1153,7 @@ p.ui.font.small {
 }
 
 #root.headless:not(.collapsedEditorTools) {
-    #filelist {
+    #editorSidebar {
         left: 0;
         z-index: 40;
     }
@@ -1387,7 +1384,7 @@ p.ui.font.small {
         #boardview {
             width: 6.5rem !important;
         }
-        #filelistOverlay {
+        #miniSimOverlay {
             width: 6.5rem !important;
             height: 5.5rem !important;
         }
@@ -1400,7 +1397,7 @@ p.ui.font.small {
 
 /* >= Small Monitor (Small Monitor + Large Monitor + Wide Monitor) */
 @media only screen and (min-width: @computerBreakpoint) {
-    .collapsedEditorTools:not(.headless) #filelist {
+    .collapsedEditorTools:not(.headless) #editorSidebar {
         min-width: 21px;
         width: 21px;
         padding: 0;
@@ -1435,7 +1432,7 @@ p.ui.font.small {
 /* <= Small Monitor (Mobile + Tablet + Small Monitor) */
 @media only screen and (max-width: @largestSmallMonitor) {
     /* Layout */
-    #filelist, #downloadArea {
+    #editorSidebar, #downloadArea {
         min-width:@simulatorWidthSmall;
         max-width:@simulatorWidthSmall;
     }
@@ -1476,8 +1473,8 @@ p.ui.font.small {
         margin: 0;
     }
     /* Layout */
-    #filelist {
-        position:absolute;
+    .simPanel.ui.items {
+        position: fixed;
         padding: 0;
         margin: 1em;
         bottom: ~"calc(4.5rem + var(--extra-mobile-sim-padding))" !important;
@@ -1491,12 +1488,12 @@ p.ui.font.small {
         overflow: visible;
         z-index: 20;
     }
-    #filelist .simtoolbar > .buttons {
+    .simPanel .simtoolbar > .buttons {
         > .debug-button {
             display: block !important;
         }
     }
-    .collapsedEditorTools #filelist {
+    .collapsedEditorTools .simPanel {
         > div {
             display: none !important;
         }
@@ -1504,14 +1501,14 @@ p.ui.font.small {
             display: none !important;
         }
     }
-    #filelistOverlay {
+    #miniSimOverlay {
         position: absolute;
         display: block;
         width: 10rem; /* match width of div.simframe */
         height: 9rem;
     }
 
-    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #filelist {
+    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, .simPanel {
         bottom: @editorToolsCollapsedMobileHeight;
     }
 
@@ -1536,26 +1533,33 @@ p.ui.font.small {
         }
     }
 
+    #editorSidebar {
+        min-width: unset;
+        max-width: unset;
+        width: 0;
+        padding: 0;
+    }
+
     #root:not(.fullscreensim):not(.headless):not(.sandbox) {
         #boardview {
             display: inline-block;
             width: 10rem;
         }
-        #filelist .simtoolbar {
+        .simPanel .simtoolbar {
             margin: 0.5em 0;
             width: 3rem;
             float: right;
         }
-        #filelist .simtoolbar > div:not(:first-child),
-        #filelist .simtoolbar > .buttons > .button {
+        .simPanel .simtoolbar > div:not(:first-child),
+        .simPanel .simtoolbar > .buttons > .button {
             display: none;
         }
-        #filelist .simtoolbar > div:first-child {
+        .simPanel .simtoolbar > div:first-child {
             flex-direction: column;
             border-radius: 4px;
             overflow: hidden;
         }
-        #filelist .simtoolbar > div:first-child > button {
+        .simPanel .simtoolbar > div:first-child > button {
             border-radius: 0;
             font-size: .92857143rem;
         }
@@ -1565,7 +1569,7 @@ p.ui.font.small {
         }
     }
     #root.headless {
-        #filelist {
+        .simPanel {
             left: 5rem!important;
             z-index: 42!important;
         }
@@ -1766,11 +1770,11 @@ p.ui.font.small {
     #maineditor {
         top: @thinMenuHeight;
     }
-    #filelist {
+    #editorSidebar {
         top: @thinMenuHeight;
         padding: 0.5rem 1.5rem;
     }
-    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #filelist {
+    #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #editorSidebar {
         bottom: @editorToolsThinHeight;
     }
 
@@ -1795,7 +1799,7 @@ p.ui.font.small {
     }
 }
 
-.simView #filelist {
+.simView .simPanel {
     position: fixed;
     z-index: @fullscreenZIndex;
     top:0 !important;
@@ -1897,7 +1901,7 @@ div.simframe.ui.embed {
     }
 
     /* Not needed in triple toggle view */
-    #filelistOverlay {
+    #miniSimOverlay {
         display: none;
     }
 
@@ -2048,7 +2052,7 @@ div.signin-button:focus {
         display: inherit;
     }
 
-    #filelist .simtoolbar {
+    .editorSidebar .simtoolbar {
         position: fixed;
         bottom: 0.25em;
         left: auto;

--- a/theme/editor-sidebar.less
+++ b/theme/editor-sidebar.less
@@ -1,0 +1,17 @@
+.tab-container {
+    display: flex;
+    flex-direction: column;
+}
+
+.tab-navigation {
+    display: flex;
+}
+
+.tab-element {
+    padding: 0.5rem;
+    cursor: pointer;
+}
+
+.tab-element:hover {
+    opacity: 0.6;
+}

--- a/theme/greenscreen.less
+++ b/theme/greenscreen.less
@@ -14,7 +14,7 @@
         bottom: 0;
         width:100%;
         height:100%;
-        background-color: @greenScreenColor !important;        
+        background-color: @greenScreenColor !important;
     }
     .videoContainer video {
         min-width:100%;
@@ -24,7 +24,7 @@
         transform: scaleX(-1);
     }
 
-    #maineditor, #filelist, .blocklyToolboxDiv, svg.blocklySvg,
+    #maineditor, #editorSidebar, .blocklyToolboxDiv, svg.blocklySvg,
     .monaco-editor, .monaco-editor .margin, .monaco-editor .monaco-editor-background,
     .monacoToolboxDiv {
         background-image: none !important;
@@ -68,6 +68,6 @@
         background-image: none !important;
         background-color: transparent !important;
         border: none !important;
-        box-shadow: none !important;    
+        box-shadow: none !important;
     }
 }

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -204,7 +204,7 @@
     #root {
         background: @HCRootBackground !important;
     }
-    #filelist {
+    #editorSidebar {
         background: @HCsimulatorBackground !important;
 
         #boardview {

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -24,6 +24,7 @@
 @import 'errorList';
 @import 'asset-editor';
 @import 'tutorialCodeValidation';
+@import 'editor-sidebar';
 
 @import 'light';
 @import 'accessibility';

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -666,7 +666,7 @@ code.lang-filterblocks {
  * CSS for embedded tutorial used in the skills map
  */
 .tutorial.tutorial-embed {
-    #filelist, #maineditor, &.sideDocs #sidedocs, .simView #simulators {
+    #editorSidebar, #maineditor, &.sideDocs #sidedocs, .simView #simulators {
         top: @tutorialEmbedMenuHeight;
     }
     .simView #boardview {
@@ -808,7 +808,7 @@ code.lang-filterblocks {
     * CSS for embedded tutorial used in the skills map
     */
     .tutorial.tutorial-embed {
-        #filelist {
+        #editorSidebar {
             top: unset;
         }
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -25,10 +25,8 @@ import * as accessibility from "./accessibility";
 import * as tutorial from "./tutorial";
 import * as sidebarTutorial from "./sidebarTutorial";
 import * as editortoolbar from "./editortoolbar";
-import * as simtoolbar from "./simtoolbar";
 import * as dialogs from "./dialogs";
 import * as identity from "./identity";
-import * as filelist from "./filelist";
 import * as container from "./container";
 import * as scriptsearch from "./scriptsearch";
 import * as projects from "./projects";
@@ -47,6 +45,7 @@ import * as auth from "./auth";
 import * as cloud from "./cloud";
 import * as user from "./user";
 import * as headerbar from "./headerbar";
+import * as sidepanel from "./sidepanel";
 
 import * as monaco from "./monaco"
 import * as pxtjson from "./pxtjson"
@@ -134,7 +133,6 @@ export class ProjectView
     chooseHwDialog: projects.ChooseHwDialog;
     prevEditorId: string;
     screenshotHandlers: ((msg: pxt.editor.ScreenshotData) => void)[] = [];
-    fileListRef: HTMLDivElement;
 
     private lastChangeTime: number;
     private reload: boolean;
@@ -185,6 +183,7 @@ export class ProjectView
         this.hideLightbox = this.hideLightbox.bind(this);
         this.openSimSerial = this.openSimSerial.bind(this);
         this.openDeviceSerial = this.openDeviceSerial.bind(this);
+        this.openSerial = this.openSerial.bind(this);
         this.toggleGreenScreen = this.toggleGreenScreen.bind(this);
         this.toggleSimulatorFullscreen = this.toggleSimulatorFullscreen.bind(this);
         this.toggleSimulatorCollapse = this.toggleSimulatorCollapse.bind(this);
@@ -4221,20 +4220,6 @@ export class ProjectView
         this.profileDialog = c;
     }
 
-    private handleFileListRef = (c: HTMLDivElement) => {
-        this.fileListRef = c;
-        if (c && typeof ResizeObserver !== "undefined") {
-            const observer = new ResizeObserver(() => {
-                const scrollVisible = c.scrollHeight > c.clientHeight;
-                if (scrollVisible)
-                    this.fileListRef.classList.remove("invisibleScrollbar");
-                else
-                    this.fileListRef.classList.add("invisibleScrollbar");
-            })
-            observer.observe(c);
-        }
-    }
-
     ///////////////////////////////////////////////////////////
     ////////////             RENDER               /////////////
     ///////////////////////////////////////////////////////////
@@ -4348,30 +4333,19 @@ export class ProjectView
                     {!(isSidebarTutorial && flyoutOnly) && inTutorial && <tutorial.TutorialCard ref={ProjectView.tutorialCardId} parent={this} pokeUser={this.state.pokeUserComponent == ProjectView.tutorialCardId} />}
                     {flyoutOnly && <tutorial.WorkspaceHeader parent={this} />}
                 </div>}
+                <sidepanel.Sidepanel parent={this} inHome={inHome}
+                    showKeymap={this.state.keymap && simOpts.keymap}
+                    showSerialButtons={useSerialEditor}
+                    showFileList={showFileList}
+                    showFullscreenButton={!isHeadless}
 
-                <div id="simulator" className="simulator">
-                    <div id="filelist" ref={this.handleFileListRef} className="ui items">
-                        <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0}>
-                        </div>
-                        <simtoolbar.SimulatorToolbar
-                            parent={this}
-                            collapsed={this.state.collapseEditorTools}
-                            simSerialActive={this.state.simSerialActive}
-                            devSerialActive={this.state.deviceSerialActive}
-                        />
-                        {this.state.keymap && simOpts.keymap && <keymap.Keymap parent={this} />}
-                        <div className="ui item portrait hide hidefullscreen">
-                            {pxt.options.debug ? <sui.Button key='hwdebugbtn' className='teal' icon="xicon chip" text={"Dev Debug"} onClick={this.hwDebug} /> : ''}
-                        </div>
-                        {useSerialEditor ?
-                            <div id="serialPreview" className="ui editorFloat portrait hide hidefullscreen">
-                                <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={this.openSimSerial} parent={this} />
-                                <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.openDeviceSerial} parent={this} />
-                            </div> : undefined}
-                        {showFileList ? <filelist.FileList parent={this} /> : undefined}
-                        {!isHeadless && <div id="filelistOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.toggleSimulatorFullscreen}></div>}
-                    </div>
-                </div>
+                    collapseEditorTools={this.state.collapseEditorTools}
+                    simSerialActive={this.state.simSerialActive}
+                    devSerialActive={this.state.deviceSerialActive}
+
+                    openSerial={this.openSerial}
+                    handleHardwareDebugClick={this.hwDebug}
+                    handleFullscreenButtonClick={this.toggleSimulatorFullscreen} />
                 <div id="maineditor" className={(sandbox ? "sandbox" : "") + (inDebugMode ? "debugging" : "")} role="main" aria-hidden={inHome}>
                     {showCollapseButton && <sui.Button id='computertogglesim' className={`computer only collapse-button large`} icon={`inverted chevron ${showRightChevron ? 'right' : 'left'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
                     {this.allEditors.map(e => e.displayOuter(expandedStyle))}

--- a/webapp/src/components/core/TabContent.tsx
+++ b/webapp/src/components/core/TabContent.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export interface TabContentProps {
+    name: string;
+    icon?: string;
+    title?: string;
+    children?: React.ReactNode;
+}
+
+export function TabContent(props: TabContentProps) {
+    return <div>{props.children}</div>
+}

--- a/webapp/src/components/core/TabPane.tsx
+++ b/webapp/src/components/core/TabPane.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+
+import { TabContentProps } from "./TabContent";
+
+interface TabPaneProps {
+    id?: string;
+    className?: string;
+    children?: any;
+    activeTabName?: string;
+}
+
+interface TabPaneState {
+    activeTabName: string;
+}
+
+export class TabPane extends React.Component<TabPaneProps, TabPaneState> {
+    protected containerRef: HTMLDivElement;
+    constructor(props: TabPaneProps) {
+        super(props);
+
+        this.state = { activeTabName: props.activeTabName || props.children?.[0]?.props?.name };
+    }
+
+    protected handleContainerRef = (c: HTMLDivElement) => {
+        this.containerRef = c;
+        if (c && typeof ResizeObserver !== "undefined") {
+            const observer = new ResizeObserver(() => {
+                const scrollVisible = c.scrollHeight > c.clientHeight;
+                if (scrollVisible)
+                    this.containerRef.classList.remove("invisibleScrollbar");
+                else
+                    this.containerRef.classList.add("invisibleScrollbar");
+            })
+            observer.observe(c);
+        }
+    }
+
+    protected getTabClickHandler = (name: string) => {
+        return () => this.setState({ activeTabName: name });
+    }
+
+    render() {
+        const { id, children, className } = this.props;
+        const { activeTabName } = this.state;
+
+        return <div id={id} className={`tab-container ${className || ""}`} ref={this.handleContainerRef}>
+            {Array.isArray(children) && <div className="tab-navigation">
+                {children.map(el => {
+                    const { name, icon, title } = el.props as TabContentProps;
+                    return <div key={name} className={`tab-element ${name == activeTabName ? "active" : ""}`} onClick={this.getTabClickHandler(name)}>
+                        <i className={`ui icon ${icon}`} />
+                        <span>{title}</span>
+                    </div>
+                })}
+            </div>}
+            {Array.isArray(children)
+                ? children.map((el: any) => {
+                    const { name } = el.props as TabContentProps;
+                    return <div className={`tab-content ${name !== activeTabName ? "hidden" : ""}`}>
+                        {el}
+                    </div>
+                })
+                : children
+            }
+        </div>
+    }
+}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -1,0 +1,89 @@
+/// <reference path="../../built/pxtlib.d.ts" />
+
+import * as React from "react";
+import * as data from "./data";
+import * as sui from "./sui";
+
+import * as filelist from "./filelist";
+import * as keymap from "./keymap";
+import * as serialindicator from "./serialindicator"
+import * as simtoolbar from "./simtoolbar";
+
+interface SidepanelState {
+}
+
+interface SidepanelProps extends pxt.editor.ISettingsProps {
+    inHome: boolean;
+
+    showKeymap?: boolean;
+    showSerialButtons?: boolean;
+    showFileList?: boolean;
+    showFullscreenButton?: boolean;
+
+    collapseEditorTools?: boolean;
+    simSerialActive?: boolean;
+    deviceSerialActive?: boolean;
+
+    openSerial: (isSim: boolean) => void;
+    handleHardwareDebugClick: () => void;
+    handleFullscreenButtonClick: () => void;
+}
+
+export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
+    protected fileListRef: HTMLDivElement;
+
+    constructor(props: SidepanelProps) {
+        super(props);
+    }
+
+    protected handleSimSerialClick = () => {
+        this.props.openSerial(true);
+    }
+
+    protected handleDeviceSerialClick = () => {
+        this.props.openSerial(false);
+    }
+
+    protected handleFileListRef = (c: HTMLDivElement) => {
+        this.fileListRef = c;
+        if (c && typeof ResizeObserver !== "undefined") {
+            const observer = new ResizeObserver(() => {
+                const scrollVisible = c.scrollHeight > c.clientHeight;
+                if (scrollVisible)
+                    this.fileListRef.classList.remove("invisibleScrollbar");
+                else
+                    this.fileListRef.classList.add("invisibleScrollbar");
+            })
+            observer.observe(c);
+        }
+    }
+
+    renderCore() {
+        const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton,
+            collapseEditorTools, simSerialActive, deviceSerialActive,
+            handleHardwareDebugClick, handleFullscreenButtonClick } = this.props;
+
+        return <div id="simulator" className="simulator">
+            <div>
+                <div className="sidepanelTab"></div>
+                <div className="sidepanelTab"></div>
+            </div>
+            <div id="sidepanel">
+                <div id="filelist" ref={this.handleFileListRef} className="ui items">
+                    <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
+                    <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} />
+                    {showKeymap && <keymap.Keymap parent={parent} />}
+                    <div className="ui item portrait hide hidefullscreen">
+                        {pxt.options.debug && <sui.Button key='hwdebugbtn' className='teal' icon="xicon chip" text={"Dev Debug"} onClick={handleHardwareDebugClick} />}
+                    </div>
+                    {showSerialButtons && <div id="serialPreview" className="ui editorFloat portrait hide hidefullscreen">
+                        <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={this.handleSimSerialClick} parent={parent} />
+                        <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.handleDeviceSerialClick} parent={parent} />
+                    </div>}
+                    {showFileList && <filelist.FileList parent={parent} />}
+                    {showFullscreenButton && <div id="filelistOverlay" role="button" title={lf("Open in fullscreen")} onClick={handleFullscreenButtonClick} />}
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -9,6 +9,9 @@ import * as keymap from "./keymap";
 import * as serialindicator from "./serialindicator"
 import * as simtoolbar from "./simtoolbar";
 
+import { TabContent } from "./components/core/TabContent";
+import { TabPane } from "./components/core/TabPane";
+
 interface SidepanelState {
 }
 
@@ -30,8 +33,6 @@ interface SidepanelProps extends pxt.editor.ISettingsProps {
 }
 
 export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
-    protected fileListRef: HTMLDivElement;
-
     constructor(props: SidepanelProps) {
         super(props);
     }
@@ -44,46 +45,30 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         this.props.openSerial(false);
     }
 
-    protected handleFileListRef = (c: HTMLDivElement) => {
-        this.fileListRef = c;
-        if (c && typeof ResizeObserver !== "undefined") {
-            const observer = new ResizeObserver(() => {
-                const scrollVisible = c.scrollHeight > c.clientHeight;
-                if (scrollVisible)
-                    this.fileListRef.classList.remove("invisibleScrollbar");
-                else
-                    this.fileListRef.classList.add("invisibleScrollbar");
-            })
-            observer.observe(c);
-        }
-    }
-
     renderCore() {
         const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton,
             collapseEditorTools, simSerialActive, deviceSerialActive,
             handleHardwareDebugClick, handleFullscreenButtonClick } = this.props;
 
         return <div id="simulator" className="simulator">
-            <div>
-                <div className="sidepanelTab"></div>
-                <div className="sidepanelTab"></div>
-            </div>
-            <div id="sidepanel">
-                <div id="filelist" ref={this.handleFileListRef} className="ui items">
-                    <div id="boardview" className={`ui vertical editorFloat`} role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
-                    <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} />
-                    {showKeymap && <keymap.Keymap parent={parent} />}
-                    <div className="ui item portrait hide hidefullscreen">
-                        {pxt.options.debug && <sui.Button key='hwdebugbtn' className='teal' icon="xicon chip" text={"Dev Debug"} onClick={handleHardwareDebugClick} />}
+            <TabPane id="editorSidebar">
+                <TabContent name="tab-simulator">
+                    <div className="ui items simPanel">
+                        <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
+                        <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} />
+                        {showKeymap && <keymap.Keymap parent={parent} />}
+                        <div className="ui item portrait hide hidefullscreen">
+                            {pxt.options.debug && <sui.Button key="hwdebugbtn" className="teal" icon="xicon chip" text={"Dev Debug"} onClick={handleHardwareDebugClick} />}
+                        </div>
+                        {showSerialButtons && <div id="serialPreview" className="ui editorFloat portrait hide hidefullscreen">
+                            <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={this.handleSimSerialClick} parent={parent} />
+                            <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.handleDeviceSerialClick} parent={parent} />
+                        </div>}
+                        {showFileList && <filelist.FileList parent={parent} />}
+                        {showFullscreenButton && <div id="miniSimOverlay" role="button" title={lf("Open in fullscreen")} onClick={handleFullscreenButtonClick} />}
                     </div>
-                    {showSerialButtons && <div id="serialPreview" className="ui editorFloat portrait hide hidefullscreen">
-                        <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={this.handleSimSerialClick} parent={parent} />
-                        <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.handleDeviceSerialClick} parent={parent} />
-                    </div>}
-                    {showFileList && <filelist.FileList parent={parent} />}
-                    {showFullscreenButton && <div id="filelistOverlay" role="button" title={lf("Open in fullscreen")} onClick={handleFullscreenButtonClick} />}
-                </div>
-            </div>
+                </TabContent>
+            </TabPane>
         </div>
     }
 }


### PR DESCRIPTION
reopening https://github.com/microsoft/pxt/pull/8308

there is no visual difference with this change, it just shifts the DOM elements around to make the tutorial implementation easier! adds a tabbed pane component and separates the filelist div element into an editorSidebar parent and a simPanel child element, so that we can later show the tutorial view and the small simulator