### PR TITLE
Initial CSS for horizontal tutorial tab

### DIFF
--- a/theme/common-components.less
+++ b/theme/common-components.less
@@ -5,6 +5,7 @@
 
 .tab-navigation {
     display: flex;
+    flex-shrink: 0;
 }
 
 .tab-icon {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -1,3 +1,5 @@
+@defaultTutorialHeight: 18rem;
+
 /*******************************
         Tutorial Tab
 *******************************/
@@ -15,6 +17,11 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+
+    .ui.button {
+        margin: 0;
+        box-shadow: none;
+    }
 }
 
 .tutorial-content {
@@ -30,6 +37,40 @@
 }
 
 /*******************************
+       Tutorial Top Buttons
+*******************************/
+
+.tutorial-top-bar {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem 0;
+}
+
+/*******************************
+         Step Counter
+*******************************/
+
+.tutorial-step-counter {
+    flex: 1;
+    margin-right: 0.5rem;
+}
+
+.tutorial-step-bar {
+    height: 1rem;
+    overflow: hidden;
+    border-radius: 1rem;
+    background-color: @blue;
+    cursor: pointer;
+}
+
+.tutorial-step-bar-fill {
+    background-color: @teal;
+    height: 100%;
+    transition: width 0.5s ease-out;
+    pointer-events: none;
+}
+
+/*******************************
         Tutorial Controls
 *******************************/
 
@@ -42,7 +83,6 @@
         margin: 0 0.4rem;
         color: @blue;
         background: @teal;
-        box-shadow: none;
         font-size: 1.2rem;
         white-space: nowrap;
         overflow: hidden;
@@ -97,40 +137,6 @@
 }
 
 /*******************************
-       Tutorial Top Buttons
-*******************************/
-
-.tutorial-top-bar {
-    display: flex;
-    align-items: center;
-    padding: 0.5rem 1rem 0;
-}
-
-/*******************************
-         Step Counter
-*******************************/
-
-.tutorial-step-counter {
-    flex: 1;
-    margin-right: 0.5rem;
-}
-
-.tutorial-step-bar {
-    height: 1rem;
-    overflow: hidden;
-    border-radius: 1rem;
-    background-color: @blue;
-    cursor: pointer;
-}
-
-.tutorial-step-bar-fill {
-    background-color: @teal;
-    height: 100%;
-    transition: width 0.5s ease-out;
-    pointer-events: none;
-}
-
-/*******************************
         Simulator Tab
 *******************************/
 
@@ -171,5 +177,96 @@
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
     .tutorialhint {
         left: 2rem;
+    }
+}
+
+/* <= Tablet (Mobile + Tablet) */
+@media only screen and (max-width: @largestTabletScreen) {
+    .tutorialVertical #maineditor > .full-abs {
+        top: @defaultTutorialHeight;
+    }
+
+    .tutorialVertical #editorSidebar {
+        top: @mobileMenuHeight;
+        height: @defaultTutorialHeight;
+        width: 100%;
+        border-right: 0;
+        border-bottom: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
+    }
+
+    .tab-tutorial.tab-content {
+        padding-top: 0;
+    }
+
+    .tutorial-container {
+        flex-direction: row;
+    }
+
+    .tutorial-content {
+        margin: 0;
+        padding: 1rem;
+    }
+
+    /*******************************
+        Tutorial Top Buttons
+    *******************************/
+
+    .tutorial-top-bar {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 14rem;
+        flex-direction: row-reverse;
+        padding: 0.2rem 1rem;
+    }
+
+    #editorSidebar .immersive-reader-button.ui.item,
+    #editorSidebar .immersive-reader-button.ui.item:focus{
+        background-image: @immersiveReaderLightIcon;
+    }
+
+    /*******************************
+            Step Counter
+    *******************************/
+
+    .tutorial-step-counter {
+        margin-left: 1rem;
+        margin-right: 0;
+        color: @white;
+    }
+
+    .tutorial-step-bar {
+        background-color: @white;
+    }
+
+    .tutorial-step-bar-fill {
+        background-color: @blue;
+    }
+
+    /*******************************
+            Tutorial Controls
+    *******************************/
+
+    .tutorial-container {
+        .ui.button {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            width: 4rem;
+            color: @teal;
+            background: @white;
+            box-shadow: none;
+            border-radius: 0;
+
+            > .arrow {
+                margin-bottom: 0.5rem!important;
+                font-size: 2rem;
+            }
+
+            > .text {
+                margin: 0 !important;
+            }
+        }
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4256,7 +4256,7 @@ export class ProjectView
         const tutorialOptions = this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
-        const isVerticalTutorial = pxt.BrowserUtils.isVerticalTutorial();
+        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.isVerticalTutorial();
         const inTutorialExpanded = inTutorial && tutorialOptions.tutorialStepExpanded;
         const hideTutorialIteration = inTutorial && tutorialOptions.metadata && tutorialOptions.metadata.hideIteration;
         const inDebugMode = this.state.debugging;
@@ -4271,8 +4271,6 @@ export class ProjectView
         const selectLanguage = targetTheme.selectLanguage;
         const showEditorToolbar = inEditor && !hideEditorToolbar && this.editor.hasEditorToolbar();
         const useSerialEditor = pxt.appTarget.serial && !!pxt.appTarget.serial.useEditor;
-        // Check to see if we should show the mini simulator (<= tablet size)
-        const showMiniSim = this.state.showMiniSim || window?.innerWidth <= pxt.BREAKPOINT_TABLET;
 
         const showSideDoc = sideDocs && this.state.sideDocsLoadUrl && !this.state.sideDocsCollapsed;
         const showCollapseButton = showEditorToolbar && !inHome && !sandbox && !targetTheme.simCollapseInMenu && (!isHeadless || inDebugMode) && !isVerticalTutorial;
@@ -4296,13 +4294,14 @@ export class ProjectView
             transparentEditorToolbar ? "transparentEditorTools" : '',
             invertedTheme ? 'inverted-theme' : '',
             this.state.fullscreen ? 'fullscreensim' : '',
-            showMiniSim ? 'miniSim' : '',
+            this.state.showMiniSim ? 'miniSim' : '',
             hc ? 'hc' : '',
             showSideDoc ? 'sideDocs' : '',
             pxt.shell.layoutTypeClass(),
             inHome ? 'inHome' : '',
             inTutorial && !isVerticalTutorial ? 'tutorial' : '',
             inTutorialExpanded && !isVerticalTutorial ? 'tutorialExpanded' : '',
+            isVerticalTutorial ? 'tutorialVertical' : '',
             isSidebarTutorial ? 'sidebarTutorial' : '',
             inDebugMode ? 'debugger' : '',
             pxt.options.light ? 'light' : '',

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -22,6 +22,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const { parent, name, steps, tutorialOptions, onTutorialStepChange } = props;
     const [ currentStep, setCurrentStep ] = React.useState(props.currentStep || 0);
     const [ hideModal, setHideModal ] = React.useState(false);
+    const [ layout, setLayout ] = React.useState<"vertical" | "horizontal">("vertical");
 
     const currentStepInfo = steps[currentStep];
     if (!steps[currentStep]) return <div />;
@@ -43,6 +44,19 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const tutorialStepNext = () => setTutorialStep(Math.min(currentStep + 1, props.steps.length - 1));
     const tutorialStepBack = () => setTutorialStep(Math.max(currentStep - 1, 0));
 
+    React.useEffect(() => {
+        const observer = new ResizeObserver(() => {
+            if (window.innerWidth <= pxt.BREAKPOINT_TABLET) {
+                setLayout("horizontal");
+            } else {
+                setLayout("vertical");
+            }
+        });
+        observer.observe(document.body)
+        return () => observer.disconnect();
+    }, [document.body])
+
+
     let modalActions: ModalButton[] = [
         { label: lf("Back"), onclick: tutorialStepBack, icon: "arrow circle left", disabled: !showBack, labelPosition: "left" },
         { label: lf("Ok"), onclick: tutorialStepNext, icon: "arrow circle right", disabled: !showNext, className: "green" }
@@ -62,16 +76,18 @@ export function TutorialContainer(props: TutorialContainerProps) {
             <TutorialStepCounter currentStep={visibleStep} totalSteps={steps.length} setTutorialStep={setTutorialStep} />
             {showImmersiveReader && <ImmersiveReaderButton content={markdown} tutorialOptions={tutorialOptions} />}
         </div>
+        {layout === "horizontal" &&
+            <Button icon="arrow circle left" disabled={!showBack} text={lf("Back")} onClick={tutorialStepBack} />}
         <div className="tutorial-content">
             <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent} />
         </div>
-        <div className="tutorial-controls">
-            <Button icon="arrow circle left" disabled={!showBack}
-                text={lf("Back")} onClick={tutorialStepBack} />
+        {layout === "horizontal" &&
+            <Button icon="arrow circle right" disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />}
+        {layout === "vertical" && <div className="tutorial-controls">
+            <Button icon="arrow circle left" disabled={!showBack} text={lf("Back")} onClick={tutorialStepBack} />
             <TutorialHint markdown={hintMarkdown} parent={parent} />
-            <Button icon="arrow circle right" disabled={!showNext}
-                text={lf("Next")} onClick={tutorialStepNext} />
-        </div>
+            <Button icon="arrow circle right" disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />
+        </div>}
         {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={name} buttons={modalActions}
             className="hintdialog" onClose={showNext ? tutorialStepNext : () => setHideModal(true)} dimmer={true}
             longer={true} closeOnDimmerClick closeOnDocumentClick closeOnEscape>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/130833905-1782573e-ef54-4811-b62c-3bcd8370f4d5.png)

vertical view for the markdown! doesn't handle the simulator tab or resizing the tutorial card based on content length yet, that will be the next PR