### PR TITLE
Include parameters in monaco snippet if they are in the blockdef

### DIFF
--- a/pxtcompiler/emitter/snippets.ts
+++ b/pxtcompiler/emitter/snippets.ts
@@ -147,12 +147,19 @@ namespace ts.pxtc.service {
             return getParameterDefault(decl.parameters[0]);
         }
 
+        const element = fn as pxtc.SymbolInfo;
+        const params = pxt.blocks.compileInfo(element);
+
         const blocksById = blocksInfo.blocksById
 
         // TODO: move out of getSnippet for general reuse
-
+        const blockParameters = attrs._def?.parameters
+            .filter(param => !!params.definitionNameToParam[param.name])
+            .map(param => params.definitionNameToParam[param.name].actualName) || [];
         const includedParameters = decl.parameters ? decl.parameters
-            .filter(param => !param.initializer && !param.questionToken) : []
+            // Only keep required parameters and parameters included in the blockdef
+            .filter(param => (!param.initializer && !param.questionToken)
+                || (blockParameters.indexOf(param.name.getText()) >= 0)) : []
 
         const args = includedParameters
             .map(getParameterDefault)
@@ -164,7 +171,6 @@ namespace ts.pxtc.service {
                     isLiteral: true
                 }) as SnippetNode)
 
-        const element = fn as pxtc.SymbolInfo;
         if (element.attributes.block) {
             if (element.attributes.defaultInstance) {
                 snippetPrefix = element.attributes.defaultInstance;
@@ -221,7 +227,6 @@ namespace ts.pxtc.service {
                     isInstance = true;
                 }
                 else if (element.kind == pxtc.SymbolKind.Method || element.kind == pxtc.SymbolKind.Property) {
-                    const params = pxt.blocks.compileInfo(element);
                     if (params.thisParameter) {
                         let varName: string = undefined
                         if (params.thisParameter.definitionName) {


### PR DESCRIPTION
for https://github.com/microsoft/pxt-arcade/issues/891

check to see if the parameter is visible on the block and includes it in the snippet if so. we also still include required parameters, regardless of if they're on the block.