### PR TITLE
Better aria labels/descriptions and fix nested modal focus

### DIFF
--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -28,6 +28,7 @@ export const Button = (props: ButtonProps) => {
         className,
         ariaLabel,
         ariaHidden,
+        ariaDescribedBy,
         ariaControls,
         ariaExpanded,
         ariaHasPopup,
@@ -74,7 +75,8 @@ export const Button = (props: ButtonProps) => {
             aria-expanded={ariaExpanded}
             aria-haspopup={ariaHasPopup as any}
             aria-posinset={ariaPosInSet}
-            aria-setsize={ariaSetSize}>
+            aria-setsize={ariaSetSize}
+            aria-describedby={ariaDescribedBy}>
                 <span className="common-button-flex">
                     {leftIcon && <i className={leftIcon} aria-hidden={true}/>}
                     <span className="common-button-label">

--- a/react-common/components/controls/FocusTrap.tsx
+++ b/react-common/components/controls/FocusTrap.tsx
@@ -23,6 +23,8 @@ export const FocusTrap = (props: FocusTrapProps) => {
 
     let container: HTMLDivElement;
 
+    const [stoleFocus, setStoleFocus] = React.useState(false);
+
     const getElements = () => {
         const all = nodeListToArray(
             includeOutsideTabOrder ? container.querySelectorAll(`[tabindex]`) :
@@ -36,8 +38,11 @@ export const FocusTrap = (props: FocusTrapProps) => {
         if (!ref) return;
         container = ref;
 
-        if (!dontStealFocus && !ref.contains(document.activeElement) && getElements().length) {
+        if (!dontStealFocus && !stoleFocus && !ref.contains(document.activeElement) && getElements().length) {
             container.focus();
+
+            // Only steal focus once
+            setStoleFocus(true);
         }
     }
 

--- a/react-common/components/profile/BadgeInfo.tsx
+++ b/react-common/components/profile/BadgeInfo.tsx
@@ -15,7 +15,7 @@ export const BadgeInfo = (props: BadgeInfoProps) => {
         <div className="profile-badge-info-image">
             <Badge badge={badge} disabled={!badge.timestamp} />
         </div>
-        <div className="profile-badge-info-item">
+        <div className="profile-badge-info-item" id={"profile-badge-info-" + badge.id}>
             <div className="profile-badge-info-header">
                 {lf("Awarded For:")}
             </div>
@@ -42,7 +42,14 @@ export const badgeDescription = (badge: pxt.auth.Badge) => {
         case "skillmap-completion":
             return <span>{jsxLF(
                 lf("Completing {0}"),
-                <a target="_blank" rel="noopener noreferrer" href={sourceURLToSkillmapURL(badge.sourceURL)}>{pxt.U.rlf(badge.title)}</a>
+                <a
+                    tabIndex={0}
+                    aria-labelledby={"profile-badge-info-" + badge.id}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={sourceURLToSkillmapURL(badge.sourceURL)}>
+                        {pxt.U.rlf(badge.title)}
+                </a>
             )}</span>
     }
 }

--- a/react-common/components/profile/BadgeList.tsx
+++ b/react-common/components/profile/BadgeList.tsx
@@ -33,7 +33,7 @@ export const BadgeList = (props: BadgeListProps) => {
     }
 
     return <div className="profile-badge-list">
-        <div className="profile-badge-header">
+        <div className="profile-badge-header" id="profile-badge-header">
             <span className="profile-badge-title">
                 {lf("Badges")}
             </span>
@@ -43,15 +43,15 @@ export const BadgeList = (props: BadgeListProps) => {
             </span>
         </div>
         <div className="profile-badges-scroller">
-            <div className="profile-badges">
-                <div className="profile-badges-background-container">
+            <div className="profile-badges" role="list" aria-labelledby="profile-badge-header">
+                <div className="profile-badges-background-container" aria-hidden="true">
                     <div className="profile-badges-background">
                         { bg }
                     </div>
                 </div>
                 { badges.map(badge =>
-                    <div className="profile-badge-and-title">
-                        <Badge key={badge.id}
+                    <div className="profile-badge-and-title" key={badge.id} role="listitem">
+                        <Badge
                             onClick={onBadgeClick}
                             badge={badge}
                             disabled={!unlocked[badge.id]}

--- a/react-common/components/profile/Profile.tsx
+++ b/react-common/components/profile/Profile.tsx
@@ -26,6 +26,11 @@ export const Profile = (props: ProfileProps) => {
             header: lf("{0} Badge", badge.title),
             size: "tiny",
             hasCloseIcon: true,
+            onClose: () => {
+                // Hack to support retrapping focus in the fullscreen modal that contains this element
+                const focusable = document.body.querySelector(".common-modal-container.fullscreen [tabindex]");
+                if (focusable) (focusable as HTMLElement).focus();
+            },
             jsx: <BadgeInfo badge={badge} />
         });
     }

--- a/react-common/components/profile/UserPane.tsx
+++ b/react-common/components/profile/UserPane.tsx
@@ -21,7 +21,7 @@ export const UserPane = (props: UserPaneProps) => {
     const emailLabel = <>
         {emailChecked === CheckboxStatus.Waiting ? <div className="common-spinner" /> : undefined}
         {lf("I would like to receive the MakeCode newsletter. ")}
-        <a href="https://makecode.com/privacy" target="_blank" rel="noopener noreferrer">{lf("View Privacy Statement")}</a>
+        <a href="https://makecode.com/privacy" target="_blank" rel="noopener noreferrer" tabIndex={0}>{lf("View Privacy Statement")}</a>
     </>
 
     return <div className="profile-user-pane">

--- a/react-common/components/types.d.ts
+++ b/react-common/components/types.d.ts
@@ -26,4 +26,5 @@ interface DialogOptions {
     confirmationText?: string;      // Display a text input the user must type to confirm.
     confirmationCheckbox?: string;  // Display a checkbox the user must check to confirm.
     confirmationGranted?: boolean;
+    onClose?: () => void;
 }

--- a/react-common/components/util.tsx
+++ b/react-common/components/util.tsx
@@ -5,6 +5,7 @@ export interface ControlProps {
     className?: string;
     ariaLabel?: string;
     ariaHidden?: boolean;
+    ariaDescribedBy?: string;
     role?: string;
 }
 

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -140,7 +140,7 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
         }
 
         const avatarElem = this.avatarPicUrl()
-            ? <div className="avatar"><img src={this.avatarPicUrl()} aria-hidden="true"/></div>
+            ? <div className="avatar"><img src={this.avatarPicUrl()} aria-hidden="true" alt={lf("Profile Image")}/></div>
             : undefined;
 
         const initialsElem = <span><div className="avatar-initials" aria-hidden="true">{pxt.auth.userInitials(profile)}</div></span>

--- a/skillmap/src/components/HeaderBar.tsx
+++ b/skillmap/src/components/HeaderBar.tsx
@@ -140,10 +140,10 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
         }
 
         const avatarElem = this.avatarPicUrl()
-            ? <div className="avatar"><img src={this.avatarPicUrl()} alt={lf("User Menu")}/></div>
+            ? <div className="avatar"><img src={this.avatarPicUrl()} aria-hidden="true"/></div>
             : undefined;
 
-        const initialsElem = <span><div className="avatar-initials">{pxt.auth.userInitials(profile)}</div></span>
+        const initialsElem = <span><div className="avatar-initials" aria-hidden="true">{pxt.auth.userInitials(profile)}</div></span>
 
         return <div className="user-menu">
             {signedIn
@@ -163,7 +163,7 @@ export class HeaderBarImpl extends React.Component<HeaderBarProps> {
         const settingItems = this.getSettingItems();
         const helpItems = this.getHelpItems();
 
-        return <MenuBar className="header">
+        return <MenuBar className="header" ariaLabel={lf("Header")}>
             <div className="header-left">
                 {this.getOrganizationLogo(appTheme)}
                 {this.getTargetLogo(appTheme)}

--- a/skillmap/src/components/SkillGraph.tsx
+++ b/skillmap/src/components/SkillGraph.tsx
@@ -98,10 +98,9 @@ class SkillGraphImpl extends React.Component<SkillGraphProps> {
             </g>
             {items.map((el, i) => {
                 return <GraphNode key={`graph-activity-${i}`}
-                    title={el.activity.displayName}
+                    node={el.activity}
                     theme={theme}
                     kind={el.activity.kind}
-                    activityId={el.activity.activityId}
                     position={el.position}
                     width={5 * unit}
                     selected={el.activity.activityId === selectedActivityId}

--- a/skillmap/src/components/SkillGraphContainer.tsx
+++ b/skillmap/src/components/SkillGraphContainer.tsx
@@ -72,7 +72,7 @@ export class SkillGraphContainerImpl extends React.Component<SkillGraphContainer
 
         return <div className="skill-graph-wrapper">
             <div className={`skill-graph-content ${useBackground ? "has-background" : ""}`}>
-                <MenuBar className="skill-graph-activities">
+                <MenuBar className="skill-graph-activities" ariaLabel={lf("Skill Map")}>
                     <svg viewBox={`-${widthDiff + padding} -${heightDiff + padding} ${width + padding * 2} ${height + padding * 2}`} preserveAspectRatio="xMidYMid meet">
                         {graphs.map((el, i) => {
                             translateY += el.height;

--- a/skillmap/src/components/UserProfile.tsx
+++ b/skillmap/src/components/UserProfile.tsx
@@ -51,7 +51,7 @@ export class UserProfileImpl extends React.Component<UserProfileProps, UserProfi
         const { notification, modal, emailSelected } = this.state;
 
         return <Modal
-            title={profile?.idp?.displayName || ""}
+            title={lf("My Profile")}
             fullscreen={true}
             onClose={this.handleOnClose}
             parentElement={document.querySelector(".app-container") || undefined}>
@@ -169,7 +169,10 @@ export class UserProfileImpl extends React.Component<UserProfileProps, UserProfi
     }
 
     closeModal = () => {
+        const onClose = this.state.modal?.onClose;
+
         this.setState({ modal: undefined });
+        if (onClose) onClose();
     }
 }
 

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -175,6 +175,7 @@ export interface DialogOptions {
     confirmationText?: string;      // Display a text input the user must type to confirm.
     confirmationCheckbox?: string;  // Display a checkbox the user must check to confirm.
     confirmationGranted?: boolean;
+    onClose?: () => void;
 }
 
 export function dialogAsync(options: DialogOptions): Promise<void> {

--- a/webapp/src/coretsx.tsx
+++ b/webapp/src/coretsx.tsx
@@ -42,6 +42,7 @@ export class CoreDialog extends React.Component<core.PromptOptions, CoreDialogSt
     close(result?: any) {
         this.setState({ visible: false });
         this.resolve(result);
+        if (this.props.onClose) this.props.onClose();
     }
 
     componentDidMount() {


### PR DESCRIPTION
This pr does a few things:

1. Fixes aria labels, roles, hidden/not hidden, and descriptions throughout the skillmap. I did this based off testing with MacOS' VoiceOver, but we should also try this out on Windows with JAWS/NVDA
2. Fixes focus trapping on nested modals in the user profile

We should get rid of the showDialog stuff inside of react-common now that we're using the react portal thing for modals; just didn't want to do it in this pr