### PR TITLE
Check skillmap user locale against target's available locales before setting

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -168,7 +168,10 @@ class AppImpl extends React.Component<AppProps, AppState> {
             force: force,
         });
 
-        pxt.BrowserUtils.setCookieLang(useLang!);
+        if (pxt.Util.isLocaleEnabled(useLang!)) {
+            pxt.BrowserUtils.setCookieLang(useLang!);
+            pxt.Util.setUserLanguage(useLang!);
+        }
     }
 
     protected async fetchAndParseSkillMaps(source: MarkdownSource, url: string) {
@@ -515,7 +518,6 @@ async function updateLocalizationAsync(opts: LocalizationUpdateOptions): Promise
         ts.pxtc.Util.TranslationsKind.SkillMap
     );
 
-    pxt.Util.setUserLanguage(code);
     if (translations) {
         pxt.Util.setLocalizedStrings(translations);
     }

--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -138,13 +138,17 @@ class AppImpl extends React.Component<AppProps, AppState> {
             force = !!mlang && !!mlang[2];
         }
 
+        const defLocale = pxt.appTarget.appTheme.defaultLocale;
+        if (!force && !pxt.Util.isLocaleEnabled(useLang!)) {
+            useLang = defLocale;
+        }
+
         // TODO: include the pxt webconfig so that we can get the commitcdnurl (and not always pass live=true)
         const baseUrl = "";
         const targetId = pxt.appTarget.id;
         const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;
         const targetBranch = pxt.appTarget.versions.targetCrowdinBranch;
 
-        const defLocale = pxt.appTarget.appTheme.defaultLocale;
         const langLowerCase = useLang?.toLocaleLowerCase();
         const localDevServe = pxt.BrowserUtils.isLocalHostDev()
             && (!langLowerCase || (defLocale
@@ -164,9 +168,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
             force: force,
         });
 
-        if (pxt.Util.isLocaleEnabled(useLang!)) {
-            pxt.BrowserUtils.setCookieLang(useLang!);
-        }
+        pxt.BrowserUtils.setCookieLang(useLang!);
     }
 
     protected async fetchAndParseSkillMaps(source: MarkdownSource, url: string) {


### PR DESCRIPTION
we were always passing the user's locale to crowdin, even if it wasn't in the list of available locales for that target. this checks if there's a `force` flag or if the locale has been enabled, and if not it resets to the target's default locale. 

i tested `forcelang=ru`, as well as setting the browser locale to an enabled (chinese) and non-enabled (russian) locale and it seems to be working as expected (localizes for the first two cases, doesn't for the third), but let me know if there's any scenarios i missed!