### PR TITLE
Reset current indent when parsing a new section of the skillmap

### DIFF
--- a/skillmap/src/lib/skillMapParser.ts
+++ b/skillmap/src/lib/skillMapParser.ts
@@ -80,6 +80,7 @@ export function getSectionsFromText(text: string) {
                 }
                 currentKey = null;
                 currentValue = null;
+                currentIndent = 0;
                 continue;
             }
         }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4419

issue was the trailing list from the certificate node set the current indent, which caused the parser to try and pop a list from the stack and add the current key/value pair (name: "activity name") to it. this fails gracefully, but means that the last activity doesn't have a name attribute and uses the node name ("forest6") instead