### PR TITLE
fix: command line bugs when run pxt init

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -3051,7 +3051,7 @@ export function installAsync(parsed?: commandParser.ParsedCommand): Promise<void
     ensurePkgDir();
     const packageName = parsed && parsed.args.length ? parsed.args[0] : undefined;
     const hwvariant = parseHwVariant(parsed);
-    const lnk = parsed.flags["link"] as string
+    const lnk = parsed?.flags?.["link"];
     if (lnk && !fs.existsSync(lnk))
         U.userError(`folder not found: ${lnk}`)
     return installPackageNameAsync(packageName)


### PR DESCRIPTION
when i test `pxt init` in the doc of the website [https://makecode.com/cli](https://makecode.com/cli)，it happens as bellow: 

```bash
➜  pxt init
Using target microbit with build engine yotta
  target: v4.0.12 ****/pxt-t1/node_modules/pxt-microbit
  pxt-core: v7.0.8 *****/pxt-t1/node_modules/pxt-core
name [blink]: 
description []: hello
license [undefined]: MIT
installing dependencies...
INTERNAL ERROR: TypeError: Cannot read property 'flags' of undefined
    at installAsync (****/pxt-t1/node_modules/pxt-core/built/pxt.js:156876:24)
    at *****/pxt-t1/node_modules/pxt-core/built/pxt.js:157023:21
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

and it seems like a pxt-cli bugs in pxt repo that the parsed varaible can not found , when `installAsync()` called without any params.