### PR TITLE
remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "test:fmt": "gulp testfmt",
     "test:lang": "gulp testlang",
     "update": "gulp update",
-    "watch-streamer": "cd docs/static/streamer && tsc -t es6 --watch",
-    "postinstall": "cd skillmap && npm install"
+    "watch-streamer": "cd docs/static/streamer && tsc -t es6 --watch"
   }
 }


### PR DESCRIPTION
This was causing a build failure in pxt-arcade. I'll look into a better way to do this later.