### PR TITLE
Add blockly workspace search plugin, hooked up to ctrl+F

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -427,6 +427,7 @@ declare namespace pxt {
         githubEditor?: boolean; // allow editing github repositories from the editor
         githubCompiledJs?: boolean; // commit binary.js in commit when creating a github release,
         blocksCollapsing?: boolean; // collapse/uncollapse functions/event in blocks
+        workspaceSearch?: boolean; // allow CTRL+F blocks workspace search
         hideHomeDetailsVideo?: boolean; // hide video/large image from details card
         tutorialBlocksDiff?: boolean; // automatically display blocks diffs in tutorials
         tutorialTextDiff?: boolean; // automatically display text diffs in tutorials

--- a/localtypings/pxtblockly.d.ts
+++ b/localtypings/pxtblockly.d.ts
@@ -99,7 +99,7 @@ declare namespace Blockly {
  * Used for accessible blocks experiment
  */
 
- declare class NavigationController {
+declare class NavigationController {
     init(): void;
     addWorkspace(workspace: Blockly.WorkspaceSvg): void;
     enable(workspace: Blockly.WorkspaceSvg): void;
@@ -114,3 +114,19 @@ declare class Navigation {
 }
 
 declare type BlocklyNavigationState = "workspace" | "toolbox" | "flyout";
+
+/**
+ * Blockly Workspace Search plugin
+ * Used for accessible blocks experiment
+ */
+
+declare class WorkspaceSearch {
+    constructor(workspace: Blockly.WorkspaceSvg);
+    protected workspace_: Blockly.WorkspaceSvg;
+    protected htmlDiv_: HTMLDivElement;
+    init(): void;
+    protected createDom_(): void;
+    protected addEvent_(node: Element, name: string, thisObject: Object, func: Function): void;
+    open(): void;
+    close(): void;
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@blockly/keyboard-navigation": "^0.1.18",
+    "@blockly/plugin-workspace-search": "^4.0.10",
     "@microsoft/immersive-reader-sdk": "1.1.0",
     "applicationinsights-js": "^1.0.20",
     "browserify": "16.2.0",

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -3086,4 +3086,40 @@ namespace pxt.blocks {
     export function getBlockDataForField(block: Blockly.Block, field: string) {
         return getBlockData(block).fieldData[field];
     }
+
+    export class PxtWorkspaceSearch extends WorkspaceSearch {
+        protected createDom_() {
+            super.createDom_();
+            this.addEvent_(this.workspace_.getInjectionDiv(), "click", this, (e: any) => {
+                if (!this.htmlDiv_.contains(e.target)) {
+                    this.close()
+                }
+            });
+        }
+
+        protected highlightSearchGroup_(blocks: Blockly.BlockSvg[]) {
+            blocks.forEach((block) => {
+                const blockPath = block.pathObject.svgPath;
+                Blockly.utils.dom.addClass(blockPath, 'blockly-ws-search-highlight-pxt');
+            });
+        }
+
+        protected unhighlightSearchGroup_ (blocks: Blockly.BlockSvg[]) {
+            blocks.forEach((block) => {
+                const blockPath = block.pathObject.svgPath;
+                Blockly.utils.dom.removeClass(blockPath, 'blockly-ws-search-highlight-pxt');
+            });
+        }
+
+        open() {
+            super.open();
+            Blockly.utils.dom.addClass(this.workspace_.getInjectionDiv(), 'blockly-ws-searching');
+        }
+
+        close() {
+            super.close();
+            Blockly.utils.dom.removeClass(this.workspace_.getInjectionDiv(), 'blockly-ws-searching');
+        }
+
+    }
 }

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -317,6 +317,22 @@ text.blocklyCheckbox {
 }
 
 /*******************************
+        Workspace Search
+*******************************/
+
+.blockly-ws-searching {
+    path.blocklyPath:not(.blockly-ws-search-highlight-pxt) {
+        opacity: 0.6;
+    }
+
+    path.blocklyPath.blockly-ws-search-highlight-pxt.blockly-ws-search-current {
+        stroke: #FFF200;
+        stroke-width: 4px;
+        transition: none;
+    }
+}
+
+/*******************************
         Media Adjustments
 *******************************/
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -40,7 +40,9 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
     protected debuggerToolbox: DebuggerToolbox;
 
+    // Blockly plugins
     protected navigationController: NavigationController;
+    protected workspaceSearch: WorkspaceSearch;
 
     public nsMap: pxt.Map<toolbox.BlockDefinition[]>;
 
@@ -475,6 +477,13 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
+    private initWorkspaceSearch() {
+        if (pxt.appTarget.appTheme.workspaceSearch && !this.workspaceSearch) {
+            this.workspaceSearch  = new pxt.blocks.PxtWorkspaceSearch(this.editor);
+            this.workspaceSearch.init();
+        }
+    }
+
     private reportDeprecatedBlocks() {
         const deprecatedMap: pxt.Map<number> = {};
         let deprecatedBlocksFound = false;
@@ -596,6 +605,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.initBlocklyToolbox();
         this.initWorkspaceSounds();
         this.initAccessibleBlocks();
+        this.initWorkspaceSearch();
         this.resize();
 
         pxt.perf.measureEnd("prepareBlockly")


### PR DESCRIPTION
![fix-workspace-search](https://user-images.githubusercontent.com/34112083/145653718-9fdacca5-d378-43e8-a05f-632b6553ea44.gif)

adds blockly's workspace search plugin! with some small tweaks to how rendering is handled