### PR TITLE
Integrate blockly keyboard navigation for accessible blocks experiment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,6 +66,7 @@ const reactCommonPackageJson = () => {
 const pxtblockly = () => gulp.src([
     "webapp/public/blockly/blockly_compressed.js",
     "webapp/public/blockly/blocks_compressed.js",
+    "webapp/public/blockly/plugins.js",
     "webapp/public/blockly/msg/js/en.js",
     "built/pxtblocks.js"
 ])
@@ -534,6 +535,10 @@ const copyBlocklyCompressed = () => gulp.src([
 ])
     .pipe(gulp.dest("webapp/public/blockly/"));
 
+const copyBlocklyExtensions = () => gulp.src("node_modules/@blockly/**/dist/index.js")
+    .pipe(concat("plugins.js"))
+    .pipe(gulp.dest("webapp/public/blockly/"));
+
 const copyBlocklyEnJs = () => gulp.src("node_modules/pxt-blockly/msg/js/en.js")
     .pipe(gulp.dest("webapp/public/blockly/msg/js/"));
 
@@ -546,7 +551,7 @@ const copyBlocklyMedia = () => gulp.src("node_modules/pxt-blockly/media/*")
 const copyBlocklyTypings = () => gulp.src("node_modules/pxt-blockly/typings/blockly.d.ts")
     .pipe(gulp.dest("localtypings/"))
 
-const copyBlockly = gulp.parallel(copyBlocklyCompressed, copyBlocklyEnJs, copyBlocklyEnJson, copyBlocklyMedia, copyBlocklyTypings);
+const copyBlockly = gulp.parallel(copyBlocklyCompressed, copyBlocklyExtensions, copyBlocklyEnJs, copyBlocklyEnJson, copyBlocklyMedia, copyBlocklyTypings);
 
 
 /********************************************************

--- a/localtypings/pxtblockly.d.ts
+++ b/localtypings/pxtblockly.d.ts
@@ -93,3 +93,24 @@ declare namespace Blockly {
     class FunctionDefinitionBlock extends FunctionBlockAbstract { }
     class FunctionCallBlock extends FunctionBlockAbstract { }
 }
+
+/**
+ * Blockly Keyboard Navigation plugin
+ * Used for accessible blocks experiment
+ */
+
+declare class NavigationController {
+    init: () => void;
+    addWorkspace: (workspace: Blockly.WorkspaceSvg) => void;
+    enable: (workspace: Blockly.WorkspaceSvg) => void;
+    disable: (workspace: Blockly.WorkspaceSvg) => void;
+    focusToolbox: (workspace: Blockly.WorkspaceSvg) => void;
+    navigation: Navigation;
+}
+
+declare class Navigation {
+    resetFlyout: (workspace: Blockly.WorkspaceSvg, shouldHide: boolean) => void;
+    setState: (workspace: Blockly.WorkspaceSvg, state: BlocklyNavigationState) => void;
+}
+
+declare type BlocklyNavigationState = "workspace" | "toolbox" | "flyout";

--- a/localtypings/pxtblockly.d.ts
+++ b/localtypings/pxtblockly.d.ts
@@ -99,18 +99,18 @@ declare namespace Blockly {
  * Used for accessible blocks experiment
  */
 
-declare class NavigationController {
-    init: () => void;
-    addWorkspace: (workspace: Blockly.WorkspaceSvg) => void;
-    enable: (workspace: Blockly.WorkspaceSvg) => void;
-    disable: (workspace: Blockly.WorkspaceSvg) => void;
-    focusToolbox: (workspace: Blockly.WorkspaceSvg) => void;
+ declare class NavigationController {
+    init(): void;
+    addWorkspace(workspace: Blockly.WorkspaceSvg): void;
+    enable(workspace: Blockly.WorkspaceSvg): void;
+    disable(workspace: Blockly.WorkspaceSvg): void;
+    focusToolbox(workspace: Blockly.WorkspaceSvg): void;
     navigation: Navigation;
 }
 
 declare class Navigation {
-    resetFlyout: (workspace: Blockly.WorkspaceSvg, shouldHide: boolean) => void;
-    setState: (workspace: Blockly.WorkspaceSvg, state: BlocklyNavigationState) => void;
+    resetFlyout(workspace: Blockly.WorkspaceSvg, shouldHide: boolean): void;
+    setState(workspace: Blockly.WorkspaceSvg, state: BlocklyNavigationState): void;
 }
 
 declare type BlocklyNavigationState = "workspace" | "toolbox" | "flyout";

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "npm": ">=3.0.0"
   },
   "dependencies": {
+    "@blockly/keyboard-navigation": "^0.1.18",
     "@microsoft/immersive-reader-sdk": "1.1.0",
     "applicationinsights-js": "^1.0.20",
     "browserify": "16.2.0",

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4296,8 +4296,9 @@ export class ProjectView
     }
 
     setAccessibleBlocks(enabled: boolean) {
-        // TODO: Add accessible blocks plugin from Blockly
         pxt.tickEvent("app.accessibleblocks", { on: enabled ? 1 : 0 });
+        this.blocksEditor.enableAccessibleBlocks(enabled);
+        this.setState({ accessibleBlocks: enabled })
     }
 
     setBannerVisible(b: boolean) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -40,6 +40,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     protected debuggerToolbox: DebuggerToolbox;
 
+    protected navigationController: NavigationController;
+
     public nsMap: pxt.Map<toolbox.BlockDefinition[]>;
 
     constructor(parent: pxt.editor.IProjectView) {
@@ -448,7 +450,29 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     private initAccessibleBlocks() {
-        // TODO: Add accessible blocks plugin from Blockly
+        const enabled = pxt.appTarget.appTheme?.accessibleBlocks;
+        if (enabled && !this.navigationController) {
+            this.navigationController = new NavigationController();
+
+            this.navigationController.init();
+            this.navigationController.addWorkspace(this.editor);
+
+            (Navigation as any).prototype.focusToolbox = (workspace: Blockly.WorkspaceSvg) => {
+                const toolbox = this.toolbox;
+                if (!toolbox) return;
+                this.focusToolbox();
+                this.navigationController.navigation.resetFlyout(workspace, false);
+                this.navigationController.navigation.setState(workspace, "toolbox");
+            }
+        }
+    }
+
+    public enableAccessibleBlocks(enable: boolean) {
+        if (enable) {
+            this.navigationController.enable(this.editor);
+        } else {
+            this.navigationController.disable(this.editor);
+        }
     }
 
     private reportDeprecatedBlocks() {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -549,7 +549,10 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
         const { toolbox } = this.props;
         const isRtl = Util.isUserLanguageRtl();
 
-        const accessibleBlocksEnabled = (Blockly.getMainWorkspace() as any).keyboardAccessibilityMode;
+        const mainWorkspace = Blockly.getMainWorkspace() as any;
+        const accessibleBlocksEnabled = mainWorkspace.keyboardAccessibilityMode;
+        const accessibleBlocksState = accessibleBlocksEnabled
+            && (toolbox.props.parent as any).navigationController?.navigation?.getState(mainWorkspace);
         const keyMap: { [key: string]: number } = {
             "DOWN": accessibleBlocksEnabled ? 83 : 40, // 'S' || down arrow
             "UP": accessibleBlocksEnabled ? 87 : 38, // 'W' || up arrow
@@ -558,28 +561,35 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
         }
 
         const charCode = core.keyCodeFromEvent(e);
-        if (charCode == keyMap["DOWN"]) {
-            this.nextItem();
-        } else if (charCode == keyMap["UP"]) {
-            this.previousItem();
-        } else if ((charCode == keyMap["RIGHT"] && !isRtl)
-            || (charCode == keyMap["LEFT"] && isRtl)) {
-            // Focus inside flyout
-            toolbox.moveFocusToFlyout();
-        } else if (charCode == 27) { // ESCAPE
-            // Close the flyout
-            toolbox.closeFlyout();
-        } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
-            sui.fireClickOnEnter.call(this, e);
-        } else if (charCode == core.TAB_KEY
-            || charCode == 37 /* Left arrow key */
-            || charCode == 39 /* Left arrow key */
-            || charCode == 17 /* Ctrl Key */
-            || charCode == 16 /* Shift Key */
-            || charCode == 91 /* Cmd Key */) {
-            // Escape tab and shift key
-        } else if (!accessibleBlocksEnabled) {
-            toolbox.setSearch();
+        if (!accessibleBlocksEnabled || accessibleBlocksState == "toolbox") {
+            if (charCode == keyMap["DOWN"]) {
+                this.nextItem();
+            } else if (charCode == keyMap["UP"]) {
+                this.previousItem();
+            } else if ((charCode == keyMap["RIGHT"] && !isRtl)
+                || (charCode == keyMap["LEFT"] && isRtl)) {
+                // Focus inside flyout
+                toolbox.moveFocusToFlyout();
+            } else if (charCode == 27) { // ESCAPE
+                // Close the flyout
+                toolbox.closeFlyout();
+            } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
+                sui.fireClickOnEnter.call(this, e);
+            } else if (charCode == core.TAB_KEY
+                || charCode == 37 /* Left arrow key */
+                || charCode == 39 /* Left arrow key */
+                || charCode == 17 /* Ctrl Key */
+                || charCode == 16 /* Shift Key */
+                || charCode == 91 /* Cmd Key */) {
+                // Escape tab and shift key
+            } else if (!accessibleBlocksEnabled) {
+                toolbox.setSearch();
+            }
+        } else if (accessibleBlocksEnabled && accessibleBlocksState == "flyout"
+            && ((charCode == keyMap["LEFT"] && !isRtl)
+            || (charCode == keyMap["RIGHT"] && isRtl))) {
+            this.focusElement();
+            e.stopPropagation();
         }
     }
 


### PR DESCRIPTION
- updates the build so we automatically bundle anything under the /@blockly node_modules folder as a plugin
- adds the keyboard nav plugin and integrates it into our accessible blocks experiment