### PR TITLE
Save generated ID to the project header when the user shares

### DIFF
--- a/localtypings/projectheader.d.ts
+++ b/localtypings/projectheader.d.ts
@@ -19,6 +19,7 @@ declare namespace pxt.workspace {
         targetVersion: string;
         pubId: string; // for published scripts
         pubCurrent: boolean; // is this exactly pubId, or just based on it
+        pubVersions?: PublishVersion[];
         githubId?: string;
         githubTag?: string; // the release tag if any (commit.tag)
         githubCurrent?: boolean;
@@ -54,5 +55,10 @@ declare namespace pxt.workspace {
 
         // Other
         _rev: string; // used for idb / pouchdb revision tracking
+    }
+
+    interface PublishVersion {
+        id: string;
+        type: "temporary" | "persistent";
     }
 }

--- a/localtypings/projectheader.d.ts
+++ b/localtypings/projectheader.d.ts
@@ -59,6 +59,6 @@ declare namespace pxt.workspace {
 
     interface PublishVersion {
         id: string;
-        type: "temporary" | "persistent";
+        type: "snapshot" | "permalink";
     }
 }

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -348,6 +348,8 @@ export function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptM
     pxt.debug(`publishing script; ${stext.length} bytes`)
     return Cloud.privatePostAsync("scripts", scrReq, /* forceLiveEndpoint */ true)
         .then((inf: Cloud.JsonScript) => {
+            if (!h.pubVersions) h.pubVersions = [];
+            h.pubVersions.push({ id: inf.id, type: "temporary" });
             if (inf.shortid) inf.id = inf.shortid;
             h.pubId = inf.shortid
             h.pubCurrent = h.saveId === saveId

--- a/webapp/src/workspace.ts
+++ b/webapp/src/workspace.ts
@@ -349,7 +349,7 @@ export function anonymousPublishAsync(h: Header, text: ScriptText, meta: ScriptM
     return Cloud.privatePostAsync("scripts", scrReq, /* forceLiveEndpoint */ true)
         .then((inf: Cloud.JsonScript) => {
             if (!h.pubVersions) h.pubVersions = [];
-            h.pubVersions.push({ id: inf.id, type: "temporary" });
+            h.pubVersions.push({ id: inf.id, type: "snapshot" });
             if (inf.shortid) inf.id = inf.shortid;
             h.pubId = inf.shortid
             h.pubCurrent = h.saveId === saveId


### PR DESCRIPTION
when we add the persistent share UI we can hook it up to this as well. open to other thoughts on the type of version timestamp, i'm using "temporary" and "persistent" because that's what we've been calling them but not sure if "onetime"/"persistent" or something would be better