### PR TITLE
[stable7.4] Cherry-pick blocks/blockly fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "monaco-editor": "0.24.0",
     "pouchdb": "7.2.1",
     "pouchdb-adapter-memory": "7.2.1",
-    "pxt-blockly": "4.0.7",
+    "pxt-blockly": "4.0.8",
     "react": "16.8.3",
     "react-dom": "16.11.0",
     "react-modal": "3.3.2",

--- a/pxtblocks/fields/field_toggle.ts
+++ b/pxtblocks/fields/field_toggle.ts
@@ -207,15 +207,22 @@ namespace pxtblockly {
                 let leftPadding = 0, rightPadding = 0;
                 switch (outputShape) {
                     case Blockly.OUTPUT_SHAPE_HEXAGONAL:
-                        width = innerWidth;
+                        width = size.width / 2;
                         halfWidth = width / 2;
-                        let quarterWidth = halfWidth / 2;
-                        // TODO: the left padding calculation is a hack, we should calculate left padding based on width (generic case)
-                        leftPadding = -halfWidth + quarterWidth;
-                        rightPadding = -quarterWidth;
-                        const topLeftPoint = -quarterWidth;
-                        const bottomRightPoint = halfWidth;
-                        this.toggleThumb_.setAttribute('points', `${topLeftPoint},-14 ${topLeftPoint - 14},0 ${topLeftPoint},14 ${bottomRightPoint},14 ${bottomRightPoint + 14},0 ${bottomRightPoint},-14`);
+                        leftPadding = -halfWidth; // total translation when toggle is left-aligned = 0
+                        rightPadding = halfWidth - innerWidth; // total translation when right-aligned = width
+
+                        /**
+                         *  Toggle defined clockwise from bottom left:
+                         *
+                         *        0,  14 ----------- width, 14
+                         *       /                           \
+                         *  -14, 0                            width + 14, 0
+                         *       \                           /
+                         *        0, -14 ----------- width, -14
+                         */
+
+                        this.toggleThumb_.setAttribute('points', `${0},-14 -14,0 ${0},14 ${width},14 ${width + 14},0 ${width},-14`);
                         break;
                     case Blockly.OUTPUT_SHAPE_ROUND:
                     case Blockly.OUTPUT_SHAPE_SQUARE:

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1564,7 +1564,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         // reflow if scale changed
         const flyoutWs = nw.getWorkspace();
         const targetWs = nw.targetWorkspace;
-        const scaleChange = flyoutWs.getScale() !== targetWs.getScale();
+        const scaleChange = (flyoutWs as any).oldScale_ !== targetWs.getScale();
         if (scaleChange) {
             nw.reflow();
         }

--- a/webapp/src/components/tutorial/TutorialCallout.tsx
+++ b/webapp/src/components/tutorial/TutorialCallout.tsx
@@ -25,7 +25,8 @@ export function TutorialCallout(props: TutorialCalloutProps) {
         setVisible(false);
     }
 
-    const toggleCallout = () => {
+    const toggleCallout = (e: any) => {
+        captureEvent(e);
         if (!visible) {
             document.addEventListener("click", closeCallout);
         } else {
@@ -34,10 +35,10 @@ export function TutorialCallout(props: TutorialCalloutProps) {
         setVisible(!visible);
     }
 
-    const handleButtonClick = () => {
+    const handleButtonClick = (e: any) => {
         const { onClick } = props;
         if (onClick) onClick(visible);
-        toggleCallout();
+        toggleCallout(e);
     }
 
     return <div className={className}>


### PR DESCRIPTION
- fix flyout scale cashing (#8693)
- fix 'Reset Code' x button (#8694)
- remove 'Inline/External Inputs' from block context menu (#8695) 
- fix toggle rendering (#8698)