### PR TITLE
Only close search on workspace click if search is open

### DIFF
--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -3102,7 +3102,7 @@ namespace pxt.blocks {
         protected createDom_() {
             super.createDom_();
             this.addEvent_(this.workspace_.getInjectionDiv(), "click", this, (e: any) => {
-                if (!this.htmlDiv_.contains(e.target)) {
+                if (this.htmlDiv_.style.display == "flex" && !this.htmlDiv_.contains(e.target)) {
                     this.close()
                 }
             });


### PR DESCRIPTION
the function to close the workspace search also clears the blocks which unselects the selected input