### PR TITLE
Get rid of extraneous dependencies to resurrect the ---asseteditor page

### DIFF
--- a/docs/develop/accessibility/accessibility-keyboard.md
+++ b/docs/develop/accessibility/accessibility-keyboard.md
@@ -24,15 +24,15 @@ The tab index is defined in HTML or JavaScript depending the page initialization
 
 Many elements respond to a mouse click. This is usually defined with the ``onClick`` attribute. If no additonal interaction is needed with a component, it is required that pressing the ``Enter`` or ``Space`` key has the same behavior to the ``onClick``.
 
-There are a helper methods to automate this action. Feel free to use them. In **React**, for example, the method is ``sui.fireClickOnEnter``.
+There are a helper methods to automate this action. Feel free to use them. In **React**, for example, the method is ``util.fireClickOnEnter``.
 You will also have to decide on which keyboard event to use: ``KeyDown``, ``KeyUp`` or ``KeyPress``. When possible, always use the ``KeyDown`` event as ``KeyPress`` has compatibility problems with Internet Explorer.
 
 Here is an example of implementation using React:
 
 ```js
-import * as sui from "./sui";
+import * as {fireClickOnEnter} from "./util";
 [...]
-<div tabIndex={0} onClick={() => action() } onKeyDown={sui.fireClickOnEnter}>Interactive element</div>
+<div tabIndex={0} onClick={() => action() } onKeyDown={fireClickOnEnter}>Interactive element</div>
 ```
 
 ## Focus trap

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5119,6 +5119,17 @@ document.addEventListener("DOMContentLoaded", async () => {
     appcache.init(() => theEditor.reloadEditor());
     blocklyFieldView.init();
 
+    pxt.react.getTilemapProject = () => {
+        const epkg = pkg.mainEditorPkg();
+
+        if (!epkg.tilemapProject) {
+            epkg.tilemapProject = new pxt.TilemapProject();
+            epkg.tilemapProject.loadPackage(pkg.mainPkg);
+        }
+
+        return epkg.tilemapProject;
+    }
+
     pxt.hexloader.showLoading = (msg) => core.showLoading("hexcloudcompiler", msg);
     pxt.hexloader.hideLoading = () => core.hideLoading("hexcloudcompiler");
     pxt.docs.requireMarked = () => require("marked");

--- a/webapp/src/assets.ts
+++ b/webapp/src/assets.ts
@@ -34,3 +34,77 @@ export function getNewInternalID() {
     const project = pxt.react.getTilemapProject();
     return project.getNewInternalId();
 }
+
+export function getAssets(gallery = false, firstType = pxt.AssetType.Image, tempAssets: pxt.Asset[] = []): pxt.Asset[] {
+    const project = pxt.react.getTilemapProject();
+    const imgConv = new pxt.ImageConverter();
+
+    const toGalleryItem = <U extends pxt.Asset>(asset: U) => assetToGalleryItem(asset, imgConv) as U;
+
+    const getAssetType = gallery ? project.getGalleryAssets.bind(project) : project.getAssets.bind(project);
+
+    const images = getAssetType(pxt.AssetType.Image).map(toGalleryItem).sort(compareInternalId);
+    const tiles = getAssetType(pxt.AssetType.Tile).map(toGalleryItem)
+        .filter((t: pxt.Tile) => !t.id.match(/^myTiles.transparency(8|16|32)$/gi)).sort(compareInternalId);
+    const tilemaps = getAssetType(pxt.AssetType.Tilemap).map(toGalleryItem).sort(compareInternalId);
+    const animations = getAssetType(pxt.AssetType.Animation).map(toGalleryItem).sort(compareInternalId);
+
+    for (const asset of tempAssets) {
+        switch (asset.type) {
+            case pxt.AssetType.Image:
+                images.push(toGalleryItem(asset));
+                break;
+            case pxt.AssetType.Tile:
+                tiles.push(toGalleryItem(asset));
+                break;
+            case pxt.AssetType.Animation:
+                animations.push(toGalleryItem(asset));
+                break;
+            case pxt.AssetType.Tilemap:
+                tilemaps.push(toGalleryItem(asset));
+                break;
+        }
+    }
+
+    let assets: pxt.Asset[] = [];
+    switch (firstType) {
+        case pxt.AssetType.Image:
+            assets = images.concat(tiles).concat(animations).concat(tilemaps);
+            break;
+        case pxt.AssetType.Tile:
+            assets = tiles.concat(images).concat(animations).concat(tilemaps);
+            break;
+        case pxt.AssetType.Animation:
+            assets = animations.concat(images).concat(tiles).concat(tilemaps);
+            break;
+        case pxt.AssetType.Tilemap:
+            assets = tilemaps.concat(tiles).concat(images).concat(animations)
+    }
+
+    pxt.tickEvent(gallery ? "assets.gallery" : "assets.update", { count: assets.length });
+
+    return assets;
+}
+
+export function assetToGalleryItem(asset: pxt.Asset, imgConv = new pxt.ImageConverter()) {
+    switch (asset.type) {
+        case pxt.AssetType.Image:
+        case pxt.AssetType.Tile:
+            asset.previewURI = imgConv.convert("data:image/x-mkcd-f," + asset.jresData);
+            return asset;
+
+        case pxt.AssetType.Tilemap:
+            let tilemap = asset.data.tilemap;
+            asset.previewURI = pxtblockly.tilemapToImageURI(asset.data, Math.max(tilemap.width, tilemap.height), false);
+            return asset;
+        case pxt.AssetType.Animation:
+            if (asset.frames?.length <= 0) return null;
+            asset.framePreviewURIs = asset.frames.map(bitmap => imgConv.convert("data:image/x-mkcd-f," + pxt.sprite.base64EncodeBitmap(bitmap)));
+            asset.previewURI = asset.framePreviewURIs[0];
+            return asset;
+    }
+}
+
+function compareInternalId(a: pxt.Asset, b: pxt.Asset) {
+    return a.internalID - b.internalID;
+}

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -4,8 +4,6 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import { ImageFieldEditor } from "./components/ImageFieldEditor";
-import { TilemapFieldEditor } from "./components/TilemapFieldEditor";
-import * as pkg from "./package";
 
 export interface EditorBounds {
     top: number;
@@ -242,15 +240,11 @@ export function init() {
         return current;
     }
 
+    let project = new pxt.TilemapProject();
+
+    // This is overriden in app.tsx
     pxt.react.getTilemapProject = () => {
-        const epkg = pkg.mainEditorPkg();
-
-        if (!epkg.tilemapProject) {
-            epkg.tilemapProject = new pxt.TilemapProject();
-            epkg.tilemapProject.loadPackage(pkg.mainPkg);
-        }
-
-        return epkg.tilemapProject;
+        return project;
     }
 }
 

--- a/webapp/src/carousel.tsx
+++ b/webapp/src/carousel.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as sui from "./sui";
 import * as data from "./data";
+import { fireClickOnEnter } from "./util";
 
 export interface ICarouselProps extends React.Props<Carousel> {
     // Percentage of child width to bleed over either edge of the page
@@ -88,7 +89,7 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
 
         return <div className="ui carouselouter">
             {!leftDisabled && <span role="button" className={"carouselarrow left aligned"} tabIndex={0} title={lf("See previous")}
-                aria-label={lf("See previous")} onClick={this.onLeftArrowClick} onKeyDown={sui.fireClickOnEnter} ref={this.handleArrowRefs}>
+                aria-label={lf("See previous")} onClick={this.onLeftArrowClick} onKeyDown={fireClickOnEnter} ref={this.handleArrowRefs}>
                 <sui.Icon icon={"circle angle " + (!isRTL ? "left" : "right")} />
             </span>}
             <div className="carouselcontainer" ref={this.handleContainerRef}>
@@ -102,7 +103,7 @@ export class Carousel extends data.Component<ICarouselProps, ICarouselState> {
                 </div>
             </div>
             {!rightDisabled && <span role="button" className={"carouselarrow right aligned"} tabIndex={0} title={lf("See more")}
-                aria-label={lf("See more")} onClick={this.onRightArrowClick} onKeyDown={sui.fireClickOnEnter} ref={this.handleArrowRefs}>
+                aria-label={lf("See more")} onClick={this.onRightArrowClick} onKeyDown={fireClickOnEnter} ref={this.handleArrowRefs}>
                 <sui.Icon icon={"circle angle " + (!pxt.Util.isUserLanguageRtl() ? "right" : "left")} />
             </span>}
         </div>

--- a/webapp/src/codecard.tsx
+++ b/webapp/src/codecard.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as sui from "./sui";
 import * as data from "./data";
 import * as cloud from "./cloud";
+import { fireClickOnEnter } from "./util";
 
 const repeat = pxt.Util.repeatMap;
 
@@ -97,7 +98,7 @@ export class CodeCardView extends data.Component<CodeCardProps, CodeCardState> {
         const style = card.style || "card"
         const cardDiv = <div className={`ui ${style} ${color} ${card.onClick ? "link" : ''} ${className ? className : ''}`}
             role={card.role} aria-selected={card.role === "option" ? "true" : undefined} aria-label={ariaLabel} title={card.title}
-            onClick={clickHandler} tabIndex={card.onClick ? card.tabIndex || 0 : null} onKeyDown={card.onClick ? sui.fireClickOnEnter : null}>
+            onClick={clickHandler} tabIndex={card.onClick ? card.tabIndex || 0 : null} onKeyDown={card.onClick ? fireClickOnEnter : null}>
             {card.header ?
                 <div key="header" className={"ui content " + (card.responsive ? " tall desktop only" : "")}>
                     {card.header}

--- a/webapp/src/components/FilterPanel.tsx
+++ b/webapp/src/components/FilterPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as sui from "../sui";
+import { fireClickOnEnter } from "../util";
 
 interface FilterTagProps {
     tag: string;
@@ -15,10 +15,10 @@ export class FilterTag extends React.Component<FilterTagProps> {
 
     render() {
         return <div className="filter-tag">
-            <div className="filter-tag-box" role="checkbox" onClick={this.clickHandler} onKeyDown={sui.fireClickOnEnter} aria-checked={this.props.selected}>
+            <div className="filter-tag-box" role="checkbox" onClick={this.clickHandler} onKeyDown={fireClickOnEnter} aria-checked={this.props.selected}>
                 <i className={`icon square outline ${this.props.selected ? "check" : ""}`}></i>
             </div>
-            <div className="filter-tag-name" role="button" onClick={this.clickHandler} onKeyDown={sui.fireClickOnEnter}>{pxtc.U.rlf(this.props.tag)}</div>
+            <div className="filter-tag-name" role="button" onClick={this.clickHandler} onKeyDown={fireClickOnEnter}>{pxtc.U.rlf(this.props.tag)}</div>
         </div>
     }
 
@@ -40,7 +40,7 @@ export class FilterPanelSubheading extends React.Component<FilterPanelSubheading
     render() {
         return <div className="filter-subheading-row">
             <div className="filter-subheading-title">{`${this.props.subheading}:`}</div>
-            {this.props.buttonText && <div className="filter-subheading-button" role="button" style={this.props.buttonStyle} onClick={this.props.buttonAction} onKeyDown={sui.fireClickOnEnter}>{this.props.buttonText}</div>}
+            {this.props.buttonText && <div className="filter-subheading-button" role="button" style={this.props.buttonStyle} onClick={this.props.buttonAction} onKeyDown={fireClickOnEnter}>{this.props.buttonText}</div>}
         </div>
     }
 }

--- a/webapp/src/components/ImageEditor/util.ts
+++ b/webapp/src/components/ImageEditor/util.ts
@@ -98,7 +98,7 @@ export function clientCoord(ev: PointerEvent | MouseEvent | TouchEvent): ClientC
 }
 
 /**
- * Similar to sui.fireClickOnEnter, but interactions limited to enter key / ignores
+ * Similar to fireClickOnEnter, but interactions limited to enter key / ignores
  * space bar.
  */
 export function fireClickOnlyOnEnter(e: React.KeyboardEvent<HTMLElement>): void {

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
-import * as sui from "../sui";
 
 import { FieldEditorComponent } from '../blocklyFieldView';
 import { AssetCardView } from "./assetEditor/assetCard";
-import { assetToGalleryItem, getAssets } from "./assetEditor/store/assetEditorReducer";
+import { assetToGalleryItem, getAssets } from "../assets";
 import { ImageEditor } from "./ImageEditor/ImageEditor";
 import { obtainShortcutLock, releaseShortcutLock } from "./ImageEditor/keyboardShortcuts";
 import { GalleryTile, setTelemetryFunction } from './ImageEditor/store/imageReducer';
 import { FilterPanel } from './FilterPanel';
+import { fireClickOnEnter } from "../util";
 
 export interface ImageFieldEditorProps {
     singleFrame: boolean;
@@ -122,7 +122,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                     <ImageEditorToggle options={toggleOptions} view={currentView} />
                 </div>
                 <div className="image-editor-header-right">
-                    <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={sui.fireClickOnEnter}>
+                    <div className={`gallery-filter-button ${this.state.currentView === "gallery" ? '' : "hidden"}`} role="button" onClick={this.toggleFilter} onKeyDown={fireClickOnEnter}>
                         <div className="gallery-filter-button-icon">
                             <i className="icon filter" />
                         </div>

--- a/webapp/src/components/assetEditor/actions/dispatch.ts
+++ b/webapp/src/components/assetEditor/actions/dispatch.ts
@@ -1,5 +1,5 @@
 import * as actions from './types'
-import { GalleryView } from '../store/assetEditorReducer';
+import { GalleryView } from '../store/assetEditorReducerState';
 
 export const dispatchChangeSelectedAsset = (assetType?: pxt.AssetType, assetId?: string) => ({ type: actions.CHANGE_SELECTED_ASSET, assetType, assetId });
 export const dispatchChangeGalleryView = (view: GalleryView, assetType?: pxt.AssetType, assetId?: string) => ({ type: actions.CHANGE_GALLERY_VIEW, view, assetType, assetId });

--- a/webapp/src/components/assetEditor/assetCard.tsx
+++ b/webapp/src/components/assetEditor/assetCard.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect } from 'react-redux';
 
-import { AssetEditorState, isGalleryAsset } from './store/assetEditorReducer';
+import { AssetEditorState, isGalleryAsset } from './store/assetEditorReducerState';
 import { dispatchChangeSelectedAsset } from './actions/dispatch';
 
 import { AssetPreview } from "./assetPreview";

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -3,7 +3,7 @@ import * as pkg from "../../package";
 import * as sui from "../../sui";
 import { connect } from 'react-redux';
 
-import { AssetEditorState, GalleryView } from "./store/assetEditorReducer";
+import { AssetEditorState, GalleryView } from './store/assetEditorReducerState';
 import { dispatchUpdateUserAssets } from './actions/dispatch';
 
 import { AssetCardList } from "./assetCardList";

--- a/webapp/src/components/assetEditor/assetGalleryTab.tsx
+++ b/webapp/src/components/assetEditor/assetGalleryTab.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect } from 'react-redux';
 
-import { AssetEditorState, GalleryView } from './store/assetEditorReducer';
+import { AssetEditorState, GalleryView } from './store/assetEditorReducerState';
 import { dispatchChangeGalleryView } from './actions/dispatch';
 
 interface AssetGalleryTabProps {

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -4,7 +4,7 @@ import * as simulator from "../../simulator";
 import * as sui from "../../sui";
 import { connect } from 'react-redux';
 
-import { AssetEditorState, GalleryView, isGalleryAsset } from './store/assetEditorReducer';
+import { AssetEditorState, GalleryView, isGalleryAsset } from './store/assetEditorReducerState';
 import { dispatchChangeGalleryView, dispatchChangeSelectedAsset, dispatchUpdateUserAssets } from './actions/dispatch';
 
 import { AssetPreview } from "./assetPreview";

--- a/webapp/src/components/assetEditor/assetTopbar.tsx
+++ b/webapp/src/components/assetEditor/assetTopbar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { GalleryView } from './store/assetEditorReducer';
+import { GalleryView } from './store/assetEditorReducerState';
 import { AssetGalleryTab } from './assetGalleryTab'
 
 export class AssetTopbar extends React.Component<{}> {

--- a/webapp/src/components/assetEditor/store/assetEditorReducer.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducer.ts
@@ -1,18 +1,9 @@
 import * as actions from '../actions/types'
 import * as pkg from '../../../package';
 import { getBlocksEditor } from '../../../app';
+import { AssetEditorState, GalleryView } from './assetEditorReducerState';
+import { assetToGalleryItem, getAssets } from '../../../assets';
 
-export const enum GalleryView {
-    User,
-    Gallery
-}
-
-export interface AssetEditorState {
-    view: GalleryView;
-    assets: pxt.Asset[];
-    galleryAssets: pxt.Asset[];
-    selectedAsset?: pxt.Asset;
-}
 
 const initialState: AssetEditorState = {
     view: GalleryView.User,
@@ -57,9 +48,7 @@ const topReducer = (state: AssetEditorState = initialState, action: any): AssetE
     }
 }
 
-function compareInternalId(a: pxt.Asset, b: pxt.Asset) {
-    return a.internalID - b.internalID;
-}
+
 
 function getSelectedAsset(state: AssetEditorState, type: pxt.AssetType, id: string) {
     if (!type || !id) return undefined;
@@ -68,82 +57,10 @@ function getSelectedAsset(state: AssetEditorState, type: pxt.AssetType, id: stri
         || state.galleryAssets.find(el => el.type == type && el.id == id);
 }
 
-export function getAssets(gallery = false, firstType = pxt.AssetType.Image, tempAssets: pxt.Asset[] = []): pxt.Asset[] {
-    const project = pxt.react.getTilemapProject();
-    const imgConv = new pxt.ImageConverter();
 
-    const toGalleryItem = <U extends pxt.Asset>(asset: U) => assetToGalleryItem(asset, imgConv) as U;
-
-    const getAssetType = gallery ? project.getGalleryAssets.bind(project) : project.getAssets.bind(project);
-
-    const images = getAssetType(pxt.AssetType.Image).map(toGalleryItem).sort(compareInternalId);
-    const tiles = getAssetType(pxt.AssetType.Tile).map(toGalleryItem)
-        .filter((t: pxt.Tile) => !t.id.match(/^myTiles.transparency(8|16|32)$/gi)).sort(compareInternalId);
-    const tilemaps = getAssetType(pxt.AssetType.Tilemap).map(toGalleryItem).sort(compareInternalId);
-    const animations = getAssetType(pxt.AssetType.Animation).map(toGalleryItem).sort(compareInternalId);
-
-    for (const asset of tempAssets) {
-        switch (asset.type) {
-            case pxt.AssetType.Image:
-                images.push(toGalleryItem(asset));
-                break;
-            case pxt.AssetType.Tile:
-                tiles.push(toGalleryItem(asset));
-                break;
-            case pxt.AssetType.Animation:
-                animations.push(toGalleryItem(asset));
-                break;
-            case pxt.AssetType.Tilemap:
-                tilemaps.push(toGalleryItem(asset));
-                break;
-        }
-    }
-
-    let assets: pxt.Asset[] = [];
-    switch (firstType) {
-        case pxt.AssetType.Image:
-            assets = images.concat(tiles).concat(animations).concat(tilemaps);
-            break;
-        case pxt.AssetType.Tile:
-            assets = tiles.concat(images).concat(animations).concat(tilemaps);
-            break;
-        case pxt.AssetType.Animation:
-            assets = animations.concat(images).concat(tiles).concat(tilemaps);
-            break;
-        case pxt.AssetType.Tilemap:
-            assets = tilemaps.concat(tiles).concat(images).concat(animations)
-    }
-
-    pxt.tickEvent(gallery ? "assets.gallery" : "assets.update", { count: assets.length });
-
-    return assets;
-}
-
-export function assetToGalleryItem(asset: pxt.Asset, imgConv = new pxt.ImageConverter()) {
-    switch (asset.type) {
-        case pxt.AssetType.Image:
-        case pxt.AssetType.Tile:
-            asset.previewURI = imgConv.convert("data:image/x-mkcd-f," + asset.jresData);
-            return asset;
-
-        case pxt.AssetType.Tilemap:
-            let tilemap = asset.data.tilemap;
-            asset.previewURI = pxtblockly.tilemapToImageURI(asset.data, Math.max(tilemap.width, tilemap.height), false);
-            return asset;
-        case pxt.AssetType.Animation:
-            if (asset.frames?.length <= 0) return null;
-            asset.framePreviewURIs = asset.frames.map(bitmap => imgConv.convert("data:image/x-mkcd-f," + pxt.sprite.base64EncodeBitmap(bitmap)));
-            asset.previewURI = asset.framePreviewURIs[0];
-            return asset;
-    }
-}
 
 function isBlocksProject() {
     return pkg.mainPkg?.config?.preferredEditor === pxt.BLOCKS_PROJECT_NAME;
-}
-
-export function isGalleryAsset(asset?: pxt.Asset) {
-    return asset?.id.startsWith("sprites.");
 }
 
 export default topReducer;

--- a/webapp/src/components/assetEditor/store/assetEditorReducerState.ts
+++ b/webapp/src/components/assetEditor/store/assetEditorReducerState.ts
@@ -1,0 +1,15 @@
+export const enum GalleryView {
+    User,
+    Gallery
+}
+
+export interface AssetEditorState {
+    view: GalleryView;
+    assets: pxt.Asset[];
+    galleryAssets: pxt.Asset[];
+    selectedAsset?: pxt.Asset;
+}
+
+export function isGalleryAsset(asset?: pxt.Asset) {
+    return asset?.id.startsWith("sprites.");
+}

--- a/webapp/src/components/core/TabPane.tsx
+++ b/webapp/src/components/core/TabPane.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { fireClickOnEnter } from "../../sui";
+import { fireClickOnEnter } from "../../util";
 import { TabContentProps } from "./TabContent";
 
 interface TabPaneProps {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -12,6 +12,7 @@ import * as cloudsync from "./cloudsync";
 import * as pkg from "./package";
 import * as ImmersiveReader from "./immersivereader";
 import {showWinAppDeprecateAsync} from "./dialogs";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -634,7 +635,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
                         sandbox={`allow-scripts allow-same-origin allow-forms ${lockedEditor ? "" : "allow-popups"}`} />
                 </div>
                 {!lockedEditor && <div className="ui app hide" id="sidedocsbar">
-                    <a className="ui icon link" role="button" tabIndex={0} data-content={lf("Open documentation in new tab")} aria-label={lf("Open documentation in new tab")} onClick={this.popOut} onKeyDown={sui.fireClickOnEnter} >
+                    <a className="ui icon link" role="button" tabIndex={0} data-content={lf("Open documentation in new tab")} aria-label={lf("Open documentation in new tab")} onClick={this.popOut} onKeyDown={fireClickOnEnter} >
                         <sui.Icon icon="external" />
                     </a>
                 </div>}

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -9,6 +9,7 @@ import * as cloudsync from "./cloudsync";
 
 import Cloud = pxt.Cloud;
 import Util = pxt.Util;
+import { fireClickOnEnter } from "./util";
 
 let dontShowDownloadFlag = false;
 
@@ -558,7 +559,7 @@ export function showImportGithubDialogAsync() {
                             <i className="large plus circle middle aligned icon"></i>
                             <div className="content">
                                 <a onClick={createNew} role="button" className="header"
-                                    tabIndex={0} onKeyDown={sui.fireClickOnEnter}
+                                    tabIndex={0} onKeyDown={fireClickOnEnter}
                                     title={lf("Create new GitHub repository")}>
                                     <b>{lf("Create new...")}</b>
                                 </a>
@@ -572,7 +573,7 @@ export function showImportGithubDialogAsync() {
                                 <i className="large github middle aligned icon"></i>
                                 <div className="content">
                                     <a onClick={r.onClick} role="button" className="header"
-                                        tabIndex={0}  onKeyDown={sui.fireClickOnEnter}
+                                        tabIndex={0}  onKeyDown={fireClickOnEnter}
                                     >{r.name}</a>
                                     <div className="description">
                                         {pxt.Util.timeSince(r.updatedAt)}

--- a/webapp/src/errorList.tsx
+++ b/webapp/src/errorList.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as sui from "./sui";
+import { fireClickOnEnter } from "./util";
 
 type GroupedError = {
     error: pxtc.KsDiagnostic,
@@ -68,13 +69,13 @@ export class ErrorList extends React.Component<ErrorListProps, ErrorListState> {
 
         return (
             <div className={`errorList ${isCollapsed ? 'errorListSummary' : ''} ${this.props.isInBlocksEditor ? 'errorListBlocks' : ''}`} hidden={!errorsAvailable}>
-                <div className="errorListHeader" role="button" aria-label={lf("{0} error list", isCollapsed ? lf("Expand") : lf("Collapse"))} onClick={this.onCollapseClick} onKeyDown={sui.fireClickOnEnter} tabIndex={0}>
+                <div className="errorListHeader" role="button" aria-label={lf("{0} error list", isCollapsed ? lf("Expand") : lf("Collapse"))} onClick={this.onCollapseClick} onKeyDown={fireClickOnEnter} tabIndex={0}>
                     <h4>{lf("Problems")}</h4>
                     <div className="ui red circular label countBubble">{errorCount}</div>
                     <div className="toggleButton"><sui.Icon icon={`chevron ${isCollapsed ? 'up' : 'down'}`} /></div>
                 </div>
                 {!isCollapsed && <div className="errorListInner">
-                    {exception && <div className="debuggerSuggestion" role="button" onClick={this.props.startDebugger} onKeyDown={sui.fireClickOnEnter} tabIndex={0}>
+                    {exception && <div className="debuggerSuggestion" role="button" onClick={this.props.startDebugger} onKeyDown={fireClickOnEnter} tabIndex={0}>
                         {lf("Debug this project")}
                         <sui.Icon className="debug-icon" icon="icon bug" />
                     </div>}
@@ -203,7 +204,7 @@ class ErrorListItem extends React.Component<ErrorListItemProps, ErrorListItemSta
 
         return <div className={`item ${stackframe ? 'stackframe' : ''}`} role="button"
             onClick={!blockError ? this.onErrorListItemClick : undefined}
-            onKeyDown={sui.fireClickOnEnter}
+            onKeyDown={fireClickOnEnter}
             aria-label={lf("Go to {0}: {1}", stackframe ? '' : 'error', message)}
             tabIndex={0}>
             {message} {(errorCount <= 1) ? null : <div className="ui gray circular label countBubble">{errorCount}</div>}

--- a/webapp/src/filelist.tsx
+++ b/webapp/src/filelist.tsx
@@ -5,6 +5,7 @@ import * as data from "./data";
 import * as sui from "./sui";
 import * as pkg from "./package";
 import * as core from "./core";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -388,7 +389,7 @@ export class FileList extends data.Component<ISettingsProps, FileListState> {
         const plus = showFiles && !pxt.shell.isReadOnly() && (!mainPkg.files[customFile] || pxt.appTarget.appTheme.addNewTypeScriptFile);
         const meta: pkg.PackageMeta = this.getData("open-pkg-meta:" + mainPkg.getPkgId());
         return <div role="tree" className={`ui tiny vertical ${targetTheme.invertedMenu ? `inverted` : ''} menu filemenu landscape only hidefullscreen`}>
-            <div role="treeitem" aria-selected={showFiles} aria-expanded={showFiles} aria-label={lf("File explorer toolbar")} key="projectheader" className="link item" onClick={this.toggleVisibility} tabIndex={0} onKeyDown={sui.fireClickOnEnter}>
+            <div role="treeitem" aria-selected={showFiles} aria-expanded={showFiles} aria-label={lf("File explorer toolbar")} key="projectheader" className="link item" onClick={this.toggleVisibility} tabIndex={0} onKeyDown={fireClickOnEnter}>
                 {lf("Explorer")}
                 <sui.Icon icon={`chevron ${showFiles ? "up" : "down"} icon`} />
                 {plus ? <sui.Button className="primary label" icon="plus" title={lf("Add custom blocks?")} onClick={this.handleCustomBlocksClick} onKeyDown={this.handleButtonKeydown} /> : undefined}
@@ -512,7 +513,7 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
             role="treeitem"
             aria-selected={isActive}
             aria-label={isActive ? lf("{0}, it is the current opened file in the JavaScript editor", file.name) : file.name}
-            onKeyDown={sui.fireClickOnEnter}
+            onKeyDown={fireClickOnEnter}
             className={className}>
             {this.props.children}
             {hasDelete && <sui.Button className="primary label" icon="trash"
@@ -520,8 +521,8 @@ class FileTreeItem extends sui.StatelessUIElement<FileTreeItemProps> {
                 onClick={this.handleRemove}
                 onKeyDown={this.handleButtonKeydown} />}
             {meta && meta.numErrors ? <span className='ui label red button' role="button" title={lf("Go to error")}>{meta.numErrors}</span> : undefined}
-            {shareUrl && <sui.Button className="button primary label" icon="share alternate" title={lf("Share")} onClick={this.handleShare} onKeyDown={sui.fireClickOnEnter} />}
-            {previewUrl && <sui.Button className="button primary label" icon="flask" title={lf("Preview")} onClick={this.handlePreview} onKeyDown={sui.fireClickOnEnter} />}
+            {shareUrl && <sui.Button className="button primary label" icon="share alternate" title={lf("Share")} onClick={this.handleShare} onKeyDown={fireClickOnEnter} />}
+            {previewUrl && <sui.Button className="button primary label" icon="flask" title={lf("Preview")} onClick={this.handlePreview} onKeyDown={fireClickOnEnter} />}
             {!!addLocalizedFile && <sui.Button className="primary label" icon="xicon globe"
                 title={lf("Add localized file")}
                 onClick={this.handleAddLocale}
@@ -576,7 +577,7 @@ class PackgeTreeItem extends sui.StatelessUIElement<PackageTreeItemProps> {
         return <div className="header link item" role="treeitem"
             aria-selected={isActive} aria-expanded={isActive}
             aria-label={lf("{0}, {1}", p.getPkgId(), isActive ? lf("expanded") : lf("collapsed"))}
-            onClick={this.handleClick} tabIndex={0} onKeyDown={sui.fireClickOnEnter} {...rest}>
+            onClick={this.handleClick} tabIndex={0} onKeyDown={fireClickOnEnter} {...rest}>
             <sui.Icon icon={`chevron ${isActive ? "up" : "down"} icon`} />
             {hasRefresh ? <sui.Button className="primary label" icon="refresh" title={lf("Refresh extension {0}", p.getPkgId())}
                 onClick={this.handleRefresh} onKeyDown={this.handleButtonKeydown} text={version || ''}></sui.Button> : undefined}

--- a/webapp/src/githubbutton.tsx
+++ b/webapp/src/githubbutton.tsx
@@ -3,6 +3,7 @@ import * as sui from "./sui";
 import * as pkg from "./package";
 import * as cloudsync from "./cloudsync";
 import * as workspace from "./workspace";
+import { fireClickOnEnter } from "./util";
 
 interface GithubButtonProps extends pxt.editor.ISettingsProps {
     className?: string;
@@ -79,7 +80,7 @@ export class GithubButton extends sui.UIElement<GithubButtonProps, GithubButtonS
         return <div key="githubeditorbtn" role="button" className={`${defaultCls}
             ${this.props.className || ""}`}
             title={title}
-            onClick={this.handleClick} onKeyDown={sui.fireClickOnEnter}
+            onClick={this.handleClick} onKeyDown={fireClickOnEnter}
             tabIndex={0}
         >
             <i className="github icon" />

--- a/webapp/src/gitjson.tsx
+++ b/webapp/src/gitjson.tsx
@@ -12,6 +12,7 @@ import * as compiler from "./compiler";
 import * as cloudsync from "./cloudsync";
 import * as tutorial from "./tutorial";
 import * as _package from "./package";
+import { fireClickOnEnter } from "./util"
 
 const MAX_COMMIT_DESCRIPTION_LENGTH = 70;
 
@@ -256,7 +257,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                             <i className="large github middle aligned icon"></i>
                             <div className="content">
                                 <a onClick={r.onClick} role="menuitem" className="header"
-                                    tabIndex={0} onKeyDown={sui.fireClickOnEnter}>{r.name}</a>
+                                    tabIndex={0} onKeyDown={fireClickOnEnter}>{r.name}</a>
                                 <div className="description">
                                     {r.description}
                                 </div>
@@ -306,7 +307,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                 org = <div className="ui small">
                     {lf("If you already have write permissions to this repository, you may have to authorize the MakeCode App in the {0} organization.", parsed.owner)}
                     <sui.PlainCheckbox label={lf("Remember me")} onChange={handleRememberMeChanged} />
-                    <sui.Link className="ui link" text={lf("Authorize MakeCode")} onClick={handleAutorize} onKeyDown={sui.fireClickOnEnter} />
+                    <sui.Link className="ui link" text={lf("Authorize MakeCode")} onClick={handleAutorize} onKeyDown={fireClickOnEnter} />
                 </div>
             }
         }
@@ -766,16 +767,16 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                 <div className="ui serialHeader">
                     <div className="leftHeaderWrapper">
                         <div className="leftHeader">
-                            <sui.Button title={lf("Go back")} icon="arrow left" text={lf("Go back")} textClass="landscape only" tabIndex={0} onClick={this.goBack} onKeyDown={sui.fireClickOnEnter} />
+                            <sui.Button title={lf("Go back")} icon="arrow left" text={lf("Go back")} textClass="landscape only" tabIndex={0} onClick={this.goBack} onKeyDown={fireClickOnEnter} />
                         </div>
                     </div>
                     <div className="rightHeader">
                         <sui.Button icon={`${hasissue ? "exclamation circle" : haspull ? "long arrow alternate down" : "check"}`}
                             className={haspull === true ? "positive" : ""}
-                            text={lf("Pull changes")} title={lf("Pull changes from GitHub to get your code up-to-date.")} onClick={this.handlePullClick} onKeyDown={sui.fireClickOnEnter} />
+                            text={lf("Pull changes")} title={lf("Pull changes from GitHub to get your code up-to-date.")} onClick={this.handlePullClick} onKeyDown={fireClickOnEnter} />
                         {!isBlocksMode && isOwner &&
                             <sui.Link className="ui item button desktop only" icon="user plus" href={`https://github.com/${githubId.slug}/settings/collaboration`} target="_blank" title={lf("Invite others to contributes to this GitHub repository.")} />}
-                        <sui.Link className="ui button" icon="external alternate" href={url} title={lf("Open repository in GitHub.")} target="_blank" onKeyDown={sui.fireClickOnEnter} />
+                        <sui.Link className="ui button" icon="external alternate" href={url} title={lf("Open repository in GitHub.")} target="_blank" onKeyDown={fireClickOnEnter} />
                     </div>
                 </div>
                 <MessageComponent parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />
@@ -789,7 +790,7 @@ class GithubComponent extends data.Component<GithubProps, GithubState> {
                     <h3 className="header">
                         <i className="large github icon" />
                         <span className="repo-name">{githubId.fullName}</span>
-                        <span onClick={this.handleBranchClick} onKeyDown={sui.fireClickOnEnter} tabIndex={0} role="button" className="repo-branch">{"#" + githubId.tag}<i className="dropdown icon" /></span>
+                        <span onClick={this.handleBranchClick} onKeyDown={fireClickOnEnter} tabIndex={0} role="button" className="repo-branch">{"#" + githubId.tag}<i className="dropdown icon" /></span>
                     </h3>
                     {needsCommit && <CommmitComponent parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
                     {showPrResolved && !needsCommit && <PullRequestZone parent={this} needsToken={needsToken} githubId={githubId} master={master} gs={gs} isBlocks={isBlocksMode} needsCommit={needsCommit} user={user} pullStatus={pullStatus} pullRequest={pr} />}
@@ -1171,7 +1172,7 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
                 <div className="content">
                     {closed && lf("This Pull Request is closed!")}
                     {merged && lf("This pull request has been merged.")}
-                    <span role="button" className="ui link" onClick={this.handleSwitchMasterBranch} onKeyDown={sui.fireClickOnEnter}>{lf("Switch to master branch")}</span>
+                    <span role="button" className="ui link" onClick={this.handleSwitchMasterBranch} onKeyDown={fireClickOnEnter}>{lf("Switch to master branch")}</span>
                 </div>
             </div>;
 
@@ -1189,7 +1190,7 @@ class MessageComponent extends sui.StatelessUIElement<GitHubViewProps> {
                 <i className="exclamation circle icon"></i>
                 <div className="content">
                     {lf("This branch was not found, please pull again or switch to a different branch.")}
-                    <span role="button" className="ui link" onClick={this.handleSwitchMasterBranch} onKeyDown={sui.fireClickOnEnter}>{lf("Switch to master branch")}</span>
+                    <span role="button" className="ui link" onClick={this.handleSwitchMasterBranch} onKeyDown={fireClickOnEnter}>{lf("Switch to master branch")}</span>
                 </div>
             </div>
 
@@ -1246,7 +1247,7 @@ class CommmitComponent extends sui.StatelessUIElement<GitHubViewProps> {
                     error={descrError} />
             </div>
             <div className="ui field">
-                <sui.Button className="green" text={lf("Commit and push changes")} icon="long arrow alternate up" onClick={this.handleCommitClick} onKeyDown={sui.fireClickOnEnter} />
+                <sui.Button className="green" text={lf("Commit and push changes")} icon="long arrow alternate up" onClick={this.handleCommitClick} onKeyDown={fireClickOnEnter} />
                 <span className="inline-help">{lf("Save your changes in GitHub.")}
                     {sui.helpIconLink("/github/commit", lf("Learn about commiting and pushing code into GitHub."))}
                 </span>
@@ -1317,7 +1318,7 @@ class PullRequestZone extends sui.StatelessUIElement<GitHubViewProps> {
         /*
                     {!mergeableUnknown && <div className="ui field">
                         <sui.Button text={lf("Sync branch")}
-                            onClick={this.handleMergeUpstreamClick} onKeyDown={sui.fireClickOnEnter} />
+                            onClick={this.handleMergeUpstreamClick} onKeyDown={fireClickOnEnter} />
                         <span className="inline-help">{lf("Merge changes from master into this branch.")}</span>
                     </div>}
         */
@@ -1339,7 +1340,7 @@ class PullRequestZone extends sui.StatelessUIElement<GitHubViewProps> {
             </div>}
             {mergeable && <div className="ui field">
                 <sui.Button className={color} text={lf("Squash and merge")}
-                    onClick={this.handleMergeClick} onKeyDown={sui.fireClickOnEnter} />
+                    onClick={this.handleMergeClick} onKeyDown={fireClickOnEnter} />
                 <span className="inline-help">{lf("Merge your changes as a single commit into the base branch.")}
                     {sui.helpIconLink("/github/pull-requests", lf("Learn about merging pull requests in GitHub."))}
                 </span>
@@ -1418,7 +1419,7 @@ class ReleaseZone extends sui.StatelessUIElement<GitHubViewProps> {
                     text={lf("Create release")}
                     inverted={inverted}
                     onClick={this.handleBumpClick}
-                    onKeyDown={sui.fireClickOnEnter} />
+                    onKeyDown={fireClickOnEnter} />
                 <span className="inline-help">
                     {lf("Snapshot and publish your code.")}
                     {sui.helpIconLink("/github/release", lf("Learn more about extension releases."))}
@@ -1494,7 +1495,7 @@ class ExtensionZone extends sui.StatelessUIElement<GitHubViewProps> {
                 <sui.Button className="basic" text={lf("Fork repository")}
                     onClick={this.handleForkClick}
                     inverted={inverted}
-                    onKeyDown={sui.fireClickOnEnter} />
+                    onKeyDown={fireClickOnEnter} />
                 <span className="inline-help">
                     {lf("Fork your own copy of {0} to your account.", githubId.slug)}
                     {sui.helpIconLink("/github/fork", lf("Learn more about forking repositories."))}
@@ -1515,7 +1516,7 @@ class ExtensionZone extends sui.StatelessUIElement<GitHubViewProps> {
                 <sui.Button className="basic" text={lf("Save for offline")}
                     onClick={this.handleSaveClick}
                     inverted={inverted}
-                    onKeyDown={sui.fireClickOnEnter} />
+                    onKeyDown={fireClickOnEnter} />
                 <span className="inline-help">
                     {lf("Export this extension to a file that can be imported without Internet.")}
                     {sui.helpIconLink("/github/offline", lf("Learn more about offline support for extensions."))}
@@ -1623,9 +1624,9 @@ class CommitView extends sui.UIElement<CommitViewProps, CommitViewState> {
         if (expanded && !diffFiles && !loading)
             this.loadDiffFilesAsync();
 
-        return <div className={`ui item link`} role="button" onClick={onClick} onKeyDown={sui.fireClickOnEnter}>
+        return <div className={`ui item link`} role="button" onClick={onClick} onKeyDown={fireClickOnEnter}>
             <div className="content">
-                {expanded && <sui.Button loading={loading} className="right floated" text={lf("Restore")} onClick={this.handleRestore} onKeyDown={sui.fireClickOnEnter} />}
+                {expanded && <sui.Button loading={loading} className="right floated" text={lf("Restore")} onClick={this.handleRestore} onKeyDown={fireClickOnEnter} />}
                 <div className="meta">
                     <span>{date.toLocaleTimeString()}</span>
                 </div>
@@ -1679,7 +1680,7 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
                 <sui.Button loading={loading} className="basic" text={lf("View commits")}
                     onClick={this.handleLoadClick}
                     inverted={inverted}
-                    onKeyDown={sui.fireClickOnEnter} />
+                    onKeyDown={fireClickOnEnter} />
                 <span className="inline-help">
                     {lf("Restore your project to a previous commit.")}
                     {sui.helpIconLink("/github/history", lf("Learn more about history of commits."))}
@@ -1694,7 +1695,7 @@ class HistoryZone extends sui.UIElement<GitHubViewProps, HistoryState> {
                             pxt.tickEvent("github.history.selectday");
                             this.setState({ selectedDay: selectedDay === day ? undefined : day, selectedCommit: undefined });
                         }}
-                        onKeyDown={sui.fireClickOnEnter}>
+                        onKeyDown={fireClickOnEnter}>
                         <div className="content">
                             <div className="ui header">{day}
                                 <div className="ui label button">

--- a/webapp/src/greenscreen.tsx
+++ b/webapp/src/greenscreen.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from "react-dom";
 import * as data from "./data";
 import * as sui from "./sui";
 import * as core from "./core";
+import { fireClickOnEnter } from "./util";
 
 export interface WebCamProps {
     close: () => void;
@@ -176,7 +177,7 @@ class WebCamCard extends data.Component<WebCamCardProps, {}> {
 
     renderCore() {
         const { header, icon } = this.props;
-        return <div role="button" className="ui card link" tabIndex={0} onClick={this.handleClick} onKeyDown={sui.fireClickOnEnter}>
+        return <div role="button" className="ui card link" tabIndex={0} onClick={this.handleClick} onKeyDown={fireClickOnEnter}>
             <div className="imageicon">
                 <sui.Icon icon={`${icon} massive`} />
             </div>

--- a/webapp/src/identity.tsx
+++ b/webapp/src/identity.tsx
@@ -5,6 +5,7 @@ import * as auth from "./auth";
 import * as data from "./data";
 import * as cloudsync from "./cloudsync";
 import * as cloud from "./cloud";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -71,7 +72,7 @@ export class LoginDialog extends auth.Component<LoginDialogProps, LoginDialogSta
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape>
                 <p>{lf("Sign in with your Microsoft Account. We'll save your projects to the cloud, where they're accessible from anywhere.")}</p>
                 <p>{lf("Don't have a Microsoft Account? Start signing in to create one!")}</p>
-                <sui.Link className="ui" text={lf("Learn more")} icon="external alternate" ariaLabel={lf("Learn more")} href="/identity/sign-in" target="_blank" onKeyDown={sui.fireClickOnEnter} />
+                <sui.Link className="ui" text={lf("Learn more")} icon="external alternate" ariaLabel={lf("Learn more")} href="/identity/sign-in" target="_blank" onKeyDown={fireClickOnEnter} />
             </sui.Modal>
         );
     }

--- a/webapp/src/immersivereader.tsx
+++ b/webapp/src/immersivereader.tsx
@@ -6,6 +6,7 @@ import * as auth from "./auth";
 import * as ImmersiveReader from '@microsoft/immersive-reader-sdk';
 
 import Cloud = pxt.Cloud;
+import { fireClickOnEnter } from "./util";
 
 export type ImmersiveReaderToken = {
     token: string;
@@ -289,7 +290,7 @@ export class ImmersiveReaderButton extends data.Component<ImmersiveReaderProps, 
 
     render() {
         return <div className='immersive-reader-button ui item' onClick={this.buttonClickHandler}
-            aria-label={lf("Launch Immersive Reader")} role="button" onKeyDown={sui.fireClickOnEnter} tabIndex={0}
+            aria-label={lf("Launch Immersive Reader")} role="button" onKeyDown={fireClickOnEnter} tabIndex={0}
             title={lf("Launch Immersive Reader")}/>
     }
 }

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -11,6 +11,7 @@ import * as identity from "./identity";
 import * as codecard from "./codecard"
 import * as carousel from "./carousel";
 import { showAboutDialogAsync } from "./dialogs";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -145,7 +146,7 @@ export class Projects extends auth.Component<ISettingsProps, ProjectsState> {
             <div key={`mystuff_gallerysegment`} className="ui segment gallerysegment mystuff-segment" role="region" aria-label={lf("My Projects")}>
                 <div className="ui heading">
                     <div className="column" style={{ zIndex: 1 }}
-                        role={scriptManager && "button"} onClick={scriptManager && this.showScriptManager} onKeyDown={scriptManager && sui.fireClickOnEnter}
+                        role={scriptManager && "button"} onClick={scriptManager && this.showScriptManager} onKeyDown={scriptManager && fireClickOnEnter}
                     >
                         {scriptManager ? <h2 className="ui header myproject-header">
                             {lf("My Projects")}
@@ -207,10 +208,10 @@ export class Projects extends auth.Component<ISettingsProps, ProjectsState> {
                 )}
             {targetTheme.organizationUrl || targetTheme.organizationUrl || targetTheme.privacyUrl || targetTheme.copyrightText ? <div className="ui horizontal small divided link list homefooter" role="contentinfo">
                 {targetTheme.organizationUrl && targetTheme.organization ? <a className="item" target="_blank" rel="noopener noreferrer" href={targetTheme.organizationUrl}>{targetTheme.organization}</a> : undefined}
-                {targetTheme.selectLanguage ? <sui.Link className="item" icon="xicon globe" text={lf("Language")} onClick={this.showLanguagePicker} onKeyDown={sui.fireClickOnEnter} role="button" /> : undefined}
+                {targetTheme.selectLanguage ? <sui.Link className="item" icon="xicon globe" text={lf("Language")} onClick={this.showLanguagePicker} onKeyDown={fireClickOnEnter} role="button" /> : undefined}
                 {targetTheme.termsOfUseUrl ? <a target="_blank" className="item" href={targetTheme.termsOfUseUrl} rel="noopener noreferrer">{lf("Terms of Use")}</a> : undefined}
                 {targetTheme.privacyUrl ? <a target="_blank" className="item" href={targetTheme.privacyUrl} rel="noopener noreferrer">{lf("Privacy")}</a> : undefined}
-                {pxt.appTarget.versions ? <sui.Link className="item" text={`v${pxt.appTarget.versions.target}`} onClick={this.showAboutDialog} onKeyDown={sui.fireClickOnEnter} role="button" /> : undefined}
+                {pxt.appTarget.versions ? <sui.Link className="item" text={`v${pxt.appTarget.versions.target}`} onClick={this.showAboutDialog} onKeyDown={fireClickOnEnter} role="button" /> : undefined}
                 {targetTheme.copyrightText ? <div className="ui item copyright">{targetTheme.copyrightText}</div> : undefined}
             </div> : undefined}
         </div>;
@@ -744,14 +745,14 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                 .slice(0, ProjectsCarousel.NUM_PROJECTS_HOMESCREEN);
             return <carousel.Carousel tickId="myprojects" bleedPercent={20}>
                 {showNewProject && <div role="button" className="ui card link buttoncard newprojectcard" title={lf("Creates a new empty project")}
-                    onClick={this.newProject} onKeyDown={sui.fireClickOnEnter} >
+                    onClick={this.newProject} onKeyDown={fireClickOnEnter} >
                     <div className="content">
                         <sui.Icon icon="huge add circle" />
                         <span className="header">{lf("New Project")}</span>
                     </div>
                 </div>}
                 {showCloudProjectsCard && <div role="button" className="ui card link buttoncard cloudprojectscard" title={lf("Sign in to see cloud projects")}
-                    onClick={e => this.props.parent.showLoginDialog()} onKeyDown={sui.fireClickOnEnter}>
+                    onClick={e => this.props.parent.showLoginDialog()} onKeyDown={fireClickOnEnter}>
                         <div className="content">
                             <sui.Icon icon="huge xicon cloud-profile"/>
                             <span className="header">{lf("Cloud Projects")}</span>
@@ -783,7 +784,7 @@ export class ProjectsCarousel extends data.Component<ProjectsCarouselProps, Proj
                     />;
                 })}
                 {showScriptManagerCard && <div role="button" className="ui card link buttoncard scriptmanagercard" title={lf("See all projects")}
-                    onClick={this.showScriptManager} onKeyDown={sui.fireClickOnEnter} >
+                    onClick={this.showScriptManager} onKeyDown={fireClickOnEnter} >
                     <div className="content">
                         <sui.Icon icon="huge right angle" />
                         <span className="header">{lf("See all projects")}</span>
@@ -1152,7 +1153,7 @@ function cardActionButton(props: Partial<ProjectsDetailProps>, className: string
             text={text}
             className={className}
             onClick={onClick}
-            onKeyDown={sui.fireClickOnEnter}
+            onKeyDown={fireClickOnEnter}
             autoFocus={autoFocus}
             title={label} ariaLabel={label}
         />

--- a/webapp/src/pxtjson.tsx
+++ b/webapp/src/pxtjson.tsx
@@ -6,6 +6,7 @@ import * as core from "./core";
 import * as data from "./data";
 
 import Util = pxt.Util;
+import { fireClickOnEnter } from "./util";
 
 export class Editor extends srceditor.Editor {
     config: pxt.PackageConfig = {} as any;
@@ -139,7 +140,7 @@ export class Editor extends srceditor.Editor {
             <div className="ui content">
                 <div className="ui small header">
                     <div className="content">
-                        <sui.Button autoFocus title={lf("Go back")} tabIndex={0} onClick={this.goBack} onKeyDown={sui.fireClickOnEnter}>
+                        <sui.Button autoFocus title={lf("Go back")} tabIndex={0} onClick={this.goBack} onKeyDown={fireClickOnEnter}>
                             <sui.Icon icon="arrow left" />
                             <span className="ui text landscape only">{lf("Go back")}</span>
                         </sui.Button>

--- a/webapp/src/scriptmanager.tsx
+++ b/webapp/src/scriptmanager.tsx
@@ -8,6 +8,7 @@ import * as auth from "./auth";
 
 import { SearchInput } from "./components/searchInput";
 import { ProjectsCodeCard } from "./projects";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -435,13 +436,13 @@ export class ScriptManagerDialog extends data.Component<ScriptManagerDialogProps
                         <table className={`ui definition unstackable table ${darkTheme ? 'inverted' : ''}`}>
                             <thead className="full-width">
                                 <tr>
-                                    <th onClick={this.handleSelectAll} tabIndex={0} onKeyDown={sui.fireClickOnEnter} title={selectedAll ? lf("De-select all projects") : lf("Select all projects")} style={{ cursor: 'pointer' }}>
+                                    <th onClick={this.handleSelectAll} tabIndex={0} onKeyDown={fireClickOnEnter} title={selectedAll ? lf("De-select all projects") : lf("Select all projects")} style={{ cursor: 'pointer' }}>
                                         <sui.Icon icon={`circle outline large ${selectedAll ? 'check' : ''}`} />
                                     </th>
-                                    <th onClick={this.handleToggleSortName} tabIndex={0} onKeyDown={sui.fireClickOnEnter} title={lf("Sort by Name {0}", sortedAsc ? lf("ascending") : lf("descending"))} style={{ cursor: 'pointer' }}>
+                                    <th onClick={this.handleToggleSortName} tabIndex={0} onKeyDown={fireClickOnEnter} title={lf("Sort by Name {0}", sortedAsc ? lf("ascending") : lf("descending"))} style={{ cursor: 'pointer' }}>
                                         {lf("Name")} {sortedBy == 'name' ? <sui.Icon icon={`arrow ${sortedAsc ? 'up' : 'down'}`} /> : undefined}
                                     </th>
-                                    <th onClick={this.handleToggleSortTime} tabIndex={0} onKeyDown={sui.fireClickOnEnter} title={lf("Sort by Last Modified {0}", sortedAsc ? lf("ascending") : lf("descending"))} style={{ cursor: 'pointer' }}>
+                                    <th onClick={this.handleToggleSortTime} tabIndex={0} onKeyDown={fireClickOnEnter} title={lf("Sort by Last Modified {0}", sortedAsc ? lf("ascending") : lf("descending"))} style={{ cursor: 'pointer' }}>
                                         {lf("Last Modified")} {sortedBy == 'time' ? <sui.Icon icon={`arrow ${sortedAsc ? 'up' : 'down'}`} /> : undefined}
                                     </th>
                                 </tr>
@@ -499,7 +500,7 @@ class ProjectsCodeRow extends sui.StatelessUIElement<ProjectsCodeRowProps> {
 
     renderCore() {
         const { scr, onRowClicked, onClick, selected, markedNew, children, ...rest } = this.props;
-        return <tr tabIndex={0} {...rest} onKeyDown={sui.fireClickOnEnter} onClick={this.handleClick} style={{ cursor: 'pointer' }} className={`${markedNew ? 'warning' : selected ? 'positive' : ''}`}>
+        return <tr tabIndex={0} {...rest} onKeyDown={fireClickOnEnter} onClick={this.handleClick} style={{ cursor: 'pointer' }} className={`${markedNew ? 'warning' : selected ? 'positive' : ''}`}>
             <td className="collapsing" onClick={this.handleCheckboxClick}>
                 <sui.Icon icon={`circle outline large ${selected ? `check green` : markedNew ? 'black' : ''}`} />
             </td>

--- a/webapp/src/serial.tsx
+++ b/webapp/src/serial.tsx
@@ -8,6 +8,7 @@ import * as data from "./data";
 import * as auth from "./auth";
 
 import Util = pxt.Util
+import { fireClickOnEnter } from "./util"
 
 const maxEntriesPerChart: number = 4000;
 
@@ -457,7 +458,7 @@ export class Editor extends srceditor.Editor {
                 <div id="serialHeader" className="ui serialHeader">
                     <div className="leftHeaderWrapper">
                         <div className="leftHeader">
-                            <sui.Button title={lf("Go back")} tabIndex={0} onClick={this.goBack} onKeyDown={sui.fireClickOnEnter}>
+                            <sui.Button title={lf("Go back")} tabIndex={0} onClick={this.goBack} onKeyDown={fireClickOnEnter}>
                                 <sui.Icon icon="arrow left" />
                                 <span className="ui text landscape only">{lf("Go back")}</span>
                             </sui.Button>

--- a/webapp/src/serialindicator.tsx
+++ b/webapp/src/serialindicator.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import * as sui from "./sui";
 import * as data from "./data";
+import { fireClickOnEnter } from "./util";
 
 export interface SerialIndicatorProps {
     isSim: boolean,
@@ -57,7 +58,7 @@ export class SerialIndicator extends data.Component<SerialIndicatorProps, Serial
     renderCore() {
         if (!this.active()) return <div />;
         return (
-            <div role="button" title={lf("Open console")} className="ui label circular" tabIndex={0} onClick={this.props.onClick} onKeyDown={sui.fireClickOnEnter}>
+            <div role="button" title={lf("Open console")} className="ui label circular" tabIndex={0} onClick={this.props.onClick} onKeyDown={fireClickOnEnter}>
                 <div className="detail">
                     <img alt={lf("Animated bar chart")} className="barcharticon" src={pxt.Util.pathJoin(pxt.webConfig.commitCdnUrl, `images/Bars_black.gif`)}></img>
                 </div>

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -4,6 +4,7 @@ import * as sui from "./sui";
 import * as simulator from "./simulator";
 import * as screenshot from "./screenshot";
 import * as qr from "./qr";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -516,7 +517,7 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                         {!qrCodeFull && <sui.Input id="projectUri" class="mini" readOnly={true} lines={1} value={url} copy={true} autoFocus={!pxt.BrowserUtils.isMobile()} selectOnClick={true} aria-describedby="projectUriLabel" autoComplete={false} />}
                         {!qrCodeFull && <label htmlFor="projectUri" id="projectUriLabel" className="accessible-hidden">{lf("This is the read-only internet address of your project.")}</label>}
                         {!!qrCodeUri && <img className={`ui ${qrCodeFull ? "huge" : "small"} image ${qrCodeExpanded ? "centered" : "floated right"} button pixelart`} alt={lf("QR Code of the saved program")}
-                            src={qrCodeUri} onClick={this.handleQrCodeClick} title={lf("Click to expand or collapse.")} tabIndex={0} aria-label={lf("QR Code of the saved program")} onKeyDown={sui.fireClickOnEnter}/>}
+                            src={qrCodeUri} onClick={this.handleQrCodeClick} title={lf("Click to expand or collapse.")} tabIndex={0} aria-label={lf("QR Code of the saved program")} onKeyDown={fireClickOnEnter}/>}
                         {showSocialIcons ? <div className="social-icons">
                             <SocialButton url={url} ariaLabel="Facebook" type='facebook' heading={lf("Share on Facebook")} />
                             <SocialButton url={url} ariaLabel="Twitter" type='twitter' heading={lf("Share on Twitter")} />
@@ -624,7 +625,7 @@ class SocialButton extends data.Component<SocialButtonProps, {}> {
     renderCore() {
         const { type, label, ariaLabel, icon } = this.props;
         return <a role="button" className={`ui button large ${label ? "labeled" : ""} icon ${type}`} tabIndex={0} aria-label={ariaLabel}
-            onClick={this.handleClick} onKeyDown={sui.fireClickOnEnter}><sui.Icon icon={icon || type} />{label}</a>
+            onClick={this.handleClick} onKeyDown={fireClickOnEnter}><sui.Icon icon={icon || type} />{label}</a>
     }
 }
 

--- a/webapp/src/sidebarTutorial.tsx
+++ b/webapp/src/sidebarTutorial.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import * as sui from "./sui";
 import * as md from "./marked";
 import { TutorialCard, TutorialHint } from "./tutorial";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -28,7 +29,7 @@ export class SidebarTutorialHint extends TutorialHint {
             className: 'green'
         }]
         return <div id="callout" className={`callout-container`}>
-            <sui.Button className={`callout-hint ui circular label blue hintbutton`} icon="lightbulb outline" tabIndex={-1} onKeyDown={sui.fireClickOnEnter} />
+            <sui.Button className={`callout-hint ui circular label blue hintbutton`} icon="lightbulb outline" tabIndex={-1} onKeyDown={fireClickOnEnter} />
             {!showDialog ? <div className={`callout-wrapper`}>
                 <div className="callout-hint-header">Hint:</div>
                 <div className="callout-hint-text"><md.MarkedContent markdown={tutorialHint} unboxSnippets={true} parent={this.props.parent}/></div>
@@ -67,7 +68,7 @@ export class SidebarTutorialCard extends TutorialCard {
         return <div id="sidebar">
             <div className={`tutorialTitle`}><p>{tutorialName}</p></div>
             <div ref="tutorialmessage" className={`tutorialMessage`} role="alert" aria-label={tutorialAriaLabel} tabIndex={hasHint ? 0 : -1}
-                onKeyDown={hasHint ? sui.fireClickOnEnter : undefined}>
+                onKeyDown={hasHint ? fireClickOnEnter : undefined}>
                 <div className="content">
                     {!showDialog && <md.MarkedContent className="no-select" markdown={tutorialCardContent} parent={this.props.parent} onDidRender={this.onMarkdownDidRender} />}
                 </div>

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -13,6 +13,7 @@ import * as simulator from "./simulator";
 import { TabContent } from "./components/core/TabContent";
 import { TabPane } from "./components/core/TabPane";
 import { TutorialContainer } from "./components/tutorial/TutorialContainer";
+import { fireClickOnEnter } from "./util";
 
 interface SidepanelState {
     activeTab?: string;
@@ -119,7 +120,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
 
     protected tutorialExitButton = () => {
         return <div className="tutorial-exit" aria-label={lf("Exit tutorial")} tabIndex={0}
-            onClick={() => this.props.parent.exitTutorial()} onKeyDown={sui.fireClickOnEnter}>
+            onClick={() => this.props.parent.exitTutorial()} onKeyDown={fireClickOnEnter}>
             {lf("Exit Tutorial")}
         </div>;
     }

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -6,6 +6,7 @@ import * as ReactTooltip from 'react-tooltip';
 import * as data from "./data";
 import * as core from "./core";
 import * as auth from "./auth";
+import { fireClickOnEnter } from "./util";
 
 export const appElement = document.getElementById('content');
 
@@ -46,14 +47,6 @@ export function genericContent(props: UiProps) {
     ]
     if (props.icon && props.rightIcon) retVal = retVal.reverse();
     return retVal;
-}
-
-export function fireClickOnEnter(e: React.KeyboardEvent<HTMLElement>): void {
-    const charCode = core.keyCodeFromEvent(e);
-    if (charCode === core.ENTER_KEY || charCode === core.SPACE_KEY) {
-        e.preventDefault();
-        (e.currentTarget as HTMLElement).click();
-    }
 }
 
 export class UIElement<T, S> extends data.Component<T, S> {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -8,6 +8,7 @@ import * as core from "./core"
 import * as coretsx from "./coretsx";
 
 import Util = pxt.Util;
+import { fireClickOnEnter } from "./util"
 
 export const enum CategoryNameID {
     Loops = "loops",
@@ -578,7 +579,7 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
                 // Close the flyout
                 toolbox.closeFlyout();
             } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
-                sui.fireClickOnEnter.call(this, e);
+                fireClickOnEnter.call(this, e);
             } else if (charCode == core.TAB_KEY
                 || charCode == 37 /* Left arrow key */
                 || charCode == 39 /* Left arrow key */
@@ -784,7 +785,7 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
             style={treeRowStyle} tabIndex={0}
             aria-label={lf("Toggle category {0}", rowTitle)} aria-expanded={selected}
             onMouseEnter={this.onmouseenter} onMouseLeave={this.onmouseleave}
-            onClick={onClick} onContextMenu={onClick} onKeyDown={onKeyDown ? onKeyDown : sui.fireClickOnEnter}>
+            onClick={onClick} onContextMenu={onClick} onKeyDown={onKeyDown ? onKeyDown : fireClickOnEnter}>
             <span className="blocklyTreeIcon" role="presentation"></span>
             {iconImageStyle}
             <span style={{ display: 'inline-block' }} className={`blocklyTreeIcon ${iconClass}`} role="presentation">{iconContent}</span>

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -15,6 +15,7 @@ import { ProjectView } from "./app";
 import * as editortoolbar from "./editortoolbar";
 import * as ImmersiveReader from "./immersivereader";
 import * as TutorialCodeValidation from "./tutorialCodeValidation";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -225,7 +226,7 @@ export class TutorialMenuItemLink extends data.Component<TutorialMenuItemLinkPro
 
     renderCore() {
         const { className, ariaLabel, index } = this.props;
-        return <a className={className} role="menuitem" aria-label={ariaLabel} tabIndex={0} onClick={this.handleClick} onKeyDown={sui.fireClickOnEnter}>
+        return <a className={className} role="menuitem" aria-label={ariaLabel} tabIndex={0} onClick={this.handleClick} onKeyDown={fireClickOnEnter}>
             {this.props.children}
         </a>;
     }
@@ -265,13 +266,13 @@ export class TutorialStepCircle extends data.Component<ITutorialMenuProps, {}> {
 
         return <div id="tutorialsteps" className={`ui item ${this.props.className}`}>
             <div className="ui item" role="menubar">
-                <sui.Button role="button" icon={`${isRtl ? 'right' : 'left'} chevron`} disabled={!hasPrev} className={`prevbutton left ${!hasPrev ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.handlePrevClick} onKeyDown={sui.fireClickOnEnter} />
+                <sui.Button role="button" icon={`${isRtl ? 'right' : 'left'} chevron`} disabled={!hasPrev} className={`prevbutton left ${!hasPrev ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.handlePrevClick} onKeyDown={fireClickOnEnter} />
                 <span className="step-label" key={'tutorialStep' + currentStep}>
                     <sui.ProgressCircle progress={currentStep + 1} steps={tutorialStepInfo.length} stroke={4.5} />
                     <span className={`ui circular label blue selected ${!tutorialReady ? 'disabled' : ''}`}
                         aria-label={lf("You are currently at tutorial step {0}.")}>{tutorialStep + 1}</span>
                 </span>
-                <sui.Button role="button" icon={`${isRtl ? 'left' : 'right'} chevron`} disabled={!hasNext} rightIcon className={`nextbutton right ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")} onClick={this.handleNextClick} onKeyDown={sui.fireClickOnEnter} />
+                <sui.Button role="button" icon={`${isRtl ? 'left' : 'right'} chevron`} disabled={!hasNext} rightIcon className={`nextbutton right ${!hasNext ? 'disabled' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")} onClick={this.handleNextClick} onKeyDown={fireClickOnEnter} />
             </div>
         </div>;
     }
@@ -725,7 +726,7 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
         return <div id="tutorialcard" className={`ui ${tutorialStepExpanded ? 'tutorialExpanded' : ''} ${tutorialReady ? 'tutorialReady' : ''} ${this.state.showSeeMore ? 'seemore' : ''}  ${!this.state.showHint ? 'showTooltip' : ''} ${hasHint ? 'hasHint' : ''}`} style={tutorialStepExpanded ? this.getExpandedCardStyle('height') : null} >
             {hasHint && this.state.showHint && !showDialog && <div className="mask" role="region" onClick={this.closeHint}></div>}
             <div className='ui buttons'>
-                {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {hasPrevious ? <sui.Button icon={`${isRtl ? 'right' : 'left'} chevron large`} className={`prevbutton left attached ${!hasPrevious ? 'disabled' : ''}`} text={lf("Back")} textClass="widedesktop only" ariaLabel={lf("Go to the previous step of the tutorial.")} onClick={this.previousTutorialStep} onKeyDown={fireClickOnEnter} /> : undefined}
                 <div className="ui segment attached tutorialsegment">
                     <div ref="tutorialmessage" className={`tutorialmessage`} role="alert">
                         <div className="content">
@@ -737,19 +738,19 @@ export class TutorialCard extends data.Component<TutorialCardProps, TutorialCard
                             className={`ui circular label blue hintbutton hidelightbox ${this.props.pokeUser ? 'shake flash' : ''}`}
                             icon="lightbulb"
                             aria-label={tutorialAriaLabel} title={tutorialHintTooltip}
-                            onClick={hintOnClick} onKeyDown={sui.fireClickOnEnter}
+                            onClick={hintOnClick} onKeyDown={fireClickOnEnter}
                         />}
                         {(!showDialog && hasHint) && <HintTooltip ref="hinttooltip" pokeUser={this.props.pokeUser} text={tutorialHintTooltip} onClick={hintOnClick} />}
                         <TutorialHint ref="tutorialhint" parent={this.props.parent} />
                     </div>
-                    {this.state.showSeeMore && !tutorialStepExpanded && <sui.Button className="fluid compact lightgrey" icon="chevron down" tabIndex={0} text={lf("More...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} />}
-                    {this.state.showSeeMore && tutorialStepExpanded && <sui.Button className="fluid compact lightgrey" icon="chevron up" tabIndex={0} text={lf("Less...")} onClick={this.toggleExpanded} onKeyDown={sui.fireClickOnEnter} />}
+                    {this.state.showSeeMore && !tutorialStepExpanded && <sui.Button className="fluid compact lightgrey" icon="chevron down" tabIndex={0} text={lf("More...")} onClick={this.toggleExpanded} onKeyDown={fireClickOnEnter} />}
+                    {this.state.showSeeMore && tutorialStepExpanded && <sui.Button className="fluid compact lightgrey" icon="chevron up" tabIndex={0} text={lf("Less...")} onClick={this.toggleExpanded} onKeyDown={fireClickOnEnter} />}
                 </div>
                 {hasNext ? <sui.Button icon={`${isRtl ? 'left' : 'right'} chevron large`} className={`nextbutton right attached ${!hasNext ? 'disabled' : ''}  ${tutorialCodeValidated ? 'isValidated' : ''}`} text={lf("Next")} textClass="widedesktop only" ariaLabel={lf("Go to the next step of the tutorial.")}
-                    onClick={nextOnClick} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                    onClick={nextOnClick} onKeyDown={fireClickOnEnter} /> : undefined}
                 {showTutorialValidationMessage &&
                     <TutorialCodeValidation.ShowValidationMessage onYesButtonClick={this.nextTutorialStep} onNoButtonClick={this.closeTutorialValidationMessage} initialVisible={this.state.showTutorialValidationMessage} isTutorialCodeInvalid={!tutorialCodeValidated} ruleComponents={stepInfo.listOfValidationRules} areStrictRulesPresent={strictRulePresent} validationTelemetry={this.validationTelemetry} parent={this.props.parent} />}
-                {hasFinish ? <sui.Button icon="left checkmark" className={`orange right attached ${!tutorialReady ? 'disabled' : ''}`} text={lf("Finish")} ariaLabel={lf("Finish the tutorial.")} onClick={this.finishTutorial} onKeyDown={sui.fireClickOnEnter} /> : undefined}
+                {hasFinish ? <sui.Button icon="left checkmark" className={`orange right attached ${!tutorialReady ? 'disabled' : ''}`} text={lf("Finish")} ariaLabel={lf("Finish the tutorial.")} onClick={this.finishTutorial} onKeyDown={fireClickOnEnter} /> : undefined}
             </div>
         </div>;
     }

--- a/webapp/src/tutorialCodeValidation.tsx
+++ b/webapp/src/tutorialCodeValidation.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import * as data from "./data";
 import * as sui from "./sui";
 import * as compiler from "./compiler";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -133,8 +134,8 @@ export class ShowValidationMessage extends data.Component<TutorialCodeValidation
                     {lf("Do you still want to continue?")}
                 </div>
                 <div className="moveOnButtons">
-                    <sui.Button className="yes" ariaLabel={lf("yes button for tutorial code validation")} onClick={this.moveOnToNextTutorialStep.bind(this)} onKeyDown={sui.fireClickOnEnter} > {lf("Continue Anyway")} </sui.Button>
-                    <sui.Button className="no" ariaLabel={lf("no button for tutorial code validation")} onClick={this.stayOnThisTutorialStep.bind(this)} onKeyDown={sui.fireClickOnEnter} > {lf("Keep Editing")} </sui.Button>
+                    <sui.Button className="yes" ariaLabel={lf("yes button for tutorial code validation")} onClick={this.moveOnToNextTutorialStep.bind(this)} onKeyDown={fireClickOnEnter} > {lf("Continue Anyway")} </sui.Button>
+                    <sui.Button className="no" ariaLabel={lf("no button for tutorial code validation")} onClick={this.stayOnThisTutorialStep.bind(this)} onKeyDown={fireClickOnEnter} > {lf("Keep Editing")} </sui.Button>
                 </div>
             </div>
         </div>;

--- a/webapp/src/user.tsx
+++ b/webapp/src/user.tsx
@@ -3,6 +3,7 @@ import * as sui from "./sui";
 import * as core from "./core";
 import * as auth from "./auth";
 import * as cloudsync from "./cloudsync";
+import { fireClickOnEnter } from "./util";
 
 type ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -231,7 +232,7 @@ class FeedbackPanel extends sui.UIElement<FeedbackPanelProps, {}> {
                     {lf("What do you think about the Sign In & Cloud Save feature? Is there something you'd like to change? Did you encounter issues? Please let us know!")}
                 </div>
                 <div className="row-span-two">
-                    <sui.Link className="ui" text={lf("Take the Survey")} icon="external alternate" ariaLabel={lf("Provide feedback in a form")} href="https://aka.ms/AAcnpaj" target="_blank" onKeyDown={sui.fireClickOnEnter} />
+                    <sui.Link className="ui" text={lf("Take the Survey")} icon="external alternate" ariaLabel={lf("Provide feedback in a form")} href="https://aka.ms/AAcnpaj" target="_blank" onKeyDown={fireClickOnEnter} />
                 </div>
             </div>
         );

--- a/webapp/src/util.ts
+++ b/webapp/src/util.ts
@@ -1,0 +1,7 @@
+export function fireClickOnEnter(e: React.KeyboardEvent<HTMLElement>): void {
+    const charCode = (typeof e.which == "number") ? e.which : e.keyCode;
+    if (charCode === /*enter*/13 || charCode === /*space*/32) {
+        e.preventDefault();
+        (e.currentTarget as HTMLElement).click();
+    }
+}


### PR DESCRIPTION
This looks way, way, scarier than it actually is! All this PR does is move things around a bit to make our dependency graph a little less complicated. Basically, the /---asseteditor page broke a while back when the cloudsync stuff went in. Obviously the cloudsync stuff shouldn't even be in the  /---asseteditor page at all, so I had to untangle our imports a bit.

The big culprit was `fireClickOnEnter` which we use all over the place and is exported by `sui.tsx` (which itself requires `app.tsx`). I factored that out into a new file along with some of the asset editor utils that were also drawing in `package.ts` for no good reason.


To fix this, I wrote a script to trace the dependency graph and figure out the culprit. Here's how the dependency graph looked for the `package.ts` issues:

```
cloudsync-> /dialogs.js-> /container.js-> /headerbar.js-> /app.js-> /cloud.js-> /auth.js-> /core.js->
/compiler.js-> /workspace.js-> /package.js-> /components/assetEditor/store/assetEditorReducer.js->
/components/assetEditor/assetCard.js-> /components/ImageFieldEditor.js-> /assetEditor.js
```