### PR TITLE
Include reward node progress when importing local state

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import store from "./store/store";
 import * as authClient from "./lib/authClient";
-import { getCompletedBadges, getFlattenedHeaderIds, hasUrlBeenStarted } from "./lib/skillMapUtils";
+import { getCompletedBadges, getFlattenedHeaderIds, hasUrlBeenStarted, isRewardNode } from "./lib/skillMapUtils";
 
 import {
     dispatchAddSkillMap,
@@ -282,6 +282,10 @@ class AppImpl extends React.Component<AppProps, AppState> {
                                         activityState[activity] = {
                                             ...localActivity,
                                             headerId: headerMap[localActivity.headerId] || localActivity.headerId
+                                        };
+                                    } else if (isRewardNode(state.maps[map].activities[activity])) {
+                                        activityState[activity] = {
+                                            ...localActivity
                                         };
                                     }
                                 }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4363

we were skipping reward nodes since they don't have a headerid