### PR TITLE
Space out the email checkbox

### DIFF
--- a/react-common/styles/profile/profile.css
+++ b/react-common/styles/profile/profile.css
@@ -70,6 +70,7 @@
 
 .profile-email {
     display: flex;
+    padding-bottom: 1rem;
 }
 
 .profile-email .checkbox {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4401

I added some padding to the bottom of the email checkbox -- I didn't do anything with Delete/Sign Out since I think that's by design...?

looks like 
![image](https://user-images.githubusercontent.com/18712271/143925107-6d219b1a-21b8-4490-a349-b21079e570ac.png)
