### PR TITLE
Add a secret accessibility menu to the editor toggle

### DIFF
--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -20,6 +20,7 @@ export interface ButtonProps extends ControlProps {
     ariaHasPopup?: string;
     ariaPosInSet?: number;
     ariaSetSize?: number;
+    ariaSelected?: boolean;
 }
 
 export const Button = (props: ButtonProps) => {
@@ -34,6 +35,7 @@ export const Button = (props: ButtonProps) => {
         ariaHasPopup,
         ariaPosInSet,
         ariaSetSize,
+        ariaSelected,
         role,
         onClick,
         onKeydown,
@@ -76,7 +78,8 @@ export const Button = (props: ButtonProps) => {
             aria-haspopup={ariaHasPopup as any}
             aria-posinset={ariaPosInSet}
             aria-setsize={ariaSetSize}
-            aria-describedby={ariaDescribedBy}>
+            aria-describedby={ariaDescribedBy}
+            aria-selected={ariaSelected}>
                 <span className="common-button-flex">
                     {leftIcon && <i className={leftIcon} aria-hidden={true}/>}
                     <span className="common-button-label">

--- a/react-common/components/controls/EditorToggle.tsx
+++ b/react-common/components/controls/EditorToggle.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
-import { useState } from "react";
 import { classList, ControlProps } from "../util";
 import { Button } from "./Button";
+import { FocusList } from "./FocusList";
 import { MenuDropdown } from "./MenuDropdown";
 
 export interface EditorToggleProps extends ControlProps {
     items: EditorToggleItem[];
     selected: number;
+    id: string;
 }
 
 export type EditorToggleItem = BasicEditorToggleItem | DropdownEditorToggleItem;
@@ -43,42 +44,47 @@ export const EditorToggle = (props: EditorToggleProps) => {
     }
 
     return (
-        <div id={id}
-            className={classList("common-editor-toggle", hasDropdown && "has-dropdown", className)}
-            role={role || "tablist"}
-            aria-hidden={ariaHidden}
-            aria-label={ariaLabel}>
-                {items.map((item, index) => {
-                    const isSelected = selected === index;
-                    return (
-                        <div key={index}
-                            className={classList(
-                                "common-editor-toggle-item",
-                                isSelected && "selected",
-                                isDropdownItem(item) && "common-editor-toggle-item-dropdown",
-                            )} >
-                            <ToggleButton item={item} isSelected={isSelected} onKeydown={onKeydown} />
-                            { isDropdownItem(item) &&
-                                <MenuDropdown
-                                    id="toggle-dropdown"
-                                    className="toggle-dropdown"
-                                    icon="fas fa-chevron-down"
-                                    title={lf("More options")}
-                                    items={items.map(item => ({
-                                        title: item.title,
-                                        label: item.label,
-                                        onClick: item.onClick,
-                                        leftIcon: item.icon
-                                    }))}
-                                    />
-                            }
-                        </div>
-                    );
-                })}
+        <div className="common-editor-toggle-outer">
+            <EditorToggleAccessibleMenu {...props} />
+            <div id={id}
+                className={classList("common-editor-toggle", hasDropdown && "has-dropdown", className)}
+                role={role || "tablist"}
+                aria-hidden={true}
+                aria-label={ariaLabel}>
+                    {items.map((item, index) => {
+                        const isSelected = selected === index;
+                        return (
+                            <div key={index}
+                                className={classList(
+                                    "common-editor-toggle-item",
+                                    isSelected && "selected",
+                                    isDropdownItem(item) && "common-editor-toggle-item-dropdown",
+                                )} >
+                                <ToggleButton item={item} isSelected={isSelected} onKeydown={onKeydown} />
+                                { isDropdownItem(item) &&
+                                    <MenuDropdown
+                                        id="toggle-dropdown"
+                                        className="toggle-dropdown"
+                                        icon="fas fa-chevron-down"
+                                        title={lf("More options")}
+                                        tabIndex={-1}
+                                        ariaHidden={true}
+                                        items={item.items.map(item => ({
+                                            title: item.title,
+                                            label: item.label,
+                                            onClick: item.onClick,
+                                            leftIcon: item.icon
+                                        }))}
+                                        />
+                                }
+                            </div>
+                        );
+                    })}
 
-                <div className="common-editor-toggle-handle"
-                    aria-hidden={true}
-                />
+                    <div className="common-editor-toggle-handle"
+                        aria-hidden={true}
+                    />
+            </div>
         </div>
     );
 }
@@ -95,13 +101,51 @@ const ToggleButton = (props: ToggleButtonProps) => {
 
     return <Button
         role={focusable ? "tab" : undefined}
-        tabIndex={focusable && isSelected ? 0 : -1}
+        tabIndex={-1}
         onKeydown={onKeydown}
         label={label}
         title={title}
         onClick={onClick}
         leftIcon={icon}
-        aria-selected={isSelected} />
+        ariaHidden={true}
+        />
+}
+
+
+interface ToggleTab extends BasicEditorToggleItem {
+    selected?: boolean;
+}
+
+const EditorToggleAccessibleMenu = (props: EditorToggleProps) => {
+    const { items, id, selected, ariaHidden } = props;
+
+    const tabs = items.reduce((prev, current, index) => {
+        const next: ToggleTab[] = [...prev]
+        next.push({...current});
+
+        // The selected item will always be a top-level option, not in a dropdown
+        if (selected === index) next[next.length - 1].selected = true;
+
+        if (isDropdownItem(current)) {
+            next.push(...current.items.filter(i => i.focusable))
+        }
+        return next;
+    }, [] as ToggleTab[]);
+
+    return <FocusList id={id} role="tablist" className="common-toggle-accessibility" childTabStopId={id + "-selected"}>
+        {tabs.map((item, index) =>
+            <Button
+                key={index}
+                className={item.selected ? "selected" : undefined}
+                id={item.selected ? id + "-selected" : undefined}
+                role="tab"
+                title={item.title}
+                label={item.label}
+                onClick={item.onClick}
+                ariaSelected={item.selected}
+                ariaHidden={ariaHidden}/>
+        )}
+    </FocusList>
 }
 
 function isDropdownItem(item: EditorToggleItem): item is DropdownEditorToggleItem {

--- a/react-common/components/controls/FocusList.tsx
+++ b/react-common/components/controls/FocusList.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+import { ContainerProps } from "../util";
+
+export interface FocusListProps extends ContainerProps {
+    role: string;
+    childTabStopId?: string;
+}
+
+/**
+ * A list of focusable items that represents a single tab stop in the tab order. The
+ * children of the list can be navigated between using the arrow keys. Any child with
+ * a tabindex other than -1 will be included in the list.
+ *
+ * If childTabStopId is specified, then the tab stop will be placed on the child with
+ * the given id instead of the outer div.
+ */
+export const FocusList = (props: FocusListProps) => {
+    const {
+        id,
+        className,
+        role,
+        ariaHidden,
+        ariaLabel,
+        childTabStopId,
+        children,
+    } = props;
+
+    let focusableElements: HTMLElement[];
+    let focusList: HTMLDivElement;
+
+    const handleRef = (ref: HTMLDivElement) => {
+        if (!ref || focusList) return;
+
+        focusList = ref;
+
+        const focusable = ref.querySelectorAll(`[tabindex]:not([tabindex="-1"]),[data-isfocusable]`);
+        focusableElements = [];
+
+        for (const element of focusable.values()) {
+            focusableElements.push(element as HTMLElement);
+
+            // Remove them from the tab order, menu items are navigable using the arrow keys
+            element.setAttribute("tabindex", "-1");
+            element.setAttribute("data-isfocusable", "true");
+        }
+
+        if (childTabStopId) {
+            const childTabStop = focusList.querySelector("#" + childTabStopId);
+
+            if (childTabStop) {
+                childTabStop.setAttribute("tabindex", "0");
+            }
+        }
+    }
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+        if  (!focusableElements?.length) return;
+
+        const target = document.activeElement as HTMLElement;
+        const index = focusableElements.indexOf(target);
+
+        if (index === -1 && target !== focusList) return;
+
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+
+            if (target.click) {
+                target.click();
+            }
+            else {
+                // SVG Elements
+                target.dispatchEvent(new Event("click"));
+            }
+        }
+        else if (e.key === "ArrowRight") {
+            if (index === focusableElements.length - 1 || target === focusList) {
+                focusableElements[0].focus();
+            }
+            else {
+                focusableElements[index + 1].focus();
+            }
+            e.preventDefault();
+            e.stopPropagation();
+        }
+        else if (e.key === "ArrowLeft") {
+            if (index === 0 || target === focusList) {
+                focusableElements[focusableElements.length - 1].focus();
+            }
+            else {
+                focusableElements[Math.max(index - 1, 0)].focus();
+            }
+            e.preventDefault();
+            e.stopPropagation();
+        }
+        else if (e.key === "Home") {
+            focusableElements[0].focus();
+            e.preventDefault();
+            e.stopPropagation();
+        }
+        else if (e.key === "End") {
+            focusableElements[focusableElements.length - 1].focus();
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    }
+
+    return (
+        <div id={id}
+            className={className}
+            role={role}
+            tabIndex={childTabStopId ? undefined : 0}
+            onKeyDown={onKeyDown}
+            ref={handleRef}
+            aria-hidden={ariaHidden}
+            aria-label={ariaLabel}>
+            {children}
+        </div>
+    );
+}

--- a/react-common/components/controls/MenuBar.tsx
+++ b/react-common/components/controls/MenuBar.tsx
@@ -1,101 +1,11 @@
 import * as React from "react";
 import { classList, ContainerProps } from "../util";
+import { FocusList } from "./FocusList";
 
 export interface MenuBarProps extends ContainerProps {
 }
 
-export const MenuBar = (props: MenuBarProps) => {
-    const {
-        id,
-        className,
-        role,
-        ariaHidden,
-        ariaLabel,
-        children
-    } = props;
-
-    let focusableElements: HTMLElement[];
-    let menubar: HTMLDivElement;
-
-    const handleRef = (ref: HTMLDivElement) => {
-        if (!ref || menubar) return;
-
-        menubar = ref;
-
-        const focusable = ref.querySelectorAll(`[tabindex]:not([tabindex="-1"]),[data-isfocusable]`);
-        focusableElements = [];
-
-        for (const element of focusable.values()) {
-            focusableElements.push(element as HTMLElement);
-
-            // Remove them from the tab order, menu items are navigable using the arrow keys
-            element.setAttribute("tabindex", "-1");
-            element.setAttribute("data-isfocusable", "true");
-        }
-    }
-
-    const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-        if  (!focusableElements?.length) return;
-
-        const target = document.activeElement as HTMLElement;
-        const index = focusableElements.indexOf(target);
-
-        if (index === -1 && target !== menubar) return;
-
-        if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            e.stopPropagation();
-
-            if (target.click) {
-                target.click();
-            }
-            else {
-                // SVG Elements
-                target.dispatchEvent(new Event("click"));
-            }
-        }
-        else if (e.key === "ArrowRight") {
-            if (index === focusableElements.length - 1 || target === menubar) {
-                focusableElements[0].focus();
-            }
-            else {
-                focusableElements[index + 1].focus();
-            }
-            e.preventDefault();
-            e.stopPropagation();
-        }
-        else if (e.key === "ArrowLeft") {
-            if (index === 0 || target === menubar) {
-                focusableElements[focusableElements.length - 1].focus();
-            }
-            else {
-                focusableElements[Math.max(index - 1, 0)].focus();
-            }
-            e.preventDefault();
-            e.stopPropagation();
-        }
-        else if (e.key === "Home") {
-            focusableElements[0].focus();
-            e.preventDefault();
-            e.stopPropagation();
-        }
-        else if (e.key === "End") {
-            focusableElements[focusableElements.length - 1].focus();
-            e.preventDefault();
-            e.stopPropagation();
-        }
-    }
-
-    return (
-        <div id={id}
-            className={classList("common-menubar", className)}
-            role={role || "menubar"}
-            tabIndex={0}
-            onKeyDown={onKeyDown}
-            ref={handleRef}
-            aria-hidden={ariaHidden}
-            aria-label={ariaLabel}>
-            {children}
-        </div>
-    );
-}
+export const MenuBar = (props: MenuBarProps) =>
+    <FocusList {...props}
+        role="menubar"
+        className={classList("common-menubar", props.className)} />

--- a/react-common/components/controls/MenuDropdown.tsx
+++ b/react-common/components/controls/MenuDropdown.tsx
@@ -15,6 +15,7 @@ export interface MenuDropdownProps extends ControlProps {
     label?: string | JSX.Element;
     title: string;
     icon?: string;
+    tabIndex?: number;
 }
 
 export const MenuDropdown = (props: MenuDropdownProps) => {
@@ -27,7 +28,8 @@ export const MenuDropdown = (props: MenuDropdownProps) => {
         items,
         label,
         title,
-        icon
+        icon,
+        tabIndex
     } = props;
 
     const [ expanded, setExpanded ] = React.useState(false);
@@ -66,6 +68,7 @@ export const MenuDropdown = (props: MenuDropdownProps) => {
         <Button
             id={id}
             label={label}
+            tabIndex={tabIndex}
             buttonRef={handleButtonRef}
             title={title}
             leftIcon={icon}

--- a/react-common/styles/controls/EditorToggle.less
+++ b/react-common/styles/controls/EditorToggle.less
@@ -1,3 +1,7 @@
+.common-editor-toggle-outer {
+    position: relative;
+}
+
 .common-editor-toggle {
     position: relative;
     border-radius: 0.2rem;
@@ -124,6 +128,40 @@
         /* toggle positioning, three items, second item in toggle has dropdown */
         .common-editor-toggle-item + .common-editor-toggle-item.common-editor-toggle-item-dropdown + .common-editor-toggle-item.selected ~ .common-editor-toggle-handle { margin-left: 70%; }
     }
+}
+
+/*****************************************************
+ *                Accessibility Menu                 *
+ ****************************************************/
+
+.common-toggle-accessibility {
+    position: absolute;
+    z-index: 2;
+    width: 0px;
+    height: 0px;
+    left: 0;
+    background: white;
+
+    .common-button {
+        width: 0px;
+        height: 0px;
+        min-height: 0px;
+
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+    .common-button:focus {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+.common-toggle-accessibility:focus-within {
+    width: 100%;
+    height: 100%;
 }
 
 

--- a/theme/image-editor/imageEditor.less
+++ b/theme/image-editor/imageEditor.less
@@ -108,6 +108,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
 }
 
 .image-editor-header-right {

--- a/webapp/src/components/ImageFieldEditor.tsx
+++ b/webapp/src/components/ImageFieldEditor.tsx
@@ -131,6 +131,7 @@ export class ImageFieldEditor<U extends pxt.Asset> extends React.Component<Image
                 <div className="image-editor-header-left" />
                 <div className="image-editor-header-center">
                     <EditorToggle
+                        id="image-editor-toggle"
                         className="slim tablet-compact"
                         items={toggleOptions}
                         selected={toggleOptions.findIndex(i => i.view === currentView)}


### PR DESCRIPTION
Add a secret accessibility menu to the editor toggle

This is sort of similar to the secret menu you get when you tab in the main editor. This is to work around our UI pattern of a toggle with a dropdown which doesn't really have a corresponding aria role. The secret menu takes the form of a tab list where all navigable items are present (including the ones buried in the dropdown). The menu is hidden until it receives focus; then the current tab takes over the toggle.

The tab list is navigable using the arrow keys, just like a menu bar. Unlike a menu bar, the first item to get focus when you tab in is always the active tab.

![2022-03-08 11 16 24](https://user-images.githubusercontent.com/13754588/157309534-cd0a4bef-3a8f-43f2-8b1f-57e91c65f704.gif)

