### PR TITLE
Fullscreen sprite editor on tablet tutorial, CSS fixes

### DIFF
--- a/pxtlib/browserutils.ts
+++ b/pxtlib/browserutils.ts
@@ -164,6 +164,14 @@ namespace pxt.BrowserUtils {
         } catch (e) { return false; }
     }
 
+    export function isTabletSize(): boolean {
+        return window?.innerWidth < pxt.BREAKPOINT_TABLET;
+    }
+
+    export function isComputerSize(): boolean {
+        return window?.innerWidth >= pxt.BREAKPOINT_TABLET;
+    }
+
     export function noSharedLocalStorage(): boolean {
         try {
             return /nosharedlocalstorage/i.test(window.location.href);

--- a/theme/common.less
+++ b/theme/common.less
@@ -1056,6 +1056,7 @@ p.ui.font.small {
         max-width: 100%;
         min-width: 100%;
         height:100% !important;
+        background-color: @simulatorBackground;
     }
     #miniSimOverlay {
         display: none;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -8,6 +8,8 @@
 @tutorialTabletButtonColor: #f3f3f3;
 @tutorialTabletStepCounterWidth: 16rem;
 
+@tutorialHintMaskZIndex: -1; // Below tutorial pane
+
 /*******************************
         Tutorial Tab
 *******************************/
@@ -217,6 +219,7 @@
     left: 0;
     bottom: 0;
     right: 0;
+    z-index: @tutorialHintMaskZIndex;
 }
 
 /*******************************
@@ -280,8 +283,8 @@
 }
 
 // Mini sim is visible when tab is hidden
-#root:not(.fullscreensim) {
-    .tab-simulator.tab-content.hidden {
+#root {
+    &:not(.fullscreensim) .tab-simulator.tab-content.hidden {
         height: 0;
         padding: 0;
 
@@ -297,7 +300,7 @@
     }
     .tab-simulator.tab-content:not(.hidden) {
         .simPanel {
-            .sidebar-button { display: none !important; }
+            .sidebar-button, .hidefullscreen { display: none !important; }
         }
     }
 }
@@ -520,7 +523,7 @@
     /*******************************
             Simulator Tab
     *******************************/
-    #root.tabTutorial .tab-simulator:not(.hidden) {
+    #root.tabTutorial:not(.fullscreensim) .tab-simulator:not(.hidden) {
         .simPanel {
             display: flex;
 
@@ -596,7 +599,7 @@
 
 /* Mobile */
 @media only screen and (max-width: @largestMobileScreen) {
-    #root.tabTutorial .tab-simulator:not(.hidden) .simPanel {
+    #root.tabTutorial:not(.fullscreensim) .tab-simulator:not(.hidden) .simPanel {
         #simulators {
             width: 16rem;
         }

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4216,7 +4216,7 @@ export class ProjectView
         if (this.isTutorial()) {
             if (!pxt.BrowserUtils.useOldTutorialLayout()) {
                 const sidebarEl = document?.getElementById("editorSidebar");
-                if (sidebarEl && window?.innerWidth < pxt.BREAKPOINT_TABLET) {
+                if (sidebarEl && pxt.BrowserUtils.isTabletSize()) {
                     this.setState({ editorOffset: sidebarEl.offsetHeight + "px" });
                 } else {
                     this.setState({ editorOffset: undefined });
@@ -5327,7 +5327,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
             // Check to see if we should show the mini simulator (<= tablet size)
             if (!theEditor.isTutorial() || pxt.BrowserUtils.useOldTutorialLayout()) {
-                if (window?.innerWidth < pxt.BREAKPOINT_TABLET) {
+                if (pxt.BrowserUtils.isTabletSize()) {
                     theEditor.showMiniSim(true);
                 } else {
                     theEditor.showMiniSim(false);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -621,7 +621,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     protected resizeFieldEditorView() {
         if (!window) return;
         const blocklyDiv = this.getBlocksEditorDiv();
-        if (blocklyDiv && this.parent.isTutorial()) {
+        if (blocklyDiv && this.parent.isTutorial() && !pxt.BrowserUtils.isTabletSize()) {
             const containerRect = blocklyDiv.getBoundingClientRect();
             blocklyFieldView.setEditorBounds({
                 top: containerRect.top,

--- a/webapp/src/components/assetEditor/editor.tsx
+++ b/webapp/src/components/assetEditor/editor.tsx
@@ -61,7 +61,7 @@ export class AssetEditor extends Editor {
     resize(e?: Event) {
         const container = this.getAssetEditorDiv();
         // In tutorial view, the image editor is smaller and has no padding
-        if (container && this.parent.isTutorial()) {
+        if (container && this.parent.isTutorial() && !pxt.BrowserUtils.isTabletSize()) {
             const containerRect = container.getBoundingClientRect();
             const editorTools = document.getElementById("editortools");
             blocklyFieldView.setEditorBounds({

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -41,7 +41,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     React.useEffect(() => {
         const observer = new ResizeObserver(() => {
-            if (window.innerWidth < pxt.BREAKPOINT_TABLET) {
+            if (pxt.BrowserUtils.isTabletSize()) {
                 setLayout("horizontal");
             } else {
                 setLayout("vertical");

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -849,7 +849,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             const logoHeight = (this.parent.isJavaScriptActive()) ? this.parent.updateEditorLogo(toolboxWidth, this.getEditorColor()) : 0;
 
             this.editor.layout({ width: monacoArea.offsetWidth - toolboxWidth, height: monacoArea.offsetHeight - logoHeight });
-            if (monacoArea && this.parent.isTutorial()) {
+            if (monacoArea && this.parent.isTutorial() && !pxt.BrowserUtils.isTabletSize()) {
                 const containerRect = monacoArea.getBoundingClientRect();
                 blocklyFieldView.setEditorBounds({
                     top: containerRect.top,


### PR DESCRIPTION
- only apply tablet simtoolbar styles when not full screen, hide unnecessary buttons from playable sim view (fixes https://github.com/microsoft/pxt-arcade/issues/4061)
- change z-index of tutorial-hint-mask component (fixes https://github.com/microsoft/pxt-arcade/issues/3999)
- add isTabletSize browser util function, add check to monaco, blocks, and asset editors to fullscreen the sprite editor on small screens (fixes https://github.com/microsoft/pxt-arcade/issues/4057)