### PR TITLE
Add detection for chromium-based Edge

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -63,20 +63,26 @@ namespace pxt.BrowserUtils {
     Notes on browser detection
 
     Actually:             Claims to be:
-                          IE  MicrosoftEdge    Chrome  Safari  Firefox
+                          IE  MicrosoftEdge   Chrome  Safari  Firefox  NewEdge
               IE          X                           X?
     Microsoft Edge                    X       X       X
               Chrome                          X       X
               Safari                                  X       X
               Firefox                                         X
+              New Edge                        X       X                X
 
-    I allow Opera to go about claiming to be Chrome because it might as well be
+    I allow Opera to go about claiming to be Chrome because it might as well be. Same for Chromium-based Edge.
     */
 
     //Microsoft Edge lies about its user agent and claims to be Chrome, but Microsoft Edge/Version
     //is always at the end
     export function isEdge(): boolean {
         return hasNavigator() && /Edge/i.test(navigator.userAgent);
+    }
+
+    //Chromium-based Edge. Note that `isChrome()` also detects this browser, and that's ok. In most cases Chromium-Edge can be treated like Chrome. Use this method if you need to differentiate them.
+    export function isChromiumEdge(): boolean {
+        return hasNavigator() && /Edg\//i.test(navigator.userAgent);
     }
 
     //IE11 also lies about its user agent, but has Trident appear somewhere in
@@ -86,7 +92,7 @@ namespace pxt.BrowserUtils {
         return hasNavigator() && /Trident/i.test(navigator.userAgent);
     }
 
-    //Microsoft Edge and IE11 lie about being Chrome
+    //Microsoft Edge and IE11 lie about being Chrome. Chromium-based Edge ("Edgeium") will be detected as Chrome, that is ok. If you're looking for Edgeium, use `isChromiumEdge()`.
     export function isChrome(): boolean {
         return !isEdge() && !isIE() && !!navigator && (/Chrome/i.test(navigator.userAgent) || /Chromium/i.test(navigator.userAgent));
     }

--- a/pxtlib/localStorage.ts
+++ b/pxtlib/localStorage.ts
@@ -128,9 +128,14 @@ namespace pxt.storage.shared {
         return routingEnabled && pxt.BrowserUtils.isLocalHostDev() && !pxt.BrowserUtils.noSharedLocalStorage();
     }
 
+    function storageNamespace(): string {
+        if (pxt.BrowserUtils.isChromiumEdge()) { return "chromium-edge"; }
+        return pxt.BrowserUtils.browser();
+    }
+
     export async function getAsync<T>(container: string, key: string): Promise<T> {
         if (useSharedLocalStorage()) {
-            container += '-' + pxt.BrowserUtils.browser();
+            container += '-' + storageNamespace();
             const resp = await pxt.Util.requestAsync({
                 url: `${localhostStoreUrl}${encodeURIComponent(container)}/${encodeURIComponent(key)}`,
                 method: "GET",
@@ -161,7 +166,7 @@ namespace pxt.storage.shared {
         else
             sval = val.toString();
         if (useSharedLocalStorage()) {
-            container += '-' + pxt.BrowserUtils.browser();
+            container += '-' + storageNamespace();
             const data = {
                 type: (typeof val === "object") ? "json" : "text",
                 val: sval
@@ -179,7 +184,7 @@ namespace pxt.storage.shared {
 
     export async function delAsync(container: string, key: string): Promise<void> {
         if (useSharedLocalStorage()) {
-            container += '-' + pxt.BrowserUtils.browser();
+            container += '-' + storageNamespace();
             await pxt.Util.requestAsync({
                 url: `${localhostStoreUrl}${encodeURIComponent(container)}/${encodeURIComponent(key)}`,
                 method: "DELETE",


### PR DESCRIPTION
Adds a method to detect the Chromium-based Edge browser. It will still be detected as Chrome (`isChrome` method), and that is fine. Use `isChromiumEdge()` in the few cases where they need to be differentiated.

Updated local shared storage to use isChromiumEdge, as we want to differentiate storage by browser for local testing.