### PR TITLE
Fix CodeQL scan errors in build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,8 @@ name: "CodeQL"
 on:
   push:
     branches: [ 'master', 'stable*', 'v[0-9]*' ]
+    paths-ignore:
+      - webapp/public/vs/language/typescript/tsWorker.js
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -390,7 +390,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         // preemptively remove script tags, although they'll be escaped anyway
         // prevents ugly <script ...> rendering in docs
-        markdown = markdown.replace(/<\s*script[^>]*>.*<\/\s*script\s*>/gi, '');
+        markdown = markdown.replace(/<\s*script[^>]*>.*<\/\s*script[^>]*>/gi, '');
 
         // Render the markdown into a div outside of the DOM tree to prevent the page from reflowing
         // when we edit the HTML it produces. Then, add the finished result to the content div

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -390,7 +390,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         // preemptively remove script tags, although they'll be escaped anyway
         // prevents ugly <script ...> rendering in docs
-        markdown = markdown.replace(/<\s*script[^>]*>.*<\/\s*script\s*>/g, '');
+        markdown = markdown.replace(/<\s*script[^>]*>?.*(?:<\/\s*script\s*>)?/gi, '');
 
         // Render the markdown into a div outside of the DOM tree to prevent the page from reflowing
         // when we edit the HTML it produces. Then, add the finished result to the content div

--- a/webapp/src/marked.tsx
+++ b/webapp/src/marked.tsx
@@ -390,7 +390,7 @@ export class MarkedContent extends data.Component<MarkedContentProps, MarkedCont
 
         // preemptively remove script tags, although they'll be escaped anyway
         // prevents ugly <script ...> rendering in docs
-        markdown = markdown.replace(/<\s*script[^>]*>?.*(?:<\/\s*script\s*>)?/gi, '');
+        markdown = markdown.replace(/<\s*script[^>]*>.*<\/\s*script\s*>/gi, '');
 
         // Render the markdown into a div outside of the DOM tree to prevent the page from reflowing
         // when we edit the HTML it produces. Then, add the finished result to the content div


### PR DESCRIPTION
- add ignore-path to skip tsWorker file, since we don't generate that one
- update marked regex to ignore case. this regex is cosmetic anyway, we'll dismiss the warning for it