### PR TITLE
Horizontal tutorial view simulator CSS, resizing

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -84,6 +84,7 @@ namespace pxt.editor {
         bannerVisible?: boolean;
         pokeUserComponent?: string;
         flashHint?: boolean;
+        editorOffset?: string;
 
         print?: boolean;
         greenScreen?: boolean;
@@ -267,6 +268,7 @@ namespace pxt.editor {
         stopPokeUserActivity(): void;
         clearUserPoke(): void;
         setHintSeen(step: number): void;
+        setEditorOffset(): void;
 
         anonymousPublishAsync(screenshotUri?: string): Promise<string>;
         anonymousPublishHeaderByIdAsync(headerId: string): Promise<Cloud.JsonScript>;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -273,38 +273,40 @@
     /*******************************
             Simulator Tab
     *******************************/
-    .tab-simulator:not(.hidden) .simPanel {
-        display: flex;
+    #root.tutorialVertical .tab-simulator:not(.hidden) {
+        .simPanel {
+            display: flex;
 
-        #simulators {
-            width: 34rem;
-            margin: auto;
+            #simulators {
+                width: 34rem;
+                margin: auto;
+            }
+
+            .simframe {
+                padding-bottom: 39% !important;
+            }
+
+            .simtoolbar {
+                flex-direction: column;
+                flex-grow: 0;
+                width: 6rem;
+                margin-left: 1rem;
+            }
+
+            .simtoolbar > .buttons {
+                flex-direction: column;
+            }
         }
 
-        .simframe {
-            padding-bottom: 39% !important;
+        #boardview {
+            width: 100% !important;
         }
-
-        .simtoolbar {
-            flex-direction: column;
-            flex-grow: 0;
-            width: 6rem;
-            margin-left: 1rem;
-        }
-
-        .simtoolbar > .buttons {
-            flex-direction: column;
-        }
-    }
-
-    #root.tutorialVertical .tab-simulator:not(.hidden) #boardview {
-        width: 100% !important;
     }
 }
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-    .tab-simulator:not(.hidden) .simPanel {
+    #root.tutorialVertical .tab-simulator:not(.hidden) .simPanel {
         #simulators {
             width: 16rem;
         }

--- a/webapp/src/components/core/TabPane.tsx
+++ b/webapp/src/components/core/TabPane.tsx
@@ -5,12 +5,13 @@ import { TabContentProps } from "./TabContent";
 interface TabPaneProps {
     id?: string;
     className?: string;
+    style?: any;
     children?: any;
     activeTabName?: string;
 }
 
 export function TabPane(props: TabPaneProps) {
-    const { id, children, className, activeTabName } = props;
+    const { id, children, className, style, activeTabName } = props;
     const [ activeTab, setActiveTab ] = React.useState(activeTabName);
     const childArray = Array.isArray(children) ? children.filter((el: any) => !!el) : [children];
 
@@ -28,7 +29,7 @@ export function TabPane(props: TabPaneProps) {
         }
     }, [activeTabName])
 
-    return <div id={id} className={`tab-container ${className || ""}`}>
+    return <div id={id} className={`tab-container ${className || ""}`} style={style}>
         {childArray.length > 1 && <div className="tab-navigation">
             {childArray.map(el => {
                 const { name, icon, title, onSelected } = el.props as TabContentProps;

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -16,13 +16,18 @@ interface TutorialContainerProps {
     tutorialOptions?: pxt.tutorial.TutorialOptions; // TODO (shakao) pass in only necessary subset
 
     onTutorialStepChange?: (step: number) => void;
+    setParentHeight?: (height?: number) => void;
 }
 
+const MIN_HEIGHT = 80;
+const MAX_HEIGHT = 212;
+
 export function TutorialContainer(props: TutorialContainerProps) {
-    const { parent, name, steps, tutorialOptions, onTutorialStepChange } = props;
+    const { parent, name, steps, tutorialOptions, onTutorialStepChange, setParentHeight } = props;
     const [ currentStep, setCurrentStep ] = React.useState(props.currentStep || 0);
     const [ hideModal, setHideModal ] = React.useState(false);
     const [ layout, setLayout ] = React.useState<"vertical" | "horizontal">("vertical");
+    const contentRef = React.useRef(undefined);
 
     const currentStepInfo = steps[currentStep];
     if (!steps[currentStep]) return <div />;
@@ -56,6 +61,16 @@ export function TutorialContainer(props: TutorialContainerProps) {
         return () => observer.disconnect();
     }, [document.body])
 
+    React.useEffect(() => {
+        if (layout == "horizontal") {
+            const scrollHeight = contentRef?.current?.firstElementChild?.scrollHeight;
+            if (scrollHeight) {
+                setParentHeight(Math.min(Math.max(scrollHeight + 2, MIN_HEIGHT), MAX_HEIGHT));
+            }
+        } else {
+            setParentHeight();
+        }
+    })
 
     let modalActions: ModalButton[] = [
         { label: lf("Back"), onclick: tutorialStepBack, icon: "arrow circle left", disabled: !showBack, labelPosition: "left" },
@@ -78,8 +93,8 @@ export function TutorialContainer(props: TutorialContainerProps) {
         </div>
         {layout === "horizontal" &&
             <Button icon="arrow circle left" disabled={!showBack} text={lf("Back")} onClick={tutorialStepBack} />}
-        <div className="tutorial-content">
-            <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent} />
+        <div className="tutorial-content" ref={contentRef}>
+            <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent}/>
         </div>
         {layout === "horizontal" &&
             <Button icon="arrow circle right" disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -15,6 +15,7 @@ import { TutorialContainer } from "./components/tutorial/TutorialContainer";
 
 interface SidepanelState {
     activeTab?: string;
+    height?: number;
 }
 
 interface SidepanelProps extends pxt.editor.ISettingsProps {
@@ -31,6 +32,7 @@ interface SidepanelProps extends pxt.editor.ISettingsProps {
 
     tutorialOptions?: pxt.tutorial.TutorialOptions;
     onTutorialStepChange?: (step: number) => void;
+    setEditorOffset?: () => void;
 
     showMiniSim: (visible?: boolean) => void;
     openSerial: (isSim: boolean) => void;
@@ -59,9 +61,13 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         }
     }
 
+    componentDidUpdate(props: SidepanelProps, state: SidepanelState) {
+        if ((this.state.height || state.height) && this.state.height != state.height) this.props.setEditorOffset();
+    }
+
     protected showSimulatorTab = () => {
         this.props.showMiniSim(false);
-        this.setState({ activeTab: SIMULATOR_TAB });
+        this.setState({ activeTab: SIMULATOR_TAB, height: undefined });
     }
 
     protected showTutorialTab = () => {
@@ -101,13 +107,18 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         }
     }
 
+    protected setComponentHeight = (height?: number) => {
+        if (height != this.state.height) this.setState({ height });
+    }
+
     renderCore() {
         const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton,
             collapseEditorTools, simSerialActive, deviceSerialActive, tutorialOptions,
             handleHardwareDebugClick, onTutorialStepChange } = this.props;
+        const { activeTab, height } = this.state;
 
         return <div id="simulator" className="simulator">
-            <TabPane id="editorSidebar" activeTabName={this.state.activeTab}>
+            <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + 5.5rem)` } : undefined}>
                 <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
@@ -127,7 +138,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                 {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="pencil" onSelected={this.showTutorialTab}>
                     <TutorialContainer parent={parent} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}
                         currentStep={tutorialOptions.tutorialStep} tutorialOptions={tutorialOptions}
-                        onTutorialStepChange={onTutorialStepChange} />
+                        onTutorialStepChange={onTutorialStepChange} setParentHeight={this.setComponentHeight} />
                 </TabContent>}
             </TabPane>
         </div>

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -597,6 +597,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
             }
         }
         this.setState({ showSeeMore: show });
+        this.props.parent.setEditorOffset();
     }
 
     getCardHeight() {


### PR DESCRIPTION
- https://github.com/microsoft/pxt/commit/99c2c9eaea453a33f175feeda7b6be63716732f8 CSS for the horizontal sim pane

![image](https://user-images.githubusercontent.com/34112083/130885225-d61f703e-a79f-465e-a5c2-a1f4d21d4f30.png)

- https://github.com/microsoft/pxt/commit/6c55727129619a303435621fe4b04409b540184f resize tutorial card (and blocks workspace) if there is less content. two pieces--the tutorial card sizes itself based on its content, the blocks workspace resizes by directly accessing the DOM to grab the `editorSidebar` height in the following cases: 1. when the window resizes 2. when the tutorial card changes steps 3. when you switch between the simulator and tutorial tabs