### PR TITLE
Speed up the clone operation for api info and apptarget

### DIFF
--- a/pxtlib/main.ts
+++ b/pxtlib/main.ts
@@ -48,7 +48,7 @@ namespace pxt {
     export function setAppTarget(trg: TargetBundle) {
         appTarget = trg || <TargetBundle>{};
         patchAppTarget();
-        savedAppTarget = U.clone(appTarget)
+        savedAppTarget = U.cloneTargetBundle(appTarget)
     }
 
     let apiInfo: Map<PackageApiInfo>;
@@ -254,7 +254,7 @@ namespace pxt {
     export function reloadAppTargetVariant(temporary = false) {
         pxt.perf.measureStart("reloadAppTargetVariant")
         const curr = temporary ? "" : JSON.stringify(appTarget);
-        appTarget = U.clone(savedAppTarget)
+        appTarget = U.cloneTargetBundle(savedAppTarget)
         if (appTargetVariant) {
             const v = appTarget.variants && appTarget.variants[appTargetVariant];
             if (v)

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1609,6 +1609,142 @@ namespace ts.pxtc.Util {
         }
         return url
     }
+    export function cloneTargetBundle(target: pxt.TargetBundle) {
+        target = {
+            ...target
+        };
+
+        const apiInfo = target.apiInfo;
+        delete target.apiInfo;
+
+        const bundleddirs = target.bundleddirs;
+        delete target.bundleddirs;
+
+        const bundledpkgs = target.bundledpkgs;
+        delete target.bundledpkgs;
+
+        const tutorialInfo = target.tutorialInfo;
+        delete target.tutorialInfo;
+
+        const res = clone(target);
+
+        if (apiInfo) {
+            res.apiInfo = {};
+            for (const key of Object.keys(apiInfo)) {
+                const apis = apiInfo[key].apis;
+
+                res.apiInfo[key] = {
+                    sha: apiInfo[key].sha,
+                    apis: {
+                        jres: { ...apis.jres },
+                        byQName: cloneApis(apis.byQName)
+                    }
+                }
+            }
+        }
+
+        if (bundleddirs) {
+            res.bundleddirs = [...bundleddirs]
+        }
+
+        if (bundledpkgs) {
+            res.bundledpkgs = {};
+            for (const key of Object.keys(bundledpkgs)) {
+                res.bundledpkgs[key] = {
+                    ...bundledpkgs[key]
+                };
+            }
+        }
+
+        if (tutorialInfo) {
+            res.tutorialInfo = {};
+
+            for (const key of Object.keys(tutorialInfo)) {
+                const built = tutorialInfo[key];
+
+                res.tutorialInfo[key] = {
+                    hash: built.hash,
+                    usedBlocks: {
+                        ...built.usedBlocks
+                    },
+                    snippetBlocks: {
+                        ...built.snippetBlocks
+                    }
+                }
+            }
+        }
+
+        return res;
+    }
+
+    export function cloneApis(byQName: pxt.Map<pxtc.SymbolInfo>) {
+        const res: pxt.Map<pxtc.SymbolInfo> = {};
+
+        for (const key of Object.keys(byQName)) {
+            res[key] = cloneSymbolInfo(byQName[key]);
+        }
+
+        return res;
+    }
+
+    export function cloneSymbolInfo(sym: pxtc.SymbolInfo): pxtc.SymbolInfo {
+        return {
+            // FIXME: This is a little dangerous, because we do edit the symbol attributes in some places
+            // for localization. However, most of those edits are to top-level properties and only edits
+            // to child objects matter so it *should* be fine
+            attributes: {
+                ...sym.attributes
+            },
+
+            parameters: sym.parameters?.map(cloneParameterDesc),
+            extendsTypes: sym.extendsTypes ? [...sym.extendsTypes] : undefined,
+            pkgs: sym.pkgs ? [...sym.pkgs] : undefined,
+            combinedProperties: sym.combinedProperties ? [...sym.combinedProperties] : undefined,
+
+            name: sym.name,
+            namespace: sym.namespace,
+            fileName: sym.fileName,
+            kind: sym.kind,
+            retType: sym.retType,
+            isInstance: sym.isInstance,
+            isContextual: sym.isContextual,
+            qName: sym.qName,
+            pkg: sym.pkg,
+            snippet: sym.snippet,
+            snippetName: sym.snippetName,
+            snippetWithMarkers: sym.snippetWithMarkers,
+            pySnippet: sym.pySnippet,
+            pySnippetName: sym.pySnippetName,
+            pySnippetWithMarkers: sym.pySnippetWithMarkers,
+            blockFields: sym.blockFields,
+            isReadOnly: sym.isReadOnly,
+            pyName: sym.pyName,
+            pyQName: sym.pyQName,
+            snippetAddsDefinitions: sym.snippetAddsDefinitions,
+        }
+    }
+
+    function cloneParameterDesc(param: pxtc.ParameterDesc): pxtc.ParameterDesc {
+        return {
+            name: param.name,
+            description: param.description,
+            type: param.type,
+            pyTypeString: param.pyTypeString,
+            initializer: param.initializer,
+            default: param.default,
+            properties: param.properties?.map(clonePropertyDesc),
+            handlerParameters: param.handlerParameters?.map(clonePropertyDesc),
+            options: param.options ? U.clone(param.options) : undefined,
+            isEnum: param.isEnum
+        }
+    }
+
+    function clonePropertyDesc(prop: pxtc.PropertyDesc): pxtc.PropertyDesc {
+        return {
+            name: prop.name,
+            type: prop.type
+        }
+    }
 }
 
 namespace ts.pxtc.BrowserImpl {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4968,8 +4968,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     } else {
         pxt.options.wsPort = 3233;
     }
+    pxt.perf.measureStart("setAppTarget");
     pkg.setupAppTarget((window as any).pxtTargetBundle);
     pxt.setBundledApiInfo((window as any).pxtTargetBundle.apiInfo);
+    pxt.perf.measureEnd("setAppTarget");
+    pxt.perf.report();
 
     enableAnalytics()
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4972,7 +4972,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     pkg.setupAppTarget((window as any).pxtTargetBundle);
     pxt.setBundledApiInfo((window as any).pxtTargetBundle.apiInfo);
     pxt.perf.measureEnd("setAppTarget");
-    pxt.perf.report();
 
     enableAnalytics()
 

--- a/webapp/src/compiler.ts
+++ b/webapp/src/compiler.ts
@@ -692,18 +692,20 @@ async function getCachedApiInfoAsync(project: pkg.EditorPackage, bundled: pxt.Ma
 
     for (const used of usedPackageInfo) {
         if (!used) continue;
-        const { info, dirname } = used;
+        let { info, dirname } = used;
+
+        const byQName = U.cloneApis(info.apis.byQName);
 
         // reinclude the pkg the api originates from, which is trimmed during compression
-        for (const api of Object.keys(info.apis.byQName)) {
-            info.apis.byQName[api].pkg = dirname;
+        for (const api of Object.keys(byQName)) {
+            byQName[api].pkg = dirname;
 
             // We had a bug where we were caching the translated language code and it broke translations.
             // make sure we clear it on any old cached entries from before the bug was fixed
-            delete info.apis.byQName[api].attributes._translatedLanguageCode;
-        }
+            delete byQName[api].attributes._translatedLanguageCode;
 
-        pxt.Util.jsonCopyFrom(result.byQName, info.apis.byQName);
+            result.byQName[api] = byQName[api];
+        }
     }
 
     result.jres = pkg.mainPkg.getJRes() || {};


### PR DESCRIPTION
I was doing some profiling on performance and noticed we spend a lot of time in our clone function in util.ts. That clone function just looks like this:

```ts
    export function clone<T>(v: T): T {
        if (v == null) return null
        return JSON.parse(JSON.stringify(v))
    }
```

Turns out, the vast majority of the time spent cloning was in two places: cloning the apptarget when initially setting it up and cloning the cached api info in webapp/src/compiler.ts. We were basically cloning the entirety of target.js (a 10.1 MB file in pxt-arcade) multiple times!

This PR speeds things up considerably by implementing functions for specifically cloning the SymbolInfo and TargetBundle types. In my testing, it cut it down to about 1/3 of what it was before when setting up the AppTarget (I didn't time the cached API info changes but there should be similar gains)