### PR TITLE
Add 'tutorial' links to skillmap completion modal action

### DIFF
--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -96,6 +96,8 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
                 return lf("Start Skill Map")
             case "editor":
                 return lf("Keep Building")
+            case "tutorial":
+                return lf("Start Tutorial")
             case "docs":
             default:
                 return lf("Learn More")
@@ -138,6 +140,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
                         modalActions.push(action as ModalAction);
                     }
                     break;
+                case "tutorial":
                 case "map":
                 case "docs":
                 default:

--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -95,7 +95,7 @@ export async function getMarkdownAsync(source: MarkdownSource, url: string): Pro
  */
 async function fetchSkillMapFromGithub(path: string): Promise<MarkdownFetchResult | undefined> {
     const ghid = pxt.github.parseRepoId(path)
-    const config = await pxt.packagesConfigAsync();
+    const config = await pxt.packagesConfigAsync() || {};
 
     const baseRepo = pxt.github.parseRepoId(ghid.slug);
     const repoStatus = pxt.github.repoStatus(baseRepo, config);

--- a/skillmap/src/lib/skillMap.d.ts
+++ b/skillmap/src/lib/skillMap.d.ts
@@ -82,7 +82,7 @@ interface MapCompletionNode extends MapReward {
 }
 
 interface MapCompletionAction {
-    kind: "activity" | "map" | "docs" | "editor";
+    kind: "activity" | "map" | "docs" | "editor" | "tutorial";
     label?: string;
     activityId?: string;
     url?: string;

--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -290,6 +290,12 @@ function inflateMapReward(section: MarkdownSection, base: Partial<MapReward>): M
                         parsedActions.push({ kind: "map", label, url: `#${prefix}:${link}` });
                     }
                     break;
+                case "tutorial":
+                    if (link) {
+                        if (!validGithubUrl(link) && !validDocsUrl(link)) error(`URL: ${link} must be to Github or MakeCode documentation`);
+                        parsedActions.push({ kind: "tutorial", label, url: `/#tutorial:${link}` });
+                    }
+                    break;
                 case "docs":
                     if (link) {
                         let docsUrl = (link.startsWith("/") ? "" : "/") + link;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4120

@kiki-lee adding a tutorial action type for the completion modal! it's specified like:

`* tutorial: [Catch Some Flies!](/tutorials/froggy)`