### PR TITLE
Add tutorial exit event type to EditorMessageTutorialEventRequest

### DIFF
--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -109,7 +109,8 @@ namespace pxt.editor {
 
     export type EditorMessageTutorialEventRequest = EditorMessageTutorialProgressEventRequest |
         EditorMessageTutorialCompletedEventRequest |
-        EditorMessageTutorialLoadedEventRequest;
+        EditorMessageTutorialLoadedEventRequest |
+        EditorMessageTutorialExitEventRequest;
 
     export interface EditorMessageTutorialProgressEventRequest extends EditorMessageRequest {
         action: "tutorialevent";

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -286,6 +286,9 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             case "completed":
                 this.onTutorialFinished();
                 break;
+            case "exit":
+                dispatchSaveAndCloseActivity();
+                break;
         }
     }
 


### PR DESCRIPTION
and restore code for handling "exit" event ("Exit Tutorial" link in tutorial tab bar clicked) in the skillmap

fixes https://github.com/microsoft/pxt-arcade/issues/4285