### PR TITLE
[stable7.2] fix scroll in safari

### DIFF
--- a/theme/themes/pxt/modules/modal.overrides
+++ b/theme/themes/pxt/modules/modal.overrides
@@ -47,6 +47,7 @@
 .modals.dimmer .ui.scrolling.modal {
     margin: 3.5rem auto !important;
     top: auto;
+    position: absolute;
 }
 
 .ui.modal {


### PR DESCRIPTION
Port https://github.com/microsoft/pxt/pull/8539 to arcade stable, fix hw scroll in safari

I did look a bit to see when it regressed, looks like it was present in https://arcade.makecode.com/v1.6.16 so it actually wasn't a last minute bug / came from the semantic ui upgrade itself, not any of the follow up fixes. I guess we just hit an unlucky combo of undefined behavior for scrollable `position: fixed` here that only safari diverged on.