### PR TITLE
Display tutorial hint in horizontal/tablet view

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -176,7 +176,7 @@
 
 /* Small Monitor */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
-    .tutorialhint {
+    .tab-tutorial .tutorialhint {
         left: 2rem;
     }
 }
@@ -249,7 +249,7 @@
     *******************************/
 
     .tutorial-container {
-        .ui.button {
+        > .ui.button {
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -270,6 +270,47 @@
             }
         }
     }
+
+    /*******************************
+            Tutorial Hint
+    *******************************/
+
+    .tutorial-controls {
+        position: absolute;
+        right: 6rem;
+        margin-top: 1rem;
+    }
+
+    .tutorial-hint.ui.button {
+        width: unset;
+        height: unset;
+        font-size: 1rem;
+        border-radius: 0.2rem;
+
+        &.disabled {
+            display: none;
+        }
+    }
+
+    // Overrides
+    .tab-tutorial {
+        .tutorialhint {
+            top: 12.5rem;
+            right: 3.2rem;
+            bottom: unset;
+            left: unset;
+            max-width: 80%;
+        }
+
+        .tutorialhint:before {
+            top: -2.5rem;
+            left: unset;
+            bottom: auto;
+            right: 4rem;
+            transform: rotate(90deg);
+        }
+    }
+
 
     /*******************************
             Simulator Tab

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -103,11 +103,11 @@ export function TutorialContainer(props: TutorialContainerProps) {
             <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent}/>
         </div>
         {layout === "horizontal" && nextButton}
-        {layout === "vertical" && <div className="tutorial-controls">
-            { backButton }
-            <TutorialHint markdown={hintMarkdown} parent={parent} />
-            { nextButton }
-        </div>}
+        <div className="tutorial-controls">
+            { layout === "vertical" && backButton }
+            <TutorialHint markdown={hintMarkdown} parent={parent} showLabel={layout === "horizontal"} />
+            { layout === "vertical" && nextButton }
+        </div>
         {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={name} buttons={modalActions}
             className="hintdialog" onClose={showNext ? tutorialStepNext : () => setHideModal(true)} dimmer={true}
             longer={true} closeOnDimmerClick closeOnDocumentClick closeOnEscape>

--- a/webapp/src/components/tutorial/TutorialHint.tsx
+++ b/webapp/src/components/tutorial/TutorialHint.tsx
@@ -6,10 +6,12 @@ import { MarkedContent } from "../../marked";
 interface TutorialHintProps {
     parent: pxt.editor.IProjectView;
     markdown: string;
+
+    showLabel?: boolean;
 }
 
 export function TutorialHint(props: TutorialHintProps) {
-    const { parent, markdown } = props;
+    const { parent, markdown, showLabel } = props;
     const [ visible, setVisible ] = React.useState(false);
 
     const captureEvent = (e: any) => {
@@ -33,7 +35,8 @@ export function TutorialHint(props: TutorialHintProps) {
     }
 
     return <div className="tutorial-hint-container">
-        <Button icon="lightbulb" className="tutorial-hint" disabled={!markdown} onClick={markdown ? toggleHint : undefined} />
+        <Button icon="lightbulb" text={showLabel ? lf("Hint") : undefined} className="tutorial-hint"
+            disabled={!markdown} onClick={markdown ? toggleHint : undefined} />
         {visible && <div className={`tutorialhint no-select`} onClick={captureEvent}>
             <MarkedContent markdown={markdown} unboxSnippets={true} parent={parent} />
         </div>}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/131044334-be6eb84e-d1ea-4261-9b2d-f8195bb2130a.png)

hint! we're going to have to make some design adjustments for steps that don't have a title to ensure backwards compat with content, but just getting this in for now so i can turn it on in beta :)