### PR TITLE
Expand inline blocks regex to allow arrays

### DIFF
--- a/pxtrunner/renderer.ts
+++ b/pxtrunner/renderer.ts
@@ -774,7 +774,7 @@ namespace pxt.runner {
                 return renderNextAsync();
             }
 
-            const m = /^\[([^\]]+)\]$/.exec(text);
+            const m = /^\[(.+)\]$/.exec(text);
             if (!m) return renderNextAsync();
 
             const code = m[1];


### PR DESCRIPTION
our blocks format allows inline blocks defined like ` ``[scene.setBackgroundColor(3)]`` ` . this expands the regex to allow arrays in the inline block code ( ` ``[let a = [1, 2]]`` ` )