### PR TITLE
Smarter user preference patch queuing

### DIFF
--- a/pxtlib/tilemap.ts
+++ b/pxtlib/tilemap.ts
@@ -1484,8 +1484,8 @@ namespace pxt {
     export function assetEquals(a: Asset, b: Asset) {
         if (a == b) return true;
         if (a.id !== b.id || a.type !== b.type ||
-            !arrayEquals(a.meta.tags, b.meta.tags) ||
-            !arrayEquals(a.meta.blockIDs, b.meta.blockIDs) ||
+            !U.arrayEquals(a.meta.tags, b.meta.tags) ||
+            !U.arrayEquals(a.meta.blockIDs, b.meta.blockIDs) ||
             a.meta.displayName !== b.meta.displayName
         )
             return false;
@@ -1496,7 +1496,7 @@ namespace pxt {
                 return sprite.bitmapEquals(a.bitmap, (b as ProjectImage | Tile).bitmap);
             case AssetType.Animation:
                     const bAnimation = b as Animation;
-                    return a.interval === bAnimation.interval && arrayEquals(a.frames, bAnimation.frames, sprite.bitmapEquals);
+                    return a.interval === bAnimation.interval && U.arrayEquals(a.frames, bAnimation.frames, sprite.bitmapEquals);
             case AssetType.Tilemap:
                 return a.data.equals((b as ProjectTilemap).data);
         }
@@ -1626,16 +1626,6 @@ namespace pxt {
         }
 
         return id;
-    }
-
-    function arrayEquals<U>(a: U[], b: U[], compare: (c: U, d: U) => boolean = (c, d) => c === d) {
-        if (a == b) return true;
-        if (!a && b || !b && a || a.length !== b.length) return false;
-
-        for (let i = 0; i < a.length; i++) {
-            if (!compare(a[i], b[i])) return false;
-        }
-        return true;
     }
 
     function serializeTilemap(tilemap: sprite.TilemapData, id: string, name: string): JRes {

--- a/pxtlib/util.ts
+++ b/pxtlib/util.ts
@@ -215,6 +215,16 @@ namespace ts.pxtc.Util {
         return arr
     }
 
+    export function arrayEquals<U>(a: U[], b: U[], compare: (c: U, d: U) => boolean = (c, d) => c === d) {
+        if (a == b) return true;
+        if (!a && b || !b && a || a.length !== b.length) return false;
+
+        for (let i = 0; i < a.length; i++) {
+            if (!compare(a[i], b[i])) return false;
+        }
+        return true;
+    }
+
     export function iterMap<T>(m: pxt.Map<T>, f: (k: string, v: T) => void) {
         Object.keys(m).forEach(k => f(k, m[k]))
     }
@@ -2145,6 +2155,10 @@ namespace ts.pxtc.jsonPatch {
                 ops.replace(parent, lastKey, op.value);
             }
         }
+    }
+
+    export function opsAreEqual(a: PatchOperation, b: PatchOperation): boolean {
+        return (a.op === b.op && U.arrayEquals(a.path, b.path));
     }
 }
 


### PR DESCRIPTION
When queuing changes to user preferences, don't accumulate redundant patches. Instead, replace the old one with the new one.

For this fix I needed an implementation of `arrayEquals`. I found an existing one in tilemap.ts and moved it over to util.ts.

Fixes https://github.com/microsoft/pxt-arcade/issues/4313