### PR TITLE
Autofocus simulator when expanding the mini sim

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -202,7 +202,7 @@ export class ProjectView
         this.initSimulatorMessageHandlers();
 
         // add user hint IDs and callback to hint manager
-        this.hintManager.addHint(ProjectView.tutorialCardId, this.tutorialCardHintCallback.bind(this));
+        if (pxt.BrowserUtils.useOldTutorialLayout) this.hintManager.addHint(ProjectView.tutorialCardId, this.tutorialCardHintCallback.bind(this));
     }
 
     private autoRunOnStart(): boolean {

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -8,6 +8,7 @@ import * as filelist from "./filelist";
 import * as keymap from "./keymap";
 import * as serialindicator from "./serialindicator"
 import * as simtoolbar from "./simtoolbar";
+import * as simulator from "./simulator";
 
 import { TabContent } from "./components/core/TabContent";
 import { TabPane } from "./components/core/TabPane";
@@ -70,6 +71,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
     protected showSimulatorTab = () => {
         this.props.showMiniSim(false);
         this.setState({ activeTab: SIMULATOR_TAB, height: undefined });
+        simulator.driver.focus();
     }
 
     protected showTutorialTab = () => {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/3996

\+ bonus fix for a console error with the old tutorial hint manager