### PR TITLE
A couple small perf improvements

### DIFF
--- a/cli/hid.ts
+++ b/cli/hid.ts
@@ -64,7 +64,7 @@ export function dmesgAsync() {
     return initAsync()
         .then(d => d.talkAsync(pxt.HF2.HF2_CMD_DMESG)
             .then(resp => {
-                console.log(U.fromUTF8(U.uint8ArrayToString(resp)))
+                console.log(U.fromUTF8Array(resp))
                 return d.disconnectAsync()
             }))
 }

--- a/pxtlib/hf2.ts
+++ b/pxtlib/hf2.ts
@@ -538,7 +538,7 @@ namespace pxt.HF2 {
                     return this.talkAsync(HF2_CMD_INFO)
                 })
                 .then(buf => {
-                    this.infoRaw = U.fromUTF8(U.uint8ArrayToString(buf));
+                    this.infoRaw = pxt.Util.fromUTF8Array(buf);
                     pxt.debug("Info: " + this.infoRaw)
                     let info = {} as any
                     ("Header: " + this.infoRaw).replace(/^([\w\-]+):\s*([^\n\r]*)/mg,

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1358,7 +1358,7 @@ namespace ts.pxtc {
                 if (len >= 0) {
                     fnbuf = fnbuf.slice(0, len)
                 }
-                filename = U.fromUTF8(U.uint8ArrayToString(fnbuf))
+                filename = U.fromUTF8Array(fnbuf);
                 fileSize = wordAt(28)
             }
 
@@ -1584,7 +1584,7 @@ namespace ts.pxtc {
                     for (let i = 32; i < 32 + 256; ++i)
                         currBlock[i] = 0xff
                     if (f.filename) {
-                        U.memcpy(currBlock, 32 + 256, U.stringToUint8Array(U.toUTF8(f.filename)))
+                        U.memcpy(currBlock, 32 + 256, U.toUTF8Array(f.filename))
                     }
                     f.blocks.push(currBlock)
                     f.ptrs.push(needAddr)

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1745,6 +1745,15 @@ namespace ts.pxtc.Util {
             type: prop.type
         }
     }
+
+
+    export function toUTF8Array(s: string) {
+        return (new TextEncoder()).encode(s);
+    }
+
+    export function fromUTF8Array(s: Uint8Array) {
+        return (new TextDecoder()).decode(s);
+    }
 }
 
 namespace ts.pxtc.BrowserImpl {
@@ -1939,7 +1948,7 @@ namespace ts.pxtc.BrowserImpl {
 
     export function sha256string(s: string) {
         pxt.perf.measureStart("sha256buffer")
-        const res = sha256buffer((new TextEncoder()).encode(s));
+        const res = sha256buffer(Util.toUTF8Array(s));
         pxt.perf.measureEnd("sha256buffer")
         return res;
     }

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -1938,7 +1938,10 @@ namespace ts.pxtc.BrowserImpl {
     }
 
     export function sha256string(s: string) {
-        return sha256buffer(Util.stringToUint8Array(Util.toUTF8(s)))
+        pxt.perf.measureStart("sha256buffer")
+        const res = sha256buffer((new TextEncoder()).encode(s));
+        pxt.perf.measureEnd("sha256buffer")
+        return res;
     }
 }
 

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -619,7 +619,7 @@ namespace pxsim {
         }
 
         export function toString(buf: RefBuffer): string {
-            return U.fromUTF8(U.uint8ArrayToString(buf.data))
+            return U.fromUTF8Array(buf.data);
         }
 
         function memmove(dst: Uint8Array, dstOff: number, src: Uint8Array, srcOff: number, len: number) {
@@ -707,6 +707,6 @@ namespace pxsim {
 
 namespace pxsim.control {
     export function createBufferFromUTF8(str: string) {
-        return new pxsim.RefBuffer(U.stringToUint8Array(U.toUTF8(str)));
+        return new pxsim.RefBuffer(U.toUTF8Array(str));
     }
 }

--- a/pxtsim/runtime.ts
+++ b/pxtsim/runtime.ts
@@ -239,6 +239,14 @@ namespace pxsim {
             return res;
         }
 
+        export function toUTF8Array(s: string) {
+            return (new TextEncoder()).encode(s);
+        }
+
+        export function fromUTF8Array(s: Uint8Array) {
+            return (new TextDecoder()).decode(s);
+        }
+
         export function isPxtElectron(): boolean {
             return typeof window != "undefined" && !!(window as any).pxtElectron;
         }


### PR DESCRIPTION
A couple small changes to improve tutorial loading perf. All of these measurements were done in chrome with the 6x CPU slowdown:

1. When rendering the markdown snippets, do it outside the dom to prevent a style recalculation (went from ~90ms to ~45ms)
2. Replaced the UTF8 encoding/decoding we do in a few places to use the TextEncoder/TextDecoder APIs which are now supported in all the browsers we support and node. I mainly did this because I was noticing a lot of time spent getting a SHA256 hash on extensions (went from ~150ms to ~60ms but this is called a few times with different timings)

AFAIK the result of the TextEncoder/TextDecoder should be the same as our implementations. I confirmed it at least returned the same results in the calls to the SHA256 function.

Doesn't make a *ton* of difference on my machine but I can see the improvements in the performance tab of devtools. Hopefully I will have time to go into the office and pick up a chromebook this week (my work laptop is a little too speedy for accurate numbers).

