### PR TITLE
blog link for tweeted url

### DIFF
--- a/docs/blog/arcade/in.md
+++ b/docs/blog/arcade/in.md
@@ -1,0 +1,40 @@
+# Introducing Cloud Sync for MakeCode Arcade
+
+**Posted on August 12th, 2021 by [eanders-ms](https://github.com/eanders-ms)**
+
+**Note**: As of this writing, sign-in and cloud sync are only available in [MakeCode Arcade](https://arcade.makecode.com).
+
+Over the past year we've been working hard to bring you the ability to sign into MakeCode with a [Microsoft Account](https://aka.ms/AAdd6f8). When you sign into MakeCode, you make it possible for us to remember who you are, and this unlocks a bunch of exciting new possibilities. For example, it becomes possible for us to remember what you were working on and make your projects available wherever you use MakeCode. In fact this is the first feature we've built for our signed in users, and we're calling it **Cloud Sync**.
+
+## What is Cloud Sync?
+
+Have you ever been working on a MakeCode project at school and wanted to take it home? In the past, users have found creative ways to move projects from device to device and browser to browser, and these methods will still work! But Cloud Sync makes this a seamless experience: when you sign into MakeCode, your cloud-saved projects are downloaded to your browser automatically.
+
+Perhaps you've had the experience of returning to a lab computer only to realize the machine had been reset overnight, erasing your projects with it. Losing all your work can be devastating. Cloud Sync guards against this by continouously saving your work to the cloud as you edit your project.
+
+## Nice! How do I enable it?
+
+Cloud sync is enabled automatically when you sign into MakeCode. However, after signing in, your existing projects remain local, meaning they're not automatically transferred to the cloud all at once. To transfer an existing project to the cloud, just open it in the editor. The editor's auto-save feature will trigger a cloud save and voilà, your project is in the cloud. New projects are cloud-synced automatically from the start. Look for the editor's new cloud save indicator:
+
+![Cloud Save Indicator](/static/blog/arcade/intro-cloud-sync/cloud-save.gif)
+
+On the home screen, you can tell a project is saved to cloud if it has a visible cloud status icon:
+
+![Cloud Status Icon](/static/blog/arcade/intro-cloud-sync/cloud-status-icon.png)
+
+## The Future
+
+The addition of identity to MakeCode represents a new foundation upon which a wide range of user-aware features can be built. We're excited by all the possiblities! But we're going to build on this new foundation carefully and thoughtfully, with your privacy and safety always our first priority.
+
+## Feedback?
+
+Love it? Hate it? Have a suggestion? We'd love to hear from you! Drop us a note in the MakeCode forums at https://forum.makecode.com.
+
+## Additional Resources
+
+* Learn more about Cloud Sync [here](/identity/cloud-sync).
+* More on identity in MakeCode [here](/identity/sign-in).
+* [What are Microsoft Accounts?](https://account.microsoft.com/account)
+* [Create a Microsoft Account](https://signup.live.com/signup)
+* [MSA Terms of Service](https://www.microsoft.com/servicesagreement)
+* [Microsoft Privacy Statement](https://privacy.microsoft.com/privacystatement)


### PR DESCRIPTION
Tweeted link was truncated to https://makecode.com/blog/arcade/in, so let's put the blog post there.