### PR TITLE
Display meta data for skillmap cards

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -429,6 +429,9 @@
         background-color: @homeCardBackgroundColor;
         .ui.image, .ui.imagewrapper, .content {
             border-radius: @homeCardImageBorderRadius !important;
+            .tags {
+                font-size: 1rem;
+            }
         }
         .header {
             color: @homeCardHeaderColor;
@@ -653,11 +656,9 @@
     }
 
     .projectsdialog {
-        .ui.card, .ui.cards>.card {
+        .ui.card.buttoncard {
             width: 9rem;
             height: 9rem;
-        }
-        .ui.card.buttoncard {
             .content {
                 padding: 1rem;
             }
@@ -681,6 +682,12 @@
             .ui.image~.content {
                 height: 2.4rem;
                 padding: 0.7rem;
+            }
+            .ui.image~.content.tall {
+                height: 3rem;
+                .tags {
+                    font-size: .8rem;
+                }
             }
         }
         .ui.card.file {

--- a/theme/home.less
+++ b/theme/home.less
@@ -430,6 +430,7 @@
         .ui.image, .ui.imagewrapper, .content {
             border-radius: @homeCardImageBorderRadius !important;
             .tags {
+                color:#717171;
                 font-size: 1rem;
             }
         }

--- a/theme/themes/pxt/views/card.overrides
+++ b/theme/themes/pxt/views/card.overrides
@@ -195,6 +195,10 @@ a.ui.card:focus,
     .ui.image ~ .content {
         height: 3rem;
     }
+
+    .ui.image ~ .content.tall {
+        height: 4rem;
+    }
 }
 
 .setExampleCardFullHeight() when (@exampleCardFullHeight) {

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -7,7 +7,11 @@ const repeat = pxt.Util.repeatMap;
 
 export interface CodeCardState { }
 
-export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
+interface CodeCardProps extends pxt.CodeCard {
+    tallCard?: boolean;
+}
+
+export class CodeCardView extends data.Component<CodeCardProps, CodeCardState> {
 
     public element: HTMLDivElement;
 
@@ -122,8 +126,10 @@ export class CodeCardView extends data.Component<pxt.CodeCard, CodeCardState> {
                     </div>
                 </div> : undefined}
             {(card.shortName || name || descriptions) ?
-                <div className="content">
-                    {card.shortName || name ? <div className="header">{card.shortName || name}</div> : null}
+                <div className={`content ${this.props.tallCard? "tall" : ""}`}>
+                    {card.shortName || name ? <div className="header">{card.shortName || name}
+                            <div className="tags">{card.tags}</div>
+                        </div> : null}
                     {descriptions && descriptions.map((element, index) => {
                         return <div key={`line${index}`} className={`description tall ${card.icon || card.iconContent || card.imageUrl ? "" : "long"}`}>{renderMd(element)}</div>
                     })

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -686,6 +686,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                 </div>
             } else {
                 const selectedElement = cards[selectedIndex];
+                const hasTags = cards.some(c => c.tags && c.tags.length != 0)
                 return <div>
                     <carousel.Carousel ref="carousel" tickId={path} bleedPercent={20} selectedIndex={selectedIndex}>
                         {cards.map((scr, index) =>
@@ -704,6 +705,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                                 scr={scr} index={index}
                                 onCardClick={this.handleCardClick}
                                 cardType={scr.cardType}
+                                tallCard={hasTags}
                                 tutorialStep={scr.tutorialStep}
                                 tutorialLength={scr.tutorialLength}
                             />
@@ -796,6 +798,7 @@ interface ProjectsCodeCardProps extends pxt.CodeCard {
     scr: any;
     id?: string;
     index?: number;
+    tallCard?: boolean;
     onCardClick: (e: any, scr: any, index?: number, id?: string) => void;
     onLabelClick?: (e: any, scr: any, index?: number, id?: string) => void;
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3835


looks like 
![image](https://user-images.githubusercontent.com/18712271/133703755-b3b4b988-905a-4749-8cfe-ddc42d695ee8.png)
with tags, but these are just test tags for now :) 

