### PR TITLE
Fix asset editor modal high contrast, z-index

### DIFF
--- a/react-common/components/controls/Modal.tsx
+++ b/react-common/components/controls/Modal.tsx
@@ -24,7 +24,7 @@ export interface ModalProps extends ContainerProps {
     actions?: ModalAction[];
     onClose?: () => void;
     fullscreen?: boolean;
-    parentElement?: HTMLElement;
+    parentElement?: Element;
 }
 
 export const Modal = (props: ModalProps) => {

--- a/react-common/components/controls/Modal.tsx
+++ b/react-common/components/controls/Modal.tsx
@@ -1,4 +1,5 @@
 import React = require("react");
+import ReactDOM = require("react-dom");
 import { classList, ContainerProps } from "../util";
 import { Button } from "./Button";
 import { FocusTrap } from "./FocusTrap";
@@ -23,6 +24,7 @@ export interface ModalProps extends ContainerProps {
     actions?: ModalAction[];
     onClose?: () => void;
     fullscreen?: boolean;
+    parentElement?: HTMLElement;
 }
 
 export const Modal = (props: ModalProps) => {
@@ -37,6 +39,7 @@ export const Modal = (props: ModalProps) => {
         title,
         actions,
         onClose,
+        parentElement,
         fullscreen
     } = props;
 
@@ -50,7 +53,7 @@ export const Modal = (props: ModalProps) => {
         className
     );
 
-    return <FocusTrap className={classes} onEscape={closeClickHandler}>
+    return ReactDOM.createPortal(<FocusTrap className={classes} onEscape={closeClickHandler}>
         <div id={id}
             className="common-modal"
             role={role || "dialog"}
@@ -104,5 +107,5 @@ export const Modal = (props: ModalProps) => {
                 </div>
             }
         </div>
-    </FocusTrap>
+    </FocusTrap>, parentElement || document.body)
 }

--- a/react-common/styles/controls/Button.less
+++ b/react-common/styles/controls/Button.less
@@ -180,13 +180,15 @@
  *                 High Contrast                    *
  ****************************************************/
 
-.high-contrast .common-button {
-    color: @highContrastTextColor !important;
-    background: @highContrastBackgroundColor !important;
-    border-color: @highContrastTextColor !important;
+.high-contrast, .hc {
+    .common-button {
+        color: @highContrastTextColor !important;
+        background: @highContrastBackgroundColor !important;
+        border-color: @highContrastTextColor !important;
 
-    &:hover, &:focus {
-        outline: @highContrastFocusOutline !important;
-        z-index: @highContrastFocusZIndex;
+        &:hover, &:focus {
+            outline: @highContrastFocusOutline !important;
+            z-index: @highContrastFocusZIndex;
+        }
     }
 }

--- a/react-common/styles/controls/Modal.less
+++ b/react-common/styles/controls/Modal.less
@@ -8,7 +8,7 @@
     right: 0;
     bottom: 0;
     background-color: var(--modal-overlay-color);
-    z-index: var(--modal-dimmer-zindex);
+    z-index: @modalDimmerZIndex;
 }
 
 .common-modal-container.fullscreen {
@@ -108,7 +108,7 @@
  *                 High Contrast                    *
  ****************************************************/
 
-.high-contrast {
+.high-contrast, .hc {
     .common-modal-header,
     .common-modal-body,
     .common-modal-footer {

--- a/react-common/styles/react-common-variables.less
+++ b/react-common/styles/react-common-variables.less
@@ -28,6 +28,7 @@
 @modalHeaderBackgroundColor: @modalBodyBackgroundColor;
 @modalFooterBackgroundColor: #f9fafb;
 @modalSeparatorBorder: 1px solid rgba(34, 36, 38, .15);
+@modalDimmerZIndex: 1000;
 
 
 /****************************************************

--- a/skillmap/src/components/UserProfile.tsx
+++ b/skillmap/src/components/UserProfile.tsx
@@ -50,7 +50,11 @@ export class UserProfileImpl extends React.Component<UserProfileProps, UserProfi
         const { profile, preferences } = this.props;
         const { notification, modal, emailSelected } = this.state;
 
-        return <Modal title={profile?.idp?.displayName || ""} fullscreen={true} onClose={this.handleOnClose}>
+        return <Modal
+            title={profile?.idp?.displayName || ""}
+            fullscreen={true}
+            onClose={this.handleOnClose}
+            parentElement={document.querySelector(".app-container") || undefined}>
                 <Profile
                     user={{profile, preferences}}
                     signOut={this.handleSignout}

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -675,7 +675,8 @@
     #assetEditor {
         .asset-editor-sidebar,
         .asset-editor-sidebar-preview,
-        .asset-editor-preview {
+        .asset-editor-preview,
+        .asset-editor-sidebar-temp {
             color: @HCtextColor;
             background-color: @HCbackground;
             border-color: @HCtextColor;
@@ -691,7 +692,10 @@
             border-bottom: 1px solid @HCtextColor;
         }
 
-        .asset-editor-button,
+        .common-button {
+            border: 1px solid;
+        }
+
         .asset-editor-card,
         .create-new {
             color: @HCtextColor;
@@ -704,10 +708,7 @@
             color: @HCbackground;
         }
 
-        .delete-asset {
-            border: 1px solid @red;
-        }
-
+        .asset-editor-card.selected,
         .asset-editor-gallery-tab.selected,
         .asset-editor-button:hover,
         .create-new:hover {

--- a/webapp/src/components/assetEditor/assetGallery.tsx
+++ b/webapp/src/components/assetEditor/assetGallery.tsx
@@ -124,7 +124,8 @@ class AssetGalleryImpl extends React.Component<AssetGalleryProps, AssetGallerySt
             {showCreateModal && <Modal
                 className="asset-editor-create-dialog"
                 onClose={this.hideCreateModal}
-                title={lf("Create New Asset")}>
+                title={lf("Create New Asset")}
+                parentElement={document.getElementById("root")}>
                 <div>{lf("Choose your asset type from the options below:")}</div>
                 <List className="asset-editor-create-options">{
                     this.assetCreateOptions.map((opt, i) => {

--- a/webapp/src/components/assetEditor/assetSidebar.tsx
+++ b/webapp/src/components/assetEditor/assetSidebar.tsx
@@ -223,7 +223,8 @@ class AssetSidebarImpl extends React.Component<AssetSidebarProps, AssetSidebarSt
                 className="asset-editor-delete-dialog"
                 onClose={this.hideDeleteModal}
                 title={lf("Delete Asset")}
-                actions={actions}>
+                actions={actions}
+                parentElement={document.getElementById("root")}>
                 <div>{lf("Are you sure you want to delete {0}? Deleted assets cannot be recovered.", name)}</div>
             </Modal>}
         </div>


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4544
fixes https://github.com/microsoft/pxt-arcade/issues/4549 

general CSS fixes for high contrast, updates the modal component to use a react portal so that we can render it at the root of the DOM

there's another issue with fontawesome icons not showing up in the webapp (looks like the font isn't included somehow?) which i'm still investigating