### PR TITLE
Marquee resize fixes :)

### DIFF
--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -96,15 +96,15 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
         return <div ref="canvas-bounds" className={`image-editor-canvas ${isPortrait ? "portrait" : "landscape"}`} onContextMenu={this.preventContextMenu}>
             <div className="paint-container">
                 {!this.props.lightMode && <canvas ref="paint-surface-bg" className="paint-surface" />}
-                <canvas ref="paint-surface" className="paint-surface" />
+                <canvas ref="paint-surface" className="paint-surface main" />
                 {overlayLayers.map((layer, index) => {
                     return <canvas ref={`paint-surface-${layer.toString()}`} className={`paint-surface overlay ${!this.props.overlayEnabled ? 'hide' : ''}`} key={index} />
                 })}
                 <div ref="floating-layer-border" className="image-editor-floating-layer" />
-                <div ref="floating-layer-nw-corner" className="image-editor-floating-layer-corner"/>
-                <div ref="floating-layer-ne-corner" className="image-editor-floating-layer-corner"/>
-                <div ref="floating-layer-se-corner" className="image-editor-floating-layer-corner"/>
-                <div ref="floating-layer-sw-corner" className="image-editor-floating-layer-corner"/>
+                {!this.props.isTilemap && <div ref="floating-layer-nw-corner" className="image-editor-floating-layer-corner"/>}
+                {!this.props.isTilemap && <div ref="floating-layer-ne-corner" className="image-editor-floating-layer-corner"/>}
+                {!this.props.isTilemap && <div ref="floating-layer-se-corner" className="image-editor-floating-layer-corner"/>}
+                {!this.props.isTilemap && <div ref="floating-layer-sw-corner" className="image-editor-floating-layer-corner"/>}
             </div>
         </div>
     }
@@ -445,9 +445,8 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
 
             if (!this.cursorLocation || x !== this.cursorLocation[0] || y !== this.cursorLocation[1]) {
                 this.cursorLocation = [x, y, coord.clientX, coord.clientY];
-
                 if (this.hasHover)
-                    this.props.dispatchChangeCursorLocation((x < 0 || y < 0 || x >= this.imageWidth || y >= this.imageHeight) ? null : this.cursorLocation);
+                    this.props.dispatchChangeCursorLocation(this.cursorLocation);
 
                 if (!this.edit) this.redraw();
 
@@ -506,7 +505,7 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
     }
 
     protected updateEdit(x: number, y: number) {
-        if (this.edit && this.edit.inBounds(x, y)) {
+        if ((this.edit && this.edit.inBounds(x, y)) || (this.edit && this.isResizing)) {
             this.edit.update(x, y);
 
             this.redraw();
@@ -695,7 +694,8 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
         else {
             floatingRect.style.display = "none"
             cornerHandles.forEach(corner => {
-                corner.style.display = "none"
+                if (corner)
+                    corner.style.display = "none"
             })
         }
     }

--- a/webapp/src/components/ImageEditor/ImageCanvas.tsx
+++ b/webapp/src/components/ImageEditor/ImageCanvas.tsx
@@ -92,6 +92,7 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
     render() {
         const imageState = this.getImageState();
         const isPortrait = !imageState || (imageState.bitmap.height > imageState.bitmap.width);
+        const showResizeHandles = !this.props.isTilemap && this.props.tool == ImageEditorTool.Marquee;
 
         return <div ref="canvas-bounds" className={`image-editor-canvas ${isPortrait ? "portrait" : "landscape"}`} onContextMenu={this.preventContextMenu}>
             <div className="paint-container">
@@ -101,10 +102,10 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
                     return <canvas ref={`paint-surface-${layer.toString()}`} className={`paint-surface overlay ${!this.props.overlayEnabled ? 'hide' : ''}`} key={index} />
                 })}
                 <div ref="floating-layer-border" className="image-editor-floating-layer" />
-                {!this.props.isTilemap && <div ref="floating-layer-nw-corner" className="image-editor-floating-layer-corner"/>}
-                {!this.props.isTilemap && <div ref="floating-layer-ne-corner" className="image-editor-floating-layer-corner"/>}
-                {!this.props.isTilemap && <div ref="floating-layer-se-corner" className="image-editor-floating-layer-corner"/>}
-                {!this.props.isTilemap && <div ref="floating-layer-sw-corner" className="image-editor-floating-layer-corner"/>}
+                { showResizeHandles && <div ref="floating-layer-nw-corner" className="image-editor-floating-layer-corner"/>}
+                { showResizeHandles && <div ref="floating-layer-ne-corner" className="image-editor-floating-layer-corner"/>}
+                { showResizeHandles && <div ref="floating-layer-se-corner" className="image-editor-floating-layer-corner"/>}
+                { showResizeHandles && <div ref="floating-layer-sw-corner" className="image-editor-floating-layer-corner"/>}
             </div>
         </div>
     }
@@ -505,9 +506,8 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
     }
 
     protected updateEdit(x: number, y: number) {
-        if ((this.edit && this.edit.inBounds(x, y)) || (this.edit && this.isResizing)) {
+        if (this.edit && (this.edit.inBounds(x, y) || this.isResizing)) {
             this.edit.update(x, y);
-
             this.redraw();
         }
     }
@@ -662,33 +662,36 @@ export class ImageCanvasImpl extends React.Component<ImageCanvasProps, {}> imple
             floatingRect.style.borderRight = state.layerOffsetX + state.floating.image.width <= state.width ? "" : "none";
             floatingRect.style.borderBottom = state.layerOffsetY + state.floating.image.height <= state.height ? "" : "none";
 
-            const handleWidth = 16;
-            const borderThickness = 3;
+            const hasHandles = nwCorner != undefined;
+            if (hasHandles) {
+                const handleWidth = 16;
+                const borderThickness = 3;
 
-            if (!this.props.isTilemap) {
-                cornerHandles.forEach( corner => {
-                    corner.style.display = ""
-                    corner.style.width = handleWidth + "px";
-                    corner.style.height = handleWidth + "px";
-                    corner.style.border = borderThickness + "px solid black"
-                    corner.style.position = "absolute";
-                    corner.style.backgroundColor = "white";
-                })
-                nwCorner.style.left = (calcLeft - handleWidth ) + "px";
-                nwCorner.style.top = (calcTop - handleWidth) + "px";
-                nwCorner.style.cursor = "nw-resize"
+                if (!this.props.isTilemap) {
+                    cornerHandles.forEach( corner => {
+                        corner.style.display = ""
+                        corner.style.width = handleWidth + "px";
+                        corner.style.height = handleWidth + "px";
+                        corner.style.border = borderThickness + "px solid black"
+                        corner.style.position = "absolute";
+                        corner.style.backgroundColor = "white";
+                    })
+                    nwCorner.style.left = (calcLeft - handleWidth ) + "px";
+                    nwCorner.style.top = (calcTop - handleWidth) + "px";
+                    nwCorner.style.cursor = "nw-resize"
 
-                neCorner.style.left = (calcLeft + calcWidth) + "px";
-                neCorner.style.top = (calcTop - handleWidth) + "px";
-                neCorner.style.cursor = "ne-resize"
+                    neCorner.style.left = (calcLeft + calcWidth) + "px";
+                    neCorner.style.top = (calcTop - handleWidth) + "px";
+                    neCorner.style.cursor = "ne-resize"
 
-                seCorner.style.left = (calcLeft + calcWidth) + "px";
-                seCorner.style.top = (calcTop + calcHeight) + "px";
-                seCorner.style.cursor = "se-resize"
+                    seCorner.style.left = (calcLeft + calcWidth) + "px";
+                    seCorner.style.top = (calcTop + calcHeight) + "px";
+                    seCorner.style.cursor = "se-resize"
 
-                swCorner.style.left = (calcLeft - handleWidth) + "px";
-                swCorner.style.top = (calcTop + calcHeight) + "px";
-                swCorner.style.cursor = "sw-resize"
+                    swCorner.style.left = (calcLeft - handleWidth) + "px";
+                    swCorner.style.top = (calcTop + calcHeight) + "px";
+                    swCorner.style.cursor = "sw-resize"
+                }
             }
         }
         else {

--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -723,7 +723,13 @@ export class MarqueeEdit extends SelectionEdit {
                         farthestCorner = corners[i];
                     }
                 }
-                const canvas = document.getElementsByClassName("paint-surface")![0] as HTMLCanvasElement
+                const surfaces = document.getElementsByClassName("paint-surface")
+                let canvas: HTMLCanvasElement;
+                for (var i = 0; i < surfaces.length; i++) {
+                    if (surfaces[i].className.includes('main')) {
+                        canvas = surfaces[i] as HTMLCanvasElement
+                    }
+                }
                 const canvasLeft = canvas.getBoundingClientRect().left;
                 const canvasTop = canvas.getBoundingClientRect().top;
                 const canvasWidth = canvas.getBoundingClientRect().width;

--- a/webapp/src/components/ImageEditor/toolDefinitions.ts
+++ b/webapp/src/components/ImageEditor/toolDefinitions.ts
@@ -725,7 +725,7 @@ export class MarqueeEdit extends SelectionEdit {
                 }
                 const surfaces = document.getElementsByClassName("paint-surface")
                 let canvas: HTMLCanvasElement;
-                for (var i = 0; i < surfaces.length; i++) {
+                for (let i = 0; i < surfaces.length; i++) {
                     if (surfaces[i].className.includes('main')) {
                         canvas = surfaces[i] as HTMLCanvasElement
                     }


### PR DESCRIPTION
GROUP A
fixes https://github.com/microsoft/pxt-arcade/issues/4540
fixes https://github.com/microsoft/pxt-arcade/issues/4543
fixes https://github.com/microsoft/pxt-arcade/issues/4548

GROUP B
fixes https://github.com/microsoft/pxt-arcade/issues/4541

GROUP C
fixes https://github.com/microsoft/pxt-arcade/issues/4563

This PR fixes 3 things, and the first thing fixes all the bugs in GROUP A.

Group A's fix: The cursor wasn't registering anything when it moved off the canvas, so I allowed the cursor to be updated even if it was beyond the canvas.

Group B's fix: There's a bunch of control points and canvas surfaces being made when doing the tile editor within the tilemap editor. So I added some rules to only add control points if it's NOT the tilemap editor, and to pick the LAST main canvas surface so it can properly calculate the resize. Before it was null-ing out. I added a fix for Group C too where we don't show the handles when it's not the marquee tool too