### PR TITLE
Keep Code CSS, closing behavior fixes

### DIFF
--- a/theme/tutorial-sidebar.less
+++ b/theme/tutorial-sidebar.less
@@ -599,18 +599,18 @@
     // Overrides
     .tab-tutorial {
         .tutorial-callout {
-            top: 18.5rem;
             right: 1.6rem;
             bottom: unset;
             left: unset;
             max-width: 80%;
+            transform: translateY(15px);
         }
 
         .tutorial-callout:before {
             top: -2.5rem;
             left: unset;
             bottom: auto;
-            right: 4rem;
+            right: 3.5rem;
             transform: rotate(90deg);
         }
     }
@@ -626,8 +626,8 @@
         width: 4rem;
 
         .tutorial-callout {
-            top: 22.5rem;
             max-width: 32rem;
+            transform: translateY(65px);
         }
 
         .tutorial-replace-code-actions .ui.button {
@@ -635,7 +635,7 @@
         }
     }
 
-    .tutorial-replace-code + .tutorial-controls > .tutorial-hint {
+    .tutorial-replace-code ~ .tutorial-controls > .tutorial-hint {
         width: 5rem;
     }
 

--- a/webapp/src/components/tutorial/TutorialResetCode.tsx
+++ b/webapp/src/components/tutorial/TutorialResetCode.tsx
@@ -4,7 +4,7 @@ import { Button } from "../../sui";
 import { TutorialCallout } from "./TutorialCallout";
 
 interface TutorialResetCodeProps {
-    resetTemplateCode: (keepAssets: boolean) => void;
+    resetTemplateCode: (keepAssets: boolean) => Promise<void>;
 
     // Telemetry data
     tutorialId: string;
@@ -18,9 +18,12 @@ export function TutorialResetCode(props: TutorialResetCodeProps) {
     const onResetClick = async () => {
         pxt.tickEvent(`tutorial.resetcode`, { tutorial: tutorialId, step: currentStep });
         setReloading(true);
-        await resetTemplateCode(true);
-        document.dispatchEvent(new Event("click"));
-        setReloading(false);
+        try {
+            await resetTemplateCode(true);
+        } finally {
+            document.dispatchEvent(new Event("click"));
+            setReloading(false);
+        }
     }
 
     return <TutorialCallout buttonLabel={lf("Replace my code")} className="tutorial-replace-code">

--- a/webapp/src/components/tutorial/TutorialResetCode.tsx
+++ b/webapp/src/components/tutorial/TutorialResetCode.tsx
@@ -13,11 +13,14 @@ interface TutorialResetCodeProps {
 
 export function TutorialResetCode(props: TutorialResetCodeProps) {
     const { resetTemplateCode, tutorialId, currentStep } = props;
+    const [ reloading, setReloading ] = React.useState(false);
 
-    const onResetClick = () => {
+    const onResetClick = async () => {
         pxt.tickEvent(`tutorial.resetcode`, { tutorial: tutorialId, step: currentStep });
-        resetTemplateCode(true);
+        setReloading(true);
+        await resetTemplateCode(true);
         document.dispatchEvent(new Event("click"));
+        setReloading(false);
     }
 
     return <TutorialCallout buttonLabel={lf("Replace my code")} className="tutorial-replace-code">
@@ -25,7 +28,7 @@ export function TutorialResetCode(props: TutorialResetCodeProps) {
         <p>{lf("Click below to replace your code with updated blocks.")}</p>
         <p>{lf("This will delete all your current code blocks. Any custom images and tiles can still be found in the gallery under \"My Assets\".")}</p>
         <div className="tutorial-replace-code-actions">
-            <Button className="primary" text={lf("Replace my code")} onClick={onResetClick} />
+            <Button className="primary" text={lf("Replace my code")} disabled={reloading} onClick={onResetClick} />
         </div>
     </TutorialCallout>
 }


### PR DESCRIPTION
- small CSS tweaks for tablet view
- keep the modal open until the workspace is visibly reloading