### PR TITLE
Implement loadedAsync in browser workspace, add native host message

### DIFF
--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -24,4 +24,5 @@ namespace pxt.commands {
     export let electronDeployAsync: (r: ts.pxtc.CompileResult) => Promise<void> = undefined; // A pointer to the Electron deploy function, so that targets can access it in their extension.ts
     export let webUsbPairDialogAsync: (pairAsync: () => Promise<boolean>, confirmAsync: (options: any) => Promise<number>) => Promise<number> = undefined;
     export let onTutorialCompleted: () => void = undefined;
+    export let workspaceLoadedAsync: () => Promise<void> = undefined;
 }

--- a/webapp/src/browserworkspace.ts
+++ b/webapp/src/browserworkspace.ts
@@ -146,10 +146,16 @@ function resetAsync() {
     // workspace.resetAsync already clears all tables
     return Promise.resolve();
 }
+
+function loadedAsync(): Promise<void> {
+    return pxt.commands.workspaceLoadedAsync?.();
+}
+
 export const provider: WorkspaceProvider = {
     getAsync,
     setAsync,
     deleteAsync,
     listAsync,
     resetAsync,
+    loadedAsync
 }

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -174,6 +174,17 @@ function nativeHostSaveCoreAsync(resp: pxtc.CompileResult): Promise<void> {
     return Promise.resolve();
 }
 
+function nativeHostWorkspaceLoadedCoreAsync(): Promise<void> {
+    log(`native workspace loaded`)
+    const nativePostMessage = nativeHostPostMessageFunction();
+    if (nativePostMessage) {
+        nativePostMessage(<pxt.editor.NativeHostMessage>{
+            cmd: "workspaceloaded"
+        })
+    }
+    return Promise.resolve();
+}
+
 export function nativeHostBackAsync(): Promise<void> {
     log(`native back`)
     const nativePostMessage = nativeHostPostMessageFunction();
@@ -418,6 +429,7 @@ export async function initAsync() {
         log(`deploy: webkit deploy/save`);
         pxt.commands.deployCoreAsync = nativeHostDeployCoreAsync;
         pxt.commands.saveOnlyAsync = nativeHostSaveCoreAsync;
+        pxt.commands.workspaceLoadedAsync = nativeHostWorkspaceLoadedCoreAsync;
     } else if (pxt.winrt.isWinRT()) { // windows app
         log(`deploy: winrt`)
         pxt.packetio.mkPacketIOAsync = pxt.winrt.mkWinRTPacketIOAsync;


### PR DESCRIPTION
request from the foundation for the iOS app, they want to receive a message when the workspace is loaded/when the event listeners are fully registered (https://github.com/microbit-foundation/microbit-ios/issues/63). this implements loadedAsync on the browser workspace and adds a command for sending the message. i didn't want to add something too native host specific to our main browser workspace loading flow, open to other suggestions if folks have em!