### PR TITLE
fix local serve docs again

### DIFF
--- a/pxtrunner/runner.ts
+++ b/pxtrunner/runner.ts
@@ -218,9 +218,14 @@ namespace pxt.runner {
             const mlang = /(live)?(force)?lang=([a-z]{2,}(-[A-Z]+)?)/i.exec(href);
             lang = mlang ? mlang[3] : (cookieValue && cookieValue[1] || pxt.appTarget.appTheme.defaultLocale || (navigator as any).userLanguage || navigator.language);
 
-            const liveTranslationsDisabled = pxt.BrowserUtils.isPxtElectron()
-                || (pxt.BrowserUtils.isLocalHostDev() && (pxt.appTarget.appTheme.defaultLocale || "en") === lang)
-                || pxt.appTarget.appTheme.disableLiveTranslations;
+            const defLocale = pxt.appTarget.appTheme.defaultLocale;
+            const langLowerCase = lang?.toLocaleLowerCase();
+            const localDevServe = pxt.BrowserUtils.isLocalHostDev()
+                && (!langLowerCase || (defLocale
+                    ? defLocale.toLocaleLowerCase() === langLowerCase
+                    : "en" === langLowerCase || "en-us" === langLowerCase));
+            const serveLocal = pxt.BrowserUtils.isPxtElectron() || localDevServe;
+            const liveTranslationsDisabled = serveLocal || pxt.appTarget.appTheme.disableLiveTranslations;
             if (!liveTranslationsDisabled || !!mlang?.[1]) {
                 pxt.Util.enableLiveLocalizationUpdates();
             }

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -138,8 +138,15 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const targetId = pxt.appTarget.id;
         const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;
         const targetBranch = pxt.appTarget.versions.targetCrowdinBranch;
-        if (!(pxt.BrowserUtils.isLocalHostDev() && (pxt.appTarget.appTheme.defaultLocale || "en") === useLang)
-            && !pxt.BrowserUtils.isPxtElectron()) {
+
+        const defLocale = pxt.appTarget.appTheme.defaultLocale;
+        const langLowerCase = useLang?.toLocaleLowerCase();
+        const localDevServe = pxt.BrowserUtils.isLocalHostDev()
+            && (!langLowerCase || (defLocale
+                ? defLocale.toLocaleLowerCase() === langLowerCase
+                : "en" === langLowerCase || "en-us" === langLowerCase));
+        const serveLocal = pxt.BrowserUtils.isPxtElectron() || localDevServe;
+        if (!serveLocal) {
             pxt.Util.enableLiveLocalizationUpdates();
         }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5070,8 +5070,13 @@ document.addEventListener("DOMContentLoaded", async () => {
                 useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
 
                 const locstatic = /staticlang=1/i.test(window.location.href);
-                const serveLocal = pxt.BrowserUtils.isPxtElectron()
-                    || (pxt.BrowserUtils.isLocalHostDev() && (pxt.appTarget.appTheme.defaultLocale || "en") === useLang);
+                const defLocale = pxt.appTarget.appTheme.defaultLocale;
+                const langLowerCase = useLang?.toLocaleLowerCase();
+                const localDevServe = pxt.BrowserUtils.isLocalHostDev()
+                    && (!langLowerCase || (defLocale
+                        ? defLocale.toLocaleLowerCase() === langLowerCase
+                        : "en" === langLowerCase || "en-us" === langLowerCase));
+                const serveLocal = pxt.BrowserUtils.isPxtElectron() || localDevServe;
                 const stringUpdateDisabled = locstatic || serveLocal || theme.disableLiveTranslations;
 
                 if (!stringUpdateDisabled || requestLive) {


### PR DESCRIPTION
Looks like the logic for local serving docs broke again, this time I'm getting a different default locale from chrome (that is, "en-US" instead of "en"). This then failed the check here and enabled the server translations, which should only be enabled in non-default lang

If this breaks again I'll just add a url flag and cut out all the special casing logic here I think, it's getting way too tedious