### PR TITLE
Increase max wait on C++ builds to 5 min

### DIFF
--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1375,7 +1375,7 @@ namespace pxt.hexloader {
                             .then(ret => new Promise<string>((resolve, reject) => {
                                 let retry = 0;
                                 const delay = 8000; // ms
-                                const maxWait = 240000; // ms
+                                const maxWait = 300000; // ms
                                 const startTry = U.now();
                                 const tryGet = () => {
                                     retry++;


### PR DESCRIPTION
esp32 builds are really slow