### PR TITLE
Adding a couple useful keyboard shortcuts to the image/tilemap editor

### DIFF
--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -3,7 +3,7 @@ import { Store } from 'react-redux';
 import { ImageEditorTool, ImageEditorStore, TilemapState, AnimationState } from './store/imageReducer';
 import { dispatchChangeZoom, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchChangeImageTool, dispatchSwapBackgroundForeground, dispatchChangeSelectedColor, dispatchImageEdit} from './actions/dispatch';
 import { mainStore } from './store/imageStore';
-import { EditState, flipEdit, getEditState, rotateEdit } from './toolDefinitions';
+import { EditState, flipEdit, getEditState, outlineEdit, rotateEdit } from './toolDefinitions';
 let store = mainStore;
 
 let lockRefs: number[] = [];
@@ -66,6 +66,13 @@ function overrideBlocklyShortcuts(event: KeyboardEvent) {
 
 function handleKeyDown(event: KeyboardEvent) {
     if (!areShortcutsEnabled()) return;
+
+    if (event.shiftKey && event.ctrlKey && /^(?:Digit[1-9])|(?:Key[A-F])$/.test(event.code)) {
+        if (event.code.indexOf("Digit") == 0) outline(parseInt(event.code.substring(5)))
+        else outline(parseInt(event.code.substring(3), 16));
+        return;
+    }
+
     // Mostly copied from the photoshop shortcuts
     switch (event.key) {
         case "e":
@@ -175,4 +182,13 @@ export function rotate(clockwise: boolean) {
     const [ editState, type ] = currentEditState();
     const rotated = rotateEdit(editState, clockwise, type === "tilemap", type === "animation");
     dispatchAction(dispatchImageEdit(rotated.toImageState()));
+}
+
+export function outline(color: number) {
+    const [ editState, type ] = currentEditState();
+
+    if (type === "tilemap") return;
+
+    const outlined = outlineEdit(editState, color);
+    dispatchAction(dispatchImageEdit(outlined.toImageState()));
 }

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -3,7 +3,7 @@ import { Store } from 'react-redux';
 import { ImageEditorTool, ImageEditorStore, TilemapState, AnimationState } from './store/imageReducer';
 import { dispatchChangeZoom, dispatchUndoImageEdit, dispatchRedoImageEdit, dispatchChangeImageTool, dispatchSwapBackgroundForeground, dispatchChangeSelectedColor, dispatchImageEdit} from './actions/dispatch';
 import { mainStore } from './store/imageStore';
-import { EditState, flipEdit, getEditState, outlineEdit, rotateEdit } from './toolDefinitions';
+import { EditState, flipEdit, getEditState, outlineEdit, replaceColorEdit, rotateEdit } from './toolDefinitions';
 let store = mainStore;
 
 let lockRefs: number[] = [];
@@ -121,6 +121,11 @@ function handleKeyDown(event: KeyboardEvent) {
 
     const editorState = store.getState().editor;
 
+    if (event.shiftKey && event.ctrlKey && event.code === "KeyR") {
+        replaceColor(editorState.backgroundColor, editorState.selectedColor);
+        return;
+    }
+
     if (!editorState.isTilemap && /^Digit\d$/.test(event.code)) {
         const keyAsNum = +event.code.slice(-1);
         const color = keyAsNum + (event.shiftKey ? 9 : 0);
@@ -191,4 +196,10 @@ export function outline(color: number) {
 
     const outlined = outlineEdit(editState, color);
     dispatchAction(dispatchImageEdit(outlined.toImageState()));
+}
+
+export function replaceColor(fromColor: number, toColor: number) {
+    const [ editState, type ] = currentEditState();
+    const replaced = replaceColorEdit(editState, fromColor, toColor);
+    dispatchAction(dispatchImageEdit(replaced.toImageState()));
 }

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -121,7 +121,7 @@ function handleKeyDown(event: KeyboardEvent) {
 
     const editorState = store.getState().editor;
 
-    if (event.shiftKey && event.ctrlKey && event.code === "KeyR") {
+    if (event.shiftKey && event.ctrlKey && event.code === "KeyS") {
         replaceColor(editorState.backgroundColor, editorState.selectedColor);
         return;
     }

--- a/webapp/src/components/ImageEditor/keyboardShortcuts.ts
+++ b/webapp/src/components/ImageEditor/keyboardShortcuts.ts
@@ -121,7 +121,7 @@ function handleKeyDown(event: KeyboardEvent) {
 
     const editorState = store.getState().editor;
 
-    if (event.shiftKey && event.ctrlKey && event.code === "KeyS") {
+    if (event.shiftKey && event.code === "KeyR") {
         replaceColor(editorState.backgroundColor, editorState.selectedColor);
         return;
     }

--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -884,9 +884,9 @@ export function flipEdit(image: EditState, vertical: boolean, isTilemap: boolean
 
 export function outlineEdit(image: EditState, color: number) {
     const source = image.floating?.image ? image.floating : image;
+    const out = image.copy();
 
-    const newImage = new pxt.sprite.Bitmap(source.image.width, source.image.height);
-    newImage.apply(source.image);
+    const newImage = image?.floating?.image ? out.floating.image : out.image;
 
     for (let x = 0; x < source.image.width; x++) {
         for (let y = 0; y < source.image.height; y++) {
@@ -899,12 +899,22 @@ export function outlineEdit(image: EditState, color: number) {
         }
     }
 
+    return out;
+}
+
+export function replaceColorEdit(image: EditState, fromColor: number, toColor: number) {
+    const source = image.floating?.image ? image.floating : image;
     const out = image.copy();
-    if (out.floating?.image) {
-        out.floating.image = newImage
+
+    const newImage = image?.floating?.image ? out.floating.image : out.image;
+
+    for (let x = 0; x < source.image.width; x++) {
+        for (let y = 0; y < source.image.height; y++) {
+            if (source.image.get(x, y) === fromColor) {
+                newImage.set(x, y, toColor);
+            }
+        }
     }
-    else {
-        out.image = newImage;
-    }
+
     return out;
 }

--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -881,3 +881,30 @@ export function flipEdit(image: EditState, vertical: boolean, isTilemap: boolean
         }
     }
 }
+
+export function outlineEdit(image: EditState, color: number) {
+    const source = image.floating?.image ? image.floating : image;
+
+    const newImage = new pxt.sprite.Bitmap(source.image.width, source.image.height);
+    newImage.apply(source.image);
+
+    for (let x = 0; x < source.image.width; x++) {
+        for (let y = 0; y < source.image.height; y++) {
+            if (source.image.get(x, y) === 0) {
+                if (source.image.get(x - 1, y) !== 0 || source.image.get(x, y - 1) !== 0 ||
+                    source.image.get(x + 1, y) !== 0 || source.image.get(x, y + 1) !== 0) {
+                    newImage.set(x, y, color);
+                }
+            }
+        }
+    }
+
+    const out = image.copy();
+    if (out.floating?.image) {
+        out.floating.image = newImage
+    }
+    else {
+        out.image = newImage;
+    }
+    return out;
+}


### PR DESCRIPTION
On Friday we did an art livestream and it reminded me of two keyboard shortcuts I've been meaning to add to the image editor forever. These are both very self contained and should be safe to include in the patch release

1. Outline image (image editor only): **ctrl + shift + [1-9a-f]**
This one outlines the current sprite in the color indicated by the number. Outlining sprites is a super tedious process to do by hand
![2022-01-14 15 58 39](https://user-images.githubusercontent.com/13754588/149999885-0221f289-1838-4e02-a3c3-d37eb260b1bf.gif)
2. Replace color/tile: **ctrl + shift + r**
Replaces the currently selected background color/tile with the currently selected foreground color/tile. Another super tedious thing to do by hand, especially for larger images with a lot of colors
![replace color](https://user-images.githubusercontent.com/13754588/149999733-4cc8df9f-2d8c-4c01-891d-15ce36724a6c.gif)