### PR TITLE
Make icon selector more specific to fix asset editor buttons

### DIFF
--- a/theme/asset-editor.less
+++ b/theme/asset-editor.less
@@ -239,7 +239,7 @@
         background-color: darken(@assetTypeButton, 5%);
     }
 
-    i {
+    i.icon {
         font-size: 4rem;
         line-height: 4rem;
         margin: 1rem;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/4026

The semantic ui upgrade made it so that a lot of our selectors are being overridden by the semantic ones and need to be made *slightly* more specific.