### PR TITLE
Mini sim buttons, tutorial title, notification badge

### DIFF
--- a/theme/common-components.less
+++ b/theme/common-components.less
@@ -8,6 +8,16 @@
     flex-shrink: 0;
 }
 
+.tab-badge {
+    position: absolute;
+    height: 0.75rem;
+    width: 0.75rem;
+    margin-left: 1.75rem;
+    margin-top: -0.2rem;
+    background-color: @red;
+    border-radius: 50%;
+}
+
 .tab-icon {
     padding: 1rem;
     font-size: 1.5rem;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -219,7 +219,13 @@
             #boardview { display: inline-block; }
 
             .simtoolbar, #miniSimOverlay { display: block; }
-            .fullscreen-button, .expand-button { display: block !important; }
+            .sidebar-button, .play-button { display: block !important; }
+            .expand-button, .fullscreen-button { display: none !important; }
+        }
+    }
+    .tab-simulator.tab-content:not(.hidden) {
+        .simPanel {
+            .sidebar-button { display: none !important; }
         }
     }
 }

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -62,6 +62,21 @@
     margin-right: 0.5rem;
 }
 
+.tutorial-step-label {
+    display: flex;
+}
+
+.tutorial-step-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tutorial-step-number {
+    flex-shrink: 0;
+    margin-left: 0.5rem;
+}
+
 .tutorial-step-bar {
     height: 1rem;
     overflow: hidden;

--- a/webapp/src/components/core/TabContent.tsx
+++ b/webapp/src/components/core/TabContent.tsx
@@ -4,6 +4,7 @@ export interface TabContentProps {
     name: string;
     icon?: string;
     title?: string;
+    showBadge?: boolean;
     children?: React.ReactNode;
     onSelected?: () => void;
 }

--- a/webapp/src/components/core/TabPane.tsx
+++ b/webapp/src/components/core/TabPane.tsx
@@ -37,10 +37,11 @@ export function TabPane(props: TabPaneProps) {
     return <div id={id} className={`tab-container ${className || ""}`} style={style}>
         {childArray.length > 1 && <div className="tab-navigation">
             {childArray.map(el => {
-                const { name, icon, title } = el.props as TabContentProps;
+                const { name, icon, title, showBadge } = el.props as TabContentProps;
                 const tabClickHandler = () => selectTab(el.props);
 
                 return <div key={name} className={`tab-icon ${name} ${name == activeTab ? "active" : ""}`} onClick={tabClickHandler}>
+                    {showBadge && <div className="tab-badge" />}
                     <i className={`ui icon ${icon}`} />
                     <span>{title}</span>
                 </div>

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -100,7 +100,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     return <div className="tutorial-container">
         <div className="tutorial-top-bar">
-            <TutorialStepCounter currentStep={visibleStep} totalSteps={steps.length} setTutorialStep={setTutorialStep} />
+            <TutorialStepCounter currentStep={visibleStep} totalSteps={steps.length} title={name} setTutorialStep={setTutorialStep} />
             {showImmersiveReader && <ImmersiveReaderButton content={markdown} tutorialOptions={tutorialOptions} />}
         </div>
         {layout === "horizontal" && backButton}
@@ -114,7 +114,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
             { layout === "vertical" && nextButton }
         </div>
         {layout === "horizontal" && nextButton}
-        {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={title || name} buttons={modalActions}
+        {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={currentStepInfo.title || name} buttons={modalActions}
             className="hintdialog" onClose={showNext ? tutorialStepNext : () => setHideModal(true)} dimmer={true}
             longer={true} closeOnDimmerClick closeOnDocumentClick closeOnEscape>
             <MarkedContent markdown={currentStepInfo.contentMd} parent={parent} />

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -3,12 +3,12 @@ import * as React from "react";
 interface TutorialStepCounterProps {
     currentStep: number;
     totalSteps: number;
+    title?: string;
     setTutorialStep: (step: number) => void;
 }
 
 export function TutorialStepCounter(props: TutorialStepCounterProps) {
-    const { currentStep, totalSteps } = props;
-    const tutorialStepLabel = `${lf("Step")} ${currentStep + 1}/${totalSteps}`;
+    const { currentStep, totalSteps, title } = props;
 
     const handleStepBarClick = (e: React.MouseEvent<HTMLDivElement>) => {
         const { totalSteps, setTutorialStep } = props;
@@ -20,7 +20,8 @@ export function TutorialStepCounter(props: TutorialStepCounterProps) {
 
     return <div className="tutorial-step-counter">
         <div className="tutorial-step-label">
-            {tutorialStepLabel}
+            <span className="tutorial-step-title">{title || lf("Step")}</span>
+            <span className="tutorial-step-number">{`${currentStep + 1}/${totalSteps}`}</span>
         </div>
         <div className="tutorial-step-bar" onClick={handleStepBarClick}>
             <div className="tutorial-step-bar-fill" style={{ width: ((currentStep + 1) / totalSteps) * 100 + "%" }} />

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -125,7 +125,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                 {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
-                        <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} />
+                        <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} showSimulatorSidebar={this.showSimulatorTab} />
                         {showKeymap && <keymap.Keymap parent={parent} />}
                         <div className="ui item portrait hide hidefullscreen">
                             {pxt.options.debug && <sui.Button key="hwdebugbtn" className="teal" icon="xicon chip" text={"Dev Debug"} onClick={handleHardwareDebugClick} />}

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -138,7 +138,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         {showFullscreenButton && <div id="miniSimOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.handleSimOverlayClick} />}
                     </div>
                 </TabContent>}
-                {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="pencil" onSelected={this.showTutorialTab}>
+                {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="pencil" showBadge={activeTab !== TUTORIAL_TAB} onSelected={this.showTutorialTab}>
                     <TutorialContainer parent={parent} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}
                         currentStep={tutorialOptions.tutorialStep} tutorialOptions={tutorialOptions}
                         onTutorialStepChange={onTutorialStepChange} onTutorialComplete={onTutorialComplete}

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -10,6 +10,8 @@ export interface SimulatorProps extends ISettingsProps {
     collapsed?: boolean;
     simSerialActive?: boolean;
     devSerialActive?: boolean;
+
+    showSimulatorSidebar?: () => void;
 }
 
 export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
@@ -88,7 +90,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
     }
 
     renderCore() {
-        const { collapsed, devSerialActive, parent, simSerialActive } = this.props;
+        const { collapsed, devSerialActive, parent, simSerialActive, showSimulatorSidebar } = this.props;
 
         const parentState = parent.state;
         if (!parentState.currFile || parentState.home) return <div />
@@ -105,6 +107,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const isFullscreen = parentState.fullscreen;
         const isMuted = parentState.mute;
         const inTutorial = !!parentState.tutorialOptions && !!parentState.tutorialOptions.tutorial;
+        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.isVerticalTutorial(); // TODO shakao merge with "isverticaltutorial" rename change
         const inCodeEditor = parent.isBlocksActive() || parent.isJavaScriptActive() || parent.isPythonActive();
 
         const run = true;
@@ -126,6 +129,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const restartTooltip = lf("Restart the simulator");
         const debugTooltip = lf("Toggle debug mode");
         const keymapTooltip = lf("View simulator keyboard shortcuts");
+        const sidebarTooltip = lf("Show simulator in sidebar");
         const fullscreenTooltip = isFullscreen ? lf("Exit fullscreen mode") : lf("Launch in fullscreen");
         const muteTooltip = isMuted ? lf("Unmute audio") : lf("Mute audio");
         const screenshotTooltip = targetTheme.simScreenshotKey ? lf("Take Screenshot (shortcut {0})", targetTheme.simScreenshotKey) : lf("Take Screenshot");
@@ -137,6 +141,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
 
         return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait ")} role="complementary" aria-label={lf("Simulator toolbar")}>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
+                {isVerticalTutorial && <sui.Button key='simsidebarbtn' className="sidebar-button tablet only" icon="arrow circle left" title={sidebarTooltip} onClick={showSimulatorSidebar} />}
                 {make && <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} />}
                 {run && !targetTheme.bigRunButton && <PlayButton parent={parent} simState={parentState.simState} debugging={parentState.debugging} />}
                 {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button tablet only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -107,7 +107,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const isFullscreen = parentState.fullscreen;
         const isMuted = parentState.mute;
         const inTutorial = !!parentState.tutorialOptions && !!parentState.tutorialOptions.tutorial;
-        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.isVerticalTutorial(); // TODO shakao merge with "isverticaltutorial" rename change
+        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.useVerticalTutorialLayout();
         const inCodeEditor = parent.isBlocksActive() || parent.isJavaScriptActive() || parent.isPythonActive();
 
         const run = true;


### PR DESCRIPTION
three small changes bundled together 
- https://github.com/microsoft/pxt/commit/39232e019a0346370596fad7004dec6ea410a147 - instead of fullscreen and collapse simulator buttons, show "switch to simulator tab" (with temporary icon) and start/stop (without collapse) buttons by the mini sim, in tutorial view 
- https://github.com/microsoft/pxt/commit/752f52970fd7ef66ab91fe79f93855c6d0f5379d - tutorial title by the step number
- https://github.com/microsoft/pxt/commit/3f21c08c50354db18d8b59da1b62897a2e9e84be - show a red dot on the tutorial tab when the simulator tab is visible 

fixes https://github.com/microsoft/pxt-arcade/issues/3905
fixes https://github.com/microsoft/pxt-arcade/issues/3906