### PR TITLE
Performance Improvement for background images

### DIFF
--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -10,6 +10,7 @@ namespace pxtblockly {
         disableResize: string;
 
         filter?: string;
+        lightMode: boolean;
     }
 
     export interface ParsedFieldAnimationOptions {
@@ -17,6 +18,7 @@ namespace pxtblockly {
         initHeight: number;
         disableResize: boolean;
         filter?: string;
+        lightMode: boolean;
     }
 
     // 32 is specifically chosen so that we can scale the images for the default
@@ -226,12 +228,15 @@ namespace pxtblockly {
         const parsed: ParsedFieldAnimationOptions = {
             initWidth: 16,
             initHeight: 16,
-            disableResize: false
+            disableResize: false,
+            lightMode: false
         };
 
         if (!opts) {
             return parsed;
         }
+
+        parsed.lightMode = opts.lightMode;
 
         if (opts.filter) {
             parsed.filter = opts.filter;

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -15,6 +15,7 @@ namespace pxtblockly {
         initWidth: number;
         initHeight: number;
         disableResize: boolean;
+        lightMode: boolean;
     }
 
     // 32 is specifically chosen so that we can scale the images for the default
@@ -294,12 +295,11 @@ namespace pxtblockly {
         }
 
         protected parseFieldOptions(opts: U): V {
-            // NOTE: This implementation is duplicated in pxtcompiler/emitter/service.ts
-            // TODO: Refactor to share implementation.
             const parsed: ParsedFieldAssetEditorOptions = {
                 initWidth: 16,
                 initHeight: 16,
                 disableResize: false,
+                lightMode: false
             };
 
             if (!opts) {
@@ -312,6 +312,7 @@ namespace pxtblockly {
 
             parsed.initWidth = withDefault(opts.initWidth, parsed.initWidth);
             parsed.initHeight = withDefault(opts.initHeight, parsed.initHeight);
+            parsed.lightMode = (opts as any).lightMode;
 
             return parsed as V;
 

--- a/pxtblocks/fields/field_sprite.ts
+++ b/pxtblocks/fields/field_sprite.ts
@@ -16,6 +16,7 @@ namespace pxtblockly {
         disableResize: string;
 
         filter?: string;
+        lightMode: boolean;
     }
 
     interface ParsedSpriteEditorOptions {
@@ -24,6 +25,7 @@ namespace pxtblockly {
         initHeight: number;
         disableResize: boolean;
         filter?: string;
+        lightMode: boolean;
     }
 
     export class FieldSpriteEditor extends FieldAssetEditor<FieldSpriteEditorOptions, ParsedSpriteEditorOptions> {
@@ -86,11 +88,14 @@ namespace pxtblockly {
             initWidth: 16,
             initHeight: 16,
             disableResize: false,
+            lightMode: false,
         };
 
         if (!opts) {
             return parsed;
         }
+
+        parsed.lightMode = opts.lightMode;
 
         if (opts.sizes) {
             const pairs = opts.sizes.split(";");

--- a/pxtblocks/fields/field_tilemap.ts
+++ b/pxtblocks/fields/field_tilemap.ts
@@ -9,6 +9,7 @@ namespace pxtblockly {
         tileWidth: string | number;
 
         filter?: string;
+        lightMode: boolean;
     }
 
     interface ParsedFieldTilemapOptions {
@@ -17,6 +18,7 @@ namespace pxtblockly {
         disableResize: boolean;
         tileWidth: 8 | 16 | 32;
         filter?: string;
+        lightMode: boolean;
     }
 
     export class FieldTilemap extends FieldAssetEditor<FieldTilemapOptions, ParsedFieldTilemapOptions> {
@@ -88,12 +90,15 @@ namespace pxtblockly {
             initWidth: 16,
             initHeight: 16,
             disableResize: false,
-            tileWidth: 16
+            tileWidth: 16,
+            lightMode: false
         };
 
         if (!opts) {
             return parsed;
         }
+
+        parsed.lightMode = opts.lightMode;
 
         if (opts.filter) {
             parsed.filter = opts.filter;

--- a/pxtlib/spriteutils.ts
+++ b/pxtlib/spriteutils.ts
@@ -838,7 +838,7 @@ namespace pxt.sprite {
         buf[offset + 1] = (value >> 8) & 0xff;
     }
 
-    function colorStringToRGB(color: string) {
+    export function colorStringToRGB(color: string) {
         const parsed = parseColorString(color);
         return [_r(parsed), _g(parsed), _b(parsed)]
     }

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -12,6 +12,7 @@ import { GestureTarget, ClientCoordinates, bindGestureEvents, TilemapPatch, crea
 import { Edit, EditState, getEdit, getEditState, ToolCursor, tools } from './toolDefinitions';
 import { createTile } from '../../assets';
 import { areShortcutsEnabled } from './keyboardShortcuts';
+import { LIGHT_MODE_TRANSPARENT } from './ImageEditor';
 
 const IMAGE_MIME_TYPE = "image/x-mkcd-f4"
 
@@ -38,6 +39,7 @@ export interface ImageCanvasProps {
     tilemapState?: TilemapState;
     imageState?: pxt.sprite.ImageState;
     prevFrame?: pxt.sprite.ImageState;
+    lightMode?: boolean;
 
     suppressShortcuts: boolean;
 }
@@ -88,7 +90,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
 
         return <div ref="canvas-bounds" className={`image-editor-canvas ${isPortrait ? "portrait" : "landscape"}`} onContextMenu={this.preventContextMenu}>
             <div className="paint-container">
-                <canvas ref="paint-surface-bg" className="paint-surface" />
+                {!this.props.lightMode && <canvas ref="paint-surface-bg" className="paint-surface" />}
                 <canvas ref="paint-surface" className="paint-surface" />
                 {overlayLayers.map((layer, index) => {
                     return <canvas ref={`paint-surface-${layer.toString()}`} className={`paint-surface overlay ${!this.props.overlayEnabled ? 'hide' : ''}`} key={index} />
@@ -552,7 +554,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
             }
 
             // Only redraw checkerboard if the image size has changed
-            if (this.background.width != this.canvas.width << 1 || this.background.height != this.canvas.height << 1) {
+            if (this.background && (this.background.width != this.canvas.width << 1 || this.background.height != this.canvas.height << 1)) {
                 this.background.width = this.canvas.width << 1;
                 this.background.height = this.canvas.height << 1;
 
@@ -581,7 +583,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         }
     }
 
-    protected drawImage(bitmap: pxt.sprite.Bitmap, x0 = 0, y0 = 0, transparent = true) {
+    protected drawImage(bitmap: pxt.sprite.Bitmap, x0 = 0, y0 = 0, transparent = !this.props.lightMode) {
         if (this.props.isTilemap) this.drawTilemap(bitmap, x0, y0, transparent);
         else this.drawBitmap(bitmap, x0, y0, transparent);
     }
@@ -623,7 +625,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         }
     }
 
-    protected drawOverlayLayers(layers: pxt.sprite.Bitmap[], x0 = 0, y0 = 0, transparent = true) {
+    protected drawOverlayLayers(layers: pxt.sprite.Bitmap[], x0 = 0, y0 = 0, transparent = !this.props.lightMode) {
         if (layers) {
             layers.forEach((layer, index) => {
                 this.drawBitmap(layer, x0, y0, transparent, this.canvasLayers[index]);
@@ -631,19 +633,26 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         }
     }
 
-    protected drawBitmap(bitmap: pxt.sprite.Bitmap, x0 = 0, y0 = 0, transparent = false, target = this.canvas) {
+    protected drawBitmap(bitmap: pxt.sprite.Bitmap, x0 = 0, y0 = 0, transparent = !this.props.lightMode, target = this.canvas) {
         if (!this.colors) {
             this.colors = new Uint8ClampedArray(this.props.colors.length * 4);
 
-            for (let i = 0; i < this.props.colors.length; i++) {
+            const transparent = pxt.sprite.colorStringToRGB(LIGHT_MODE_TRANSPARENT);
+            this.colors[0] = transparent[0];
+            this.colors[1] = transparent[1];
+            this.colors[2] = transparent[2];
+
+            for (let i = 1; i < this.props.colors.length; i++) {
                 const [r, g, b] = pxt.sprite.colorStringToRGB(this.props.colors[i]);
                 const start = i << 2;
                 this.colors[start] = r;
                 this.colors[start + 1] = g;
                 this.colors[start + 2] = b;
-                this.colors[start + 3] = (transparent && i === 0) ? 0 : 255;
+                this.colors[start + 3] = 255;
             }
         }
+
+        this.colors[3] = transparent ? 0 : 255;
 
         const context = target.getContext("2d");
         const data = context.getImageData(0, 0, target.width, target.height);
@@ -668,12 +677,12 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         const tileImage = document.createElement("canvas");
         tileImage.width = tileset.tileWidth;
         tileImage.height = tileset.tileWidth;
-        this.drawBitmap(pxt.sprite.Bitmap.fromData(tileset.tiles[index].bitmap), 0, 0, true, tileImage);
+        this.drawBitmap(pxt.sprite.Bitmap.fromData(tileset.tiles[index].bitmap), 0, 0, !this.props.lightMode, tileImage);
         this.tileCache[index] = tileImage;
         return tileImage;
     }
 
-    protected drawTilemap(tilemap: pxt.sprite.Bitmap, x0 = 0, y0 = 0, transparent = true, target = this.canvas) {
+    protected drawTilemap(tilemap: pxt.sprite.Bitmap, x0 = 0, y0 = 0, transparent = !this.props.lightMode, target = this.canvas) {
         const { tilemapState: { tileset } } = this.props;
 
         const context = target.getContext("2d");
@@ -683,6 +692,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         this.tileCache = [];
 
         context.imageSmoothingEnabled = false;
+        context.fillStyle = LIGHT_MODE_TRANSPARENT;
         for (let x = 0; x < tilemap.width; x++) {
             for (let y = 0; y < tilemap.height; y++) {
                 index = tilemap.get(x, y);
@@ -701,7 +711,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
                     context.drawImage(tileImage, (x + x0) * this.cellWidth, (y + y0) * this.cellWidth);
                 }
                 else {
-                    if (!transparent) context.clearRect((x + x0) * this.cellWidth, (y + y0) * this.cellWidth, this.cellWidth, this.cellWidth);
+                    if (!transparent) context.fillRect((x + x0) * this.cellWidth, (y + y0) * this.cellWidth, this.cellWidth, this.cellWidth);
                 }
             }
         }
@@ -738,7 +748,11 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
                 context.fillStyle = this.props.colors[color]
                 context.fillRect(left * this.cellWidth, top * this.cellWidth, width * this.cellWidth, width * this.cellWidth);
             }
-        } else {
+        } else if (this.props.lightMode) {
+            context.fillStyle = LIGHT_MODE_TRANSPARENT;
+            context.fillRect(left * this.cellWidth, top * this.cellWidth, width * this.cellWidth, width * this.cellWidth);
+        }
+        else {
             context.clearRect(left * this.cellWidth, top * this.cellWidth, width * this.cellWidth, width * this.cellWidth);
         }
     }
@@ -850,7 +864,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
             this.canvas.style.clipPath = `polygon(${this.panX}px ${this.panY}px, ${this.panX + bounds.width}px ${this.panY}px, ${this.panX + bounds.width}px ${this.panY + bounds.height}px, ${this.panX}px ${this.panY + bounds.height}px)`;
             // this.canvas.style.imageRendering = "pixelated"
 
-            this.cloneCanvasStyle(this.canvas, this.background);
+            if (this.background) this.cloneCanvasStyle(this.canvas, this.background);
             this.canvasLayers.forEach(layer => this.cloneCanvasStyle(this.canvas, layer));
 
             this.redrawFloatingLayer(this.editState, true);

--- a/webapp/src/components/ImageEditor/ImageEditor.tsx
+++ b/webapp/src/components/ImageEditor/ImageEditor.tsx
@@ -17,6 +17,8 @@ import { imageStateToBitmap, imageStateToTilemap, applyBitmapData } from './util
 import { Unsubscribe, Action } from 'redux';
 import { createNewImageAsset, getNewInternalID } from '../../assets';
 
+export const LIGHT_MODE_TRANSPARENT = "#dedede";
+
 export interface ImageEditorSaveState {
     editor: EditorState;
     past: AnimationState[];
@@ -30,6 +32,7 @@ export interface ImageEditorProps {
     onDoneClicked?: (value: pxt.Asset) => void;
     onTileEditorOpenClose?: (open: boolean) => void;
     nested?: boolean;
+    lightMode?: boolean;
 }
 
 export interface ImageEditorState {
@@ -69,7 +72,7 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
     }
 
     render(): JSX.Element {
-        const { singleFrame } = this.props;
+        const { singleFrame, lightMode } = this.props;
         const instanceStore = this.getStore();
 
         const { tileToEdit, editingTile, alert } = this.state;
@@ -81,8 +84,8 @@ export class ImageEditor extends React.Component<ImageEditorProps, ImageEditorSt
                 <div className={`image-editor ${editingTile ? "editing-tile" : ""}`}>
                     <TopBar singleFrame={singleFrame} />
                     <div className="image-editor-content">
-                        <SideBar />
-                        <ImageCanvas suppressShortcuts={editingTile} />
+                        <SideBar lightMode={lightMode} />
+                        <ImageCanvas suppressShortcuts={editingTile} lightMode={lightMode} />
                         {isAnimationEditor && !singleFrame ? <Timeline /> : undefined}
                     </div>
                     <BottomBar singleFrame={singleFrame} onDoneClick={this.onDoneClick} />

--- a/webapp/src/components/ImageEditor/SideBar.tsx
+++ b/webapp/src/components/ImageEditor/SideBar.tsx
@@ -13,18 +13,19 @@ interface SideBarProps {
     selectedTool: ImageEditorTool;
     isTilemap: boolean;
     dispatchChangeImageTool: (tool: ImageEditorTool) => void;
+    lightMode: boolean;
 }
 
 export class SideBarImpl extends React.Component<SideBarProps,{}> {
     protected handlers: (() => void)[] = [];
 
     render() {
-        const { selectedTool, isTilemap } = this.props;
+        const { selectedTool, isTilemap, lightMode } = this.props;
         return (
             <div className={`image-editor-sidebar ${isTilemap ? "tilemap" : ""}`}>
                 {isTilemap &&
                     <div className="image-editor-tilemap-minimap">
-                        <Minimap />
+                        <Minimap lightMode={lightMode} />
                     </div>
                 }
                 <div className="image-editor-tool-buttons">

--- a/webapp/src/components/ImageEditor/tilemap/Minimap.tsx
+++ b/webapp/src/components/ImageEditor/tilemap/Minimap.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { LIGHT_MODE_TRANSPARENT } from '../ImageEditor';
 import { ImageEditorStore, TilemapState, TileCategory } from '../store/imageReducer';
 
 export interface MinimapProps {
     colors: string[];
     tileset: pxt.TileSet;
     tilemap: pxt.sprite.ImageState;
+    lightMode: boolean;
 }
 
 const SCALE = pxt.BrowserUtils.isEdge() ? 25 : 1;
@@ -30,7 +32,7 @@ class MinimapImpl extends React.Component<MinimapProps, {}> {
     }
 
     redrawCanvas() {
-        const { tilemap } = this.props;
+        const { tilemap, lightMode } = this.props;
         let { bitmap, floating, layerOffsetX, layerOffsetY } = tilemap;
 
         const context = this.canvas.getContext("2d");
@@ -52,7 +54,10 @@ class MinimapImpl extends React.Component<MinimapProps, {}> {
                     context.fillStyle = this.getColor(index);
                     context.fillRect(x * SCALE, y * SCALE, SCALE, SCALE);
                 }
-                else {
+                else if (lightMode) {
+                    context.fillStyle = LIGHT_MODE_TRANSPARENT;
+                    context.fillRect(x * SCALE, y * SCALE, SCALE, SCALE);
+                } else {
                     context.clearRect(x * SCALE, y * SCALE, SCALE, SCALE);
                 }
             }

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -39,6 +39,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     protected galleryAssets: pxt.Asset[];
     protected userAssets: pxt.Asset[];
     protected shortcutLock: number;
+    protected lightMode: boolean;
 
     protected get asset() {
         return this.ref?.getAsset();
@@ -134,7 +135,13 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
             </div>}
             <div className="image-editor-gallery-window">
                 <div className="image-editor-gallery-content">
-                    <ImageEditor ref="image-editor" singleFrame={this.props.singleFrame} onDoneClicked={this.onDoneClick} onTileEditorOpenClose={this.onTileEditorOpenClose} />
+                    <ImageEditor
+                        ref="image-editor"
+                        singleFrame={this.props.singleFrame}
+                        onDoneClicked={this.onDoneClick}
+                        onTileEditorOpenClose={this.onTileEditorOpenClose}
+                        lightMode={this.lightMode}
+                        />
                     <ImageEditorGallery
                         items={filteredAssets}
                         hidden={currentView === "editor"}
@@ -163,6 +170,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
     init(value: U, close: () => void, options?: any) {
         this.closeEditor = close;
         this.options = options;
+        this.lightMode = options.lightMode;
 
         switch (value.type) {
             case pxt.AssetType.Image:

--- a/webapp/src/components/TilemapFieldEditor.tsx
+++ b/webapp/src/components/TilemapFieldEditor.tsx
@@ -14,6 +14,7 @@ export interface TilemapFieldEditorState {
 
 export class TilemapFieldEditor extends React.Component<TilemapFieldEditorProps, TilemapFieldEditorState> implements FieldEditorComponent<pxt.ProjectTilemap> {
     protected blocksInfo: pxtc.BlocksInfo;
+    protected lightMode: boolean;
     protected ref: ImageEditor;
     protected closeEditor: () => void;
 
@@ -45,6 +46,7 @@ export class TilemapFieldEditor extends React.Component<TilemapFieldEditorProps,
 
     init(value: pxt.ProjectTilemap, close: () => void, options?: any) {
         this.closeEditor = close;
+        this.lightMode = options.lightMode;
         this.initTilemap(value, options);
     }
 


### PR DESCRIPTION
A few changes to improve the performance of the image editor, especially for background images. This PR brings back light mode for the image+tilemap editor to remove transparency and one of the canvases. It also changes how we draw the images to use imageData instead of the rendering context, which has major perf gains on my machine.

Weirdly, when I attempted to time the perf gains from using ImageData I got worse numbers for the new implementation but it is way, way, smoother when actually in use. I have no idea how to explain that. You can try it for yourself though, using this link:

https://arcade.makecode.com/app/2646b82239a5635071a5c34c2e41d3e6025d9b68-58fd418611

I recommend trying to edit a 500x500 image to really see the difference.