### PR TITLE
Load entire toolbox instead of exiting tutorial on filter error

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1696,9 +1696,8 @@ export class ProjectView
             .catch(e => {
                 // Failed to decompile
                 pxt.tickEvent('tutorial.faileddecompile', { tutorial: t.tutorial });
-                core.errorNotification(lf("Oops, an error occured as we were loading the tutorial."));
-                // Reset state (delete the current project and exit the tutorial)
-                this.exitTutorial(true);
+                this.setState({ editorState: { searchBar: false, filters: undefined} });
+                core.warningNotification(lf("Could not filter tutorial blocks, displaying full toolbox."))
             })
             .finally(() => {
                 pxt.perf.measureEnd("loadTutorial loadBlockly")


### PR DESCRIPTION
i can get into this state (https://github.com/microsoft/pxt-arcade/issues/3852) by forcing an error in `loadTutorialFiltersAsync`. not really sure how recent changes would have caused an error here but it's one of the only places that calls exitTutorial and throwing an error elsewhere causes the workspace to hang (instead of exiting the tutorial)

regardless, i think this fix won't cause any harm--instead of exiting we just load the entire toolbox. this is a slightly worse tutorial experience but at least the tutorial is still there