### PR TITLE
Check for placeholder type before guessing a new type

### DIFF
--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -226,7 +226,7 @@ namespace pxt.blocks {
                                 if (t.parentType) {
                                     return t.parentType;
                                 }
-                                tp = ground(t.type + "[]");
+                                tp = t.type ? ground(t.type + "[]") : mkPoint(null);
                                 genericLink(tp, t);
                                 break;
                             }
@@ -260,7 +260,7 @@ namespace pxt.blocks {
                     if (parentType.childType) {
                         return parentType.childType;
                     }
-                    const p = isArrayType(parentType.type) ? mkPoint(parentType.type.substr(0, parentType.type.length - 2)) : mkPoint(null);
+                    const p = isArrayType(parentType.type) && parentType.type !== "Array" ? mkPoint(parentType.type.substr(0, parentType.type.length - 2)) : mkPoint(null);
                     genericLink(parentType, p);
                     return p;
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3808

I'm still not entirely sure what the trigger for this bug is and I couldn't find a small enough repro to make a test case, but I'm fairly certain this is a safe fix to check in.