### PR TITLE
Add exit tutorial button, style report abuse/exit to match new header

### DIFF
--- a/theme/themes/pxt/collections/menu.overrides
+++ b/theme/themes/pxt/collections/menu.overrides
@@ -97,7 +97,20 @@
     }
 }
 
+#mainmenu .link-button {
+    font-family: @segoeUIFont;
 
+    &.link.ui.item:hover {
+        > .text { text-decoration: underline }
+        > .icon { transform: none }
+    }
+
+    .text {
+        font-size: @smallFontSize;
+        font-weight: 400;
+        text-transform: uppercase;
+    }
+}
 
 .ui.vertical.menu .item > .label {
     background-color: #8F8F8F;

--- a/theme/themes/pxt/globals/site.variables
+++ b/theme/themes/pxt/globals/site.variables
@@ -44,6 +44,8 @@
 @emSize      : 14px;
 @fontSize    : 12pt;
 
+@smallFontSize    : 0.875rem;
+
 /*-------------------
    Links
 --------------------*/

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -41,6 +41,10 @@
     span.docs.inlineblock {
         white-space: break-spaces;
     }
+
+    p {
+        line-height: 1.5em;
+    }
 }
 
 /*******************************
@@ -118,8 +122,8 @@
     margin-bottom: 1rem;
 
     .ui.button {
-        margin: 0 0.4rem;
-        color: @tutorialSecondaryColor;
+        margin: 0 1rem;
+        color: @white;
         background: @tutorialPrimaryColor;
         font-size: @tutorialFontSize;
         white-space: nowrap;
@@ -203,6 +207,9 @@
     color: @white;
     background-color: @tutorialPrimaryColor;
     line-height: 2.5rem;
+}
+.formatted-bullet-ul .formatted-bullet-li:last-child {
+    min-height: 3.5rem;
 }
 .formatted-bullet-ul .formatted-bullet-li:last-child .formatted-bullet:after {
     content: " ";

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -44,6 +44,27 @@
 }
 
 /*******************************
+        Exit Tutorial
+*******************************/
+
+.tutorial-exit {
+    position: absolute;
+    margin-right: 1rem;
+    top: 0;
+    right: 0;
+    color: @white;
+    font-family: @segoeUIFont;
+    font-size: @smallFontSize;
+    text-transform: uppercase;
+    line-height: 3.5rem;
+    cursor: pointer;
+}
+
+.tutorial-exit:hover {
+    text-decoration: underline;
+}
+
+/*******************************
        Tutorial Top Buttons
 *******************************/
 
@@ -300,6 +321,15 @@
     .tutorial-content {
         margin: 0;
         padding: 1rem;
+    }
+
+    /*******************************
+            Exit Tutorial
+    *******************************/
+
+    .tab-simulator.hidden .tutorial-exit {
+        // Shift in tutorial tab to make space for step counter
+        right: 14rem;
     }
 
     /*******************************

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -197,6 +197,7 @@ export class ProjectView
         this.showMiniSim = this.showMiniSim.bind(this);
         this.setTutorialStep = this.setTutorialStep.bind(this);
         this.completeTutorialAsync = this.completeTutorialAsync.bind(this);
+        this.exitTutorial = this.exitTutorial.bind(this);
         this.setEditorOffset = this.setEditorOffset.bind(this);
         this.initSimulatorMessageHandlers();
 

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -21,7 +21,7 @@ interface TutorialContainerProps {
 }
 
 const MIN_HEIGHT = 80;
-const MAX_HEIGHT = 170;
+const MAX_HEIGHT = 194;
 
 export function TutorialContainer(props: TutorialContainerProps) {
     const { parent, name, steps, tutorialOptions, onTutorialStepChange, onTutorialComplete, setParentHeight } = props;

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -636,7 +636,25 @@ export function showReportAbuseAsync(pubId?: string) {
     const ghid = pxt.github.parseRepoId(pubId);
     if (ghid) {
         pxt.tickEvent("reportabuse.github");
-        window.open("https://github.com/contact/report-content", "_blank");
+        core.confirmAsync({
+            header: lf("Is this content inappropriate?"),
+            hasCloseIcon: true,
+            agreeLbl: lf("Report"),
+            disagreeLbl: lf("Cancel"),
+            jsx: <div className="ui form">
+                <div className="ui field">
+                    <p>{lf("This content was written by an independent user and may be inappropriate or abusive. Help us block or filter that content by reporting it to Github.")}</p>
+                </div>
+                <div className="ui field">
+                    <label id="githubContentUrlLabel">{lf("Content URL")}</label>
+                    <sui.Input type="url" aria-labelledby="githubContentUrlLabel" readOnly lines={1} copy={true} autoFocus={!pxt.BrowserUtils.isMobile()} selectOnClick={true} value={pubId}></sui.Input>
+                </div>
+            </div>,
+        }).then(res => {
+            if (res) {
+                window.open("https://github.com/contact/report-content", "_blank");
+            }
+        });
         return;
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -265,7 +265,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
                 break;
             case View.Computer:
             default:
-                downloadButtonClasses += "huge fluid ";
+                downloadButtonClasses += "large fluid ";
                 hwIconClasses = "large";
         }
 

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -167,10 +167,16 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
             case "tutorial-vertical":
                 const tutorialButtons = [];
                 if (tutorialOptions?.tutorialReportId) {
-                    tutorialButtons.push(<sui.ButtonMenuItem key="tutorial-report" className="report-tutorial-btn" role="menuitem" icon="warning circle" text={lf("Report Abuse")} textClass="landscape only" onClick={this.showReportAbuse} />)
+                    const reportTutorialLabel = lf("Unapproved Content");
+                    tutorialButtons.push(<sui.Item key="tutorial-report" role="menuitem" icon="exclamation triangle"
+                        className="report-tutorial-btn link-button icon-and-text" textClass="landscape only"
+                        text={reportTutorialLabel} ariaLabel={reportTutorialLabel} onClick={this.showReportAbuse} />);
                 }
-                if (!targetTheme.lockedEditor && !tutorialOptions?.metadata?.hideIteration && view !== "tutorial-vertical") {
-                    tutorialButtons.push(<sui.ButtonMenuItem key="tutorial-exit" className="exit-tutorial-btn" role="menuitem" icon="sign out" text={lf("Exit tutorial")} textClass="landscape only" onClick={this.exitTutorial} />)
+                if (!targetTheme.lockedEditor && !tutorialOptions?.metadata?.hideIteration && (view !== "tutorial-vertical" || pxt.appTarget.simulator?.headless)) {
+                    const exitTutorialLabel = lf("Exit tutorial");
+                    tutorialButtons.push(<sui.Item key="tutorial-exit" role="menuitem" icon="sign out large"
+                        className="exit-tutorial-btn link-button icon-and-text" textClass="landscape only"
+                        text={exitTutorialLabel} ariaLabel={exitTutorialLabel} onClick={this.exitTutorial} />);
                 }
 
                 if (!!tutorialButtons.length) return tutorialButtons;

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -111,18 +111,24 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         if (height != this.state.height) this.setState({ height });
     }
 
+    protected tutorialExitButton = () => {
+        return <div className="tutorial-exit" onClick={() => this.props.parent.exitTutorial()}>{lf("Exit Tutorial")}</div>;
+    }
+
     renderCore() {
         const { parent, inHome, showKeymap, showSerialButtons, showFileList, showFullscreenButton,
             collapseEditorTools, simSerialActive, deviceSerialActive, tutorialOptions,
             handleHardwareDebugClick, onTutorialStepChange, onTutorialComplete } = this.props;
         const { activeTab, height } = this.state;
 
+        const isVerticalTutorial = tutorialOptions?.tutorial && pxt.BrowserUtils.useVerticalTutorialLayout();
         const hasSimulator = !pxt.appTarget.simulator?.headless;
         const marginHeight = hasSimulator ? "6.5rem" : "3rem";
 
         return <div id="simulator" className="simulator">
             <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + ${marginHeight})` } : undefined}>
                 {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
+                    {isVerticalTutorial && this.tutorialExitButton()}
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
                         <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} />

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -1336,7 +1336,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
             </div>
             {!isFullscreen && (this.props.actions && this.props.actions.length || this.props.buttons && this.props.buttons.length) ?
                 <div className="actions">
-                    {this.props.actions?.map(action => <div className="left-action">{action}</div>)}
+                    {this.props.actions?.map((action, i) => <div key={`action_left_${i}`} className="left-action">{action}</div>)}
                     {this.props.buttons?.map(action =>
                         action.url ?
                             <Link


### PR DESCRIPTION
- exit tutorial button in tutorial tab bar, or in header when there are no tabs (headless)
- report abuse button styled like exit button, opens new modal with explanation of content + link to tutorial

![image](https://user-images.githubusercontent.com/34112083/132907404-6739a476-3b5b-41e5-92db-6778c350657b.png)
![image](https://user-images.githubusercontent.com/34112083/132907442-425402d4-6d29-44de-8e88-be922c0198fd.png)
