### PR TITLE
allow specifying pkgs to compile hex files for in staticpkg

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -494,6 +494,10 @@ declare namespace pxt {
     interface TargetBundle extends AppTarget {
         bundledpkgs: Map<Map<string>>;   // @internal use only (cache)
         bundleddirs: string[];
+        staticpkgdirs?: {
+            base: string[];
+            extensions: string[];
+        }      // if defined, used in staticpkg as pkgs to combine with bundled dirs. Otherwise, bundled dirs will be combined with eachother.
         versions: TargetVersions;        // @derived
         apiInfo?: Map<PackageApiInfo>;
         tutorialInfo?: Map<BuiltTutorialInfo>; // hash of tutorial code mapped to prebuilt info for each tutorial


### PR DESCRIPTION
Allow specifying a subset of bundleddirs to include hexfile combos for in staticpkg / offline app to fix electron app build; currently it's timing out due to trying every combination of two bundleddirs.

I'll note that there are still lots of hexfile errors sent out during the staticpkg build, as expected -- e.g. hw---rpi doesn't play nicely with lots of the hardware extensions.

There were also two issues with comparing to check that they might be compatible -- it wasn't recognizing versions of the package as being the same (e.g. it would attempt core + core---samd when they shouldn't work together), and depending on the os it would fail to compare in the first place as it resolved the paths first (e.g. it would end up with `libs\\core` vs `libs/core`).

Also added some more logging so it's easier to figure out what's up in the future.

and pxtarget change for arcade: https://github.com/microsoft/pxt-arcade/pull/3888