### PR TITLE
[port to master] hoist up telemetryItem properties definition

### DIFF
--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -18,12 +18,12 @@
         appInsights.queue.push(function () {
             appInsights.context.addTelemetryInitializer(function (envelope) {
                 var telemetryItem = envelope.data.baseData;
+                telemetryItem.properties = telemetryItem.properties || {};
                 telemetryItem.properties["cookie"] = isProduction;
                 if (typeof pxtConfig === "undefined" || !pxtConfig) {
                     telemetryItem.properties["target"] = "@targetid@";
                     return;
                 }
-                telemetryItem.properties = telemetryItem.properties || {};
                 telemetryItem.properties["target"] = pxtConfig.targetId;
                 telemetryItem.properties["stage"] = (pxtConfig.relprefix || "/--").replace(/[^a-z]/ig, '')
                 if (typeof Windows !== "undefined")


### PR DESCRIPTION
port https://github.com/microsoft/pxt/pull/8562 from stable7.0 to master

Didn't fix the issue like I was hoping but still should be ported to master to avoid unnecessary crashes / lost telemetry, the exception shows up in arcade docs as well