### PR TITLE
Don't let blocks overflow, add scrollbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.1.2",
+    "pxt-blockly": "3.1.3",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "devDependencies": {
     "monaco-editor": "0.19.3",
-    "pxt-blockly": "3.0.25",
+    "pxt-blockly": "3.1.2",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -35,7 +35,7 @@ svg.blocklySvg {
     width: 100%;
     height: 100%;
     .injectionDiv svg {
-        overflow: visible;
+        overflow: hidden;
     }
     > div.loading {
         position: absolute;

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -37,6 +37,12 @@
     top: @workspaceHeaderHeight;
 }
 
+.tutorial.flyoutOnly.hideIteration {
+    #tutorialcard .tutorialmessage .content {
+        overflow-y: auto;
+    }
+}
+
 /* Tutorial Mode */
 .menubar .ui.menu .item.tutorial-menuitem {
     background: rgba(27, 28, 29, 0.3) !important;
@@ -145,7 +151,7 @@ body#docs.tutorial {
     width: 100%;
     font-size: 12pt;
     padding-left: 1rem;
-    height: calc(@tutorialCardHeight - 1rem);
+    height: calc(@tutorialCardHeight - 1.5rem);
     margin-bottom: 0.4rem;
     overflow-y: hidden;
     overflow-x: auto;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1544,6 +1544,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             if (this.parent.state?.accessibleBlocks) newFlyout.svgGroup_.focus();
         } else if ((this.editor as any).flyout_) {
             (this.editor as any).flyout_.show(xmlList);
+            (this.editor as any).flyout_.setTwoScrolls();
             (this.editor as any).flyout_.scrollToStart();
         }
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/1991

but needs this change! https://github.com/microsoft/pxt-blockly/pull/360

looks like this:
![image](https://user-images.githubusercontent.com/18712271/140440987-0db846cc-5577-4d61-be2e-a7d40cdb7f67.png)

ideally would have more CSS changes to restrict the size of the flyout to always be a certain width. Right now the sizes get kinda wild sometimes. Another EZ option would be removing the double scroll, and just cutting off the blocks. You can see the whole block when you drag one out (shannon's idea!) 

a good way to test is to make your screen small, and then press the + button 

(I still need to test this in game)

Try here:
https://minecraft.makecode.com/app/ab924030ba350913bc71b432bfb45f4b33feb968-9ded06f80b#tutorial:/hour-of-code/reforestation

also fllyoutonly no hideiteration
https://minecraft.makecode.com/app/ab924030ba350913bc71b432bfb45f4b33feb968-9ded06f80b#tutorial:36607-16422-18962-51568

and the basic upload 
https://minecraft.makecode.com/app/ab924030ba350913bc71b432bfb45f4b33feb968-9ded06f80b