### PR TITLE
Tutorial tab navigation, blockly field view sizing, CSS fixes

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -238,7 +238,8 @@
     flex-shrink: 0;
     background: linear-gradient(@tutorialPrimaryColor, @tutorialPrimaryColor) ~'no-repeat 45% / 2px 100%';
 }
-.formatted-bullet i {
+.formatted-bullet i.icon,
+.formatted-bullet i.xicon {
     display: block;
     width: 2.5rem;
     height: 2.5rem;
@@ -271,9 +272,10 @@
 .tab-simulator .simPanel {
     height: 100%;
     padding: 1rem 0.5rem 1rem 1rem;
-    margin-top: 0;
     overflow-x: hidden;
     overflow-y: scroll;
+
+    &.ui.items { margin-top: 0; }
 }
 
 // Mini sim is visible when tab is hidden

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -620,13 +620,24 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     protected resizeFieldEditorView() {
         if (!window) return;
-        // Full-screen editor
-        blocklyFieldView.setEditorBounds({
-            top: 0,
-            left: 0,
-            width: window.innerWidth,
-            height: window.innerHeight
-        });
+        const blocklyDiv = this.getBlocksEditorDiv();
+        if (blocklyDiv && this.parent.isTutorial()) {
+            const containerRect = blocklyDiv.getBoundingClientRect();
+            blocklyFieldView.setEditorBounds({
+                top: containerRect.top,
+                left: containerRect.left,
+                width: containerRect.width,
+                height: containerRect.height
+            });
+        } else {
+            // Full-screen editor
+            blocklyFieldView.setEditorBounds({
+                top: 0,
+                left: 0,
+                width: window.innerWidth,
+                height: window.innerHeight
+            });
+        }
     }
 
     hasUndo() {

--- a/webapp/src/components/core/TabContent.tsx
+++ b/webapp/src/components/core/TabContent.tsx
@@ -4,6 +4,7 @@ export interface TabContentProps {
     name: string;
     icon?: string;
     title?: string;
+    ariaLabel?: string;
     showBadge?: boolean;
     children?: React.ReactNode;
     onSelected?: () => void;

--- a/webapp/src/components/core/TabPane.tsx
+++ b/webapp/src/components/core/TabPane.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { fireClickOnEnter } from "../../sui";
 import { TabContentProps } from "./TabContent";
 
 interface TabPaneProps {
@@ -37,10 +38,11 @@ export function TabPane(props: TabPaneProps) {
     return <div id={id} className={`tab-container ${className || ""}`} style={style}>
         {childArray.length > 1 && <div className="tab-navigation">
             {childArray.map(el => {
-                const { name, icon, title, showBadge } = el.props as TabContentProps;
+                const { name, icon, title, ariaLabel, showBadge } = el.props as TabContentProps;
                 const tabClickHandler = () => selectTab(el.props);
 
-                return <div key={name} className={`tab-icon ${name} ${name == activeTab ? "active" : ""}`} onClick={tabClickHandler}>
+                return <div key={name} className={`tab-icon ${name} ${name == activeTab ? "active" : ""}`}
+                    aria-label={ariaLabel} tabIndex={0} onClick={tabClickHandler} onKeyDown={fireClickOnEnter}>
                     {showBadge && <div className="tab-badge" />}
                     <i className={`icon ${icon}`} />
                     <span>{title}</span>

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -68,10 +68,13 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     React.useEffect(() => {
         setCurrentStep(props.currentStep);
-        setShowScrollGradient(contentRef?.current?.scrollHeight > contentRef?.current?.offsetHeight);
     }, [props.currentStep])
 
     React.useEffect(() => {
+        const contentDiv = contentRef?.current;
+        contentDiv.scrollTo(0, 0);
+        setShowScrollGradient(contentDiv.scrollHeight > contentDiv.offsetHeight);
+
         onTutorialStepChange(currentStep);
         if (showNext) setHideModal(false);
     }, [currentStep])

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -849,13 +849,22 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             const logoHeight = (this.parent.isJavaScriptActive()) ? this.parent.updateEditorLogo(toolboxWidth, this.getEditorColor()) : 0;
 
             this.editor.layout({ width: monacoArea.offsetWidth - toolboxWidth, height: monacoArea.offsetHeight - logoHeight });
-
-            blocklyFieldView.setEditorBounds({
-                top: 0,
-                left: 0,
-                width: window.innerWidth,
-                height: window.innerHeight
-            });
+            if (monacoArea && this.parent.isTutorial()) {
+                const containerRect = monacoArea.getBoundingClientRect();
+                blocklyFieldView.setEditorBounds({
+                    top: containerRect.top,
+                    left: containerRect.left,
+                    width: containerRect.width,
+                    height: containerRect.height
+                });
+            } else {
+                blocklyFieldView.setEditorBounds({
+                    top: 0,
+                    left: 0,
+                    width: window.innerWidth,
+                    height: window.innerHeight
+                });
+            }
 
             if (monacoToolboxDiv) monacoToolboxDiv.style.height = `100%`;
         }

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -113,7 +113,10 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     }
 
     protected tutorialExitButton = () => {
-        return <div className="tutorial-exit" onClick={() => this.props.parent.exitTutorial()}>{lf("Exit Tutorial")}</div>;
+        return <div className="tutorial-exit" aria-label={lf("Exit tutorial")} tabIndex={0}
+            onClick={() => this.props.parent.exitTutorial()} onKeyDown={sui.fireClickOnEnter}>
+            {lf("Exit Tutorial")}
+        </div>;
     }
 
     renderCore() {
@@ -128,7 +131,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
 
         return <div id="simulator" className="simulator">
             <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + ${marginHeight})` } : undefined}>
-                {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab}>
+                {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="game" onSelected={this.showSimulatorTab} ariaLabel={lf("Open the simulator tab")}>
                     {isTabTutorial && this.tutorialExitButton()}
                     <div className="ui items simPanel" ref={this.handleSimPanelRef}>
                         <div id="boardview" className="ui vertical editorFloat" role="region" aria-label={lf("Simulator")} tabIndex={inHome ? -1 : 0} />
@@ -145,7 +148,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         {showFullscreenButton && <div id="miniSimOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.handleSimOverlayClick} />}
                     </div>
                 </TabContent>}
-                {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="list" showBadge={activeTab !== TUTORIAL_TAB} onSelected={this.showTutorialTab}>
+                {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="tasks" showBadge={activeTab !== TUTORIAL_TAB} onSelected={this.showTutorialTab} ariaLabel={lf("Open the tutorial tab")}>
                     <TutorialContainer parent={parent} tutorialId={tutorialOptions.tutorial} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}
                         currentStep={tutorialOptions.tutorialStep} tutorialOptions={tutorialOptions} hideIteration={tutorialOptions.metadata?.hideIteration}
                         onTutorialStepChange={onTutorialStepChange} onTutorialComplete={onTutorialComplete}


### PR DESCRIPTION
- set blockly field view bounds for monaco and blocks editors to not cover the tutorial sidebar (fixes https://github.com/microsoft/pxt-arcade/issues/3984)
- tab navigation + aria labels for sidebar tab pane and tutorial exit (fixes https://github.com/microsoft/pxt-arcade/issues/4022)
- reset scroll when navigating to new step (fixes https://github.com/microsoft/pxt-arcade/issues/4024)
- CSS fixes (top margin in sim tab, change icon for tutorial tab, fix fancy bullet CSS to handle semantic update)