### PR TITLE
Hide back button on tutorial modals, tablet hint design

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -1,4 +1,4 @@
-@defaultTutorialHeight: 18.75rem;
+@defaultTutorialHeight: 18.625rem;
 @tutorialFontSize: 1.125rem;
 @tutorialTitleFontSize: 1.5rem;
 
@@ -300,26 +300,37 @@
             Tutorial Controls
     *******************************/
 
-    .tutorial-container {
-        > .ui.button {
+    .tutorial-container,
+    .tutorial-controls {
+        .ui.button {
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
             width: 4rem;
-            color: @teal;
-            background: @white;
-            box-shadow: none;
-            border-radius: 0;
+            height: unset;
+            font-size: 1rem;
 
-            > .arrow, > .check {
+            i.icon {
+                display: flex;
+                align-items: center;
+                justify-content: center;
                 margin-bottom: 0.5rem!important;
                 font-size: 2rem;
             }
 
-            > .text {
-                margin: 0 !important;
+            > .icon-and-text.icon~.ui.text {
+                margin-left: 0 !important;
             }
+        }
+    }
+
+    .tutorial-container {
+        > .ui.button {
+            color: @teal;
+            background: @white;
+            box-shadow: none;
+            border-radius: 0;
         }
     }
 
@@ -328,16 +339,16 @@
     *******************************/
 
     .tutorial-controls {
-        position: absolute;
-        right: 6rem;
-        margin-top: 1rem;
+        display: flex;
+        align-items: center;
+        margin: 0;
     }
 
     .tutorial-hint.ui.button {
-        width: unset;
-        height: unset;
-        font-size: 1rem;
         border-radius: 0.2rem;
+        color: @teal;
+        background: @blue;
+        margin: 1rem;
 
         &.disabled {
             display: none;
@@ -347,8 +358,8 @@
     // Overrides
     .tab-tutorial {
         .tutorialhint {
-            top: 12.5rem;
-            right: 3.2rem;
+            top: 18.5rem;
+            right: 1.6rem;
             bottom: unset;
             left: unset;
             max-width: 80%;

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -21,7 +21,7 @@ interface TutorialContainerProps {
 }
 
 const MIN_HEIGHT = 80;
-const MAX_HEIGHT = 212;
+const MAX_HEIGHT = 170;
 
 export function TutorialContainer(props: TutorialContainerProps) {
     const { parent, name, steps, tutorialOptions, onTutorialStepChange, onTutorialComplete, setParentHeight } = props;
@@ -75,10 +75,11 @@ export function TutorialContainer(props: TutorialContainerProps) {
         }
     })
 
-    let modalActions: ModalButton[] = [
-        { label: lf("Back"), onclick: tutorialStepBack, icon: "arrow circle left", disabled: !showBack, labelPosition: "left" },
-        { label: lf("Ok"), onclick: tutorialStepNext, icon: "arrow circle right", disabled: !showNext, className: "green" }
-    ];
+    let modalActions: ModalButton[] = [{ label: lf("Ok"), onclick: tutorialStepNext,
+        icon: "arrow circle right", disabled: !showNext, className: "green" }];
+
+    if (showBack) modalActions.unshift({ label: lf("Back"), onclick: tutorialStepBack,
+        icon: "arrow circle left", disabled: !showBack, labelPosition: "left" })
 
     if (showImmersiveReader) {
         modalActions.push({
@@ -104,12 +105,12 @@ export function TutorialContainer(props: TutorialContainerProps) {
             {title && <div className="tutorial-title">{title}</div>}
             <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent}/>
         </div>
-        {layout === "horizontal" && nextButton}
         <div className="tutorial-controls">
             { layout === "vertical" && backButton }
             <TutorialHint markdown={hintMarkdown} parent={parent} showLabel={layout === "horizontal"} />
             { layout === "vertical" && nextButton }
         </div>
+        {layout === "horizontal" && nextButton}
         {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={name} buttons={modalActions}
             className="hintdialog" onClose={showNext ? tutorialStepNext : () => setHideModal(true)} dimmer={true}
             longer={true} closeOnDimmerClick closeOnDocumentClick closeOnEscape>

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -118,7 +118,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         const { activeTab, height } = this.state;
 
         return <div id="simulator" className="simulator">
-            <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + 5.5rem)` } : undefined}>
+            <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + 8rem)` } : undefined}>
                 <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />


### PR DESCRIPTION
feedback from design office hours:
- hide back button on modal when there is nothing to go "back" to
- update hint design for tablet view

![image](https://user-images.githubusercontent.com/34112083/131912082-93030e60-f624-44cb-b055-04670de08b25.png)
