### PR TITLE
Refresh Blockly theme when blocks div comes into view

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -37,6 +37,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     breakpointsSet: number[]; // the IDs of the breakpoints set.
 
     private errorChangesListeners: pxt.Map<(errors: pxt.blocks.BlockDiagnostic[]) => void> = {};
+    protected intersectionObserver: IntersectionObserver;
 
     protected debuggerToolbox: DebuggerToolbox;
 
@@ -606,9 +607,25 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.initWorkspaceSounds();
         this.initAccessibleBlocks();
         this.initWorkspaceSearch();
+        this.setupIntersectionObserver();
         this.resize();
 
         pxt.perf.measureEnd("prepareBlockly")
+    }
+
+    protected setupIntersectionObserver() {
+        if (!('IntersectionObserver' in window) || this.intersectionObserver) return;
+
+        this.intersectionObserver = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.intersectionRatio > 0) {
+                    this.intersectionObserver.unobserve(entry.target);
+                    this.editor.refreshTheme();
+                }
+            })
+        });
+        const blocklyDiv = document.getElementById('blocksEditor');
+        this.intersectionObserver.observe(blocklyDiv);
     }
 
     resize(e?: Event) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/4579

Blockly computes the field text height constants by dynamically measuring DOM elements. in the skillmap, we load the blocks workspace before the div is visible which causes these constants to be zero. this adds a `refreshTheme` call when the blocks div becomes visible so that we recompute these constants