### PR TITLE
Add editor message for restricting editor languages for loaded project

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -597,7 +597,10 @@ declare namespace pxt.editor {
         Standard = "",
         PythonOnly = "python-only",
         JavaScriptOnly = "javascript-only",
-        NoBlocks = "no-blocks"
+        BlocksOnly = "blocks-only",
+        NoBlocks = "no-blocks",
+        NoPython = "no-python",
+        NoJavaScript = "no-javascript"
     }
 }
 

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -377,6 +377,7 @@ namespace pxt.editor {
         saveLocalProjectsToCloudAsync(headerIds: string[]): Promise<pxt.Map<string> | undefined>;
         requestProjectCloudStatus(headerIds: string[]): Promise<void>;
         convertCloudProjectsToLocal(userId: string): Promise<void>;
+        setLanguageRestrictionAsync(restriction: pxt.editor.LanguageRestriction): Promise<void>;
     }
 
     export interface IHexFileImporter {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -593,6 +593,10 @@ namespace pxt.editor {
                                 }
                                 case "setlanguagerestriction": {
                                     const msg = data as EditorSetLanguageRestriction;
+                                    if (msg.restriction === "no-blocks") {
+                                        console.warn("no-blocks language restriction is not supported");
+                                        throw new Error("no-blocks language restriction is not supported")
+                                    }
                                     return projectView.setLanguageRestrictionAsync(msg.restriction);
                                 }
                             }

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -59,6 +59,7 @@ namespace pxt.editor {
         | "projectcloudstatus"
         | "requestprojectcloudstatus"
         | "convertcloudprojectstolocal"
+        | "setlanguagerestriction"
 
         | "toggletrace" // EditorMessageToggleTraceRequest
         | "togglehighcontrast"
@@ -361,6 +362,11 @@ namespace pxt.editor {
         script: Cloud.JsonScript;
     }
 
+    export interface EditorSetLanguageRestriction extends EditorMessageRequest {
+        action: "setlanguagerestriction";
+        restriction: pxt.editor.LanguageRestriction;
+    }
+
     const pendingRequests: pxt.Map<{
         resolve: (res?: EditorMessageResponse | PromiseLike<EditorMessageResponse>) => void;
         reject: (err: any) => void;
@@ -584,6 +590,10 @@ namespace pxt.editor {
                                 case "convertcloudprojectstolocal": {
                                     const msg = data as EditorMessageConvertCloudProjectsToLocal;
                                     return projectView.convertCloudProjectsToLocal(msg.userId);
+                                }
+                                case "setlanguagerestriction": {
+                                    const msg = data as EditorSetLanguageRestriction;
+                                    return projectView.setLanguageRestrictionAsync(msg.restriction);
                                 }
                             }
                             return Promise.resolve();

--- a/webapp/public/controller.html
+++ b/webapp/public/controller.html
@@ -64,6 +64,17 @@
             logs.innerText += "filter: " + filter + "\n";
         }
 
+        var languageRestrictions = [
+            "python-only",
+            "javascript-only",
+            "blocks-only",
+            "no-blocks",
+            "no-python",
+            "no-javascript",
+            ""
+        ];
+        var languageRestrictionIndex = 0;
+
         var pendingMsgs = {};
         var fullScreen = false;
         function sendMessage(action) {
@@ -91,6 +102,10 @@
                 msg.enabled = true;
             } else if (action == 'setsimulatorfullscreen') {
                 msg.enabled = fullScreen = !fullScreen;
+            }
+            else if (action == 'setlanguagerestriction') {
+                msg.restriction = languageRestrictions[languageRestrictionIndex];
+                languageRestrictionIndex = (languageRestrictionIndex + 1) % languageRestrictions.length;
             }
             if (msg.response)
                 pendingMsgs[msg.id] = msg;
@@ -160,6 +175,7 @@
     <div id="buttons" class="ui buttons">
         <button class="ui button" onclick="sendMessage('switchblocks')">switch to blocks</button>
         <button class="ui button" onclick="sendMessage('switchjavascript')">switch to javascript</button>
+        <button class="ui button" onclick="sendMessage('setlanguagerestriction')">restrict language</button>
         <button class="ui button" onclick="sendMessage('startsimulator')">start sim</button>
         <button class="ui button" onclick="sendMessage('restartsimulator')">reset sim</button>
         <button class="ui button" onclick="sendMessage('stopsimulator')">stop sim</button>

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -605,6 +605,10 @@ export class ProjectView
         this.shouldTryDecompile = false;
     }
 
+    /**
+     * Same as openBlocks but waits for the return and ensures that main.blocks exist
+     * @returns
+     */
     async openBlocksAsync() {
         if (this.updatingEditorFile) return; // already transitioning
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -460,19 +460,44 @@ export class EditorSelector extends data.Component<IEditorSelectorProps, {}> {
         const dropdownActive = python && (parent.isJavaScriptActive() || parent.isPythonActive());
         const tsOnly = languageRestriction === pxt.editor.LanguageRestriction.JavaScriptOnly;
         const pyOnly = languageRestriction === pxt.editor.LanguageRestriction.PythonOnly;
+        const blocksOnly = languageRestriction === pxt.editor.LanguageRestriction.BlocksOnly;
+        const noJavaScript = languageRestriction === pxt.editor.LanguageRestriction.NoJavaScript;
+        const noPython = languageRestriction === pxt.editor.LanguageRestriction.NoPython;
+        const noBlocks = languageRestriction === pxt.editor.LanguageRestriction.NoBlocks;
 
         // show python in toggle if: python editor currently active, or blocks editor active & saved language pref is python
-        const showPython = python && !tsOnly && (parent.isPythonActive() || pxt.shell.isPyLangPref());
-        const showBlocks = !pyOnly && !tsOnly && !!pkg.mainEditorPkg().files[pxt.MAIN_BLOCKS];
+        const pythonIsActive = (parent.isPythonActive() || pxt.shell.isPyLangPref());
+        const showPython = python && !tsOnly && !blocksOnly && !noPython;
+        const showBlocks = !pyOnly && !tsOnly && !noBlocks && !!pkg.mainEditorPkg().files[pxt.MAIN_BLOCKS];
+        const showJavaScript = !noJavaScript && !pyOnly && !blocksOnly;
         const showSandbox = sandbox && !headless;
-        const showDropdown = !pyOnly && !tsOnly && python;
+        const showDropdown = showPython && showJavaScript && showBlocks;
         const showAssets = pxt.appTarget.appTheme.assetEditor && !sandbox;
+
+        let textLanguage: JSX.Element = undefined;
+        let secondTextLanguage: JSX.Element = undefined;
+
+        if (showDropdown) {
+            if (pythonIsActive) textLanguage = <PythonMenuItem parent={parent}/>
+            else textLanguage = <JavascriptMenuItem parent={parent}/>
+        }
+        else if (showPython && showJavaScript) {
+            textLanguage = <JavascriptMenuItem parent={parent}/>;
+            secondTextLanguage  = <PythonMenuItem parent={parent}/>;
+        }
+        else if (showPython) {
+            textLanguage = <PythonMenuItem parent={parent}/>;
+        }
+        else if (showJavaScript) {
+            textLanguage = <JavascriptMenuItem parent={parent}/>
+        }
 
         return (
             <div id="editortoggle" className={`ui grid padded ${(pyOnly || tsOnly) ? "one-language" : ""}`} role="listbox" aria-orientation="horizontal">
                 {showSandbox && <SandboxMenuItem parent={parent} />}
                 {showBlocks && <BlocksMenuItem parent={parent} />}
-                {showPython ? <PythonMenuItem parent={parent} /> : <JavascriptMenuItem parent={parent} />}
+                {textLanguage}
+                {secondTextLanguage}
                 {showDropdown && <sui.DropdownMenu id="editordropdown" role="menuitem" icon="chevron down" rightIcon title={lf("Select code editor language")} className={`item button attached right ${dropdownActive ? "active" : ""}`}>
                     <JavascriptMenuItem parent={parent} />
                     <PythonMenuItem parent={parent} />

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -401,6 +401,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     public openBlocks() {
+        this.openBlocksAsync();
+    }
+
+
+    public async openBlocksAsync() {
         pxt.tickEvent(`typescript.showBlocks`);
         let initPromise = Promise.resolve();
 
@@ -412,7 +417,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (!this.currFile) {
             const mainPkg = pkg.mainEditorPkg();
             if (mainPkg && mainPkg.files[pxt.MAIN_TS]) {
-                initPromise = this.loadFileAsync(mainPkg.files[pxt.MAIN_TS]);
+                await this.loadFileAsync(mainPkg.files[pxt.MAIN_TS]);
             }
             else {
                 return;
@@ -531,6 +536,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         });
 
         core.showLoadingAsync("switchtoblocks", lf("switching to blocks..."), promise);
+        return initPromise;
     }
 
     public showBlockConversionFailedDialog(blockFile: string, programTooLarge: boolean): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/3976

Adds an editor message to control the allowed languages of a project inside an iframe. The options are:

* "python-only",
* "javascript-only",
* "blocks-only",
* "no-blocks",
* "no-python",
* "no-javascript",
* "" (all languages)

The message should look like this:

```
{
    type: "pxteditor",
    action: "setlanguagerestriction",
    restriction: "blocks-only"
}
```