### PR TITLE
Include authcode in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "built/web/vs/language/typescript/src/*.js",
     "built/web/skillmap/css/*.css",
     "built/web/skillmap/js/*.js",
+    "built/web/authcode/css/*.css",
+    "built/web/authcode/js/*.js",
     "pxtcompiler/ext-typescript/lib/lib.d.ts",
     "pxtcompiler/ext-typescript/lib/typescript.js",
     "pxtcompiler/ext-typescript/lib/typescriptServices.d.ts",


### PR DESCRIPTION
authcode wasn't in the list of files to include in the npm publish.

Alternately we could disable the authcode component and exclude it from the build since it isn't used at the moment.