### PR TITLE
Suggested fix for tutorial docs headings

### DIFF
--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -441,7 +441,6 @@ namespace pxt.docs {
             // remove tutorial macros
             if (text)
                 text = text.replace(/@(fullscreen|unplugged|showdialog|showhint)/gi, '');
-            text = text.trim();
             // remove brackets for hiding step title
             if (text.match(/\{([\s\S]+)\}/))
                 text = text.substr(1, text.length - 2).trim()

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -437,16 +437,17 @@ namespace pxt.docs {
             if (m) {
                 text = m[1]
                 id = m[2]
-            } else {
-                id = raw.toLowerCase().replace(/[^\w]+/g, '-')
             }
             // remove tutorial macros
             if (text)
                 text = text.replace(/@(fullscreen|unplugged|showdialog|showhint)/gi, '');
             text = text.trim();
             // remove brackets for hiding step title
-            if (text.match(/^\{([\s\S]+)\}$/))
-                text = text.substr(1, text.length - 2);
+            if (text.match(/\{([\s\S]+)\}/))
+                text = text.substr(1, text.length - 2).trim()
+            if (id === "") {
+                id = text.toLowerCase().replace(/[^\w]+/g, '-')
+            }
             return `<h${level} id="${(this as any).options.headerPrefix}${id}">${text}</h${level}>`
         }
     }

--- a/pxtlib/docsrender.ts
+++ b/pxtlib/docsrender.ts
@@ -443,7 +443,7 @@ namespace pxt.docs {
                 text = text.replace(/@(fullscreen|unplugged|showdialog|showhint)/gi, '');
             // remove brackets for hiding step title
             if (text.match(/\{([\s\S]+)\}/))
-                text = text.substr(1, text.length - 2).trim()
+                text = text.match(/\{([\s\S]+)\}/)[1].trim()
             if (id === "") {
                 id = text.toLowerCase().replace(/[^\w]+/g, '-')
             }


### PR DESCRIPTION
The braces on the tutorial doc headings aren't removed when served from azure. I suspect there is a difference in the behavior of `string.trim()`. Here is a suggested fix for `render.heading` to address this. An additional change is in there to better form the header id's as well.

Fixes #8670