### PR TITLE
[DRAFT] Enable localized instructions for skillmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "3.1.0",
     "karma-mocha": "2.0.1",
-    "less": "3.13.1",
+    "less": "^3.13.1",
     "lzma": "2.3.2",
     "marked": "0.3.19",
     "mocha": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "3.1.0",
     "karma-mocha": "2.0.1",
-    "less": "^3.13.1",
+    "less": "3.13.1",
     "lzma": "2.3.2",
     "marked": "0.3.19",
     "mocha": "5.1.0",

--- a/skillmap/src/lib/browserUtils.ts
+++ b/skillmap/src/lib/browserUtils.ts
@@ -103,6 +103,7 @@ async function fetchSkillmapFromDocs(path: string): Promise<MarkdownFetchResult 
  * will just be the path. For github, it will be githubUser/reponame#path/to/skillmap.md
  */
 async function fetchSkillMapFromGithub(path: string): Promise<MarkdownFetchResult | undefined> {
+    fetchSkillmapFromDocs(path);
     const ghid = pxt.github.parseRepoId(path)
     const config = await pxt.packagesConfigAsync() || {};
 
@@ -149,6 +150,7 @@ async function fetchSkillMapFromGithub(path: string): Promise<MarkdownFetchResul
 }
 
 async function fetchSkillMapFromLocal(path: string): Promise<MarkdownFetchResult | undefined> {
+    fetchSkillmapFromDocs(path);
     if (isLocal()) {
         path = path.replace(/^\//, "").replace(/\.md$/, "");
         let res = await fetch("docs/" + path + ".md");


### PR DESCRIPTION
Addresses https://github.com/microsoft/pxt-arcade/issues/4371

Tested via https://arcade.makecode.com/app/9ba86a097e77454684e8f98b82af7aa451c51427-9fb2074b29--skillmap#forest by first changing the language with the change in https://github.com/microsoft/pxt-arcade/pull/4374

I'm not entirely sure this is the correct way to implement the fix but for now it enables the skillmap to be localized:
<img width="591" alt="image" src="https://user-images.githubusercontent.com/3288375/142331942-d51f6e0e-3b61-4769-966e-cf791195d3e3.png">
