### PR TITLE
Tutorial telemetry pass

### DIFF
--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -9,6 +9,7 @@ import { TutorialHint } from "./TutorialHint";
 
 interface TutorialContainerProps {
     parent: pxt.editor.IProjectView;
+    tutorialId: string;
     name: string;
     steps: pxt.tutorial.TutorialStepInfo[];
     currentStep?: number;
@@ -25,7 +26,7 @@ const MIN_HEIGHT = 80;
 const MAX_HEIGHT = 194;
 
 export function TutorialContainer(props: TutorialContainerProps) {
-    const { parent, name, steps, hideIteration, tutorialOptions,
+    const { parent, tutorialId, name, steps, hideIteration, tutorialOptions,
         onTutorialStepChange, onTutorialComplete, setParentHeight } = props;
     const [ currentStep, setCurrentStep ] = React.useState(props.currentStep || 0);
     const [ hideModal, setHideModal ] = React.useState(false);
@@ -84,8 +85,18 @@ export function TutorialContainer(props: TutorialContainerProps) {
     const markdown = steps[visibleStep].headerContentMd;
     const hintMarkdown = steps[visibleStep].hintContentMd;
 
-    const tutorialStepNext = () => setCurrentStep(Math.min(currentStep + 1, props.steps.length - 1));
-    const tutorialStepBack = () => setCurrentStep(Math.max(currentStep - 1, 0));
+    const tutorialStepNext = () => {
+        const step = Math.min(currentStep + 1, props.steps.length - 1);
+        pxt.tickEvent("tutorial.next", { tutorial: tutorialId, step: step, isModal: isModal ? 1 : 0 }, { interactiveConsent: true });
+        setCurrentStep(step);
+    }
+
+    const tutorialStepBack = () => {
+        const step = Math.max(currentStep - 1, 0);
+        pxt.tickEvent("tutorial.previous", { tutorial: tutorialId, step: step, isModal: isModal ? 1 : 0 }, { interactiveConsent: true });
+        setCurrentStep(step);
+    }
+
     const onModalClose = showNext ? tutorialStepNext : () => setHideModal(true);
 
     const tutorialContentScroll = () => {
@@ -115,7 +126,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     return <div className="tutorial-container">
         <div className="tutorial-top-bar">
-            <TutorialStepCounter currentStep={visibleStep} totalSteps={steps.length} title={name} setTutorialStep={setCurrentStep} />
+            <TutorialStepCounter tutorialId={tutorialId} currentStep={visibleStep} totalSteps={steps.length} title={name} setTutorialStep={setCurrentStep} />
             {showImmersiveReader && <ImmersiveReaderButton content={markdown} tutorialOptions={tutorialOptions} />}
         </div>
         {layout === "horizontal" && backButton}
@@ -125,7 +136,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         </div>
         <div className="tutorial-controls">
             { layout === "vertical" && backButton }
-            <TutorialHint markdown={hintMarkdown} parent={parent} showLabel={layout === "horizontal"} />
+            <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} showLabel={layout === "horizontal"} />
             { layout === "vertical" && nextButton }
         </div>
         {layout === "horizontal" && nextButton}

--- a/webapp/src/components/tutorial/TutorialHint.tsx
+++ b/webapp/src/components/tutorial/TutorialHint.tsx
@@ -6,12 +6,15 @@ import { MarkedContent } from "../../marked";
 interface TutorialHintProps {
     parent: pxt.editor.IProjectView;
     markdown: string;
-
     showLabel?: boolean;
+
+    // Telemetry data
+    tutorialId: string;
+    currentStep: number;
 }
 
 export function TutorialHint(props: TutorialHintProps) {
-    const { parent, markdown, showLabel } = props;
+    const { parent, markdown, showLabel, tutorialId, currentStep } = props;
     const [ visible, setVisible ] = React.useState(false);
 
     const captureEvent = (e: any) => {
@@ -27,6 +30,7 @@ export function TutorialHint(props: TutorialHintProps) {
 
     const toggleHint = () => {
         if (!visible) {
+            pxt.tickEvent(`tutorial.showhint`, { tutorial: tutorialId, step: currentStep });
             document.addEventListener("click", closeHint);
         } else {
             document.removeEventListener("click", closeHint);

--- a/webapp/src/components/tutorial/TutorialStepCounter.tsx
+++ b/webapp/src/components/tutorial/TutorialStepCounter.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 interface TutorialStepCounterProps {
+    tutorialId: string;
     currentStep: number;
     totalSteps: number;
     title?: string;
@@ -8,14 +9,16 @@ interface TutorialStepCounterProps {
 }
 
 export function TutorialStepCounter(props: TutorialStepCounterProps) {
-    const { currentStep, totalSteps, title } = props;
+    const { tutorialId, currentStep, totalSteps, title } = props;
 
     const handleStepBarClick = (e: React.MouseEvent<HTMLDivElement>) => {
         const { totalSteps, setTutorialStep } = props;
         const target = e.target as HTMLDivElement;
         const rect = target.getBoundingClientRect();
+        const step = Math.floor(((e.clientX - rect.left) / target.clientWidth) * totalSteps);
 
-        setTutorialStep(Math.floor(((e.clientX - rect.left) / target.clientWidth) * totalSteps));
+        pxt.tickEvent("tutorial.step", { tutorial: tutorialId, step: step }, { interactiveConsent: true });
+        setTutorialStep(step);
     }
 
     return <div className="tutorial-step-counter">

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -146,7 +146,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                     </div>
                 </TabContent>}
                 {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="list" showBadge={activeTab !== TUTORIAL_TAB} onSelected={this.showTutorialTab}>
-                    <TutorialContainer parent={parent} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}
+                    <TutorialContainer parent={parent} tutorialId={tutorialOptions.tutorial} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}
                         currentStep={tutorialOptions.tutorialStep} tutorialOptions={tutorialOptions} hideIteration={tutorialOptions.metadata?.hideIteration}
                         onTutorialStepChange={onTutorialStepChange} onTutorialComplete={onTutorialComplete}
                         setParentHeight={this.setComponentHeight} />

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -88,7 +88,7 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                     for (let bi = 0; bi < allblocks.length; ++bi) {
                         const blk = allblocks[bi];
                         if (blk.type == "typescript_statement") {
-                            pxt.tickEvent(`tutorial.usedblocks.greyblock`, { tutorial: id, code: code[i] });
+                            pxt.tickEvent(`tutorial.usedblocks.greyblock`, { tutorial: id, code: code[i]?.substring(0, 2000) });
                         } else if (!blk.isShadow()) {
                             if (!snippetBlocks[snippetHash][blk.type]) {
                                 snippetBlocks[snippetHash][blk.type] = 0;


### PR DESCRIPTION
check to make sure all tick events from the old `tutorial.tsx` file are represented in the new components as well

the one i am not carrying over is `tutorial.hint.next` (from clicking "OK" on a modal in a tutorial), instead i'm adding an `isModal` measurement to the previous and next tick events, @abchatra does that work? i don't think we used the hint.next tick in many queries