### PR TITLE
Bump pxt-blockly to 4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "monaco-editor": "0.24.0",
     "pouchdb": "7.2.1",
     "pouchdb-adapter-memory": "7.2.1",
-    "pxt-blockly": "4.0.5",
+    "pxt-blockly": "4.0.6",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4403
fixes https://github.com/microsoft/pxt-arcade/issues/4399

removes calls to callValidator, which were causing console errors/blockly crashes.