### PR TITLE
Properly extract the name of the yotta target for the directory path

### DIFF
--- a/cli/buildengine.ts
+++ b/cli/buildengine.ts
@@ -179,7 +179,7 @@ export function setThisBuild(b: BuildEngine) {
 
 function patchYottaHexInfo(extInfo: pxtc.ExtensionInfo) {
     let buildEngine = thisBuild
-    let hexPath = buildEngine.buildPath + "/build/" + pxt.appTarget.compileService.yottaTarget
+    let hexPath = buildEngine.buildPath + "/build/" + pxt.appTarget.compileService.yottaTarget.split("@")[0]
         + "/source/" + pxt.appTarget.compileService.yottaBinary;
 
     return {

--- a/cli/gdb.ts
+++ b/cli/gdb.ts
@@ -239,7 +239,7 @@ function codalBin() {
         return be.buildPath + "/" + be.outputPath
     if (cs.codalBinary)
         return be.buildPath + "/build/" + cs.codalBinary
-    return be.buildPath + "/build/" + cs.yottaTarget + "/source/" + cs.yottaBinary.replace(/\.hex$/, "").replace(/-combined$/, "")
+    return be.buildPath + "/build/" + (cs.yottaTarget.split("@")[0]) + "/source/" + cs.yottaBinary.replace(/\.hex$/, "").replace(/-combined$/, "")
 }
 
 let cachedMap = ""


### PR DESCRIPTION
RE: https://github.com/microsoft/pxt/issues/8650

@Amerlander try giving this branch a shot.

Also for the docker image, you can try using `pext/yotta:update-yotta3` instead of `pext/yotta:latest`. Let me know if this works locally for you, and I'll update our compile service.