### PR TITLE
Use arcade-sim icons.css :)

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -717,7 +717,6 @@ function targetFileList() {
     if (simDir() != "sim")
         lst = lst.concat(nodeutil.allFiles(path.join("sim", "public"), 5, true))
     pxt.debug(`target files (on disk): ${lst.join('\r\n    ')}`)
-    lst = lst.filter(f => !f.includes("icons.css")) // We want to pull icons.css from pxt-core, not the target
     return lst;
 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3925

the icons.css in the sim also has....semantic icons at the end. I can't figure out how to append that in our build, so I'm just gonna update icons.css in arcade-sim.