### PR TITLE
Customize webpack aliases for local skillmap build

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2078,6 +2078,7 @@ function buildWebStringsAsync() {
 function buildSkillMapAsync(parsed: commandParser.ParsedCommand) {
     // local serve
     const skillmapRoot = "node_modules/pxt-core/skillmap";
+    const reactScriptsConfigRoot = `${skillmapRoot}/node_modules/react-scripts/config`;
     const docsPath = parsed.flags["docs"];
     return rimrafAsync(`${skillmapRoot}/public/blb`, {})
         .then(() => rimrafAsync(`${skillmapRoot}/build/assets`, {}))
@@ -2094,6 +2095,13 @@ function buildSkillMapAsync(parsed: commandParser.ParsedCommand) {
 
             // copy 'assets' over from docs/static
             nodeutil.cpR("docs/static/skillmap/assets", `${skillmapRoot}/public/assets`);
+
+            // copy default react-scripts webpack config into a webpack.config.base file if necessary
+            if (!fs.existsSync(`${reactScriptsConfigRoot}/webpack.config.base.js`)) {
+                nodeutil.cp(`${reactScriptsConfigRoot}/webpack.config.js`, reactScriptsConfigRoot, "webpack.config.base.js");
+            }
+            // wrap the config in our webpack.config.override for build customization
+            nodeutil.cp(`${skillmapRoot}/webpack.config.override.js`, reactScriptsConfigRoot, "webpack.config.js");
 
             if (docsPath) {
                 // copy docs over from specified path

--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -359,9 +359,9 @@ export function cpR(src: string, dst: string, maxDepth = 8) {
     }
 }
 
-export function cp(srcFile: string, destDirectory: string) {
+export function cp(srcFile: string, destDirectory: string, destName?: string) {
     mkdirP(destDirectory);
-    let dest = path.resolve(destDirectory, path.basename(srcFile));
+    let dest = path.resolve(destDirectory, destName || path.basename(srcFile));
     let buf = fs.readFileSync(path.resolve(srcFile));
     fs.writeFileSync(dest, buf);
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -560,21 +560,21 @@ const copyBlockly = gulp.parallel(copyBlocklyCompressed, copyBlocklyExtensions, 
 
 const skillmapRoot = "skillmap";
 const skillmapOut = "built/web/skillmap";
+const reactScriptsConfigRoot = `${skillmapRoot}/node_modules/react-scripts/config`;
 
 const cleanSkillmap = () => rimraf(skillmapOut);
 
-const copyWebpackBase = () => gulp.src([`${skillmapRoot}/node_modules/react-scripts/config/webpack.config.js`])
+const copyWebpackBase = () => gulp.src([`${reactScriptsConfigRoot}/webpack.config.js`])
     .pipe(concat("webpack.config.base.js"))
-    .pipe(gulp.dest(`${skillmapRoot}/node_modules/react-scripts/config`))
+    .pipe(gulp.dest(`${reactScriptsConfigRoot}`))
 
 const copyWebpackOverride = () => gulp.src([`${skillmapRoot}/webpack.config.override.js`])
     .pipe(concat("webpack.config.js"))
-    .pipe(gulp.dest(`${skillmapRoot}/node_modules/react-scripts/config`));
+    .pipe(gulp.dest(`${reactScriptsConfigRoot}`));
 
-const replaceWebpackBase = () => gulp.src([`${skillmapRoot}/node_modules/react-scripts/config/webpack.config.base.js`])
+const replaceWebpackBase = () => gulp.src([`${reactScriptsConfigRoot}/webpack.config.base.js`])
     .pipe(concat("webpack.config.js"))
-    .pipe(gulp.dest(`${skillmapRoot}/node_modules/react-scripts/config`));
-
+    .pipe(gulp.dest(`${reactScriptsConfigRoot}`));
 
 const npmInstallSkillmap = () => exec(!fs.existsSync(`${skillmapRoot}/node_modules`) ? "npm ci --prefer-offline" : "echo \"Skip install\"", false, { cwd: skillmapRoot });
 const npmBuildSkillmap = () => exec("npm run build", true, { cwd: skillmapRoot });
@@ -582,7 +582,7 @@ const npmBuildSkillmap = () => exec("npm run build", true, { cwd: skillmapRoot }
 const buildSkillmap = async () => {
     try {
         await npmInstallSkillmap();
-        await copyWebpackBase();
+        if (!fs.existsSync(`${reactScriptsConfigRoot}/webpack.config.base.js`)) await copyWebpackBase();
         await copyWebpackOverride();
         await npmBuildSkillmap();
     }

--- a/skillmap/webpack.config.override.js
+++ b/skillmap/webpack.config.override.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
 const paths = require('./paths');
 
 const configFactory = require('../config/webpack.config.base');
@@ -35,6 +36,10 @@ module.exports = function (webpackEnv) {
         : undefined
     )
   ))
+
+  if (!isEnvProduction) {
+    config.resolve.alias['react'] = path.resolve('../node_modules/react');
+  }
 
   config.module.rules = config.module.rules.filter(el => !(el.use && el.use.some(item => !!(item.options && item.options.eslintPath))));
   return config;


### PR DESCRIPTION
adds an alias for the react package so that react-common components and the general skillmap components use the same path for react (the path to pxt's node_modules rather than pxt/skillmap)