### PR TITLE
Add flag for new tutorial layout, hook up to tutorialOptions state

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -164,6 +164,12 @@ namespace pxt.BrowserUtils {
         } catch (e) { return false; }
     }
 
+    export function isVerticalTutorial(): boolean {
+        try {
+            return /tutoriallayout=v/.test(window.location.href);
+        } catch (e) { return false; }
+    }
+
     export function hasPointerEvents(): boolean {
         return typeof window != "undefined" && !!(window as any).PointerEvent;
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -190,6 +190,7 @@ export class ProjectView
         this.showKeymap = this.showKeymap.bind(this);
         this.toggleKeymap = this.toggleKeymap.bind(this);
         this.showMiniSim = this.showMiniSim.bind(this);
+        this.setTutorialStep = this.setTutorialStep.bind(this);
         this.initSimulatorMessageHandlers();
 
         // add user hint IDs and callback to hint manager
@@ -1274,7 +1275,7 @@ export class ProjectView
 
         this.stopPokeUserActivity();
         let tc = this.refs[ProjectView.tutorialCardId] as tutorial.TutorialCard;
-        if (!tc) return;
+        if (!this.isTutorial()) return;
         if (step > -1) {
             let tutorialOptions = this.state.tutorialOptions;
             tutorialOptions.tutorialStep = step;
@@ -1284,7 +1285,7 @@ export class ProjectView
                 workspace.saveAsync(this.state.header);
             });
             const showHint = tutorialOptions.tutorialStepInfo[step].showHint;
-            if (showHint) this.showTutorialHint();
+            if (showHint && tc) this.showTutorialHint();
 
             const isCompleted = tutorialOptions.tutorialStepInfo[step].tutorialCompleted;
             if (isCompleted && pxt.commands.onTutorialCompleted) pxt.commands.onTutorialCompleted();
@@ -4370,7 +4371,8 @@ export class ProjectView
                     handleHardwareDebugClick={this.hwDebug}
                     handleFullscreenButtonClick={this.toggleSimulatorFullscreen}
 
-                    tutorialOptions={isVerticalTutorial ? tutorialOptions : undefined}/>
+                    tutorialOptions={isVerticalTutorial ? tutorialOptions : undefined}
+                    onTutorialStepChange={this.setTutorialStep} />
                 <div id="maineditor" className={(sandbox ? "sandbox" : "") + (inDebugMode ? "debugging" : "")} role="main" aria-hidden={inHome}>
                     {showCollapseButton && <sui.Button id='computertogglesim' className={`computer only collapse-button large`} icon={`inverted chevron ${showRightChevron ? 'right' : 'left'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
                     {this.allEditors.map(e => e.displayOuter(expandedStyle))}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4255,6 +4255,7 @@ export class ProjectView
         const tutorialOptions = this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
+        const isVerticalTutorial = pxt.BrowserUtils.isVerticalTutorial();
         const inTutorialExpanded = inTutorial && tutorialOptions.tutorialStepExpanded;
         const hideTutorialIteration = inTutorial && tutorialOptions.metadata && tutorialOptions.metadata.hideIteration;
         const inDebugMode = this.state.debugging;
@@ -4273,7 +4274,7 @@ export class ProjectView
         const showMiniSim = this.state.showMiniSim || window?.innerWidth <= pxt.BREAKPOINT_TABLET;
 
         const showSideDoc = sideDocs && this.state.sideDocsLoadUrl && !this.state.sideDocsCollapsed;
-        const showCollapseButton = showEditorToolbar && !inHome && !sandbox && !targetTheme.simCollapseInMenu && (!isHeadless || inDebugMode);
+        const showCollapseButton = showEditorToolbar && !inHome && !sandbox && !targetTheme.simCollapseInMenu && (!isHeadless || inDebugMode) && !isVerticalTutorial;
         const shouldHideEditorFloats = this.state.hideEditorFloats || this.state.collapseEditorTools;
         const logoWide = !!targetTheme.logoWide;
         const hwDialog = !sandbox && pxt.hasHwVariants();
@@ -4299,8 +4300,8 @@ export class ProjectView
             showSideDoc ? 'sideDocs' : '',
             pxt.shell.layoutTypeClass(),
             inHome ? 'inHome' : '',
-            inTutorial ? 'tutorial' : '',
-            inTutorialExpanded ? 'tutorialExpanded' : '',
+            inTutorial && !isVerticalTutorial ? 'tutorial' : '',
+            inTutorialExpanded && !isVerticalTutorial ? 'tutorialExpanded' : '',
             isSidebarTutorial ? 'sidebarTutorial' : '',
             inDebugMode ? 'debugger' : '',
             pxt.options.light ? 'light' : '',
@@ -4350,7 +4351,7 @@ export class ProjectView
                         <headerbar.HeaderBar parent={this} />
                     </header>}
                 {isSidebarTutorial && flyoutOnly && inTutorial && <sidebarTutorial.SidebarTutorialCard ref={ProjectView.tutorialCardId} parent={this} pokeUser={this.state.pokeUserComponent == ProjectView.tutorialCardId} />}
-                {inTutorial && <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
+                {inTutorial && !isVerticalTutorial && <div id="maineditor" className={sandbox ? "sandbox" : ""} role="main">
                     {!(isSidebarTutorial && flyoutOnly) && inTutorial && <tutorial.TutorialCard ref={ProjectView.tutorialCardId} parent={this} pokeUser={this.state.pokeUserComponent == ProjectView.tutorialCardId} />}
                     {flyoutOnly && <tutorial.WorkspaceHeader parent={this} />}
                 </div>}
@@ -4367,7 +4368,9 @@ export class ProjectView
                     showMiniSim={this.showMiniSim}
                     openSerial={this.openSerial}
                     handleHardwareDebugClick={this.hwDebug}
-                    handleFullscreenButtonClick={this.toggleSimulatorFullscreen} />
+                    handleFullscreenButtonClick={this.toggleSimulatorFullscreen}
+
+                    tutorialOptions={isVerticalTutorial ? tutorialOptions : undefined}/>
                 <div id="maineditor" className={(sandbox ? "sandbox" : "") + (inDebugMode ? "debugging" : "")} role="main" aria-hidden={inHome}>
                     {showCollapseButton && <sui.Button id='computertogglesim' className={`computer only collapse-button large`} icon={`inverted chevron ${showRightChevron ? 'right' : 'left'}`} title={collapseIconTooltip} onClick={this.toggleSimulatorCollapse} />}
                     {this.allEditors.map(e => e.displayOuter(expandedStyle))}
@@ -5145,10 +5148,12 @@ document.addEventListener("DOMContentLoaded", async () => {
             }
 
             // Check to see if we should show the mini simulator (<= tablet size)
-            if (window?.innerWidth <= pxt.BREAKPOINT_TABLET) {
-                theEditor.showMiniSim(true);
-            } else {
-                theEditor.showMiniSim(false);
+            if (!theEditor.isTutorial() || !pxt.BrowserUtils.isVerticalTutorial()) {
+                if (window?.innerWidth <= pxt.BREAKPOINT_TABLET) {
+                    theEditor.showMiniSim(true);
+                } else {
+                    theEditor.showMiniSim(false);
+                }
             }
         }
     }, false);

--- a/webapp/src/components/core/TabPane.tsx
+++ b/webapp/src/components/core/TabPane.tsx
@@ -10,15 +10,23 @@ interface TabPaneProps {
 }
 
 export function TabPane(props: TabPaneProps) {
-    const { id, children, className } = props;
-    const [ activeTab, setActiveTab ] = React.useState(props.activeTabName);
+    const { id, children, className, activeTabName } = props;
+    const [ activeTab, setActiveTab ] = React.useState(activeTabName);
     const childArray = Array.isArray(children) ? children.filter((el: any) => !!el) : [children];
 
     React.useEffect(() => {
         if (!childArray.some((el: any) => el.props.name === activeTab)) {
-            setActiveTab(childArray[0].props.name)
+            setActiveTab(childArray[0].props.name);
         }
     }, [children])
+
+    React.useEffect(() => {
+        if (childArray.some((el: any) => el.props.name === activeTabName)) {
+            setActiveTab(activeTabName);
+        } else {
+            setActiveTab(childArray[0].props.name);
+        }
+    }, [activeTabName])
 
     return <div id={id} className={`tab-container ${className || ""}`}>
         {childArray.length > 1 && <div className="tab-navigation">

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -12,18 +12,25 @@ interface TutorialContainerProps {
     currentStep?: number;
 
     tutorialOptions?: pxt.tutorial.TutorialOptions; // TODO (shakao) pass in only necessary subset
+
+    onTutorialStepChange?: (step: number) => void;
 }
 
 export function TutorialContainer(props: TutorialContainerProps) {
-    const { parent, steps, tutorialOptions } = props;
+    const { parent, steps, tutorialOptions, onTutorialStepChange } = props;
     const [ currentStep, setCurrentStep ] = React.useState(props.currentStep || 0);
 
     const markdown = steps[currentStep].headerContentMd;
     const showImmersiveReader = pxt.appTarget.appTheme.immersiveReader;
 
+    const setTutorialStep = (step: number) => {
+        onTutorialStepChange(step);
+        setCurrentStep(step);
+    }
+
     return <div className="tutorial-container">
         <div className="tutorial-top-bar">
-            <TutorialStepCounter currentStep={currentStep} totalSteps={steps.length} setTutorialStep={setCurrentStep} />
+            <TutorialStepCounter currentStep={currentStep} totalSteps={steps.length} setTutorialStep={setTutorialStep} />
             {showImmersiveReader && <ImmersiveReaderButton content={markdown} tutorialOptions={tutorialOptions} />}
         </div>
         <div className="tutorial-content">
@@ -31,10 +38,10 @@ export function TutorialContainer(props: TutorialContainerProps) {
         </div>
         <div className="tutorial-controls">
             <Button icon="arrow circle left" disabled={currentStep === 0}
-                text={lf("Back")} onClick={() => setCurrentStep(Math.max(currentStep - 1, 0))} />
+                text={lf("Back")} onClick={() => setTutorialStep(Math.max(currentStep - 1, 0))} />
             <Button icon="lightbulb" className="tutorial-hint" />
             <Button icon="arrow circle right" disabled={currentStep === steps.length - 1}
-                text={lf("Next")} onClick={() => setCurrentStep(Math.min(currentStep + 1, props.steps.length - 1))} />
+                text={lf("Next")} onClick={() => setTutorialStep(Math.min(currentStep + 1, props.steps.length - 1))} />
         </div>
     </div>
 }

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -83,7 +83,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
             return "sandbox";
         } else if (debugging) {
             return "debugging";
-        } else if (!!tutorialOptions?.tutorial) {
+        } else if (!!tutorialOptions?.tutorial && !pxt.BrowserUtils.isVerticalTutorial()) {
             return "tutorial";
         } else {
             return "editor";
@@ -116,7 +116,8 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         const languageRestriction = pkg.mainPkg?.config?.languageRestriction;
         // If there is only one editor (eg Py only, no assets), we display a label instead of a toggle
         const hideToggle = !showAssets && (languageRestriction === pxt.editor.LanguageRestriction.JavaScriptOnly
-            || languageRestriction === pxt.editor.LanguageRestriction.PythonOnly) || targetTheme.blocksOnly;
+            || languageRestriction === pxt.editor.LanguageRestriction.PythonOnly) || targetTheme.blocksOnly
+            || pxt.BrowserUtils.isVerticalTutorial();
 
         switch (view) {
             case "tutorial":

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -14,6 +14,7 @@ import { TabPane } from "./components/core/TabPane";
 import { TutorialContainer } from "./components/tutorial/TutorialContainer";
 
 interface SidepanelState {
+    activeTab?: string;
 }
 
 interface SidepanelProps extends pxt.editor.ISettingsProps {
@@ -55,7 +56,18 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     }
 
     protected handleTutorialTabSelected = () => {
+        this.setState({ activeTab: "tab-tutorial" });
         this.props.showMiniSim(true);
+    }
+
+    protected handleSimOverlayClick = () => {
+        const { tutorialOptions, handleFullscreenButtonClick } = this.props;
+        if (!tutorialOptions || !pxt.BrowserUtils.isVerticalTutorial()) {
+            handleFullscreenButtonClick();
+        } else {
+            this.setState({ activeTab: "tab-simulator" });
+            this.props.showMiniSim(false);
+        }
     }
 
     protected handleSimPanelRef = (c: HTMLDivElement) => {
@@ -75,10 +87,10 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     renderCore() {
         const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton,
             collapseEditorTools, simSerialActive, deviceSerialActive, tutorialOptions,
-            handleHardwareDebugClick, handleFullscreenButtonClick } = this.props;
+            handleHardwareDebugClick } = this.props;
 
         return <div id="simulator" className="simulator">
-            <TabPane id="editorSidebar">
+            <TabPane id="editorSidebar" activeTabName={this.state.activeTab}>
                 <TabContent name="tab-simulator" icon="game" onSelected={this.handleSimTabSelected}>
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
@@ -92,7 +104,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                             <serialindicator.SerialIndicator ref="devIndicator" isSim={false} onClick={this.handleDeviceSerialClick} parent={parent} />
                         </div>}
                         {showFileList && <filelist.FileList parent={parent} />}
-                        {showFullscreenButton && <div id="miniSimOverlay" role="button" title={lf("Open in fullscreen")} onClick={handleFullscreenButtonClick} />}
+                        {showFullscreenButton && <div id="miniSimOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.handleSimOverlayClick} />}
                     </div>
                 </TabContent>
                 {tutorialOptions && <TabContent name="tab-tutorial" icon="pencil" onSelected={this.handleTutorialTabSelected}>

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -44,6 +44,12 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         super(props);
     }
 
+    UNSAFE_componentWillReceiveProps(props: SidepanelProps) {
+        if (!this.props.tutorialOptions && props.tutorialOptions) {
+            this.setState({ activeTab: "tab-tutorial" });
+        }
+    }
+
     protected handleSimSerialClick = () => {
         this.props.openSerial(true);
     }

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -30,6 +30,7 @@ interface SidepanelProps extends pxt.editor.ISettingsProps {
     deviceSerialActive?: boolean;
 
     tutorialOptions?: pxt.tutorial.TutorialOptions;
+    onTutorialStepChange?: (step: number) => void;
 
     showMiniSim: (visible?: boolean) => void;
     openSerial: (isSim: boolean) => void;
@@ -87,7 +88,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     renderCore() {
         const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton,
             collapseEditorTools, simSerialActive, deviceSerialActive, tutorialOptions,
-            handleHardwareDebugClick } = this.props;
+            handleHardwareDebugClick, onTutorialStepChange } = this.props;
 
         return <div id="simulator" className="simulator">
             <TabPane id="editorSidebar" activeTabName={this.state.activeTab}>
@@ -109,7 +110,8 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                 </TabContent>
                 {tutorialOptions && <TabContent name="tab-tutorial" icon="pencil" onSelected={this.handleTutorialTabSelected}>
                     <TutorialContainer parent={parent} steps={tutorialOptions?.tutorialStepInfo}
-                        currentStep={tutorialOptions?.tutorialStep} tutorialOptions={tutorialOptions} />
+                        currentStep={tutorialOptions?.tutorialStep} tutorialOptions={tutorialOptions}
+                        onTutorialStepChange={onTutorialStepChange} />
                 </TabContent>}
             </TabPane>
         </div>


### PR DESCRIPTION
bunch of small changes to hook up the new components! each commit is one item:
- https://github.com/microsoft/pxt/commit/c01809922b539ea161c3cd8863c1127b41370964 adds `tutoriallayout=v` url flag for viewing the new layout! temporary name, ultimately i want to turn the vertical layout on by default and have a force=horizontal flag or something 
- https://github.com/microsoft/pxt/commit/c8840d225b078a90876bb01b15706be949af95e3 clicking on the screen of the mini sim opens the simulator tab (no animation yet) 
- https://github.com/microsoft/pxt/commit/e17f1a487ffbd2af40375c1a649c134d8b32c034 callback for saving the step change into the project header 
- https://github.com/microsoft/pxt/commit/279c9750ea5f65faead447ca69c162e888e42ff4 open tutorial tab by default. might swap the Sidepanel to be a functional component/use hooks later as well