### PR TITLE
Allow skill map end action without link

### DIFF
--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -276,7 +276,7 @@ function inflateMapReward(section: MarkdownSection, base: Partial<MapReward>): M
         const actions = section.listAttributes["actions"];
         for (const action of actions) {
             let [kind, ...rest] = action.split(":");
-            const valueMatch = /\s*\[\s*(.*)\s*\]\(([^\s]+)\)/gi.exec(rest.join(":"));
+            const valueMatch = /\s*\[\s*(.*)\s*\](?:\(([^\s]+)\))?/gi.exec(rest.join(":"));
             const label = valueMatch?.[1];
             const link = valueMatch?.[2];
             switch (kind) {


### PR DESCRIPTION
fix for the skillmap end modal action to export the finished project to the full editor--it's formatted like `* editor: [Link Text Here]` without the parenthesis/link