### PR TITLE
Add media query breakpoints

### DIFF
--- a/react-common/styles/profile/profile.less
+++ b/react-common/styles/profile/profile.less
@@ -335,7 +335,7 @@
     }
 }
 
-@media only screen and (max-width: 1200px) and (min-width: 992px) {
+@media @computerAndBelow {
     .profile-badges, .profile-badges-background {
         background-size: 25%;
         grid-template-columns: repeat(4, 1fr);
@@ -343,7 +343,7 @@
     }
 }
 
-@media only screen and (max-width: 991px) {
+@media @tabletAndBelow {
     .profile-badges, .profile-badges-background {
         background-size: 33%;
         grid-template-columns: repeat(3, 1fr);

--- a/react-common/styles/react-common-variables.less
+++ b/react-common/styles/react-common-variables.less
@@ -2,6 +2,23 @@
 @commonBorderColor: rgb(96, 94, 92);
 @commonBackgroundDisabledColor: rgb(243, 242, 241);
 
+@mobileBreakpoint: 320px;
+@tabletBreakpoint: 768px;
+@computerBreakpoint: 992px;
+@largeMonitorBreakpoint: 1200px;
+@widescreenMonitorBreakpoint: 1920px;
+
+@largestMobileScreen: (@tabletBreakpoint - 1px);
+@largestTabletScreen: (@computerBreakpoint - 1px);
+@largestSmallMonitor: (@largeMonitorBreakpoint - 1px);
+@largestLargeMonitor: (@widescreenMonitorBreakpoint - 1px);
+
+@mobileAndBelow: ~"only screen and (max-width: @{largestMobileScreen})";
+@tabletAndBelow: ~"only screen and (max-width: @{largestTabletScreen})";
+@computerAndBelow: ~"only screen and (max-width: @{largestSmallMonitor})";
+@largeMonitorAndBelow: ~"only screen and (max-width: @{largestLargeMonitor})";
+
+
 /****************************************************
  *                    Buttons                       *
  ****************************************************/

--- a/theme/common.less
+++ b/theme/common.less
@@ -9,6 +9,11 @@
              Layout
 *******************************/
 
+@mobileAndBelow: ~"only screen and (max-width: @{largestMobileScreen})";
+@tabletAndBelow: ~"only screen and (max-width: @{largestTabletScreen})";
+@computerAndBelow: ~"only screen and (max-width: @{largestSmallMonitor})";
+@largeMonitorAndBelow: ~"only screen and (max-width: @{largestLargeMonitor})";
+
 html {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
This PR duplicates the semantic ui screen size breakpoints in react common and adds new macros to make them easier to read. I only added helpers for the max-width media queries for each screen size; @shakao and I talked it over and we felt the best way to do media queries was to always cascade from large screen to small

I think going forward we want to standardize on this style (cascading from large to small) rather than our current jumble of media queries which are hard to read/interpret. In particular we want to move away from queries that specify both a min and max width like this:

```less
@media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
}
```

As we component-ize things, we'll slowly start removing the old ones (unless folks object).

@livcheerful @jwunderl FYI