### PR TITLE
Make loading start earlier and add locked badges

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1165,6 +1165,7 @@ declare namespace pxt.auth {
         type: BadgeType;
         title: string;
         image: string;
+        lockedImage?: string;
         timestamp?: number;
     }
 

--- a/react-common/components/profile/Badge.tsx
+++ b/react-common/components/profile/Badge.tsx
@@ -15,16 +15,18 @@ export const Badge = (props: BadgeProps) => {
         onClick(badge);
     })
 
+    const image = (disabled && badge.lockedImage) || badge.image;
+    const alt = disabled ? pxt.U.lf("Locked '{0}' badge", badge.title) : badge.title;
+
     return (
-        <div className={`profile-badge ${disabled ? "disabled" : ""} ${onClick ? "clickable" : ""}`}
+        <div className={`profile-badge ${onClick ? "clickable" : ""}`}
             role={onClick ? "button" : undefined}
             tabIndex={onClick ? 0 : undefined}
             title={lf("{0} Badge", badge.title)}
             onClick={onBadgeClick}
             onKeyDown={fireClickOnEnter}>
             {isNew && <div className="profile-badge-notification">{pxt.U.lf("New!")}</div>}
-            <img src={badge.image} alt={badge.title} />
-            {disabled && <i className="ui huge icon lock" />}
+            <img src={image} alt={alt} />
         </div>
     );
 }

--- a/react-common/styles/profile/profile.css
+++ b/react-common/styles/profile/profile.css
@@ -178,11 +178,6 @@
 }
 
 
-.profile-badge.disabled img {
-    filter: grayscale(1);
-    opacity: 0.5;
-}
-
 .profile-badge.disabled i.ui.icon {
     line-height: 1;
     vertical-align: middle;


### PR DESCRIPTION
This PR does two things:

1. Moves the "saving to cloud" loader earlier so that it shows up when you navigate to the page if you're signed in. This prevents the bait and switch of appearing to load before showing a loader
2. Adds support for locked badge images:

<img width="1197" alt="Screen Shot 2021-11-15 at 4 13 51 PM" src="https://user-images.githubusercontent.com/13754588/141873833-6ed9e9a4-281f-4994-8f90-6e97b433474f.png">

