### PR TITLE
bump browserify patch version to latest 16.2.* patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@microsoft/immersive-reader-sdk": "1.1.0",
     "applicationinsights-js": "^1.0.20",
-    "browserify": "16.2.0",
+    "browserify": "16.2.3",
     "chai": "^3.5.0",
     "cssnano": "4.1.10",
     "dompurify": "2.0.8",


### PR DESCRIPTION
almost everyone uses this patch anyway / it's long been stable and it fixes an issue in a transitive dep

![image](https://user-images.githubusercontent.com/5615930/155787111-3a1b87bd-a6cf-48b3-b8cd-5a84a6d92599.png)
