### PR TITLE
Updates to sync with Blockly changes through July 2021

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "monaco-editor": "0.24.0",
     "pouchdb": "7.2.1",
     "pouchdb-adapter-memory": "7.2.1",
-    "pxt-blockly": "3.0.35",
+    "pxt-blockly": "4.0.5",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -1732,7 +1732,7 @@ namespace pxt.blocks {
     export function compileBlockAsync(b: Blockly.Block, blockInfo: pxtc.BlocksInfo): Promise<BlockCompilationResult> {
         const w = b.workspace;
         const e = mkEnv(w, blockInfo);
-        infer(w && w.getAllBlocks(), e, w);
+        infer(w && w.getAllBlocks(false), e, w);
         const compiled = compileStatementBlock(e, b)
         removeAllPlaceholders();
         return tdASTtoTS(e, compiled);
@@ -1754,7 +1754,7 @@ namespace pxt.blocks {
     function compileWorkspace(e: Environment, w: Blockly.Workspace, blockInfo: pxtc.BlocksInfo): [JsNode[], BlockDiagnostic[]] {
         try {
             // all compiled top level blocks are events
-            let allBlocks = w.getAllBlocks();
+            let allBlocks = w.getAllBlocks(false);
 
             if (pxt.react.getTilemapProject) {
                 pxt.react.getTilemapProject().removeInactiveBlockAssets(allBlocks.map(b => b.id));
@@ -2058,13 +2058,9 @@ namespace pxt.blocks {
     }
 
     function maybeAddComment(b: Blockly.Block, comments: string[]) {
-        if (b.comment) {
-            if ((typeof b.comment) === "string") {
-                comments.push(b.comment as string)
-            }
-            else {
-                comments.push((b.comment as Blockly.Comment).getText())
-            }
+        const text = b.getCommentText();
+        if (text) {
+            comments.push(text)
         }
     }
 

--- a/pxtblocks/blocklycompiler.ts
+++ b/pxtblocks/blocklycompiler.ts
@@ -2058,7 +2058,8 @@ namespace pxt.blocks {
     }
 
     function maybeAddComment(b: Blockly.Block, comments: string[]) {
-        const text = b.getCommentText();
+        // Check if getCommentText exists, block may be placeholder
+        const text = b.getCommentText?.();
         if (text) {
             comments.push(text)
         }

--- a/pxtblocks/blocklydiff.ts
+++ b/pxtblocks/blocklydiff.ts
@@ -115,9 +115,9 @@ namespace pxt.blocks {
 
         // we'll ignore disabled blocks in the final output
 
-        const oldBlocks = oldWs.getAllBlocks().filter(b => b.isEnabled());
+        const oldBlocks = oldWs.getAllBlocks(false).filter(b => b.isEnabled());
         const oldTopBlocks = oldWs.getTopBlocks(false).filter(b => b.isEnabled());
-        const newBlocks = newWs.getAllBlocks().filter(b => b.isEnabled());
+        const newBlocks = newWs.getAllBlocks(false).filter(b => b.isEnabled());
         log(`blocks`, newBlocks.map(b => b.toDevString()));
         log(newBlocks);
 
@@ -143,11 +143,11 @@ namespace pxt.blocks {
         pxt.blocks.domToWorkspaceNoEvents(Blockly.Xml.textToDom(newXml), ws);
 
         // delete disabled blocks from final workspace
-        ws.getAllBlocks().filter(b => !b.isEnabled()).forEach(b => {
+        ws.getAllBlocks(false).filter(b => !b.isEnabled()).forEach(b => {
             log('disabled ', b.toDevString())
             b.dispose(false)
         })
-        const todoBlocks = Util.toDictionary(ws.getAllBlocks(), b => b.id);
+        const todoBlocks = Util.toDictionary(ws.getAllBlocks(false), b => b.id);
         log(`todo blocks`, todoBlocks)
         logTodo('start')
 
@@ -158,7 +158,7 @@ namespace pxt.blocks {
                 done(b);
                 const b2 = cloneIntoDiff(b);
                 done(b2);
-                b2.setDisabled(true);
+                b2.setEnabled(false);
             });
             logTodo('deleted top')
         }
@@ -230,7 +230,7 @@ namespace pxt.blocks {
         logTodo('unmodified')
 
         // if nothing is left in the workspace, we "missed" change
-        if (!ws.getAllBlocks().length) {
+        if (!ws.getAllBlocks(false).length) {
             pxt.tickEvent("blocks.diff", { missed: 1 })
             return {
                 ws,
@@ -267,7 +267,7 @@ namespace pxt.blocks {
         function stitch(b: Blockly.Block) {
             log(`stitching ${b.toDevString()}->${dids[b.id]}`)
             const wb = ws.getBlockById(dids[b.id]);
-            wb.setDisabled(true);
+            wb.setEnabled(false);
             markUsed(wb);
             done(wb);
             // connect previous connection to delted or existing block
@@ -308,7 +308,7 @@ namespace pxt.blocks {
         }
 
         function cloneIntoDiff(b: Blockly.Block): Blockly.Block {
-            const bdom = Blockly.Xml.blockToDom(b, false);
+            const bdom = Blockly.Xml.blockToDom(b, false) as Element;
             const b2 = Blockly.Xml.domToBlock(bdom, ws);
             // disconnect
             if (b2.nextConnection && b2.nextConnection.targetConnection)
@@ -414,7 +414,7 @@ namespace pxt.blocks {
     }
 
     function normalizedDom(b: Blockly.Block, keepChildren?: boolean): string {
-        const dom = Blockly.Xml.blockToDom(b, true);
+        const dom = Blockly.Xml.blockToDom(b, true) as Element;
         normalizeAttributes(dom);
         visDom(dom, (e) => {
             normalizeAttributes(e);

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -32,10 +32,10 @@ namespace pxt.blocks {
     function applyMetaComments(workspace: Blockly.Workspace) {
         // process meta comments
         // @highlight -> highlight block
-        workspace.getAllBlocks()
-            .filter(b => !!b.comment && b.comment instanceof Blockly.Comment)
+        workspace.getAllBlocks(false)
+            .filter(b => !!b.getCommentText())
             .forEach(b => {
-                const c = (<Blockly.Comment>b.comment).getText();
+                const c = b.getCommentText();
                 if (/@highlight/.test(c)) {
                     const cc = c.replace(/@highlight/g, '').trim();
                     b.setCommentText(cc || null);
@@ -99,7 +99,7 @@ namespace pxt.blocks {
         let xmlBlock = Blockly.Xml.textToDom(text);
         let block = Blockly.Xml.domToBlock(xmlBlock, ws) as Blockly.BlockSvg;
         if (ws.getMetrics) {
-            let metrics = ws.getMetrics() as Blockly.Metrics;
+            let metrics = ws.getMetrics();
             let blockDimensions = block.getHeightWidth();
             block.moveBy(
               metrics.viewLeft + (metrics.viewWidth / 2) - (blockDimensions.width / 2),

--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -148,7 +148,7 @@ namespace pxt.blocks.layout {
     export function flow(ws: Blockly.WorkspaceSvg, opts?: FlowOptions) {
         if (opts) {
             if (opts.useViewWidth) {
-                const metrics = ws.getMetrics() as Blockly.Metrics;
+                const metrics = ws.getMetrics();
 
                 // Only use the width if in portrait, otherwise the blocks are too spread out
                 if (metrics.viewHeight > metrics.viewWidth) {

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -819,7 +819,7 @@ namespace pxt.blocks {
                                 inputCheck = pr.type;
                             } else if (pr.type == "number" && pr.shadowBlockId && pr.shadowBlockId == "value") {
                                 inputName = undefined;
-                                fields.push(namedField(new Blockly.FieldTextInput("0", Blockly.FieldTextInput.numberValidator), defName));
+                                fields.push(namedField(new Blockly.FieldNumber("0"), defName));
                             } else if (pr.type == "string" && pr.shadowOptions && pr.shadowOptions.toString) {
                                 inputCheck = null;
                             } else {
@@ -2124,11 +2124,6 @@ namespace pxt.blocks {
                     let blockText = '<xml>' +
                         '<block type="variables_change" gap="' + gap + '">' +
                         Blockly.Variables.generateVariableFieldXmlString(mostRecentVariable) +
-                        '<value name="DELTA">' +
-                        '<shadow type="math_number">' +
-                        '<field name="NUM">1</field>' +
-                        '</shadow>' +
-                        '</value>' +
                         '</block>' +
                         '</xml>';
                     let block = Blockly.Xml.textToDom(blockText).firstChild as HTMLElement;

--- a/pxtblocks/blocklyrenderer.ts
+++ b/pxtblocks/blocklyrenderer.ts
@@ -75,7 +75,7 @@ namespace pxt.blocks {
                 break;
         }
 
-        let metrics = workspace.getMetrics() as Blockly.Metrics;
+        let metrics = workspace.getMetrics();
 
         const svg = blocklyDiv.querySelectorAll('svg')[0].cloneNode(true) as SVGSVGElement;
         pxt.blocks.layout.cleanUpBlocklySvg(svg);

--- a/pxtblocks/fields/field_animation.ts
+++ b/pxtblocks/fields/field_animation.ts
@@ -39,14 +39,7 @@ namespace pxtblockly {
         protected asset: pxt.Animation;
         protected initInterval: number;
 
-        init() {
-            if (this.fieldGroup_) {
-                // Field has already been initialized once.
-                return;
-            }
-
-            super.init();
-
+        initView() {
             // Register mouseover events for animating preview
             (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot().addEventListener("mouseenter", this.onMouseEnter);
             (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot().addEventListener("mouseleave", this.onMouseLeave);

--- a/pxtblocks/fields/field_asset.ts
+++ b/pxtblocks/fields/field_asset.ts
@@ -163,8 +163,11 @@ namespace pxtblockly {
 
         getDisplayText_() {
             // This is only used when isGreyBlock is true
-            const text = pxt.Util.htmlUnescape(this.valueText);
-            return text.substr(0, text.indexOf("(")) + "(...)";;
+            if (this.isGreyBlock) {
+                const text = pxt.Util.htmlUnescape(this.valueText);
+                return text.substr(0, text.indexOf("(")) + "(...)";
+            }
+            return "";
         }
 
         updateEditable() {

--- a/pxtblocks/fields/field_base.ts
+++ b/pxtblocks/fields/field_base.ts
@@ -18,23 +18,9 @@ namespace pxtblockly {
         protected abstract onValueChanged(newValue: string): string;
 
         init() {
-            if (this.isInitialized()) return;
-
-            // Build the DOM.
-            this.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null) as SVGGElement;
-            if (!this.visible_) {
-                (this.fieldGroup_ as any).style.display = 'none';
-            }
-
+            super.init();
             this.onInit();
-
-            this.updateEditable();
-            (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot().appendChild(this.fieldGroup_);
-
-            // Force a render.
-            this.render_();
-            (this as any).mouseDownWrapper_ = Blockly.bindEventWithChecks_((this as any).getClickTarget_(), "mousedown", this, (this as any).onMouseDown_)
-        }
+       }
 
         dispose() {
             this.onDispose();

--- a/pxtblocks/fields/field_breakpoint.ts
+++ b/pxtblocks/fields/field_breakpoint.ts
@@ -25,17 +25,11 @@ namespace pxtblockly {
             this.type_ = params.type;
         }
 
-        init() {
-            if (this.fieldGroup_) {
-                // Field has already been initialized once.
+        initView() {
+            if (!this.fieldGroup_) {
                 return;
             }
 
-            // Build the DOM.
-            this.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null) as SVGGElement;
-            if (!this.visible_) {
-                (this.fieldGroup_ as any).style.display = 'none';
-            }
             // Add an attribute to cassify the type of field.
             if ((this as any).getArgTypes() !== null) {
                 if (this.sourceBlock_.isShadow()) {
@@ -71,18 +65,11 @@ namespace pxtblockly {
                 },
                 this.fieldGroup_) as SVGTextElement;
 
-            this.updateEditable();
-            (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot().appendChild(this.fieldGroup_);
-
             this.switchToggle(this.state_);
             this.setValue(this.getValue());
 
             // Force a render.
-            this.render_();
-            this.size_.width = 0;
-            (this as any).mouseDownWrapper_ =
-                Blockly.bindEventWithChecks_((this as any).getClickTarget_(), 'mousedown', this,
-                    (this as any).onMouseDown_);
+            this.markDirty();
         }
 
         updateSize_() {

--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -258,7 +258,7 @@ namespace pxtblockly {
 
         render_() {
             if (!this.visible_) {
-                this.size_.width = 0;
+                this.markDirty();
                 return;
             }
 

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -84,7 +84,7 @@ namespace pxtblockly {
             // playing twice (once in the editor and once when the code runs in the sim)
             Blockly.Events.fire(new Blockly.Events.Ui(this.sourceBlock_, "melody-editor", false, true))
 
-            Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_, () => {
+            Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_ as Blockly.BlockSvg, () => {
                 this.onEditorClose();
                 // revert all style attributes for dropdown div
                 pxt.BrowserUtils.removeClass(contentDiv, "melody-content-div");

--- a/pxtblocks/fields/field_note.ts
+++ b/pxtblocks/fields/field_note.ts
@@ -326,7 +326,7 @@ namespace pxtblockly {
             }
 
             Blockly.DropDownDiv.setColour(this.primaryColour, this.borderColour);
-            Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_, () => this.onHide());
+            Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_ as Blockly.BlockSvg, () => this.onHide());
         }
 
         protected playKey(key: HTMLDivElement, frequency: number) {

--- a/pxtblocks/fields/field_procedure.ts
+++ b/pxtblocks/fields/field_procedure.ts
@@ -37,7 +37,7 @@ namespace pxtblockly {
         public dropdownCreate() {
             let functionList: string[] = [];
             if (this.sourceBlock_ && this.sourceBlock_.workspace) {
-                let blocks = this.sourceBlock_.workspace.getAllBlocks();
+                let blocks = this.sourceBlock_.workspace.getAllBlocks(false);
                 // Iterate through every block and check the name.
                 for (let i = 0; i < blocks.length; i++) {
                     if ((blocks[i] as any).getProcedureDef) {
@@ -70,10 +70,6 @@ namespace pxtblockly {
 
         onItemSelected(menu: any, menuItem: any) {
             let itemText = menuItem.getValue();
-            if (this.sourceBlock_) {
-                // Call any validation function, and allow it to override.
-                itemText = this.callValidator(itemText);
-            }
             if (itemText !== null) {
                 this.setValue(itemText);
             }

--- a/pxtblocks/fields/field_tileset.ts
+++ b/pxtblocks/fields/field_tileset.ts
@@ -83,9 +83,8 @@ namespace pxtblockly {
             this.blocksInfo = options.blocksInfo;
         }
 
-        init() {
-            super.init();
-
+        initView() {
+            super.initView();
             if (this.sourceBlock_ && this.sourceBlock_.isInFlyout) {
                 this.setValue(this.getOptions()[0][1]);
             }

--- a/pxtblocks/fields/field_toggle.ts
+++ b/pxtblocks/fields/field_toggle.ts
@@ -24,15 +24,9 @@ namespace pxtblockly {
             this.type_ = params.type;
         }
 
-        init() {
-            if (this.fieldGroup_) {
-                // Field has already been initialized once.
+        initView() {
+            if (!this.fieldGroup_) {
                 return;
-            }
-            // Build the DOM.
-            this.fieldGroup_ = Blockly.utils.dom.createSvgElement('g', {}, null) as SVGGElement;
-            if (!this.visible_) {
-                (this.fieldGroup_ as any).style.display = 'none';
             }
             // Add an attribute to cassify the type of field.
             if ((this as any).getArgTypes() !== null) {
@@ -118,11 +112,7 @@ namespace pxtblockly {
             this.setValue(this.getValue());
 
             // Force a render.
-            this.render_();
-            this.size_.width = 0;
-            (this as any).mouseDownWrapper_ =
-                Blockly.bindEventWithChecks_((this as any).getClickTarget_(), 'mousedown', this,
-                    (this as any).onMouseDown_);
+            this.markDirty();
         }
 
         getDisplayText_() {

--- a/pxtblocks/fields/field_turnratio.ts
+++ b/pxtblocks/fields/field_turnratio.ts
@@ -36,7 +36,7 @@ namespace pxtblockly {
 
         createLabelDom_(labelText: string) {
             let labelContainer = document.createElement('div');
-            let svg = Blockly.utils.dom.createSvgElement('svg', {
+            let svg = Blockly.utils.dom.createSvgElement<SVGElement>('svg', {
                 'xmlns': 'http://www.w3.org/2000/svg',
                 'xmlns:html': 'http://www.w3.org/1999/xhtml',
                 'xmlns:xlink': 'http://www.w3.org/1999/xlink',
@@ -44,15 +44,15 @@ namespace pxtblockly {
                 'height': (FieldTurnRatio.HALF + FieldTurnRatio.HANDLE_RADIUS + 10) + 'px',
                 'width': (FieldTurnRatio.HALF * 2) + 'px'
             }, labelContainer);
-            let defs = Blockly.utils.dom.createSvgElement('defs', {}, svg);
-            let marker = Blockly.utils.dom.createSvgElement('marker', {
+            let defs = Blockly.utils.dom.createSvgElement<SVGElement>('defs', {}, svg);
+            let marker = Blockly.utils.dom.createSvgElement<SVGElement>('marker', {
                 'id': 'head',
                 'orient': "auto",
                 'markerWidth': '2',
                 'markerHeight': '4',
                 'refX': '0.1', 'refY': '1.5'
             }, defs);
-            let markerPath = Blockly.utils.dom.createSvgElement('path', {
+            let markerPath = Blockly.utils.dom.createSvgElement<SVGElement>('path', {
                 'd': 'M0,0 V3 L1.5,1.5 Z',
                 'fill': '#f12a21'
             }, marker);
@@ -62,12 +62,12 @@ namespace pxtblockly {
                 'style': 'font-size: 50px',
                 'class': 'sim-text inverted number'
             }) as SVGTextElement;
-            this.path_ = Blockly.utils.dom.createSvgElement('path', {
+            this.path_ = Blockly.utils.dom.createSvgElement<SVGPathElement>('path', {
                 'x1': FieldTurnRatio.HALF,
                 'y1': FieldTurnRatio.HALF,
                 'marker-end': 'url(#head)',
                 'style': 'fill: none; stroke: #f12a21; stroke-width: 10'
-            }, svg) as SVGPathElement;
+            }, svg);
             this.updateGraph_();
             let readout = document.createElement('span');
             readout.setAttribute('class', 'blocklyFieldSliderReadout');

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -72,7 +72,7 @@ body.blocklyMinimalBody {
         Blockly Text
 *******************************/
 
-.pxt-renderer {
+.pxt-renderer.classic-theme {
     text.blocklyFlyoutLabelText, .blocklyFlyoutButton text.blocklyText {
         font-family: @pageFont !important;
     }
@@ -90,12 +90,12 @@ body.blocklyMinimalBody {
         font-style: italic;
     }
 
-    text.semanticIcon {
+    .blocklyEditableText>text.semanticIcon {
         fill: #fff;
         font-family: "Icons";
         font-size: 19px;
     }
-    text.semanticIcon.inverted {
+    .blocklyEditableText>text.semanticIcon.inverted {
         fill: #000;
     }
 }
@@ -107,6 +107,13 @@ body.blocklyMinimalBody {
     color: white;
 }
 
+/*******************************
+        Blockly Toolbox
+*******************************/
+
+.blocklyTreeIcon {
+    visibility: visible;
+}
 
 /*******************************
         Blockly Flyout
@@ -216,17 +223,19 @@ text.blocklyCheckbox {
 }
 
 /* (arcade only) Sets the correct background color for the sprite image field */
-.pxt-renderer .blocklyNonEditableText > rect.blocklySpriteField,
-.pxt-renderer .blocklyNonEditableText > rect.blocklyAnimationField,
-.pxt-renderer .blocklyNonEditableText > rect.blocklyTilemapField,
-.pxt-renderer .blocklyEditableText > rect.blocklySpriteField,
-.pxt-renderer .blocklyEditableText > rect.blocklyAnimationField,
-.pxt-renderer .blocklyEditableText > rect.blocklyTilemapField {
-    fill: #dedede;
-    stroke: #898989;
-    stroke-width: 1;
-}
+.pxt-renderer.classic-theme {
+    .blocklyNonEditableText > rect.blocklySpriteField,
+    .blocklyNonEditableText > rect.blocklyAnimationField,
+    .blocklyNonEditableText > rect.blocklyTilemapField,
+    .blocklyEditableText > rect.blocklySpriteField,
+    .blocklyEditableText > rect.blocklyAnimationField,
+    .blocklyEditableText > rect.blocklyTilemapField {
+        fill: #dedede;
+        stroke: #898989;
+        stroke-width: 1;
+    }
 
+}
 
 /*******************************
         Blocks

--- a/theme/melodyeditor.less
+++ b/theme/melodyeditor.less
@@ -250,8 +250,8 @@
 }
 
 .melody-content-div,
-.pxt-renderer g.blocklyEditableText > &,
-.pxt-renderer g.blocklyNonEditableText > & {
+.pxt-renderer.classic-theme g.blocklyEditableText > &,
+.pxt-renderer.classic-theme g.blocklyNonEditableText > & {
     .melody-red {
         fill: #A80000;
         background: #A80000;

--- a/theme/print.less
+++ b/theme/print.less
@@ -102,7 +102,7 @@
     }
 
     /** blockly **/
-    svg, .pxt-renderer {
+    svg, .pxt-renderer.classic-theme {
         .blocklyPath {
             stroke-width: 3px !important;
             stroke: black !important;

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -8,6 +8,7 @@
     color: @blocklyToolboxText;
     overflow-x: visible;
     overflow-y: auto;
+    padding-top: 0;
     z-index: @blocklyToolboxZIndex;
     /* so blocks go over toolbox when dragging */
     -webkit-tap-highlight-color: transparent;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4296,12 +4296,7 @@ export class ProjectView
     }
 
     setAccessibleBlocks(enabled: boolean) {
-        if (enabled) {
-            Blockly.navigation.enableKeyboardAccessibility();
-        } else {
-            Blockly.navigation.disableKeyboardAccessibility();
-        }
-        this.setState({ accessibleBlocks: enabled });
+        // TODO: Add accessible blocks plugin from Blockly
         pxt.tickEvent("app.accessibleblocks", { on: enabled ? 1 : 0 });
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -67,7 +67,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const breakpoints: number[] = []
         const map = this.breakpointsByBlock;
         if (map && this.editor) {
-            this.editor.getAllBlocks().forEach(block => {
+            this.editor.getAllBlocks(false).forEach(block => {
                 if (map[block.id] && block.isBreakpointSet()) {
                     breakpoints.push(this.breakpointsByBlock[block.id]);
                 }
@@ -283,7 +283,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     private initLayout() {
         let needsLayout = false;
-        let flyoutOnly = !this.editor.toolbox_ && (this.editor as any).flyout_;
+        let flyoutOnly = !this.editor.getToolbox() && this.editor.getFlyout();
 
         let minDistanceFromOrigin: number;
         let closestToOrigin: Blockly.utils.Rect;
@@ -448,24 +448,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private initAccessibleBlocks() {
-        const enabled = pxt.appTarget.appTheme?.accessibleBlocks;
-        // Append listener to open toolbox on 'T' key if accessible blocks is enabled
-        if (enabled) {
-            document.querySelector("#blocksEditor").addEventListener("keydown", this.handleKeyDown)
-        }
-
-        const self = this;
-        const onBlocklyAction = Blockly.navigation.onBlocklyAction;
-        Blockly.navigation.onBlocklyAction = function (action) {
-            if (pxt.appTarget.appTheme?.accessibleBlocks) {
-                if (!self.editor.keyboardAccessibilityMode &&
-                    (action as any).name === Blockly.navigation.actionNames.TOGGLE_KEYBOARD_NAV) {
-                    self.parent.setState({ accessibleBlocks: true });
-                }
-                return onBlocklyAction(action);
-            }
-            return false;
-        };
+        // TODO: Add accessible blocks plugin from Blockly
     }
 
     private reportDeprecatedBlocks() {
@@ -478,7 +461,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         });
 
-        this.editor.getAllBlocks().forEach(block => {
+        this.editor.getAllBlocks(false).forEach(block => {
             if (deprecatedMap[block.type] >= 0) {
                 deprecatedMap[block.type]++;
                 deprecatedBlocksFound = true;
@@ -524,11 +507,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
         this.editor.addChangeListener((ev: any) => {
             Blockly.Events.disableOrphans(ev);
-            if (ev.type != 'ui' || this.markIncomplete) {
+            if ((ev.type != Blockly.Events.UI && ev.type != Blockly.Events.VIEWPORT_CHANGE)
+                || this.markIncomplete) {
                 this.changeCallback();
                 this.markIncomplete = false;
             }
-            if (ev.type == 'create') {
+            if (ev.type == Blockly.Events.CREATE) {
                 let blockId = ev.xml.getAttribute('type');
                 if (blockId == "variables_set") {
                     // Need to bump suffix in flyout
@@ -544,12 +528,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     this.parent.setState({ hideEditorFloats: false });
                 workspace.fireEvent({ type: 'create', editor: 'blocks', blockId } as pxt.editor.events.CreateEvent);
             }
-            else if (ev.type == "var_create" || ev.type == "var_rename" || ev.type == "delete") {
+            else if (ev.type == Blockly.Events.VAR_CREATE || ev.type == Blockly.Events.VAR_RENAME || ev.type == Blockly.Events.VAR_DELETE) {
                 // a new variable name is used or blocks were removed,
                 // clear the toolbox caches as some blocks may need to be recomputed
                 this.clearFlyoutCaches();
             }
-            else if (ev.type == 'ui') {
+            else if (ev.type == Blockly.Events.UI) {
                 if (ev.element == 'category') {
                     let toolboxVisible = !!ev.newValue;
                     if (toolboxVisible) pxt.setInteractiveConsent(true);
@@ -722,7 +706,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     async validateTutorialCode(tutorial: pxt.tutorial.TutorialOptions) {
         // Current tutorial step
         const { tutorialStep } = tutorial;
-        const blocks = this.editor.getAllBlocks();
+        const blocks = this.editor.getAllBlocks(false);
         const tutorialRulesValidated: pxt.tutorial.TutorialRuleStatus[] = await pxt.tutorial.validate(tutorial, blocks, this.blockInfo);
         this.parent.setTutorialCodeStatus(tutorialStep, tutorialRulesValidated);
     }
@@ -750,11 +734,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     public moveFocusToFlyout() {
-        const flyout = this.editor.toolbox_.getFlyout();
-        if (flyout && this.parent.state?.accessibleBlocks) {
-            (Blockly.navigation as any).focusFlyout_();
-            flyout.svgGroup_.focus();
-        }
+        // TODO: Add accessible blocks plugin from Blockly
     }
 
     focusToolbox() {
@@ -798,7 +778,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     showPackageDialog() {
         pxt.tickEvent("blocks.addpackage");
-        if (this.editor.toolbox_) this.editor.toolbox_.clearSelection();
+        if (this.editor.getToolbox()) this.editor.getToolbox().clearSelection();
         this.parent.showPackageDialog();
     }
 
@@ -839,7 +819,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (!this.editor) return;
         const b = this.editor.newBlock(pxtc.TS_DEBUGGER_TYPE) as Blockly.BlockSvg;
         // move block roughly to the center of the screen
-        const m = this.editor.getMetrics() as Blockly.Metrics;
+        const m = this.editor.getMetrics();
         b.moveBy(m.viewWidth / 2, m.viewHeight / 3);
         b.initSvg();
         b.render();
@@ -957,7 +937,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             return;
 
         // clear previous warnings on non-disabled blocks
-        this.editor.getAllBlocks().filter(b => b.isEnabled()).forEach((b: Blockly.BlockSvg) => {
+        this.editor.getAllBlocks(false).filter(b => b.isEnabled()).forEach((b: Blockly.BlockSvg) => {
             b.setWarningText(null);
             b.setHighlightWarning(false);
         });
@@ -1013,7 +993,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     const p = b.getRelativeToSurfaceXY();
                     const c = b.getHeightWidth();
                     const s = this.editor.scale;
-                    const m = this.editor.getMetrics() as Blockly.Metrics;
+                    const m = this.editor.getMetrics();
                     // don't center if block is still on the screen
                     const marginx = 4;
                     const marginy = 4;
@@ -1138,7 +1118,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         const hasCategories = this.shouldShowCategories(!forceFlyoutOnly);
 
         // We might need to switch the toolbox type
-        if ((this.editor.toolbox_ && hasCategories) || ((this.editor as any).flyout_ && !hasCategories)) {
+        if ((this.editor.getToolbox() && hasCategories) || ((this.editor as any).flyout_ && !hasCategories)) {
             // Toolbox is consistent with current mode, safe to update
             if (hasCategories) {
                 this.toolbox.setState({ loading: false, categories: this.getAllCategories(), showSearchBox: this.shouldShowSearch() });
@@ -1236,8 +1216,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     public hideFlyout() {
-        if (this.editor.toolbox_) {
-            this.editor.toolbox_.getFlyout().hide();
+        if (this.editor.getToolbox()) {
+            this.editor.getFlyout().hide();
         }
         if (this.toolbox) this.toolbox.clear();
     }
@@ -1542,15 +1522,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         old.setVisible(false)
 
         // set the "current" flyout
-        this.editor.toolbox_.setFlyout(nw);
+        this.editor.getToolbox().setFlyout(nw);
 
         // show the new flyout
         nw.setVisible(true)
 
         // reflow if scale changed
-        const flyoutWs = nw.workspace_ as Blockly.WorkspaceSvg;
-        const targetWs = nw.targetWorkspace_ as Blockly.WorkspaceSvg;
-        const scaleChange = flyoutWs.scale !== targetWs.scale;
+        const flyoutWs = nw.getWorkspace();
+        const targetWs = nw.targetWorkspace;
+        const scaleChange = flyoutWs.getScale() !== targetWs.getScale();
         if (scaleChange) {
             nw.reflow();
         }
@@ -1559,8 +1539,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private flyouts: pxt.Map<{ flyout: Blockly.VerticalFlyout, blocksHash: number }> = {};
     private showFlyoutInternal_(xmlList: Element[], flyoutName: string = "default") {
         if ((!this.parent.state.editorState || this.parent.state.editorState.hasCategories !== false)
-            && this.editor.toolbox_) {
-            const oldFlyout = this.editor.toolbox_.getFlyout() as Blockly.VerticalFlyout;
+            && this.editor.getToolbox()) {
+            const oldFlyout = this.editor.getFlyout() as Blockly.VerticalFlyout;
 
             // determine if the cached flyout exists and isn't stale
             const hasCachedFlyout = flyoutName in this.flyouts
@@ -1569,7 +1549,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             const isFlyoutUpToDate = cachedBlocksHash === currentBlocksHash && !!cachedBlocksHash
 
             const mkFlyout = () => {
-                const workspace = this.editor.toolbox_.workspace_ as Blockly.WorkspaceSvg
+                const workspace = this.editor.getToolbox().getWorkspace();
                 const oldSvg = oldFlyout.svgGroup_;
                 const flyout = Blockly.Functions.createFlyout(workspace, oldSvg)
                 return flyout as Blockly.VerticalFlyout;
@@ -1798,7 +1778,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (!this.editor) return; // not loaded yet
 
         const debugging = !!this.parent.state.debugging;
-        const blocks = this.editor.getAllBlocks();
+        const blocks = this.editor.getAllBlocks(false);
         blocks.forEach(block => {
             if (block.previousConnection) {
                 block.enableBreakpoint(debugging);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -112,11 +112,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
         else {
             pxt.Util.toArray(document.querySelectorAll(classes)).forEach((el: HTMLElement) => el.style.display = 'none');
-            if (this.editor) {
-                Blockly.hideChaff();
-                // By default the size is set to (0, 0), which means Blockly does not update the cached size
-                this.editor.setCachedParentSvgSize(1, 1);
-            }
+            if (this.editor) Blockly.hideChaff();
             if (this.toolbox) this.toolbox.clearExpandedItem();
         }
     }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -112,7 +112,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
         else {
             pxt.Util.toArray(document.querySelectorAll(classes)).forEach((el: HTMLElement) => el.style.display = 'none');
-            if (this.editor) Blockly.hideChaff();
+            if (this.editor) {
+                Blockly.hideChaff();
+                // By default the size is set to (0, 0), which means Blockly does not update the cached size
+                this.editor.setCachedParentSvgSize(1, 1);
+            }
             if (this.toolbox) this.toolbox.clearExpandedItem();
         }
     }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -213,14 +213,8 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
             // Hide flyout
             this.closeFlyout();
-            if (parent.parent.state?.accessibleBlocks) {
-                Blockly.navigation.setState(Blockly.navigation.STATE_WS);
-            }
         } else {
             let handled = false;
-            if (parent.parent.state?.accessibleBlocks) {
-                Blockly.navigation.setState(Blockly.navigation.STATE_TOOLBOX);
-            }
             if (customClick) {
                 handled = customClick(parent);
                 if (handled) return;
@@ -556,7 +550,6 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
         const isRtl = Util.isUserLanguageRtl();
 
         const accessibleBlocksEnabled = (Blockly.getMainWorkspace() as any).keyboardAccessibilityMode;
-        const blocklyNavigationState = (Blockly.navigation as any).currentState_ as number;
         const keyMap: { [key: string]: number } = {
             "DOWN": accessibleBlocksEnabled ? 83 : 40, // 'S' || down arrow
             "UP": accessibleBlocksEnabled ? 87 : 38, // 'W' || up arrow
@@ -565,35 +558,28 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
         }
 
         const charCode = core.keyCodeFromEvent(e);
-        if (!accessibleBlocksEnabled || blocklyNavigationState != 1) {
-            if (charCode == keyMap["DOWN"]) {
-                this.nextItem();
-            } else if (charCode == keyMap["UP"]) {
-                this.previousItem();
-            } else if ((charCode == keyMap["RIGHT"] && !isRtl)
-                || (charCode == keyMap["LEFT"] && isRtl)) {
-                // Focus inside flyout
-                toolbox.moveFocusToFlyout();
-            } else if (charCode == 27) { // ESCAPE
-                // Close the flyout
-                toolbox.closeFlyout();
-            } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
-                sui.fireClickOnEnter.call(this, e);
-            } else if (charCode == core.TAB_KEY
-                || charCode == 37 /* Left arrow key */
-                || charCode == 39 /* Left arrow key */
-                || charCode == 17 /* Ctrl Key */
-                || charCode == 16 /* Shift Key */
-                || charCode == 91 /* Cmd Key */) {
-                // Escape tab and shift key
-            } else if (!accessibleBlocksEnabled) {
-                toolbox.setSearch();
-            }
-        } else if (accessibleBlocksEnabled && blocklyNavigationState == 1
-            && ((charCode == keyMap["LEFT"] && !isRtl)
-            || (charCode == keyMap["RIGHT"] && isRtl))) {
-            this.focusElement();
-            e.stopPropagation();
+        if (charCode == keyMap["DOWN"]) {
+            this.nextItem();
+        } else if (charCode == keyMap["UP"]) {
+            this.previousItem();
+        } else if ((charCode == keyMap["RIGHT"] && !isRtl)
+            || (charCode == keyMap["LEFT"] && isRtl)) {
+            // Focus inside flyout
+            toolbox.moveFocusToFlyout();
+        } else if (charCode == 27) { // ESCAPE
+            // Close the flyout
+            toolbox.closeFlyout();
+        } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
+            sui.fireClickOnEnter.call(this, e);
+        } else if (charCode == core.TAB_KEY
+            || charCode == 37 /* Left arrow key */
+            || charCode == 39 /* Left arrow key */
+            || charCode == 17 /* Ctrl Key */
+            || charCode == 16 /* Shift Key */
+            || charCode == 91 /* Cmd Key */) {
+            // Escape tab and shift key
+        } else if (!accessibleBlocksEnabled) {
+            toolbox.setSearch();
         }
     }
 

--- a/webapp/src/tutorial.tsx
+++ b/webapp/src/tutorial.tsx
@@ -83,7 +83,7 @@ function getUsedBlocksInternalAsync(code: string[], id: string, language?: strin
                         pxt.debug(`used blocks xml failed to load\n${blocksXml}`);
                         throw new Error("blocksXml failed to load");
                     }
-                    const allblocks = headless.getAllBlocks();
+                    const allblocks = headless.getAllBlocks(false);
                     snippetBlocks[snippetHash] = {}
                     for (let bi = 0; bi < allblocks.length; ++bi) {
                         const blk = allblocks[bi];


### PR DESCRIPTION
requires https://github.com/microsoft/pxt-blockly/pull/359

mostly small fixes to sync with blockly-side changes. i also removed all the code for handling the accessible blocks experiment, since it's moved out of blockly-core into an extension and we need to re-integrate with it. 

(this will fail the build until i can update the npm package, since that's where the typings come from)

builds!
https://arcade.makecode.com/app/894739978b4be11010c202ea303e01047d102420-e3d1f85bce
https://makecode.microbit.org/app/9e9f521b48ac103e33139fe979e611db76c9eab1-d62781acca