### PR TITLE
Fix some built-in block help paths

### DIFF
--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -325,7 +325,7 @@ namespace pxt.blocks {
             'pxt_controls_for': {
                 name: Util.lf("a loop that repeats the number of times you say"),
                 tooltip: Util.lf("Have the variable '{0}' take on the values from 0 to the end number, counting by 1, and do the specified blocks."), // The name of the iteration variable that goes in {0} is replaced in blocklyloader
-                url: 'blocks/loops/for',
+                url: '/blocks/loops/for',
                 category: 'loops',
                 block: {
                     message0: Util.lf("for %1 from 0 to %2"),
@@ -336,7 +336,7 @@ namespace pxt.blocks {
             'controls_simple_for': {
                 name: Util.lf("a loop that repeats the number of times you say"),
                 tooltip: Util.lf("Have the variable '{0}' take on the values from 0 to the end number, counting by 1, and do the specified blocks."), // The name of the iteration variable that goes in {0} is replaced in blocklyloader
-                url: 'blocks/loops/for',
+                url: '/blocks/loops/for',
                 category: 'loops',
                 block: {
                     message0: Util.lf("for %1 from 0 to %2"),
@@ -347,7 +347,7 @@ namespace pxt.blocks {
             'pxt_controls_for_of': {
                 name: Util.lf("a loop that repeats for each value in an array"),
                 tooltip: Util.lf("Have the variable '{0}' take the value of each item in the array one by one, and do the specified blocks."), // The name of the iteration variable that goes in {0} is replaced in blocklyloader
-                url: 'blocks/loops/for-of',
+                url: '/blocks/loops/for-of',
                 category: 'loops',
                 block: {
                     message0: Util.lf("for element %1 of %2"),
@@ -358,7 +358,7 @@ namespace pxt.blocks {
             'controls_for_of': {
                 name: Util.lf("a loop that repeats for each value in an array"),
                 tooltip: Util.lf("Have the variable '{0}' take the value of each item in the array one by one, and do the specified blocks."), // The name of the iteration variable that goes in {0} is replaced in blocklyloader
-                url: 'blocks/loops/for-of',
+                url: '/blocks/loops/for-of',
                 category: 'loops',
                 block: {
                     message0: Util.lf("for element %1 of %2"),
@@ -643,7 +643,7 @@ namespace pxt.blocks {
             'text': {
                 name: Util.lf("a piece of text"),
                 tooltip: Util.lf("A letter, word, or line of text."),
-                url: 'types/string',
+                url: '/types/string',
                 category: 'text',
                 block: {
                     search: Util.lf("a piece of text") // Only used for search; this string is not surfaced in the block's text
@@ -652,7 +652,7 @@ namespace pxt.blocks {
             'text_length': {
                 name: Util.lf("number of characters in the string"),
                 tooltip: Util.lf("Returns the number of letters (including spaces) in the provided text."),
-                url: 'reference/text/length',
+                url: '/reference/text/length',
                 category: 'text',
                 block: {
                     TEXT_LENGTH_TITLE: Util.lf("length of %1")
@@ -661,7 +661,7 @@ namespace pxt.blocks {
             'text_join': {
                 name: Util.lf("join items to create text"),
                 tooltip: Util.lf("Create a piece of text by joining together any number of items."),
-                url: 'reference/text/join',
+                url: '/reference/text/join',
                 category: 'text',
                 block: {
                     TEXT_JOIN_TITLE_CREATEWITH: Util.lf("join")
@@ -670,7 +670,7 @@ namespace pxt.blocks {
             'procedures_defnoreturn': {
                 name: Util.lf("define the function"),
                 tooltip: Util.lf("Create a function."),
-                url: 'types/function/define',
+                url: '/types/function/define',
                 category: 'functions',
                 block: {
                     PROCEDURES_DEFNORETURN_TITLE: Util.lf("function"),
@@ -680,7 +680,7 @@ namespace pxt.blocks {
             'procedures_callnoreturn': {
                 name: Util.lf("call the function"),
                 tooltip: Util.lf("Call the user-defined function."),
-                url: 'types/function/call',
+                url: '/types/function/call',
                 category: 'functions',
                 block: {
                     PROCEDURES_CALLNORETURN_TITLE: Util.lf("call function")
@@ -689,7 +689,7 @@ namespace pxt.blocks {
             'function_return': {
                 name: Util.lf("return a value from within a function"),
                 tooltip: Util.lf("Return a value from within a user-defined function."),
-                url: 'types/function/return',
+                url: '/types/function/return',
                 category: 'functions',
                 block: {
                     message_with_value: Util.lf("return %1"),
@@ -699,7 +699,7 @@ namespace pxt.blocks {
             'function_definition': {
                 name: Util.lf("define the function"),
                 tooltip: Util.lf("Create a function."),
-                url: 'types/function/define',
+                url: '/types/function/define',
                 category: 'functions',
                 block: {
                     FUNCTIONS_EDIT_OPTION: Util.lf("Edit Function")
@@ -708,7 +708,7 @@ namespace pxt.blocks {
             'function_call': {
                 name: Util.lf("call the function"),
                 tooltip: Util.lf("Call the user-defined function."),
-                url: 'types/function/call',
+                url: '/types/function/call',
                 category: 'functions',
                 block: {
                     FUNCTIONS_CALL_TITLE: Util.lf("call"),
@@ -718,7 +718,7 @@ namespace pxt.blocks {
             'function_call_output': {
                 name: Util.lf("call the function with a return value"),
                 tooltip: Util.lf("Call the user-defined function with a return value."),
-                url: 'types/function/call',
+                url: '/types/function/call',
                 category: 'functions',
                 block: {
                 }


### PR DESCRIPTION
A number of built-in blocks have incomplete help paths (missing the leading '/'). This causes the help doc to open in a new tab rather than as sidedoc.

Fixes #7377