### PR TITLE
Small tutorial flag rename and cleanup

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -170,9 +170,9 @@ namespace pxt.BrowserUtils {
         } catch (e) { return false; }
     }
 
-    export function useVerticalTutorialLayout(): boolean {
+    export function useOldTutorialLayout(): boolean {
         try {
-            return !(/tutoriallayout=h/.test(window.location.href));
+            return (/tutorialview=old/.test(window.location.href));
         } catch (e) { return false; }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4091,7 +4091,7 @@ export class ProjectView
 
     setEditorOffset() {
         if (this.isTutorial()) {
-            if (pxt.BrowserUtils.useVerticalTutorialLayout()) {
+            if (!pxt.BrowserUtils.useOldTutorialLayout()) {
                 const sidebarEl = document?.getElementById("editorSidebar");
                 if (sidebarEl && window?.innerWidth < pxt.BREAKPOINT_TABLET) {
                     this.setState({ editorOffset: sidebarEl.offsetHeight + "px" });
@@ -4302,7 +4302,7 @@ export class ProjectView
         const tutorialOptions = this.state.tutorialOptions;
         const inTutorial = !!tutorialOptions && !!tutorialOptions.tutorial;
         const isSidebarTutorial = pxt.appTarget.appTheme.sidebarTutorial;
-        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.useVerticalTutorialLayout();
+        const isVerticalTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();
         const inTutorialExpanded = inTutorial && tutorialOptions.tutorialStepExpanded;
         const hideTutorialIteration = inTutorial && tutorialOptions.metadata && tutorialOptions.metadata.hideIteration;
         const inDebugMode = this.state.debugging;
@@ -5195,13 +5195,14 @@ document.addEventListener("DOMContentLoaded", async () => {
             }
 
             // Check to see if we should show the mini simulator (<= tablet size)
-            if (!theEditor.isTutorial() || !pxt.BrowserUtils.useVerticalTutorialLayout()) {
+            if (!theEditor.isTutorial() || pxt.BrowserUtils.useOldTutorialLayout()) {
                 if (window?.innerWidth < pxt.BREAKPOINT_TABLET) {
                     theEditor.showMiniSim(true);
                 } else {
                     theEditor.showMiniSim(false);
                 }
             } else if (theEditor.isTutorial()) {
+                // For the tabbed tutorial, set the editor offset
                 theEditor.setEditorOffset();
             }
         }

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -13,7 +13,7 @@ import * as projects from "./projects";
 import * as tutorial from "./tutorial";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
-type HeaderBarView = "home" | "editor" | "tutorial" | "tutorial-vertical" | "debugging" | "sandbox";
+type HeaderBarView = "home" | "editor" | "tutorial" | "tutorial-tab" | "debugging" | "sandbox";
 const LONGPRESS_DURATION = 750;
 
 export class HeaderBar extends data.Component<ISettingsProps, {}> {
@@ -83,8 +83,8 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
             return "sandbox";
         } else if (debugging) {
             return "debugging";
-        } else if (pxt.BrowserUtils.useVerticalTutorialLayout() && !!tutorialOptions?.tutorial) {
-            return "tutorial-vertical"
+        } else if (!pxt.BrowserUtils.useOldTutorialLayout() && !!tutorialOptions?.tutorial) {
+            return "tutorial-tab"
         } else if (!!tutorialOptions?.tutorial) {
             return "tutorial";
         } else {
@@ -130,7 +130,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                 if (activityName) return <div className="ui item">{activityName}</div>
                 if (!hideIteration) return <tutorial.TutorialMenu parent={this.props.parent} />
                 break;
-            case "tutorial-vertical":
+            case "tutorial-tab":
                 return <div />
             case "debugging":
                 return  <sui.MenuItem className="centered" icon="large bug" name="Debug Mode" />
@@ -164,7 +164,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                 if (!targetTheme.hideEmbedEdit) return <sui.Item role="menuitem" icon="external" textClass="mobile hide" text={lf("Edit")} onClick={this.launchFullEditor} />
                 break;
             case "tutorial":
-            case "tutorial-vertical":
+            case "tutorial-tab":
                 const tutorialButtons = [];
                 if (tutorialOptions?.tutorialReportId) {
                     const reportTutorialLabel = lf("Unapproved Content");
@@ -172,7 +172,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                         className="report-tutorial-btn link-button icon-and-text" textClass="landscape only"
                         text={reportTutorialLabel} ariaLabel={reportTutorialLabel} onClick={this.showReportAbuse} />);
                 }
-                if (!targetTheme.lockedEditor && !tutorialOptions?.metadata?.hideIteration && (view !== "tutorial-vertical" || pxt.appTarget.simulator?.headless)) {
+                if (!targetTheme.lockedEditor && !tutorialOptions?.metadata?.hideIteration && (view !== "tutorial-tab" || pxt.appTarget.simulator?.headless)) {
                     const exitTutorialLabel = lf("Exit tutorial");
                     tutorialButtons.push(<sui.Item key="tutorial-exit" role="menuitem" icon="sign out large"
                         className="exit-tutorial-btn link-button icon-and-text" textClass="landscape only"
@@ -192,7 +192,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         switch (view){
             case "home":
                 return <projects.ProjectSettingsMenu parent={this.props.parent} />
-            case "tutorial-vertical":
+            case "tutorial-tab":
             case "editor":
                 return <container.SettingsMenu parent={this.props.parent} greenScreen={greenScreen} accessibleBlocks={accessibleBlocks} showShare={!!header} />
             default:
@@ -212,7 +212,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
         const activeEditor = this.props.parent.isPythonActive() ? "Python"
             : (this.props.parent.isJavaScriptActive() ? "JavaScript" : "Blocks");
 
-        const showHomeButton = (view === "editor" || view === "tutorial-vertical") && !targetTheme.lockedEditor && !isController;
+        const showHomeButton = (view === "editor" || view === "tutorial-tab") && !targetTheme.lockedEditor && !isController;
         const showShareButton = view === "editor" && header && pxt.appTarget.cloud?.sharing && !isController;
         const showHelpButton = view === "editor" && targetTheme.docMenu?.length;
 
@@ -238,7 +238,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
                 {showShareButton && <sui.Item className="icon shareproject mobile hide" role="menuitem" ariaLabel={lf("Share Project")} icon="share alternate large" onClick={this.showShareDialog} />}
                 {showHelpButton && <container.DocsMenu parent={this.props.parent} editor={activeEditor} />}
                 {this.getSettingsMenu(view)}
-                {hasIdentity && (view === "home" || view === "editor" || view === "tutorial-vertical") && <identity.UserMenu parent={this.props.parent} />}
+                {hasIdentity && (view === "home" || view === "editor" || view === "tutorial-tab") && <identity.UserMenu parent={this.props.parent} />}
             </div>
         </div>
     }

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -87,7 +87,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
 
     protected handleSimOverlayClick = () => {
         const { tutorialOptions, handleFullscreenButtonClick } = this.props;
-        if (!tutorialOptions || !pxt.BrowserUtils.useVerticalTutorialLayout()) {
+        if (!tutorialOptions || pxt.BrowserUtils.useOldTutorialLayout()) {
             handleFullscreenButtonClick();
         } else {
             this.showSimulatorTab();
@@ -122,14 +122,14 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
             handleHardwareDebugClick, onTutorialStepChange, onTutorialComplete } = this.props;
         const { activeTab, height } = this.state;
 
-        const isVerticalTutorial = tutorialOptions?.tutorial && pxt.BrowserUtils.useVerticalTutorialLayout();
+        const isTabTutorial = tutorialOptions?.tutorial && !pxt.BrowserUtils.useOldTutorialLayout();
         const hasSimulator = !pxt.appTarget.simulator?.headless;
         const marginHeight = hasSimulator ? "6.5rem" : "3rem";
 
         return <div id="simulator" className="simulator">
             <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + ${marginHeight})` } : undefined}>
                 {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
-                    {isVerticalTutorial && this.tutorialExitButton()}
+                    {isTabTutorial && this.tutorialExitButton()}
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
                         <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} showSimulatorSidebar={this.showSimulatorTab} />

--- a/webapp/src/simtoolbar.tsx
+++ b/webapp/src/simtoolbar.tsx
@@ -107,7 +107,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
         const isFullscreen = parentState.fullscreen;
         const isMuted = parentState.mute;
         const inTutorial = !!parentState.tutorialOptions && !!parentState.tutorialOptions.tutorial;
-        const isVerticalTutorial = inTutorial && pxt.BrowserUtils.useVerticalTutorialLayout();
+        const isTabTutorial = inTutorial && !pxt.BrowserUtils.useOldTutorialLayout();
         const inCodeEditor = parent.isBlocksActive() || parent.isJavaScriptActive() || parent.isPythonActive();
 
         const run = true;
@@ -141,7 +141,7 @@ export class SimulatorToolbar extends data.Component<SimulatorProps, {}> {
 
         return <aside className={"ui item grid centered simtoolbar" + (sandbox ? "" : " portrait ")} role="complementary" aria-label={lf("Simulator toolbar")}>
             <div className={`ui icon tiny buttons`} style={{ padding: "0" }}>
-                {isVerticalTutorial && <sui.Button key='simsidebarbtn' className="sidebar-button tablet only" icon="arrow circle left" title={sidebarTooltip} onClick={showSimulatorSidebar} />}
+                {isTabTutorial && <sui.Button key='simsidebarbtn' className="sidebar-button tablet only" icon="arrow circle left" title={sidebarTooltip} onClick={showSimulatorSidebar} />}
                 {make && <sui.Button disabled={debugging} icon='configure' className="secondary" title={makeTooltip} onClick={this.openInstructions} />}
                 {run && !targetTheme.bigRunButton && <PlayButton parent={parent} simState={parentState.simState} debugging={parentState.debugging} />}
                 {fullscreen && <sui.Button key='fullscreenbtn' className="fullscreen-button tablet only hidefullscreen" icon="xicon fullscreen" title={fullscreenTooltip} onClick={this.toggleSimulatorFullscreen} />}


### PR DESCRIPTION
moving away from "vertical"/"horizontal" naming, using "tabbed tutorial" for the new view. the flag to enable the old view will be `?tutorialview=old`