### PR TITLE
Check flyout oldScale_ instead of current scale when rendering

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1564,7 +1564,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         // reflow if scale changed
         const flyoutWs = nw.getWorkspace();
         const targetWs = nw.targetWorkspace;
-        const scaleChange = flyoutWs.getScale() !== targetWs.getScale();
+        const scaleChange = (flyoutWs as any).oldScale_ !== targetWs.getScale();
         if (scaleChange) {
             nw.reflow();
         }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4586

eventually we might want to look at a cleaner way of hooking this into Blockly's setup, just patching the flow quickly for this release