### PR TITLE
Fix high contrast for non-identity platforms

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -5156,7 +5156,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         .then(async () => {
             const href = window.location.href;
             let force = false;
-            const cloudLang = auth.userPreferences()?.language;
+            const userLang = data.getData<string>(auth.LANGUAGE);
             // kick of a user preferences check; if the language is different we'll request they reload
             auth.initialUserPreferencesAsync().then((pref) => {
                 const cookieLang = pxt.BrowserUtils.getCookieLang()
@@ -5182,7 +5182,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                 const hashLang = hashLangMatch?.[3];
                 const cookieLang = pxt.BrowserUtils.getCookieLang()
                 // chose the user's language using the following ordering:
-                useLang = hashLang || cloudLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
+                useLang = hashLang || userLang || cookieLang || theme.defaultLocale || (navigator as any).userLanguage || navigator.language;
 
                 const locstatic = /staticlang=1/i.test(window.location.href);
                 const defLocale = pxt.appTarget.appTheme.defaultLocale;

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -107,6 +107,13 @@ class AuthClient extends pxt.auth.AuthClient {
                 cli.initialUserPreferencesAsync().then(() => { });
             }
             return AuthClient.internalUserPreferencesHandler(path);
+        } else {
+            // Identity not available, read from local storage
+            switch (path) {
+                case HIGHCONTRAST: return /^true$/i.test(pxt.storage.getLocal(HIGHCONTRAST));
+                case LANGUAGE: return pxt.storage.getLocal(LANGUAGE);
+                case READER: return pxt.storage.getLocal(READER);
+            }
         }
         return null;
     }
@@ -212,27 +219,48 @@ export async function patchUserPreferencesAsync(ops: ts.pxtc.jsonPatch.PatchOper
 }
 
 export async function setHighContrastPrefAsync(highContrast: boolean): Promise<void> {
-    await patchUserPreferencesAsync({
-        op: 'replace',
-        path: ['highContrast'],
-        value: highContrast
-    });
+    const cli = await clientAsync();
+    if (cli) {
+        await cli.patchUserPreferencesAsync({
+            op: 'replace',
+            path: ['highContrast'],
+            value: highContrast
+        });
+    } else {
+        // Identity not available, save this setting locally
+        pxt.storage.setLocal(HIGHCONTRAST, highContrast.toString());
+        data.invalidate(HIGHCONTRAST);
+    }
 }
 
 export async function setLangaugePrefAsync(lang: string): Promise<void> {
-    await patchUserPreferencesAsync({
-        op: 'replace',
-        path: ['language'],
-        value: lang
-    }, { immediate: true }); // sync this change immediately, as the page is about to reload.
+    const cli = await clientAsync();
+    if (cli) {
+        await cli.patchUserPreferencesAsync({
+            op: 'replace',
+            path: ['language'],
+            value: lang
+        }, { immediate: true }); // sync this change immediately, as the page is about to reload.
+    } else {
+        // Identity not available, save this setting locally
+        pxt.storage.setLocal(LANGUAGE, lang);
+        data.invalidate(LANGUAGE);
+    }
 }
 
 export async function setImmersiveReaderPrefAsync(pref: string): Promise<void> {
-    await patchUserPreferencesAsync({
-        op: 'replace',
-        path: ['reader'],
-        value: pref
-    });
+    const cli = await clientAsync();
+    if (cli) {
+        await cli.patchUserPreferencesAsync({
+            op: 'replace',
+            path: ['reader'],
+            value: pref
+        });
+    } else {
+        // Identity not available, save this setting locally
+        pxt.storage.setLocal(READER, pref);
+        data.invalidate(READER);
+    }
 }
 
 export async function setEmailPrefAsync(pref: boolean): Promise<pxt.auth.SetPrefResult> {


### PR DESCRIPTION
The high contrast setting on non-identity targets has been broken since the auth refactor to support identity in skillmap. This fixes it.

Fixes https://github.com/microsoft/pxt-arcade/issues/4388