### PR TITLE
Remember block view

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -427,7 +427,9 @@ export class ProjectView
         this.saveSettings()
         this.editor.domUpdate();
         simulator.setState(this.state.header ? this.state.header.editor : '', this.state.tutorialOptions && !!this.state.tutorialOptions.tutorial)
-        this.editor.resize();
+        if (!this.state.fullscreen) {
+            this.editor.resize();
+        }
 
         let p = Promise.resolve();
         if (this.editor && this.editor.isReady) {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -361,6 +361,8 @@ export class ProjectView
                 cmds.maybeReconnectAsync(false, true);
             }
         }
+
+        if (this.editor) this.editor.onPageVisibilityChanged(active);
     }
 
     saveSettings() {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -40,6 +40,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     protected intersectionObserver: IntersectionObserver;
 
     protected debuggerToolbox: DebuggerToolbox;
+    protected highlightedStatement: pxtc.LocationInfo;
 
     // Blockly plugins
     protected navigationController: NavigationController;
@@ -225,6 +226,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     }
                 });
         }
+    }
+
+    onPageVisibilityChanged(isVisible: boolean) {
+        if (!isVisible) return;
+        this.highlightStatement(this.highlightedStatement);
     }
 
     isDropdownDivVisible(): boolean {
@@ -1053,6 +1059,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (!this.compilationResult || this.delayLoadXml || this.loadingXml)
             return false;
         this.updateDebuggerVariables(brk);
+        this.highlightedStatement = stmt;
         if (stmt) {
             let bid = pxt.blocks.findBlockIdByLine(this.compilationResult.sourceMap, { start: stmt.line, length: stmt.endLine - stmt.line });
             if (bid) {

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -20,6 +20,8 @@ export class Editor implements pxt.editor.IEditor {
     }
     simStateChanged() { }
 
+    onPageVisibilityChanged(isVisible: boolean) {}
+
     /*******************************
      Methods called before loadFile
       this.editor may be undefined


### PR DESCRIPTION
First commit fixes https://github.com/microsoft/pxt-microbit/issues/2713

Second commit fixes https://github.com/microsoft/pxt-arcade/issues/3631

I _finally_ tracked down that second issue; we were resizing the blockly workspace when it wasn't visible in the DOM causing the view metrics to get messed up.