### PR TITLE
Use default preferences for users if none exist

### DIFF
--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -369,7 +369,7 @@ namespace pxt.auth {
                 }
 
                 // Apply queued patches to the remote state in isolation and develop a final diff to send to the backend
-                const remotePrefs = U.deepCopy(getResult.resp);
+                const remotePrefs = U.deepCopy(getResult.resp) || DEFAULT_USER_PREFERENCES();
                 const patchQueue = this.patchQueue;
                 this.patchQueue = []; // Reset the queue
                 patchQueue.forEach(patch => {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4429

The issue is when we fetch the user preferences from the cloud, for new users they won't have any, and we don't pass in default preferences here. Adding default preferences