### PR TITLE
Fix Blockly CSS in docs snippet, SpriteKind decompilation

### DIFF
--- a/pxtblocks/blocklylayout.ts
+++ b/pxtblocks/blocklylayout.ts
@@ -241,7 +241,7 @@ namespace pxt.blocks.layout {
 
     export function cleanUpBlocklySvg(svg: SVGElement): SVGElement {
         pxt.BrowserUtils.removeClass(svg, "blocklySvg");
-        pxt.BrowserUtils.addClass(svg, "blocklyPreview pxt-renderer");
+        pxt.BrowserUtils.addClass(svg, "blocklyPreview pxt-renderer classic-theme");
 
         // Remove background elements
         pxt.U.toArray(svg.querySelectorAll('.blocklyMainBackground,.blocklyScrollbarBackground'))

--- a/pxtblocks/fields/field_kind.ts
+++ b/pxtblocks/fields/field_kind.ts
@@ -6,7 +6,6 @@ namespace pxtblockly {
 
         initView() {
             super.initView();
-            this.initVariables();
         }
 
         onItemSelected_(menu: Blockly.Menu, menuItem: Blockly.MenuItem) {
@@ -24,6 +23,11 @@ namespace pxtblockly {
             // update cached option list when adding a new kind
             if (this.opts?.initialMembers && !this.opts.initialMembers.find(el => el == value)) this.getOptions();
             return super.doClassValidation_(value);
+        }
+
+        getOptions(opt_useCache?: boolean) {
+            this.initVariables();
+            return super.getOptions(opt_useCache);
         }
 
         private initVariables() {


### PR DESCRIPTION
two bugs:
- docs/tutorial hint block snippets don't have the blockly css -> need to add the theme class
- spritekind dropdown always displayed "Player" when decompiling from blocks -> the fromXML flow changed so we need to initialize the spritekind variables differently