### PR TITLE
Skillmap activities 'Keep Code' by default, add 'Replace my code' to tutorial pane

### DIFF
--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -1147,6 +1147,7 @@ declare namespace pxt.tutorial {
         jres?: string; // JRES to be used when generating hints; necessary for tilemaps
         customTs?: string; // custom typescript code loaded in a separate file for the tutorial
         tutorialValidationRules?: pxt.Map<boolean>; //a map of rules used in a tutorial and if the rules are activated
+        templateLoaded?: boolean; // if the template code has been loaded once, we skip
     }
     interface TutorialCompletionInfo {
         // id of the tutorial

--- a/pxtblocks/blocklyimporter.ts
+++ b/pxtblocks/blocklyimporter.ts
@@ -39,7 +39,7 @@ namespace pxt.blocks {
                 if (/@highlight/.test(c)) {
                     const cc = c.replace(/@highlight/g, '').trim();
                     b.setCommentText(cc || null);
-                    (workspace as Blockly.WorkspaceSvg).highlightBlock(b.id)
+                    (workspace as Blockly.WorkspaceSvg).highlightBlock?.(b.id)
                 }
             });
     }

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -1583,6 +1583,17 @@ namespace pxt.blocks {
                 options.push(screenshotOption);
             }
 
+            if (pxt.appTarget.appTheme.workspaceSearch) {
+                options.push({
+                    text: lf("Find..."),
+                    enabled: topBlocks.length > 0,
+                    callback: () => {
+                        pxt.tickEvent("blocks.context.workspacesearch", undefined, { interactiveConsent: true });
+                        this.getComponentManager()?.getComponent("workspaceSearch")?.open();
+                    }
+                });
+            }
+
             // custom options...
             if (onShowContextMenu)
                 onShowContextMenu(this, options);

--- a/pxteditor/editor.ts
+++ b/pxteditor/editor.ts
@@ -225,6 +225,7 @@ namespace pxt.editor {
         openProjectByHeaderIdAsync(headerId: string): Promise<void>;
         overrideTypescriptFile(text: string): void;
         overrideBlocksFile(text: string): void;
+        resetTutorialTemplateCode(keepAssets: boolean): Promise<void>;
 
         exportAsync(): Promise<string>;
 

--- a/skillmap/src/components/ActivityActions.tsx
+++ b/skillmap/src/components/ActivityActions.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { connect } from 'react-redux';
 
-import { dispatchOpenActivity, dispatchShowRestartActivityWarning, dispatchShowShareModal, dispatchShowCarryoverModal, dispatchShowLoginModal } from '../actions/dispatch';
+import { dispatchOpenActivity, dispatchShowRestartActivityWarning, dispatchShowShareModal, dispatchRestartActivity, dispatchShowLoginModal } from '../actions/dispatch';
 
-import { ActivityStatus, isCodeCarryoverEnabled } from '../lib/skillMapUtils';
+import { ActivityStatus, isCodeCarryoverEnabled, lookupPreviousCompletedActivityState } from '../lib/skillMapUtils';
 import { tickEvent } from '../lib/browserUtils';
 import { editorUrl } from "./makecodeFrame";
 import { SkillMapState } from "../store/reducer";
@@ -15,6 +15,7 @@ interface OwnProps {
     activityId: string;
     status?: ActivityStatus;
     completedHeaderId?: string;
+    previousHeaderId?: string;
     showCodeCarryoverModal?: boolean;
     signedIn?: boolean;
 }
@@ -23,7 +24,7 @@ interface DispatchProps {
     dispatchOpenActivity: (mapId: string, activityId: string) => void;
     dispatchShowRestartActivityWarning: (mapId: string, activityId: string) => void;
     dispatchShowShareModal: (mapId: string, activityId: string) => void;
-    dispatchShowCarryoverModal: (mapId: string, activityId: string) => void;
+    dispatchRestartActivity: (mapId: string, activityId: string, previousHeaderId?: string, carryoverCode?: boolean) => void;
     dispatchShowLoginModal: () => void;
 }
 
@@ -50,7 +51,8 @@ export class ActivityActionsImpl extends React.Component<ActivityActionsProps> {
     }
 
     protected handleActionButtonClick = () => {
-        const { status, mapId, activityId, dispatchOpenActivity, dispatchShowCarryoverModal, showCodeCarryoverModal } = this.props;
+        const { status, mapId, activityId, previousHeaderId,
+            dispatchOpenActivity, dispatchRestartActivity, showCodeCarryoverModal } = this.props;
 
         if (status === "locked") return;
 
@@ -58,7 +60,7 @@ export class ActivityActionsImpl extends React.Component<ActivityActionsProps> {
         switch (status) {
             case "notstarted":
                 if (showCodeCarryoverModal) {
-                    dispatchShowCarryoverModal(mapId, activityId);
+                    dispatchRestartActivity(mapId, activityId, previousHeaderId, !!previousHeaderId);
                 } else {
                     dispatchOpenActivity(mapId, activityId);
                 }
@@ -164,7 +166,10 @@ function mapStateToProps(state: SkillMapState, ownProps: any) {
     const props = ownProps as OwnProps;
     const map = state.maps[props.mapId];
     const activity = map.activities[props.activityId] as MapActivity;
+    const previousState = lookupPreviousCompletedActivityState(state.user, state.pageSourceUrl, map, props.activityId);
+
     return {
+        previousHeaderId: previousState?.headerId,
         showCodeCarryoverModal: isCodeCarryoverEnabled(state.user, state.pageSourceUrl, map, activity),
         signedIn: state.auth.signedIn
     };
@@ -174,7 +179,7 @@ const mapDispatchToProps = {
     dispatchOpenActivity,
     dispatchShowRestartActivityWarning,
     dispatchShowShareModal,
-    dispatchShowCarryoverModal,
+    dispatchRestartActivity,
     dispatchShowLoginModal
 }
 

--- a/skillmap/src/components/AppModal.tsx
+++ b/skillmap/src/components/AppModal.tsx
@@ -223,7 +223,7 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
     }
 
     renderRestartWarning() {
-        const  { mapId, activity, dispatchRestartActivity, showCodeCarryoverModal, dispatchShowCarryoverModal } = this.props;
+        const  { userState, pageSourceUrl, skillMap, mapId, activity, dispatchRestartActivity, showCodeCarryoverModal, dispatchShowCarryoverModal } = this.props;
         const restartModalTitle = lf("Restart Activity?");
         const restartModalText = lf("Are you sure you want to restart {0}? You won't lose your path progress but the code you have written for this activity will be deleted.", "{0}");
         const restartModalTextSegments = restartModalText.split("{0}");
@@ -232,8 +232,12 @@ export class AppModalImpl extends React.Component<AppModalProps, AppModalState> 
             { label: lf("CANCEL"), onClick: this.handleOnClose },
             { label: lf("RESTART"), onClick: () => {
                 tickEvent("skillmap.activity.restart", { path: mapId, activity: activity!.activityId });
-                if (showCodeCarryoverModal) dispatchShowCarryoverModal(mapId, activity!.activityId);
-                else dispatchRestartActivity(mapId, activity!.activityId);
+                if (showCodeCarryoverModal) {
+                    const previousState = lookupPreviousCompletedActivityState(userState!, pageSourceUrl!, skillMap!, activity!.activityId);
+                    dispatchRestartActivity(mapId, activity!.activityId, previousState.headerId, !!previousState.headerId);
+                } else {
+                    dispatchRestartActivity(mapId, activity!.activityId);
+                }
             }}
         ]
 

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -3,11 +3,12 @@ import { connect } from 'react-redux';
 
 import { SkillMapState } from '../store/reducer';
 import { dispatchChangeSelectedItem, dispatchShowCompletionModal,
-    dispatchSetSkillMapCompleted, dispatchOpenActivity, dispatchShowCarryoverModal } from '../actions/dispatch';
+    dispatchSetSkillMapCompleted, dispatchOpenActivity, dispatchRestartActivity } from '../actions/dispatch';
 import { GraphNode } from './GraphNode';
 import { GraphPath } from "./GraphPath";
 
-import { getActivityStatus, isCodeCarryoverEnabled, lookupActivityProgress } from '../lib/skillMapUtils';
+import { getActivityStatus, isCodeCarryoverEnabled, lookupActivityProgress,
+    lookupPreviousCompletedActivityState } from '../lib/skillMapUtils';
 import { SvgGraphItem, SvgGraphPath } from '../lib/skillGraphUtils';
 import { tickEvent } from "../lib/browserUtils";
 
@@ -32,7 +33,7 @@ export interface SkillGraphProps {
     dispatchShowCompletionModal: (mapId: string, activityId?: string) => void;
     dispatchSetSkillMapCompleted: (mapId: string) => void;
     dispatchOpenActivity: (mapId: string, activityId: string) => void;
-    dispatchShowCarryoverModal: (mapId: string, activityId: string) => void;
+    dispatchRestartActivity: (mapId: string, activityId: string, previousHeaderId?: string, carryoverCode?: boolean) => void;
 }
 
 class SkillGraphImpl extends React.Component<SkillGraphProps> {
@@ -61,14 +62,16 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
     }
 
     protected onItemDoubleClick = (activityId: string, kind: MapNodeKind) => {
-        const { user, pageSourceUrl, map, dispatchOpenActivity, dispatchShowCarryoverModal } = this.props;
+        const { user, pageSourceUrl, map, dispatchOpenActivity, dispatchRestartActivity } = this.props;
         const { status } = getActivityStatus(user, pageSourceUrl, map, activityId);
         const activity = map.activities[activityId];
         tickEvent("skillmap.activity.open.doubleclick", { path: map.mapId, activity: activityId, status: status || "" });
 
         const progress = lookupActivityProgress(user, pageSourceUrl, map.mapId, activity.activityId);
+        const previousState = lookupPreviousCompletedActivityState(user, pageSourceUrl, map, activity.activityId);
+
         if (isCodeCarryoverEnabled(user, pageSourceUrl, map, activity) && !progress?.headerId) {
-            dispatchShowCarryoverModal(map.mapId, activityId);
+            dispatchRestartActivity(map.mapId, activityId, previousState.headerId, !!previousState.headerId);
         } else if (kind == "activity" && status !== "locked") {
             dispatchOpenActivity(map.mapId, activityId);
         }
@@ -131,7 +134,7 @@ const mapDispatchToProps = {
     dispatchShowCompletionModal,
     dispatchSetSkillMapCompleted,
     dispatchOpenActivity,
-    dispatchShowCarryoverModal
+    dispatchRestartActivity
 };
 
 export const SkillGraph = connect(mapStateToProps, mapDispatchToProps)(SkillGraphImpl);

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -819,7 +819,7 @@
         }
     }
 
-    .tutorialhint {
+    .tutorialhint, .tutorial-hint .tutorial-callout {
         border-color: @HCtextColor;
         background-color: @HCbackground;
         color: @HCtextColor;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -541,8 +541,6 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            width: 4rem;
-            height: unset;
             margin: 0;
             font-size: 1rem;
 
@@ -550,7 +548,6 @@
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                margin-bottom: 0.5rem!important;
                 font-size: 2rem;
             }
 
@@ -575,6 +572,10 @@
         }
     }
 
+    .tutorial-container > .ui.button i.icon {
+        margin-bottom: 0.5rem!important;
+    }
+
     /*******************************
             Tutorial Hint
     *******************************/
@@ -586,7 +587,6 @@
     }
 
     .tutorial-hint .tutorial-callout-button.ui.button {
-        border-radius: 0.2rem;
         color: @tutorialPrimaryColor;
         background: @tutorialSecondaryColor;
         margin: 1rem;
@@ -621,8 +621,9 @@
 
     .tutorial-replace-code {
         position: absolute;
-        right: 5rem;
+        right: 4.5rem;
         bottom: -0.5rem;
+        width: 4rem;
 
         .tutorial-callout {
             top: 22.5rem;
@@ -632,6 +633,10 @@
         .tutorial-replace-code-actions .ui.button {
             width: unset;
         }
+    }
+
+    .tutorial-replace-code + .tutorial-controls > .tutorial-hint {
+        width: 5rem;
     }
 
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -62,8 +62,12 @@
     position: absolute;
     height: 3rem;
     width: calc(~'100% - 1rem');
-    bottom: 9rem;
+    bottom: 6rem;
     background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), @white);
+}
+
+.tutorial-replace-code + .tutorial-scroll-gradient {
+    bottom: 9rem;
 }
 
 .tutorial-container,
@@ -305,7 +309,7 @@
         color: #0064BF;
         background: none transparent;
         font-family: 'Segoe UI', Roboto, 'Open Sans', 'Helvetica Neue', sans-serif;
-        font-weight: 300;
+        font-weight: 500;
     }
 
     .tutorial-callout-button.ui.button:hover,
@@ -316,6 +320,7 @@
     .tutorial-callout {
         bottom: 13.5rem;
         padding: 1rem;
+        max-width: 32rem;
     }
 
     .tutorial-replace-code-actions {
@@ -470,6 +475,7 @@
         padding: 1rem;
     }
 
+    .tutorial-replace-code + .tutorial-scroll-gradient,
     .tutorial-scroll-gradient {
         width: calc(~'100% - 15rem');
         bottom: 0;
@@ -618,6 +624,7 @@
 
         .tutorial-callout {
             top: 22.5rem;
+            max-width: 32rem;
         }
 
         .tutorial-replace-code-actions .ui.button {

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -188,7 +188,7 @@
         Tutorial Hint
 *******************************/
 
-.tutorial-hint.ui.button {
+.tutorial-hint .ui.button {
     height: 3.2rem;
     width: 3.2rem;
     margin: 0;
@@ -196,8 +196,8 @@
     font-size: @tutorialTitleFontSize;
 }
 
-.tutorial-hint.ui.button,
-.tutorial-hint.ui.button > i {
+.tutorial-hint .ui.button,
+.tutorial-hint .ui.button > i {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -205,7 +205,7 @@
 
 // Overrides, largely using old tutorial hint CSS
 .tab-tutorial {
-    .tutorialhint {
+    .tutorial-hint .tutorial-callout {
         position: fixed;
         top: unset;
         right: unset;
@@ -214,7 +214,7 @@
         max-width: 50%;
     }
 
-    .tutorialhint:before {
+    .tutorial-hint .tutorial-callout:before {
         top: auto;
         left: 6.5rem;
         bottom: -2.5rem;
@@ -222,7 +222,7 @@
     }
 }
 
-.tutorial-hint-mask {
+.tutorial-callout-mask {
     position: fixed;
     top: 0;
     left: 0;
@@ -526,7 +526,7 @@
         margin: 0;
     }
 
-    .tutorial-hint.ui.button {
+    .tutorial-hint .tutorial-callout-button.ui.button {
         border-radius: 0.2rem;
         color: @tutorialPrimaryColor;
         background: @tutorialSecondaryColor;
@@ -539,7 +539,7 @@
 
     // Overrides
     .tab-tutorial {
-        .tutorialhint {
+        .tutorial-hint .tutorial-callout {
             top: 18.5rem;
             right: 1.6rem;
             bottom: unset;
@@ -547,7 +547,7 @@
             max-width: 80%;
         }
 
-        .tutorialhint:before {
+        .tutorial-hint .tutorial-callout:before {
             top: -2.5rem;
             left: unset;
             bottom: auto;
@@ -639,7 +639,7 @@
             background-color: @tutorialPrimaryColor;
         }
 
-        .tutorial-hint.ui.button {
+        .tutorial-hint .tutorial-callout-button.ui.button {
             flex-direction: row;
             width: 12rem;
             margin: 3.5rem 1rem 0;

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -62,7 +62,7 @@
     position: absolute;
     height: 3rem;
     width: calc(~'100% - 1rem');
-    bottom: 6rem;
+    bottom: 9rem;
     background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), @white);
 }
 
@@ -205,7 +205,7 @@
 
 // Overrides, largely using old tutorial hint CSS
 .tab-tutorial {
-    .tutorial-hint .tutorial-callout {
+    .tutorial-callout {
         position: fixed;
         top: unset;
         right: unset;
@@ -214,11 +214,28 @@
         max-width: 50%;
     }
 
-    .tutorial-hint .tutorial-callout:before {
+    .tutorial-callout:before {
         top: auto;
         left: 6.5rem;
         bottom: -2.5rem;
         transform: rotate(-90deg);
+    }
+
+    .tutorial-callout-close.ui.button {
+        position: absolute;
+        right: 1rem;
+        padding: 0;
+        width: 1.5rem;
+        height: 1.5rem;
+        color: @white;
+        background-color: #000;
+        border-radius: 50%;
+
+        i.icon {
+            opacity: 1;
+            font-size: 1rem;
+            margin: 0 !important;
+        }
     }
 }
 
@@ -273,6 +290,40 @@
     left: 0.75rem;
     border-bottom: 2px solid @tutorialPrimaryColor;
 }
+
+/*******************************
+    Tutorial Replace Code
+*******************************/
+.tutorial-replace-code {
+    display: flex;
+    justify-content: center;
+    font-family: 'Segoe UI', Roboto, 'Open Sans', 'Helvetica Neue', sans-serif;
+
+    .tutorial-callout-button.ui.button {
+        padding: 0;
+        margin: 0 0 2rem;
+        color: #0064BF;
+        background: none transparent;
+        font-family: 'Segoe UI', Roboto, 'Open Sans', 'Helvetica Neue', sans-serif;
+        font-weight: 300;
+    }
+
+    .tutorial-callout-button.ui.button:hover,
+    .tutorial-callout-button.ui.button:focus {
+        color: #003C94;
+    }
+
+    .tutorial-callout {
+        bottom: 13.5rem;
+        padding: 1rem;
+    }
+
+    .tutorial-replace-code-actions {
+        display: flex;
+        justify-content: flex-end;
+    }
+}
+
 
 /*******************************
         Simulator Tab
@@ -539,7 +590,7 @@
 
     // Overrides
     .tab-tutorial {
-        .tutorial-hint .tutorial-callout {
+        .tutorial-callout {
             top: 18.5rem;
             right: 1.6rem;
             bottom: unset;
@@ -547,12 +598,30 @@
             max-width: 80%;
         }
 
-        .tutorial-hint .tutorial-callout:before {
+        .tutorial-callout:before {
             top: -2.5rem;
             left: unset;
             bottom: auto;
             right: 4rem;
             transform: rotate(90deg);
+        }
+    }
+
+    /*******************************
+         Tutorial Replace Code
+    *******************************/
+
+    .tutorial-replace-code {
+        position: absolute;
+        right: 5rem;
+        bottom: -0.5rem;
+
+        .tutorial-callout {
+            top: 22.5rem;
+        }
+
+        .tutorial-replace-code-actions .ui.button {
+            width: unset;
         }
     }
 

--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -4,6 +4,8 @@
 
 @tutorialPrimaryColor: @teal;
 @tutorialSecondaryColor: @blue;
+@tutorialLinkColor: #0064BF;
+@tutorialLinkHoverColor: #003C94;
 
 @tutorialTabletButtonColor: #f3f3f3;
 @tutorialTabletSimulatorButtonColor: rgba(0, 0, 0, 0.05);
@@ -301,20 +303,20 @@
 .tutorial-replace-code {
     display: flex;
     justify-content: center;
-    font-family: 'Segoe UI', Roboto, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: @segoeUIFont;
 
     .tutorial-callout-button.ui.button {
         padding: 0;
         margin: 0 0 2rem;
-        color: #0064BF;
+        color: @tutorialLinkColor;
         background: none transparent;
-        font-family: 'Segoe UI', Roboto, 'Open Sans', 'Helvetica Neue', sans-serif;
+        font-family: @segoeUIFont;
         font-weight: 500;
     }
 
     .tutorial-callout-button.ui.button:hover,
     .tutorial-callout-button.ui.button:focus {
-        color: #003C94;
+        color: @tutorialLinkHoverColor;
     }
 
     .tutorial-callout {

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -170,7 +170,7 @@ body#docs.tutorial {
 
 #tutorialcard .tutorialmessage .content p,
 .tutorialhint p,
-.tutorial-hint .tutorial-callout p {
+.tutorial-callout p {
     line-height: 1.4em !important;
     color: @tutorialSegmentColor;
 }
@@ -224,14 +224,14 @@ body#docs.tutorial {
 @media only screen and (min-height: 400px) {
     .hintdialog .ui.segment .blocklyPreview,
     .tutorialhint .ui.segment .blocklyPreview,
-    .tutorial-hint .tutorial-callout .ui.segment .blocklyPreview {
+    .tutorial-callout .ui.segment .blocklyPreview {
         max-height: 45vh;
     }
 }
 
 @media only screen and (max-height: 800px) {
     .tutorialhint img,
-    .tutorial-hint .tutorial-callout img {
+    .tutorial-callout img {
         max-height: 30vh;
     }
 }
@@ -362,7 +362,7 @@ code.lang-filterblocks {
 }
 
 .tutorialhint,
-.tutorial-hint .tutorial-callout {
+.tutorial-callout {
     position: absolute;
     max-width: 100%;
     min-width: 300px;
@@ -377,7 +377,7 @@ code.lang-filterblocks {
 }
 
 .tutorialhint:before,
-.tutorial-hint .tutorial-callout:before {
+.tutorial-callout:before {
     content: ' ';
     position: absolute;
     width: 0;
@@ -391,18 +391,18 @@ code.lang-filterblocks {
 }
 
 .tutorialhint > div,
-.tutorial-hint .tutorial-callout > div {
+.tutorial-callout > div {
     max-height: 60vh;
     overflow: auto;
 }
 
 .tutorialhint.hidden,
-.tutorial-hint .tutorial-callout.hidden {
+.tutorial-callout.hidden {
     display: none;
 }
 
 .tutorialhint .lang-blocks .segment.raised,
-.tutorial-hint .tutorial-callout .lang-blocks .segment.raised {
+.tutorial-callout .lang-blocks .segment.raised {
     border: none;
     background: none;
     box-shadow: none;

--- a/theme/tutorial.less
+++ b/theme/tutorial.less
@@ -169,7 +169,8 @@ body#docs.tutorial {
 }
 
 #tutorialcard .tutorialmessage .content p,
-.tutorialhint p {
+.tutorialhint p,
+.tutorial-hint .tutorial-callout p {
     line-height: 1.4em !important;
     color: @tutorialSegmentColor;
 }
@@ -222,13 +223,15 @@ body#docs.tutorial {
 
 @media only screen and (min-height: 400px) {
     .hintdialog .ui.segment .blocklyPreview,
-    .tutorialhint .ui.segment .blocklyPreview {
+    .tutorialhint .ui.segment .blocklyPreview,
+    .tutorial-hint .tutorial-callout .ui.segment .blocklyPreview {
         max-height: 45vh;
     }
 }
 
 @media only screen and (max-height: 800px) {
-    .tutorialhint img {
+    .tutorialhint img,
+    .tutorial-hint .tutorial-callout img {
         max-height: 30vh;
     }
 }
@@ -358,7 +361,8 @@ code.lang-filterblocks {
     }
 }
 
-.tutorialhint {
+.tutorialhint,
+.tutorial-hint .tutorial-callout {
     position: absolute;
     max-width: 100%;
     min-width: 300px;
@@ -372,7 +376,8 @@ code.lang-filterblocks {
     box-shadow: 0px 0px 8px 1px rgba(0, 0, 0, .3);
 }
 
-.tutorialhint:before {
+.tutorialhint:before,
+.tutorial-hint .tutorial-callout:before {
     content: ' ';
     position: absolute;
     width: 0;
@@ -385,16 +390,19 @@ code.lang-filterblocks {
     transform: rotateZ(-135deg);
 }
 
-.tutorialhint > div {
+.tutorialhint > div,
+.tutorial-hint .tutorial-callout > div {
     max-height: 60vh;
     overflow: auto;
 }
 
-.tutorialhint.hidden {
+.tutorialhint.hidden,
+.tutorial-hint .tutorial-callout.hidden {
     display: none;
 }
 
-.tutorialhint .lang-blocks .segment.raised {
+.tutorialhint .lang-blocks .segment.raised,
+.tutorial-hint .tutorial-callout .lang-blocks .segment.raised {
     border: none;
     background: none;
     box-shadow: none;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -70,7 +70,7 @@ import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 import { HintManager } from "./hinttooltip";
 import { CodeCardView } from "./codecard";
-import { mergeProjectCode } from "./mergeProjects";
+import { mergeProjectCode, appendTemporaryAssets } from "./mergeProjects";
 
 pxsim.util.injectPolyphils();
 
@@ -199,6 +199,7 @@ export class ProjectView
         this.completeTutorialAsync = this.completeTutorialAsync.bind(this);
         this.exitTutorial = this.exitTutorial.bind(this);
         this.setEditorOffset = this.setEditorOffset.bind(this);
+        this.resetTutorialTemplateCode = this.resetTutorialTemplateCode.bind(this);
         this.initSimulatorMessageHandlers();
 
         // add user hint IDs and callback to hint manager
@@ -1889,17 +1890,13 @@ export class ProjectView
         if (keepAssets) {
             // Convert all temporary assets to named assets before we load in the template
             let currentText = await workspace.getTextAsync(header.id);
-            let newText: pxt.workspace.ScriptText = mergeProjectCode(currentText, currentText, false);
-
-            for (const file of Object.keys(newText)) {
-                if (newText[file] !== undefined) {
-                    pkg.mainEditorPkg().setFile(file, newText[file]);
-                }
-            }
+            const imageJres = appendTemporaryAssets(currentText[pxt.MAIN_BLOCKS], currentText[pxt.IMAGES_JRES]);
+            pkg.mainEditorPkg().setFile(pxt.IMAGES_JRES, imageJres);
             await mainPkg.saveFilesAsync();
         }
 
         header.tutorial.templateLoaded = false;
+        delete header.tutorial.mergeHeaderId;
         await this.reloadHeaderAsync();
     }
 

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+
+import { Button } from "../../sui";
+
+interface TutorialCalloutProps extends React.PropsWithChildren<{}> {
+    className?: string;
+    buttonIcon?: string;
+    buttonLabel?: string;
+
+    onClick?: (visible: boolean) => void;
+}
+
+export function TutorialCallout(props: TutorialCalloutProps) {
+    const { children, className, buttonIcon, buttonLabel } = props;
+    const [ visible, setVisible ] = React.useState(false);
+
+    const captureEvent = (e: any) => {
+        e.preventDefault();
+        e.stopPropagation();
+        e.nativeEvent?.stopImmediatePropagation();
+    }
+
+    const closeCallout = (e: any) => {
+        document.removeEventListener("click", closeCallout);
+        setVisible(false);
+    }
+
+    const toggleCallout = () => {
+        if (!visible) {
+            document.addEventListener("click", closeCallout);
+        } else {
+            document.removeEventListener("click", closeCallout);
+        }
+        setVisible(!visible);
+    }
+
+    const handleButtonClick = () => {
+        const { onClick } = props;
+        if (onClick) onClick(visible);
+        toggleCallout();
+    }
+
+    return <div className={className}>
+        <Button icon={buttonIcon}
+            text={buttonLabel}
+            className="tutorial-callout-button"
+            disabled={!children}
+            onClick={children ? handleButtonClick : undefined} />
+        {visible && <div className={`tutorial-callout no-select`} onClick={captureEvent}>
+            {children}
+        </div>}
+        {visible && <div className="tutorial-callout-mask" onClick={closeCallout} />}
+    </div>
+
+}

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -47,6 +47,7 @@ export function TutorialCallout(props: TutorialCalloutProps) {
             disabled={!children}
             onClick={children ? handleButtonClick : undefined} />
         {visible && <div className={`tutorial-callout no-select`} onClick={captureEvent}>
+            <Button icon="close" className="tutorial-callout-close" onClick={closeCallout} />
             {children}
         </div>}
         {visible && <div className="tutorial-callout-mask" onClick={closeCallout} />}

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -146,7 +146,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         {showScrollGradient && <div className="tutorial-scroll-gradient" />}
         <div className="tutorial-controls">
             { layout === "vertical" && backButton }
-            <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} showLabel={layout === "horizontal"} />
+            <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} />
             { layout === "vertical" && nextButton }
         </div>
         {layout === "horizontal" && nextButton}

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -6,6 +6,7 @@ import { Button, Modal, ModalButton } from "../../sui";
 import { ImmersiveReaderButton, launchImmersiveReader } from "../../immersivereader";
 import { TutorialStepCounter } from "./TutorialStepCounter";
 import { TutorialHint } from "./TutorialHint";
+import { TutorialCallout } from "./TutorialCallout";
 
 interface TutorialContainerProps {
     parent: pxt.editor.IProjectView;
@@ -127,6 +128,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
         ? <Button icon="check circle" text={lf("Done")} onClick={onTutorialComplete} />
         : <Button icon="arrow circle right" disabled={!showNext} text={lf("Next")} onClick={tutorialStepNext} />;
 
+
     return <div className="tutorial-container">
         <div className="tutorial-top-bar">
             <TutorialStepCounter tutorialId={tutorialId} currentStep={visibleStep} totalSteps={steps.length} title={name} setTutorialStep={setCurrentStep} />
@@ -137,6 +139,14 @@ export function TutorialContainer(props: TutorialContainerProps) {
             {title && <div className="tutorial-title">{title}</div>}
             <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent}/>
         </div>
+        {<TutorialCallout buttonLabel={lf("Replace my code")} className="tutorial-replace-code">
+            <p>{lf("Did the code you're working with get off track? It happens.")}</p>
+            <p>{lf("Click below to replace your code with updated blocks.")}</p>
+            <p>{lf("This will delete all your current code blocks. Any custom images and tiles can still be found in the gallery under \"My Assets\"")}</p>
+            <div className="tutorial-replace-code-actions">
+                <Button className="primary" text={lf("Replace my code")} onClick={() => parent.resetTutorialTemplateCode(true)} />
+            </div>
+        </TutorialCallout>}
         <div className="tutorial-controls">
             { layout === "vertical" && backButton }
             <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} showLabel={layout === "horizontal"} />

--- a/webapp/src/components/tutorial/TutorialContainer.tsx
+++ b/webapp/src/components/tutorial/TutorialContainer.tsx
@@ -6,7 +6,7 @@ import { Button, Modal, ModalButton } from "../../sui";
 import { ImmersiveReaderButton, launchImmersiveReader } from "../../immersivereader";
 import { TutorialStepCounter } from "./TutorialStepCounter";
 import { TutorialHint } from "./TutorialHint";
-import { TutorialCallout } from "./TutorialCallout";
+import { TutorialResetCode } from "./TutorialResetCode";
 
 interface TutorialContainerProps {
     parent: pxt.editor.IProjectView;
@@ -15,6 +15,7 @@ interface TutorialContainerProps {
     steps: pxt.tutorial.TutorialStepInfo[];
     currentStep?: number;
     hideIteration?: boolean;
+    hasTemplate?: boolean;
 
     tutorialOptions?: pxt.tutorial.TutorialOptions; // TODO (shakao) pass in only necessary subset
 
@@ -27,7 +28,7 @@ const MIN_HEIGHT = 80;
 const MAX_HEIGHT = 194;
 
 export function TutorialContainer(props: TutorialContainerProps) {
-    const { parent, tutorialId, name, steps, hideIteration, tutorialOptions,
+    const { parent, tutorialId, name, steps, hideIteration, hasTemplate, tutorialOptions,
         onTutorialStepChange, onTutorialComplete, setParentHeight } = props;
     const [ currentStep, setCurrentStep ] = React.useState(props.currentStep || 0);
     const [ hideModal, setHideModal ] = React.useState(false);
@@ -85,6 +86,7 @@ export function TutorialContainer(props: TutorialContainerProps) {
 
     const isModal = currentStepInfo.showDialog;
     const visibleStep = isModal ? Math.min(currentStep + 1, steps.length - 1) : currentStep;
+    const firstNonModalStep = steps.findIndex(el => !el.showDialog);
     const title = steps[visibleStep].title;
     const markdown = steps[visibleStep].headerContentMd;
     const hintMarkdown = steps[visibleStep].hintContentMd;
@@ -139,21 +141,15 @@ export function TutorialContainer(props: TutorialContainerProps) {
             {title && <div className="tutorial-title">{title}</div>}
             <MarkedContent className="no-select" tabIndex={0} markdown={markdown} parent={parent}/>
         </div>
-        {<TutorialCallout buttonLabel={lf("Replace my code")} className="tutorial-replace-code">
-            <p>{lf("Did the code you're working with get off track? It happens.")}</p>
-            <p>{lf("Click below to replace your code with updated blocks.")}</p>
-            <p>{lf("This will delete all your current code blocks. Any custom images and tiles can still be found in the gallery under \"My Assets\"")}</p>
-            <div className="tutorial-replace-code-actions">
-                <Button className="primary" text={lf("Replace my code")} onClick={() => parent.resetTutorialTemplateCode(true)} />
-            </div>
-        </TutorialCallout>}
+        {hasTemplate && currentStep == firstNonModalStep &&
+            <TutorialResetCode tutorialId={tutorialId} currentStep={visibleStep} resetTemplateCode={parent.resetTutorialTemplateCode} />}
+        {showScrollGradient && <div className="tutorial-scroll-gradient" />}
         <div className="tutorial-controls">
             { layout === "vertical" && backButton }
             <TutorialHint tutorialId={tutorialId} currentStep={visibleStep} markdown={hintMarkdown} parent={parent} showLabel={layout === "horizontal"} />
             { layout === "vertical" && nextButton }
         </div>
         {layout === "horizontal" && nextButton}
-        {showScrollGradient && <div className="tutorial-scroll-gradient" />}
         {isModal && !hideModal && <Modal isOpen={isModal} closeIcon={false} header={currentStepInfo.title || name} buttons={modalActions}
             className="hintdialog" onClose={onModalClose} dimmer={true}
             longer={true} closeOnDimmerClick closeOnDocumentClick closeOnEscape>

--- a/webapp/src/components/tutorial/TutorialHint.tsx
+++ b/webapp/src/components/tutorial/TutorialHint.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import { Button } from "../../sui";
 import { MarkedContent } from "../../marked";
 import { TutorialCallout } from "./TutorialCallout";
 

--- a/webapp/src/components/tutorial/TutorialHint.tsx
+++ b/webapp/src/components/tutorial/TutorialHint.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { Button } from "../../sui";
 import { MarkedContent } from "../../marked";
+import { TutorialCallout } from "./TutorialCallout";
 
 interface TutorialHintProps {
     parent: pxt.editor.IProjectView;
@@ -15,36 +16,17 @@ interface TutorialHintProps {
 
 export function TutorialHint(props: TutorialHintProps) {
     const { parent, markdown, showLabel, tutorialId, currentStep } = props;
-    const [ visible, setVisible ] = React.useState(false);
 
-    const captureEvent = (e: any) => {
-        e.preventDefault();
-        e.stopPropagation();
-        e.nativeEvent?.stopImmediatePropagation();
-    }
-
-    const closeHint = (e: any) => {
-        document.removeEventListener("click", closeHint);
-        setVisible(false);
-    }
-
-    const toggleHint = () => {
+    const onHintClick = (visible: boolean) => {
         if (!visible) {
             pxt.tickEvent(`tutorial.showhint`, { tutorial: tutorialId, step: currentStep });
-            document.addEventListener("click", closeHint);
-        } else {
-            document.removeEventListener("click", closeHint);
         }
-        setVisible(!visible);
     }
 
-    return <div className="tutorial-hint-container">
-        <Button icon="lightbulb" text={showLabel ? lf("Hint") : undefined} className="tutorial-hint"
-            disabled={!markdown} onClick={markdown ? toggleHint : undefined} />
-        {visible && <div className={`tutorialhint no-select`} onClick={captureEvent}>
-            <MarkedContent markdown={markdown} unboxSnippets={true} parent={parent} />
-        </div>}
-        {visible && <div className="tutorial-hint-mask" onClick={closeHint} />}
-    </div>
-
+    return <TutorialCallout className="tutorial-hint"
+            buttonLabel={showLabel ? lf("Hint") : undefined}
+            buttonIcon="lightbulb"
+            onClick={onHintClick}>
+                {markdown && <MarkedContent markdown={markdown} unboxSnippets={true} parent={parent} />}
+        </TutorialCallout>
 }

--- a/webapp/src/components/tutorial/TutorialHint.tsx
+++ b/webapp/src/components/tutorial/TutorialHint.tsx
@@ -6,7 +6,6 @@ import { TutorialCallout } from "./TutorialCallout";
 interface TutorialHintProps {
     parent: pxt.editor.IProjectView;
     markdown: string;
-    showLabel?: boolean;
 
     // Telemetry data
     tutorialId: string;
@@ -14,7 +13,7 @@ interface TutorialHintProps {
 }
 
 export function TutorialHint(props: TutorialHintProps) {
-    const { parent, markdown, showLabel, tutorialId, currentStep } = props;
+    const { parent, markdown, tutorialId, currentStep } = props;
 
     const onHintClick = (visible: boolean) => {
         if (!visible) {
@@ -23,7 +22,6 @@ export function TutorialHint(props: TutorialHintProps) {
     }
 
     return <TutorialCallout className="tutorial-hint"
-            buttonLabel={showLabel ? lf("Hint") : undefined}
             buttonIcon="lightbulb"
             onClick={onHintClick}>
                 {markdown && <MarkedContent markdown={markdown} unboxSnippets={true} parent={parent} />}

--- a/webapp/src/components/tutorial/TutorialResetCode.tsx
+++ b/webapp/src/components/tutorial/TutorialResetCode.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { Button } from "../../sui";
+import { TutorialCallout } from "./TutorialCallout";
+
+interface TutorialResetCodeProps {
+    resetTemplateCode: (keepAssets: boolean) => void;
+
+    // Telemetry data
+    tutorialId: string;
+    currentStep: number;
+}
+
+export function TutorialResetCode(props: TutorialResetCodeProps) {
+    const { resetTemplateCode, tutorialId, currentStep } = props;
+
+    const onResetClick = () => {
+        pxt.tickEvent(`tutorial.resetcode`, { tutorial: tutorialId, step: currentStep });
+        resetTemplateCode(true);
+        document.dispatchEvent(new Event("click"));
+    }
+
+    return <TutorialCallout buttonLabel={lf("Replace my code")} className="tutorial-replace-code">
+        <p>{lf("Did the code you're working with get off track? It happens.")}</p>
+        <p>{lf("Click below to replace your code with updated blocks.")}</p>
+        <p>{lf("This will delete all your current code blocks. Any custom images and tiles can still be found in the gallery under \"My Assets\"")}</p>
+        <div className="tutorial-replace-code-actions">
+            <Button className="primary" text={lf("Replace my code")} onClick={onResetClick} />
+        </div>
+    </TutorialCallout>
+}

--- a/webapp/src/components/tutorial/TutorialResetCode.tsx
+++ b/webapp/src/components/tutorial/TutorialResetCode.tsx
@@ -23,7 +23,7 @@ export function TutorialResetCode(props: TutorialResetCodeProps) {
     return <TutorialCallout buttonLabel={lf("Replace my code")} className="tutorial-replace-code">
         <p>{lf("Did the code you're working with get off track? It happens.")}</p>
         <p>{lf("Click below to replace your code with updated blocks.")}</p>
-        <p>{lf("This will delete all your current code blocks. Any custom images and tiles can still be found in the gallery under \"My Assets\"")}</p>
+        <p>{lf("This will delete all your current code blocks. Any custom images and tiles can still be found in the gallery under \"My Assets\".")}</p>
         <div className="tutorial-replace-code-actions">
             <Button className="primary" text={lf("Replace my code")} onClick={onResetClick} />
         </div>

--- a/webapp/src/mergeProjects.ts
+++ b/webapp/src/mergeProjects.ts
@@ -181,7 +181,7 @@ function mergeJRES(previous: string, next: string) {
     return JSON.stringify(nextParsed);
 }
 
-function appendTemporaryAssets(blocks: string, assets: string) {
+export function appendTemporaryAssets(blocks: string, assets: string) {
     if (!blocks) return assets;
 
     let jres = pxt.U.jsonTryParse(assets) as pxt.Map<Partial<pxt.JRes> | string> || {};

--- a/webapp/src/sidepanel.tsx
+++ b/webapp/src/sidepanel.tsx
@@ -163,9 +163,17 @@ export class Sidepanel extends data.Component<SidepanelProps, SidepanelState> {
                     </div>}
                 </TabContent>}
                 {tutorialOptions && <TabContent name={TUTORIAL_TAB} icon="icon tasks" showBadge={activeTab !== TUTORIAL_TAB} onSelected={this.showTutorialTab} ariaLabel={lf("Open the tutorial tab")}>
-                    <TutorialContainer parent={parent} tutorialId={tutorialOptions.tutorial} name={tutorialOptions.tutorialName} steps={tutorialOptions.tutorialStepInfo}
-                        currentStep={tutorialOptions.tutorialStep} tutorialOptions={tutorialOptions} hideIteration={tutorialOptions.metadata?.hideIteration}
-                        onTutorialStepChange={onTutorialStepChange} onTutorialComplete={onTutorialComplete}
+                    <TutorialContainer
+                        parent={parent}
+                        tutorialId={tutorialOptions.tutorial}
+                        name={tutorialOptions.tutorialName}
+                        steps={tutorialOptions.tutorialStepInfo}
+                        currentStep={tutorialOptions.tutorialStep}
+                        tutorialOptions={tutorialOptions}
+                        hideIteration={tutorialOptions.metadata?.hideIteration}
+                        hasTemplate={!!tutorialOptions.templateCode}
+                        onTutorialStepChange={onTutorialStepChange}
+                        onTutorialComplete={onTutorialComplete}
                         setParentHeight={this.setComponentHeight} />
                 </TabContent>}
             </TabPane>


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4203

![image](https://user-images.githubusercontent.com/34112083/152212442-828a7039-92ad-4d08-b424-1069ac35f73c.png)

changes:
- add a TutorialCallout component that has the hint styling, so that we can reuse the bubble styles 
- adds the 'Replace my code' link and callout UI
- no longer deletes the template code from the header tutorialOptions; adds a 'templateLoaded' flag so that we can reload if necessary
- removes the keep code modal from the skillmap; always automatically carryover code

build: https://arcade.makecode.com/app/7cb86b6806a1f8147e41f0a59d907ca24aee0b15-694e1027e7--skillmap