### PR TITLE
[stable7.3] Check skillmap user locale against target's available locales before setting (#8619)

### DIFF
--- a/skillmap/src/App.tsx
+++ b/skillmap/src/App.tsx
@@ -138,13 +138,17 @@ class AppImpl extends React.Component<AppProps, AppState> {
             force = !!mlang && !!mlang[2];
         }
 
+        const defLocale = pxt.appTarget.appTheme.defaultLocale;
+        if (!force && !pxt.Util.isLocaleEnabled(useLang!)) {
+            useLang = defLocale;
+        }
+
         // TODO: include the pxt webconfig so that we can get the commitcdnurl (and not always pass live=true)
         const baseUrl = "";
         const targetId = pxt.appTarget.id;
         const pxtBranch = pxt.appTarget.versions.pxtCrowdinBranch;
         const targetBranch = pxt.appTarget.versions.targetCrowdinBranch;
 
-        const defLocale = pxt.appTarget.appTheme.defaultLocale;
         const langLowerCase = useLang?.toLocaleLowerCase();
         const localDevServe = pxt.BrowserUtils.isLocalHostDev()
             && (!langLowerCase || (defLocale
@@ -166,6 +170,7 @@ class AppImpl extends React.Component<AppProps, AppState> {
 
         if (pxt.Util.isLocaleEnabled(useLang!)) {
             pxt.BrowserUtils.setCookieLang(useLang!);
+            pxt.Util.setUserLanguage(useLang!);
         }
     }
 
@@ -513,7 +518,6 @@ async function updateLocalizationAsync(opts: LocalizationUpdateOptions): Promise
         ts.pxtc.Util.TranslationsKind.SkillMap
     );
 
-    pxt.Util.setUserLanguage(code);
     if (translations) {
         pxt.Util.setLocalizedStrings(translations);
     }


### PR DESCRIPTION
* Check skillmap user locale against target's available locales before setting

* Only persist user language for approved locales