### PR TITLE
Rename 'isVerticalTutorial' check, only apply headerbar styles in tutorial mode

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -170,7 +170,7 @@ namespace pxt.BrowserUtils {
         } catch (e) { return false; }
     }
 
-    export function isVerticalTutorial(): boolean {
+    export function useVerticalTutorialLayout(): boolean {
         try {
             return !(/tutoriallayout=h/.test(window.location.href));
         } catch (e) { return false; }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4084,7 +4084,7 @@ export class ProjectView
 
     setEditorOffset() {
         if (this.isTutorial()) {
-            if (pxt.BrowserUtils.isVerticalTutorial()) {
+            if (pxt.BrowserUtils.useVerticalTutorialLayout()) {
                 const sidebarEl = document?.getElementById("editorSidebar");
                 if (sidebarEl && window?.innerWidth < pxt.BREAKPOINT_TABLET) {
                     this.setState({ editorOffset: sidebarEl.offsetHeight + "px" });
@@ -4295,7 +4295,7 @@ export class ProjectView
         const tutorialOptions = this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
-        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.isVerticalTutorial();
+        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.useVerticalTutorialLayout();
         const inTutorialExpanded = inTutorial && tutorialOptions.tutorialStepExpanded;
         const hideTutorialIteration = inTutorial && tutorialOptions.metadata && tutorialOptions.metadata.hideIteration;
         const inDebugMode = this.state.debugging;
@@ -5188,7 +5188,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             }
 
             // Check to see if we should show the mini simulator (<= tablet size)
-            if (!theEditor.isTutorial() || !pxt.BrowserUtils.isVerticalTutorial()) {
+            if (!theEditor.isTutorial() || !pxt.BrowserUtils.useVerticalTutorialLayout()) {
                 if (window?.innerWidth < pxt.BREAKPOINT_TABLET) {
                     theEditor.showMiniSim(true);
                 } else {

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -83,7 +83,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
             return "sandbox";
         } else if (debugging) {
             return "debugging";
-        } else if (pxt.BrowserUtils.isVerticalTutorial()) {
+        } else if (pxt.BrowserUtils.useVerticalTutorialLayout() && !!tutorialOptions?.tutorial) {
             return "tutorial-vertical"
         } else if (!!tutorialOptions?.tutorial) {
             return "tutorial";

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -86,7 +86,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
 
     protected handleSimOverlayClick = () => {
         const { tutorialOptions, handleFullscreenButtonClick } = this.props;
-        if (!tutorialOptions || !pxt.BrowserUtils.isVerticalTutorial()) {
+        if (!tutorialOptions || !pxt.BrowserUtils.useVerticalTutorialLayout()) {
             handleFullscreenButtonClick();
         } else {
             this.showSimulatorTab();


### PR DESCRIPTION
i've made this same mistake at least twice (isVerticalTutorial() checks for the URL flag but not whether the project is actually a tutorial) so i'm renaming `isVerticalTutorial` -> `useVerticalTutorialLayout` to hopefully make the flag clearer

this is the bugfix: https://github.com/microsoft/pxt/pull/8472/files#diff-94834a36659c6506f142b87ee5375cb5a79e412002687c17752c78627d9902b2L86

fixes https://github.com/microsoft/pxt-arcade/issues/3902