### PR TITLE
Fixing undefined target from Asphodel

### DIFF
--- a/docfiles/tracking.html
+++ b/docfiles/tracking.html
@@ -20,7 +20,7 @@
                 var telemetryItem = envelope.data.baseData;
                 telemetryItem.properties = telemetryItem.properties || {};
                 telemetryItem.properties["cookie"] = isProduction;
-                if (typeof pxtConfig === "undefined" || !pxtConfig) {
+                if (typeof pxtConfig === "undefined" || !pxtConfig || !pxtConfig.targetId) {
                     telemetryItem.properties["target"] = "@targetid@";
                     return;
                 }


### PR DESCRIPTION
In the simulator pxtConfig present and only contains simURL. Special casing for the same. This is spewing out "undefined" targets in the telemetry.