### PR TITLE
trust editor extensions in debug mode

### DIFF
--- a/webapp/src/extensionManager.ts
+++ b/webapp/src/extensionManager.ts
@@ -121,8 +121,10 @@ export async function resolveExtensionUrl(pkg: pxt.Package) {
         && extension.localUrl;
     if (debug) {
         url = "http://localhost:3232/extension.html";
+        trusted = true;
     } else if (localDebug) {
         url = extension.localUrl;
+        trusted = true;
     }
     // ALL EDITOR EXTENSIONS MUST NOW BE IN THE APPROVED LIST
     else if (extension.url

--- a/webapp/src/extensions.tsx
+++ b/webapp/src/extensions.tsx
@@ -104,25 +104,13 @@ export class Extensions extends data.Component<ISettingsProps, ExtensionsState> 
     }
 
     showExtensionAsync(extension: string, url: string) {
-        // sanity check: URL must be approved in targetconfig.json
-        return pxt.targetConfigAsync()
-            .then(config => {
-
-                // sanity check: this should have been caught earlier
-                const packagesConfig = config?.packages;
-                if (!(packagesConfig?.approvedEditorExtensionUrls?.indexOf(url) > -1))
-                    pxt.U.userError("Trying to load an unapproved extension")
-
-                // loading
-                this.setState({ visible: true, extension: extension, url: url }, () => {
-                    this.send(extension, {
-                        target: pxt.appTarget.id,
-                        type: "pxtpkgext",
-                        event: "extshown"
-                    } as pxt.editor.ShownEvent);
-                })
-            })
-
+        this.setState({ visible: true, extension: extension, url: url }, () => {
+            this.send(extension, {
+                target: pxt.appTarget.id,
+                type: "pxtpkgext",
+                event: "extshown"
+            } as pxt.editor.ShownEvent);
+        })
     }
 
     initializeFrame() {


### PR DESCRIPTION
The check are overly aggressive and prevent from doing localhost testing. If localeditorextensions is set, trust localhost server.