### PR TITLE
Display Back and Next buttons on simulator tab in tutorial

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -1326,7 +1326,7 @@ p.ui.font.small {
     .simPanel.ui.items {
         position: fixed;
         padding: 0;
-        margin: 1em;
+        margin: 1em 1em 0;
         bottom: ~"calc(5.5rem + var(--extra-mobile-sim-padding))" !important;
         right: 0.5rem;
         top: unset;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -6,9 +6,15 @@
 @tutorialSecondaryColor: @blue;
 
 @tutorialTabletButtonColor: #f3f3f3;
+@tutorialTabletSimulatorButtonColor: rgba(0, 0, 0, 0.05);
 @tutorialTabletStepCounterWidth: 16rem;
 
 @tutorialHintMaskZIndex: -1; // Below tutorial pane
+
+@tutorialControlsOffset: 5.725rem;
+@tutorialBoardviewOffset: 3rem;
+@tutorialTabBarOffset: 3.5rem;
+@tutorialSimulatorMinHeight: 250px;
 
 /*******************************
         Tutorial Tab
@@ -27,11 +33,6 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-
-    .ui.button, .ui.button:hover {
-        box-shadow: none;
-        background-image: none;
-    }
 }
 
 .tutorial-content {
@@ -63,6 +64,14 @@
     width: calc(~'100% - 1rem');
     bottom: 6rem;
     background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), @white);
+}
+
+.tutorial-container,
+.tutorial-controls {
+    .ui.button, .ui.button:hover {
+        box-shadow: none;
+        background-image: none;
+    }
 }
 
 /*******************************
@@ -297,9 +306,13 @@
             .sidebar-button, .play-button { display: block !important; }
             .expand-button, .fullscreen-button { display: none !important; }
         }
+
+        .tutorial-controls { display: none; }
     }
     .tab-simulator.tab-content:not(.hidden) {
         .simPanel {
+            height: calc(100% - @tutorialControlsOffset);
+
             .sidebar-button, .button.hidefullscreen { display: none !important; }
         }
     }
@@ -352,6 +365,29 @@
 /*******************************
         Media Adjustments
 *******************************/
+
+/* Desktop Only */
+@media only screen and (max-height: @tallEditorBreakpoint) and (min-width: @largestTabletScreen) {
+    #root.tabTutorial:not(.fullscreensim) .tab-simulator:not(.hidden) {
+        .simPanel {
+            height: calc(100% - @tutorialControlsOffset);
+            min-height: @tutorialSimulatorMinHeight;
+        }
+        #boardview {
+            height: calc(100% - @tutorialBoardviewOffset);
+            min-height: @tutorialSimulatorMinHeight;
+        }
+        #simulators {
+            height: 100%;
+            min-height: @tutorialSimulatorMinHeight;
+        }
+        .simframe {
+            padding-bottom: unset !important;
+            height: 100%;
+            min-height: @tutorialSimulatorMinHeight;
+        }
+    }
+}
 
 /* <= Tablet (Mobile + Tablet) */
 @media only screen and (max-width: @largestTabletScreen) {
@@ -465,7 +501,8 @@
         }
     }
 
-    .tutorial-container {
+    .tutorial-container,
+    .tutorial-controls {
         > .ui.button, > .ui.button:focus {
             color: @tutorialPrimaryColor;
             background: @tutorialTabletButtonColor;
@@ -526,6 +563,10 @@
     #root.tabTutorial:not(.fullscreensim) .tab-simulator:not(.hidden) {
         .simPanel {
             display: flex;
+            position: relative;
+            height: 100%;
+            margin: 0 4rem;
+            z-index: 30;
 
             #simulators {
                 width: 34rem;
@@ -550,6 +591,23 @@
 
         #boardview {
             width: 100% !important;
+        }
+
+        .tutorial-controls {
+            position: absolute;
+            top: @tutorialTabBarOffset;
+            width: 100%;
+            height: calc(100% - @tutorialTabBarOffset);
+            justify-content: space-between;
+            z-index: 10;
+
+            .ui.button {
+                height: 100%;
+            }
+
+            .ui.button:not(:hover) {
+                background-color: @tutorialTabletSimulatorButtonColor;
+            }
         }
     }
 

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -2,14 +2,13 @@
 
 import * as React from "react";
 import * as data from "./data";
-import * as sui from "./sui";
-
 import * as filelist from "./filelist";
 import * as keymap from "./keymap";
 import * as serialindicator from "./serialindicator"
 import * as simtoolbar from "./simtoolbar";
 import * as simulator from "./simulator";
 
+import { fireClickOnEnter, Button } from "./sui";
 import { TabContent } from "./components/core/TabContent";
 import { TabPane } from "./components/core/TabPane";
 import { TutorialContainer } from "./components/tutorial/TutorialContainer";
@@ -119,7 +118,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
 
     protected tutorialExitButton = () => {
         return <div className="tutorial-exit" aria-label={lf("Exit tutorial")} tabIndex={0}
-            onClick={() => this.props.parent.exitTutorial()} onKeyDown={sui.fireClickOnEnter}>
+            onClick={() => this.props.parent.exitTutorial()} onKeyDown={fireClickOnEnter}>
             {lf("Exit Tutorial")}
         </div>;
     }
@@ -135,6 +134,9 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
         const hasSimulator = !pxt.appTarget.simulator?.headless;
         const marginHeight = hasSimulator ? "6.5rem" : "3rem";
 
+        const backButton = <Button icon="arrow circle left" text={lf("Back")} onClick={this.showTutorialTab} />;
+        const nextButton = <Button icon="arrow circle right" text={lf("Next")} onClick={this.showTutorialTab} />;
+
         return <div id="simulator" className="simulator">
             <TabPane id="editorSidebar" activeTabName={activeTab} style={height ? { height: `calc(${height}px + ${marginHeight})` } : undefined}>
                 {hasSimulator && <TabContent name={SIMULATOR_TAB} icon="xicon gamepad" onSelected={this.showSimulatorTab} ariaLabel={lf("Open the simulator tab")}>
@@ -144,7 +146,7 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         <simtoolbar.SimulatorToolbar parent={parent} collapsed={collapseEditorTools} simSerialActive={simSerialActive} devSerialActive={deviceSerialActive} showSimulatorSidebar={this.showSimulatorTab} />
                         {showKeymap && <keymap.Keymap parent={parent} />}
                         <div className="ui item portrait hide hidefullscreen">
-                            {pxt.options.debug && <sui.Button key="hwdebugbtn" className="teal" icon="xicon chip" text={"Dev Debug"} onClick={handleHardwareDebugClick} />}
+                            {pxt.options.debug && <Button key="hwdebugbtn" className="teal" icon="xicon chip" text={"Dev Debug"} onClick={handleHardwareDebugClick} />}
                         </div>
                         {showSerialButtons && <div id="serialPreview" className="ui editorFloat portrait hide hidefullscreen">
                             <serialindicator.SerialIndicator ref="simIndicator" isSim={true} onClick={this.handleSimSerialClick} parent={parent} />
@@ -153,6 +155,11 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                         {showFileList && <filelist.FileList parent={parent} />}
                         {showFullscreenButton && <div id="miniSimOverlay" role="button" title={lf("Open in fullscreen")} onClick={this.handleSimOverlayClick} />}
                     </div>
+                    {isTabTutorial && <div className="tutorial-controls">
+                        { backButton }
+                        <Button icon="lightbulb" disabled={true} className="tutorial-hint" />
+                        { nextButton }
+                    </div>}
                 </TabContent>}
                 {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="icon tasks" showBadge={activeTab !== TUTORIAL_TAB} onSelected={this.showTutorialTab} ariaLabel={lf("Open the tutorial tab")}>
                     <TutorialContainer parent={parent} tutorialId={tutorialOptions.tutorial} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34112083/144520928-085c4f82-5336-4e14-af98-5d8567756915.png)
![image](https://user-images.githubusercontent.com/34112083/144520990-c2fd4d7a-403d-49ff-afa6-76ae06f04253.png)

build: https://arcade.makecode.com/app/417ebce3e68c882a7e60fc089eddf4028974077b-ca22d467a8