### PR TITLE
Add timeout to cloud sync check

### DIFF
--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -81,8 +81,8 @@ namespace pxt.auth {
     let _client: AuthClient;
     export function client(): AuthClient { return _client; }
 
-    const PREFERENCES_DEBOUNCE_MS = 5 * 1000;
-    const PREFERENCES_DEBOUNCE_MAX_MS = 30 * 1000;
+    const PREFERENCES_DEBOUNCE_MS = 1 * 1000;
+    const PREFERENCES_DEBOUNCE_MAX_MS = 10 * 1000;
     let debouncePreferencesChangedTimeout = 0;
     let debouncePreferencesChangedStarted = 0;
 


### PR DESCRIPTION
At skillmap startup time, the app asks the editor iframe to do a cloud sync check to make sure skillmap has latest cloud state. This check does some complicated cloud operations, then posts back a completion message. Skillmap won't save anything to the cloud until it gets this message, but there are times when it never arrives. On these occasions, skillmap sync will stay in a disabled state. This PR adds a timeout to the cloud sync check. If it doesn't return in a reasonable amount of time, we assume it failed somewhere and move on.

The failure seems to be infrequent, and I will keep looking into the issue, but this timeout seems like a good thing regardless.