### PR TITLE
Delay the readyPromise until the workspace is loaded, add skillmap loader to main page

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -358,7 +358,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
         const maps = Object.keys(skillMaps).map((id: string) => skillMaps[id]);
         return (<div className={`app-container ${pxt.appTarget.id}`}>
                 <HeaderBar />
-                {syncingLocalState &&<div className={"makecode-frame-loader"}>
+                {syncingLocalState && <div className={"makecode-frame-loader"}>
                     <img src={resolvePath("assets/logo.svg")} alt={lf("MakeCode Logo")} />
                 <div className="makecode-frame-loader-text">{lf("Saving to cloud...")}</div>
                 </div>}

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -235,7 +235,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
     protected async cloudSyncCheckAsync() {
         const res = await this.ready();
         if (!await authClient.loggedInAsync()) {
-            this.setState({cloudSyncCheckHasFinished: true});
+            this.setState({cloudSyncCheckHasFinished: true, syncingLocalState: false});
         } else {
             this.setState({syncingLocalState: true});
             const doCloudSyncCheckAsync = async () => {
@@ -433,7 +433,8 @@ class AppImpl extends React.Component<AppProps, AppState> {
             }
         }
 
-        if (!this.props.signedIn || (this.props.signedIn && this.state.cloudSyncCheckHasFinished)) {
+        if ((!this.props.signedIn || (this.props.signedIn && this.state.cloudSyncCheckHasFinished))
+            && this.state.syncingLocalState) {
             this.setState({ syncingLocalState: false });
         }
 

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -165,6 +165,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             case "newproject":
                 if (!this.state.workspaceReady) {
                     this.setState({ workspaceReady: true });
+                    this.sendMessageAsync(); // Flush message queue
                     this.props.onWorkspaceReady((message) => this.sendMessageAsync(message));
                 }
                 if (this.state.frameState === "loading") {
@@ -184,7 +185,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
         }
     }
 
-    protected sendMessageAsync(message: any) {
+    protected sendMessageAsync(message?: any) {
         return new Promise(resolve => {
             const sendMessageCore = (message: any) => {
                 message.response = true;
@@ -204,7 +205,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
                     while (this.messageQueue.length) {
                         sendMessageCore(this.messageQueue.shift());
                     }
-                    sendMessageCore(message);
+                    if (message) sendMessageCore(message);
                 }
             }
         });

--- a/skillmap/src/components/makecodeFrame.tsx
+++ b/skillmap/src/components/makecodeFrame.tsx
@@ -32,7 +32,7 @@ interface MakeCodeFrameProps {
     dispatchSetShareStatus: (headerId?: string, url?: string) => void;
     dispatchShowLoginPrompt: () => void;
     dispatchSetCloudStatus: (headerId: string, status: string) => void;
-    onFrameLoaded: (sendMessageAsync: (message: any) => Promise<any>) => void;
+    onWorkspaceReady: (sendMessageAsync: (message: any) => Promise<any>) => void;
 }
 
 type FrameState = "loading" | "no-project" | "opening-project" | "project-open" | "closing-project";
@@ -143,8 +143,6 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
             const root = document.getElementById("root");
             if (root) pxt.BrowserUtils.addClass(root, "editor");
-
-            this.props.onFrameLoaded((message) => this.sendMessageAsync(message));
         }
     }
 
@@ -165,6 +163,10 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
 
         switch (data.action) {
             case "newproject":
+                if (!this.state.workspaceReady) {
+                    this.setState({ workspaceReady: true });
+                    this.props.onWorkspaceReady((message) => this.sendMessageAsync(message));
+                }
                 if (this.state.frameState === "loading") {
                     this.setState({ frameState: "no-project" });
                 }
@@ -195,7 +197,7 @@ class MakeCodeFrameImpl extends React.Component<MakeCodeFrameProps, MakeCodeFram
             }
 
             if (this.ref) {
-                if (!this.ref.contentWindow) {
+                if (!this.state.workspaceReady) {
                     this.messageQueue.push(message);
                 }
                 else {

--- a/skillmap/src/styles/makecode-editor.css
+++ b/skillmap/src/styles/makecode-editor.css
@@ -27,7 +27,8 @@
     display: none;
 }
 
-.makecode-frame-loader img {
+.makecode-frame-loader img,
+.makecode-skillmap-loader  {
     max-width: 200px;
     vertical-align: middle;
 

--- a/skillmap/src/styles/makecode-editor.css
+++ b/skillmap/src/styles/makecode-editor.css
@@ -27,8 +27,7 @@
     display: none;
 }
 
-.makecode-frame-loader img,
-.makecode-skillmap-loader  {
+.makecode-frame-loader img {
     max-width: 200px;
     vertical-align: middle;
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4331

we're still not really sure what's causing this bug.... but delaying the progress syncing until the workspace has loaded seems to fix it (for now). this means there's a noticable pause between logging in and your local progress importing, so we also added a loader during that state. 

build: https://arcade.makecode.com/app/de3eb561356a7951f9b6614556c3b56c968ee044-5f756ce822--skillmap 