### PR TITLE
CSS adjustments for headless (no simulator) tutorial view

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -152,6 +152,7 @@ pre {
 .transparentEditorTools #editortools {
     background-color: transparent;
     z-index: (@blocklyFlyoutZIndex)-1;
+    border: unset;
 }
 
 #blocksArea, #monacoEditor, #pxtJsonEditor, #serialEditor, #assetEditor, #editorSidebar {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -2,6 +2,9 @@
 @tutorialFontSize: 1.125rem;
 @tutorialTitleFontSize: 1.5rem;
 
+@tutorialPrimaryColor: @teal;
+@tutorialSecondaryColor: @blue;
+
 /*******************************
         Tutorial Tab
 *******************************/
@@ -63,12 +66,12 @@
     height: 1rem;
     overflow: hidden;
     border-radius: 1rem;
-    background-color: @blue;
+    background-color: @tutorialSecondaryColor;
     cursor: pointer;
 }
 
 .tutorial-step-bar-fill {
-    background-color: @teal;
+    background-color: @tutorialPrimaryColor;
     height: 100%;
     transition: width 0.5s ease-out;
     pointer-events: none;
@@ -95,8 +98,8 @@
 
     .ui.button {
         margin: 0 0.4rem;
-        color: @blue;
-        background: @teal;
+        color: @tutorialSecondaryColor;
+        background: @tutorialPrimaryColor;
         font-size: @tutorialFontSize;
         white-space: nowrap;
         overflow: hidden;
@@ -169,7 +172,7 @@
 .formatted-bullet {
     margin-right: 0.5rem;
     flex-shrink: 0;
-    background: linear-gradient(@teal, @teal) ~'no-repeat 45% / 2px 100%';
+    background: linear-gradient(@tutorialPrimaryColor, @tutorialPrimaryColor) ~'no-repeat 45% / 2px 100%';
 }
 .formatted-bullet i {
     display: block;
@@ -177,7 +180,7 @@
     height: 2.5rem;
     border-radius: 50%;
     color: @white;
-    background-color: @teal;
+    background-color: @tutorialPrimaryColor;
     line-height: 2.5rem;
 }
 .formatted-bullet-ul .formatted-bullet-li:last-child .formatted-bullet:after {
@@ -186,7 +189,7 @@
     width: 1rem;
     bottom: 0;
     left: 0.75rem;
-    border-bottom: 2px solid @teal;
+    border-bottom: 2px solid @tutorialPrimaryColor;
 }
 
 /*******************************
@@ -221,7 +224,6 @@
     }
 }
 
-
 /*******************************
       Skill Map Embed View
 *******************************/
@@ -232,6 +234,29 @@
     }
     .simView #boardview {
         padding-top: 0;
+    }
+}
+
+/*******************************
+    Headless (no simulator)
+*******************************/
+
+#root.headless.tutorialVertical {
+    #editorSidebar {
+        position: relative;
+        display: block !important;
+        width: @simulatorWidth;
+        height: calc(~'100%' - @mainMenuHeight);
+        top: @mainMenuHeight;
+        left: 0;
+    }
+
+    #boardview, .filemenu {
+        display: auto;
+    }
+
+    #maineditor {
+        left: @simulatorWidth;
     }
 }
 
@@ -249,16 +274,19 @@
 
 /* <= Tablet (Mobile + Tablet) */
 @media only screen and (max-width: @largestTabletScreen) {
-    .tutorialVertical #maineditor > .full-abs {
-        top: @defaultTutorialHeight;
-    }
+    #root.tutorialVertical,
+    #root.headless.tutorialVertical {
+        #maineditor > .full-abs {
+            top: @defaultTutorialHeight;
+        }
 
-    .tutorialVertical #editorSidebar {
-        top: @mobileMenuHeight;
-        height: @defaultTutorialHeight;
-        width: 100%;
-        border-right: 0;
-        border-bottom: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
+        #editorSidebar {
+            top: @mobileMenuHeight;
+            height: @defaultTutorialHeight;
+            width: 100%;
+            border-right: 0;
+            border-bottom: 2px solid darken(desaturate(@blocklyToolboxColor, 60%), 10%);
+        }
     }
 
     .tab-tutorial.tab-content {
@@ -307,7 +335,7 @@
     }
 
     .tutorial-step-bar-fill {
-        background-color: @blue;
+        background-color: @tutorialSecondaryColor;
     }
 
     /*******************************
@@ -341,7 +369,7 @@
 
     .tutorial-container {
         > .ui.button {
-            color: @teal;
+            color: @tutorialPrimaryColor;
             background: @white;
             box-shadow: none;
             border-radius: 0;
@@ -360,8 +388,8 @@
 
     .tutorial-hint.ui.button {
         border-radius: 0.2rem;
-        color: @teal;
-        background: @blue;
+        color: @tutorialPrimaryColor;
+        background: @tutorialSecondaryColor;
         margin: 1rem;
 
         &.disabled {
@@ -419,6 +447,49 @@
 
         #boardview {
             width: 100% !important;
+        }
+    }
+
+    /*******************************
+        Headless (no simulator)
+    *******************************/
+
+    #root.headless.tutorialVertical.collapsedEditorTools {
+        #maineditor { left: 0; }
+        #editorSidebar { width: 100%; }
+
+        .tutorial-top-bar {
+           right: 4rem;
+        }
+
+        #editorSidebar .immersive-reader-button.ui.item,
+        #editorSidebar .immersive-reader-button.ui.item:focus{
+            background-image: @immersiveReaderIcon;
+        }
+        .tutorial-step-counter {
+            color: @black;
+        }
+
+        .tutorial-step-bar {
+            background-color: @tutorialSecondaryColor;
+        }
+
+        .tutorial-step-bar-fill {
+            background-color: @tutorialPrimaryColor;
+        }
+
+        .tutorial-hint.ui.button {
+            flex-direction: row;
+            width: 12rem;
+            margin: 3.5rem 1rem 0;
+        }
+
+        .tutorial-controls {
+            align-items: flex-start;
+
+            .ui.button i.icon {
+                margin-bottom: 0!important;
+            }
         }
     }
 }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4086,7 +4086,7 @@ export class ProjectView
         if (this.isTutorial()) {
             if (pxt.BrowserUtils.isVerticalTutorial()) {
                 const sidebarEl = document?.getElementById("editorSidebar");
-                if (sidebarEl && window?.innerWidth <= pxt.BREAKPOINT_TABLET) {
+                if (sidebarEl && window?.innerWidth < pxt.BREAKPOINT_TABLET) {
                     this.setState({ editorOffset: sidebarEl.offsetHeight + "px" });
                 } else {
                     this.setState({ editorOffset: undefined });
@@ -5187,7 +5187,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
             // Check to see if we should show the mini simulator (<= tablet size)
             if (!theEditor.isTutorial() || !pxt.BrowserUtils.isVerticalTutorial()) {
-                if (window?.innerWidth <= pxt.BREAKPOINT_TABLET) {
+                if (window?.innerWidth < pxt.BREAKPOINT_TABLET) {
                     theEditor.showMiniSim(true);
                 } else {
                     theEditor.showMiniSim(false);

--- a/webapp/src/components/core/TabPane.tsx
+++ b/webapp/src/components/core/TabPane.tsx
@@ -12,8 +12,10 @@ interface TabPaneProps {
 
 export function TabPane(props: TabPaneProps) {
     const { id, children, className, style, activeTabName } = props;
+    const childArray = (Array.isArray(children) ? children : [children]).filter((el: any) => !!el);
+    if (!childArray || childArray.length == 0) return <div />;
+
     const [ activeTab, setActiveTab ] = React.useState(activeTabName);
-    const childArray = Array.isArray(children) ? children.filter((el: any) => !!el) : [children];
 
     const selectTab = (tabProps: TabContentProps) => {
         const { name, onSelected } = tabProps as TabContentProps;

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -54,7 +54,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     React.useEffect(() => {
         const observer = new ResizeObserver(() => {
-            if (window.innerWidth <= pxt.BREAKPOINT_TABLET) {
+            if (window.innerWidth < pxt.BREAKPOINT_TABLET) {
                 setLayout("horizontal");
             } else {
                 setLayout("vertical");
@@ -66,7 +66,10 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     React.useEffect(() => {
         if (layout == "horizontal") {
-            const scrollHeight = contentRef?.current?.children?.[1]?.scrollHeight;
+            let scrollHeight = 0;
+            const children = contentRef?.current?.children ? pxt.Util.toArray(contentRef?.current?.children) : [];
+            children.forEach((el: any) => scrollHeight += el?.scrollHeight);
+
             if (scrollHeight) {
                 setParentHeight(Math.min(Math.max(scrollHeight + 2, MIN_HEIGHT), MAX_HEIGHT));
             }
@@ -111,7 +114,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
             { layout === "vertical" && nextButton }
         </div>
         {layout === "horizontal" && nextButton}
-        {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={name} buttons={modalActions}
+        {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={title || name} buttons={modalActions}
             className="hintdialog" onClose={showNext ? tutorialStepNext : () => setHideModal(true)} dimmer={true}
             longer={true} closeOnDimmerClick closeOnDocumentClick closeOnEscape>
             <MarkedContent markdown={currentStepInfo.contentMd} parent={parent} />

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -117,9 +117,12 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
             handleHardwareDebugClick, onTutorialStepChange, onTutorialComplete } = this.props;
         const { activeTab, height } = this.state;
 
+        const hasSimulator = !pxt.appTarget.simulator?.headless;
+        const marginHeight = hasSimulator ? "6.5rem" : "3rem";
+
         return <div id="simulator" className="simulator">
-            <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + 8rem)` } : undefined}>
-                <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
+            <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + ${marginHeight})` } : undefined}>
+                {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
                         <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} />
@@ -134,7 +137,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         {showFileList && <filelist.FileList parent={parent} />}
                         {showFullscreenButton && <div id="miniSimOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.handleSimOverlayClick} />}
                     </div>
-                </TabContent>
+                </TabContent>}
                 {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="pencil" onSelected={this.showTutorialTab}>
                     <TutorialContainer parent={parent} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}
                         currentStep={tutorialOptions.tutorialStep} tutorialOptions={tutorialOptions}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/132046954-8b088690-0fbb-46d9-9c6a-7633bf4b4bc6.png)

![image](https://user-images.githubusercontent.com/34112083/132046989-d5021612-6520-4ed0-8874-693a856416af.png)

i'm not doing any of the minecraft-specific styles (blocky buttons, fonts, colors) in this PR. there will also be a separate one to restore the HoC styles (hideiteration flag, etc)
