### PR TITLE
Never use the icons.css from pxt-arcade-sim

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -717,6 +717,7 @@ function targetFileList() {
     if (simDir() != "sim")
         lst = lst.concat(nodeutil.allFiles(path.join("sim", "public"), 5, true))
     pxt.debug(`target files (on disk): ${lst.join('\r\n    ')}`)
+    lst.filter(f => {!f.includes("icons.css")})
     return lst;
 }
 
@@ -1250,7 +1251,7 @@ function uploadCoreAsync(opts: UploadOptions) {
 
     // only keep the last version of each uploadFileName()
     opts.fileList = U.values(U.toDictionary(opts.fileList, uploadFileName))
-
+    
     // check size
     const maxSize = checkFileSize(opts.fileList);
     if (maxSize > 30000000) // 30Mb max

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -717,7 +717,7 @@ function targetFileList() {
     if (simDir() != "sim")
         lst = lst.concat(nodeutil.allFiles(path.join("sim", "public"), 5, true))
     pxt.debug(`target files (on disk): ${lst.join('\r\n    ')}`)
-    lst = lst.filter(f => !f.includes("icons.css"))
+    lst = lst.filter(f => !f.includes("icons.css")) // We want to pull icons.css from pxt-core, not the target
     return lst;
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -717,7 +717,7 @@ function targetFileList() {
     if (simDir() != "sim")
         lst = lst.concat(nodeutil.allFiles(path.join("sim", "public"), 5, true))
     pxt.debug(`target files (on disk): ${lst.join('\r\n    ')}`)
-    lst.filter(f => !f.includes("icons.css"))
+    lst = lst.filter(f => !f.includes("icons.css"))
     return lst;
 }
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -717,7 +717,7 @@ function targetFileList() {
     if (simDir() != "sim")
         lst = lst.concat(nodeutil.allFiles(path.join("sim", "public"), 5, true))
     pxt.debug(`target files (on disk): ${lst.join('\r\n    ')}`)
-    lst.filter(f => {!f.includes("icons.css")})
+    lst.filter(f => !f.includes("icons.css"))
     return lst;
 }
 
@@ -1251,7 +1251,7 @@ function uploadCoreAsync(opts: UploadOptions) {
 
     // only keep the last version of each uploadFileName()
     opts.fileList = U.values(U.toDictionary(opts.fileList, uploadFileName))
-    
+
     // check size
     const maxSize = checkFileSize(opts.fileList);
     if (maxSize > 30000000) // 30Mb max


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3851


I'm not 100000% sure that this will fix the problem, but let me tell you why I suspect it will:

The issue was that the icons.css in https://github.com/microsoft/pxt-32-built/blob/master/icons.css wasn't being updated at all, and the reason we were seeing it surface in skillmap and not the regular app is b/c the regular webapp takes icons.css and adds it to the semantic stylesheet (which is handled correctly).

I am suspicious that the reason why icons.css isn't uploading correctly is because of [this line](https://github.com/microsoft/pxt/blob/4d89bf1bfcaf541a43f558b735f11581a6bdcbdb/cli/cli.ts#L1252) only copying the last seen path for each filename -- and in this case, the last path was for `node_modules\pxt-arcade-sim\public\icons.css -> icons.css (text/css)` and not `node_modules\pxt-core\built\web\icons.css -> icons.css (text/css)`. This PR special cases the icons.css from arcade-sim and ignores it (tell me if theres a better way to do this)

The reason I'm not sure if this will fix it is I've been testing with uploadtrg, and with this change the icons are still wrong. But I'm wondering if that's....because of online things vs my build? I'm not sure. If you think this is the wrong approach lmk 👍