### PR TITLE
New share modal components in react-common

### DIFF
--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -21,7 +21,7 @@ export interface InputProps extends ControlProps {
     onIconClick?: (value: string) => void;
 }
 
-export function Input(props: InputProps) {
+export const Input = (props: InputProps) => {
     const {
         id,
         className,
@@ -78,7 +78,7 @@ export function Input(props: InputProps) {
 
     return (
         <div className={classList("common-input-wrapper", disabled && "disabled", className)}>
-            {label && <label className="common-input-label">
+            {label && <label className="common-input-label" htmlFor={id}>
                 {label}
             </label>}
             <div className="common-input-group">
@@ -86,8 +86,8 @@ export function Input(props: InputProps) {
                     id={id}
                     className={classList("common-input", icon && "has-icon")}
                     title={title}
-                    role={role || "button"}
-                    tabIndex={disabled ? 0 : -1}
+                    role={role || "textbox"}
+                    tabIndex={disabled ? -1 : 0}
                     aria-label={ariaLabel}
                     aria-hidden={ariaHidden}
                     type={type || "text"}

--- a/react-common/components/controls/Textarea.tsx
+++ b/react-common/components/controls/Textarea.tsx
@@ -44,6 +44,11 @@ export const Textarea = (props: TextareaProps) => {
 
     const [value, setValue] = React.useState(initialValue || "");
 
+    React.useEffect(() => {
+        setValue(initialValue)
+    }, [initialValue])
+
+
     const changeHandler = (e: React.ChangeEvent<any>) => {
         const newValue = (e.target as any).value;
         if (!readOnly && (value !== newValue)) {

--- a/react-common/components/share/GifInfo.tsx
+++ b/react-common/components/share/GifInfo.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { Button } from "../controls/Button";
+import { GifRecorder } from "./GifRecorder";
+
+export interface GifInfoProps {
+    initialUri?: string;
+
+    onApply: (uri: string) => void;
+    onCancel: () => void;
+
+    screenshotAsync?: () => Promise<string>;
+    gifRecordAsync?: () => Promise<void>;
+    gifRenderAsync?: () => Promise<string | void>;
+}
+
+export const GifInfo = (props: GifInfoProps) => {
+    const { initialUri, onApply, onCancel, screenshotAsync, gifRecordAsync, gifRenderAsync } = props;
+    const [ uri, setUri ] =  React.useState(initialUri);
+
+    const handleApplyClick = (evt?: any) => {
+        onApply(uri);
+    }
+
+    const handleScreenshotClick = async () => {
+        const screenshotUri = await screenshotAsync();
+        setUri(screenshotUri);
+    }
+
+    const handleRecordStopClick = async () => {
+        const gifUri = await gifRenderAsync();
+        if (gifUri) setUri(gifUri);
+    }
+
+    return <>
+        <span className="thumbnail-label">{lf("Current Thumbnail")}</span>
+        <div className="thumbnail-image">
+            {uri
+                ? <img src={uri} />
+                : <div className="thumbnail-placeholder" />
+            }
+        </div>
+        <div className="thumbnail-actions">
+            <Button className="primary"
+                title={lf("Apply")}
+                label={lf("Apply")}
+                onClick={handleApplyClick} />
+            <Button title={lf("Cancel")}
+                label={lf("Cancel")}
+                onClick={onCancel} />
+        </div>
+        <GifRecorder onScreenshot={screenshotAsync ? handleScreenshotClick : undefined}
+            onRecordStart={gifRecordAsync}
+            onRecordStop={handleRecordStopClick} />
+    </>
+}

--- a/react-common/components/share/GifInfo.tsx
+++ b/react-common/components/share/GifInfo.tsx
@@ -11,10 +11,15 @@ export interface GifInfoProps {
     screenshotAsync?: () => Promise<string>;
     gifRecordAsync?: () => Promise<void>;
     gifRenderAsync?: () => Promise<string | void>;
+    gifAddFrame?: (dataUri: ImageData, delay?: number) => boolean;
+
+    registerSimulatorMsgHandler?: (handler: (msg: any) => void) => void;
+    unregisterSimulatorMsgHandler?: () => void;
 }
 
 export const GifInfo = (props: GifInfoProps) => {
-    const { initialUri, onApply, onCancel, screenshotAsync, gifRecordAsync, gifRenderAsync } = props;
+    const { initialUri, onApply, onCancel, screenshotAsync, gifRecordAsync, gifRenderAsync, gifAddFrame,
+        registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
     const [ uri, setUri ] =  React.useState(initialUri);
 
     const handleApplyClick = (evt?: any) => {
@@ -50,6 +55,9 @@ export const GifInfo = (props: GifInfoProps) => {
         </div>
         <GifRecorder onScreenshot={screenshotAsync ? handleScreenshotClick : undefined}
             onRecordStart={gifRecordAsync}
-            onRecordStop={handleRecordStopClick} />
+            onRecordStop={handleRecordStopClick}
+            onGifFrame={gifAddFrame}
+            registerSimulatorMsgHandler={registerSimulatorMsgHandler}
+            unregisterSimulatorMsgHandler={unregisterSimulatorMsgHandler} />
     </>
 }

--- a/react-common/components/share/GifRecorder.tsx
+++ b/react-common/components/share/GifRecorder.tsx
@@ -1,20 +1,27 @@
 import * as React from "react";
 import { Button } from "../controls/Button";
 
+type RecorderState = "default" | "recording" | "rendering";
 
 export interface GifRecorderProps {
     onScreenshot?: () => void;
     onRecordStart?: () => void;
     onRecordStop?: () => Promise<void>;
+    onGifFrame?: (dataUri: ImageData, delay?: number) => boolean;
+    registerSimulatorMsgHandler?: (handler: (msg: any) => void) => void;
+    unregisterSimulatorMsgHandler?: () => void;
 }
 
 export const GifRecorder = (props: GifRecorderProps) => {
-    const { onScreenshot, onRecordStart, onRecordStop } = props;
-    const [ recorderState, setRecorderState ] = React.useState<"default" | "recording" | "rendering">("default");
+    const { onScreenshot, onRecordStart, onRecordStop, onGifFrame,
+        registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
+    const [ recorderState, _setRecorderState ] = React.useState<RecorderState>("default");
+    const recorderStateRef = React.useRef(recorderState);
+    const targetTheme = pxt.appTarget.appTheme;
 
-    const onGifRecordStart = () => {
-        setRecorderState("recording");
-        onRecordStart();
+    const setRecorderState = (state: RecorderState) => {
+        _setRecorderState(state);
+        recorderStateRef.current = state;
     }
 
     const onGifRecordStop = async () => {
@@ -23,17 +30,66 @@ export const GifRecorder = (props: GifRecorderProps) => {
         setRecorderState("default");
     }
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+        const pressed = e.key.toLocaleLowerCase();
+        if (targetTheme.simScreenshotKey && pressed === targetTheme.simScreenshotKey.toLocaleLowerCase()) {
+            onScreenshot();
+        } else if (targetTheme.simGifKey && pressed === targetTheme.simGifKey.toLocaleLowerCase()) {
+            if (recorderStateRef.current === "recording") {
+                onGifRecordStop();
+            } else {
+                onGifRecordStart();
+            }
+        }
+    }
+
+    const handleSimulatorMsg = (e: any) => {
+        if (e.type === "screenshot") {
+            if (recorderStateRef.current === "recording") {
+                // Adds frame, returns true if we've exceeded the max frame count
+                if (onGifFrame(e.data, e.delay)) {
+                    onGifRecordStop();
+                }
+            } else {
+                onScreenshot();
+            }
+        } else if (e.event === "start") {
+            onGifRecordStart();
+        } else if (e.event === "stop") {
+            onGifRecordStop();
+        }
+    }
+
+    React.useEffect(() => {
+        document.addEventListener("keydown", handleKeyDown);
+        if (registerSimulatorMsgHandler) registerSimulatorMsgHandler(handleSimulatorMsg);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            if (unregisterSimulatorMsgHandler) unregisterSimulatorMsgHandler();
+        }
+    }, []);
+
+    const onGifRecordStart = () => {
+        setRecorderState("recording");
+        onRecordStart();
+    }
+
+    const screenshotLabel = lf("Take screenshot ({0})", targetTheme.simScreenshotKey);
+    const startRecordingLabel = lf("Record game play ({0})", targetTheme.simGifKey);
+    const stopRecordingLabel = lf("Stop recording ({0})", targetTheme.simGifKey) ;
+
     return <div className="gif-recorder">
         <div className="gif-recorder-label">{lf("Pick your project thumbnail")}</div>
         <div className="gif-recorder-actions">
             {!!onScreenshot && <Button className="teal inverted"
-                title={lf("Take screenshot")}
-                label={lf("Take screenshot")}
+                title={screenshotLabel}
+                label={screenshotLabel}
                 leftIcon="fas fa-camera"
                 onClick={onScreenshot} />}
             {!!onRecordStart && <Button className="teal inverted"
-                title={recorderState === "recording" ? lf("Stop recording") : lf("Record game play")}
-                label={recorderState === "recording" ? lf("Stop recording") : lf("Record game play")}
+                title={recorderState === "recording" ? stopRecordingLabel : startRecordingLabel}
+                label={recorderState === "recording" ? stopRecordingLabel : startRecordingLabel}
                 leftIcon={`fas fa-${recorderState === "recording" ? "square" : "circle"}`}
                 onClick={recorderState === "recording" ? onGifRecordStop : onGifRecordStart} />}
         </div>

--- a/react-common/components/share/GifRecorder.tsx
+++ b/react-common/components/share/GifRecorder.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { Button } from "../controls/Button";
+
+
+export interface GifRecorderProps {
+    onScreenshot?: () => void;
+    onRecordStart?: () => void;
+    onRecordStop?: () => Promise<void>;
+}
+
+export const GifRecorder = (props: GifRecorderProps) => {
+    const { onScreenshot, onRecordStart, onRecordStop } = props;
+    const [ recorderState, setRecorderState ] = React.useState<"default" | "recording" | "rendering">("default");
+
+    const onGifRecordStart = () => {
+        setRecorderState("recording");
+        onRecordStart();
+    }
+
+    const onGifRecordStop = async () => {
+        setRecorderState("rendering");
+        await onRecordStop();
+        setRecorderState("default");
+    }
+
+    return <div className="gif-recorder">
+        <div className="gif-recorder-label">{lf("Pick your project thumbnail")}</div>
+        <div className="gif-recorder-actions">
+            {!!onScreenshot && <Button className="teal inverted"
+                title={lf("Take screenshot")}
+                label={lf("Take screenshot")}
+                leftIcon="fas fa-camera"
+                onClick={onScreenshot} />}
+            {!!onRecordStart && <Button className="teal inverted"
+                title={recorderState === "recording" ? lf("Stop recording") : lf("Record game play")}
+                label={recorderState === "recording" ? lf("Stop recording") : lf("Record game play")}
+                leftIcon={`fas fa-${recorderState === "recording" ? "square" : "circle"}`}
+                onClick={recorderState === "recording" ? onGifRecordStop : onGifRecordStart} />}
+        </div>
+    </div>
+}

--- a/react-common/components/share/Share.tsx
+++ b/react-common/components/share/Share.tsx
@@ -1,0 +1,44 @@
+/// <reference path="../types.d.ts" />
+
+import * as React from "react";
+import { ShareInfo } from "./ShareInfo";
+
+export interface ShareData {
+    url: string;
+    embed: {
+        code?: string;
+        editor?: string;
+        simulator?: string;
+        url?: string;
+    }
+    qr?: string;
+    error?: any;
+}
+
+export interface ShareProps {
+    projectName: string;
+    screenshotUri?: string;
+
+    screenshotAsync: () => Promise<string>;
+    gifRecordAsync: () => Promise<void>;
+    gifRenderAsync: () => Promise<string | void>;
+    publishAsync: (name: string, screenshotUri?: string) => Promise<ShareData>;
+    showModalAsync(options: DialogOptions): Promise<void>;
+}
+
+export const Share = (props: ShareProps) => {
+    const { projectName, screenshotUri, screenshotAsync, gifRecordAsync,
+        gifRenderAsync, publishAsync, showModalAsync } = props;
+
+return <div className="project-share">
+        {(!!screenshotAsync || !!gifRecordAsync) && <div className="project-share-simulator">
+            <div id="shareLoanedSimulator" />
+        </div>}
+        <ShareInfo projectName={projectName}
+            screenshotUri={screenshotUri}
+            screenshotAsync={screenshotAsync}
+            gifRecordAsync={gifRecordAsync}
+            gifRenderAsync={gifRenderAsync}
+            publishAsync={publishAsync} />
+    </div>
+}

--- a/react-common/components/share/Share.tsx
+++ b/react-common/components/share/Share.tsx
@@ -22,13 +22,15 @@ export interface ShareProps {
     screenshotAsync: () => Promise<string>;
     gifRecordAsync: () => Promise<void>;
     gifRenderAsync: () => Promise<string | void>;
+    gifAddFrame: (dataUri: ImageData, delay?: number) => boolean;
     publishAsync: (name: string, screenshotUri?: string) => Promise<ShareData>;
-    showModalAsync(options: DialogOptions): Promise<void>;
+    registerSimulatorMsgHandler?: (handler: (msg: any) => void) => void;
+    unregisterSimulatorMsgHandler?: () => void;
 }
 
 export const Share = (props: ShareProps) => {
-    const { projectName, screenshotUri, screenshotAsync, gifRecordAsync,
-        gifRenderAsync, publishAsync, showModalAsync } = props;
+    const { projectName, screenshotUri, screenshotAsync, gifRecordAsync, gifRenderAsync, gifAddFrame,
+        publishAsync, registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
 
 return <div className="project-share">
         {(!!screenshotAsync || !!gifRecordAsync) && <div className="project-share-simulator">
@@ -39,6 +41,9 @@ return <div className="project-share">
             screenshotAsync={screenshotAsync}
             gifRecordAsync={gifRecordAsync}
             gifRenderAsync={gifRenderAsync}
-            publishAsync={publishAsync} />
+            gifAddFrame={gifAddFrame}
+            publishAsync={publishAsync}
+            registerSimulatorMsgHandler={registerSimulatorMsgHandler}
+            unregisterSimulatorMsgHandler={unregisterSimulatorMsgHandler} />
     </div>
 }

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -16,11 +16,15 @@ export interface ShareInfoProps {
     screenshotAsync?: () => Promise<string>;
     gifRecordAsync?: () => Promise<void>;
     gifRenderAsync?: () => Promise<string | void>;
+    gifAddFrame?: (dataUri: ImageData, delay?: number) => boolean;
     publishAsync: (name: string, screenshotUri?: string) => Promise<ShareData>;
+    registerSimulatorMsgHandler?: (handler: (msg: any) => void) => void;
+    unregisterSimulatorMsgHandler?: () => void;
 }
 
 export const ShareInfo = (props: ShareInfoProps) => {
-    const { projectName, description, screenshotUri, screenshotAsync, gifRecordAsync, gifRenderAsync, publishAsync } = props;
+    const { projectName, description, screenshotUri, screenshotAsync, gifRecordAsync, gifRenderAsync, gifAddFrame,
+        publishAsync, registerSimulatorMsgHandler, unregisterSimulatorMsgHandler } = props;
     const [ name, setName ] = React.useState(projectName);
     const [ thumbnailUri, setThumbnailUri ] = React.useState(screenshotUri);
     const [ shareState, setShareState ] = React.useState<"share" | "gifrecord" | "publish">("share");
@@ -154,7 +158,8 @@ export const ShareInfo = (props: ShareInfoProps) => {
                         heading={lf("Share on Twitter")} />
                 </div>}
                 {embedState !== "none" && <div className="project-embed">
-                    <EditorToggle className="slim tablet-compact"
+                    <EditorToggle id="project-embed-toggle"
+                        className="slim tablet-compact"
                         items={embedOptions}
                         selected={embedOptions.findIndex(i => i.name === embedState)} />
                     <Textarea readOnly={true}
@@ -171,7 +176,10 @@ export const ShareInfo = (props: ShareInfoProps) => {
                 onCancel={exitGifRecord}
                 screenshotAsync={screenshotAsync}
                 gifRecordAsync={gifRecordAsync}
-                gifRenderAsync={gifRenderAsync}  />}
+                gifRenderAsync={gifRenderAsync}
+                gifAddFrame={gifAddFrame}
+                registerSimulatorMsgHandler={registerSimulatorMsgHandler}
+                unregisterSimulatorMsgHandler={unregisterSimulatorMsgHandler} />}
         </div>
     </>
 }

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -1,0 +1,177 @@
+import * as React from "react";
+import { Button } from "../controls/Button";
+import { EditorToggle } from "../controls/EditorToggle";
+import { Input } from "../controls/Input";
+import { Textarea } from "../controls/Textarea";
+
+import { ShareData } from "./Share";
+import { GifInfo } from "./GifInfo";
+import { SocialButton } from "./SocialButton";
+
+export interface ShareInfoProps {
+    projectName: string;
+    description?: string;
+    screenshotUri?: string;
+
+    screenshotAsync?: () => Promise<string>;
+    gifRecordAsync?: () => Promise<void>;
+    gifRenderAsync?: () => Promise<string | void>;
+    publishAsync: (name: string, screenshotUri?: string) => Promise<ShareData>;
+}
+
+export const ShareInfo = (props: ShareInfoProps) => {
+    const { projectName, description, screenshotUri, screenshotAsync, gifRecordAsync, gifRenderAsync, publishAsync } = props;
+    const [ name, setName ] = React.useState(projectName);
+    const [ thumbnailUri, setThumbnailUri ] = React.useState(screenshotUri);
+    const [ shareState, setShareState ] = React.useState<"share" | "gifrecord" | "publish">("share");
+    const [ shareData, setShareData ] = React.useState<ShareData>();
+    const [ embedState, setEmbedState ] = React.useState<"none" | "code" | "editor" | "simulator">("none");
+    const [ showQRCode, setShowQRCode ] = React.useState(false);
+
+    const showSimulator = !!screenshotAsync || !!gifRecordAsync;
+
+    React.useEffect(() => {
+        setThumbnailUri(screenshotUri)
+    }, [screenshotUri])
+
+    const exitGifRecord = () => {
+        setShareState("share");
+    }
+
+    const applyGifChange = (uri: string) => {
+        setThumbnailUri(uri);
+        exitGifRecord();
+    }
+
+    const handlePublishClick = async () => {
+        let publishedShareData = await publishAsync(name, thumbnailUri);
+        setShareData(publishedShareData);
+        if (!publishedShareData.error) setShareState("publish");
+    }
+
+    const handleCopyClick = () => {
+        navigator.clipboard.writeText(shareData.url);
+    }
+
+    const handleEmbedClick = () => {
+        if (embedState === "none") {
+            setShowQRCode(false);
+            setEmbedState("code");
+        } else {
+            setEmbedState("none");
+        }
+    }
+
+    const handleQRCodeClick = () => {
+        if (!showQRCode) {
+            setEmbedState("none");
+            setShowQRCode(true);
+        } else {
+            setShowQRCode(false);
+        }
+    }
+
+
+    const embedOptions = [{
+        name: "code",
+        label: lf("Code"),
+        title: lf("Code"),
+        focusable: true,
+        onClick: () => setEmbedState("code")
+    },
+    {
+        name: "editor",
+        label: lf("Editor"),
+        title: lf("Editor"),
+        focusable: true,
+        onClick: () => setEmbedState("editor")
+    },
+    {
+        name: "simulator",
+        label: lf("Simulator"),
+        title: lf("Simulator"),
+        focusable: true,
+        onClick: () => setEmbedState("simulator")
+    }];
+
+    return <>
+        <div className="project-share-info">
+            {(shareState === "share" || shareState === "publish") && <>
+                {showSimulator && <h2>{lf("About your project")}</h2>}
+                <Input label={lf("Project Name")}
+                    initialValue={name}
+                    placeholder={lf("Name your project")}
+                    readOnly={shareState === "publish"}
+                    onChange={setName} />
+                <Textarea label={lf("Description")}
+                    initialValue={description}
+                    placeholder={lf("Tell others about your game")}
+                    readOnly={shareState === "publish"}
+                    rows={5} />
+                {shareState === "share" && <>
+                    {showSimulator && <div className="project-share-thumbnail">
+                        {thumbnailUri
+                            ? <img src={thumbnailUri} />
+                            : <div className="project-thumbnail-placeholder" />
+                        }
+                        <Button title={lf("Update project thumbnail")}
+                            label={lf("Update project thumbnail")}
+                            onClick={() => setShareState("gifrecord")} />
+                    </div>}
+                    <div>{lf("By publishing you agree that you are allowed to share this game.")}</div>
+                    {shareData.error && <div className="project-share-error">
+                        {(shareData.error.statusCode === 413
+                            && pxt.appTarget?.cloud?.cloudProviders?.github)
+                            ? lf("Oops! Your project is too big. You can create a GitHub repository to share it.")
+                            : lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}
+                    </div>}
+                    <Button className="primary"
+                        title={lf("Publish to share")}
+                        label={lf("Publish to share")}
+                        onClick={handlePublishClick} />
+                </>}
+                {shareState === "publish" && <div className="project-share-actions">
+                    <Button className="teal"
+                        title={lf("Copy link")}
+                        label={lf("Copy link")}
+                        leftIcon="fas fa-link"
+                        onClick={handleCopyClick} />
+                    <Button className="share-button"
+                        title={lf("Show QR code")}
+                        leftIcon="fas fa-qrcode"
+                        onClick={handleQRCodeClick} />
+                    <Button className="share-button"
+                        title={lf("Show embed code")}
+                        leftIcon="fas fa-code"
+                        onClick={handleEmbedClick} />
+                    <SocialButton className="share-button"
+                        url={shareData.url}
+                        type='facebook'
+                        heading={lf("Share on Facebook")} />
+                    <SocialButton className="share-button"
+                        url={shareData.url}
+                        type='twitter'
+                        heading={lf("Share on Twitter")} />
+                </div>}
+                {embedState !== "none" && <div className="project-embed">
+                    <EditorToggle className="slim tablet-compact"
+                        items={embedOptions}
+                        selected={embedOptions.findIndex(i => i.name === embedState)} />
+                    <Textarea readOnly={true}
+                        rows={5}
+                        initialValue={shareData.embed[embedState]} />
+                </div>}
+                {showQRCode && <div className="project-qrcode">
+                    <img src={shareData.qr} />
+                </div>}
+            </>}
+            {shareState === "gifrecord" && <GifInfo
+                initialUri={thumbnailUri}
+                onApply={applyGifChange}
+                onCancel={exitGifRecord}
+                screenshotAsync={screenshotAsync}
+                gifRecordAsync={gifRecordAsync}
+                gifRenderAsync={gifRenderAsync}  />}
+        </div>
+    </>
+}

--- a/react-common/components/share/ShareInfo.tsx
+++ b/react-common/components/share/ShareInfo.tsx
@@ -46,7 +46,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
     const handlePublishClick = async () => {
         let publishedShareData = await publishAsync(name, thumbnailUri);
         setShareData(publishedShareData);
-        if (!publishedShareData.error) setShareState("publish");
+        if (!publishedShareData?.error) setShareState("publish");
     }
 
     const handleCopyClick = () => {
@@ -119,7 +119,7 @@ export const ShareInfo = (props: ShareInfoProps) => {
                             onClick={() => setShareState("gifrecord")} />
                     </div>}
                     <div>{lf("By publishing you agree that you are allowed to share this game.")}</div>
-                    {shareData.error && <div className="project-share-error">
+                    {shareData?.error && <div className="project-share-error">
                         {(shareData.error.statusCode === 413
                             && pxt.appTarget?.cloud?.cloudProviders?.github)
                             ? lf("Oops! Your project is too big. You can create a GitHub repository to share it.")
@@ -145,11 +145,11 @@ export const ShareInfo = (props: ShareInfoProps) => {
                         leftIcon="fas fa-code"
                         onClick={handleEmbedClick} />
                     <SocialButton className="share-button"
-                        url={shareData.url}
+                        url={shareData?.url}
                         type='facebook'
                         heading={lf("Share on Facebook")} />
                     <SocialButton className="share-button"
-                        url={shareData.url}
+                        url={shareData?.url}
                         type='twitter'
                         heading={lf("Share on Twitter")} />
                 </div>}
@@ -159,10 +159,10 @@ export const ShareInfo = (props: ShareInfoProps) => {
                         selected={embedOptions.findIndex(i => i.name === embedState)} />
                     <Textarea readOnly={true}
                         rows={5}
-                        initialValue={shareData.embed[embedState]} />
+                        initialValue={shareData?.embed[embedState]} />
                 </div>}
                 {showQRCode && <div className="project-qrcode">
-                    <img src={shareData.qr} />
+                    <img src={shareData?.qr} />
                 </div>}
             </>}
             {shareState === "gifrecord" && <GifInfo

--- a/react-common/components/share/SocialButton.tsx
+++ b/react-common/components/share/SocialButton.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Button } from "../controls/Button";
+
+interface SocialButtonProps {
+    className?: string;
+    url?: string;
+    type?: "facebook" | "twitter" | "discourse";
+    heading?: string;
+}
+
+export const SocialButton = (props: SocialButtonProps) => {
+    const { className, url, type, heading } = props;
+
+    const handleClick = () => {
+        const socialOptions = pxt.appTarget.appTheme.socialOptions;
+        let socialUrl = '';
+        switch (type) {
+            case "facebook": {
+                socialUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+                break;
+            }
+            case "twitter": {
+                let twitterText = lf("Check out what I made!");
+                if (socialOptions.twitterHandle && socialOptions.orgTwitterHandle) {
+                    twitterText = lf("Check out what I made with @{0} and @{1}!", socialOptions.twitterHandle, socialOptions.orgTwitterHandle);
+                } else if (socialOptions.twitterHandle) {
+                    twitterText = lf("Check out what I made with @{0}!", socialOptions.twitterHandle);
+                } else if (socialOptions.orgTwitterHandle) {
+                    twitterText = lf("Check out what I made with @{0}!", socialOptions.orgTwitterHandle);
+                }
+                socialUrl = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}` +
+                    `&text=${encodeURIComponent(twitterText)}` +
+                    (socialOptions.hashtags ? `&hashtags=${encodeURIComponent(socialOptions.hashtags)}` : '') +
+                    (socialOptions.related ? `&related=${encodeURIComponent(socialOptions.related)}` : '');
+                break;
+            }
+            case "discourse": {
+                // https://meta.discourse.org/t/compose-a-new-pre-filled-topic-via-url/28074
+                socialUrl = `${socialOptions.discourse || "https://forum.makecode.com/"}new-topic?title=${encodeURIComponent(url)}`;
+                if (socialOptions.discourseCategory)
+                socialUrl += `&category=${encodeURIComponent(socialOptions.discourseCategory)}`;
+                break;
+            }
+        }
+        pxt.BrowserUtils.popupWindow(socialUrl, heading, 600, 600);
+    }
+
+    return <Button className={className}
+        ariaLabel={type}
+        title={type}
+        leftIcon={`icon ${type}`}
+        onClick={handleClick} />
+}

--- a/react-common/styles/controls/Modal.less
+++ b/react-common/styles/controls/Modal.less
@@ -1,3 +1,5 @@
+
+
 .common-modal-container {
     position: fixed;
     display: flex;
@@ -7,12 +9,12 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: var(--modal-overlay-color);
+    background-color: @modalOverlayColor;
     z-index: @modalDimmerZIndex;
 }
 
 .common-modal-container.fullscreen {
-    z-index: var(--fullscreen-modal-zindex)
+    z-index: @modalFullscreenZIndex;
 }
 
 .common-modal {
@@ -44,7 +46,7 @@
 }
 
 .common-modal-body {
-    background-color: @modalBodyBackgroundColor;
+    background-color: @pageBackground;
     min-height: 4rem;
     padding: 1.25rem 1.5rem;
 }
@@ -77,7 +79,7 @@
 }
 
 .fullscreen > .common-modal > .common-modal-header {
-    background-color: var(--primary-color);
+    background-color: @primaryColor;
     color: white;
     margin-bottom: 0;
 
@@ -99,7 +101,7 @@
 
 .fullscreen > .common-modal > .common-modal-body {
     flex-grow: 1;
-    background-color: var(--body-background-color);
+    background-color: @homeScreenBackground;
     padding: 1rem;
     max-height: unset;
 }

--- a/react-common/styles/react-common-variables.less
+++ b/react-common/styles/react-common-variables.less
@@ -45,7 +45,9 @@
 @modalHeaderBackgroundColor: @modalBodyBackgroundColor;
 @modalFooterBackgroundColor: #f9fafb;
 @modalSeparatorBorder: 1px solid rgba(34, 36, 38, .15);
+@modalOverlayColor: rgba(0, 0, 0, 0.5);
 @modalDimmerZIndex: 1000;
+@modalFullscreenZIndex: @modalDimmerZIndex;
 
 
 /****************************************************

--- a/react-common/styles/react-common.less
+++ b/react-common/styles/react-common.less
@@ -1,4 +1,5 @@
 @import "profile/profile.less";
+@import "share/share.less";
 @import "controls/Button.less";
 @import "controls/Checkbox.less";
 @import "controls/EditorToggle.less";

--- a/react-common/styles/share/share.less
+++ b/react-common/styles/share/share.less
@@ -1,0 +1,116 @@
+.sharedialog.fullscreen.common-modal-container > .common-modal > .common-modal-body {
+    padding: 0;
+}
+
+.project-share {
+    display: flex;
+    height: 100%;
+}
+
+.project-share-simulator {
+    flex: 1;
+    height: 100%;
+    background-color: @simulatorBackground;
+
+    #shareLoanedSimulator {
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+
+    .simframe {
+        padding-bottom: 56.25%!important;
+    }
+}
+
+.project-share-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1;
+
+    > div {
+        margin-bottom: 1rem;
+        flex-shrink: 0;
+    }
+}
+
+.project-share-thumbnail {
+    display: flex;
+    flex-direction: column;
+
+    .project-thumbnail-placeholder,
+    img {
+        margin: 0.3rem 0;
+        width: 15rem;
+        height: 11.25rem;
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+}
+
+.fullscreen {
+    .project-share > div {
+        padding: 2rem;
+    }
+
+    .project-share-info {
+        flex: unset;
+        width: 28rem;
+    }
+}
+
+/////////////////////////////////////////
+//           Embed                     //
+/////////////////////////////////////////
+
+.project-share-actions {
+    display: flex;
+
+    .share-button {
+        width: 3rem;
+        padding: 1rem 0.75rem;
+
+        i {
+            margin: 0;
+        }
+    }
+}
+
+
+/////////////////////////////////////////
+//           Gif Recorder              //
+/////////////////////////////////////////
+
+.gif-recorder {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    bottom: 0;
+    left: calc(~'(100vw - 25rem)/2');
+    padding: 1rem;
+    transform: translateX(-50%);
+    background: @white;
+    border: @teal;
+    border-radius: 0.2rem;
+    font-family: @segoeUIFont;
+}
+
+.gif-recorder-label,
+.thumbnail-label {
+    margin-bottom: 0.5rem;
+    font-family: @segoeUIFont;
+}
+
+.gif-recorder-actions {
+    display: flex;
+}
+
+.thumbnail-image,
+.thumbnail-placeholder {
+    display: flex;
+    background-color: rgba(0, 0, 0, 0.05);
+    width: 24.5rem;
+    height: 18.375rem;
+}

--- a/skillmap/src/App.css
+++ b/skillmap/src/App.css
@@ -19,7 +19,6 @@
     --card-hover-color: #BFBFBF;
     --card-border-color: #e9eef2;
     --dropdown-hover-color: #CCC;
-    --modal-overlay-color: rgba(0, 0, 0, 0.5);
     --inverted-text-color: var(--white);
     --subtitle-text-color: #6e6e6e;
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2311,10 +2311,10 @@ export class ProjectView
                 .then(img => pxt.BrowserUtils.browserDownloadDataUri(img, pkg.genFileName(".png")))
     }
 
-    pushScreenshotHandler(handler: (msg: pxt.editor.ScreenshotData) => void): void {
+    pushScreenshotHandler = (handler: (msg: pxt.editor.ScreenshotData) => void): void => {
         this.screenshotHandlers.push(handler);
     }
-    popScreenshotHandler(): void {
+    popScreenshotHandler = (): void => {
         this.screenshotHandlers.pop();
     }
 

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -72,7 +72,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         this.handleScreenshotClick = this.handleScreenshotClick.bind(this);
         this.handleScreenshotMessage = this.handleScreenshotMessage.bind(this);
         this.handleCreateGitHubRepository = this.handleCreateGitHubRepository.bind(this);
-        this.handleQrCodeClick = this.handleQrCodeClick.bind(this);
     }
 
     hide() {
@@ -221,13 +220,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         this.props.parent.restartSimulator();
     }
 
-    handleQrCodeClick(e: React.MouseEvent<HTMLImageElement>) {
-        pxt.tickEvent('share.qrtoggle');
-        e.stopPropagation();
-        const { qrCodeExpanded } = this.state;
-        this.setState({ qrCodeExpanded: !qrCodeExpanded });
-    }
-
     handleScreenshotClick() {
         pxt.tickEvent("share.takescreenshot", { view: 'computer', collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
         if (this.state.recordingState != ShareRecordingState.None) return;
@@ -264,39 +256,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         if (this._gifEncoder) return Promise.resolve(this._gifEncoder);
         return screenshot.loadGifEncoderAsync()
             .then(encoder => this._gifEncoder = encoder);
-    }
-
-    gifRecord2() {
-        pxt.tickEvent("share.gifrecord", { view: 'computer', collapsedTo: '' + !this.props.parent.state.collapseEditorTools }, { interactiveConsent: true });
-
-        if (this.state.recordingState != ShareRecordingState.None) return;
-
-        this.setState({ recordingState: ShareRecordingState.GifLoading, screenshotUri: undefined },
-            () => this.loadEncoderAsync()
-                .then(encoder => {
-                    if (!encoder) {
-                        this.setState({
-                            recordingState: ShareRecordingState.None,
-                            recordError: lf("Oops, gif encoder could not load. Please try again.")
-                        });
-                    } else {
-                        encoder.start();
-                        const gifwidth = pxt.appTarget.appTheme.simGifWidth || 160;
-                        this.setState({ recordingState: ShareRecordingState.GifRecording },
-                            () => simulator.driver.startRecording(gifwidth));
-                    }
-                })
-                .catch(e => {
-                    pxt.reportException(e);
-                    this.setState({
-                        recordingState: ShareRecordingState.None,
-                        recordError: lf("Oops, gif recording failed. Please try again.")
-                    });
-                    if (this._gifEncoder) {
-                        this._gifEncoder.cancel();
-                    }
-                })
-        );
     }
 
     gifRecord = async () => {
@@ -357,35 +316,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         this.setState({ recordingState: ShareRecordingState.None })
         // TODO shakao return error
         return uri;
-    }
-
-    gifRender2() {
-        pxt.debug(`render gif`)
-        simulator.driver.stopRecording();
-        if (!this._gifEncoder) return;
-
-        this.setState({ recordingState: ShareRecordingState.GifRendering, recordError: undefined },
-            () => {
-                this.props.parent.stopSimulator();
-                this._gifEncoder.renderAsync()
-                    .then(uri => {
-                        pxt.log(`gif: ${uri ? uri.length : 0} chars`)
-                        const maxSize = pxt.appTarget.appTheme.simScreenshotMaxUriLength;
-                        let recordError: string = undefined;
-                        if (uri) {
-                            if (maxSize && uri.length > maxSize) {
-                                pxt.tickEvent(`gif.toobig`, { size: uri.length });
-                                uri = undefined;
-                                recordError = lf("Gif is too big, try recording a shorter time.");
-                            } else
-                                pxt.tickEvent(`gif.ok`, { size: uri.length });
-                        }
-
-                        this.setState({ recordingState: ShareRecordingState.None, screenshotUri: uri, recordError })
-                        // give a breather to the browser to render the gif
-                        pxt.Util.delay(1000).then(() => this.props.parent.startSimulator());
-                    })
-            });
     }
 
     handleCreateGitHubRepository() {
@@ -473,219 +403,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
                     publishAsync={publishAsync} />
             </Modal>
             : <></>
-    }
-
-    renderCore2() {
-        const { visible, projectName: newProjectName, loading, recordingState, screenshotUri, thumbnails, recordError, pubId, qrCodeUri, qrCodeExpanded, title, sharingError } = this.state;
-        const targetTheme = pxt.appTarget.appTheme;
-        const header = this.props.parent.state.header;
-        const hideEmbed = !!targetTheme.hideShareEmbed || qrCodeExpanded;
-        const socialOptions = targetTheme.socialOptions;
-        const showSocialIcons = !!socialOptions && !pxt.BrowserUtils.isUwpEdge()
-            && !qrCodeExpanded;
-        const ready = !!pubId;
-        let mode = this.state.mode;
-        let url = '';
-        let embed = '';
-
-        let shareUrl = pxt.appTarget.appTheme.shareUrl || "https://makecode.com/";
-        if (!/\/$/.test(shareUrl)) shareUrl += '/';
-        let rootUrl = pxt.appTarget.appTheme.embedUrl
-        if (!/\/$/.test(rootUrl)) rootUrl += '/';
-        const verPrefix = pxt.webConfig.verprefix || '';
-
-        if (header) {
-            if (ready) {
-                url = `${shareUrl}${pubId}`;
-                let editUrl = `${rootUrl}${verPrefix}#pub:${pubId}`;
-                switch (mode) {
-                    case ShareMode.Code:
-                        embed = pxt.docs.codeEmbedUrl(`${rootUrl}${verPrefix}`, pubId);
-                        break;
-                    case ShareMode.Editor:
-                        embed = pxt.docs.embedUrl(`${rootUrl}${verPrefix}`, "pub", pubId);
-                        break;
-                    case ShareMode.Simulator:
-                        let padding = '81.97%';
-                        // TODO: parts aspect ratio
-                        let simulatorRunString = `${verPrefix}---run`;
-                        if (pxt.webConfig.runUrl) {
-                            if (pxt.webConfig.isStatic) {
-                                simulatorRunString = pxt.webConfig.runUrl;
-                            }
-                            else {
-                                // Always use live, not /beta etc.
-                                simulatorRunString = pxt.webConfig.runUrl.replace(pxt.webConfig.relprefix, "/---")
-                            }
-                        }
-                        if (pxt.appTarget.simulator) padding = (100 / pxt.appTarget.simulator.aspectRatio).toPrecision(4) + '%';
-                        const runUrl = rootUrl + simulatorRunString.replace(/^\//, '');
-                        embed = pxt.docs.runUrl(runUrl, padding, pubId);
-                        break;
-                    case ShareMode.Url:
-                        embed = editUrl;
-                        break;
-                }
-            }
-        }
-        const publish = () => {
-            pxt.tickEvent("menu.embed.publish", undefined, { interactiveConsent: true });
-            this.setState({ sharingError: undefined, loading: true });
-            let p = Promise.resolve();
-            if (newProjectName && this.props.parent.state.projectName != newProjectName) {
-                // save project name if we've made a change change
-                p = this.props.parent.updateHeaderNameAsync(newProjectName);
-            }
-            // if screenshots are enabled, always take one
-            if (targetTheme.simScreenshot && !screenshotUri) {
-                p = p.then(this.screenshotAsync);
-            }
-            p.then(() => this.props.parent.anonymousPublishAsync(this.state.screenshotUri))
-                .then((id) => {
-                    this.setState({ pubId: id, qrCodeUri: undefined, qrCodeExpanded: false });
-                    if (pxt.appTarget.appTheme.qrCode)
-                        qr.renderAsync(`${shareUrl}${id}`)
-                            .then(qruri => {
-                                if (this.state.pubId == id) // race
-                                    this.setState({ qrCodeUri: qruri });
-                            });
-                    this.forceUpdate();
-                })
-                .catch((e: Error) => {
-                    pxt.tickEvent("menu.embed.error", { code: (e as any).statusCode })
-                    this.setState({
-                        pubId: undefined,
-                        sharingError: e,
-                        qrCodeUri: undefined,
-                        qrCodeExpanded: false
-                    });
-                });
-            this.forceUpdate();
-        }
-
-        const formats = [
-            { mode: ShareMode.Code, label: lf("Code") },
-            { mode: ShareMode.Editor, label: lf("Editor") },
-            { mode: ShareMode.Simulator, label: lf("Simulator") },
-        ];
-
-        const action = !ready ? lf("Publish project") : undefined;
-        const actionLoading = loading && !this.state.sharingError;
-
-        let actions: sui.ModalButton[] = [];
-        if (action) {
-            actions.push({
-                label: action,
-                onclick: publish,
-                icon: 'share alternate',
-                loading: actionLoading,
-                className: 'primary',
-                disabled: recordingState != ShareRecordingState.None
-            })
-        }
-
-        const light = !!pxt.options.light;
-        const disclaimer = lf("You need to publish your project to share it or embed it in other web pages.") + " " +
-            lf("You acknowledge having consent to publish this project.");
-        const screenshotDisabled = actionLoading || recordingState != ShareRecordingState.None;
-        const screenshotText = this.loanedSimulator && targetTheme.simScreenshotKey
-            ? lf("Take Screenshot (shortcut: {0})", targetTheme.simScreenshotKey) : lf("Take Screenshot");
-        const screenshot = targetTheme.simScreenshot;
-        const gif = !light && !!targetTheme.simGif;
-        const isGifRecording = recordingState == ShareRecordingState.GifRecording;
-        const isGifRendering = recordingState == ShareRecordingState.GifRendering;
-        const gifIcon = isGifRecording ? "stop" : "circle";
-        const gifTitle = isGifRecording
-            ? (targetTheme.simGifKey ? lf("Stop recording (shortcut: {0})", targetTheme.simGifKey) : lf("Stop recording"))
-            : isGifRendering ? lf("Cancel rendering")
-                : (targetTheme.simGifKey ? lf("Start recording (shortcut: {0})", targetTheme.simGifKey)
-                    : lf("Start recording"));
-        const gifRecordingClass = isGifRecording ? "glow" : "";
-        const gifDisabled = actionLoading;
-        const gifLoading = recordingState == ShareRecordingState.GifLoading
-            || isGifRendering;
-        const screenshotMessage = recordError ? recordError
-            : isGifRecording ? lf("Recording in progress...")
-                : isGifRendering ? lf("Rendering gif...")
-                    : undefined;
-        const screenshotMessageClass = recordError ? "warning" : "";
-        const tooBigErrorSuggestGitHub = sharingError
-            && (sharingError as any).statusCode === 413
-            && pxt.appTarget?.cloud?.cloudProviders?.github;
-        const unknownError = sharingError && !tooBigErrorSuggestGitHub;
-        const qrCodeFull = !!qrCodeUri && qrCodeExpanded;
-        const classes = this.props.parent.createModalClasses("sharedialog");
-
-        return (
-            <sui.Modal isOpen={visible} className={classes}
-                size={thumbnails ? "" : "small"}
-                onClose={this.hide}
-                dimmer={true} header={title || lf("Share Project")}
-                closeIcon={true} buttons={actions}
-                closeOnDimmerClick
-                closeOnDocumentClick
-                closeOnEscape>
-                <div className={`ui form`}>
-                    {action && !this.loanedSimulator ? <div className="ui field">
-                        <div>
-                            <sui.Input ref="filenameinput" placeholder={lf("Name")} autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
-                                ariaLabel={lf("Type a name for your project")} autoComplete={false}
-                                value={newProjectName || ''} onChange={this.handleProjectNameChange} />
-                        </div>
-                    </div> : undefined}
-                    {action && this.loanedSimulator ? <div className="ui fields">
-                        <div id="shareLoanedSimulator" className={`simulator ui six wide field landscape only ${gifRecordingClass}`}></div>
-                        <div className="ui ten wide field">
-                            <sui.Input ref="filenameinput" placeholder={lf("Name")} autoFocus={!pxt.BrowserUtils.isMobile()} id={"projectNameInput"}
-                                ariaLabel={lf("Type a name for your project")} autoComplete={false}
-                                value={newProjectName || ''} onChange={this.handleProjectNameChange} />
-                            <label></label>
-                            <div className="ui buttons landscape only">
-                                <sui.Button icon="refresh" title={lf("Restart")} ariaLabel={lf("Restart")} onClick={this.restartSimulator} disabled={screenshotDisabled} />
-                                {screenshot ? <sui.Button icon="camera" title={screenshotText} ariaLabel={screenshotText} onClick={this.handleScreenshotClick} disabled={screenshotDisabled} /> : undefined}
-                                {gif ? <sui.Button icon={gifIcon} title={gifTitle} loading={gifLoading} onClick={this.handleRecordClick} disabled={gifDisabled} /> : undefined}
-                            </div>
-                            {screenshotUri || screenshotMessage ?
-                                <div className={`ui ${screenshotMessageClass} segment landscape only`}>{
-                                    (screenshotUri && !screenshotMessage)
-                                        ? <img className="ui small centered image" src={screenshotUri} alt={lf("Recorded gif")} />
-                                        : <p className="no-select">{screenshotMessage}</p>}</div> : undefined}
-                            <p className="ui tiny message info">{disclaimer}</p>
-                        </div>
-                    </div> : undefined}
-                    {action && !this.loanedSimulator ? <p className="ui tiny message info">{disclaimer}</p> : undefined}
-                    {tooBigErrorSuggestGitHub && <p className="ui orange inverted segment">{lf("Oops! Your project is too big. You can create a GitHub repository to share it.")}
-                        <sui.Button className="inverted basic" text={lf("Create")} icon="github" onClick={this.handleCreateGitHubRepository} />
-                    </p>}
-                    {unknownError && <p className="ui red inverted segment">{lf("Oops! There was an error. Please ensure you are connected to the Internet and try again.")}</p>}
-                    {url && ready ? <div>
-                        {!qrCodeFull && <p>{lf("Your project is ready! Use the address below to share your projects.")}</p>}
-                        {!qrCodeFull && <sui.Input id="projectUri" class="mini" readOnly={true} lines={1} value={url} copy={true} autoFocus={!pxt.BrowserUtils.isMobile()} selectOnClick={true} aria-describedby="projectUriLabel" autoComplete={false} />}
-                        {!qrCodeFull && <label htmlFor="projectUri" id="projectUriLabel" className="accessible-hidden">{lf("This is the read-only internet address of your project.")}</label>}
-                        {!!qrCodeUri && <img className={`ui ${qrCodeFull ? "huge" : "small"} image ${qrCodeExpanded ? "centered" : "floated right"} button pixelart`} alt={lf("QR Code of the saved program")}
-                            src={qrCodeUri} onClick={this.handleQrCodeClick} title={lf("Click to expand or collapse.")} tabIndex={0} aria-label={lf("QR Code of the saved program")} onKeyDown={fireClickOnEnter}/>}
-                        {showSocialIcons ? <div className="social-icons">
-                            <SocialButton url={url} ariaLabel="Facebook" type='facebook' heading={lf("Share on Facebook")} />
-                            <SocialButton url={url} ariaLabel="Twitter" type='twitter' heading={lf("Share on Twitter")} />
-                            {socialOptions.discourse ? <SocialButton url={url} icon={"comments"} ariaLabel={lf("Post to Forum")} type='discourse' heading={lf("Share on Forum")} /> : undefined}
-                        </div> : undefined}
-                    </div> : undefined}
-                    {(ready && !hideEmbed) && <div>
-                        <div className="ui divider"></div>
-                        <sui.ExpandableMenu title={lf("Embed")}>
-                            <sui.Menu pointing secondary>
-                                {formats.map(f =>
-                                    <EmbedMenuItem key={`tab${f.label}`} onClick={this.setAdvancedMode} currentMode={mode} {...f} />)}
-                            </sui.Menu>
-                            <sui.Field>
-                                <sui.Input id="embedCode" class="mini" readOnly={true} lines={4} value={embed} copy={ready} disabled={!ready} selectOnClick={true} autoComplete={false} />
-                                <label htmlFor="embedCode" id="embedCodeLabel" className="accessible-hidden">{lf("This is the read-only code for the selected tab.")}</label>
-                            </sui.Field>
-                        </sui.ExpandableMenu>
-                    </div>}
-                </div>
-            </sui.Modal >
-        )
     }
 
     componentDidUpdate() {

--- a/webapp/src/share.tsx
+++ b/webapp/src/share.tsx
@@ -68,7 +68,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         this.setAdvancedMode = this.setAdvancedMode.bind(this);
         this.handleProjectNameChange = this.handleProjectNameChange.bind(this);
         this.restartSimulator = this.restartSimulator.bind(this);
-        this.handleScreenshotMessage = this.handleScreenshotMessage.bind(this);
         this.handleCreateGitHubRepository = this.handleCreateGitHubRepository.bind(this);
     }
 
@@ -86,7 +85,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
         if (this.loanedSimulator) {
             simulator.driver.unloanSimulator();
             this.loanedSimulator = undefined;
-            this.props.parent.popScreenshotHandler();
             simulator.driver.stopRecording();
         }
         this.setState({
@@ -110,7 +108,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             && (pxt.appTarget.appTheme.simScreenshot || pxt.appTarget.appTheme.simGif);
         if (thumbnails) {
             this.loanedSimulator = simulator.driver.loanSimulator();
-            // this.props.parent.pushScreenshotHandler(this.handleScreenshotMessage);
         }
         this.setState({
             thumbnails,
@@ -124,20 +121,6 @@ export class ShareEditor extends data.Component<ShareEditorProps, ShareEditorSta
             title,
             projectName: header.name
         }, thumbnails ? (() => this.props.parent.startSimulator()) : undefined);
-    }
-
-    handleScreenshotMessage(msg: pxt.editor.ScreenshotData) {
-        const { visible } = this.state;
-
-        if (!msg || !visible) return;
-
-        if (this.state.recordingState == ShareRecordingState.GifRecording) {
-            this._gifEncoder.addFrame(msg.data, msg.delay);
-        } else {
-            // ignore
-            // make sure simulator is stopped
-            simulator.driver.stopRecording();
-        }
     }
 
     UNSAFE_componentWillReceiveProps(newProps: ShareEditorProps) {


### PR DESCRIPTION
react-common modal, new share components following Alex's fullscreen design for when screenshot/simulator is enabled and just the old modal design for when screenshots are disabled (microbit)

builds:
https://arcade.makecode.com/app/4fd34183d6d629192d9a075628999ec00a366090-b5a5921b34
https://makecode.microbit.org/app/548b0b0e67ceeaa611ad69936640cdd2ae58727f-93ebe2f317

i still need to clean up/reconnect the gif hotkeys but it's a little finicky because the gif encoder lives in the webapp (to avoid react-common dependencies) and all the gif state is in the new component, will do in a separate PR