### PR TITLE
Center offscreen blocks when doing workspace search

### DIFF
--- a/localtypings/pxtblockly.d.ts
+++ b/localtypings/pxtblockly.d.ts
@@ -124,6 +124,7 @@ declare class WorkspaceSearch {
     constructor(workspace: Blockly.WorkspaceSvg);
     protected workspace_: Blockly.WorkspaceSvg;
     protected htmlDiv_: HTMLDivElement;
+    protected inputElement_: HTMLInputElement;
     init(): void;
     protected createDom_(): void;
     protected addEvent_(node: Element, name: string, thisObject: Object, func: Function): void;

--- a/pxtblocks/blocklyloader.ts
+++ b/pxtblocks/blocklyloader.ts
@@ -3115,15 +3115,83 @@ namespace pxt.blocks {
             });
         }
 
-        protected unhighlightSearchGroup_ (blocks: Blockly.BlockSvg[]) {
+        protected unhighlightSearchGroup_(blocks: Blockly.BlockSvg[]) {
             blocks.forEach((block) => {
                 const blockPath = block.pathObject.svgPath;
                 Blockly.utils.dom.removeClass(blockPath, 'blockly-ws-search-highlight-pxt');
             });
         }
 
+        /**
+         * https://github.com/google/blockly-samples/blob/master/plugins/workspace-search/src/WorkspaceSearch.js#L633
+         *
+         * Modified to center offscreen blocks.
+         */
+        protected scrollToVisible_(block: Blockly.BlockSvg) {
+            if (!this.workspace_.isMovable()) {
+                // Cannot scroll to block in a non-movable workspace.
+                return;
+            }
+            // XY is in workspace coordinates.
+            const xy = block.getRelativeToSurfaceXY();
+            const scale = this.workspace_.scale;
+
+            // Block bounds in pixels relative to the workspace origin (0,0 is centre).
+            const width = block.width * scale;
+            const height = block.height * scale;
+            const top = xy.y * scale;
+            const bottom = (xy.y + block.height) * scale;
+            // In RTL the block's position is the top right of the block, not top left.
+            const left = this.workspace_.RTL ? xy.x * scale - width : xy.x * scale;
+            const right = this.workspace_.RTL ? xy.x * scale : xy.x * scale + width;
+
+            const metrics = this.workspace_.getMetrics();
+
+            let targetLeft = metrics.viewLeft;
+            const overflowLeft = left < metrics.viewLeft;
+            const overflowRight = right > metrics.viewLeft + metrics.viewWidth;
+            const wideBlock = width > metrics.viewWidth;
+
+            if ((!wideBlock && overflowLeft) || (wideBlock && !this.workspace_.RTL)) {
+                // Scroll to show left side of block
+                targetLeft = left;
+            } else if ((!wideBlock && overflowRight) ||
+                (wideBlock && this.workspace_.RTL)) {
+                // Scroll to show right side of block
+                targetLeft = right - metrics.viewWidth;
+            }
+
+            let targetTop = metrics.viewTop;
+            const overflowTop = top < metrics.viewTop;
+            const overflowBottom = bottom > metrics.viewTop + metrics.viewHeight;
+            const tallBlock = height > metrics.viewHeight;
+
+            if (overflowTop || (tallBlock && overflowBottom)) {
+                // Scroll to show top of block
+                targetTop = top;
+            } else if (overflowBottom) {
+                // Scroll to show bottom of block
+                targetTop = bottom - metrics.viewHeight;
+            }
+            if (targetLeft !== metrics.viewLeft || targetTop !== metrics.viewTop) {
+                const activeEl = document.activeElement as HTMLElement;
+                if (wideBlock || tallBlock) {
+                    this.workspace_.scroll(-targetLeft, -targetTop);
+                } else {
+                    this.workspace_.centerOnBlock(block.id);
+                }
+
+                if (activeEl) {
+                    // Blockly.WidgetDiv.hide called in scroll is taking away focus.
+                    // TODO: Review setFocused call in Blockly.WidgetDiv.hide.
+                    activeEl.focus();
+                }
+            }
+        }
+
         open() {
             super.open();
+            this.inputElement_.select();
             Blockly.utils.dom.addClass(this.workspace_.getInjectionDiv(), 'blockly-ws-searching');
         }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4574

we're doing almost exactly the same thing as the default plugin, but centering the blocks instead of scrolling them just into view (except in the case of blocks taller or wider than the viewport, in which case we scroll the top/left side of that block into view)