### PR TITLE
slower hero banner

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -58,8 +58,8 @@
         }
     }
     .ui.segment.getting-started-segment.hero {
-        -webkit-transition: background-image 0.2s ease-in;
-        transition: background-image 0.2s ease-in;
+        -webkit-transition: background-image 0.5s ease-in;
+        transition: background-image 0.5s ease-in;
         overflow: hidden;
 
         .hero-banner-contents {
@@ -94,7 +94,7 @@
         }
 
         .dots button {
-            transition: background-color 0.2s;
+            transition: background-color 0.5s;
             border: 2px solid @heroBannerDotOutlineColor;
             margin-right: 1.25rem;
 

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -305,7 +305,7 @@ interface HeroBannerState {
     paused?: boolean;
 }
 
-const HERO_BANNER_DELAY = 6000; // 6 seconds per card
+const HERO_BANNER_DELAY = 9000; // 9 seconds per card
 class HeroBanner extends data.Component<ISettingsProps, HeroBannerState> {
     protected prevGalleries: pxt.CodeCard[];
     protected static fetchedImages: pxt.Map<HTMLImageElement> = {};


### PR DESCRIPTION
close https://github.com/microsoft/pxt-arcade/issues/4056

Make the transition animation take a bit longer, and the transition time 3 seconds longer~