### PR TITLE
Use pxt.Cloud markdownAsync function in skillmap for localized files

### DIFF
--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -51,9 +51,7 @@ export async function getMarkdownAsync(source: MarkdownSource, url: string): Pro
 
     switch (source) {
         case "docs":
-            toFetch = getDocsIdentifier(url);
-            status = "approved";
-            break;
+            return fetchSkillmapFromDocs(url);
         case "github":
             return await fetchSkillMapFromGithub(url);
         case "local":
@@ -88,6 +86,17 @@ export async function getMarkdownAsync(source: MarkdownSource, url: string): Pro
     };
 }
 
+async function fetchSkillmapFromDocs(path: string): Promise<MarkdownFetchResult | undefined > {
+    const markdown = await pxt.Cloud.markdownAsync(cleanDocsUrl(path));
+    if (markdown) {
+        return {
+            text: markdown,
+            identifier: getDocsIdentifier(path),
+            status: "approved"
+        }
+    }
+    return undefined;
+}
 
 /**
  * Fetches the result and returns an identifier to key the content on. For docs, it
@@ -154,8 +163,12 @@ async function fetchSkillMapFromLocal(path: string): Promise<MarkdownFetchResult
     return undefined;
 }
 
+function cleanDocsUrl(path: string) {
+    return path.trim().replace(/^[\\/]/i, "").replace(/\.md$/i, "");
+}
+
 export function getDocsIdentifier(path: string) {
-    path = path.trim().replace(/^[\\/]/i, "").replace(/\.md$/i, "");
+    path = cleanDocsUrl(path);
     const target = (window as any).pxtTargetBundle?.name || "arcade";
     return `${apiRoot}/md/${target}/${path}`;
 }


### PR DESCRIPTION
@dmonroym was right, looks like we aren't returning localized skillmap files right now! this updates it so that we're using the shared markdownAsync function, which should pull the correct locale from the user settings.