### PR TITLE
Fix image editor marquee tool and tilemap perf

### DIFF
--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -40,6 +40,7 @@ export interface ImageCanvasProps {
     imageState?: pxt.sprite.ImageState;
     prevFrame?: pxt.sprite.ImageState;
     lightMode?: boolean;
+    tilesetRevision: number;
 
     suppressShortcuts: boolean;
 }
@@ -54,7 +55,7 @@ const WALL_COLOR = 2;
  */
 const overlayLayers = [TileDrawingMode.Wall];
 
-class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements GestureTarget {
+export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements GestureTarget {
     protected canvas: HTMLCanvasElement;
 
     protected imageWidth: number;
@@ -80,6 +81,7 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
     protected lastTool: ImageEditorTool;
 
     protected tileCache: HTMLCanvasElement[] = [];
+    protected tileCacheRevision: number;
     protected hasHover: boolean;
 
     protected waitingToZoom: boolean;
@@ -696,7 +698,10 @@ class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> implements G
         let index: number;
         let tileImage: HTMLCanvasElement;
 
-        this.tileCache = [];
+        if (this.tileCacheRevision !== this.props.tilesetRevision) {
+            this.tileCache = [];
+            this.tileCacheRevision = this.props.tilesetRevision;
+        }
 
         context.imageSmoothingEnabled = false;
         context.fillStyle = LIGHT_MODE_TRANSPARENT;
@@ -1075,6 +1080,7 @@ function mapStateToProps({ store: { present }, editor }: ImageEditorStore, ownPr
             isTilemap: editor.isTilemap,
             drawingMode: editor.drawingMode,
             gallery: editor.tileGallery,
+            tilesetRevision: editor.tilesetRevision
         };
     }
 
@@ -1092,6 +1098,7 @@ function mapStateToProps({ store: { present }, editor }: ImageEditorStore, ownPr
         backgroundColor: editor.backgroundColor,
         prevFrame: state.frames[state.currentFrame - 1],
         isTilemap: editor.isTilemap,
+        tilesetRevision: editor.tilesetRevision
     };
 }
 

--- a/webapp/src/components/ImageEditor/store/imageReducer.ts
+++ b/webapp/src/components/ImageEditor/store/imageReducer.ts
@@ -87,6 +87,7 @@ export interface EditorState {
     overlayEnabled?: boolean;
     alert?: AlertInfo;
     resizeDisabled?: boolean;
+    tilesetRevision: number; // used to track changes to the tileset and invalidate the tile cache in ImageCanvas
 }
 
 export interface GalleryTile {
@@ -170,6 +171,7 @@ const initialStore: ImageEditorStore = {
         previewAnimating: false,
         onionSkinEnabled: false,
         overlayEnabled: true,
+        tilesetRevision: 0,
         isTilemap: false
     }
 }
@@ -255,7 +257,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     referencedTiles: toOpen.data.projectReferences,
                     previewAnimating: false,
                     onionSkinEnabled: false,
-
+                    tilesetRevision: 0,
                     // Properties below this comment carry over if keep past is true
                     tool: action.keepPast ? state.editor.tool : initialStore.editor.tool,
                     cursorSize: action.keepPast ? state.editor.cursorSize : initialStore.editor.cursorSize,
@@ -264,6 +266,7 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
 
                 } : {
                     isTilemap: false,
+                    tilesetRevision: 0,
 
                     // Properties below this comment carry over if keep past is true
                     selectedColor: action.keepPast ? state.editor.selectedColor : initialStore.editor.selectedColor,
@@ -312,6 +315,10 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     past: state.store.past.slice(0, state.store.past.length - 1),
                     present: state.store.past[state.store.past.length - 1],
                     future: [...state.store.future, state.store.present]
+                },
+                editor: {
+                    ...state.editor,
+                    tilesetRevision: state.editor.tilesetRevision + 1
                 }
             };
         case actions.REDO_IMAGE_EDIT:
@@ -325,6 +332,10 @@ const topReducer = (state: ImageEditorStore = initialStore, action: any): ImageE
                     past: [...state.store.past, state.store.present],
                     present: state.store.future[state.store.future.length - 1],
                     future: state.store.future.slice(0, state.store.future.length - 1),
+                },
+                editor: {
+                    ...state.editor,
+                    tilesetRevision: state.editor.tilesetRevision + 1
                 }
             };
         default:
@@ -497,7 +508,8 @@ const editorReducer = (state: EditorState, action: any, store: EditorStore): Edi
                 ...state,
                 deletedTiles: (state.deletedTiles || []).concat([action.id]),
                 selectedColor: action.index === state.selectedColor ? 0 : state.selectedColor,
-                backgroundColor: action.index === state.backgroundColor ? 0 : state.backgroundColor
+                backgroundColor: action.index === state.backgroundColor ? 0 : state.backgroundColor,
+                tilesetRevision: state.tilesetRevision + 1
             };
         case actions.OPEN_TILE_EDITOR:
             const editType = action.index ? "edit" : "new";
@@ -519,7 +531,8 @@ const editorReducer = (state: EditorState, action: any, store: EditorStore): Edi
                 ...state,
                 editedTiles,
                 selectedColor: action.index || (store.present as TilemapState).tileset.tiles.length,
-                editingTile: undefined
+                editingTile: undefined,
+                tilesetRevision: state.tilesetRevision + 1
             };
         case actions.SHOW_ALERT:
             tickEvent("show-alert");


### PR DESCRIPTION
Fixes the image editor marquee tool regression i introduced in https://github.com/microsoft/pxt/pull/8448

Also speeds up the tilemap editor a bit by reducing the frequency with which we invalidate our cache of tiles.