### PR TITLE
Sync language change immediately, don't wait for debouncer to fire

### DIFF
--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -203,9 +203,9 @@ export async function deleteProfileAsync(): Promise<void> {
     await cli?.deleteProfileAsync();
 }
 
-export async function patchUserPreferencesAsync(ops: ts.pxtc.jsonPatch.PatchOperation | ts.pxtc.jsonPatch.PatchOperation[]): Promise<void> {
+export async function patchUserPreferencesAsync(ops: ts.pxtc.jsonPatch.PatchOperation | ts.pxtc.jsonPatch.PatchOperation[], immediate = false): Promise<void> {
     const cli = await clientAsync();
-    await cli?.patchUserPreferencesAsync(ops);
+    await cli?.patchUserPreferencesAsync(ops, immediate);
 }
 
 export async function setHighContrastPrefAsync(highContrast: boolean): Promise<void> {
@@ -221,7 +221,7 @@ export async function setLangaugePrefAsync(lang: string): Promise<void> {
         op: 'replace',
         path: ['language'],
         value: lang
-    });
+    }, true); // sync this change immediately, as the page is about to reload.
 }
 
 export async function setImmersiveReaderPrefAsync(pref: string): Promise<void> {


### PR DESCRIPTION
Because skillmap updates user preferences so frequently, I added a debouncer to ease network traffic. Changes to user preferences are accumulated and sent in batch after a timeout. For signed in users, language setting is also saved in this blob. The issue was that after changing language, the page is reloaded. Due to the debounce, the change hadn't been synced to the cloud yet. When the page reloads, it pulls latest preferences from the cloud, which still has the old language selection.

I also added a queue to accumulate pending changes. I think we had a bug where only the most recent patch would be synced up.

Fixes: https://github.com/microsoft/pxt-arcade/issues/4310
