### PR TITLE
Make copies of local projects when importing skillmap progress to cloud

### DIFF
--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -374,7 +374,7 @@ namespace pxt.editor {
 
         openNewTab(header: pxt.workspace.Header, dependent: boolean): void;
         createGitHubRepositoryAsync(): Promise<void>;
-        saveLocalProjectsToCloudAsync(headerIds: string[]): Promise<void>;
+        saveLocalProjectsToCloudAsync(headerIds: string[]): Promise<pxt.Map<string> | undefined>;
         requestProjectCloudStatus(headerIds: string[]): Promise<void>;
     }
 

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -232,6 +232,11 @@ namespace pxt.editor {
         headerIds: string[];
     }
 
+    export interface EditorMessageSaveLocalProjectsToCloudResponse extends EditorMessageResponse {
+        action: "savelocalprojectstocloud";
+        headerIdMap?: pxt.Map<string>;
+    }
+
     export interface EditorMessageProjectCloudStatus extends EditorMessageRequest {
         action: "projectcloudstatus";
         headerId: string;
@@ -558,7 +563,12 @@ namespace pxt.editor {
                                 }
                                 case "savelocalprojectstocloud": {
                                     const msg = data as EditorMessageSaveLocalProjectsToCloud;
-                                    return projectView.saveLocalProjectsToCloudAsync(msg.headerIds);
+                                    return projectView.saveLocalProjectsToCloudAsync(msg.headerIds)
+                                        .then(guidMap => {
+                                            resp = <EditorMessageSaveLocalProjectsToCloudResponse>{
+                                                headerIdMap: guidMap
+                                            };
+                                        })
                                 }
                                 case "requestprojectcloudstatus": {
                                     // Responses are sent as separate "projectcloudstatus" messages.

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import store from "./store/store";
 import * as authClient from "./lib/authClient";
-import { getFlattenedHeaderIds as getHeaderIdsForUnstartedMaps } from "./lib/skillMapUtils";
+import { getHeaderIdsForUnstartedMaps } from "./lib/skillMapUtils";
 
 import {
     dispatchAddSkillMap,

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import store from "./store/store";
 import * as authClient from "./lib/authClient";
-import { getHeaderIdsForUnstartedMaps } from "./lib/skillMapUtils";
+import { getFlattenedHeaderIds } from "./lib/skillMapUtils";
 
 import {
     dispatchAddSkillMap,
@@ -213,7 +213,9 @@ class AppImpl extends React.Component<AppProps, AppState> {
             const state = store.getState();
             const localUser = await getLocalUserStateAsync();
 
-            let headerIds = getHeaderIdsForUnstartedMaps(localUser, state.pageSourceUrl, state.user);
+            let currentUser = state.user;
+
+            let headerIds = getFlattenedHeaderIds(localUser, state.pageSourceUrl, state.user);
 
             // Tell the editor to transfer local skillmap projects to the cloud.
             const headerMap = (await this.sendMessageAsync({
@@ -282,13 +284,14 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
                 this.props.dispatchSetUser(newUser)
                 await saveUserStateAsync(newUser);
+                currentUser = newUser;
             }
 
             // Tell the editor to send us the cloud status of our projects.
             await this.sendMessageAsync({
                 type: "pxteditor",
                 action: "requestprojectcloudstatus",
-                headerIds
+                headerIds: getFlattenedHeaderIds(currentUser, state.pageSourceUrl)
             } as pxt.editor.EditorMessageRequestProjectCloudStatus);
         }
     }

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import store from "./store/store";
 import * as authClient from "./lib/authClient";
-import { getFlattenedHeaderIds } from "./lib/skillMapUtils";
+import { getFlattenedHeaderIds as getHeaderIdsForUnstartedMaps } from "./lib/skillMapUtils";
 
 import {
     dispatchAddSkillMap,
@@ -32,7 +32,7 @@ import { parseHash, getMarkdownAsync, MarkdownSource, parseQuery,
     setPageTitle, setPageSourceUrl, ParsedHash } from './lib/browserUtils';
 
 import { MakeCodeFrame } from './components/makecodeFrame';
-import { getUserStateAsync, saveUserStateAsync } from './lib/workspaceProvider';
+import { getLocalUserStateAsync, getUserStateAsync, saveUserStateAsync } from './lib/workspaceProvider';
 import { Unsubscribe } from 'redux';
 
 /* eslint-disable import/no-unassigned-import */
@@ -211,13 +211,79 @@ class AppImpl extends React.Component<AppProps, AppState> {
     protected async cloudSyncCheckAsync() {
         if (await authClient.loggedInAsync() && this.sendMessageAsync && this.loadedUser) {
             const state = store.getState();
-            const headerIds = getFlattenedHeaderIds(state.user, state.pageSourceUrl);
+            const localUser = await getLocalUserStateAsync();
+
+            let headerIds = getHeaderIdsForUnstartedMaps(localUser, state.pageSourceUrl, state.user);
+
             // Tell the editor to transfer local skillmap projects to the cloud.
-            await this.sendMessageAsync({
+            const headerMap = (await this.sendMessageAsync({
                 type: "pxteditor",
                 action: "savelocalprojectstocloud",
                 headerIds
-            } as pxt.editor.EditorMessageSaveLocalProjectsToCloud);
+            } as pxt.editor.EditorMessageSaveLocalProjectsToCloud)).resp.headerIdMap;
+
+            if (headerMap) {
+                headerIds = headerIds.map(h => headerMap[h] || h);
+
+                // Patch all of the header ids in the user state and copy
+                // over the local progress that doesn't exist in the signed in
+                // user
+                const urls = Object.keys(state.user.mapProgress);
+                const newUser: UserState = {
+                    ...state.user,
+                    mapProgress: {}
+                }
+
+                for (const url of urls) {
+                    newUser.mapProgress[url] = {
+                        ...state.user.mapProgress[url],
+                    };
+
+                    if (!localUser.mapProgress[url]) continue;
+
+                    const maps = Object.keys(localUser.mapProgress[url]);
+                    for (const map of maps) {
+                        newUser.mapProgress[url][map] = {
+                            ...state.user.mapProgress[url][map]
+                        };
+
+                        // Only copy over state if the user hasn't started this map yet
+                        if (Object.keys(newUser.mapProgress[url][map].activityState).length !== 0) {
+                            continue;
+                        }
+
+                        const activityState: {[index: string]: ActivityState} = {};
+                        newUser.mapProgress[url][map].activityState = activityState;
+
+                        const signedInProgress = state.user.mapProgress[url][map].activityState;
+                        const localProgress = localUser.mapProgress[url][map].activityState
+
+                        for (const activity of Object.keys(signedInProgress)) {
+                            const oldState = signedInProgress[activity];
+                            activityState[activity] = {
+                                ...oldState,
+                                headerId: oldState.headerId ? (headerMap[oldState.headerId] || oldState.headerId) : oldState.headerId
+                            };
+                        }
+
+                        for (const activity of Object.keys(localProgress)) {
+                            const signedInActivity = signedInProgress[activity];
+                            const localActivity = localProgress[activity];
+                            if ((!signedInActivity || !signedInActivity.headerId) && localActivity.headerId) {
+                                const base = signedInActivity || localActivity;
+                                activityState[activity] = {
+                                    ...base,
+                                    headerId: localActivity.headerId ? (headerMap[localActivity.headerId] || localActivity.headerId) : localActivity.headerId
+                                };
+                            }
+                        }
+                    }
+                }
+
+                this.props.dispatchSetUser(newUser)
+                await saveUserStateAsync(newUser);
+            }
+
             // Tell the editor to send us the cloud status of our projects.
             await this.sendMessageAsync({
                 type: "pxteditor",

--- a/skillmap/src/components/UserProfile.tsx
+++ b/skillmap/src/components/UserProfile.tsx
@@ -113,7 +113,7 @@ export class UserProfileImpl extends React.Component<UserProfileProps, {}> {
     }
 }
 
-function mapStateToProps(state: SkillMapState) {
+function mapStateToProps(state: SkillMapState, ownProps: any) {
     if (!state) return {};
 
     return {

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -160,7 +160,7 @@ export function isRewardNode(node: MapNode) {
     return node.kind === "reward" || node.kind === "completion";
 }
 
-export function getFlattenedHeaderIds(user: UserState, pageSource: string, existing: UserState): string[] {
+export function getHeaderIdsForUnstartedMaps(user: UserState, pageSource: string, existing: UserState): string[] {
     return Object
         .values(user.mapProgress[pageSource] ?? [])
         .filter(map => !existing.mapProgress[pageSource]?.[map.mapId] || Object.keys(existing.mapProgress[pageSource][map.mapId].activityState).length === 0)

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -160,10 +160,10 @@ export function isRewardNode(node: MapNode) {
     return node.kind === "reward" || node.kind === "completion";
 }
 
-export function getHeaderIdsForUnstartedMaps(user: UserState, pageSource: string, existing: UserState): string[] {
+export function getFlattenedHeaderIds(user: UserState, pageSource: string, ignoreStartedMaps?: UserState): string[] {
     return Object
         .values(user.mapProgress[pageSource] ?? [])
-        .filter(map => !existing.mapProgress[pageSource]?.[map.mapId] || Object.keys(existing.mapProgress[pageSource][map.mapId].activityState).length === 0)
+        .filter(map => !ignoreStartedMaps || !ignoreStartedMaps.mapProgress[pageSource]?.[map.mapId] || Object.keys(ignoreStartedMaps.mapProgress[pageSource][map.mapId].activityState).length === 0)
         .map(map => Object.values(map.activityState))
         .reduce((a, b) => a.concat(b, []), [])
         .map(act => act.headerId)

--- a/skillmap/src/lib/skillMapUtils.ts
+++ b/skillmap/src/lib/skillMapUtils.ts
@@ -160,9 +160,10 @@ export function isRewardNode(node: MapNode) {
     return node.kind === "reward" || node.kind === "completion";
 }
 
-export function getFlattenedHeaderIds(user: UserState, pageSource: string): string[] {
+export function getFlattenedHeaderIds(user: UserState, pageSource: string, existing: UserState): string[] {
     return Object
         .values(user.mapProgress[pageSource] ?? [])
+        .filter(map => !existing.mapProgress[pageSource]?.[map.mapId] || Object.keys(existing.mapProgress[pageSource][map.mapId].activityState).length === 0)
         .map(map => Object.values(map.activityState))
         .reduce((a, b) => a.concat(b, []), [])
         .map(act => act.headerId)

--- a/skillmap/src/lib/workspaceProvider.ts
+++ b/skillmap/src/lib/workspaceProvider.ts
@@ -61,14 +61,7 @@ export async function saveUserStateAsync(user: UserState): Promise<void> {
     if (user.isDebug) return;
 
     const ws = await getWorkspaceAsync();
-    if (await pxt.auth.client()?.loggedInAsync()) {
-        // When signed in, clear locally saved progress.
-        // await ws.saveUserStateAsync({
-        //     ...user,
-        //     mapProgress: { },
-        //     completedTags: { }
-        // });
-    } else {
+    if (!(await pxt.auth.client()?.loggedInAsync())) {
         await ws.saveUserStateAsync(user);
     }
 

--- a/skillmap/src/lib/workspaceProvider.ts
+++ b/skillmap/src/lib/workspaceProvider.ts
@@ -23,14 +23,8 @@ export async function saveProjectAsync(project: pxt.workspace.Project): Promise<
     await ws.saveProjectAsync(project);
 }
 
-export async function getUserStateAsync(): Promise<UserState> {
+export async function getLocalUserStateAsync(): Promise<UserState> {
     const ws = await getWorkspaceAsync();
-
-    // User state is stored in two places, so we read both sources here and merge them.
-    // Though the entire user state is saved to the local workspace, the authClient
-    // module is the authoritative source for the completedTags and mapProgress fields
-    // when auth is enabled.
-
     let userState = await ws.getUserStateAsync();
     if (!userState) {
         userState = {
@@ -40,6 +34,16 @@ export async function getUserStateAsync(): Promise<UserState> {
             version: pxt.skillmap.USER_VERSION
         };
     }
+
+    return userState;
+}
+
+export async function getUserStateAsync(): Promise<UserState> {
+    // User state is stored in two places, so we read both sources here and merge them.
+    // Though the entire user state is saved to the local workspace, the authClient
+    // module is the authoritative source for the completedTags and mapProgress fields
+    // when auth is enabled.
+    let userState = await getLocalUserStateAsync();
 
     // Read synchronized skillmap state from cloud profile. Fallback to workspace-saved state.
     const skillmapState = await authClient.getSkillmapStateAsync();
@@ -59,11 +63,11 @@ export async function saveUserStateAsync(user: UserState): Promise<void> {
     const ws = await getWorkspaceAsync();
     if (await pxt.auth.client()?.loggedInAsync()) {
         // When signed in, clear locally saved progress.
-        await ws.saveUserStateAsync({
-            ...user,
-            mapProgress: { },
-            completedTags: { }
-        });
+        // await ws.saveUserStateAsync({
+        //     ...user,
+        //     mapProgress: { },
+        //     completedTags: { }
+        // });
     } else {
         await ws.saveUserStateAsync(user);
     }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3534,8 +3534,8 @@ export class ProjectView
         return Cloud.privatePostAsync("scripts", scrReq, /* forceLiveEndpoint */ true)
     }
 
-    async saveLocalProjectsToCloudAsync(headerIds: string[]): Promise<void> {
-        await cloud.saveLocalProjectsToCloudAsync(headerIds);
+    async saveLocalProjectsToCloudAsync(headerIds: string[]): Promise<pxt.Map<string> | undefined> {
+        return cloud.saveLocalProjectsToCloudAsync(headerIds);
     }
 
     async requestProjectCloudStatus(headerIds: string[]): Promise<void> {

--- a/webapp/src/cloud.ts
+++ b/webapp/src/cloud.ts
@@ -592,8 +592,16 @@ export async function saveLocalProjectsToCloudAsync(headerIds: string[]) {
         .filter(h => h.cloudUserId == null)
         .filter(h => headerIds.includes(h.id));
     if (headers.length) {
-        await syncAsync(headers);
+        const guidMap: pxt.Map<string> = {};
+        const newHeaders: Header[] = [];
+        for (const h of headers) {
+            const newHeader = await workspace.duplicateAsync(h, h.name);
+            guidMap[h.id] = newHeader.id;
+        }
+        await syncAsync(newHeaders);
+        return guidMap;
     }
+    return undefined;
 }
 
 export async function requestProjectCloudStatus(headerIds: string[]): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3861
Fixes https://github.com/microsoft/pxt-arcade/issues/3858

Makes a few changes to preserve the local user state when logging in on the skillmap page:

1. When syncing local skillmap headers to the cloud, syncs duplicates instead of the original
2. Local user state is no longer overwritten when logged in
3. Always copies state from the local user and not whatever is in the store

The copy only happens for maps that the signed in user has no progress in.