### PR TITLE
Make tutorial header content smaller so the text doesn't get cut off

### DIFF
--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -151,7 +151,7 @@ body#docs.tutorial {
     width: 100%;
     font-size: 12pt;
     padding-left: 1rem;
-    height: calc(@tutorialCardHeight - 1.5rem);
+    height: calc(@tutorialCardHeight - 2rem);
     margin-bottom: 0.4rem;
     overflow-y: hidden;
     overflow-x: auto;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-minecraft/issues/2144